### PR TITLE
(BSR)[API] chore: one-shot script which updates external attributes for users/venues in Saint-Martin

### DIFF
--- a/api/src/pcapi/scripts/update_external_attributes_saint_martin/main.py
+++ b/api/src/pcapi/scripts/update_external_attributes_saint_martin/main.py
@@ -1,0 +1,23 @@
+from pcapi.app import app
+from pcapi.core.external.attributes.api import update_external_pro
+from pcapi.core.external.attributes.api import update_external_user
+from pcapi.core.offerers.models import Venue
+from pcapi.core.users.models import User
+
+
+if __name__ == "__main__":
+    app.app_context().push()
+
+    users = User.query.filter(User.departementCode == "978").all()
+    print(len(users), "users found")
+
+    for i, user in enumerate(users):
+        print(i, "- Update user ID:", user.id)
+        update_external_user(user)
+
+    venues = Venue.query.filter(Venue.departementCode == "978").all()
+    print(len(venues), "venues found")
+
+    for i, venue in enumerate(venues):
+        print(i, "- Update venue ID:", venue.id)
+        update_external_pro(venue.bookingEmail)


### PR DESCRIPTION
## But de la pull request

Mise à jour des attributs sur Brevo, Batch et Beamer pour les utilisateurs et lieux à Saint-Martin.
Fait suite à la correction du département en base de données : 978 au lieu de 971.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
