### PR TITLE
(PC-32870)[API] fix: use bankAccount info for pro contacts

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -546,16 +546,16 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
         )
 
     @property
-    def hasPendingBankInformationApplication(self) -> bool:
-        if not self.bankInformation:
+    def hasPendingBankAccountApplication(self) -> bool:
+        if not self.current_bank_account:
             return False
-        return self.bankInformation.status == finance_models.BankInformationStatus.DRAFT
+        return self.current_bank_account.status == finance_models.BankAccountApplicationStatus.DRAFT
 
     @property
-    def demarchesSimplifieesIsAccepted(self) -> bool:
-        if not self.bankInformation:
+    def hasAcceptedBankAccountApplication(self) -> bool:
+        if not self.current_bank_account:
             return False
-        return self.bankInformation.status == finance_models.BankInformationStatus.ACCEPTED
+        return self.current_bank_account.status == finance_models.BankAccountApplicationStatus.ACCEPTED
 
     @property
     def has_individual_offers(self) -> bool:

--- a/api/tests/core/external/external_pro_test.py
+++ b/api/tests/core/external/external_pro_test.py
@@ -6,7 +6,7 @@ from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.external.attributes.api import get_pro_attributes
 import pcapi.core.finance.factories as finance_factories
-from pcapi.core.finance.models import BankInformationStatus
+from pcapi.core.finance.models import BankAccountApplicationStatus
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offerers.models import VenueTypeCode
 from pcapi.core.offers.factories import OfferFactory
@@ -140,8 +140,13 @@ def test_update_external_pro_user_attributes(
     )
 
     if create_dms_accepted:
-        finance_factories.BankInformationFactory(venue=venue1, status=BankInformationStatus.ACCEPTED)
-        finance_factories.BankInformationFactory(venue=venue1b, status=BankInformationStatus.ACCEPTED)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue1, bankAccount=finance_factories.BankAccountFactory(status=BankAccountApplicationStatus.ACCEPTED)
+        )
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue1b,
+            bankAccount=finance_factories.BankAccountFactory(status=BankAccountApplicationStatus.ACCEPTED),
+        )
 
     if create_virtual:
         offerer2 = offerers_factories.OffererFactory(siren="444555666", name="Culture en ligne")
@@ -158,7 +163,10 @@ def test_update_external_pro_user_attributes(
         )
 
         if create_dms_accepted:
-            finance_factories.BankInformationFactory(venue=venue2, status=BankInformationStatus.ACCEPTED)
+            offerers_factories.VenueBankAccountLinkFactory(
+                venue=venue2,
+                bankAccount=finance_factories.BankAccountFactory(status=BankAccountApplicationStatus.ACCEPTED),
+            )
 
     # Offerer not linked to user email but with the same booking email
     offerer3 = offerers_factories.OffererFactory(
@@ -189,9 +197,13 @@ def test_update_external_pro_user_attributes(
                 BookingFactory(stock=stock1)
 
     if create_dms_draft:
-        finance_factories.BankInformationFactory(venue=venue3, status=BankInformationStatus.DRAFT)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue3, bankAccount=finance_factories.BankAccountFactory(status=BankAccountApplicationStatus.DRAFT)
+        )
     elif create_dms_accepted:
-        finance_factories.BankInformationFactory(venue=venue3, status=BankInformationStatus.ACCEPTED)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue3, bankAccount=finance_factories.BankAccountFactory(status=BankAccountApplicationStatus.ACCEPTED)
+        )
     # This offerer is managed by pro user but venue has a different email address
     offerer4 = offerers_factories.OffererFactory(siren="001002003", name="Juste Libraire")
     if attached == "all":
@@ -216,12 +228,18 @@ def test_update_external_pro_user_attributes(
     )
 
     if create_dms_accepted:
-        finance_factories.BankInformationFactory(venue=venue4, status=BankInformationStatus.ACCEPTED)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue4, bankAccount=finance_factories.BankAccountFactory(status=BankAccountApplicationStatus.ACCEPTED)
+        )
     else:
-        # Bank information which do not make dms attributes return True: on offerer, on venue with other email, rejected
-        finance_factories.BankInformationFactory(offerer=offerer1, status=BankInformationStatus.ACCEPTED)
-        finance_factories.BankInformationFactory(venue=venue4, status=BankInformationStatus.ACCEPTED)
-        finance_factories.BankInformationFactory(venue=venue1, status=BankInformationStatus.REJECTED)
+        # Bank accounts which do not make ds attributes return True: on offerer, on venue with other email, refused
+        finance_factories.BankAccountFactory(offerer=offerer1, status=BankAccountApplicationStatus.ACCEPTED)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue4, bankAccount=finance_factories.BankAccountFactory(status=BankAccountApplicationStatus.ACCEPTED)
+        )
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue1, bankAccount=finance_factories.BankAccountFactory(status=BankAccountApplicationStatus.REFUSED)
+        )
 
     # Create inactive offerer and its venue, linked to email, which should not be taken into account in any attribute
     inactive_offerer = offerers_factories.OffererFactory(

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -256,38 +256,6 @@ class IsValidatedTest:
         assert not offerer.isValidated
 
 
-class HasPendingBankInformationApplicationTest:
-    def test_no_application(self):
-        venue = factories.VenueFactory()
-
-        assert venue.hasPendingBankInformationApplication is False
-
-    def test_draft_application(self):
-        venue = factories.VenueFactory()
-        finance_factories.BankInformationFactory(
-            venue=venue, status=finance_models.BankInformationStatus.DRAFT, bic=None, iban=None
-        )
-
-        assert venue.hasPendingBankInformationApplication is True
-
-    def test_accepted_application(self):
-        venue = factories.VenueFactory()
-        finance_factories.BankInformationFactory(
-            venue=venue,
-            status=finance_models.BankInformationStatus.ACCEPTED,
-        )
-
-        assert venue.hasPendingBankInformationApplication is False
-
-    def test_rejected_application(self):
-        venue = factories.VenueFactory()
-        finance_factories.BankInformationFactory(
-            venue=venue, status=finance_models.BankInformationStatus.REJECTED, bic=None, iban=None
-        )
-
-        assert venue.hasPendingBankInformationApplication is False
-
-
 class VenueDmsAdageStatusTest:
     def test_dms_adage_status_when_no_dms_application(self):
         venue = factories.VenueFactory()

--- a/api/tests/routes/external/zendesk_test.py
+++ b/api/tests/routes/external/zendesk_test.py
@@ -5,7 +5,7 @@ import pytest
 
 from pcapi import settings
 import pcapi.core.finance.factories as finance_factories
-from pcapi.core.finance.models import BankInformationStatus
+from pcapi.core.finance.models import BankAccountApplicationStatus
 import pcapi.core.history.factories as history_factories
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.users import constants as user_constants
@@ -219,7 +219,10 @@ class ZendeskWebhookTest:
 
     def test_webhook_update_pro_by_booking_email(self, client):
         venue = offerers_factories.VenueFactory(bookingEmail="venue@example.com", postalCode="06600")
-        finance_factories.BankInformationFactory(venue=venue, status=BankInformationStatus.ACCEPTED)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue,
+            bankAccount=finance_factories.BankAccountFactory(status=BankAccountApplicationStatus.ACCEPTED),
+        )
 
         response = client.post(
             "/webhooks/zendesk/ticket_notification",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32870

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
