### PR TITLE
(BSR)[API] fix: only log if a non null value is set

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -620,6 +620,9 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
 
     @description.setter
     def description(self, value: str | None) -> None:
+        if not value:
+            self._description = None
+            return
         if self.product:
             logger.error("No description should be set on an offer with a product")
             self._description = None
@@ -634,6 +637,9 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
 
     @durationMinutes.setter
     def durationMinutes(self, value: int | None) -> None:
+        if not value:
+            self._durationMinutes = None
+            return
         if self.product:
             logger.error("No durationMinutes should be set on an offer with a product")
             self._durationMinutes = None


### PR DESCRIPTION
## But de la pull request
We run through this code even if the value is None. We should not log anything in case we have a null value

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
