### PR TITLE
(BSR)[API] fix: reindexing ix_unique_offerer_address_per_label

### DIFF
--- a/api/src/pcapi/scripts/reindex_offerer_address/main.py
+++ b/api/src/pcapi/scripts/reindex_offerer_address/main.py
@@ -1,0 +1,35 @@
+import argparse
+import logging
+
+import sqlalchemy as sa
+
+from pcapi import settings
+from pcapi.app import app
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+app.app_context().push()
+
+
+def reindexing() -> None:
+    db.session.execute("COMMIT;")
+    db.session.execute(sa.text("""SET SESSION statement_timeout = '2600s' ;"""))
+    db.session.execute(sa.text("""REINDEX INDEX CONCURRENTLY ix_unique_offerer_address_per_label ;"""))
+    db.session.execute(
+        sa.text("""SET SESSION statement_timeout = :timeout ;"""), {"timeout": settings.DATABASE_STATEMENT_TIMEOUT}
+    )
+
+    db.session.execute("BEGIN;")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Default parser")
+    args = parser.parse_args()
+
+    try:
+        reindexing()
+    except:
+        db.session.rollback()
+        raise


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : réindexé l'index ix_unique_offerer_address_per_label  sur la table  offerer_address.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
