### PR TITLE
(PC-32561)[BO] fix: conditions for email updated icon

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1144,6 +1144,8 @@ def search_public_account_in_history_email(search_query: str) -> BaseQuery:
             models.UserEmailHistory.oldEmail == sanitized_term,
             models.UserEmailHistory.eventType.in_(
                 {
+                    models.EmailHistoryEventTypeEnum.NEW_EMAIL_SELECTION,
+                    models.EmailHistoryEventTypeEnum.CONFIRMATION,
                     models.EmailHistoryEventTypeEnum.VALIDATION,
                     models.EmailHistoryEventTypeEnum.ADMIN_VALIDATION,
                     models.EmailHistoryEventTypeEnum.ADMIN_UPDATE,

--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -321,6 +321,7 @@ def render_public_account_details(
         email_event.eventType
         not in (
             users_models.EmailHistoryEventTypeEnum.UPDATE_REQUEST,
+            users_models.EmailHistoryEventTypeEnum.NEW_EMAIL_SELECTION,
             users_models.EmailHistoryEventTypeEnum.CANCELLATION,
         )
         for email_event in user.email_history

--- a/api/src/pcapi/routes/backoffice/accounts/serialization.py
+++ b/api/src/pcapi/routes/backoffice/accounts/serialization.py
@@ -93,6 +93,8 @@ class EmailChangeAction(AccountAction):
         match self._email_change.eventType:
             case users_models.EmailHistoryEventTypeEnum.UPDATE_REQUEST:
                 return "Demande de changement d'email"
+            case users_models.EmailHistoryEventTypeEnum.NEW_EMAIL_SELECTION:
+                return "Saisie d'une nouvelle adresse email"
             case users_models.EmailHistoryEventTypeEnum.CONFIRMATION:
                 return "Confirmation de changement d'email"
             case users_models.EmailHistoryEventTypeEnum.CANCELLATION:

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -690,6 +690,7 @@ class GetPublicAccountTest(GetEndpointHelper):
     def test_get_public_account_with_unconfirmed_modified_email(self, authenticated_client):
         user = users_factories.UserFactory()
         users_factories.EmailUpdateEntryFactory(user=user)
+        users_factories.NewEmailSelectionEntryFactory(user=user)
         user_id = user.id
 
         with assert_num_queries(self.expected_num_queries):
@@ -702,6 +703,7 @@ class GetPublicAccountTest(GetEndpointHelper):
     def test_get_public_account_with_confirmed_modified_email(self, authenticated_client):
         user = users_factories.UserFactory()
         users_factories.EmailUpdateEntryFactory(user=user)
+        users_factories.NewEmailSelectionEntryFactory(user=user)
         users_factories.EmailConfirmationEntryFactory(user=user)
         user_id = user.id
 


### PR DESCRIPTION
`NEW_EMAIL_SELECTION` added in 2024 had never been taken into account in the backoffice

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-32561

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
