### PR TITLE
(PC-32648)[API] fix: fix expired template offers displayed status

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1096,7 +1096,7 @@ class CollectiveOfferTemplate(
         if self.validation == offer_mixin.OfferValidationStatus.DRAFT:
             return CollectiveOfferDisplayedStatus.DRAFT
 
-        if not self.isActive:
+        if not self.isActive or self.hasEndDatePassed:
             return CollectiveOfferDisplayedStatus.INACTIVE
 
         return CollectiveOfferDisplayedStatus.ACTIVE

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1072,7 +1072,10 @@ def get_collective_offer_templates_by_ids_for_adage(offer_ids: typing.Collection
     # Filter out the archived offers
     query = query.filter(educational_models.CollectiveOfferTemplate.isArchived == False)
     # Filter out the offers not displayed on adage
-    query = query.filter(educational_models.CollectiveOfferTemplate.isActive == True)
+    query = query.filter(
+        educational_models.CollectiveOfferTemplate.isActive == True,
+        educational_models.CollectiveOfferTemplate.hasEndDatePassed == False,
+    )
 
     return query.filter(educational_models.CollectiveOfferTemplate.id.in_(offer_ids))
 

--- a/api/tests/core/educational/test_models.py
+++ b/api/tests/core/educational/test_models.py
@@ -23,6 +23,7 @@ from pcapi.models import db
 from pcapi.models.offer_mixin import CollectiveOfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.validation_status_mixin import ValidationStatus
+from pcapi.utils import db as db_utils
 from pcapi.utils.image_conversion import CropParams
 from pcapi.utils.image_conversion import ImageRatio
 
@@ -652,6 +653,34 @@ class CollectiveOfferDisplayedStatusTest:
 
         assert offer.lastBookingStatus == CollectiveBookingStatus.REIMBURSED
         assert offer.displayedStatus == CollectiveOfferDisplayedStatus.REIMBURSED
+
+
+class CollectiveOfferTemplateDisplayedStatusTest:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            CollectiveOfferDisplayedStatus.ACTIVE,
+            CollectiveOfferDisplayedStatus.ARCHIVED,
+            CollectiveOfferDisplayedStatus.DRAFT,
+            CollectiveOfferDisplayedStatus.INACTIVE,
+            CollectiveOfferDisplayedStatus.REJECTED,
+            CollectiveOfferDisplayedStatus.PENDING,
+        ],
+    )
+    def test_get_offer_displayed_status(self, status):
+        offer = factories.create_collective_offer_template_by_status(status)
+
+        assert offer.displayedStatus == status
+
+    def test_get_displayed_status_for_inactive_offer_due_to_end_date_passed(self):
+        offer = factories.CollectiveOfferTemplateFactory(
+            validation=OfferValidationStatus.APPROVED,
+            dateRange=db_utils.make_timerange(
+                start=datetime.datetime.utcnow() - datetime.timedelta(days=4),
+                end=datetime.datetime.utcnow() - datetime.timedelta(hours=1),
+            ),
+        )
+        assert offer.displayedStatus == CollectiveOfferDisplayedStatus.INACTIVE
 
 
 class CollectiveOfferAllowedActionsTest:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32648

Les offres vitrines expirées (dates d'événement passées) sont marquées comme publiées dans pc pro alors qu'elles disparaissent d'ADAGE, il faut donc les marquer comme "masquées"

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
