### PR TITLE
(PC-32803)[API] fix: explicitely set archived collective offers as inactive

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 950206dfe815 (pre) (head)
-464e20772637 (post) (head)
+6519c3689ae8 (post) (head)

--- a/api/src/pcapi/alembic/versions/20241104T112917_4999605acac1_fix_archived_collective_offer_templates.py
+++ b/api/src/pcapi/alembic/versions/20241104T112917_4999605acac1_fix_archived_collective_offer_templates.py
@@ -1,0 +1,31 @@
+"""Fix archived collective offer templates
+"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "4999605acac1"
+down_revision = "464e20772637"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""SET SESSION statement_timeout = '600s'""")
+    op.execute(
+        # Test: 4 seconds on staging
+        """
+        UPDATE collective_offer_template
+        SET "isActive" = false
+        WHERE "dateArchived" IS NOT NULL
+    """
+    )
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/alembic/versions/20241104T113207_6519c3689ae8_fix_archived_collective_offers.py
+++ b/api/src/pcapi/alembic/versions/20241104T113207_6519c3689ae8_fix_archived_collective_offers.py
@@ -1,0 +1,31 @@
+"""Fix archived collective offers
+"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "6519c3689ae8"
+down_revision = "4999605acac1"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""SET SESSION statement_timeout = '600s'""")
+    op.execute(
+        # Test: 16 seconds on staging
+        """
+        UPDATE collective_offer
+        SET "isActive" = false
+        WHERE "dateArchived" IS NOT NULL
+    """
+    )
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -387,7 +387,7 @@ def create_collective_offer_by_status(
 ) -> models.CollectiveOffer:
     match status.value:
         case CollectiveOfferDisplayedStatus.ARCHIVED.value:
-            kwargs["dateArchived"] = datetime.datetime.utcnow()
+            kwargs.update({"isActive": False, "dateArchived": datetime.datetime.utcnow()})
             return CollectiveOfferFactory(**kwargs)
         case CollectiveOfferDisplayedStatus.REJECTED.value:
             kwargs["validation"] = OfferValidationStatus.REJECTED
@@ -454,7 +454,7 @@ def create_collective_offer_template_by_status(
 ) -> models.CollectiveOfferTemplate:
     match status.value:
         case CollectiveOfferDisplayedStatus.ARCHIVED.value:
-            kwargs["dateArchived"] = datetime.datetime.utcnow()
+            kwargs.update({"isActive": False, "dateArchived": datetime.datetime.utcnow()})
             return CollectiveOfferTemplateFactory(**kwargs)
 
         case CollectiveOfferDisplayedStatus.REJECTED.value:

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -416,9 +416,9 @@ def patch_collective_offers_archive(
     collective_query = educational_api_offer.get_query_for_collective_offers_by_ids_for_user(current_user, body.ids)
 
     if educational_api_offer.query_has_any_archived(collective_query):
-        raise ApiErrors({"global": ["One of the offer is already archived"]}, status_code=422)
+        raise ApiErrors({"global": ["One of the offers is already archived"]}, status_code=422)
 
-    offers_api.batch_update_collective_offers(collective_query, {"dateArchived": datetime.utcnow()})
+    offers_api.batch_update_collective_offers(collective_query, {"isActive": False, "dateArchived": datetime.utcnow()})
 
 
 @private_api.route("/collective/offers-template/active-status", methods=["PATCH"])
@@ -454,7 +454,9 @@ def patch_collective_offers_template_archive(
     collective_template_query = educational_api_offer.get_query_for_collective_offers_template_by_ids_for_user(
         current_user, body.ids
     )
-    offers_api.batch_update_collective_offers_template(collective_template_query, {"dateArchived": datetime.utcnow()})
+    offers_api.batch_update_collective_offers_template(
+        collective_template_query, {"isActive": False, "dateArchived": datetime.utcnow()}
+    )
 
 
 @private_api.route("/collective/offers/<int:offer_id>/educational_institution", methods=["PATCH"])

--- a/api/tests/core/educational/test_models.py
+++ b/api/tests/core/educational/test_models.py
@@ -304,13 +304,14 @@ class CollectiveOfferIsArchiveTest:
 
         assert offer.isArchived == False
 
+        offer.isActive = False
         offer.dateArchived = datetime.datetime.utcnow()
 
         assert offer.isArchived == True
         assert offer.status == CollectiveOfferStatus.ARCHIVED.value
 
     def test_query_is_archived(self) -> None:
-        offer_archived = factories.CollectiveOfferFactory(dateArchived=datetime.datetime.utcnow())
+        offer_archived = factories.CollectiveOfferFactory(isActive=False, dateArchived=datetime.datetime.utcnow())
         offer_not_archived = factories.CollectiveOfferFactory(dateArchived=None)
 
         results = db.session.query(CollectiveOffer.id).filter(CollectiveOffer.isArchived).all()
@@ -321,7 +322,7 @@ class CollectiveOfferIsArchiveTest:
         assert offer_not_archived.id not in results_ids
 
     def test_query_status_for_archived(self) -> None:
-        offer_archived = factories.CollectiveOfferFactory(dateArchived=datetime.datetime.utcnow())
+        offer_archived = factories.CollectiveOfferFactory(isActive=False, dateArchived=datetime.datetime.utcnow())
         offer_not_archived = factories.CollectiveOfferFactory(dateArchived=None)
 
         results = db.session.query(CollectiveOffer.id, CollectiveOffer.status).all()

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1483,7 +1483,9 @@ class GetFilteredCollectiveOffersTest:
             venue__managingOfferer=user_offerer.offerer
         )
         collective_offer_archived = educational_factories.CollectiveOfferFactory(
-            venue__managingOfferer=user_offerer.offerer, dateArchived=datetime.datetime(year=2000, month=1, day=1)
+            venue__managingOfferer=user_offerer.offerer,
+            isActive=False,
+            dateArchived=datetime.datetime(year=2000, month=1, day=1),
         )
 
         offers = repository.get_collective_offers_by_filters(

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -332,7 +332,9 @@ class GetCollectiveOfferTemplatesTest:
 
     def test_one_template_id_with_one_archived_template(self, eac_client, redactor):
         offer = educational_factories.CollectiveOfferTemplateFactory()
-        archived_offer = educational_factories.CollectiveOfferTemplateFactory(dateArchived=datetime.datetime.utcnow())
+        archived_offer = educational_factories.CollectiveOfferTemplateFactory(
+            isActive=False, dateArchived=datetime.datetime.utcnow()
+        )
 
         url = url_for(self.endpoint, ids=[offer.id, archived_offer.id])
 

--- a/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution.py
+++ b/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution.py
@@ -47,6 +47,7 @@ class CollectiveOfferTest:
             },
         )
         # this archived offer should not appear in the result
+        stocks[2].collectiveOffer.isActive = False
         stocks[2].collectiveOffer.dateArchived = datetime.utcnow() - timedelta(days=1)
 
         dst = url_for("adage_iframe.get_collective_offers_for_my_institution")


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32803

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
