### PR TITLE
(BSR)[API] fix: add BDD pytest mark on finance tests

### DIFF
--- a/api/tests/core/finance/test_validation.py
+++ b/api/tests/core/finance/test_validation.py
@@ -10,6 +10,9 @@ from pcapi.core.finance import validation
 from pcapi.core.offerers import factories as offerers_factories
 
 
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
 class CustomReimbursementRuleValidationTest:
     def _make_rule(self, **kwargs):
         tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
@@ -68,7 +71,6 @@ class CustomReimbursementRuleValidationTest:
         with pytest.raises(exceptions.WrongDateForReimbursementRule):
             validation.validate_reimbursement_rule(rule)
 
-    @pytest.mark.usefixtures("db_session")
     def test_check_no_conflict_if_timespans_do_not_overlap(self):
         today = datetime.datetime.today()
         yesterday = today - datetime.timedelta(days=1)
@@ -79,7 +81,6 @@ class CustomReimbursementRuleValidationTest:
         rule2 = self._make_rule(offererId=rule1.offererId, timespan=timespan2)
         validation.validate_reimbursement_rule(rule2)  # should not raise
 
-    @pytest.mark.usefixtures("db_session")
     def test_check_no_conflict_if_different_subcategories(self):
         tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
         timespan = (tomorrow, None)
@@ -87,13 +88,11 @@ class CustomReimbursementRuleValidationTest:
         rule2 = self._make_rule(offererId=rule1.offererId, timespan=timespan, subcategories=["VOD"])
         validation.validate_reimbursement_rule(rule2)  # should not raise
 
-    @pytest.mark.usefixtures("db_session")
     def test_check_no_conflicts_with_itself(self):
         tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
         rule = factories.CustomReimbursementRuleFactory(timespan=(tomorrow, None))
         validation.validate_reimbursement_rule(rule)
 
-    @pytest.mark.usefixtures("db_session")
     def test_check_conflicts_if_subcategories_overlap(self):
         tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
         timespan = (tomorrow, None)
@@ -102,7 +101,6 @@ class CustomReimbursementRuleValidationTest:
         with pytest.raises(exceptions.ConflictingReimbursementRule):
             validation.validate_reimbursement_rule(rule2)
 
-    @pytest.mark.usefixtures("db_session")
     def test_check_conflicts_if_existing_rule_on_all_subcategories(self):
         tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
         timespan = (tomorrow, None)


### PR DESCRIPTION
## But de la pull request

Ajout de la fixture `db_session` pour l'ensemble du fichier.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
