### PR TITLE
(PC-32625)[ADAGE] fix: handle empty json response in adage client

### DIFF
--- a/api/src/pcapi/core/educational/adage_backends/adage.py
+++ b/api/src/pcapi/core/educational/adage_backends/adage.py
@@ -1,4 +1,5 @@
 import datetime
+from json import JSONDecodeError
 import logging
 import traceback
 
@@ -34,7 +35,16 @@ class AdageHttpClient(AdageClient):
 
     @staticmethod
     def _get_api_adage_exception(api_response: requests.Response, message: str) -> exceptions.AdageException:
-        detail = dict(api_response.json()).get("detail", "")
+        try:
+            json_response = api_response.json()
+        except JSONDecodeError:
+            return exceptions.AdageException(
+                message=f"Error while reading Adage API json response - status code: {api_response.status_code}",
+                status_code=api_response.status_code,
+                response_text=api_response.text,
+            )
+
+        detail = dict(json_response).get("detail", "")
 
         full_message = f"{message} - status code: {api_response.status_code}"
         if detail:

--- a/api/tests/core/educational/adage_backends/test_adage.py
+++ b/api/tests/core/educational/adage_backends/test_adage.py
@@ -29,41 +29,33 @@ ADAGE_RESPONSE_FOR_ERROR = {
 class AdageHttpClientTest:
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_notify_prebooking_success_if_201(self, requests_mock):
-        # Given
         adage_client = AdageHttpClient()
         booking = educational_factories.CollectiveBookingFactory()
         booking_data = prebooking.serialize_collective_booking(booking)
 
-        # When
         endpoint = requests_mock.post(f"{MOCK_API_URL}/v1/prereservation", status_code=201)
         adage_client.notify_prebooking(booking_data)
 
-        # Then
         assert endpoint.called
 
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_notify_prebooking_success_if_404(self, requests_mock):
-        # Given
         adage_client = AdageHttpClient()
         booking = educational_factories.CollectiveBookingFactory()
         booking_data = prebooking.serialize_collective_booking(booking)
 
-        # When
         requests_mock.post(
             f"{MOCK_API_URL}/v1/prereservation", status_code=404, json=ADAGE_RESPONSE_FOR_INSTITUTION_WITHOUT_EMAIL
         )
 
-        # When
         adage_client.notify_prebooking(booking_data)
 
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_notify_prebooking_raises_if_500(self, requests_mock):
-        # Given
         adage_client = AdageHttpClient()
         booking = educational_factories.CollectiveBookingFactory()
         booking_data = prebooking.serialize_collective_booking(booking)
 
-        # When
         requests_mock.post(f"{MOCK_API_URL}/v1/prereservation", status_code=500, json=ADAGE_RESPONSE_FOR_ERROR)
         with pytest.raises(AdageException) as ex:
             adage_client.notify_prebooking(booking_data)
@@ -72,7 +64,6 @@ class AdageHttpClientTest:
 
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_notify_institution_association_success_if_201(self, requests_mock):
-        # Given
         adage_client = AdageHttpClient()
         offer = educational_factories.CollectiveOfferFactory(
             institution=educational_factories.EducationalInstitutionFactory(),
@@ -80,16 +71,13 @@ class AdageHttpClientTest:
         )
         offer_data = serialize_collective_offer(offer)
 
-        # When
         endpoint = requests_mock.post(f"{MOCK_API_URL}/v1/offre-assoc", status_code=201)
         adage_client.notify_institution_association(offer_data)
 
-        # Then
         assert endpoint.called
 
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_notify_institution_association_success_if_404(self, requests_mock):
-        # Given
         adage_client = AdageHttpClient()
         offer = educational_factories.CollectiveOfferFactory(
             institution=educational_factories.EducationalInstitutionFactory(),
@@ -97,18 +85,15 @@ class AdageHttpClientTest:
         )
         offer_data = serialize_collective_offer(offer)
 
-        # When
         endpoint = requests_mock.post(
             f"{MOCK_API_URL}/v1/offre-assoc", status_code=404, json=ADAGE_RESPONSE_FOR_INSTITUTION_WITHOUT_EMAIL
         )
         adage_client.notify_institution_association(offer_data)
 
-        # Then
         assert endpoint.called
 
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_notify_institution_association_raises_if_500(self, requests_mock):
-        # Given
         adage_client = AdageHttpClient()
         offer = educational_factories.CollectiveOfferFactory(
             institution=educational_factories.EducationalInstitutionFactory(),
@@ -116,7 +101,6 @@ class AdageHttpClientTest:
         )
         offer_data = serialize_collective_offer(offer)
 
-        # When
         requests_mock.post(f"{MOCK_API_URL}/v1/offre-assoc", status_code=500, json=ADAGE_RESPONSE_FOR_ERROR)
         with pytest.raises(AdageException) as ex:
             adage_client.notify_institution_association(offer_data)
@@ -124,15 +108,27 @@ class AdageHttpClientTest:
         assert ex.value.message == "Error getting Adage API - status code: 500 - error code: ERROR"
 
     @override_settings(ADAGE_API_URL=MOCK_API_URL)
+    def test_api_error_invalid_json(self, requests_mock):
+        adage_client = AdageHttpClient()
+        offer = educational_factories.CollectiveOfferFactory(
+            institution=educational_factories.EducationalInstitutionFactory(),
+            collectiveStock=educational_factories.CollectiveStockFactory(),
+        )
+        offer_data = serialize_collective_offer(offer)
+
+        requests_mock.post(f"{MOCK_API_URL}/v1/offre-assoc", status_code=500, json=None)
+        with pytest.raises(AdageException) as ex:
+            adage_client.notify_institution_association(offer_data)
+
+        assert ex.value.message == "Error while reading Adage API json response - status code: 500"
+
+    @override_settings(ADAGE_API_URL=MOCK_API_URL)
     def test_redactor_when_collective_request_is_made_success_if_201(self, requests_mock):
-        # Given
         adage_client = AdageHttpClient()
         request = educational_factories.CollectiveOfferRequestFactory()
         request_data = serialize_collective_offer_request(request)
 
-        # When
         endpoint = requests_mock.post(f"{MOCK_API_URL}/v1/offre-vitrine", status_code=201)
         adage_client.notify_redactor_when_collective_request_is_made(request_data)
 
-        # Then
         assert endpoint.called


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32625

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
