### PR TITLE
(BSR)[BO] test: split BO tests on CI

### DIFF
--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -412,7 +412,8 @@ jobs:
             "tests/core --ignore=tests/core/bookings --ignore=tests/core/offers --ignore=tests/core/finance",
             "tests/routes -m 'not backoffice'",
             "tests --ignore=tests/core --ignore=tests/routes",
-            "tests/routes/backoffice -m 'backoffice'",
+            "tests/routes/backoffice/collective_bookings_test.py tests/routes/backoffice/collective_offers_test.py tests/routes/backoffice/individual_bookings_test.py tests/routes/backoffice/offers_test.py tests/routes/backoffice/offerers_test.py -m 'backoffice'",
+            "tests/routes/backoffice -m 'backoffice' --ignore=tests/routes/backoffice/collective_bookings_test.py --ignore=tests/routes/backoffice/collective_offers_test.py --ignore=tests/routes/backoffice/individual_bookings_test.py --ignore=tests/routes/backoffice/offers_test.py --ignore=tests/routes/backoffice/offerers_test.py",
           ]
     services:
       redis:

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -26,7 +26,6 @@ from pcapi.core.permissions import models as perm_models
 from pcapi.core.providers import factories as providers_factories
 from pcapi.core.providers import models as providers_models
 from pcapi.core.testing import assert_num_queries
-from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users.backoffice import api as backoffice_api


### PR DESCRIPTION
## But de la pull request

Séparer en deux blocs les tests BO pour accélérer l'intégration continue.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
