### PR TITLE
(BSR)[PRO] test: check individual offer with tab view

### DIFF
--- a/pro/cypress/e2e/editDigitalIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/editDigitalIndividualOffer.cy.ts
@@ -1,17 +1,33 @@
 import { logAndGoToPage } from '../support/helpers.ts'
 
-describe('Modify a digital individual offer', () => {
+describe('Edit a digital individual offer', () => {
   let login: string
 
-  before(() => {
+  beforeEach(() => {
     cy.visit('/connexion')
     cy.request({
       method: 'GET',
       url: 'http://localhost:5001/sandboxes/pro/create_regular_pro_user_with_virtual_offer',
     }).then((response) => {
       login = response.body.user.email
+      cy.setFeatureFlags([{ name: 'WIP_SPLIT_OFFER', isActive: true }])
     })
-    cy.setFeatureFlags([{ name: 'WIP_SPLIT_OFFER', isActive: true }])
+  })
+
+  it('An edited offer is displayed with 4 tabs', function () {
+    logAndGoToPage(login, '/offre/individuelle/1/recapitulatif/details')
+
+    cy.contains('Récapitulatif')
+
+    cy.stepLog({ message: 'I check that the 4 tab are displayed' })
+    cy.findByRole('tablist').within(() => {
+      cy.findAllByRole('tab').eq(0).should('have.text', 'Détails de l’offre')
+      cy.findAllByRole('tab')
+        .eq(1)
+        .should('have.text', 'Informations pratiques')
+      cy.findAllByRole('tab').eq(2).should('have.text', 'Stock & Prix')
+      cy.findAllByRole('tab').eq(3).should('have.text', 'Réservations')
+    })
   })
 
   it('I should be able to modify the url of a digital offer', function () {

--- a/pro/cypress/support/commands.ts
+++ b/pro/cypress/support/commands.ts
@@ -59,6 +59,9 @@ Cypress.Commands.add(
     cy.get('button[type=submit]').click()
     cy.wait(['@signinUser', '@offererNames'])
 
+    if (redirectUrl && redirectUrl !== '/') {
+      cy.visit(redirectUrl)
+    }
     cy.url().should('contain', redirectUrl ?? '/accueil')
     cy.findAllByTestId('spinner', { timeout: 60 * 1000 }).should('not.exist')
   }


### PR DESCRIPTION
## But de la pull request

Ligne 186 du spreadsheet https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98

![CleanShot 2024-10-24 at 16 14 18@2x](https://github.com/user-attachments/assets/9e0c819d-9dc0-4be9-8c42-c25e0f1920ed)

Vérifie que le fiche d'une offre individuelle est bien présentée en onglet

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
