### PR TITLE
(PC-31264)[PRO] feat: add QuantityInput component and use it when relevant

### DIFF
--- a/pro/src/components/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus.tsx
+++ b/pro/src/components/Bookings/BookingsRecapTable/Filters/FilterByBookingStatus.tsx
@@ -145,10 +145,9 @@ export const FilterByBookingStatus = <
         {isToolTipVisible && (
           <div className={styles['bs-filter-tooltip']}>
             <fieldset>
-              <legend className={styles['bs-filter-label']}>
+              <legend className={styles['bs-filter-legend']}>
                 Afficher les réservations
               </legend>
-
               {bookingStatusOptions.map((bookingStatus) => (
                 <BaseCheckbox
                   key={bookingStatus.value}
@@ -157,6 +156,7 @@ export const FilterByBookingStatus = <
                   name={bookingStatus.value}
                   onChange={handleCheckboxChange}
                   label={bookingStatus.title}
+                  className={styles['bs-filter-checkbox']}
                 />
               ))}
             </fieldset>

--- a/pro/src/components/Bookings/BookingsRecapTable/Filters/Filters.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/Filters/Filters.module.scss
@@ -9,7 +9,7 @@
   position: relative;
   display: inline-block;
 
-  .bs-filter-label {
+  .bs-filter-legend {
     @include fonts.caption;
 
     color: var(--color-grey-dark);
@@ -28,7 +28,7 @@
     z-index: 1;
   }
 
-  label {
+  .bs-filter-checkbox {
     @include fonts.body;
 
     display: flex;

--- a/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
@@ -16,6 +16,7 @@ import { Button } from 'ui-kit/Button/Button'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
 import { DatePicker } from 'ui-kit/form/DatePicker/DatePicker'
+import { QuantityInput } from 'ui-kit/form/QuantityInput/QuantityInput'
 import { RadioButton } from 'ui-kit/form/RadioButton/RadioButton'
 import { Select } from 'ui-kit/form/Select/Select'
 import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
@@ -350,7 +351,6 @@ export const RecurrenceForm = ({
               />
               Places et tarifs par horaire
             </h2>
-
             <FieldArray
               name="quantityPerPriceCategories"
               render={(arrayHelpers) => (
@@ -358,17 +358,13 @@ export const RecurrenceForm = ({
                   {values.quantityPerPriceCategories.map(
                     (quantityPerPriceCategory, index) => (
                       <FormLayout.Row key={index} inline mdSpaceAfter>
-                        <TextInput
+                        <QuantityInput
                           label="Nombre de places"
                           name={`quantityPerPriceCategories[${index}].quantity`}
-                          type="number"
-                          step="1"
-                          isOptional
-                          placeholder="Illimité"
                           className={styles['quantity-input']}
                           hideFooter
+                          isOptional
                         />
-
                         <Select
                           label="Tarif"
                           name={`quantityPerPriceCategories[${index}].priceCategory`}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/__specs__/RecurrenceForm.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/__specs__/RecurrenceForm.spec.tsx
@@ -41,7 +41,12 @@ describe('RecurrenceForm', () => {
       format(addDays(new Date(), 1), FORMAT_ISO_DATE_ONLY)
     )
     await userEvent.type(screen.getByLabelText('Horaire 1 *'), '12:00')
-    await userEvent.type(screen.getByLabelText('Nombre de places'), '10')
+    await userEvent.type(
+      screen.getByRole('spinbutton', {
+        name: 'Nombre de places',
+      }),
+      '10'
+    )
     await userEvent.type(screen.getByLabelText('Tarif *'), '21')
     await userEvent.type(
       screen.getByLabelText('Date limite de réservation', { exact: false }),

--- a/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.module.scss
@@ -52,11 +52,11 @@
 }
 
 .head-date {
-  width: rem.torem(160px);
+  width: rem.torem(110px);
 }
 
 .head-time {
-  width: rem.torem(105px);
+  width: rem.torem(90px);
 }
 
 .head-price {
@@ -64,19 +64,19 @@
 }
 
 .head-booking-limit-datetime {
-  width: rem.torem(160px);
+  width: rem.torem(110px);
 
   // force header to break line
   padding-right: rem.torem(4px);
 }
 
 .head-remaining-quantity {
-  width: rem.torem(90px);
+  width: rem.torem(160px);
 }
 
 .head-booking-quantity {
   white-space: nowrap;
-  width: rem.torem(120px);
+  width: rem.torem(100px);
 }
 
 .head-actions {
@@ -90,4 +90,8 @@
 
 .stock-actions {
   padding-top: rem.torem(8px);
+}
+
+.quantity-input {
+  width: 4rem;
 }

--- a/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
@@ -782,6 +782,7 @@ export const StocksEventEdition = ({
                                 disabled={readOnlyFields.includes(
                                   'remainingQuantity'
                                 )}
+                                className={styles['quantity-input']}
                               />
                             </td>
 

--- a/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
@@ -45,6 +45,7 @@ import { ButtonVariant } from 'ui-kit/Button/types'
 import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
 import { BaseDatePicker } from 'ui-kit/form/DatePicker/BaseDatePicker'
 import { DatePicker } from 'ui-kit/form/DatePicker/DatePicker'
+import { QuantityInput } from 'ui-kit/form/QuantityInput/QuantityInput'
 import { Select } from 'ui-kit/form/Select/Select'
 import { SelectInput } from 'ui-kit/form/Select/SelectInput'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
@@ -768,22 +769,19 @@ export const StocksEventEdition = ({
                             </td>
 
                             <td className={styles['data']}>
-                              <TextInput
+                              <QuantityInput
                                 smallLabel
-                                name={`stocks[${index}]remainingQuantity`}
+                                isLabelHidden
+                                hideFooter
                                 label={
                                   mode === OFFER_WIZARD_MODE.EDITION
                                     ? 'Quantité restante'
                                     : 'Quantité'
                                 }
-                                isLabelHidden
-                                placeholder="Illimité"
+                                name={`stocks[${index}].remainingQuantity`}
                                 disabled={readOnlyFields.includes(
                                   'remainingQuantity'
                                 )}
-                                type="number"
-                                hasDecimal={false}
-                                hideFooter
                               />
                             </td>
 

--- a/pro/src/components/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
@@ -203,7 +203,9 @@ describe('screens:StocksEventEdition', () => {
     expect(
       screen.getByLabelText('Date limite de réservation *')
     ).toBeInTheDocument()
-    expect(screen.getByLabelText('Quantité restante *')).toBeInTheDocument()
+    expect(
+      screen.getByRole('spinbutton', { name: 'Quantité restante *' })
+    ).toBeInTheDocument()
 
     expect(screen.getAllByText('Réservations *')[0]).toBeInTheDocument()
 
@@ -404,7 +406,10 @@ describe('screens:StocksEventEdition', () => {
       stocks_count: apiStocks.length,
     })
 
-    await userEvent.type(screen.getByLabelText('Quantité restante *'), '30')
+    await userEvent.type(
+      screen.getByRole('spinbutton', { name: 'Quantité restante *' }),
+      '30'
+    )
     await userEvent.click(
       screen.getByRole('button', { name: 'Enregistrer les modifications' })
     )
@@ -567,7 +572,10 @@ describe('screens:StocksEventEdition', () => {
       STOCKS_PER_PAGE * 5 + 10,
       '?page=3'
     )
-    await userEvent.type(screen.getByLabelText('Quantité restante *'), '30')
+    await userEvent.type(
+      screen.getByRole('spinbutton', { name: 'Quantité restante *' }),
+      '30'
+    )
 
     // should block on next page
     await userEvent.click(screen.getByRole('button', { name: 'Page suivante' }))

--- a/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
@@ -30,6 +30,7 @@ import strokeEuroIcon from 'icons/stroke-euro.svg'
 import { ActionBar } from 'pages/IndividualOffer/components/ActionBar/ActionBar'
 import { Checkbox } from 'ui-kit/form/Checkbox/Checkbox'
 import { DatePicker } from 'ui-kit/form/DatePicker/DatePicker'
+import { QuantityInput } from 'ui-kit/form/QuantityInput/QuantityInput'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 
@@ -202,21 +203,18 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
     setIsDeleteConfirmVisible(false)
   }
 
-  const onChangeQuantity = async (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const quantity = event.target.value
+  const onQuantityChange = async (newQuantity: string) => {
     let remainingQuantity: number | string =
       // No need to test
       /* istanbul ignore next */
-      Number(quantity || 0) - Number(formik.values.bookingsQuantity || 0)
+      Number(newQuantity || 0) - Number(formik.values.bookingsQuantity || 0)
 
-    if (quantity === '') {
+    if (newQuantity === '') {
       remainingQuantity = 'unlimited'
     }
 
     await formik.setFieldValue(`remainingQuantity`, remainingQuantity)
-    await formik.setFieldValue(`quantity`, quantity)
+    await formik.setFieldValue(`quantity`, newQuantity)
   }
 
   const getMaximumBookingDatetime = (date: Date | undefined) => {
@@ -390,18 +388,13 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                   className={styles['field-layout-small']}
                 />
               )}
-              <TextInput
+              <QuantityInput
                 smallLabel
-                name="quantity"
-                label="Quantité"
-                placeholder="Illimité"
-                isOptional
-                classNameFooter={styles['field-layout-footer']}
                 disabled={readOnlyFields.includes('quantity')}
-                type="number"
-                hasDecimal={false}
-                onChange={onChangeQuantity}
+                onChange={onQuantityChange}
                 className={styles['field-layout-xsmall']}
+                classNameFooter={styles['field-layout-footer']}
+                isOptional
               />
               {mode === OFFER_WIZARD_MODE.EDITION && stocks.length > 0 && (
                 <>

--- a/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
@@ -30,7 +30,10 @@ import strokeEuroIcon from 'icons/stroke-euro.svg'
 import { ActionBar } from 'pages/IndividualOffer/components/ActionBar/ActionBar'
 import { Checkbox } from 'ui-kit/form/Checkbox/Checkbox'
 import { DatePicker } from 'ui-kit/form/DatePicker/DatePicker'
-import { QuantityInput } from 'ui-kit/form/QuantityInput/QuantityInput'
+import {
+  Quantity,
+  QuantityInput,
+} from 'ui-kit/form/QuantityInput/QuantityInput'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 
@@ -203,7 +206,7 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
     setIsDeleteConfirmVisible(false)
   }
 
-  const onQuantityChange = async (newQuantity: string) => {
+  const onQuantityChange = async (newQuantity: Quantity) => {
     let remainingQuantity: number | string =
       // No need to test
       /* istanbul ignore next */

--- a/pro/src/components/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
@@ -153,7 +153,11 @@ describe('screens:StocksThing', () => {
     expect(
       screen.getByLabelText('Date limite de réservation')
     ).toBeInTheDocument()
-    expect(screen.getByLabelText('Quantité')).toBeInTheDocument()
+    expect(
+      screen.getByRole('spinbutton', {
+        name: 'Quantité',
+      })
+    ).toBeInTheDocument()
   })
 
   it('should render digital stock thing', async () => {
@@ -350,7 +354,11 @@ describe('screens:StocksThing', () => {
       )
 
       await userEvent.click(screen.getByText('Valider'))
-      expect(screen.getByLabelText('Quantité')).toBeDisabled()
+      expect(
+        screen.getByRole('spinbutton', {
+          name: 'Quantité',
+        })
+      ).toBeDisabled()
 
       const priceInput = screen.getByLabelText('Prix *')
       await userEvent.clear(priceInput)
@@ -433,7 +441,11 @@ describe('screens:StocksThing', () => {
         contextValue
       )
 
-      expect(screen.getByLabelText('Quantité')).toBeDisabled()
+      expect(
+        screen.getByRole('spinbutton', {
+          name: 'Quantité',
+        })
+      ).toBeDisabled()
       const expirationInput = screen.getByLabelText("Date d'expiration *")
       expect(expirationInput).toBeDisabled()
       expect(expirationInput).toHaveValue('2020-12-15')
@@ -472,8 +484,8 @@ describe('screens:StocksThing', () => {
     async ({ value, expectedNumber }) => {
       await renderStockThingScreen([], props, contextValue)
 
-      const quantityInput = screen.getByLabelText('Quantité', {
-        exact: false,
+      const quantityInput = screen.getByRole('spinbutton', {
+        name: 'Quantité',
       })
       await userEvent.type(quantityInput, value)
       expect(quantityInput).toHaveValue(expectedNumber)
@@ -498,7 +510,12 @@ describe('screens:StocksThing', () => {
     })
 
     await renderStockThingScreen([], props, contextValue)
-    await userEvent.type(screen.getByLabelText('Quantité'), '20')
+    await userEvent.type(
+      screen.getByRole('spinbutton', {
+        name: 'Quantité',
+      }),
+      '20'
+    )
 
     await userEvent.click(screen.getByText('Go outside !'))
 
@@ -513,7 +530,12 @@ describe('screens:StocksThing', () => {
     })
 
     await renderStockThingScreen([], props, contextValue)
-    await userEvent.type(screen.getByLabelText('Quantité'), '20')
+    await userEvent.type(
+      screen.getByRole('spinbutton', {
+        name: 'Quantité',
+      }),
+      '20'
+    )
 
     await userEvent.click(screen.getByText('Go outside !'))
     expect(

--- a/pro/src/pages/Offers/OffersTable/Cells/Cells.module.scss
+++ b/pro/src/pages/Offers/OffersTable/Cells/Cells.module.scss
@@ -18,7 +18,7 @@
       margin-right: 0;
     }
 
-    label {
+    .select-offer-checkbox {
       display: inline-flex;
     }
   }

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTable.module.scss
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTable.module.scss
@@ -12,7 +12,7 @@
   position: relative;
   margin-bottom: rem.torem(20px);
 
-  label {
+  .select-all-checkbox {
     @include fonts.caption;
   }
 }

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTable.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTable.tsx
@@ -92,6 +92,7 @@ export const IndividualOffersTable = ({
             <>
               <div className={styles['select-all-container']}>
                 <BaseCheckbox
+                  className={styles['select-all-checkbox']}
                   checked={areAllOffersSelected}
                   partialCheck={
                     !areAllOffersSelected && isAtLeastOneOfferChecked

--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.module.scss
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.module.scss
@@ -61,7 +61,7 @@
   flex-direction: column;
   align-items: flex-start;
 
-  label:first-child {
+  .download-all-checkbox:first-child {
     margin-bottom: rem.torem(8px);
   }
 

--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
@@ -185,6 +185,7 @@ export const InvoiceTable = ({ invoices }: InvoiceTableProps) => {
     <>
       <div className={styles['download-actions']} aria-live="polite">
         <BaseCheckbox
+          className={styles['download-all-checkbox']}
           label="Tout sélectionner"
           checked={allInvoicesChecked !== PartialCheck.UNCHECKED}
           partialCheck={allInvoicesChecked === PartialCheck.PARTIAL}

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/AllocineProviderForm/AllocineProviderForm.tsx
@@ -10,6 +10,7 @@ import { FormLayout } from 'components/FormLayout/FormLayout'
 import { validationSchema } from 'pages/VenueSettings/VenueProvidersManager/AllocineProviderForm/validationSchema'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
+import { QuantityInput } from 'ui-kit/form/QuantityInput/QuantityInput'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 
 import { DuoCheckbox } from '../DuoCheckbox/DuoCheckbox'
@@ -96,16 +97,10 @@ export const AllocineProviderForm = ({
             />
           </FormLayout.Row>
           <FormLayout.Row>
-            <TextInput
-              type="number"
+            <QuantityInput
               label="Nombre de places/séance"
-              min="0"
-              name="quantity"
-              placeholder="Illimité"
-              step={1}
-              isOptional
-              hasDecimal={false}
               className={styles['nb-places-input']}
+              isOptional
             />
           </FormLayout.Row>
           <FormLayout.Row>

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/AllocineProviderForm/__specs__/AllocineProviderForm.spec.tsx
@@ -73,10 +73,15 @@ describe('AllocineProviderForm', () => {
   it('should display the quantity field with default value set to Illimité', async () => {
     await renderAllocineProviderForm(props)
 
-    const quantityField = screen.getByLabelText(/Nombre de places\/séance/)
+    const quantityField = screen.getByRole('spinbutton', {
+      name: /Nombre de places\/séance/,
+    })
     expect(quantityField).toBeInTheDocument()
-    expect(quantityField).toHaveAttribute('placeholder', 'Illimité')
-    expect(quantityField).toHaveAttribute('step', '1')
+    const unlimitedCheckbox = screen.getByRole('checkbox', {
+      name: /Illimité/,
+    })
+    expect(unlimitedCheckbox).toBeInTheDocument()
+    expect(unlimitedCheckbox).toBeChecked()
   })
 
   it('should display the isDuo checkbox checked by default on creation', async () => {
@@ -106,7 +111,9 @@ describe('AllocineProviderForm', () => {
     const priceField = screen.getByLabelText('Prix de vente/place *', {
       exact: false,
     })
-    const quantityField = screen.getByLabelText(/Nombre de places\/séance/)
+    const quantityField = screen.getByRole('spinbutton', {
+      name: /Nombre de places\/séance/,
+    })
     const isDuoCheckbox = screen.getByLabelText(/Accepter les réservations duo/)
 
     await userEvent.type(priceField, '10')
@@ -226,8 +233,8 @@ describe('AllocineProviderForm', () => {
     })
     expect(priceField).toHaveValue(15)
 
-    const quantityField = screen.getByLabelText(/Nombre de places\/séance/, {
-      exact: false,
+    const quantityField = screen.getByRole('spinbutton', {
+      name: /Nombre de places\/séance/,
     })
     expect(quantityField).toHaveValue(50)
 
@@ -283,7 +290,9 @@ describe('AllocineProviderForm', () => {
     }
     await renderAllocineProviderForm(props)
 
-    const quantityField = screen.getByLabelText(/Nombre de places\/séance/)
+    const quantityField = screen.getByRole('spinbutton', {
+      name: /Nombre de places\/séance/,
+    })
 
     await userEvent.clear(quantityField)
     await userEvent.type(quantityField, '-1')
@@ -305,7 +314,9 @@ describe('AllocineProviderForm', () => {
     const priceField = screen.getByLabelText('Prix de vente/place *', {
       exact: false,
     })
-    const quantityField = screen.getByLabelText(/Nombre de places\/séance/)
+    const quantityField = screen.getByRole('spinbutton', {
+      name: /Nombre de places\/séance/,
+    })
     const isDuoCheckbox = screen.getByLabelText(/Accepter les réservations duo/)
 
     await userEvent.clear(priceField)

--- a/pro/src/ui-kit/form/Checkbox/Checkbox.tsx
+++ b/pro/src/ui-kit/form/Checkbox/Checkbox.tsx
@@ -1,59 +1,46 @@
 import cn from 'classnames'
 import { useField } from 'formik'
-import React from 'react'
+import React, { ForwardedRef } from 'react'
 
-import { BaseCheckbox } from 'ui-kit/form/shared/BaseCheckbox/BaseCheckbox'
+import {
+  BaseCheckbox,
+  BaseCheckboxProps,
+} from 'ui-kit/form/shared/BaseCheckbox/BaseCheckbox'
 
 import { FieldError } from '../shared/FieldError/FieldError'
 
 import styles from './Checkbox.module.scss'
 
-interface CheckboxProps {
+interface CheckboxProps extends BaseCheckboxProps {
   name: string
-  value?: string
-  label: string | React.ReactNode
-  description?: string
   className?: string
   hideFooter?: boolean
-  icon?: string
-  disabled?: boolean
-  withBorder?: boolean
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
-  ariaDescribedBy?: string
-  checked?: boolean
+  /**
+   * A forward ref to the input element.
+   */
+  refForInput?: ForwardedRef<HTMLInputElement>
 }
 
 export const Checkbox = ({
   name,
-  value,
-  label,
   className,
-  icon,
   hideFooter,
-  disabled,
-  withBorder,
-  ariaDescribedBy,
+  refForInput,
   ...props
 }: CheckboxProps): JSX.Element => {
   const [field, meta] = useField({ name, type: 'checkbox' })
+  const hasError = meta.touched && !!meta.error
   return (
     <div className={cn(styles['checkbox'], className)}>
       <BaseCheckbox
+        ref={refForInput}
+        hasError={hasError}
         {...field}
-        icon={icon}
-        hasError={meta.touched && !!meta.error}
-        label={label}
-        value={value}
-        disabled={disabled}
-        withBorder={withBorder}
-        ariaDescribedBy={ariaDescribedBy}
         {...props}
       />
       {!hideFooter && (
         <div className={styles['checkbox-error']}>
-          {meta.touched && !!meta.error && (
-            <FieldError name={name}>{meta.error}</FieldError>
-          )}
+          {hasError && <FieldError name={name}>{meta.error}</FieldError>}
         </div>
       )}
     </div>

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.mdx
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.mdx
@@ -1,0 +1,44 @@
+{/* QuantityInput.mdx */}
+
+import { Meta, Primary, Controls, Story } from '@storybook/blocks';
+
+import * as QuantityInputStories from './QuantityInput.stories';
+
+<Meta of={QuantityInputStories} />
+
+# QuantityInput
+
+A QuantityInput component is a combinaison of a TextInput and a Checkbox
+to define **quantities**. This component should be used when undefined quantity
+is meant to be interpreted as unlimited.
+
+## Using QuantityInput over TextInput
+  
+```jsx
+<TextInput
+  label="Quantity"
+  placeholder="Illimité"
+  type="number"
+  value={quantity}
+  onChange={setQuantity}
+/>
+```
+
+This lacks accessibility support.
+Placeholders are generally something to avoid since they disappear when the input is focused,
+or when the user starts typing.
+They tend to be stylised with a lighter color, which can be hard to read for some users.
+In this case, the placeholder was used to indicate that the quantity was unlimited,
+which is not a placeholder's purpose.
+> "The placeholder text should provide a brief hint to the user as to the expected type of data that should be entered into the control."  
+> -- [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-placeholder)
+
+If undefined quantity is meant to be interpreted as unlimited, the QuantityInput component should always be used.  
+Otherwise, using TextInput is fine enough (mind min, max, and step props attributes).
+
+## Extending props 
+
+The QuantityInput component picks a few props from the TextInput component,
+which itself sees its props extended from FieldLayoutBase and BaseInput.  
+It's best to choose what needs to be picked than extending the props from the TextInput component
+so the QuantityInput component can be more flexible and easier to maintain.

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.module.scss
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.module.scss
@@ -11,5 +11,9 @@
     &-for-small-label {
       margin-top: rem.torem(42px);
     }
+
+    &-for-hidden-label {
+      margin-top: rem.torem(10px);
+    }
   }
 }

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.module.scss
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.module.scss
@@ -1,0 +1,15 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.quantity-input {
+  display: flex;
+  flex-direction: row;
+
+  &-checkbox {
+    margin-top: rem.torem(36px);
+    margin-left: rem.torem(16px);
+
+    &-for-small-label {
+      margin-top: rem.torem(42px);
+    }
+  }
+}

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.spec.tsx
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.spec.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { Formik } from 'formik'
+
+import { QuantityInput, QuantityInputProps } from './QuantityInput'
+
+const renderQuantityInput = (props: QuantityInputProps) => {
+  return render(
+    <Formik initialValues={{ quantity: '' }} onSubmit={() => {}}>
+      <QuantityInput {...props} />
+    </Formik>
+  )
+}
+
+const LABELS = {
+  input: /Quantité/,
+  checkbox: /Illimité/,
+}
+
+describe('QuantityInput', () => {
+  it('should display an input and a checkbox', () => {
+    renderQuantityInput({})
+
+    expect(
+      screen.getByRole('spinbutton', { name: LABELS.input })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('checkbox', { name: LABELS.checkbox })
+    ).toBeInTheDocument()
+  })
+
+  it('should execute the onChange callback when the input value changes', async () => {
+    const onChange = vi.fn()
+    renderQuantityInput({ onChange })
+
+    const input = screen.getByRole('spinbutton', { name: LABELS.input })
+    await userEvent.type(input, '1')
+    expect(onChange.mock.calls.length).toBe(1)
+  })
+
+  it('should empty the input value when the checkbox is checked', async () => {
+    renderQuantityInput({})
+
+    const input = screen.getByRole('spinbutton', { name: LABELS.input })
+    const checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
+
+    await userEvent.type(input, '1')
+    expect(input).toHaveValue(1)
+
+    await userEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+    expect(input).toHaveValue(null)
+  })
+
+  it('should check the checkbox when the input value is emptied manually', async () => {
+    renderQuantityInput({})
+
+    const input = screen.getByRole('spinbutton', { name: LABELS.input })
+    const checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
+
+    await userEvent.type(input, '1')
+    expect(input).toHaveValue(1)
+
+    await userEvent.clear(input)
+    expect(input).toHaveValue(null)
+    expect(checkbox).toBeChecked()
+  })
+
+  it('should move focus to the input when the checkbox is unchecked and init the input with 1', async () => {
+    renderQuantityInput({})
+
+    const input = screen.getByRole('spinbutton', { name: LABELS.input })
+    const checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
+
+    await userEvent.click(checkbox)
+    expect(checkbox).not.toBeChecked()
+    expect(input).toHaveFocus()
+    expect(input).toHaveValue(1)
+  })
+})

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.stories.tsx
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Formik } from 'formik'
+import React from 'react'
+
+import { QuantityInput } from './QuantityInput'
+
+const meta: Meta<typeof QuantityInput> = {
+  title: 'ui-kit/forms/QuantityInput',
+  component: QuantityInput,
+  decorators: [
+    (Story: any) => (
+      <Formik initialValues={{ quantity: '' }} onSubmit={() => {}}>
+        <Story />
+      </Formik>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof QuantityInput>
+
+export const Default: Story = {
+  args: {},
+}

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.tsx
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.tsx
@@ -7,6 +7,7 @@ import { TextInput, TextInputProps } from 'ui-kit/form/TextInput/TextInput'
 
 import styles from './QuantityInput.module.scss'
 
+export type Quantity = number | ''
 export type QuantityInputProps = Pick<
   TextInputProps,
   | 'disabled'
@@ -33,7 +34,7 @@ export type QuantityInputProps = Pick<
    * otherwise, setFieldValue must be called manually.
    * This is to support custom logic when the quantity changes.
    */
-  onChange?: (quantity: string) => void
+  onChange?: (quantity: Quantity) => void
 }
 
 export const QuantityInput = ({
@@ -69,7 +70,7 @@ export const QuantityInput = ({
   }, [isUnlimited])
 
   const onQuantityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newQuantity = event.target.value
+    const newQuantity = parseInt(event.target.value)
     onChange?.(newQuantity)
   }
 
@@ -77,7 +78,7 @@ export const QuantityInput = ({
     const nextIsUnlimitedState = !isUnlimited
     setIsUnlimited(nextIsUnlimitedState)
 
-    let nextFieldValue = '1'
+    let nextFieldValue: Quantity = 1
     if (nextIsUnlimitedState) {
       // If the checkbox is going to be checked,
       // we need to clear the quantity field as an empty

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.tsx
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.tsx
@@ -121,6 +121,7 @@ export const QuantityInput = ({
         checked={isUnlimited}
         className={classNames(styles['quantity-input-checkbox'], {
           [styles['quantity-input-checkbox-for-small-label']]: smallLabel,
+          [styles['quantity-input-checkbox-for-hidden-label']]: isLabelHidden,
         })}
       />
     </div>

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.tsx
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.tsx
@@ -1,0 +1,128 @@
+import classNames from 'classnames'
+import { useField, useFormikContext } from 'formik'
+import { useEffect, useState, useRef } from 'react'
+
+import { Checkbox } from 'ui-kit/form/Checkbox/Checkbox'
+import { TextInput, TextInputProps } from 'ui-kit/form/TextInput/TextInput'
+
+import styles from './QuantityInput.module.scss'
+
+export type QuantityInputProps = Pick<
+  TextInputProps,
+  | 'disabled'
+  | 'className'
+  | 'classNameFooter'
+  | 'isLabelHidden'
+  | 'smallLabel'
+  | 'hideFooter'
+  | 'isOptional'
+> & {
+  /**
+   * A label for the input,
+   * also used as the aria-label for the group.
+   */
+  label?: string
+  /**
+   * The name of the input,
+   * mind what's being used in the formik form.
+   */
+  name?: string
+  /**
+   * A callback when the quantity changes.
+   * If not provided, the value will be set in the formik form,
+   * otherwise, setFieldValue must be called manually.
+   * This is to support custom logic when the quantity changes.
+   */
+  onChange?: (quantity: string) => void
+}
+
+export const QuantityInput = ({
+  label = 'Quantité',
+  name = 'quantity',
+  onChange,
+  disabled,
+  className,
+  classNameFooter,
+  isLabelHidden,
+  smallLabel,
+  hideFooter,
+  isOptional,
+}: QuantityInputProps) => {
+  const quantityRef = useRef<HTMLInputElement>(null)
+  const unlimitedRef = useRef<HTMLInputElement>(null)
+
+  const [field] = useField(name)
+  const { setFieldValue } = useFormikContext()
+  const [isUnlimited, setIsUnlimited] = useState(!field.value)
+
+  useEffect(() => {
+    setIsUnlimited(!field.value)
+  }, [field.value])
+
+  useEffect(() => {
+    // Move focus to the quantity input if unlimited is unchecked.
+    const focusedElement = document.activeElement as HTMLElement
+    const isUnlimitedCheckboxFocused = focusedElement === unlimitedRef.current
+    if (!isUnlimited && isUnlimitedCheckboxFocused) {
+      quantityRef.current?.focus()
+    }
+  }, [isUnlimited])
+
+  const onQuantityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newQuantity = event.target.value
+    onChange?.(newQuantity)
+  }
+
+  const onCheckboxChange = async () => {
+    const nextIsUnlimitedState = !isUnlimited
+    setIsUnlimited(nextIsUnlimitedState)
+
+    let nextFieldValue = '1'
+    if (nextIsUnlimitedState) {
+      // If the checkbox is going to be checked,
+      // we need to clear the quantity field as an empty
+      // string means unlimited quantity.
+      nextFieldValue = ''
+    }
+
+    if (onChange) {
+      onChange(nextFieldValue)
+    } else {
+      await setFieldValue(name, nextFieldValue)
+    }
+  }
+
+  return (
+    <div className={styles['quantity-input']} role="group" aria-label={label}>
+      <TextInput
+        refForInput={quantityRef}
+        smallLabel={smallLabel}
+        name={name}
+        label={label}
+        isOptional={isOptional}
+        disabled={disabled}
+        type="number"
+        hasDecimal={false}
+        className={className}
+        classNameFooter={classNameFooter}
+        min={1}
+        max={1_000_000}
+        isLabelHidden={isLabelHidden}
+        hideFooter={hideFooter}
+        step={1}
+        {...(onChange && { onChange: onQuantityChange })}
+      />
+      <Checkbox
+        refForInput={unlimitedRef}
+        hideFooter
+        label="Illimité"
+        name="unlimited"
+        onChange={onCheckboxChange}
+        checked={isUnlimited}
+        className={classNames(styles['quantity-input-checkbox'], {
+          [styles['quantity-input-checkbox-for-small-label']]: smallLabel,
+        })}
+      />
+    </div>
+  )
+}

--- a/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.module.scss
+++ b/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.module.scss
@@ -19,7 +19,6 @@
     padding: rem.torem(8px);
   }
 
-  label,
   .label,
   .too-many-options {
     display: flex;
@@ -27,7 +26,6 @@
   }
 
   /* override cursor: default defined by browser */
-  label,
   .label,
   input[type="checkbox"] {
     cursor: pointer;

--- a/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.tsx
@@ -75,6 +75,10 @@ export const OptionsList = ({
                     onChange={() => {
                       selectOption(String(value))
                     }}
+                    className={cx(
+                      baseCheckboxStyles['base-checkbox-label'],
+                      styles['label']
+                    )}
                   />
                 ) : (
                   <span

--- a/pro/src/ui-kit/form/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/form/TextInput/TextInput.tsx
@@ -9,7 +9,7 @@ import {
 
 import styles from './TextInput.module.scss'
 
-type TextInputProps = FieldLayoutBaseProps &
+export type TextInputProps = FieldLayoutBaseProps &
   BaseInputProps & {
     /**
      * A flag to make the input read-only.

--- a/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.tsx
+++ b/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames'
-import { useEffect, useId, useRef } from 'react'
+import { useId, useRef, ForwardedRef, forwardRef, useEffect } from 'react'
 
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
@@ -11,8 +11,8 @@ export enum PartialCheck {
   UNCHECKED = 'unchecked',
 }
 
-interface BaseCheckboxProps
-  extends Partial<React.InputHTMLAttributes<HTMLInputElement>> {
+export interface BaseCheckboxProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
   label: string | React.ReactNode
   hasError?: boolean
   className?: string
@@ -25,79 +25,87 @@ interface BaseCheckboxProps
   ariaDescribedBy?: string
 }
 
-export const BaseCheckbox = ({
-  label,
-  hasError,
-  className,
-  icon,
-  withBorder,
-  partialCheck,
-  exceptionnallyHideLabelDespiteA11y,
-  description,
-  ariaDescribedBy,
-  ...props
-}: BaseCheckboxProps): JSX.Element => {
-  const checkboxRef = useRef<HTMLInputElement>(null)
-  const id = useId()
+export const BaseCheckbox = forwardRef(
+  (
+    {
+      label,
+      hasError,
+      className,
+      icon,
+      withBorder,
+      partialCheck,
+      exceptionnallyHideLabelDespiteA11y,
+      description,
+      ariaDescribedBy,
+      ...props
+    }: BaseCheckboxProps,
+    forwardedRef: ForwardedRef<HTMLInputElement>
+  ): JSX.Element => {
+    const innerRef = useRef<HTMLInputElement>(null)
+    const id = useId()
 
-  useEffect(() => {
-    if (checkboxRef.current) {
-      checkboxRef.current.indeterminate = partialCheck ?? false
-    }
-  }, [checkboxRef, partialCheck])
+    useEffect(() => {
+      if (innerRef.current) {
+        innerRef.current.indeterminate = partialCheck ?? false
+      }
+    }, [innerRef, partialCheck])
 
-  return (
-    <label
-      className={cn(
-        styles['base-checkbox'],
-        {
-          [styles['with-border']]: withBorder,
-          [styles['has-error']]: hasError,
-          [styles['is-disabled']]: props.disabled,
-        },
-        className
-      )}
-      htmlFor={id}
-    >
-      <span
-        className={cn(styles['base-checkbox-label-row'], {
-          [styles['base-checkbox-label-row-with-description']]:
-            Boolean(description),
-        })}
-      >
-        <input
-          ref={checkboxRef}
-          aria-invalid={hasError}
-          {...(ariaDescribedBy ? { 'aria-describedby': ariaDescribedBy } : {})}
-          type="checkbox"
-          {...props}
-          className={styles['base-checkbox-input']}
-          id={id}
-        />
-        {icon && (
-          <span className={styles['base-checkbox-icon']}>
-            <SvgIcon
-              src={icon}
-              alt=""
-              className={styles['base-checkbox-icon-svg']}
-            />
-          </span>
+    return (
+      <div
+        className={cn(
+          styles['base-checkbox'],
+          {
+            [styles['with-border']]: withBorder,
+            [styles['has-error']]: hasError,
+            [styles['is-disabled']]: props.disabled,
+          },
+          className
         )}
+      >
         <span
-          className={cn(styles['base-checkbox-label'], {
-            'visually-hidden': Boolean(exceptionnallyHideLabelDespiteA11y),
-            [styles['base-checkbox-label-with-description']]:
+          className={cn(styles['base-checkbox-label-row'], {
+            [styles['base-checkbox-label-row-with-description']]:
               Boolean(description),
           })}
         >
-          {label}
-          {description && (
-            <span className={styles['base-checkbox-description']}>
-              {description}
+          <input
+            ref={partialCheck ? innerRef : forwardedRef}
+            aria-invalid={hasError}
+            {...(ariaDescribedBy
+              ? { 'aria-describedby': ariaDescribedBy }
+              : {})}
+            type="checkbox"
+            {...props}
+            className={styles['base-checkbox-input']}
+            id={id}
+          />
+          {icon && (
+            <span className={styles['base-checkbox-icon']}>
+              <SvgIcon
+                src={icon}
+                alt=""
+                className={styles['base-checkbox-icon-svg']}
+              />
             </span>
           )}
+          <span
+            className={cn(styles['base-checkbox-label'], {
+              'visually-hidden': Boolean(exceptionnallyHideLabelDespiteA11y),
+              [styles['base-checkbox-label-with-description']]:
+                Boolean(description),
+            })}
+          >
+            <label htmlFor={id}>{label}</label>
+            {description && (
+              <span className={styles['base-checkbox-description']}>
+                {description}
+              </span>
+            )}
+          </span>
         </span>
-      </span>
-    </label>
-  )
-}
+      </div>
+    )
+  }
+)
+
+BaseCheckbox.displayName = 'BaseCheckbox'

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.tsx
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.tsx
@@ -25,14 +25,33 @@ export type FieldLayoutBaseProps = {
    */
   isLabelHidden?: boolean
   hasLabelLineBreak?: boolean
+  /**
+   * A flag to indicate that the field is optional.
+   * It will display an asterisk next to the label.
+   */
   isOptional?: boolean
   showMandatoryAsterisk?: boolean
+  /**
+   * A custom class for the field layout,
+   * where label, description, input, and footer are displayed.
+   */
   className?: string
   classNameLabel?: string
+  /**
+   * A custom class for the footer,
+   * where errors and character count are displayed.
+   */
   classNameFooter?: string
   classNameInput?: string
   filterVariant?: boolean
+  /**
+   * A flag to display a smaller label.
+   */
   smallLabel?: boolean
+  /**
+   * A flag to hide the footer.
+   * To be used with caution, as it can affect accessibility.
+   */
   hideFooter?: boolean
   inline?: boolean
   clearButtonProps?: React.ButtonHTMLAttributes<HTMLButtonElement> & {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31264

## Descriptif des modifications
- Ajout du composant QuantityInput avec documentation et usage à tous les endroits où on a besoin de définir des quantités, quantités indéfinies étant comprises comme "illimitées".
- CheckboxInput : déplacement du label pour une déclaration explicite car plus robuste #a11y (et non implicite par imbrication) + adaptation des fichiers .scss  afin de ne plus styliser par sélecteur de balise `label`, mais par classe.
- Réadaptation des tests en conséquence en privilégiant l'usage de `getByRole`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
