### PR TITLE
(PC-32593)[API] chore: Don't import DSv4 applications anymore

### DIFF
--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -172,7 +172,6 @@ def recredit_underage_users() -> None:
 def import_ds_bank_information_applications() -> None:
     procedures = [
         settings.DS_BANK_ACCOUNT_PROCEDURE_ID,
-        settings.DMS_VENUE_PROCEDURE_ID_V4,
     ]
     for procedure in procedures:
         if not procedure:


### PR DESCRIPTION
DSv4 is outdated and we should'nt try to import related applications. All applications are now going through DSv5 and all existing data has been move from BankInformation to BankAccount.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32593

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
