### PR TITLE
(PC-32131)[API] feat: disable SIRET checks with DISABLE_SIRET_CHECK FF

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -37,6 +37,7 @@ class FeatureToggle(enum.Enum):
     DISABLE_CGR_EXTERNAL_BOOKINGS = "Désactiver les réservations externes CGR"
     DISABLE_EMS_EXTERNAL_BOOKINGS = "Désactiver les réservations externes EMS"
     DISCORD_ENABLE_NEW_ACCESS = "Activer/Désactiver l'accès au serveur Discord à des nouveaux utilisateurs"
+    DISABLE_SIRET_CHECK = "Désactiver la validation de SIRET"
     DISPLAY_DMS_REDIRECTION = "Affiche une redirection vers DMS si ID Check est KO"
     EMS_CANCEL_PENDING_EXTERNAL_BOOKING = "Annuler les réservations externes EMS qui ont échouées"
     ENABLE_AUTO_VALIDATION_FOR_EXTERNAL_BOOKING = (

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -516,6 +516,7 @@ BACKOFFICE_WATCH_SCSS_CHANGE = bool(int(os.environ.get("BACKOFFICE_WATCH_SCSS_CH
 SIRENE_BACKEND = os.environ.get("SIRENE_BACKEND")
 INSEE_SIRENE_API_TOKEN = secrets_utils.get("INSEE_SIRENE_API_TOKEN", "")
 INSEE_SIRENE_API_URL = os.environ.get("INSEE_SIRENE_API_URL", "https://api.insee.fr/entreprises/sirene/V3.11")
+ENFORCE_SIRET_CHECK = bool(int(os.environ.get("ENFORCE_SIRET_CHECK", 1)))
 
 # API ENTREPRISE
 ENTREPRISE_BACKEND = os.environ.get("ENTREPRISE_BACKEND")


### PR DESCRIPTION
Security added: ENFORCE_SIRET_CHECK settings must be true. This is to avoid SIRET check deactivation in prod

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32131

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
