### PR TITLE
(PC-32071)[API] feat: improve venue location update

### DIFF
--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -69,6 +69,11 @@ class OffererAddressLabelAlreadyUsed(Exception):
     pass
 
 
+class OffererAddressIsLinkedToVenueException(ClientError):
+    def __init__(self) -> None:
+        super().__init__("OffererAddressIsLinkedToVenueException", "L'ancienne adresse est toujours liée à un lieu")
+
+
 class OffererAddressNotEditableException(Exception):
     pass
 


### PR DESCRIPTION
not updating the oa but switching to other or new. old oa get the venue common_name

## But de la pull request

Implementer la logique de gestion de modification des adresse aux lieux
* Pas de modification d'oa ou d'addresse 
* Switch d'oa ou création de nouvelle
* le label de l'ancienne oa prend la valeur du common_name de la venue afin que celui si reste pour les offres

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32071

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
