### PR TITLE
(PC-32868)[PRO] fix: Export the summary component so that it can be l…

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferNavigation/CollectiveOfferNavigation.tsx
@@ -330,17 +330,19 @@ export const CollectiveOfferNavigation = ({
         )}
       </div>
       <Divider />
-      <Tabs
-        tabs={tabs}
-        selectedKey={activeStep}
-        className={cn(styles['tabs'], {
-          [styles['tabs-active']]: [
-            CollectiveOfferStep.DETAILS,
-            CollectiveOfferStep.STOCKS,
-            CollectiveOfferStep.VISIBILITY,
-          ].includes(activeStep),
-        })}
-      />
+      {tabs.length > 0 && (
+        <Tabs
+          tabs={tabs}
+          selectedKey={activeStep}
+          className={cn(styles['tabs'], {
+            [styles['tabs-active']]: [
+              CollectiveOfferStep.DETAILS,
+              CollectiveOfferStep.STOCKS,
+              CollectiveOfferStep.VISIBILITY,
+            ].includes(activeStep),
+          })}
+        />
+      )}
       <ArchiveConfirmationModal
         onDismiss={() => setIsArchiveModalOpen(false)}
         onValidate={archiveOffer}

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.spec.tsx
@@ -5,12 +5,11 @@ import {
   GetCollectiveOfferResponseModel,
   GetCollectiveOfferTemplateResponseModel,
 } from 'apiClient/v1'
-import { Mode } from 'commons/core/OfferEducational/types'
 import { getCollectiveOfferTemplateFactory } from 'commons/utils/factories/collectiveApiFactories'
 import { sharedCurrentUserFactory } from 'commons/utils/factories/storeFactories'
 import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
-import { CollectiveOfferSummaryEditionScreen } from './CollectiveOfferSummaryEdition'
+import { CollectiveOfferSummaryEdition } from './CollectiveOfferSummaryEdition'
 
 const fetchMock = createFetchMock(vi)
 fetchMock.enableMocks()
@@ -20,10 +19,9 @@ const renderCollectiveOfferSummaryEdition = (
     | GetCollectiveOfferTemplateResponseModel
     | GetCollectiveOfferResponseModel
 ) => {
-  renderWithProviders(
-    <CollectiveOfferSummaryEditionScreen offer={offer} mode={Mode.EDITION} />,
-    { user: sharedCurrentUserFactory() }
-  )
+  renderWithProviders(<CollectiveOfferSummaryEdition offer={offer} />, {
+    user: sharedCurrentUserFactory(),
+  })
 }
 
 describe('CollectiveOfferSummary', () => {

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -2,6 +2,7 @@ import {
   GetCollectiveOfferTemplateResponseModel,
   GetCollectiveOfferResponseModel,
 } from 'apiClient/v1'
+import { Layout } from 'app/App/layout/Layout'
 import {
   Mode,
   isCollectiveOfferTemplate,
@@ -10,6 +11,8 @@ import { computeURLCollectiveOfferId } from 'commons/core/OfferEducational/utils
 import { computeCollectiveOffersUrl } from 'commons/core/Offers/utils/computeCollectiveOffersUrl'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { OfferEducationalActions } from 'components/OfferEducationalActions/OfferEducationalActions'
+import { withCollectiveOfferFromParams } from 'pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/useCollectiveOfferFromParams'
+import { CollectiveOfferLayout } from 'pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferLayout'
 import { CollectiveOfferSummary } from 'pages/CollectiveOffer/CollectiveOfferSummary/components/CollectiveOfferSummary/CollectiveOfferSummary'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -20,12 +23,10 @@ interface CollectiveOfferSummaryEditionProps {
   offer:
     | GetCollectiveOfferTemplateResponseModel
     | GetCollectiveOfferResponseModel
-  mode: Mode
 }
 
-export const CollectiveOfferSummaryEditionScreen = ({
+export const CollectiveOfferSummaryEdition = ({
   offer,
-  mode,
 }: CollectiveOfferSummaryEditionProps) => {
   const offerEditLink = `/offre/${computeURLCollectiveOfferId(
     offer.id,
@@ -40,35 +41,47 @@ export const CollectiveOfferSummaryEditionScreen = ({
   const visibilityEditLink = `/offre/${offer.id}/collectif/visibilite/edition`
 
   return (
-    <>
-      <OfferEducationalActions
-        className={styles.actions}
-        isBooked={
-          isCollectiveOfferTemplate(offer)
-            ? false
-            : Boolean(offer.collectiveStock?.isBooked)
-        }
+    <Layout layout={'sticky-actions'}>
+      <CollectiveOfferLayout
+        subTitle={offer.name}
+        isTemplate={offer.isTemplate}
         offer={offer}
-        mode={mode}
-      />
+      >
+        <OfferEducationalActions
+          className={styles.actions}
+          isBooked={
+            isCollectiveOfferTemplate(offer)
+              ? false
+              : Boolean(offer.collectiveStock?.isBooked)
+          }
+          offer={offer}
+          mode={Mode.EDITION}
+        />
 
-      <CollectiveOfferSummary
-        offer={offer}
-        offerEditLink={offerEditLink}
-        stockEditLink={stockEditLink}
-        visibilityEditLink={visibilityEditLink}
-      />
+        <CollectiveOfferSummary
+          offer={offer}
+          offerEditLink={offerEditLink}
+          stockEditLink={stockEditLink}
+          visibilityEditLink={visibilityEditLink}
+        />
 
-      <ActionsBarSticky>
-        <ActionsBarSticky.Left>
-          <ButtonLink
-            variant={ButtonVariant.PRIMARY}
-            to={computeCollectiveOffersUrl({})}
-          >
-            Retour à la liste des offres
-          </ButtonLink>
-        </ActionsBarSticky.Left>
-      </ActionsBarSticky>
-    </>
+        <ActionsBarSticky>
+          <ActionsBarSticky.Left>
+            <ButtonLink
+              variant={ButtonVariant.PRIMARY}
+              to={computeCollectiveOffersUrl({})}
+            >
+              Retour à la liste des offres
+            </ButtonLink>
+          </ActionsBarSticky.Left>
+        </ActionsBarSticky>
+      </CollectiveOfferLayout>
+    </Layout>
   )
 }
+
+// Lazy-loaded by react-router-dom
+// ts-unused-exports:disable-next-line
+export const Component = withCollectiveOfferFromParams(
+  CollectiveOfferSummaryEdition
+)


### PR DESCRIPTION
…azy-loaded by the router.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32868

**Objectif**
La page récap collective apparait comme une page blanche, il manquait l'export de `Component` pour qu'elle puisse être lazy-loaded et il manquait aussi le Layout.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
