### PR TITLE
Bsr rework pc backend

### DIFF
--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 
 function start_backend {
-    docker_compose_major=$(docker compose -v 2>&1 | sed "s/.*version v*\([0-9]\).\([0-9]*\).\([0-9]*\).*/\1/");
-    docker_compose_minor=$(docker compose -v 2>&1 | sed "s/.*version v*\([0-9]\).\([0-9]*\).\([0-9]*\).*/\2/");
-    if [ "$docker_compose_major" -le "1" ] && [ "$docker_compose_minor" -le "23" ]; then
-        echo "This script requires docker compose 1.24 or greater"
-        exit 1
-    fi
     RUN='cd $ROOT_PATH && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml build && docker compose -f "$ROOT_PATH"/docker-compose-backend.yml up'
 }
 

--- a/pc
+++ b/pc
@@ -7,13 +7,16 @@ set -o nounset
 # =============================================
 
 if [[ $# -eq 0 ]] || [[ "$1" == "-h" ]]; then
-  echo "$(basename "$0") [-h] [-e env -b backend -f file c] -- program to deal with Pass Culture ecosystem
+  echo "$(basename "$0") [-h] [-e env -b backend -f file] c [--fast --force-recreate]
+  program to deal with Pass Culture ecosystem
 where:
   -h  show this help text
   -e  specify environment to target (default: development)
   -b  specify backend to connect with local app (default: localhost)
   -f  file to upload to pod
   -t  specify version you want to deploy (create tag with this name)
+  --fast avoid rebuilding the docker images
+  --force-recreate force recreation of the docker images
   c  command that you want to run
 
 Commands:
@@ -80,13 +83,25 @@ else
   FILE_TO_UPLOAD=${FILE_TO_UPLOAD:-'none'}
 fi
 
+if [[ $# -gt 1 ]] && [[ "$2" == '--fast' ]]; then
+  FAST=true
+else
+  FAST=false
+fi
+
+if [[ $# -gt 1 ]] && [[ "$2" == '--force-recreate' ]]; then
+  SLOW=true
+else
+  SLOW=false
+fi
+
 CMD="$1"
 shift
 
 # =============================================
 # Utilities functions
 # =============================================
-
+RUN=""
 PRG="$BASH_SOURCE"
 
 while [ -h "$PRG" ]; do
@@ -191,11 +206,18 @@ elif [[ "$CMD" == "psql-file" ]]; then
 # Restart API after removing the database and files
 elif [[ "$CMD" == "restart-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
-  restart_backend
+  SLOW=true
+  drop_data
+  build_backend
+  start_backend
+
 
 elif [[ "$CMD" == "restart-proxy-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
-  restart_proxy_backend
+  SLOW=true
+  drop_data
+  build_proxy_backend
+  start_backend
 
 # Clear all data in postgresql database
 elif [[ "$CMD" == "reset-all-db" ]]; then
@@ -222,16 +244,18 @@ elif [[ "$CMD" == "restore-db" ]]; then
 # Start API server with database and nginx server (builds the images first)
 elif [[ "$CMD" == "start-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
+  build_backend
   start_backend
 
 elif [[ "$CMD" == "start-proxy-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
-  start_proxy_backend
+  build_proxy_backend
+  start_backend
 
 # Start API server with database and nginx server (without building the images)
 elif [[ "$CMD" == "up-backend" ]]; then
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
-  up_backend
+  start_backend
 
 # Commands to start API & Backoffice without docker
 elif [[ "$CMD" == "setup-no-docker" ]]; then


### PR DESCRIPTION
## But de la pull request

Refonte du code de `start-backend`, `start-proxy-backend`, `restart-backend` et `restart-proxy-backend` pour les rendre plus modulaires/maintenables, éviter la répétition de code et ajouter deux options:

`--fast` permet d'ignorer la phase re rebuild des images dockers
`--force-recreate` permet de forcer ce rebuild.

Ces deux flags sont disponibles pour les 4 commandes.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
