### PR TITLE
(PC-32653)[API] fix: IntegrityError when a venue with template in playlist is deleted

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -517,10 +517,6 @@ def delete_venue(venue_id: int) -> None:
     if venue_used_as_reimbursement_point:
         raise exceptions.CannotDeleteVenueUsedAsReimbursementPointException()
 
-    educational_models.CollectivePlaylist.query.filter(
-        educational_models.CollectivePlaylist.venueId == venue_id
-    ).delete(synchronize_session=False)
-
     offer_ids_to_delete = _delete_objects_linked_to_venue(venue_id)
 
     # Warning: we should only delete rows where the "venueId" is the
@@ -659,6 +655,16 @@ def _delete_objects_linked_to_venue(venue_id: int) -> dict:
             educational_models.CollectiveOfferRequest.collectiveOfferTemplateId.in_(collective_offer_templates_id_chunk)
         ).delete(synchronize_session=False)
 
+    educational_models.CollectivePlaylist.query.filter(
+        sa.or_(
+            educational_models.CollectivePlaylist.venueId == venue_id,
+            educational_models.CollectivePlaylist.collectiveOfferTemplateId.in_(
+                db.session.query(educational_models.CollectiveOfferTemplate.id).filter(
+                    educational_models.CollectiveOfferTemplate.venueId == venue_id
+                )
+            ),
+        )
+    ).delete(synchronize_session=False)
     educational_models.CollectiveOfferTemplate.query.filter(
         educational_models.CollectiveOfferTemplate.venueId == venue_id
     ).delete(synchronize_session=False)

--- a/api/tests/core/educational/api/test_playlists.py
+++ b/api/tests/core/educational/api/test_playlists.py
@@ -56,6 +56,11 @@ class SynchronizePlaylistsTest:
                     "collective_offer_id": str(offers[3].id),
                     "distance_in_km": updated_distance,
                 },
+                {
+                    "institution_id": str(institution.id),
+                    "collective_offer_id": str(offers[-1].id + 100),  # offer which does not exist: has been deleted
+                    "distance_in_km": updated_distance,
+                },
             ]
             playlist_api.synchronize_collective_playlist(playlist_type)
 
@@ -132,6 +137,11 @@ class SynchronizePlaylistsTest:
                     "institution_id": str(institution.id),
                     "venue_id": str(venues[3].id),
                     "distance_in_km": updated_distance,
+                },
+                {
+                    "institution_id": str(institution.id),
+                    "venue_id": str(venues[-1].id + 100),  # venue which does not exist:; has been deleted
+                    "distance_in_km": initial_distance,
                 },
             ]
             playlist_api.synchronize_collective_playlist(playlist_type)


### PR DESCRIPTION
```
(psycopg2.errors.ForeignKeyViolation) update or delete on table "collective_offer_template" violates foreign key constraint "collective_playlist_collectiveOfferTemplateId_fkey" on table "collective_playlist" DETAIL:  Key (id)=(84516) is still referenced from table "collective_playlist".
```

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32653

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
