### PR TITLE
(PC-32688)[API] feat: send withdrawal update at offer localisation up…

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -417,7 +417,8 @@ def update_offer(
 
     withdrawal_fields = {"bookingContact", "withdrawalDelay", "withdrawalDetails", "withdrawalType"}
     withdrawal_updated = updates_set & withdrawal_fields
-    if should_send_mail and withdrawal_updated:
+    oa_updated = "offererAddress" in updates
+    if should_send_mail and (withdrawal_updated or oa_updated):
         transactional_mails.send_email_for_each_ongoing_booking(offer)
 
     reason = search.IndexationReason.OFFER_UPDATE


### PR DESCRIPTION
…date

## But de la pull request
Envoyer un mail de notification de modification de retrait lors de la modification de la localisation d'une offre 
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32688

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
