### PR TITLE
(PC-32869)[BO] fix: venue edition without SIRET (regression)

### DIFF
--- a/api/src/pcapi/routes/backoffice/forms/fields.py
+++ b/api/src/pcapi/routes/backoffice/forms/fields.py
@@ -29,7 +29,6 @@ class PhoneNumberValidator:
 class SiretValidator:
     def __init__(self) -> None:
         self.field_flags = {
-            "required": True,
             "minlength": 14,
             "maxlength": 14,
             "pattern": siren_utils.SIRET_OR_RIDET_RE,
@@ -190,7 +189,7 @@ class PCPhoneNumberField(PCStringField):
 
 
 class PCSiretField(PCStringField):
-    validators = [SiretValidator()]
+    validators = [validators.DataRequired("SIRET obligatoire"), SiretValidator()]
 
 
 class PCOptSiretField(PCSiretField):


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32869

Bug : `PCOptSiretField` se retrouvait avec `"required": True`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
