### PR TITLE
(BSR)[API] fix: tests which fail from 2024-10-16

### DIFF
--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1113,23 +1113,23 @@ class IncomingEventStocksTest:
         query = repository.find_event_stocks_happening_in_x_days(number_of_days=7)
         assert {stock.id for stock in query} == {self.stock_next_week.id}
 
-    @time_machine.travel("2022-10-15 15:00:00")
+    @time_machine.travel("2024-10-15 15:00:00")
     def test_find_today_event_stock_ids_metropolitan_france(self):
         self.setup_stocks()
 
-        today_min = datetime.datetime(2022, 10, 15, 12, 00)
-        today_max = datetime.datetime(2022, 10, 15, 23, 00)
+        today_min = datetime.datetime(2024, 10, 15, 12, 00)
+        today_max = datetime.datetime(2024, 10, 15, 23, 00)
 
         stock_ids = repository.find_today_event_stock_ids_metropolitan_france(today_min, today_max)
 
         assert set(stock_ids) == {self.stock_today.id}
 
-    @time_machine.travel("2022-10-15 15:00:00")
+    @time_machine.travel("2024-10-15 15:00:00")
     def test_find_today_event_stock_ids_by_departments(self):
         self.setup_stocks()
 
-        today_min = datetime.datetime(2022, 10, 15, 8, 00)
-        today_max = datetime.datetime(2022, 10, 15, 19, 00)
+        today_min = datetime.datetime(2024, 10, 15, 8, 00)
+        today_max = datetime.datetime(2024, 10, 15, 19, 00)
 
         departments_prefixes = ["971"]
 


### PR DESCRIPTION
## But de la pull request

Réparer l'intégration continue, rouge à cause des tests basés sur la date.
Au plus rapide, en attendant mieux.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
