### PR TITLE
(PC-32741)[PRO] fix: Prevent archive an archived offer that was terim…

### DIFF
--- a/pro/src/components/ArchiveConfirmationModal/utils/__specs__/canArchiveCollectiveOffer.spec.ts
+++ b/pro/src/components/ArchiveConfirmationModal/utils/__specs__/canArchiveCollectiveOffer.spec.ts
@@ -137,4 +137,29 @@ describe('canArchiveCollectiveOffer', () => {
       )
     ).toStrictEqual(false)
   })
+
+  it('should not be able to archive when the offer is already archived and the offer is reimbursed', () => {
+    expect(
+      canArchiveCollectiveOffer(
+        collectiveOfferFactory({
+          status: CollectiveOfferStatus.ARCHIVED,
+          booking: {
+            booking_status: CollectiveBookingStatus.REIMBURSED,
+            id: 1,
+          },
+        })
+      )
+    ).toStrictEqual(false)
+  })
+
+  it('should not be able to archive from summary when the offer is already archived and the offer is reimbursed', () => {
+    expect(
+      canArchiveCollectiveOfferFromSummary(
+        getCollectiveOfferFactory({
+          status: CollectiveOfferStatus.ARCHIVED,
+          lastBookingStatus: CollectiveBookingStatus.REIMBURSED,
+        })
+      )
+    ).toStrictEqual(false)
+  })
 })

--- a/pro/src/components/ArchiveConfirmationModal/utils/canArchiveCollectiveOffer.ts
+++ b/pro/src/components/ArchiveConfirmationModal/utils/canArchiveCollectiveOffer.ts
@@ -11,6 +11,10 @@ import { isCollectiveOfferTemplate } from 'commons/core/OfferEducational/types'
 
 // FIXME: delete the functions in this file when the ticket front is finished : https://passculture.atlassian.net/browse/PC-30662
 export function canArchiveCollectiveOffer(offer: CollectiveOfferResponseModel) {
+  if (offer.status === CollectiveOfferStatus.ARCHIVED) {
+    return false
+  }
+
   const startDatetime = offer.stocks[0].beginningDatetime
 
   const canArchiveThisOffer =
@@ -36,6 +40,9 @@ export function canArchiveCollectiveOfferFromSummary(
     | GetCollectiveOfferResponseModel
     | GetCollectiveOfferTemplateResponseModel
 ) {
+  if (offer.status === CollectiveOfferStatus.ARCHIVED) {
+    return false
+  }
   if (isCollectiveOfferTemplate(offer)) {
     const canArchiveThisOffer =
       offer.status === CollectiveOfferStatus.ACTIVE ||


### PR DESCRIPTION
…nated.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32741

**Objectif**
Corriger l'affichage du bouton "Archiver" sur la page récap d'une offre réservable. Aujourd'hui quand l'offre est archivée après être terminée, le status n'est pas vérifié et on affiche le bouton "Archiver" alors que c'est déjà le cas.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
