### PR TITLE
(PC-32795)[PRO] fix: Margins of collaborator page subtitle.

### DIFF
--- a/pro/src/pages/Collaborators/Collaborators.module.scss
+++ b/pro/src/pages/Collaborators/Collaborators.module.scss
@@ -10,11 +10,7 @@
   .main-list-title {
     @include fonts-design-system.title2;
 
-    margin-top: rem.torem(26px);
-    margin-bottom: rem.torem(24px);
-    padding-bottom: rem.torem(8px);
-
-    @include fonts.bold;
+    margin: rem.torem(32px) 0;
   }
 
   .subtitle {
@@ -77,7 +73,6 @@
 
   .members-list {
     border-collapse: separate;
-    border-spacing: rem.torem(16px) 0;
     min-width: rem.torem(365px);
 
     th {
@@ -93,6 +88,7 @@
 
       vertical-align: baseline;
       text-align: left;
+      padding-right: rem.torem(16px);
     }
 
     tr:not(:last-child) td {

--- a/pro/src/pages/Collaborators/Collaborators.tsx
+++ b/pro/src/pages/Collaborators/Collaborators.tsx
@@ -104,9 +104,7 @@ export const Collaborators = (): JSX.Element | null => {
       <h1 className={styles['title']}>Collaborateurs</h1>
 
       <section className={styles['section']} ref={scrollToSection}>
-        <h2 className={styles['main-list-title-new']}>
-          {'Liste des collaborateurs'}
-        </h2>
+        <h2 className={styles['main-list-title']}>Liste des collaborateurs</h2>
 
         {members.length > 0 && (
           <div className={styles['members-container']}>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32795

**Objectif**
Correction des marges du sous-titre de la page collaborateurs.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
