### PR TITLE
(BSR)[PRO] test: add unattach 2 or all venues in financial

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/getters/pro.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/pro.py
@@ -87,6 +87,35 @@ def create_pro_user_with_financial_data() -> dict:
     return {"user": get_pro_user_helper(pro_user)}
 
 
+def create_pro_user_with_financial_data_and_3_venues() -> dict:
+    pro_user = users_factories.ProFactory()
+
+    offerer_C = offerers_factories.OffererFactory(name="Structure avec informations bancaires et 3 lieux")
+    offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer_C)
+    venue_C = offerers_factories.VenueFactory(name="Mon lieu 1", managingOfferer=offerer_C)
+    venue_D = offerers_factories.VenueFactory(name="Mon lieu 2", managingOfferer=offerer_C)
+    venue_E = offerers_factories.VenueFactory(name="Mon lieu 3", managingOfferer=offerer_C)
+    offerers_factories.VirtualVenueFactory(managingOfferer=offerer_C)
+    bank_account_C = finance_factories.BankAccountFactory(offerer=offerer_C)
+    offerers_factories.VenuePricingPointLinkFactory(
+        venue=venue_C,
+        pricingPoint=venue_C,
+    )
+    offerers_factories.VenuePricingPointLinkFactory(
+        venue=venue_D,
+        pricingPoint=venue_D,
+    )
+    offerers_factories.VenuePricingPointLinkFactory(
+        venue=venue_E,
+        pricingPoint=venue_E,
+    )
+    finance_factories.InvoiceFactory(bankAccount=bank_account_C, reimbursementPoint=venue_C)
+    finance_factories.InvoiceFactory(bankAccount=bank_account_C, reimbursementPoint=venue_D)
+    finance_factories.InvoiceFactory(bankAccount=bank_account_C, reimbursementPoint=venue_E)
+
+    return {"user": get_pro_user_helper(pro_user)}
+
+
 def create_adage_environnement() -> dict:
     current_year = educational_factories.EducationalCurrentYearFactory()
     next_year = educational_factories.EducationalYearFactory()

--- a/pro/cypress/e2e/financialManagement.cy.ts
+++ b/pro/cypress/e2e/financialManagement.cy.ts
@@ -1,231 +1,248 @@
 import { logAndGoToPage } from '../support/helpers.ts'
 
-describe('Financial Management - messages, links to external help page, reimbursement details', () => {
+export function attachmentModificationsDone() {
+  cy.stepLog({
+    message: 'Modifications done',
+  })
+  cy.findAllByTestId('global-notification-success').should(
+    'contain',
+    'Vos modifications ont bien été prises en compte.'
+  )
+  cy.wait('@getOfferers').its('response.statusCode').should('equal', 200)
+  cy.findByRole('dialog').should('not.exist')
+}
+
+describe('Financial Management - messages, links to external help page, reimbursement details, unattach', () => {
   let login: string
 
-  beforeEach(() => {
-    cy.visit('/connexion')
-    cy.request({
-      method: 'GET',
-      url: 'http://localhost:5001/sandboxes/pro/create_pro_user_with_financial_data',
-    }).then((response) => {
-      login = response.body.user.email
-    })
-    cy.intercept({ method: 'GET', url: '/offerers/*' }).as('getOfferers')
-    cy.intercept({ method: 'PATCH', url: 'offerers/*/bank-accounts/*' }).as(
-      'patchBankAccount'
-    )
-  })
-
-  it('Check messages, reimbursement details and offerer selection change', () => {
-    logAndGoToPage(login, '/remboursements')
-
-    cy.stepLog({ message: 'I can see information message about reimbursement' })
-    cy.findByText("Les remboursements s'effectuent toutes les 2 à 3 semaines")
-    cy.findByText(
-      'Nous remboursons en un virement toutes les réservations validées entre le 1ᵉʳ et le 15 du mois, et lors d’un second toutes celles validées entre le 16 et le 31 du mois.'
-    )
-    cy.findByText(
-      'Les offres de type événement se valident automatiquement 48h à 72h après leur date de réalisation, leurs remboursements peuvent se faire sur la quinzaine suivante.'
-    )
-
-    cy.stepLog({ message: 'no receipt results should be displayed' })
-    cy.findAllByTestId('spinner').should('not.exist')
-    cy.findAllByTestId('invoice-title-row').should('not.exist')
-    cy.findAllByTestId('invoice-item-row').should('not.exist')
-    cy.contains(
-      'Vous n’avez pas encore de justificatifs de remboursement disponibles'
-    )
-
-    cy.stepLog({
-      message: 'I can see a link to the next reimbursement help page',
-    })
-    cy.url().then((url: string) => {
-      cy.findByText(/En savoir plus sur les prochains remboursements/)
-        .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
-        .click()
-      // En local, ne marche pas, il faut remplacer par
-      //     cy.origin('https://aide.passculture.app', () => {
-      cy.origin('https://passculture.zendesk.com', () => {
-        // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
-        cy.url().should('include', '4411992051601')
+  describe('Data contains 2 offerers, one with 0 venue, one with 1 venue', () => {
+    beforeEach(() => {
+      cy.visit('/connexion')
+      cy.request({
+        method: 'GET',
+        url: 'http://localhost:5001/sandboxes/pro/create_pro_user_with_financial_data',
+      }).then((response) => {
+        login = response.body.user.email
       })
-      cy.visit(url)
-    })
-
-    cy.stepLog({
-      message:
-        'I can see a link to the terms and conditions of reimbursement help page',
-    })
-    cy.url().then((url: string) => {
-      cy.findByText(/Connaître les modalités de remboursement/)
-        .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
-        .click()
-      // En local, ne marche pas, il faut remplacer par
-      //     cy.origin('https://aide.passculture.app', () => {
-      cy.origin('https://passculture.zendesk.com', () => {
-        // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
-        cy.url().should('include', '4412007300369')
-      })
-      cy.visit(url)
-    })
-
-    cy.stepLog({
-      message: 'I select offerer "Structure avec informations bancaires"',
-    })
-    cy.findByTestId('offerer-select').click()
-    cy.findByText(/Changer de structure/).click()
-    cy.findByTestId('offerers-selection-menu')
-      .findByText('Structure avec informations bancaires')
-      .click()
-    cy.findByTestId('header-dropdown-menu-div').should('not.exist')
-    cy.findAllByTestId('spinner').should('not.exist')
-
-    cy.stepLog({ message: 'These receipt results should be displayed' })
-    const data = [
-      [
-        'Date du justificatif',
-        'Type de document',
-        'Compte bancaire',
-        'N° de virement',
-        'Montant remboursé',
-        'Actions',
-      ],
-      [
-        '',
-        '',
-        'Trop perçu',
-        'Libellé des coordonnées bancaires n°0',
-        'N/A',
-        '-10,00',
-      ],
-    ]
-    const numRows = data.length - 1
-    const numColumns = data[0].length
-
-    cy.findAllByTestId('spinner').should('not.exist')
-    cy.findAllByTestId('invoice-item-row').should('have.length', numRows)
-
-    // Vérification des titres des colonnes
-    const titleArray = data[0]
-    cy.findAllByTestId('invoice-title-row').within(() => {
-      cy.get('th').then(($elt) => {
-        for (let column = 0; column < numColumns; column++) {
-          if (titleArray[column] !== '') {
-            cy.wrap($elt).eq(column).should('contain', titleArray[column])
-          }
-        }
-      })
-    })
-
-    cy.stepLog({ message: 'I download reimbursement details' })
-    cy.findByTestId('dropdown-menu-trigger').click()
-    cy.findByText(/Télécharger le détail des réservations/).click()
-
-    cy.stepLog({ message: 'I can see the reimbursement details' })
-    const filename = `${Cypress.config('downloadsFolder')}/remboursements_pass_culture.csv`
-    cy.readFile(filename, { timeout: 15000 }).should('not.be.empty')
-  })
-
-  it('Automatic link venue with bank account', () => {
-    logAndGoToPage(login, '/remboursements')
-
-    cy.findByTestId('offerer-select')
-    cy.wait('@getOfferers').its('response.statusCode').should('equal', 200)
-    cy.findAllByTestId('spinner').should('not.exist')
-
-    cy.stepLog({
-      message: 'I select offerer "Structure avec informations bancaires"',
-    })
-    cy.findByTestId('offerer-select').click()
-    cy.findByText(/Changer de structure/).click()
-    cy.findByTestId('offerers-selection-menu')
-      .findByText('Structure avec informations bancaires')
-      .click()
-    cy.wait('@getOfferers').its('response.statusCode').should('equal', 200)
-    cy.findByTestId('header-dropdown-menu-div').should('not.exist')
-    cy.findAllByTestId('spinner').should('not.exist')
-
-    cy.stepLog({ message: 'I go to "Informations bancaires" view' })
-    cy.findByText('Informations bancaires').click()
-    cy.findAllByTestId('spinner').should('not.exist')
-
-    cy.stepLog({
-      message: 'I remove "Mon Lieu" venue from my bank account',
-    })
-    const venue = 'Mon Lieu'
-    cy.findByText('Aucun lieu n’est rattaché à ce compte bancaire.')
-    cy.findByText('Rattacher un lieu').click()
-
-    cy.findByRole('dialog').within(() => {
-      cy.findByText(venue).click()
-      cy.findByText('Enregistrer').click()
-    })
-    cy.wait('@getOfferers').its('response.statusCode').should('equal', 200)
-    cy.findByRole('dialog').should('not.exist')
-
-    cy.findByTestId('reimbursement-bank-account-linked-venues').within(() => {
-      cy.contains('Lieu(x) rattaché(s) à ce compte bancaire')
-      cy.contains(venue)
-      cy.findByText('Modifier').click()
-    })
-
-    cy.findByRole('dialog').within(() => {
-      cy.findByLabelText(venue).should('be.checked')
-      cy.findByLabelText(venue).uncheck()
-      cy.findByText('Enregistrer').click()
-      cy.contains(
-        'Attention : le ou les lieux désélectionnés ne seront plus remboursés sur ce compte bancaire'
+      cy.intercept({ method: 'GET', url: '/offerers/*' }).as('getOfferers')
+      cy.intercept({ method: 'PATCH', url: 'offerers/*/bank-accounts/*' }).as(
+        'patchBankAccount'
       )
-      cy.findByText('Confirmer').click()
-    })
-    cy.wait('@getOfferers').its('response.statusCode').should('equal', 200)
-    cy.findByRole('dialog').should('not.exist')
-
-    cy.stepLog({ message: 'no venue should be linked to my account' })
-    cy.findAllByTestId('global-notification-success').should(
-      'contain',
-      'Vos modifications ont bien été prises en compte.'
-    )
-    cy.findAllByTestId('spinner').should('not.exist')
-    cy.findByTestId('reimbursement-bank-account-linked-venues').within(() => {
-      cy.contains('Aucun lieu n’est rattaché à ce compte bancaire.')
     })
 
-    cy.stepLog({
-      message: 'I add "Mon Lieu" venue to my bank account',
+    it('Check messages, reimbursement details and offerer selection change', () => {
+      logAndGoToPage(login, '/remboursements')
+
+      cy.stepLog({
+        message: 'I can see information message about reimbursement',
+      })
+      cy.findByText("Les remboursements s'effectuent toutes les 2 à 3 semaines")
+      cy.findByText(
+        'Nous remboursons en un virement toutes les réservations validées entre le 1ᵉʳ et le 15 du mois, et lors d’un second toutes celles validées entre le 16 et le 31 du mois.'
+      )
+      cy.findByText(
+        'Les offres de type événement se valident automatiquement 48h à 72h après leur date de réalisation, leurs remboursements peuvent se faire sur la quinzaine suivante.'
+      )
+
+      cy.stepLog({ message: 'no receipt results should be displayed' })
+      cy.findAllByTestId('spinner').should('not.exist')
+      cy.findAllByTestId('invoice-title-row').should('not.exist')
+      cy.findAllByTestId('invoice-item-row').should('not.exist')
+      cy.contains(
+        'Vous n’avez pas encore de justificatifs de remboursement disponibles'
+      )
+
+      cy.stepLog({
+        message: 'I can see a link to the next reimbursement help page',
+      })
+      cy.url().then((url: string) => {
+        cy.findByText(/En savoir plus sur les prochains remboursements/)
+          .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
+          .click()
+        // En local, ne marche pas, il faut remplacer par
+        //     cy.origin('https://aide.passculture.app', () => {
+        cy.origin('https://passculture.zendesk.com', () => {
+          // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
+          cy.url().should('include', '4411992051601')
+        })
+        cy.visit(url)
+      })
+
+      cy.stepLog({
+        message:
+          'I can see a link to the terms and conditions of reimbursement help page',
+      })
+      cy.url().then((url: string) => {
+        cy.findByText(/Connaître les modalités de remboursement/)
+          .invoke('removeAttr', 'target') // removes target to not open it in a new tab (not supported by cypress)
+          .click()
+        // En local, ne marche pas, il faut remplacer par
+        //     cy.origin('https://aide.passculture.app', () => {
+        cy.origin('https://passculture.zendesk.com', () => {
+          // cloudfare/zendesk "Verify you are human" page cannot be used by cypress robot
+          cy.url().should('include', '4412007300369')
+        })
+        cy.visit(url)
+      })
+
+      cy.stepLog({
+        message: 'I select offerer "Structure avec informations bancaires"',
+      })
+      cy.findByTestId('offerer-select').click()
+      cy.findByText(/Changer de structure/).click()
+      cy.findByTestId('offerers-selection-menu')
+        .findByText('Structure avec informations bancaires')
+        .click()
+      cy.findByTestId('header-dropdown-menu-div').should('not.exist')
+      cy.findAllByTestId('spinner').should('not.exist')
+
+      cy.stepLog({ message: 'These receipt results should be displayed' })
+      const data = [
+        [
+          'Date du justificatif',
+          'Type de document',
+          'Compte bancaire',
+          'N° de virement',
+          'Montant remboursé',
+          'Actions',
+        ],
+        [
+          '',
+          '',
+          'Trop perçu',
+          'Libellé des coordonnées bancaires n°0',
+          'N/A',
+          '-10,00',
+        ],
+      ]
+      const numRows = data.length - 1
+      const numColumns = data[0].length
+
+      cy.findAllByTestId('spinner').should('not.exist')
+      cy.findAllByTestId('invoice-item-row').should('have.length', numRows)
+
+      // Vérification des titres des colonnes
+      const titleArray = data[0]
+      cy.findAllByTestId('invoice-title-row').within(() => {
+        cy.get('th').then(($elt) => {
+          for (let column = 0; column < numColumns; column++) {
+            if (titleArray[column] !== '') {
+              cy.wrap($elt).eq(column).should('contain', titleArray[column])
+            }
+          }
+        })
+      })
+
+      cy.stepLog({ message: 'I download reimbursement details' })
+      cy.findByTestId('dropdown-menu-trigger').click()
+      cy.findByText(/Télécharger le détail des réservations/).click()
+
+      cy.stepLog({ message: 'I can see the reimbursement details' })
+      const filename = `${Cypress.config('downloadsFolder')}/remboursements_pass_culture.csv`
+      cy.readFile(filename, { timeout: 15000 }).should('not.be.empty')
     })
-    cy.findByTestId('reimbursement-bank-account-linked-venues').within(() => {
-      cy.findByText('Rattacher un lieu').click()
+  })
+
+  describe('Data contains 1 offerer with 3 venues', () => {
+    beforeEach(() => {
+      cy.visit('/connexion')
+      cy.intercept({ method: 'GET', url: '/offerers/*' }).as('getOfferers')
+      cy.intercept({ method: 'PATCH', url: 'offerers/*/bank-accounts/*' }).as(
+        'patchBankAccount'
+      )
+      cy.request({
+        method: 'GET',
+        url: 'http://localhost:5001/sandboxes/pro/create_pro_user_with_financial_data_and_3_venues',
+      }).then((response) => {
+        login = response.body.user.email
+        logAndGoToPage(login, 'remboursements/informations-bancaires')
+        cy.findByTestId('offerer-select')
+        cy.wait('@getOfferers').its('response.statusCode').should('equal', 200)
+        cy.findAllByTestId('spinner').should('not.exist')
+
+        cy.stepLog({
+          message: 'Attach all my venues',
+        })
+        cy.findByText('Rattacher un lieu').click()
+
+        cy.findByRole('dialog').within(() => {
+          cy.findByText('Tout sélectionner').click()
+          cy.findByText('Enregistrer').click()
+        })
+
+        attachmentModificationsDone()
+      })
     })
 
-    cy.findByRole('dialog').within(() => {
-      cy.findByLabelText(venue).should('not.be.checked')
-      cy.findByLabelText(venue).check()
+    it('Attach and unattach a few venues', () => {
+      cy.stepLog({
+        message: 'Unattach 2 in 4 venues',
+      })
+      cy.findByTestId('reimbursement-bank-account-linked-venues').within(() => {
+        cy.contains('Lieu(x) rattaché(s) à ce compte bancaire')
+        cy.contains('Mon lieu 1')
+        cy.contains('Mon lieu 2')
+        cy.contains('Mon lieu 3')
+        cy.findByText('Modifier').click()
+      })
 
-      cy.findByText('Enregistrer').click()
-    })
-    cy.wait(['@getOfferers', '@patchBankAccount']).then((interception) => {
-      if (interception[0].response) {
-        expect(interception[0].response.statusCode).to.equal(200)
-      }
-      if (interception[1].response) {
-        expect(interception[1].response.statusCode).to.equal(204)
-      }
-    })
-    cy.findByRole('dialog').should('not.exist')
+      cy.findByRole('dialog').within(() => {
+        cy.findByText('Mon lieu 1').click()
+        cy.findByText('Mon lieu 2').click()
+        cy.findByText('Enregistrer').click()
+        cy.contains(
+          'Attention : le ou les lieux désélectionnés ne seront plus remboursés sur ce compte bancaire'
+        )
+        cy.findByText('Confirmer').click()
+      })
 
-    cy.stepLog({
-      message: '"Mon Lieu" venue should be linked to my account',
+      attachmentModificationsDone()
+
+      cy.stepLog({
+        message: 'Check only Mon lieu 3 is attached',
+      })
+      cy.findByTestId('reimbursement-bank-account-linked-venues').within(
+        ($elt) => {
+          cy.contains('Lieu(x) rattaché(s) à ce compte bancaire')
+          cy.contains('Certains de vos lieux ne sont pas rattachés.')
+          cy.get('div').contains('Mon lieu 3')
+          cy.wrap($elt)
+            .should('not.contain', 'Mon lieu 1')
+            .and('not.contain', 'Mon lieu 2')
+        }
+      )
     })
-    cy.findAllByTestId('global-notification-success').should(
-      'contain',
-      'Vos modifications ont bien été prises en compte.'
-    )
-    cy.findAllByTestId('spinner').should('not.exist')
-    cy.findByTestId('reimbursement-bank-account-linked-venues').within(() => {
+    it('Attach and unattach all venues', () => {
+      cy.stepLog({
+        message: 'Unattach all venues',
+      })
+
+      cy.findByText('Modifier').click()
       cy.contains('Lieu(x) rattaché(s) à ce compte bancaire')
-      cy.contains(venue)
+      cy.findByRole('dialog').within(() => {
+        cy.findByText('Tout désélectionner').click()
+        cy.findByText('Enregistrer').click()
+        cy.contains(
+          'Attention : le ou les lieux désélectionnés ne seront plus remboursés sur ce compte bancaire'
+        )
+        cy.findByText('Confirmer').click()
+      })
+
+      attachmentModificationsDone()
+
+      cy.stepLog({
+        message: 'Check no venues attached',
+      })
+      cy.findByTestId('reimbursement-bank-account-linked-venues').within(
+        ($elt) => {
+          cy.contains('Lieu(x) rattaché(s) à ce compte bancaire')
+          cy.contains('Aucun lieu n’est rattaché à ce compte bancaire.')
+          cy.wrap($elt)
+            .should('not.contain', 'Mon lieu 1')
+            .and('not.contain', 'Mon lieu 2')
+            .and('not.contain', 'Mon lieu 3')
+        }
+      )
     })
   })
 })

--- a/pro/cypress/support/helpers.ts
+++ b/pro/cypress/support/helpers.ts
@@ -48,7 +48,7 @@ export function logAndGoToPage(login: string, url: string) {
   })
   cy.findAllByTestId('spinner').should('not.exist')
 
-  cy.stepLog({ message: 'I open the "reservations/collectives" page' })
+  cy.stepLog({ message: `I open the "${url}" page` })
   cy.visit(url)
   cy.findAllByTestId('spinner').should('not.exist')
 


### PR DESCRIPTION
## But de la pull request

J'ai modifié le cas existant et rajouté 1 nouveau cas pour tester les lignes 273 et 274 du fichier https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98:
- Informations bancaire/Modification/Désassociation de 1 ou plusieurs lieux d'un compte
- Informations bancaire/Modification/Désassociation de tous les lieux d'un compte

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
