### PR TITLE
(PC-32544)[BO] fix: non-numeric ids were not rejected in autocomplete filters

### DIFF
--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -543,6 +543,12 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
         # beginningDatetime at J+7, J+6, J+5, J+3, J+1
         assert [row["ID résa"] for row in rows] == [str(collective_bookings[idx].id) for idx in (2, 0, 3, 1, 4)]
 
+    @pytest.mark.parametrize("field", ["offerer", "venue", "cashflow_batches"])
+    def test_list_collective_bookings_by_invalid_autocomplete_id(self, authenticated_client, field):
+        response = authenticated_client.get(url_for(self.endpoint, **{field: "1)"}))
+        assert response.status_code == 400
+        assert html_parser.extract_warnings(response.data) == [f"ID invalide pour {field} : 1)"]
+
 
 class MarkCollectiveBookingAsUsedTest(PostEndpointHelper):
     endpoint = "backoffice_web.collective_bookings.mark_booking_as_used"

--- a/api/tests/routes/backoffice/individual_bookings_test.py
+++ b/api/tests/routes/backoffice/individual_bookings_test.py
@@ -641,6 +641,12 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         assert "Lieux" not in str(response.data)
         assert "Partenaires culturels" in str(response.data)
 
+    @pytest.mark.parametrize("field", ["offerer", "venue", "cashflow_batches"])
+    def test_list_bookings_by_invalid_autocomplete_id(self, authenticated_client, field):
+        response = authenticated_client.get(url_for(self.endpoint, **{field: "1)"}))
+        assert response.status_code == 400
+        assert html_parser.extract_warnings(response.data) == [f"ID invalide pour {field} : 1)"]
+
 
 class MarkBookingAsUsedTest(PostEndpointHelper):
     endpoint = "backoffice_web.individual_bookings.mark_booking_as_used"


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32544
Sentry : https://sentry.passculture.team/organizations/sentry/issues/1620632/?project=5

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
