### PR TITLE
(BSR)[PRO] test: useless beforeEach takes too much time

### DIFF
--- a/pro/cypress/e2e/desk.cy.ts
+++ b/pro/cypress/e2e/desk.cy.ts
@@ -5,7 +5,7 @@ import { logAndGoToPage } from '../support/helpers.ts'
 describe('Desk (Guichet) feature', () => {
   let login: string
 
-  beforeEach(() => {
+  before(() => {
     cy.visit('/connexion')
     cy.request({
       method: 'GET',


### PR DESCRIPTION
## But de la pull request

L'exécution des tests `desk` est très long or on a pas de besoin de tout recréer avant chaque test avec un `beforeEach`, un `before` est suffisant et le temps d'exécution est ainsi divisé par 3 (46" au lieu de 2'12)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
