### PR TITLE
(PC-32602)[API] chore: delete unused columns from productMediation

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-b409480c6113 (pre) (head)
-22e94edcc427 (post) (head)
+88c4d806c740 (pre) (head)
+56372cadc547 (post) (head)

--- a/api/src/pcapi/alembic/versions/20241022T114248_88c4d806c740_alter_fields_updated_nullable.py
+++ b/api/src/pcapi/alembic/versions/20241022T114248_88c4d806c740_alter_fields_updated_nullable.py
@@ -1,0 +1,31 @@
+"""Alter table productMediation set fieldsUpdated nullable
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "88c4d806c740"
+down_revision = "b409480c6113"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "product_mediation",
+        "fieldsUpdated",
+        existing_type=postgresql.ARRAY(sa.VARCHAR(length=100)),
+        nullable=True,
+        existing_server_default="{}",
+    )
+
+
+def downgrade() -> None:
+    # If we would like to make this column non nullable,
+    # we will have to manually do a migration since some empty data could have been inserted.
+    # Since this column is unused it has no impact
+    pass

--- a/api/src/pcapi/alembic/versions/20241022T114614_56372cadc547_remove_unused_product_mediation_fields.py
+++ b/api/src/pcapi/alembic/versions/20241022T114614_56372cadc547_remove_unused_product_mediation_fields.py
@@ -1,0 +1,43 @@
+"""Alter table productMediation delete columns fieldsUpdated and idAtProviders
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "56372cadc547"
+down_revision = "22e94edcc427"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("product_mediation_idAtProviders_key", "product_mediation", type_="unique")
+    op.drop_column("product_mediation", "fieldsUpdated")
+    op.drop_column("product_mediation", "idAtProviders")
+
+
+def downgrade() -> None:
+    # We sould use a text field with a check constraint.
+    # But that would be unaligned with our models. Let's hope we sont revert
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.add_column(
+        "product_mediation", sa.Column("idAtProviders", sa.VARCHAR(length=70), autoincrement=False, nullable=True)
+    )
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.add_column(
+        "product_mediation",
+        sa.Column(
+            "fieldsUpdated",
+            postgresql.ARRAY(sa.VARCHAR(length=100)),
+            server_default=sa.text("'{}'::character varying[]"),
+            autoincrement=False,
+            nullable=True,
+        ),
+    )
+    # This table is only filled with crons during the night, there is no problem locking writes during a MEP
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.create_unique_constraint("product_mediation_idAtProviders_key", "product_mediation", ["idAtProviders"])

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -129,14 +129,17 @@ class TiteliveImageType(enum.Enum):
     VERSO = "verso"
 
 
-class ProductMediation(PcObject, Base, Model, ProvidableMixin):
+class ProductMediation(PcObject, Base, Model):
     __tablename__ = "product_mediation"
 
+    dateModifiedAtLastProvider = sa.Column(sa.DateTime, nullable=True, default=datetime.datetime.utcnow)
+    imageType = sa.Column(sa.Enum(TiteliveImageType), nullable=False)
+    lastProviderId = sa.Column(sa.BigInteger, sa.ForeignKey("provider.id"), nullable=True)
+    lastProvider: "Provider|None" = sa.orm.relationship("Provider", foreign_keys=[lastProviderId])
     productId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("product.id", ondelete="CASCADE"), index=True, nullable=False
     )
     url: str = sa.Column(sa.String(255), nullable=False, unique=True)
-    imageType = sa.Column(sa.Enum(TiteliveImageType), nullable=False)
 
 
 class GcuCompatibilityType(enum.Enum):

--- a/api/src/pcapi/core/providers/titelive_api.py
+++ b/api/src/pcapi/core/providers/titelive_api.py
@@ -252,7 +252,7 @@ class TiteliveSearch(abc.ABC, typing.Generic[TiteliveWorkType]):
         """
         product_mediations = offers_models.ProductMediation.query.filter(
             offers_models.ProductMediation.productId == product.id,
-            offers_models.ProductMediation.lastProvider == self.provider,  # pylint: disable=comparison-with-callable
+            offers_models.ProductMediation.lastProvider == self.provider,
         )
         for product_mediation in product_mediations:
             db.session.delete(product_mediation)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32602

Delete unused columns on Product Mediation

```
staging> select count(*) from product_mediation where "idAtProviders" is not null;
+-------+
| count |
|-------|
| 0     |
+-------+
SELECT 1
Time: 0.023s
staging> select count(*) from product_mediation where "fieldsUpdated" <> '{}';
+-------+
| count |
|-------|
| 0     |
+-------+
SELECT 1
Time: 0.065s
```
## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
