### PR TITLE
(BSR)[API] fix: script which repairs unique indexes in production

### DIFF
--- a/api/src/pcapi/scripts/repair_indexes/main.sql
+++ b/api/src/pcapi/scripts/repair_indexes/main.sql
@@ -1,0 +1,9 @@
+-- 3 indexes were recreated manually last week without UNIQUE, which is not consistent with the model.
+SET lock_timeout='10s';
+DROP INDEX "ix_special_event_externalId";
+CREATE UNIQUE INDEX "ix_special_event_externalId" ON special_event ("externalId");
+DROP INDEX "ix_special_event_question_externalId";
+CREATE UNIQUE INDEX "ix_special_event_question_externalId" ON special_event_question ("externalId");
+DROP INDEX "ix_special_event_response_externalId";
+CREATE UNIQUE INDEX "ix_special_event_response_externalId" ON special_event_response ("externalId");
+SET lock_timeout=0;


### PR DESCRIPTION
## But de la pull request

3 index invalides ont été recréés manuellement par le shérif la semaine dernière, mais en oubliant UNIQUE.
Le pod console a disparu depuis...

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
