### PR TITLE
(BSR)[API] fix: add missing allowed action for expired offer

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -195,6 +195,7 @@ ALLOWED_ACTIONS_BY_DISPLAYED_STATUS: typing.Final[
     CollectiveOfferDisplayedStatus.EXPIRED: (
         CollectiveOfferAllowedAction.CAN_EDIT_DATES,
         CollectiveOfferAllowedAction.CAN_ARCHIVE,
+        CollectiveOfferAllowedAction.CAN_DUPLICATE,
     ),
     CollectiveOfferDisplayedStatus.ENDED: (  # after 48h, cannot edit discount or cancel anymore
         CollectiveOfferAllowedAction.CAN_EDIT_DISCOUNT,


### PR DESCRIPTION
## But de la pull request

Une offre expirée peut être dupliquée

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
