### PR TITLE
(PC-32445)[PRO] fix: Re-render Formik form with good values when SWR call returned venues

### DIFF
--- a/pro/src/components/IndividualOfferForm/OfferLocation/OfferLocation.tsx
+++ b/pro/src/components/IndividualOfferForm/OfferLocation/OfferLocation.tsx
@@ -1,5 +1,5 @@
 import { useField, useFormikContext } from 'formik'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { VenueListItemResponseModel } from 'apiClient/v1'
 import { AddressSelect } from 'components/Address/Address'
@@ -30,6 +30,11 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
   const [showOtherAddress, setShowOtherAddress] = useState(
     formik.values.offerlocation === OFFER_LOCATION.OTHER_ADDRESS
   )
+
+  useEffect(() => {
+    setShowOtherAddress(formik.values.offerlocation === 'other')
+  }, [formik.values.offerlocation])
+
   const [manuallySetAddress, , { setValue: setManuallySetAddress }] =
     useField('manuallySetAddress')
 

--- a/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
+++ b/pro/src/screens/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
@@ -213,6 +213,7 @@ export const UsefulInformationScreen = ({
     initialValues,
     onSubmit,
     validationSchema,
+    enableReinitialize: true,
   })
   const handlePreviousStepOrBackToReadOnly = () => {
     if (mode === OFFER_WIZARD_MODE.CREATION) {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32445

Résoud le problème suivant sur l'édition d'une offre ayant l'adresse d'une venue sélectionnée :
- Lors d'un refresh de la page, la valeur "À une autre adresse" devenait cochée, alors que l'offre était bien positionnée sur l'adresse de la venue.

Le problème était lié au fait qu'une fois que `selectedVenue` était mis à jour via la requête SWR, les `initialValues` ne se mettaient pas à jour dynamiquement dans Formik parce qu'il n'actualise pas les valeurs initiales une fois qu'elles sont définies (d'où le `enableReinitialize: true`)

Il a également fallu utiliser un `useEffect` dans ce cas précis car `<Offerlocation/>` devait lire `formik.initialValues.offerlocation`, qui venait à changer dynamiquement en raison de `enableReinitialize: true`

