### PR TITLE
(PC-32489)[API] feat: change db constraint to allow multiple identica…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 88c4d806c740 (pre) (head)
-56372cadc547 (post) (head)
+5adc36a47352 (post) (head)

--- a/api/src/pcapi/alembic/versions/20241018T132623_3d909838fadc_create_index_ix_unique_offerer_address_per_label_null_not_distinct.py
+++ b/api/src/pcapi/alembic/versions/20241018T132623_3d909838fadc_create_index_ix_unique_offerer_address_per_label_null_not_distinct.py
@@ -1,0 +1,25 @@
+"""create index ix_unique_offerer_address_per_label"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "3d909838fadc"
+down_revision = "56372cadc547"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT;")
+    op.execute(
+        """CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "ix_unique_offerer_address_per_label" on "offerer_address" ("offererId", "addressId", "label")"""
+    )
+    op.execute("BEGIN;")
+
+
+def downgrade() -> None:
+    op.execute("COMMIT;")
+    op.execute("""DROP INDEX CONCURRENTLY IF EXISTS "ix_unique_offerer_address_per_label" """)
+    op.execute("BEGIN;")

--- a/api/src/pcapi/alembic/versions/20241018T142403_5adc36a47352_delete_index_ix_unique_offerer_address_per_label_null_distinct.py
+++ b/api/src/pcapi/alembic/versions/20241018T142403_5adc36a47352_delete_index_ix_unique_offerer_address_per_label_null_distinct.py
@@ -1,0 +1,25 @@
+"""delete ix_unique_offerer_address_per_label_even_with_nulls_values"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "5adc36a47352"
+down_revision = "3d909838fadc"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT;")
+    op.execute("""DROP INDEX CONCURRENTLY IF EXISTS "ix_unique_offerer_address_per_label_even_with_nulls_values" """)
+    op.execute("BEGIN;")
+
+
+def downgrade() -> None:
+    op.execute("COMMIT;")
+    op.execute(
+        """CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "ix_unique_offerer_address_per_label_even_with_nulls_values" on "offerer_address" ("offererId", "addressId", "label") NULLS NOT DISTINCT """
+    )
+    op.execute("BEGIN;")

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2818,7 +2818,7 @@ def get_or_create_offerer_address(offerer_id: int, address_id: int, label: str |
             models.OffererAddress.addressId == address_id,
         )
         .options(sa_orm.joinedload(models.OffererAddress.address))
-        .one()
+        .first()
     )
 
     return offerer_address

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -1269,15 +1269,7 @@ class OffererAddress(PcObject, Base, Model):
     offerer: sa_orm.Mapped["Offerer"] = sa_orm.relationship("Offerer", foreign_keys=[offererId])
     venues: sa_orm.Mapped[typing.Sequence["Venue"]] = sa.orm.relationship("Venue", back_populates="offererAddress")
 
-    __table_args__ = (
-        # FIXME (dramelet, 04-06-2024)
-        # Our current version of sqlalchemy (1.4) doesn't handle
-        # the option `nulls_not_distinct` from postgresql dialect
-        # Hence this declaration and the raw query in the suitable migration
-        sa.Index(
-            "ix_unique_offerer_address_per_label_even_with_nulls_values", "offererId", "addressId", "label", unique=True
-        ),
-    )
+    __table_args__ = (sa.Index("ix_unique_offerer_address_per_label", "offererId", "addressId", "label", unique=True),)
 
     _isLinkedToVenue: sa_orm.Mapped["bool|None"] = sa_orm.query_expression()
 

--- a/api/tests/routes/pro/test_offerers_addresses.py
+++ b/api/tests/routes/pro/test_offerers_addresses.py
@@ -326,8 +326,10 @@ class CreateOffererAddressesTest:
         assert response.status_code == 201
         content = response.json
         address = geography_models.Address.query.one()
-        offerer_address = offerers_models.OffererAddress.query.one()
-        assert offerer_address.id == pre_existing_oa.id
+        offerer_address = offerers_models.OffererAddress.query.order_by(
+            offerers_models.OffererAddress.id.desc()
+        ).first()
+        assert offerer_address.id != pre_existing_oa.id
         assert content["label"] == expected_data["label"] == None
         assert content["offererId"] == offerer_id
         assert content["address"]["id"] == address.id


### PR DESCRIPTION
…l offererAddress with label null

## But de la pull request
Permettre d'avoir plusieur offererAddress avec les meme adresse et offerer avec un label null

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32489

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
