### PR TITLE
(PC-32546)[API] feat: catch timeout on cinema providers

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -412,9 +412,11 @@ def _book_cinema_external_ticket(booking: Booking, stock: Stock, beneficiary: Us
             booking=booking,
             beneficiary=beneficiary,
         )
-    except external_bookings_exceptions.ExternalBookingSoldOutError as exc:
+    except external_bookings_exceptions.ExternalBookingSoldOutError:
         logger.exception("Could not book this offer as it's sold out.")
-        raise exc
+        raise
+    except external_bookings_exceptions.ExternalBookingTimeoutException:
+        raise
     except Exception as exc:
         logger.exception("Could not book external ticket: %s", exc)
         raise external_bookings_exceptions.ExternalBookingException

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -9,6 +9,7 @@ from pcapi.connectors import boost
 from pcapi.connectors.serialization import boost_serializers
 import pcapi.core.bookings.constants as bookings_constants
 import pcapi.core.bookings.models as bookings_models
+from pcapi.core.external_bookings.decorators import catch_cinema_provider_request_timeout
 import pcapi.core.external_bookings.models as external_bookings_models
 import pcapi.core.users.models as users_models
 from pcapi.utils.queue import add_to_queue
@@ -73,6 +74,7 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             request_timeout=self.request_timeout,
         )
 
+    @catch_cinema_provider_request_timeout
     def book_ticket(
         self, show_id: int, booking: bookings_models.Booking, beneficiary: users_models.User
     ) -> list[external_bookings_models.Ticket]:

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -19,6 +19,7 @@ from pcapi.core.bookings.constants import RedisExternalBookingType
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.external_bookings.cds.constants as cds_constants
 import pcapi.core.external_bookings.cds.exceptions as cds_exceptions
+from pcapi.core.external_bookings.decorators import catch_cinema_provider_request_timeout
 import pcapi.core.external_bookings.models as external_bookings_models
 from pcapi.core.external_bookings.models import Ticket
 import pcapi.core.users.models as users_models
@@ -289,6 +290,7 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
                 f"Error while canceling bookings :{sep}{sep.join([f'{barcode} : {error_msg}' for barcode, error_msg in cancel_errors.__root__.items()])}"
             )
 
+    @catch_cinema_provider_request_timeout
     def book_ticket(
         self, show_id: int, booking: bookings_models.Booking, beneficiary: users_models.User
     ) -> list[Ticket]:

--- a/api/src/pcapi/core/external_bookings/ems/client.py
+++ b/api/src/pcapi/core/external_bookings/ems/client.py
@@ -9,6 +9,7 @@ from pcapi.connectors.serialization import ems_serializers
 from pcapi.core.bookings import models as booking_models
 from pcapi.core.bookings import repository as bookings_repository
 from pcapi.core.external_bookings import models as external_bookings_models
+from pcapi.core.external_bookings.decorators import catch_cinema_provider_request_timeout
 from pcapi.core.external_bookings.exceptions import ExternalBookingSoldOutError
 from pcapi.core.users import models as users_models
 from pcapi.models.feature import FeatureToggle
@@ -46,6 +47,7 @@ class EMSClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             for ticket in content.billets
         ]
 
+    @catch_cinema_provider_request_timeout
     def book_ticket(
         self, show_id: int, booking: booking_models.Booking, beneficiary: users_models.User
     ) -> list[external_bookings_models.Ticket]:

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1401,7 +1401,7 @@ def get_shows_remaining_places_from_provider(provider_class: str | None, offer: 
 
 def _should_try_to_update_offer_stock_quantity(offer: models.Offer) -> bool:
     # The offer is to update only if it is a cinema offer, and if the venue has a cinema provider
-    if not offer.subcategory.id == subcategories.SEANCE_CINE.id:
+    if offer.subcategory.id != subcategories.SEANCE_CINE.id:
         return False
 
     if not offer.lastProviderId:  # Manual offer

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -80,6 +80,8 @@ def book_offer(user: User, body: BookOfferRequest) -> BookOfferResponse:
             extra={"offer_id": stock.offer.id, "provider_id": stock.offer.lastProviderId},
         )
         raise ApiErrors({"code": "CINEMA_PROVIDER_INACTIVE"})
+    except external_bookings_exceptions.ExternalBookingTimeoutException:
+        raise ApiErrors({"code": "PROVIDER_BOOKING_TIMEOUT"})
     except external_bookings_exceptions.ExternalBookingException as error:
         if stock.offer.lastProvider.hasProviderEnableCharlie:
             logger.info(

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -589,7 +589,7 @@ class BookOfferTest:
             url = EMSBookingConnector()._build_url("VENTE", payload)
             booking_adapter = requests_mock.post(url=re.compile(rf"{url}"), exc=exception)
 
-            with pytest.raises(external_bookings_exceptions.ExternalBookingException):
+            with pytest.raises(external_bookings_exceptions.ExternalBookingTimeoutException):
                 api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
 
             assert not Booking.query.all()
@@ -700,7 +700,7 @@ class BookOfferTest:
             url = EMSBookingConnector()._build_url("VENTE", payload)
             booking_adapter = requests_mock.post(url=re.compile(rf"{url}"), exc=exception)
 
-            with pytest.raises(external_bookings_exceptions.ExternalBookingException):
+            with pytest.raises(external_bookings_exceptions.ExternalBookingTimeoutException):
                 api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
 
             assert not Booking.query.all()
@@ -781,7 +781,7 @@ class BookOfferTest:
             url = EMSBookingConnector()._build_url("VENTE", payload)
             booking_adapter = requests_mock.post(url=re.compile(rf"{url}"), exc=exception)
 
-            with pytest.raises(external_bookings_exceptions.ExternalBookingException):
+            with pytest.raises(external_bookings_exceptions.ExternalBookingTimeoutException):
                 api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
 
             assert not Booking.query.all()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32546

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
