### PR TITLE
(PC-32248)[PRO] fix: Makes box checked by default + fix withdrawalDetails default value to an empty string

### DIFF
--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
@@ -69,7 +69,7 @@ export const UsefulInformationScreen = ({
     withdrawalInformations: boolean
   }>({ address: false, withdrawalInformations: false })
 
-  const [sendWithdrawalMail, setSendWithdrawalMail] = useState<boolean>(false)
+  const [sendWithdrawalMail, setSendWithdrawalMail] = useState<boolean>(true)
 
   const isEvent = subCategories.find(
     (subcategory) => subcategory.id === offer.subcategoryId

--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/__specs__/UsefulInformationScreen.spec.tsx
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/__specs__/UsefulInformationScreen.spec.tsx
@@ -231,7 +231,7 @@ describe('screens:IndividualOffer::UsefulInformation', () => {
       mentalDisabilityCompliant: false,
       motorDisabilityCompliant: true,
       name: undefined,
-      shouldSendMail: false,
+      shouldSendMail: true,
       url: undefined,
       visualDisabilityCompliant: false,
       withdrawalDelay: undefined,

--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/constants.ts
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/constants.ts
@@ -8,6 +8,7 @@ export const DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES: UsefulInformationFormV
   {
     isNational: false,
     bookingContact: '',
+    withdrawalDetails: '',
     withdrawalType: SUBCATEGORIES_FIELDS_DEFAULT_VALUES['withdrawalType'],
     withdrawalDelay: SUBCATEGORIES_FIELDS_DEFAULT_VALUES['withdrawalDelay'],
     receiveNotificationEmails: false,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32248

Fix de bugs en revue KO :
- La checkbox devait être pré-cochée automatiquement
- Lorsque les modalités de retrait d'une offre ayant des réservations étaient déjà enregistrées comme vides, et que l'on revenait sur le formulaire en modifiant ces modalités, et qu'on les remettait à vide ensuite, la popup apparaissait quand même (en raison de la default value à "undefined" !== '' (empty string) car il manquait la clé dans "DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES"