### PR TITLE
(PC-31450)[API] feat: add backends to clickhouse

### DIFF
--- a/api/.env.development
+++ b/api/.env.development
@@ -22,6 +22,7 @@ BATCH_IOS_API_KEY=DEV5F8EF34DD60B3437F8CF0318079     # Batch public key # ggigno
 BEAMER_BACKEND=pcapi.connectors.beamer.LoggerBackend
 CAN_RUN_SANDBOX=1
 CGR_API_USER=""
+CLICKHOUSE_BACKEND=pcapi.connectors.clickhouse.testing_backend.TestingBackend
 CLOUD_TASK_BEARER_TOKEN=cloud-task-bearer-token
 CLOUD_TASK_CALL_INTERNAL_API_ENDPOINT=1
 COMPLIANCE_API_SERVICE_ACCOUNT="api-compliance-iap-web-user@passculture-data-prod.iam.gserviceaccount.com"

--- a/api/.env.testauto
+++ b/api/.env.testauto
@@ -9,6 +9,7 @@ BOOST_API_PASSWORD=fake_password
 BOOST_API_USERNAME=fake_user
 CATCH_INDEXATION_EXCEPTIONS=0
 CDS_API_URL=test_cds_url/vad/
+CLICKHOUSE_BACKEND=pcapi.connectors.clickhouse.testing_backend.TestingBackend
 COMPLIANCE_BACKEND=pcapi.core.external.compliance_backends.test.TestBackend
 DATABASE_LOCK_TIMEOUT=500
 DEMARCHES_SIMPLIFIEES_BANK_ACCOUNT_PROCEDURE_ID=80876

--- a/api/src/pcapi/connectors/clickhouse/__init__.py
+++ b/api/src/pcapi/connectors/clickhouse/__init__.py
@@ -1,0 +1,3 @@
+from .backend import BaseBackend
+from .backend import get_backend
+from .testing_backend import TestingBackend

--- a/api/src/pcapi/connectors/clickhouse/backend.py
+++ b/api/src/pcapi/connectors/clickhouse/backend.py
@@ -1,0 +1,46 @@
+import typing
+
+from sqlalchemy import create_engine
+from sqlalchemy import engine
+
+from pcapi import settings
+from pcapi.models.api_errors import ApiErrors
+from pcapi.utils import requests
+from pcapi.utils.module_loading import import_string
+
+
+def get_backend() -> "BaseBackend":
+    backend_class = import_string(settings.CLICKHOUSE_BACKEND)
+    return backend_class()
+
+
+class BaseBackend:
+    def __init__(self) -> None:
+        self._engine: engine.Engine | None = None
+
+    def _get_engine(self) -> engine.Engine:
+        raise NotImplementedError
+
+    @property
+    def engine(self) -> engine.Engine:
+        if not self._engine:
+            self._engine = self._get_engine()
+        return self._engine
+
+    def run_query(self, query: str, params: typing.Tuple) -> list:
+        try:
+            results = self.engine.execute(query, params).fetchall()
+        except Exception as err:
+            if isinstance(err, requests.exceptions.ConnectionError):
+                raise ApiErrors(errors={"clickhouse": "Can not connect to clickhouse server"}, status_code=422)
+            raise ApiErrors(errors={"clickhouse": f"Error : {err}"}, status_code=400)
+        return results
+
+
+class ClickhouseBackend(BaseBackend):
+    def _get_engine(self) -> engine.Engine:
+        ip = settings.CLICKHOUSE_IP
+        user = settings.CLICKHOUSE_USER
+        password = settings.CLICKHOUSE_PASSWORD
+        uri = f"clickhouse://{user}:{password}@{ip}:8123/default?protocol=http"
+        return create_engine(uri, pool_pre_ping=True)

--- a/api/src/pcapi/connectors/clickhouse/queries/__init__.py
+++ b/api/src/pcapi/connectors/clickhouse/queries/__init__.py
@@ -1,0 +1,1 @@
+from .yearly_revenue import YearlyAggregatedRevenueQuery

--- a/api/src/pcapi/connectors/clickhouse/queries/base.py
+++ b/api/src/pcapi/connectors/clickhouse/queries/base.py
@@ -1,0 +1,29 @@
+import typing
+
+import pydantic.v1 as pydantic_v1
+
+import pcapi.connectors.clickhouse as clickhouse_connector
+
+
+class BaseQuery:
+    def __init__(self) -> None:
+        self.backend = clickhouse_connector.get_backend()
+
+    def _get_rows(self, params: typing.Tuple) -> list:
+        return self.backend.run_query(self.raw_query, params)
+
+    def _format_result(self, rows: list) -> dict:
+        raise NotImplementedError()
+
+    @property
+    def raw_query(self) -> str:
+        raise NotImplementedError()
+
+    @property
+    def model(self) -> type[pydantic_v1.BaseModel]:
+        raise NotImplementedError()
+
+    def execute(self, params: typing.Tuple) -> pydantic_v1.BaseModel:
+        rows = self._get_rows(params)
+        results_dict = self._format_result(rows)
+        return self.model(**results_dict)

--- a/api/src/pcapi/connectors/clickhouse/queries/yearly_revenue.py
+++ b/api/src/pcapi/connectors/clickhouse/queries/yearly_revenue.py
@@ -1,0 +1,65 @@
+from decimal import Decimal
+import json
+
+import pydantic.v1 as pydantic_v1
+
+from pcapi.connectors.clickhouse.queries.base import BaseQuery
+from pcapi.serialization.utils import to_camel
+
+
+class Revenue(pydantic_v1.BaseModel):
+    total: Decimal
+    individual: Decimal
+    collective: Decimal
+
+    class Config:
+        extra = "forbid"
+
+
+class AggregatedRevenue(pydantic_v1.BaseModel):
+    revenue: Revenue
+    expected_revenue: Revenue | None
+
+    class Config:
+        extra = "forbid"
+        alias_generator = to_camel
+
+
+class YearlyAggregatedRevenueModel(pydantic_v1.BaseModel):
+    income_by_year: dict[str, AggregatedRevenue]
+
+
+class YearlyAggregatedRevenueQuery(BaseQuery):
+    def _format_result(self, results: list) -> dict:
+        return {
+            "income_by_year": {
+                result.year: {
+                    "revenue": json.loads(result.revenue),
+                    "expectedRevenue": json.loads(result.expected_revenue),
+                }
+                for result in results
+            }
+        }
+
+    @property
+    def raw_query(self) -> str:
+        return """
+            SELECT
+                EXTRACT(YEAR FROM creation_year) AS year,
+                toJSONString(map(
+                    'individual', ROUND(SUM(individual_revenue),2),
+                    'collective', ROUND(SUM(collective_revenue),2),
+                    'total', ROUND(SUM(total_revenue),2))
+                ) as revenue,
+                toJSONString(map(
+                    'individual', ROUND(SUM(individual_expected_revenue),2),
+                    'collective', ROUND(SUM(collective_expected_revenue),2),
+                    'total', ROUND(SUM(total_expected_revenue),2))
+                ) as expected_revenue
+            FROM analytics.yearly_aggregated_venue_revenue
+            WHERE "venue_id" in %s
+            GROUP BY year
+            ORDER BY year
+        """
+
+    model = YearlyAggregatedRevenueModel

--- a/api/src/pcapi/connectors/clickhouse/testing_backend.py
+++ b/api/src/pcapi/connectors/clickhouse/testing_backend.py
@@ -1,0 +1,14 @@
+import typing
+
+from sqlalchemy import engine
+
+from .backend import BaseBackend
+
+
+class TestingBackend(BaseBackend):
+
+    def _get_engine(self) -> engine.Engine:
+        raise NotImplementedError
+
+    def run_query(self, query: str, params: typing.Tuple) -> list:
+        return []

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -606,3 +606,12 @@ DISCORD_BOT_TOKEN = secrets_utils.get("DISCORD_BOT_TOKEN")
 # TYPEFORM
 TYPEFORM_BACKEND = os.environ.get("TYPEFORM_BACKEND", "pcapi.connectors.typeform.TestingBackend")
 TYPEFORM_API_KEY = secrets_utils.get("TYPEFORM_API_KEY")
+
+# CLICKHOUSE
+CLICKHOUSE_BACKEND = os.environ.get(
+    "CLICKHOUSE_BACKEND",
+    "pcapi.connectors.clickhouse.backend.ClickhouseBackend",
+)
+CLICKHOUSE_IP = secrets_utils.get("CLICKHOUSE_IP", "127.0.0.1")
+CLICKHOUSE_USER = secrets_utils.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = secrets_utils.get("CLICKHOUSE_PASSWORD")

--- a/api/tests/connectors/clickhouse/clickhouse_test.py
+++ b/api/tests/connectors/clickhouse/clickhouse_test.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+from unittest import mock
+
+from pcapi.connectors.clickhouse import queries as clickhouse_queries
+from pcapi.core.testing import override_settings
+
+from tests.connectors.clickhouse import fixtures
+
+
+class GetYearlyAggregatedOffererRevenueTest:
+    @override_settings(CLICKHOUSE_BACKEND="pcapi.connectors.clickhouse.testing_backend.TestingBackend")
+    def test_get_yearly_revenue(self):
+        venue_ids = [1, 2]
+
+        with mock.patch("pcapi.connectors.clickhouse.testing_backend.TestingBackend.run_query") as mock_run_query:
+            mock_run_query.return_value = fixtures.YEARLY_AGGREGATED_VENUE_REVENUE
+            result = clickhouse_queries.YearlyAggregatedRevenueQuery().execute(venue_ids)
+
+        assert result.income_by_year["2024"].revenue.total == Decimal("24.24")
+        assert result.income_by_year["2024"].revenue.individual == Decimal("12.12")
+        assert result.income_by_year["2024"].revenue.collective == Decimal("12.12")
+        assert result.income_by_year["2024"].expected_revenue.total == Decimal("26.24")
+        assert result.income_by_year["2024"].expected_revenue.individual == Decimal("13.12")
+        assert result.income_by_year["2024"].expected_revenue.collective == Decimal("13.12")

--- a/api/tests/connectors/clickhouse/fixtures.py
+++ b/api/tests/connectors/clickhouse/fixtures.py
@@ -1,0 +1,31 @@
+from decimal import Decimal
+import json
+
+
+class MockYearlyAggregatedRevenueQueryResult:
+    year: int
+    revenue: dict
+    expected_revenue: dict
+
+    def __init__(
+        self,
+        year: int = 2024,
+        individual: Decimal = Decimal("12.12"),
+        collective: Decimal = Decimal("12.12"),
+        expected_individual: Decimal = Decimal("13.12"),
+        expected_collective: Decimal = Decimal("13.12"),
+    ) -> object:
+        self.year = year
+        self.revenue = json.dumps(
+            {"individual": str(individual), "collective": str(collective), "total": str(individual + collective)}
+        )
+        self.expected_revenue = json.dumps(
+            {
+                "individual": str(expected_individual),
+                "collective": str(expected_collective),
+                "total": str(expected_individual + expected_collective),
+            }
+        )
+
+
+YEARLY_AGGREGATED_VENUE_REVENUE = [MockYearlyAggregatedRevenueQueryResult()]


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31450

Ajout d'un connecteur clickhouse.
Backend clickhouse de test utilisé dans l'environnement testing. Données mockées

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
