### PR TITLE
(PC-32088)[API] feat: Fill label column with Venue.common_name when A…

### DIFF
--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -19,6 +19,7 @@ from pcapi.connectors.entreprise import exceptions as entreprise_exceptions
 from pcapi.core.educational import models as educational_models
 from pcapi.core.external.attributes import api as external_attributes_api
 from pcapi.core.finance import models as finance_models
+from pcapi.core.geography import models as geography_models
 from pcapi.core.history import api as history_api
 from pcapi.core.history import models as history_models
 from pcapi.core.mails import transactional as transactional_mails
@@ -840,12 +841,34 @@ def get_managed_venues(offerer_id: int) -> utils.BackofficeResponse:
 @repository.atomic()
 def get_offerer_addresses(offerer_id: int) -> utils.BackofficeResponse:
     offerer_addresses = (
-        offerers_models.OffererAddress.query.filter_by(offererId=offerer_id)
-        .options(
-            sa.orm.load_only(offerers_models.OffererAddress.label),
-            sa.orm.joinedload(offerers_models.OffererAddress.address),
+        db.session.query(
+            geography_models.Address.id,
+            geography_models.Address.street,
+            geography_models.Address.postalCode,
+            geography_models.Address.city,
+            geography_models.Address.banId,
+            geography_models.Address.latitude,
+            geography_models.Address.longitude,
+            sa.func.array_agg(
+                sa.func.coalesce(
+                    offerers_models.OffererAddress.label, offerers_models.Venue.publicName, offerers_models.Venue.name
+                )
+            ).label("titles"),
         )
-        .order_by(offerers_models.OffererAddress.label)
+        .select_from(geography_models.Address)
+        .join(offerers_models.OffererAddress)
+        .outerjoin(offerers_models.Venue, offerers_models.OffererAddress.id == offerers_models.Venue.offererAddressId)
+        .filter(offerers_models.OffererAddress.offererId == offerer_id)
+        .group_by(
+            geography_models.Address.id,
+            geography_models.Address.street,
+            geography_models.Address.postalCode,
+            geography_models.Address.city,
+            geography_models.Address.banId,
+            geography_models.Address.latitude,
+            geography_models.Address.longitude,
+        )
+        .order_by(geography_models.Address.street)
         .all()
     )
 

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/addresses.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/addresses.html
@@ -11,28 +11,39 @@
     </tr>
   </thead>
   <tbody>
-    {% for offerer_address in offerer_addresses %}
+    {% for address in offerer_addresses %}
       <tr>
         <th scope="row"></th>
-        <td>{{ offerer_address.label | empty_string_if_null }}</td>
-        <td>
-          {{ offerer_address.address.street | empty_string_if_null }} {{ offerer_address.address.postalCode }} {{ offerer_address.address.city }}
-        </td>
-        <td>{{ links.build_external_address_link(offerer_address.address) }}</td>
-        <td>
-          {% set search_params = {
-                      "search-0-search_field": "OFFERER",
-                      "search-0-operator": "IN",
-                      "search-0-offerer": offerer_id,
-                      "search-1-search_field": "ADDRESS",
-                      "search-1-operator": "IN",
-                      "search-1-address": offerer_address.address.id,
-                    } %}
-          <a href="{{ url_for('backoffice_web.offer.list_offers', **search_params) }}"
-             class="link-primary">individuelles</a>
-        </td>
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
-</turbo-frame>
+        {% if address.titles %}
+          <td>
+            {# Display all address.label/venue.name except `None` values #}
+            {% for title in address.titles if title %}
+              {% if not loop.last %}
+                {# Trailing comma for elements except last one #}
+                {{ title }},
+              {% else %}
+                {{ title }}
+              {% endif %}
+            {% endfor %}
+          {% else %}
+            <td></td>
+          {% endif %}
+          <td>{{ address.street | empty_string_if_null }} {{ address.postalCode }} {{ address.city }}</td>
+          <td>{{ links.build_external_address_link(address) }}</td>
+          <td>
+            {% set search_params = {
+                          "search-0-search_field": "OFFERER",
+                          "search-0-operator": "IN",
+                          "search-0-offerer": offerer_id,
+                          "search-1-search_field": "ADDRESS",
+                          "search-1-operator": "IN",
+                          "search-1-address": address.id,
+                        } %}
+            <a href="{{ url_for('backoffice_web.offer.list_offers', **search_params) }}"
+               class="link-primary">individuelles</a>
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  </turbo-frame>


### PR DESCRIPTION
…ddress.label is empty

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32088

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques

(Offerer)Address référencée par trois lieux, sans label
![Capture d’écran du 2024-11-04 16-01-35](https://github.com/user-attachments/assets/f7235401-5d14-433c-a404-f065b26d1797)
(Offerer)Address référencée par aucun lieu, sans label
(Offerer)Address référencée par un seul lieu, sans label
![Capture d’écran du 2024-11-04 16-01-16](https://github.com/user-attachments/assets/f33bd48c-5729-47e8-952a-0cf153d764f7)
