### PR TITLE
(BSR)[API] chore: Remove `db_session` fixture

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -268,7 +268,7 @@ python_files = ["*test.py", "test*.py"]
 python_classes = ["*Test"]
 python_functions = ["test_*", "when_*", "expect_*", "should_*"]
 env_files = ["local_test_env_file"]
-mocked-sessions = ["pcapi.models.db.session"]
+#mocked-sessions = ["pcapi.models.db.session"]
 junit_family = "xunit1"
 markers = [
     "backoffice"

--- a/api/src/pcapi/core/factories.py
+++ b/api/src/pcapi/core/factories.py
@@ -14,53 +14,55 @@ class BaseFactory(factory.alchemy.SQLAlchemyModelFactory):
         abstract = True
         # See comment in _save()
         # sqlalchemy_session = pcapi.models.db.session
-        sqlalchemy_session = "ignored"  # see hack in `_save()`
-        sqlalchemy_session_persistence = "commit"
+        #sqlalchemy_session = "ignored"  # see hack in `_save()`
+        sqlalchemy_session = db.session
+        #sqlalchemy_session_persistence = "commit"
+        sqlalchemy_session_persistence = "flush"
 
-    @classmethod
-    def _save(
-        cls,
-        model_class: typing.Type[models.Model],
-        session: typing.Any,
-        *args: typing.Any,
-        **kwargs: typing.Any,
-    ) -> models.Model:
-        # pytest-flask-sqlalchemy mocks (replaces) `db.session` to
-        # remove the session and rollback changes at the end of each
-        # test function (see `_session()` fixture in
-        # pytest-flask-sqlalchemy). As such, the session that is used
-        # in tests is not the session we defined in
-        # `Meta.sqlalchemy_session` above. Because of this, data added
-        # through a factory is not rollback'ed. To work around this,
-        # here is a hack.
+    #@classmethod
+    #def _save(
+    #    cls,
+    #    model_class: typing.Type[models.Model],
+    #    session: typing.Any,
+    #    *args: typing.Any,
+    #    **kwargs: typing.Any,
+    #) -> models.Model:
+    #    # pytest-flask-sqlalchemy mocks (replaces) `db.session` to
+    #    # remove the session and rollback changes at the end of each
+    #    # test function (see `_session()` fixture in
+    #    # pytest-flask-sqlalchemy). As such, the session that is used
+    #    # in tests is not the session we defined in
+    #    # `Meta.sqlalchemy_session` above. Because of this, data added
+    #    # through a factory is not rollback'ed. To work around this,
+    #    # here is a hack.
 
-        # This issue is discussed here: https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/12
-        session = db.session
+    #    # This issue is discussed here: https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/12
+    #    session = db.session
 
-        known_fields = {
-            prop.key
-            for prop in sqlalchemy.orm.class_mapper(model_class).iterate_properties
-            if isinstance(prop, (sqlalchemy.orm.ColumnProperty, sqlalchemy.orm.RelationshipProperty))
-        }
-        unknown_fields = set(kwargs.keys()) - known_fields
-        if unknown_fields:
-            raise ValueError(
-                f"{cls.__name__} received unexpected argument(s): "
-                f"{', '.join(sorted(unknown_fields))}. "
-                f"Possible arguments are: {', '.join(sorted(known_fields))}"
-            )
+    #    known_fields = {
+    #        prop.key
+    #        for prop in sqlalchemy.orm.class_mapper(model_class).iterate_properties
+    #        if isinstance(prop, (sqlalchemy.orm.ColumnProperty, sqlalchemy.orm.RelationshipProperty))
+    #    }
+    #    unknown_fields = set(kwargs.keys()) - known_fields
+    #    if unknown_fields:
+    #        raise ValueError(
+    #            f"{cls.__name__} received unexpected argument(s): "
+    #            f"{', '.join(sorted(unknown_fields))}. "
+    #            f"Possible arguments are: {', '.join(sorted(known_fields))}"
+    #        )
 
-        return super()._save(model_class, session, *args, **kwargs)
+    #    return super()._save(model_class, session, *args, **kwargs)
 
-    @classmethod
-    def _get_or_create(
-        cls,
-        model_class: typing.Type[models.Model],
-        session: typing.Any,
-        *args: typing.Any,
-        **kwargs: typing.Any,
-    ) -> models.Model:
-        # See comment in _save for the reason why we inject the
-        # session like this.
-        session = db.session
-        return super()._get_or_create(model_class, session, *args, **kwargs)
+    #@classmethod
+    #def _get_or_create(
+    #    cls,
+    #    model_class: typing.Type[models.Model],
+    #    session: typing.Any,
+    #    *args: typing.Any,
+    #    **kwargs: typing.Any,
+    #) -> models.Model:
+    #    # See comment in _save for the reason why we inject the
+    #    # session like this.
+    #    session = db.session
+    #    return super()._get_or_create(model_class, session, *args, **kwargs)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -376,7 +376,7 @@ def cloud_task_client_fixture():
 
 @pytest.fixture(name="db_session")
 def db_session():
-    yield
+    yield db.session
     clean_all_database()
 
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -374,6 +374,12 @@ def cloud_task_client_fixture():
         yield cloud_task_client_mock
 
 
+@pytest.fixture(name="db_session")
+def db_session():
+    yield
+    clean_all_database()
+
+
 class TestClient:
     WITH_DOC = False
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -180,21 +180,21 @@ def clean_database():
     clean_all_database()
 
 
-@pytest.fixture(scope="session")
-def _db(app):
-    """
-    Provide the transactional fixtures with access to the database via a Flask-SQLAlchemy
-    database connection.
-    """
-    mock_db = db
-
-    mock_db.init_app(app)
-    install_database_extensions()
-    run_migrations()
-
-    clean_all_database()
-
-    return mock_db
+#@pytest.fixture(scope="session")
+#def _db(app):
+#    """
+#    Provide the transactional fixtures with access to the database via a Flask-SQLAlchemy
+#    database connection.
+#    """
+#    mock_db = db
+#
+#    mock_db.init_app(app)
+#    install_database_extensions()
+#    run_migrations()
+#
+#    clean_all_database()
+#
+#    return mock_db
 
 
 pcapi.core.testing.register_event_for_query_logger()
@@ -374,10 +374,17 @@ def cloud_task_client_fixture():
         yield cloud_task_client_mock
 
 
-@pytest.fixture(name="db_session")
+@pytest.fixture(scope="function")
 def db_session():
-    yield db.session
-    clean_all_database()
+    #yield db.session
+    #clean_all_database()
+    pcapi.models.db.session.commit = lambda *arg, **kwargs: None
+    transaction = pcapi.models.db.session.begin_nested()
+    try:
+        yield pcapi.models.db.session
+    finally:
+        transaction.rollback()
+        pcapi.models.db.session.close()
 
 
 class TestClient:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
