### PR TITLE
(PC-32832)[PRO] fix: Re-render offers list component when structure c…

### DIFF
--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -21,6 +21,7 @@ import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useCurrentUser } from 'commons/hooks/useCurrentUser'
 import { selectCurrentOffererId } from 'commons/store/user/selectors'
 import { formatAndOrderVenues } from 'repository/venuesService'
+import { Spinner } from 'ui-kit/Spinner/Spinner'
 
 import { CollectiveOffersScreen } from './components/CollectiveOffersScreen/CollectiveOffersScreen'
 
@@ -125,18 +126,24 @@ export const CollectiveOffers = (): JSX.Element => {
 
   return (
     <Layout>
-      <CollectiveOffersScreen
-        currentPageNumber={currentPageNumber}
-        currentUser={currentUser}
-        initialSearchFilters={apiFilters}
-        isLoading={offersQuery.isLoading}
-        offerer={offerer}
-        offers={offersQuery.data}
-        redirectWithUrlFilters={redirectWithUrlFilters}
-        urlSearchFilters={urlSearchFilters}
-        venues={venues}
-        isRestrictedAsAdmin={isRestrictedAsAdmin}
-      />
+      {/* When the venues are cached for a given offerer, we still need to reset the Screen component.
+      SWR isLoading is only true when the data is not cached, while isValidating is always set to true when the key is updated */}
+      {offererQuery.isLoading || offererQuery.isValidating ? (
+        <Spinner />
+      ) : (
+        <CollectiveOffersScreen
+          currentPageNumber={currentPageNumber}
+          currentUser={currentUser}
+          initialSearchFilters={apiFilters}
+          isLoading={offersQuery.isLoading}
+          offerer={offerer}
+          offers={offersQuery.data}
+          redirectWithUrlFilters={redirectWithUrlFilters}
+          urlSearchFilters={urlSearchFilters}
+          venues={venues}
+          isRestrictedAsAdmin={isRestrictedAsAdmin}
+        />
+      )}
     </Layout>
   )
 }

--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -28,6 +28,7 @@ import {
   formatAndOrderAddresses,
   formatAndOrderVenues,
 } from 'repository/venuesService'
+import { Spinner } from 'ui-kit/Spinner/Spinner'
 
 import { IndividualOffersScreen } from './components/IndividualOffersScreen/IndividualOffersScreen'
 
@@ -62,7 +63,13 @@ export const OffersRoute = (): JSX.Element => {
     navigate(computeIndividualOffersUrl(filters), { replace: true })
   }
 
-  const { data } = useSWR([GET_VENUES_QUERY_KEY], () =>
+  const {
+    data,
+    isLoading: isLoadingVenues,
+    //  When the venues are cached for a given offerer, we still need to reset the Screen component.
+    //  SWR isLoading is only true when the data is not cached, while isValidating is always set to true when the key is updated
+    isValidating: isValidatingVenues,
+  } = useSWR([GET_VENUES_QUERY_KEY, selectedOffererId], () =>
     api.getVenues(null, null, selectedOffererId)
   )
   const venues = formatAndOrderVenues(data?.venues ?? [])
@@ -121,18 +128,22 @@ export const OffersRoute = (): JSX.Element => {
 
   return (
     <Layout>
-      <IndividualOffersScreen
-        categories={categoriesOptions}
-        currentPageNumber={currentPageNumber}
-        initialSearchFilters={apiFilters}
-        isLoading={offersQuery.isLoading}
-        offers={offers}
-        redirectWithUrlFilters={redirectWithUrlFilters}
-        urlSearchFilters={urlSearchFilters}
-        venues={venues}
-        offererAddresses={offererAddresses}
-        isRestrictedAsAdmin={isRestrictedAsAdmin}
-      />
+      {isLoadingVenues || isValidatingVenues ? (
+        <Spinner />
+      ) : (
+        <IndividualOffersScreen
+          categories={categoriesOptions}
+          currentPageNumber={currentPageNumber}
+          initialSearchFilters={apiFilters}
+          isLoading={offersQuery.isLoading}
+          offers={offers}
+          redirectWithUrlFilters={redirectWithUrlFilters}
+          urlSearchFilters={urlSearchFilters}
+          venues={venues}
+          offererAddresses={offererAddresses}
+          isRestrictedAsAdmin={isRestrictedAsAdmin}
+        />
+      )}
     </Layout>
   )
 }


### PR DESCRIPTION
…hanges.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32832

**Objectif**
Corriger les 2 bugs suivants :
- Sur la liste es offres collectives & sur la liste des offres réservables, si on coche des offres, et qu'on change de structure via le header, on voit toujours l'action bar sticky qui affiche les actions possibles sur les offres cochées.
- Dans les filtres des offres indiv, la liste des lieux ne se met pas à jour quand on change de structure via le header.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
