### PR TITLE
(PC-30711)[PRO] fix: Redirect logged users on signup confirmation page.

### DIFF
--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.tsx
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.tsx
@@ -1,41 +1,47 @@
 import React from 'react'
 
+import { useRedirectLoggedUser } from 'commons/hooks/useRedirectLoggedUser'
 import { Callout } from 'components/Callout/Callout'
 import fullMailIcon from 'icons/full-mail.svg'
 
 import styles from './SignupConfirmation.module.scss'
 
-export const SignupConfirmation = () => (
-  <section className={styles['content']}>
-    <div className={styles['hero-body']}>
-      <h1 className={styles['title']}>Merci !</h1>
-      <div className={styles['confirmation-text']}>
-        Votre compte est en cours de création.
+export const SignupConfirmation = () => {
+  useRedirectLoggedUser()
+
+  return (
+    <section className={styles['content']}>
+      <div className={styles['hero-body']}>
+        <h1 className={styles['title']}>Merci !</h1>
+        <div className={styles['confirmation-text']}>
+          Votre compte est en cours de création.
+        </div>
+        <div className={styles['confirmation-text']}>
+          Vous allez recevoir un lien de confirmation par email. Cliquez sur ce
+          lien pour confirmer la création de votre compte.
+        </div>
+        <Callout
+          links={[
+            {
+              href: 'mailto:support-pro@passculture.app',
+              isExternal: true,
+              icon: { src: fullMailIcon, alt: 'Nouvelle fenêtre, par email' },
+              label:
+                'Contacter notre support par mail à support-pro@passculture.app',
+            },
+          ]}
+        >
+          <p>
+            Si vous ne recevez pas d’email de notre part d’ici 5 minutes,
+            vérifiez que le message n’est pas dans le dossier “indésirables” ou
+            “spam” de votre messagerie.
+          </p>
+          <p className={styles['banner-text-gap']}>
+            Si vous n’avez rien reçu d’ici demain, merci de contacter le
+            support.
+          </p>
+        </Callout>
       </div>
-      <div className={styles['confirmation-text']}>
-        Vous allez recevoir un lien de confirmation par email. Cliquez sur ce
-        lien pour confirmer la création de votre compte.
-      </div>
-      <Callout
-        links={[
-          {
-            href: 'mailto:support-pro@passculture.app',
-            isExternal: true,
-            icon: { src: fullMailIcon, alt: 'Nouvelle fenêtre, par email' },
-            label:
-              'Contacter notre support par mail à support-pro@passculture.app',
-          },
-        ]}
-      >
-        <p>
-          Si vous ne recevez pas d’email de notre part d’ici 5 minutes, vérifiez
-          que le message n’est pas dans le dossier “indésirables” ou “spam” de
-          votre messagerie.
-        </p>
-        <p className={styles['banner-text-gap']}>
-          Si vous n’avez rien reçu d’ici demain, merci de contacter le support.
-        </p>
-      </Callout>
-    </div>
-  </section>
-)
+    </section>
+  )
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30711

- Rediriger les utilisateurs connectés qui arrivent sur la page de confirmation d'inscription.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
