### PR TITLE
PC 32626/feat update offer name

### DIFF
--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -2979,6 +2979,15 @@
                         "nullable": true,
                         "title": "Itemcollectiondetails",
                         "type": "string"
+                    },
+                    "name": {
+                        "description": "Offer title",
+                        "example": "Le Petit Prince",
+                        "maxLength": 140,
+                        "minLength": 1,
+                        "nullable": true,
+                        "title": "Name",
+                        "type": "string"
                     }
                 },
                 "title": "EventOfferEdition",

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -269,6 +269,7 @@ def edit_event(event_id: int, body: serialization.EventOfferEdition) -> serializ
                 idAtProvider=get_field(offer, updates, "idAtProvider"),
                 isDuo=get_field(offer, updates, "enableDoubleBookings", col="isDuo"),
                 withdrawalDetails=get_field(offer, updates, "itemCollectionDetails", col="withdrawalDetails"),
+                name=get_field(offer, updates, "name"),
             )  # type: ignore[call-arg]
             offer = offers_api.update_offer(offer, offer_body)
             if body.image:

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -578,6 +578,11 @@ class EventOfferCreation(OfferCreationBase):
         extra = "forbid"
 
 
+class OfferName(pydantic_v1.ConstrainedStr):
+    min_length = 1
+    max_length = 140
+
+
 class OfferEditionBase(serialization.ConfiguredBaseModel):
     accessibility: accessibility_serialization.PartialAccessibility | None = pydantic_v1.Field(
         description="Accessibility to disabled people. Leave fields undefined to keep current value"
@@ -592,6 +597,7 @@ class OfferEditionBase(serialization.ConfiguredBaseModel):
     image: ImageBody | None
     description: str | None = fields.OFFER_DESCRIPTION_WITH_MAX_LENGTH
     id_at_provider: str | None = fields.ID_AT_PROVIDER_WITH_MAX_LENGTH
+    name: OfferName | None = fields.OFFER_NAME
 
     class Config:
         extra = "forbid"
@@ -600,11 +606,6 @@ class OfferEditionBase(serialization.ConfiguredBaseModel):
 STOCK_EDITION_FIELD = pydantic_v1.Field(
     description="If stock is set to null, all cancellable bookings (i.e not used) will be cancelled. To prevent from further bookings, you may alternatively set stock.quantity to the bookedQuantity (but not below).",
 )
-
-
-class OfferName(pydantic_v1.ConstrainedStr):
-    min_length = 1
-    max_length = 140
 
 
 class ProductOfferEdition(OfferEditionBase):

--- a/api/tests/routes/public/individual_offers/v1/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_event_test.py
@@ -168,6 +168,7 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
             extraData={"gtl_id": "02000000"},
         )
 
+        new_name = event_offer.name + "_updated"
         response = client.with_explicit_token(plain_api_key).patch(
             self.endpoint_url.format(event_id=event_offer.id),
             json={
@@ -179,6 +180,7 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
                 "description": "A new description",
                 "image": {"file": image_data.GOOD_IMAGE},
                 "idAtProvider": "oh it has been updated",
+                "name": new_name,
             },
         )
 
@@ -191,6 +193,7 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
         assert event_offer.withdrawalDetails == "Here !"
         assert event_offer.description == "A new description"
         assert event_offer.idAtProvider == "oh it has been updated"
+        assert event_offer.name == new_name
 
         assert offers_models.Mediation.query.one()
         assert (


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32626

Avant : seuls les noms des produits pouvaient être mis à jour via l'API publique.
Après : les noms des événements et des produits peuvent être mis à jour via l'API.
