### PR TITLE
(PC-32954)[API] fix: paginate bookings status update in generate_invoice to avoid statement timeout

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -76,6 +76,7 @@ from pcapi.repository import mark_transaction_as_invalid
 from pcapi.repository import on_commit
 from pcapi.repository import transaction
 from pcapi.utils import human_ids
+from pcapi.utils.chunks import get_chunks
 import pcapi.utils.date as date_utils
 import pcapi.utils.db as db_utils
 import pcapi.utils.pdf as pdf_utils
@@ -1634,7 +1635,7 @@ def _mark_free_pricings_as_invoiced() -> None:
             models.Pricing.status == models.PricingStatus.PROCESSED,
             models.CashflowPricing.pricingId.is_(None),
         )
-        .with_entities(models.Pricing.id)
+        .with_entities(models.Pricing.id, models.Pricing.bookingId)
         .all()
     )
     if not free_pricings:
@@ -1667,30 +1668,29 @@ def _mark_free_pricings_as_invoiced() -> None:
 
     # Booking.status: USED -> REIMBURSED (but keep CANCELLED as is)
     with log_elapsed(logger, "Updating status of free individual bookings"):
-        db.session.execute(
-            sa.text(
+        booking_ids = [e[1] for e in free_pricings if e[1]]
+        for chunk in get_chunks(booking_ids, 1000):
+            db.session.execute(
+                sa.text(
+                    """
+                UPDATE booking
+                SET
+                  status =
+                    CASE WHEN booking.status = CAST(:cancelled AS booking_status)
+                    THEN CAST(:cancelled AS booking_status)
+                    ELSE CAST(:reimbursed AS booking_status)
+                    END,
+                  "reimbursementDate" = now()
+                WHERE
+                  booking.id IN :booking_ids
                 """
-            UPDATE booking
-            SET
-              status =
-                CASE WHEN booking.status = CAST(:cancelled AS booking_status)
-                THEN CAST(:cancelled AS booking_status)
-                ELSE CAST(:reimbursed AS booking_status)
-                END,
-              "reimbursementDate" = now()
-            FROM pricing
-            WHERE
-              booking.id = pricing."bookingId"
-              AND pricing.id IN :pricing_ids
-            """
-            ),
-            {
-                "cancelled": bookings_models.BookingStatus.CANCELLED.value,
-                "reimbursed": bookings_models.BookingStatus.REIMBURSED.value,
-                "pricing_ids": tuple(pricing_ids),
-                "reimbursement_date": datetime.datetime.utcnow(),
-            },
-        )
+                ),
+                {
+                    "cancelled": bookings_models.BookingStatus.CANCELLED.value,
+                    "reimbursed": bookings_models.BookingStatus.REIMBURSED.value,
+                    "booking_ids": tuple(chunk),
+                },
+            )
 
     # CollectiveBooking.status: USED -> REIMBURSED (but keep CANCELLED as is)
     with log_elapsed(logger, "Updating status of free collective bookings"):
@@ -2165,31 +2165,37 @@ def _generate_invoice(
 
     # Booking.status: USED -> REIMBURSED (but keep CANCELLED as is)
     with log_elapsed(logger, "Updating status of individual bookings"):
-        db.session.execute(
-            sa.text(
-                """
-            UPDATE booking
-            SET
-              status =
-                CASE WHEN booking.status = CAST(:cancelled AS booking_status)
-                THEN CAST(:cancelled AS booking_status)
-                ELSE CAST(:reimbursed AS booking_status)
-                END,
-              "reimbursementDate" = now()
-            FROM pricing, cashflow_pricing
-            WHERE
-              booking.id = pricing."bookingId"
-              AND pricing.id = cashflow_pricing."pricingId"
-              AND cashflow_pricing."cashflowId" IN :cashflow_ids
-            """
-            ),
-            {
-                "cancelled": bookings_models.BookingStatus.CANCELLED.value,
-                "reimbursed": bookings_models.BookingStatus.REIMBURSED.value,
-                "cashflow_ids": tuple(cashflow_ids),
-                "reimbursement_date": datetime.datetime.utcnow(),
-            },
+        booking_ids = (
+            models.Pricing.query.join(models.Pricing.cashflows)
+            .filter(
+                models.Cashflow.id.in_(cashflow_ids),
+            )
+            .with_entities(models.Pricing.bookingId)
+            .all()
         )
+        booking_ids = [b[0] for b in booking_ids]
+        for chunk in get_chunks(booking_ids, 1000):
+            db.session.execute(
+                sa.text(
+                    """
+                UPDATE booking
+                SET
+                  status =
+                    CASE WHEN booking.status = CAST(:cancelled AS booking_status)
+                    THEN CAST(:cancelled AS booking_status)
+                    ELSE CAST(:reimbursed AS booking_status)
+                    END,
+                  "reimbursementDate" = now()
+                WHERE
+                  booking.id IN :booking_ids
+                """
+                ),
+                {
+                    "cancelled": bookings_models.BookingStatus.CANCELLED.value,
+                    "reimbursed": bookings_models.BookingStatus.REIMBURSED.value,
+                    "booking_ids": tuple(chunk),
+                },
+            )
 
     # CollectiveBooking.status: USED -> REIMBURSED (but keep CANCELLED as is)
     with log_elapsed(logger, "Updating status of collective bookings"):

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -3044,6 +3044,7 @@ class GenerateInvoiceTest:
         + 1  # insert invoice_cashflows
         + 1  # update Cashflow.status and add CashflowLog
         + 1  # update Pricing.status and add PricingLog
+        + 1  # select Booking.id
         + 1  # update Booking.status
         + 1  # FF is cached in all test due to generate_cashflows call
     )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32954

Paginer la màj des bookings pour éviter le timeout lors de la génération des invoices

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
