### PR TITLE
[PC-32491] La création et la modfication d'une venue doit créer une nouvelle oa

### DIFF
--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -73,6 +73,10 @@ class OffererAddressNotEditableException(Exception):
     pass
 
 
+class OffererAddressCreationError(Exception):
+    pass
+
+
 class CannotSuspendOffererWithBookingsException(ClientError):
     def __init__(self) -> None:
         super().__init__(

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -885,6 +885,8 @@ def format_modified_info_name(info_name: str) -> str:
             return "Validation des offres"
         case "offererAddress.addressId":
             return "Adresse - ID Adresse"
+        case "offererAddress.id":
+            return "OA ID"
         case "offererAddress.address.inseeCode":
             return "Adresse - Code Insee"
         case "offererAddress.address.city":
@@ -899,6 +901,8 @@ def format_modified_info_name(info_name: str) -> str:
             return "Adresse - Latitude"
         case "offererAddress.address.longitude":
             return "Adresse - Longitude"
+        case "old_oa_label":
+            return "Ancien label OA"
         case "isActive":
             return "Actif"
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32491
l'action_history coté BO ressemble à 
![image](https://github.com/user-attachments/assets/3934cfef-3d4f-43a7-8025-8f3327e1e90e)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
