### PR TITLE
(PC-32359)[PRO] feat: Allow edition actions of collective offers in t…

### DIFF
--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -66,6 +66,18 @@ export interface CollectiveActionsCellsProps {
 
 const LOCAL_STORAGE_HAS_SEEN_MODAL_KEY = 'DUPLICATE_OFFER_MODAL_SEEN'
 
+function hasOfferAnyEditionActionAllowed(offer: CollectiveOfferResponseModel) {
+  return offer.allowedActions.some((action) =>
+    [
+      CollectiveOfferTemplateAllowedAction.CAN_EDIT_DETAILS,
+      CollectiveOfferAllowedAction.CAN_EDIT_DATES,
+      CollectiveOfferAllowedAction.CAN_EDIT_DETAILS,
+      CollectiveOfferAllowedAction.CAN_EDIT_DISCOUNT,
+      CollectiveOfferAllowedAction.CAN_EDIT_INSTITUTION,
+    ].includes(action)
+  )
+}
+
 export const CollectiveActionsCells = ({
   offer,
   editionOfferLink,
@@ -261,6 +273,12 @@ export const CollectiveActionsCells = ({
     ? offer.allowedActions.length === 0
     : offer.isShowcase && offer.status === CollectiveOfferStatus.ARCHIVED
 
+  const canEditOffer = areCollectiveNewStatusesEnabled
+    ? hasOfferAnyEditionActionAllowed(offer)
+    : offer.isEditable &&
+      !offer.isPublicApi &&
+      offer.status !== CollectiveOfferStatus.ARCHIVED
+
   return (
     <td
       className={cn(styles['offers-table-cell'], styles['actions-column'])}
@@ -345,20 +363,18 @@ export const CollectiveActionsCells = ({
                   </DropdownMenu.Item>
                 )}
 
-                {offer.isEditable &&
-                  !offer.isPublicApi &&
-                  offer.status !== CollectiveOfferStatus.ARCHIVED && (
-                    <DropdownMenu.Item className={styles['menu-item']} asChild>
-                      <ButtonLink
-                        to={editionOfferLink}
-                        icon={fullPenIcon}
-                        className={styles['button']}
-                        onClick={handleEditOfferClick}
-                      >
-                        Modifier
-                      </ButtonLink>
-                    </DropdownMenu.Item>
-                  )}
+                {canEditOffer && (
+                  <DropdownMenu.Item className={styles['menu-item']} asChild>
+                    <ButtonLink
+                      to={editionOfferLink}
+                      icon={fullPenIcon}
+                      className={styles['button']}
+                      onClick={handleEditOfferClick}
+                    >
+                      Modifier
+                    </ButtonLink>
+                  </DropdownMenu.Item>
+                )}
                 {offer.status === CollectiveOfferStatus.SOLD_OUT &&
                   offer.booking &&
                   (offer.booking.booking_status ===


### PR DESCRIPTION
…he offers list based on the allowedActions.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32359

**Objectif**
Sous FF `ENABLE_COLLECTIVE_NEW_STATUSES`. Utilisation de `offer.allowedActions` pour décider si oui ou non on affiche le bouton "Modifier" dans les actions des offres de la liste des offres collectives.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
