### PR TITLE
(PC-32961)[PRO] fix: do not show deleted members in 'Collaborateurs' page

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2248,7 +2248,9 @@ def invite_member(offerer: models.Offerer, email: str, current_user: users_model
 def get_offerer_members(offerer: models.Offerer) -> list[tuple[str, OffererMemberStatus]]:
     users_offerers = (
         models.UserOfferer.query.filter(
-            models.UserOfferer.offererId == offerer.id, sa.not_(models.UserOfferer.isRejected)
+            models.UserOfferer.offererId == offerer.id,
+            sa.not_(models.UserOfferer.isRejected),
+            sa.not_(models.UserOfferer.isDeleted),
         )
         .options(sa.orm.joinedload(models.UserOfferer.user).load_only(users_models.User.email))
         .all()

--- a/api/tests/routes/pro/get_offerer_members_test.py
+++ b/api/tests/routes/pro/get_offerer_members_test.py
@@ -20,6 +20,9 @@ class Returns200Test:
         offerers_factories.NotValidatedUserOffererFactory(
             offerer=offerer, validationStatus=ValidationStatus.REJECTED, user__email="rejected.pro@example.com"
         )
+        offerers_factories.NotValidatedUserOffererFactory(
+            offerer=offerer, validationStatus=ValidationStatus.DELETED, user__email="deleted.pro@example.com"
+        )
         offerers_factories.OffererInvitationFactory(email="invited.pro@example.com", user=pro, offerer=offerer)
         offerers_factories.OffererInvitationFactory(
             email="member.pro@example.com", user=pro, offerer=offerer, status=offerers_models.InvitationStatus.ACCEPTED


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32961

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
