### PR TITLE
(PC-32547)[PRO] feat: better support stats v2 edge cases

### DIFF
--- a/pro/src/pages/Reimbursements/Income/Income.module.scss
+++ b/pro/src/pages/Reimbursements/Income/Income.module.scss
@@ -3,19 +3,6 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .income {
-  &-error {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    color: var(--color-grey-semi-dark);
-    text-align: center;
-
-    &-icon {
-      margin-bottom: rem.torem(32px);
-    }
-  }
-
   &-filters {
     display: flex;
     flex-flow: row wrap;
@@ -80,27 +67,6 @@
             margin-right: rem.torem(8px);
           }
         }
-      }
-    }
-  }
-
-  &-no-data {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    &-icon {
-      margin-bottom: rem.torem(20px);
-    }
-
-    &-text-with-link {
-      display: flex;
-      margin-top: rem.torem(10px);
-      flex-wrap: wrap;
-      justify-content: center;
-
-      &-buttonlink {
-        margin: 0 rem.torem(10px);
       }
     }
   }

--- a/pro/src/pages/Reimbursements/Income/Income.module.scss
+++ b/pro/src/pages/Reimbursements/Income/Income.module.scss
@@ -35,6 +35,10 @@
         height: rem.torem(66.75px);
         margin-left: rem.torem(24px);
         align-items: end;
+
+        &-is-only-filter {
+          margin-left: 0;
+        }
       }
 
       &-button {

--- a/pro/src/pages/Reimbursements/Income/Income.spec.tsx
+++ b/pro/src/pages/Reimbursements/Income/Income.spec.tsx
@@ -40,6 +40,7 @@ const LABELS = {
   venuesSelector: /Partenaire/,
   incomeResultsLabel: /Chiffre d’affaires total/,
   emptyScreen: /Vous n’avez aucune réservation/,
+  mandatoryHelper: /\* sont obligatoires/,
 }
 
 const renderIncome = () => {
@@ -101,7 +102,7 @@ describe('Income', () => {
     // TODO : https://passculture.atlassian.net/browse/PC-32278
     it('should attempt to fetch income data with all venues and display a loading spinner meanwhile', () => {})
     it('should display an error message if income couldnt be fetched', () => {})
-    it('should dfisplay an empty screen if no income data was found', () => {})
+    it('should display an empty screen if no income data was found', () => {})
 
     it('should display a venue selector with all venues selected by default', async () => {
       vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: MOCK_DATA.venues })
@@ -121,6 +122,25 @@ describe('Income', () => {
             })
           ).toBeInTheDocument()
         })
+      })
+    })
+
+    it('should not display a venue selector, nor the mandatory input helper if there is only one venue', async () => {
+      vi.spyOn(api, 'getVenues').mockResolvedValue({
+        venues: [MOCK_DATA.venues[0]],
+      })
+      renderIncome()
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole('combobox', {
+            name: LABELS.venuesSelector,
+          })
+        ).not.toBeInTheDocument()
+
+        expect(
+          screen.queryByText(LABELS.mandatoryHelper)
+        ).not.toBeInTheDocument()
       })
     })
 

--- a/pro/src/pages/Reimbursements/Income/Income.spec.tsx
+++ b/pro/src/pages/Reimbursements/Income/Income.spec.tsx
@@ -89,9 +89,19 @@ describe('Income', () => {
       })
     })
 
+    it('should display an empty screen if no venues were found', async () => {
+      vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: [] })
+      renderIncome()
+
+      await waitFor(() => {
+        expect(screen.getByText(LABELS.emptyScreen)).toBeInTheDocument()
+      })
+    })
+
     // TODO : https://passculture.atlassian.net/browse/PC-32278
     it('should attempt to fetch income data with all venues and display a loading spinner meanwhile', () => {})
     it('should display an error message if income couldnt be fetched', () => {})
+    it('should dfisplay an empty screen if no income data was found', () => {})
 
     it('should display a venue selector with all venues selected by default', async () => {
       vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: MOCK_DATA.venues })

--- a/pro/src/pages/Reimbursements/Income/Income.tsx
+++ b/pro/src/pages/Reimbursements/Income/Income.tsx
@@ -70,8 +70,13 @@ export const Income = () => {
   const [incomeByYear, setIncomeByYear] = useState<IncomeByYear>()
   const [activeYear, setActiveYear] = useState<number>()
 
+  const years = Object.keys(incomeByYear || {})
+    .map(Number)
+    .sort((a, b) => b - a)
+  const finalActiveYear = activeYear || years[0]
+
   const activeYearIncome =
-    incomeByYear && activeYear ? incomeByYear[activeYear] : {}
+    incomeByYear && finalActiveYear ? incomeByYear[finalActiveYear] : {}
   const activeYearHasData =
     activeYearIncome.aggregatedRevenue || activeYearIncome.expectedRevenue
 
@@ -86,17 +91,9 @@ export const Income = () => {
       setIsIncomeLoading(true)
       const incomeByYear = MOCK_INCOME_BY_YEAR
       setIncomeByYear(incomeByYear)
-
-      if (!activeYear) {
-        const years = Object.keys(incomeByYear)
-          .map(Number)
-          .sort((a, b) => a - b)
-        setActiveYear(years[years.length - 1])
-      }
-
       setIsIncomeLoading(false)
     }
-  }, [selectedVenues, activeYear])
+  }, [selectedVenues])
 
   if (areVenuesLoading) {
     return <Spinner />
@@ -132,29 +129,26 @@ export const Income = () => {
               className={styles['income-filters-by-year']}
               aria-label="Filtrage par année"
             >
-              {Object.keys(incomeByYear)
-                .map(Number)
-                .sort((a, b) => b - a)
-                .map((year) => (
-                  <li key={year}>
-                    <button
-                      type="button"
-                      onClick={() => setActiveYear(year)}
-                      aria-label={`Afficher les revenus de l'année ${year}`}
-                      aria-controls="income-results"
-                      aria-current={year === activeYear}
-                      className={classnames(
-                        styles['income-filters-by-year-button'],
-                        {
-                          [styles['income-filters-by-year-button-active']]:
-                            year === activeYear,
-                        }
-                      )}
-                    >
-                      {year}
-                    </button>
-                  </li>
-                ))}
+              {years.map((year) => (
+                <li key={year}>
+                  <button
+                    type="button"
+                    onClick={() => setActiveYear(year)}
+                    aria-label={`Afficher les revenus de l'année ${year}`}
+                    aria-controls="income-results"
+                    aria-current={year === finalActiveYear}
+                    className={classnames(
+                      styles['income-filters-by-year-button'],
+                      {
+                        [styles['income-filters-by-year-button-active']]:
+                          year === finalActiveYear,
+                      }
+                    )}
+                  >
+                    {year}
+                  </button>
+                </li>
+              ))}
             </ul>
           </>
         )}

--- a/pro/src/pages/Reimbursements/Income/Income.tsx
+++ b/pro/src/pages/Reimbursements/Income/Income.tsx
@@ -104,6 +104,7 @@ export const Income = () => {
   }
 
   const hasVenuesData = venues.length > 0
+  const hasSingleVenue = venues.length === 1
   const hasIncomeData = incomeByYear && Object.keys(incomeByYear).length > 0
 
   if (!hasVenuesData) {
@@ -112,21 +113,28 @@ export const Income = () => {
 
   return (
     <>
-      <FormLayout.MandatoryInfo />
+      {!hasSingleVenue && <FormLayout.MandatoryInfo />}
       <div className={styles['income-filters']}>
-        <IncomeVenueSelector
-          venues={venues}
-          onChange={(venues) => {
-            if (!isEqual(selectedVenues, venues)) {
-              setSelectedVenues(venues)
-            }
-          }}
-        />
+        {!hasSingleVenue && (
+          <IncomeVenueSelector
+            venues={venues}
+            onChange={(venues) => {
+              if (!isEqual(selectedVenues, venues)) {
+                setSelectedVenues(venues)
+              }
+            }}
+          />
+        )}
         {!isIncomeLoading && !incomeApiError && hasIncomeData && (
           <>
-            <span className={styles['income-filters-divider']} />
+            {!hasSingleVenue && (
+              <span className={styles['income-filters-divider']} />
+            )}
             <ul
-              className={styles['income-filters-by-year']}
+              className={classnames(styles['income-filters-by-year'], {
+                [styles['income-filters-by-year-is-only-filter']]:
+                  hasSingleVenue,
+              })}
               aria-label="Filtrage par année"
             >
               {years.map((year) => (

--- a/pro/src/pages/Reimbursements/Income/IncomeError/IncomeError.module.scss
+++ b/pro/src/pages/Reimbursements/Income/IncomeError/IncomeError.module.scss
@@ -1,0 +1,14 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.income-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-grey-semi-dark);
+  text-align: center;
+
+  &-icon {
+    margin-bottom: rem.torem(32px);
+  }
+}

--- a/pro/src/pages/Reimbursements/Income/IncomeError/IncomeError.module.scss
+++ b/pro/src/pages/Reimbursements/Income/IncomeError/IncomeError.module.scss
@@ -5,10 +5,10 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: var(--color-grey-semi-dark);
   text-align: center;
 
   &-icon {
     margin-bottom: rem.torem(32px);
+    color: var(--color-grey-semi-dark);
   }
 }

--- a/pro/src/pages/Reimbursements/Income/IncomeError/IncomeError.tsx
+++ b/pro/src/pages/Reimbursements/Income/IncomeError/IncomeError.tsx
@@ -1,0 +1,19 @@
+import strokePageNotFoundIcon from 'icons/stroke-page-not-found.svg'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+
+import styles from './IncomeError.module.scss'
+
+export const IncomeError = () => {
+  return (
+    <div className={styles['income-error']}>
+      <SvgIcon
+        className={styles['income-error-icon']}
+        src={strokePageNotFoundIcon}
+        viewBox="0 0 130 100"
+        alt=""
+        width="100"
+      />
+      Erreur dans le chargement des données.
+    </div>
+  )
+}

--- a/pro/src/pages/Reimbursements/Income/IncomeNoData/IncomeNoData.module.scss
+++ b/pro/src/pages/Reimbursements/Income/IncomeNoData/IncomeNoData.module.scss
@@ -1,0 +1,22 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.income-no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  &-icon {
+    margin-bottom: rem.torem(20px);
+  }
+
+  &-text-with-link {
+    display: flex;
+    margin-top: rem.torem(10px);
+    flex-wrap: wrap;
+    justify-content: center;
+
+    &-buttonlink {
+      margin: 0 rem.torem(10px);
+    }
+  }
+}

--- a/pro/src/pages/Reimbursements/Income/IncomeNoData/IncomeNoData.tsx
+++ b/pro/src/pages/Reimbursements/Income/IncomeNoData/IncomeNoData.tsx
@@ -1,0 +1,51 @@
+import { useAnalytics } from 'app/App/analytics/firebase'
+import { Events } from 'commons/core/FirebaseEvents/constants'
+import strokeBookingHoldIcon from 'icons/stroke-booking-hold.svg'
+import { ButtonLink } from 'ui-kit/Button/ButtonLink'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+
+import styles from './IncomeNoData.module.scss'
+
+type IncomeNoDataProps = {
+  type: 'venues' | 'income' | 'income-year'
+}
+
+export const IncomeNoData = ({ type }: IncomeNoDataProps) => {
+  const { logEvent } = useAnalytics()
+  const noDataAtAll = type === 'venues' || type === 'income'
+
+  return (
+    <div className={styles['income-no-data']}>
+      <SvgIcon
+        className={styles['income-no-data-icon']}
+        src={strokeBookingHoldIcon}
+        alt=""
+        width="128"
+      />
+      {!noDataAtAll ? (
+        <>
+          Vous n‘avez aucune réservation sur cette période
+          <div className={styles['income-no-data-text-with-link']}>
+            Découvrez nos
+            <ButtonLink
+              isExternal
+              opensInNewTab
+              to="https://passcultureapp.notion.site/pass-Culture-Documentation-323b1a0ec309406192d772e7d803fbd0"
+              className={styles['income-no-data-text-with-link-buttonlink']}
+              onClick={() =>
+                logEvent(Events.CLICKED_BEST_PRACTICES_STUDIES, {
+                  from: location.pathname,
+                })
+              }
+            >
+              Bonnes pratiques & Études
+            </ButtonLink>
+            pour optimiser la visibilité de vos offres.
+          </div>
+        </>
+      ) : (
+        "Vous n'avez aucune réservation pour le moment"
+      )}
+    </div>
+  )
+}

--- a/pro/src/pages/Reimbursements/Income/IncomeNoData/IncomeNoData.tsx
+++ b/pro/src/pages/Reimbursements/Income/IncomeNoData/IncomeNoData.tsx
@@ -24,7 +24,7 @@ export const IncomeNoData = ({ type }: IncomeNoDataProps) => {
       />
       {!noDataAtAll ? (
         <>
-          Vous n‘avez aucune réservation sur cette période
+          Vous n’avez aucune réservation sur cette période
           <div className={styles['income-no-data-text-with-link']}>
             Découvrez nos
             <ButtonLink
@@ -44,7 +44,7 @@ export const IncomeNoData = ({ type }: IncomeNoDataProps) => {
           </div>
         </>
       ) : (
-        "Vous n'avez aucune réservation pour le moment"
+        'Vous n’avez aucune réservation pour le moment'
       )}
     </div>
   )

--- a/pro/src/pages/Reimbursements/Income/IncomeVenueSelector/IncomeVenueSelector.module.scss
+++ b/pro/src/pages/Reimbursements/Income/IncomeVenueSelector/IncomeVenueSelector.module.scss
@@ -13,6 +13,7 @@
   }
 
   @media (min-width: size.$laptop) {
-    width: calc(100vw - (size.$main-content-padding * 2) - 16.75rem)
+    width: calc(100vw - (size.$main-content-padding * 2) - 16.75rem);
+    max-width: calc(90rem - 4rem - 16.75rem);
   }
 }

--- a/pro/src/pages/Reimbursements/Income/IncomeVenueSelector/IncomeVenueSelector.module.scss
+++ b/pro/src/pages/Reimbursements/Income/IncomeVenueSelector/IncomeVenueSelector.module.scss
@@ -5,6 +5,12 @@
   max-width: rem.torem(300px);
 }
 
+// Selected tags must be displayed to occupy available width.
+// Width must be calculated based on the viewport width minus
+// various padding values since they belong to a component that
+// is not a direct child of the main content container and
+// has a restricted width.
+// Check Layout.module.scss for reference.
 .income-venue-selected-tags {
   width: calc(100vw - rem.torem(24px) * 2);
 
@@ -13,6 +19,8 @@
   }
 
   @media (min-width: size.$laptop) {
+    // 16.75rem is the width of the sidebar
+    // On very large screens the layout does not exceed 90rem.
     width: calc(100vw - (size.$main-content-padding * 2) - 16.75rem);
     max-width: calc(90rem - 4rem - 16.75rem);
   }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32547

## Objectifs 
Couvre les cas d'affichage suivants : 
- Venues en chargement, pas de venue, 1 seule venue et erreur sur la récupération des venues.
- Revenus / income en chargement, pas d'income, requête pour récupérer l'income en erreur.

## Compléments
- Petit fix #a11y sur le contraste de couleur des écrans d'erreur
- Petite optimisation pour ne pas réécrire le state et set activeYear inutilement.
- Petit fix css pour supporter les très larges écrans (tags venues)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
