### PR TITLE
(PC-32841) script: fix the offerVenue field for collective offers whe…

### DIFF
--- a/api/src/pcapi/scripts/fix_offer_venue_field/main.py
+++ b/api/src/pcapi/scripts/fix_offer_venue_field/main.py
@@ -1,0 +1,40 @@
+import argparse
+import logging
+
+from pcapi.app import app
+from pcapi.core.educational import models as educational_models
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+app.app_context().push()
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--not-dry", action="store_true")
+    args = parser.parse_args()
+
+    invalid_offers = educational_models.CollectiveOffer.query.filter(
+        educational_models.CollectiveOffer.offerVenue.op("->>")("otherAddress").is_(None)
+    ).all()
+
+    logger.info("Found %s offers with invalid offerVenue", len(invalid_offers))
+    try:
+        for offer in invalid_offers:
+            logger.info("Collective offer with id %s is invalid, fixing", offer.id)
+
+            if offer.offerVenue["otherAddress"] is not None:
+                raise ValueError(f"Offer with id {offer.id} does not have otherAddress set to None")
+
+            offer.offerVenue["otherAddress"] = ""
+    except:
+        db.session.rollback()
+        raise
+
+    if args.not_dry:
+        logger.info("Committing fixed offerVenue fields")
+        db.session.commit()
+    else:
+        logger.info("Finished dry run for fixing offerVenue field, rollbacking")
+        db.session.rollback()


### PR DESCRIPTION
…re otherAddress is null

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32841

Pour les offres avec `offerVenue["otherAddress"]` à null, on passe la valeur à "" à la place comme attendu par les schémas

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
