### PR TITLE
(PC-32867)[PRO] feat: show OA that have offers in filters

### DIFF
--- a/pro/src/components/Bookings/Bookings.tsx
+++ b/pro/src/components/Bookings/Bookings.tsx
@@ -96,7 +96,7 @@ export const BookingsScreen = <
   const offererAddressQuery = useSWR(
     [GET_OFFERER_ADDRESS_QUERY_KEY, selectedOffererId],
     ([, offererIdParam]) =>
-      offererIdParam ? api.getOffererAddresses(offererIdParam, false) : [],
+      offererIdParam ? api.getOffererAddresses(offererIdParam, true) : [],
     { fallbackData: [] }
   )
   const offererAddresses = formatAndOrderAddresses(offererAddressQuery.data)

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -70,7 +70,7 @@ export const OffersRoute = (): JSX.Element => {
     selectedOffererId && isOfferAddressEnabled
       ? [GET_OFFERER_ADDRESS_QUERY_KEY, selectedOffererId]
       : null,
-    ([, offererIdParam]) => api.getOffererAddresses(offererIdParam, false),
+    ([, offererIdParam]) => api.getOffererAddresses(offererIdParam, true),
     { fallbackData: [] }
   )
   const offererAddresses = formatAndOrderAddresses(offererAddressQuery.data)


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32867

In the offer list page and the booking list page on pro website we want to restrict the number of OffererAddress displayed using only those that have at least an offer associated.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
