### PR TITLE
(BSR)[API] chore: fix rq bump.

### DIFF
--- a/api/src/pcapi/workers/decorators.py
+++ b/api/src/pcapi/workers/decorators.py
@@ -29,7 +29,7 @@ def job(queue: Queue) -> typing.Callable:
                 return
 
             start = time.perf_counter()
-            started_at = current_job.started_at or datetime.utcnow()
+            started_at = current_job.started_at.replace(tzinfo=None) if current_job.started_at else datetime.utcnow()
             enqueued_at = current_job.enqueued_at
             assert enqueued_at is not None  # help mypy
             logger.info(


### PR DESCRIPTION
started_at is a timezone aware field while enqueued_at is not. Remove timezone information
Fixes this issue : https://sentry.passculture.team/organizations/sentry/issues/1622802/?project=5&referrer=slack


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
