### PR TITLE
(PC-30662)[PRO] feat: use can archive in eac front

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -612,9 +612,9 @@ def batch_update_collective_offers(query: BaseQuery, update_fields: dict) -> Non
 
 
 def batch_update_collective_offers_template(query: BaseQuery, update_fields: dict) -> None:
-    allowed_validation_status = [models.OfferValidationStatus.APPROVED]
+    allowed_validation_status = {models.OfferValidationStatus.APPROVED}
     if "dateArchived" in update_fields:
-        allowed_validation_status.append(models.OfferValidationStatus.DRAFT)
+        allowed_validation_status.update((models.OfferValidationStatus.DRAFT, models.OfferValidationStatus.REJECTED))
 
     collective_offer_ids_tuples = query.filter(
         educational_models.CollectiveOfferTemplate.validation.in_(allowed_validation_status)  # type: ignore[attr-defined]

--- a/pro/src/commons/core/OfferEducational/types.ts
+++ b/pro/src/commons/core/OfferEducational/types.ts
@@ -78,13 +78,15 @@ export const isCollectiveOffer = (
   value: unknown
 ): value is GetCollectiveOfferResponseModel =>
   // Could be enhanced to check that it is also a GetCollectiveOfferTemplateResponseModel
-  hasProperty(value, 'isTemplate') && value.isTemplate === false
+  (hasProperty(value, 'isTemplate') && value.isTemplate === false) ||
+  (hasProperty(value, 'isShowcase') && value.isShowcase === false)
 
 export const isCollectiveOfferTemplate = (
   value: unknown
 ): value is GetCollectiveOfferTemplateResponseModel =>
   // Could be enhanced to check that it is also a GetCollectiveOfferTemplateResponseModel
-  hasProperty(value, 'isTemplate') && value.isTemplate === true
+  (hasProperty(value, 'isTemplate') && value.isTemplate === true) ||
+  (hasProperty(value, 'isShowcase') && value.isShowcase === true)
 
 export type VisibilityFormValues = {
   visibility: 'all' | 'one'

--- a/pro/src/components/ArchiveConfirmationModal/utils/__specs__/isCollectiveOfferArchivable.spec.ts
+++ b/pro/src/components/ArchiveConfirmationModal/utils/__specs__/isCollectiveOfferArchivable.spec.ts
@@ -1,0 +1,62 @@
+import {
+  CollectiveOfferAllowedAction,
+  CollectiveOfferTemplateAllowedAction,
+  CollectiveOffersStockResponseModel,
+} from 'apiClient/v1'
+import { collectiveOfferFactory } from 'commons/utils/collectiveApiFactories'
+
+import { isCollectiveOfferArchivable } from '../isCollectiveOfferArchivable'
+
+describe('isCollectiveOfferArchivable', () => {
+  const stocks: Array<CollectiveOffersStockResponseModel> = [
+    {
+      beginningDatetime: String(new Date()),
+      hasBookingLimitDatetimePassed: false,
+      remainingQuantity: 1,
+    },
+  ]
+
+  it('should return true when collective offer is archivable', () => {
+    expect(
+      isCollectiveOfferArchivable(
+        collectiveOfferFactory({
+          stocks,
+          allowedActions: [CollectiveOfferAllowedAction.CAN_ARCHIVE],
+        })
+      )
+    ).toStrictEqual(true)
+  })
+
+  it('should return true when collective template offer is archivable', () => {
+    expect(
+      isCollectiveOfferArchivable(
+        collectiveOfferFactory({
+          isShowcase: true,
+          allowedActions: [CollectiveOfferTemplateAllowedAction.CAN_ARCHIVE],
+        })
+      )
+    ).toStrictEqual(true)
+  })
+
+  it('should return false when collective offer is not archivable', () => {
+    expect(
+      isCollectiveOfferArchivable(
+        collectiveOfferFactory({
+          stocks,
+          allowedActions: [],
+        })
+      )
+    ).toStrictEqual(false)
+  })
+
+  it('should return false when collective template offer is not archivable', () => {
+    expect(
+      isCollectiveOfferArchivable(
+        collectiveOfferFactory({
+          isShowcase: true,
+          allowedActions: [],
+        })
+      )
+    ).toStrictEqual(false)
+  })
+})

--- a/pro/src/components/ArchiveConfirmationModal/utils/isCollectiveOfferArchivable.ts
+++ b/pro/src/components/ArchiveConfirmationModal/utils/isCollectiveOfferArchivable.ts
@@ -1,0 +1,29 @@
+import {
+  GetCollectiveOfferResponseModel,
+  GetCollectiveOfferTemplateResponseModel,
+  CollectiveOfferAllowedAction,
+  CollectiveOfferTemplateAllowedAction,
+  CollectiveOfferResponseModel,
+} from 'apiClient/v1'
+import {
+  isCollectiveOffer,
+  isCollectiveOfferTemplate,
+} from 'commons/core/OfferEducational/types'
+
+export function isCollectiveOfferArchivable(
+  offer:
+    | GetCollectiveOfferResponseModel
+    | GetCollectiveOfferTemplateResponseModel
+    | CollectiveOfferResponseModel
+) {
+  return (
+    (isCollectiveOffer(offer) &&
+      offer.allowedActions.includes(
+        CollectiveOfferAllowedAction.CAN_ARCHIVE
+      )) ||
+    (isCollectiveOfferTemplate(offer) &&
+      offer.allowedActions.includes(
+        CollectiveOfferTemplateAllowedAction.CAN_ARCHIVE
+      ))
+  )
+}

--- a/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
+++ b/pro/src/components/CollectiveOfferLayout/CollectiveOfferLayout.tsx
@@ -20,7 +20,6 @@ export interface CollectiveOfferLayoutProps {
   isTemplate?: boolean
   isFromTemplate?: boolean
   requestId?: string | null
-  isArchivable?: boolean | null
   offer?:
     | GetCollectiveOfferResponseModel
     | GetCollectiveOfferTemplateResponseModel
@@ -33,7 +32,6 @@ export const CollectiveOfferLayout = ({
   isCreation = false,
   isTemplate = false,
   requestId = null,
-  isArchivable,
   offer,
 }: CollectiveOfferLayoutProps): JSX.Element => {
   const location = useLocation()
@@ -92,7 +90,6 @@ export const CollectiveOfferLayout = ({
         offerId={navigationProps.offerId}
         isTemplate={isTemplate}
         requestId={requestId}
-        isArchivable={isArchivable}
         offer={offer}
       />
 

--- a/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
+++ b/pro/src/components/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
@@ -32,6 +32,8 @@ import { useNotification } from 'commons/hooks/useNotification'
 import { useOfferStockEditionURL } from 'commons/hooks/useOfferEditionURL'
 import { selectCurrentOffererId } from 'commons/store/user/selectors'
 import { ArchiveConfirmationModal } from 'components/ArchiveConfirmationModal/ArchiveConfirmationModal'
+import { canArchiveCollectiveOfferFromSummary } from 'components/ArchiveConfirmationModal/utils/canArchiveCollectiveOffer'
+import { isCollectiveOfferArchivable } from 'components/ArchiveConfirmationModal/utils/isCollectiveOfferArchivable'
 import { Step, Stepper } from 'components/Stepper/Stepper'
 import fullArchiveIcon from 'icons/full-archive.svg'
 import fullMoreIcon from 'icons/full-more.svg'
@@ -61,7 +63,6 @@ export interface CollectiveOfferNavigationProps {
   className?: string
   isTemplate: boolean
   requestId?: string | null
-  isArchivable?: boolean | null
   offer?:
     | GetCollectiveOfferResponseModel
     | GetCollectiveOfferTemplateResponseModel
@@ -75,7 +76,6 @@ export const CollectiveOfferNavigation = ({
   offerId = 0,
   className,
   requestId = null,
-  isArchivable,
   offer,
 }: CollectiveOfferNavigationProps): JSX.Element => {
   const { logEvent } = useAnalytics()
@@ -83,6 +83,9 @@ export const CollectiveOfferNavigation = ({
   const navigate = useNavigate()
   const location = useLocation()
   const isMarseilleActive = useActiveFeature('WIP_ENABLE_MARSEILLE')
+  const areCollectiveNewStatusesEnabled = useActiveFeature(
+    'ENABLE_COLLECTIVE_NEW_STATUSES'
+  )
   const selectedOffererId = useSelector(selectCurrentOffererId)
 
   const { mutate } = useSWRConfig()
@@ -236,6 +239,10 @@ export const CollectiveOfferNavigation = ({
     }
   }
 
+  const canArchiveOffer = areCollectiveNewStatusesEnabled
+    ? offer && isCollectiveOfferArchivable(offer)
+    : offer && canArchiveCollectiveOfferFromSummary(offer)
+
   return isEditingExistingOffer ? (
     <>
       <div className={styles['duplicate-offer']}>
@@ -245,7 +252,7 @@ export const CollectiveOfferNavigation = ({
           </ButtonLink>
         )}
 
-        {isArchivable && (
+        {canArchiveOffer && (
           <Button
             onClick={() => setIsArchiveModalOpen(true)}
             icon={fullArchiveIcon}

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -1,6 +1,5 @@
 import { Layout } from 'app/App/layout/Layout'
 import { Mode } from 'commons/core/OfferEducational/types'
-import { canArchiveCollectiveOfferFromSummary } from 'components/ArchiveConfirmationModal/utils/canArchiveCollectiveOffer'
 import { CollectiveOfferLayout } from 'components/CollectiveOfferLayout/CollectiveOfferLayout'
 import {
   MandatoryCollectiveOfferFromParamsProps,
@@ -18,7 +17,6 @@ const CollectiveOfferSummaryEdition = ({
         subTitle={offer.name}
         isTemplate={isTemplate}
         offer={offer}
-        isArchivable={canArchiveCollectiveOfferFromSummary(offer)}
       >
         <CollectiveOfferSummaryEditionScreen
           offer={offer}

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -35,6 +35,7 @@ import {
 import { localStorageAvailable } from 'commons/utils/localStorageAvailable'
 import { ArchiveConfirmationModal } from 'components/ArchiveConfirmationModal/ArchiveConfirmationModal'
 import { canArchiveCollectiveOffer } from 'components/ArchiveConfirmationModal/utils/canArchiveCollectiveOffer'
+import { isCollectiveOfferArchivable } from 'components/ArchiveConfirmationModal/utils/isCollectiveOfferArchivable'
 import { CancelCollectiveBookingModal } from 'components/CancelCollectiveBookingModal/CancelCollectiveBookingModal'
 import fullClearIcon from 'icons/full-clear.svg'
 import fullCopyIcon from 'icons/full-duplicate.svg'
@@ -87,6 +88,10 @@ export const CollectiveActionsCells = ({
 
   const isNewOffersAndBookingsActive = useActiveFeature(
     'WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE'
+  )
+
+  const areCollectiveNewStatusesEnabled = useActiveFeature(
+    'ENABLE_COLLECTIVE_NEW_STATUSES'
   )
 
   const collectiveOffersQueryKeys = getCollectiveOffersSwrKeys({
@@ -224,6 +229,11 @@ export const CollectiveActionsCells = ({
 
   const canDuplicateOffer = offer.status !== CollectiveOfferStatus.DRAFT
 
+  const canArchiveOffer = areCollectiveNewStatusesEnabled
+    ? isCollectiveOfferArchivable(offer)
+    : offer.status !== CollectiveOfferStatus.ARCHIVED &&
+      canArchiveCollectiveOffer(offer)
+
   return (
     <td
       className={cn(styles['offers-table-cell'], styles['actions-column'])}
@@ -355,31 +365,27 @@ export const CollectiveActionsCells = ({
                       </DropdownMenu.Item>
                     </>
                   )}
-                {offer.status !== CollectiveOfferStatus.ARCHIVED &&
-                  canArchiveCollectiveOffer(offer) && (
-                    <>
-                      <DropdownMenu.Separator
-                        className={cn(
-                          styles['separator'],
-                          styles['tablet-only']
-                        )}
-                      />
-                      <DropdownMenu.Item
-                        className={cn(styles['menu-item'])}
-                        onSelect={() => setIsArchivedModalOpen(true)}
-                        asChild
-                      >
-                        <div className={styles['status-filter-label']}>
-                          <Button
-                            icon={strokeThingIcon}
-                            variant={ButtonVariant.TERNARY}
-                          >
-                            Archiver
-                          </Button>
-                        </div>
-                      </DropdownMenu.Item>
-                    </>
-                  )}
+                {canArchiveOffer && (
+                  <>
+                    <DropdownMenu.Separator
+                      className={cn(styles['separator'], styles['tablet-only'])}
+                    />
+                    <DropdownMenu.Item
+                      className={cn(styles['menu-item'])}
+                      onSelect={() => setIsArchivedModalOpen(true)}
+                      asChild
+                    >
+                      <div className={styles['status-filter-label']}>
+                        <Button
+                          icon={strokeThingIcon}
+                          variant={ButtonVariant.TERNARY}
+                        >
+                          Archiver
+                        </Button>
+                      </div>
+                    </DropdownMenu.Item>
+                  </>
+                )}
               </div>
             </DropdownMenu.Content>
           </DropdownMenu.Portal>

--- a/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/CollectiveOffersTable/CollectiveOffersActionsBar/CollectiveOffersActionsBar.tsx
@@ -18,6 +18,7 @@ import { selectCurrentOffererId } from 'commons/store/user/selectors'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { ArchiveConfirmationModal } from 'components/ArchiveConfirmationModal/ArchiveConfirmationModal'
 import { canArchiveCollectiveOffer } from 'components/ArchiveConfirmationModal/utils/canArchiveCollectiveOffer'
+import { isCollectiveOfferArchivable } from 'components/ArchiveConfirmationModal/utils/isCollectiveOfferArchivable'
 import fullHideIcon from 'icons/full-hide.svg'
 import fullValidateIcon from 'icons/full-validate.svg'
 import strokeThingIcon from 'icons/stroke-thing.svg'
@@ -129,6 +130,10 @@ export function CollectiveOffersActionsBar({
     'ENABLE_COLLECTIVE_NEW_STATUSES'
   )
 
+  const areCollectiveNewStatusesEnabled = useActiveFeature(
+    'ENABLE_COLLECTIVE_NEW_STATUSES'
+  )
+
   const { mutate } = useSWRConfig()
 
   const collectiveOffersQueryKeys = getCollectiveOffersSwrKeys({
@@ -217,7 +222,11 @@ export function CollectiveOffersActionsBar({
 
   function openArchiveOffersDialog() {
     const shouldOpenArchiveDialog = selectedOffers.every((offer) => {
-      if (!canArchiveCollectiveOffer(offer)) {
+      const canArchiveOffer = areCollectiveNewStatusesEnabled
+        ? isCollectiveOfferArchivable(offer)
+        : canArchiveCollectiveOffer(offer)
+
+      if (!canArchiveOffer) {
         notify.error(
           'Les offres liées à des réservations en cours ne peuvent pas être archivées'
         )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30662

SOUS FF : ENABLE_COLLECTIVE_NEW_STATUSES

Gérer via une info back dans la requête de l'offre si elle est archivable ou non -> on garde l'ancien code car l'action est conditionné au statut des offres qui sont sous FF pour le moment

## Vérifications

- [ ] J'ai écrit les tests nécessaires
