### PR TITLE
(PC-32796)[PRO] fix: Use OldLayout in logged out accessibility page.

### DIFF
--- a/pro/src/app/App/layout/OldLayout.tsx
+++ b/pro/src/app/App/layout/OldLayout.tsx
@@ -18,15 +18,8 @@ interface OldLayoutProps {
   mainHeading?: string
 }
 
-export const OldLayout = ({ children, mainHeading }: OldLayoutProps) => {
+export const OldLayout = ({ children }: OldLayoutProps) => {
   const currentUser = useSelector(selectCurrentUser)
-  const renderMainHeading = () => {
-    if (!mainHeading) {
-      return null
-    }
-
-    return <h1 className={styles['main-heading']}>{mainHeading}</h1>
-  }
 
   return (
     <>
@@ -54,10 +47,7 @@ export const OldLayout = ({ children, mainHeading }: OldLayoutProps) => {
           [styles['container-without-nav']]: true,
         })}
       >
-        <>
-          {renderMainHeading()}
-          {children}
-        </>
+        {children}
       </main>
     </>
   )

--- a/pro/src/pages/Accessibility/AccessibilityLayout.module.scss
+++ b/pro/src/pages/Accessibility/AccessibilityLayout.module.scss
@@ -1,8 +1,15 @@
 @use "styles/mixins/_layout.scss" as layout;
+@use "styles/mixins/fonts-design-system.scss" as fonts-design-system;
 @use "styles/mixins/_rem.scss" as rem;
 
 .logo-side {
   @include layout.logo-side;
+}
+
+.main-heading {
+  @include fonts-design-system.title1;
+
+  margin-bottom: rem.torem(32px);
 }
 
 .layout {

--- a/pro/src/pages/Accessibility/AccessibilityLayout.tsx
+++ b/pro/src/pages/Accessibility/AccessibilityLayout.tsx
@@ -1,4 +1,5 @@
 import { Layout, LayoutProps } from 'app/App/layout/Layout'
+import { OldLayout } from 'app/App/layout/OldLayout'
 import { useCurrentUser } from 'commons/hooks/useCurrentUser'
 import fullBackIcon from 'icons/full-back.svg'
 import logoPassCultureProFullIcon from 'icons/logo-pass-culture-pro-full.svg'
@@ -28,7 +29,7 @@ export const AccessibilityLayout = ({
   return isUserConnected ? (
     <Layout mainHeading={mainHeading}>{children}</Layout>
   ) : (
-    <Layout mainHeading={mainHeading} layout="without-nav">
+    <OldLayout>
       <header className={styles['logo-side']}>
         <SvgIcon
           className={logoStyles['logo-unlogged']}
@@ -39,6 +40,7 @@ export const AccessibilityLayout = ({
         />
       </header>
       <section className={styles['layout']} data-testid="logged-out-section">
+        <h1 className={styles['main-heading']}>{mainHeading}</h1>
         <div className={styles['content']}>{children}</div>
         {showBackToSignInButton && (
           <ButtonLink
@@ -50,6 +52,6 @@ export const AccessibilityLayout = ({
           </ButtonLink>
         )}
       </section>
-    </Layout>
+    </OldLayout>
   )
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32796

**Objectif**
Corriger l'affichage de la page d'accessibilité en mode déconnecté. Comme pour les autres pages hors connexion j'ai remplacé le `Layout` par le `OldLayout`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
