### PR TITLE
(PC-32742)[BO] feat: send transactional email when personal data is updated

### DIFF
--- a/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
+++ b/api/src/pcapi/core/mails/transactional/sendinblue_template_ids.py
@@ -98,6 +98,7 @@ class TransactionalEmail(Enum):
         id_prod=1004, id_not_prod=144, tags=["notification_avant_suppression_compte_suspendu"]
     )
     BENEFICIARY_PRE_ANONYMIZATION = models.Template(id_prod=1388, id_not_prod=166)
+    PERSONAL_DATA_UPDATED_FROM_BACKOFFICE = models.Template(id_prod=1393, id_not_prod=169, use_priority_queue=True)
 
     # UBBLE KO REMINDER
     UBBLE_KO_REMINDER_ID_CHECK_DATA_MATCH = models.Template(id_prod=824, id_not_prod=116)

--- a/api/src/pcapi/core/mails/transactional/users/personal_data_updated.py
+++ b/api/src/pcapi/core/mails/transactional/users/personal_data_updated.py
@@ -1,0 +1,40 @@
+from pcapi.core import mails
+from pcapi.core.mails import models
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+import pcapi.core.users.models as users_models
+
+
+def send_beneficiary_personal_data_updated(
+    user: users_models.User,
+    *,
+    is_first_name_updated: bool = False,
+    is_last_name_updated: bool = False,
+    is_email_updated: bool = False,
+    is_phone_number_updated: bool = False,
+) -> bool:
+    updated_fields: set[str] = set()
+
+    # Apply values expected in transactional email template
+    if is_first_name_updated:
+        updated_fields.add("FIRST_NAME")
+    if is_last_name_updated:
+        updated_fields.add("LAST_NAME")
+    if is_email_updated:
+        updated_fields.add("EMAIL")
+    if is_phone_number_updated:
+        updated_fields.add("PHONE_NUMBER")
+
+    if not updated_fields:
+        return False
+
+    data = models.TransactionalEmailData(
+        template=TransactionalEmail.PERSONAL_DATA_UPDATED_FROM_BACKOFFICE.value,
+        params={
+            "FIRSTNAME": user.firstName,
+            "LASTNAME": user.lastName,
+            "UPDATED_FIELD": ",".join(sorted(updated_fields)),
+        },
+    )
+    mails.send(recipients=[user.email], data=data)
+
+    return True

--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -347,6 +347,18 @@ def full_email_update_by_admin(user: models.User, email: str, commit: bool = Fal
         db.session.commit()
 
 
+def clear_email_by_admin(user: models.User) -> None:
+    email = f"{user.id}@email.supprime"
+
+    admin_update_event = models.UserEmailHistory.build_admin_update(user=user, new_email=email)
+    db.session.add(admin_update_event)
+
+    user.email = email
+    db.session.add(user)
+
+    db.session.flush()
+
+
 def get_active_token_expiration(user: models.User) -> datetime | None:
     """
     Returns the expiration date of the active token

--- a/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
@@ -116,7 +116,9 @@ def render_bo_user_page(user_id: int, edit_form: forms.EditBOUserForm | None = N
         raise NotFound()
 
     kwargs = user_forms.get_toggle_suspension_args(
-        user, required_permission=perm_models.Permissions.MANAGE_ADMIN_ACCOUNTS
+        user,
+        suspension_type=user_forms.SuspensionUserType.ADMIN,
+        required_permission=perm_models.Permissions.MANAGE_ADMIN_ACCOUNTS,
     )
 
     if utils.has_current_user_permission(perm_models.Permissions.READ_ADMIN_ACCOUNTS):

--- a/api/src/pcapi/routes/backoffice/users/forms.py
+++ b/api/src/pcapi/routes/backoffice/users/forms.py
@@ -16,6 +16,7 @@ from pcapi.routes.backoffice.utils import has_current_user_permission
 class SuspensionUserType(enum.Enum):
     PRO = "pro user"
     PUBLIC = "public user"
+    ADMIN = "admin_user"
 
 
 class SuspendUserForm(FlaskForm):
@@ -26,6 +27,9 @@ class SuspendUserForm(FlaskForm):
         ],
     )
     comment = fields.PCOptCommentField("Commentaire interne optionnel")
+    clear_email = fields.PCSwitchBooleanField(
+        "Supprimer l'adresse email (à utiliser pour les cas de doublons afin de la libérer)", full_row=True
+    )
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
@@ -35,11 +39,13 @@ class SuspendUserForm(FlaskForm):
                 (opt.name, users_constants.PRO_SUSPENSION_REASON_CHOICES[opt])
                 for opt in set(users_constants.PRO_SUSPENSION_REASON_CHOICES)
             ]
-        if suspension_type == SuspensionUserType.PUBLIC:
+        if suspension_type in (SuspensionUserType.PUBLIC, SuspensionUserType.ADMIN):
             self.reason.choices = [
                 (opt.name, users_constants.PUBLIC_SUSPENSION_REASON_CHOICES[opt])
                 for opt in set(users_constants.PUBLIC_SUSPENSION_REASON_CHOICES)
             ]
+        if suspension_type in (SuspensionUserType.PRO, SuspensionUserType.ADMIN):
+            del self.clear_email
 
 
 class UnsuspendUserForm(FlaskForm):

--- a/api/tests/core/mails/transactional/users/personal_data_updated_test.py
+++ b/api/tests/core/mails/transactional/users/personal_data_updated_test.py
@@ -1,0 +1,72 @@
+import dataclasses
+
+import pytest
+
+from pcapi.core.mails import testing as mails_testing
+from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.mails.transactional.users.personal_data_updated import send_beneficiary_personal_data_updated
+from pcapi.core.users import factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class PersonalDataUpdatedTest:
+    def test_nothing_updated(self) -> None:
+        user = users_factories.UserFactory()
+        assert not send_beneficiary_personal_data_updated(user)
+        assert len(mails_testing.outbox) == 0
+
+    @pytest.mark.parametrize(
+        "parameter,expected_updated_field",
+        [
+            ("is_first_name_updated", "FIRST_NAME"),
+            ("is_last_name_updated", "LAST_NAME"),
+            ("is_email_updated", "EMAIL"),
+            ("is_phone_number_updated", "PHONE_NUMBER"),
+        ],
+    )
+    def test_single_field_updated(self, parameter, expected_updated_field) -> None:
+        user = users_factories.UserFactory()
+        assert send_beneficiary_personal_data_updated(user, **{parameter: True})
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0]["template"] == dataclasses.asdict(
+            TransactionalEmail.PERSONAL_DATA_UPDATED_FROM_BACKOFFICE.value
+        )
+        assert mails_testing.outbox[0]["params"] == {
+            "FIRSTNAME": user.firstName,
+            "LASTNAME": user.lastName,
+            "UPDATED_FIELD": expected_updated_field,
+        }
+
+    def test_two_fields_updated(self) -> None:
+        user = users_factories.UserFactory()
+        assert send_beneficiary_personal_data_updated(user, is_last_name_updated=True, is_email_updated=True)
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0]["template"] == dataclasses.asdict(
+            TransactionalEmail.PERSONAL_DATA_UPDATED_FROM_BACKOFFICE.value
+        )
+        assert mails_testing.outbox[0]["params"] == {
+            "FIRSTNAME": user.firstName,
+            "LASTNAME": user.lastName,
+            "UPDATED_FIELD": "EMAIL,LAST_NAME",
+        }
+
+    def test_all_fields_updated(self) -> None:
+        user = users_factories.UserFactory()
+        assert send_beneficiary_personal_data_updated(
+            user,
+            is_first_name_updated=True,
+            is_last_name_updated=True,
+            is_email_updated=True,
+            is_phone_number_updated=True,
+        )
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0]["template"] == dataclasses.asdict(
+            TransactionalEmail.PERSONAL_DATA_UPDATED_FROM_BACKOFFICE.value
+        )
+        assert mails_testing.outbox[0]["params"] == {
+            "FIRSTNAME": user.firstName,
+            "LASTNAME": user.lastName,
+            "UPDATED_FIELD": "EMAIL,FIRST_NAME,LAST_NAME,PHONE_NUMBER",
+        }


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32742

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
