### PR TITLE
PC-32908 : Mise à jour du vocabulaire 'entité juridique' & 'partenaire culturel' dans le backoffice

### DIFF
--- a/api/src/pcapi/core/finance/siret_api.py
+++ b/api/src/pcapi/core/finance/siret_api.py
@@ -237,7 +237,7 @@ def check_can_remove_siret(
             for offerer_venue in venue.managingOfferer.managedVenues
             if offerer_venue.siret and offerer_venue.id != venue.id
         ):
-            raise CheckError(f"L'entité gérant ce {venue_label} n'a pas d'autre {venue_label} avec SIRET")
+            raise CheckError(f"L'entité juridique gérant ce {venue_label} n'a pas d'autre {venue_label} avec SIRET")
 
     if not comment:
         raise CheckError("Le commentaire est obligatoire")
@@ -284,7 +284,7 @@ def remove_siret(
         ).one_or_none()
         if not new_pricing_point_venue:
             raise CheckError(
-                f"Le nouveau point de valorisation doit être un {venue_label} avec SIRET sur la même entité"
+                f"Le nouveau point de valorisation doit être un {venue_label} avec SIRET sur la même entité juridique"
             )
         new_siret = new_pricing_point_venue.siret
 

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -24,12 +24,12 @@ class ActionType(enum.Enum):
     # Update:
     INFO_MODIFIED = "Modification des informations"
     # Validation process for offerers:
-    OFFERER_NEW = "Nouvelle structure"
-    OFFERER_PENDING = "Structure mise en attente"
-    OFFERER_VALIDATED = "Structure validée"
-    OFFERER_REJECTED = "Structure rejetée"
-    OFFERER_SUSPENDED = "Structure désactivée"
-    OFFERER_UNSUSPENDED = "Structure réactivée"
+    OFFERER_NEW = "Nouvelle entité"
+    OFFERER_PENDING = "Entité mise en attente"
+    OFFERER_VALIDATED = "Entité validée"
+    OFFERER_REJECTED = "Entité rejetée"
+    OFFERER_SUSPENDED = "Entité désactivée"
+    OFFERER_UNSUSPENDED = "Entité réactivée"
     OFFERER_ATTESTATION_CHECKED = "Attestation consultée"
     # Validation process for user-offerer relationships:
     USER_OFFERER_NEW = "Nouveau rattachement"

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -24,12 +24,12 @@ class ActionType(enum.Enum):
     # Update:
     INFO_MODIFIED = "Modification des informations"
     # Validation process for offerers:
-    OFFERER_NEW = "Nouvelle entité"
-    OFFERER_PENDING = "Entité mise en attente"
-    OFFERER_VALIDATED = "Entité validée"
-    OFFERER_REJECTED = "Entité rejetée"
-    OFFERER_SUSPENDED = "Entité désactivée"
-    OFFERER_UNSUSPENDED = "Entité réactivée"
+    OFFERER_NEW = "Nouvelle entité juridique"
+    OFFERER_PENDING = "Entité juridique mise en attente"
+    OFFERER_VALIDATED = "Entité juridique validée"
+    OFFERER_REJECTED = "Entité juridique rejetée"
+    OFFERER_SUSPENDED = "Entité juridique désactivée"
+    OFFERER_UNSUSPENDED = "Entité juridique réactivée"
     OFFERER_ATTESTATION_CHECKED = "Attestation consultée"
     # Validation process for user-offerer relationships:
     USER_OFFERER_NEW = "Nouveau rattachement"

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1295,7 +1295,7 @@ def reject_offerer(
         reject_offerer_attachment(
             user_offerer,
             author_user,
-            "Compte pro rejeté suite au rejet de l'entité",
+            "Compte pro rejeté suite au rejet de l'entité juridique",
             send_email=(user_offerer.user not in applicants),  # do not send a second email
         )
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -948,8 +948,8 @@ def create_offerer(
         author = user
 
     if offerer is not None:
-        # The user can have his attachment rejected or deleted to the structure,
-        # in this case it is passed to NEW if the structure is not rejected
+        # The user can have his attachment rejected or deleted to the offerer,
+        # in this case it is passed to NEW if the offerer is not rejected
         user_offerer = offerers_models.UserOfferer.query.filter_by(userId=user.id, offererId=offerer.id).one_or_none()
         if not user_offerer:
             user_offerer = models.UserOfferer(offerer=offerer, user=user, validationStatus=ValidationStatus.NEW)
@@ -1295,7 +1295,7 @@ def reject_offerer(
         reject_offerer_attachment(
             user_offerer,
             author_user,
-            "Compte pro rejeté suite au rejet de la structure",
+            "Compte pro rejeté suite au rejet de l'entité",
             send_email=(user_offerer.user not in applicants),  # do not send a second email
         )
 

--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -81,7 +81,7 @@ class CannotSuspendOffererWithBookingsException(ClientError):
     def __init__(self) -> None:
         super().__init__(
             "cannotSuspendOffererWithBookingsException",
-            "Structure juridique non désactivable car elle contient des réservations",
+            "Entité non désactivable car elle contient des réservations",
         )
 
 
@@ -89,7 +89,7 @@ class CannotDeleteOffererWithBookingsException(ClientError):
     def __init__(self) -> None:
         super().__init__(
             "cannotDeleteOffererWithBookingsException",
-            "Structure juridique non supprimable car elle contient des réservations",
+            "Entité non supprimable car elle contient des réservations",
         )
 
 
@@ -97,7 +97,7 @@ class CannotDeleteVenueWithBookingsException(ClientError):
     def __init__(self) -> None:
         super().__init__(
             "cannotDeleteVenueWithBookingsException",
-            "Lieu non supprimable car il contient des réservations",
+            "Partenaire culturel non supprimable car il contient des réservations",
         )
 
 
@@ -105,7 +105,7 @@ class CannotDeleteVenueUsedAsPricingPointException(ClientError):
     def __init__(self) -> None:
         super().__init__(
             "cannotDeleteVenueUsedAsPricingPointException",
-            "Lieu non supprimable car il est utilisé comme point de valorisation d'un autre lieu",
+            "Partenaire culturel non supprimable car il est utilisé comme point de valorisation d'un autre partenaire culturel",
         )
 
 
@@ -113,7 +113,7 @@ class CannotDeleteVenueUsedAsReimbursementPointException(ClientError):
     def __init__(self) -> None:
         super().__init__(
             "cannotDeleteVenueUsedAsReimbursementPointException",
-            "Lieu non supprimable car il est utilisé comme point de remboursement d'un autre lieu",
+            "Partenaire culturel non supprimable car il est utilisé comme point de remboursement d'un autre partenaire culturel",
         )
 
 

--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -81,7 +81,7 @@ class CannotSuspendOffererWithBookingsException(ClientError):
     def __init__(self) -> None:
         super().__init__(
             "cannotSuspendOffererWithBookingsException",
-            "Entité non désactivable car elle contient des réservations",
+            "Entité juridique non désactivable car elle contient des réservations",
         )
 
 
@@ -89,7 +89,7 @@ class CannotDeleteOffererWithBookingsException(ClientError):
     def __init__(self) -> None:
         super().__init__(
             "cannotDeleteOffererWithBookingsException",
-            "Entité non supprimable car elle contient des réservations",
+            "Entité juridique non supprimable car elle contient des réservations",
         )
 
 

--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -76,7 +76,7 @@ def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
                     offerers_api.reject_offerer(
                         offerer=offerer,
                         author_user=None,
-                        comment="L'entité est détectée comme inactive via l'API Sirene (INSEE)",
+                        comment="L'entité juridique est détectée comme inactive via l'API Sirene (INSEE)",
                         modified_info={"tags": {"new_info": tag.label}},
                         rejection_reason=offerers_models.OffererRejectionReason.CLOSED_BUSINESS,
                     )
@@ -85,7 +85,7 @@ def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
                         history_models.ActionType.INFO_MODIFIED,
                         author=None,
                         offerer=offerer,
-                        comment="L'entité est détectée comme inactive via l'API Sirene (INSEE)",
+                        comment="L'entité juridique est détectée comme inactive via l'API Sirene (INSEE)",
                         modified_info={"tags": {"new_info": tag.label}},
                     )
 

--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -76,7 +76,7 @@ def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
                     offerers_api.reject_offerer(
                         offerer=offerer,
                         author_user=None,
-                        comment="La structure est détectée comme inactive via l'API Sirene (INSEE)",
+                        comment="L'entité est détectée comme inactive via l'API Sirene (INSEE)",
                         modified_info={"tags": {"new_info": tag.label}},
                         rejection_reason=offerers_models.OffererRejectionReason.CLOSED_BUSINESS,
                     )
@@ -85,7 +85,7 @@ def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
                         history_models.ActionType.INFO_MODIFIED,
                         author=None,
                         offerer=offerer,
-                        comment="La structure est détectée comme inactive via l'API Sirene (INSEE)",
+                        comment="L'entité est détectée comme inactive via l'API Sirene (INSEE)",
                         modified_info={"tags": {"new_info": tag.label}},
                     )
 

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -38,12 +38,12 @@ class Permissions(enum.Enum):
     SUSPEND_USER = "suspendre un compte jeune"
     UNSUSPEND_USER = "réactiver un compte jeune"
 
-    READ_PRO_ENTITY = "visualiser une entité, un partenaire culturel ou un compte pro"
-    MANAGE_PRO_ENTITY = "gérer une entité, un partenaire culturel ou un compte pro"
-    DELETE_PRO_ENTITY = "supprimer une entité ou un partenaire culturel"
-    CREATE_PRO_ENTITY = "créer une entité"
-    READ_PRO_ENTREPRISE_INFO = "visualiser les données INSEE/RCS d'une entité"
-    READ_PRO_SENSITIVE_INFO = "vérifier les attestations URSSAF/DGFIP d'une entité"
+    READ_PRO_ENTITY = "visualiser une entité juridique, un partenaire culturel ou un compte pro"
+    MANAGE_PRO_ENTITY = "gérer une entité juridique, un partenaire culturel ou un compte pro"
+    DELETE_PRO_ENTITY = "supprimer une entité juridique ou un partenaire culturel"
+    CREATE_PRO_ENTITY = "créer une entité juridique"
+    READ_PRO_ENTREPRISE_INFO = "visualiser les données INSEE/RCS d'une entité juridique"
+    READ_PRO_SENSITIVE_INFO = "vérifier les attestations URSSAF/DGFIP d'une entité juridique"
     READ_PRO_AE_INFO = "consulter le suivi de l'inscription d'un Auto-Entrepreneur"
     CONNECT_AS_PRO = "se connecter sur PC Pro en tant qu'AC (connect-as)"
 
@@ -57,11 +57,11 @@ class Permissions(enum.Enum):
     MANAGE_OFFERS = "gérer les offres"
     MULTIPLE_OFFERS_ACTIONS = "opérations sur plusieurs offres"
 
-    VALIDATE_OFFERER = "gérer la validation des entités et des rattachements"
+    VALIDATE_OFFERER = "gérer la validation des entités juridiques et des rattachements"
 
-    READ_TAGS = "visualiser les tags entités, offres et partenaires culturels"
-    MANAGE_OFFERER_TAG = "gérer les tags entité"
-    MANAGE_TAGS_N2 = "supprimer un tag (entité, offre, partenaire culturel) et créer des catégories"
+    READ_TAGS = "visualiser les tags entités juridiques, offres et partenaires culturels"
+    MANAGE_OFFERER_TAG = "gérer les tags entité juridique"
+    MANAGE_TAGS_N2 = "supprimer un tag (entité juridique, offre, partenaire culturel) et créer des catégories"
     MANAGE_OFFERS_AND_VENUES_TAGS = "gérer les tags offres et partenaires culturels"
 
     READ_REIMBURSEMENT_RULES = "visualiser les tarifs dérogatoires"

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -38,12 +38,12 @@ class Permissions(enum.Enum):
     SUSPEND_USER = "suspendre un compte jeune"
     UNSUSPEND_USER = "réactiver un compte jeune"
 
-    READ_PRO_ENTITY = "visualiser une structure, un lieu ou un compte pro"
-    MANAGE_PRO_ENTITY = "gérer une structure, un lieu ou un compte pro"
-    DELETE_PRO_ENTITY = "supprimer une structure ou un lieu"
-    CREATE_PRO_ENTITY = "créer une structure"
-    READ_PRO_ENTREPRISE_INFO = "visualiser les données INSEE/RCS d'une structure"
-    READ_PRO_SENSITIVE_INFO = "vérifier les attestations URSSAF/DGFIP d'une structure"
+    READ_PRO_ENTITY = "visualiser une entité, un partenaire culturel ou un compte pro"
+    MANAGE_PRO_ENTITY = "gérer une entité, un partenaire culturel ou un compte pro"
+    DELETE_PRO_ENTITY = "supprimer une entité ou un partenaire culturel"
+    CREATE_PRO_ENTITY = "créer une entité"
+    READ_PRO_ENTREPRISE_INFO = "visualiser les données INSEE/RCS d'une entité"
+    READ_PRO_SENSITIVE_INFO = "vérifier les attestations URSSAF/DGFIP d'une entité"
     READ_PRO_AE_INFO = "consulter le suivi de l'inscription d'un Auto-Entrepreneur"
     CONNECT_AS_PRO = "se connecter sur PC Pro en tant qu'AC (connect-as)"
 
@@ -57,12 +57,12 @@ class Permissions(enum.Enum):
     MANAGE_OFFERS = "gérer les offres"
     MULTIPLE_OFFERS_ACTIONS = "opérations sur plusieurs offres"
 
-    VALIDATE_OFFERER = "gérer la validation des structures et des rattachements"
+    VALIDATE_OFFERER = "gérer la validation des entités et des rattachements"
 
-    READ_TAGS = "visualiser les tags structure, offres et lieux"
-    MANAGE_OFFERER_TAG = "gérer les tags structure"
-    MANAGE_TAGS_N2 = "supprimer un tag (structure, offre, lieu) et créer des catégories"
-    MANAGE_OFFERS_AND_VENUES_TAGS = "gérer les tags offres et lieux"
+    READ_TAGS = "visualiser les tags entités, offres et partenaires culturels"
+    MANAGE_OFFERER_TAG = "gérer les tags entité"
+    MANAGE_TAGS_N2 = "supprimer un tag (entité, offre, partenaire culturel) et créer des catégories"
+    MANAGE_OFFERS_AND_VENUES_TAGS = "gérer les tags offres et partenaires culturels"
 
     READ_REIMBURSEMENT_RULES = "visualiser les tarifs dérogatoires"
     CREATE_REIMBURSEMENT_RULES = "créer un tarif dérogatoire"

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -45,8 +45,8 @@ class FeatureToggle(enum.Enum):
     )
     ENABLE_BEAMER = "Active Beamer, le système de notifs du portail pro"
     ENABLE_CDS_IMPLEMENTATION = "Permet la réservation de place de cinéma avec l'API CDS"
-    ENABLE_CODIR_OFFERERS_REPORT = "Active le rapport sur les entités actives pour le CODIR (tourne la nuit)"
-    ENABLE_CRON_TO_UPDATE_OFFERER_STATS = "Active la mise à jour des statistiques des entités avec un cron"
+    ENABLE_CODIR_OFFERERS_REPORT = "Active le rapport sur les entités juridiques actives pour le CODIR (tourne la nuit)"
+    ENABLE_CRON_TO_UPDATE_OFFERER_STATS = "Active la mise à jour des statistiques des entités juridiques avec un cron"
     ENABLE_CULTURAL_SURVEY = "Activer l'affichage du questionnaire des pratiques initiales pour les bénéficiaires"
     ENABLE_DMS_LINK_ON_MAINTENANCE_PAGE_FOR_AGE_18 = (
         "Permet l'affichage du lien vers DMS sur la page de maintenance pour les 18 ans"

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -45,8 +45,8 @@ class FeatureToggle(enum.Enum):
     )
     ENABLE_BEAMER = "Active Beamer, le système de notifs du portail pro"
     ENABLE_CDS_IMPLEMENTATION = "Permet la réservation de place de cinéma avec l'API CDS"
-    ENABLE_CODIR_OFFERERS_REPORT = "Active le rapport sur les structures actives pour le CODIR (tourne la nuit)"
-    ENABLE_CRON_TO_UPDATE_OFFERER_STATS = "Active la mise à jour des statistiques des offrers avec un cron"
+    ENABLE_CODIR_OFFERERS_REPORT = "Active le rapport sur les entités actives pour le CODIR (tourne la nuit)"
+    ENABLE_CRON_TO_UPDATE_OFFERER_STATS = "Active la mise à jour des statistiques des entités avec un cron"
     ENABLE_CULTURAL_SURVEY = "Activer l'affichage du questionnaire des pratiques initiales pour les bénéficiaires"
     ENABLE_DMS_LINK_ON_MAINTENANCE_PAGE_FOR_AGE_18 = (
         "Permet l'affichage du lien vers DMS sur la page de maintenance pour les 18 ans"

--- a/api/src/pcapi/routes/backoffice/bookings/forms.py
+++ b/api/src/pcapi/routes/backoffice/bookings/forms.py
@@ -56,7 +56,7 @@ class BaseBookingListForm(FlaskForm):
         validators=(wtforms.validators.Optional(),),
     )
     offerer = fields.PCTomSelectField(
-        "Structures",
+        "Entités",
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/bookings/forms.py
+++ b/api/src/pcapi/routes/backoffice/bookings/forms.py
@@ -56,7 +56,7 @@ class BaseBookingListForm(FlaskForm):
         validators=(wtforms.validators.Optional(),),
     )
     offerer = fields.PCTomSelectField(
-        "Entités",
+        "Entités juridiques",
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/collective_offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/forms.py
@@ -34,7 +34,7 @@ class CollectiveOffersSearchAttributes(enum.Enum):
     VENUE = typing.cast(str, forms_utils.VenueRenaming("Lieux", "Partenaires culturels"))
     NAME = "Nom de l'offre"
     STATUS = "Statut"
-    OFFERER = "Entité"
+    OFFERER = "Entité juridique"
     PRICE = "Prix"
 
 
@@ -135,7 +135,7 @@ class CollectiveOfferAdvancedSearchSubForm(forms_utils.PCForm):
         ],
     )
     offerer = fields.PCTomSelectField(
-        "Entités",
+        "Entités juridiques",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -206,7 +206,9 @@ class GetCollectiveOfferAdvancedSearchForm(forms.GetOffersBaseFields):
         csrf = False
 
     method = "GET"
-    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des entités validées", full_row=True)
+    only_validated_offerers = fields.PCSwitchBooleanField(
+        "Uniquement les offres des entités juridiques validées", full_row=True
+    )
     search = fields.PCFieldListField(
         fields.PCFormField(CollectiveOfferAdvancedSearchSubForm),
         label="recherches",
@@ -276,10 +278,10 @@ class GetCollectiveOfferTemplatesListForm(forms.GetOffersBaseFields):
     q = fields.PCOptSearchField("ID, nom de l'offre")
     from_date = fields.PCDateField("Créées à partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Jusqu'au", validators=(wtforms.validators.Optional(),))
-    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des entités validées")
+    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des entités juridiques validées")
     formats = fields.PCSelectMultipleField("Formats", choices=forms_utils.choices_from_enum(subcategories.EacFormat))
     offerer = fields.PCTomSelectField(
-        "Entités",
+        "Entités juridiques",
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/collective_offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/forms.py
@@ -34,7 +34,7 @@ class CollectiveOffersSearchAttributes(enum.Enum):
     VENUE = typing.cast(str, forms_utils.VenueRenaming("Lieux", "Partenaires culturels"))
     NAME = "Nom de l'offre"
     STATUS = "Statut"
-    OFFERER = "Structure"
+    OFFERER = "Entité"
     PRICE = "Prix"
 
 
@@ -135,7 +135,7 @@ class CollectiveOfferAdvancedSearchSubForm(forms_utils.PCForm):
         ],
     )
     offerer = fields.PCTomSelectField(
-        "Structures",
+        "Entités",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -206,9 +206,7 @@ class GetCollectiveOfferAdvancedSearchForm(forms.GetOffersBaseFields):
         csrf = False
 
     method = "GET"
-    only_validated_offerers = fields.PCSwitchBooleanField(
-        "Uniquement les offres des structures validées", full_row=True
-    )
+    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des entités validées", full_row=True)
     search = fields.PCFieldListField(
         fields.PCFormField(CollectiveOfferAdvancedSearchSubForm),
         label="recherches",
@@ -278,10 +276,10 @@ class GetCollectiveOfferTemplatesListForm(forms.GetOffersBaseFields):
     q = fields.PCOptSearchField("ID, nom de l'offre")
     from_date = fields.PCDateField("Créées à partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Jusqu'au", validators=(wtforms.validators.Optional(),))
-    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des structures validées")
+    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des entités validées")
     formats = fields.PCSelectMultipleField("Formats", choices=forms_utils.choices_from_enum(subcategories.EacFormat))
     offerer = fields.PCTomSelectField(
-        "Structures",
+        "Entités",
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/forms.py
+++ b/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/forms.py
@@ -18,7 +18,7 @@ class GetCustomReimbursementRulesListForm(FlaskForm):
 
     q = fields.PCOptSearchField("Nom d'offre, ID offre")
     offerer = fields.PCTomSelectField(
-        "Entités",
+        "Entités juridiques",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -64,7 +64,7 @@ class CreateCustomReimbursementRuleForm(FlaskForm):
         locales = ["fr_FR", "fr"]
 
     offerer = fields.PCTomSelectField(
-        "Entité",
+        "Entité juridique",
         multiple=False,
         choices=[],
         validate_choice=False,
@@ -116,19 +116,22 @@ class CreateCustomReimbursementRuleForm(FlaskForm):
 
         if not offerer_id and not venue_id:
             if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
-                flash("Il faut obligatoirement renseigner une entité ou un partenaire culturel", "warning")
+                flash("Il faut obligatoirement renseigner une entité juridique ou un partenaire culturel", "warning")
             else:
-                flash("Il faut obligatoirement renseigner une entité ou un lieu", "warning")
+                flash("Il faut obligatoirement renseigner une entité juridique ou un lieu", "warning")
             return False
 
         if offerer_id and venue_id:
             if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
                 flash(
-                    "Un tarif dérogatoire ne peut pas concerner un partenaire culturel et une entité en même temps",
+                    "Un tarif dérogatoire ne peut pas concerner un partenaire culturel et une entité juridique en même temps",
                     "warning",
                 )
             else:
-                flash("Un tarif dérogatoire ne peut pas concerner un lieu et une entité en même temps", "warning")
+                flash(
+                    "Un tarif dérogatoire ne peut pas concerner un lieu et une entité juridique en même temps",
+                    "warning",
+                )
             return False
         return super().validate(extra_validators)
 

--- a/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/forms.py
+++ b/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/forms.py
@@ -18,7 +18,7 @@ class GetCustomReimbursementRulesListForm(FlaskForm):
 
     q = fields.PCOptSearchField("Nom d'offre, ID offre")
     offerer = fields.PCTomSelectField(
-        "Structures",
+        "Entités",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -64,7 +64,7 @@ class CreateCustomReimbursementRuleForm(FlaskForm):
         locales = ["fr_FR", "fr"]
 
     offerer = fields.PCTomSelectField(
-        "Structure",
+        "Entité",
         multiple=False,
         choices=[],
         validate_choice=False,
@@ -116,19 +116,19 @@ class CreateCustomReimbursementRuleForm(FlaskForm):
 
         if not offerer_id and not venue_id:
             if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
-                flash("Il faut obligatoirement renseigner une structure ou un partenaire culturel", "warning")
+                flash("Il faut obligatoirement renseigner une entité ou un partenaire culturel", "warning")
             else:
-                flash("Il faut obligatoirement renseigner une structure ou un lieu", "warning")
+                flash("Il faut obligatoirement renseigner une entité ou un lieu", "warning")
             return False
 
         if offerer_id and venue_id:
             if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
                 flash(
-                    "Un tarif dérogatoire ne peut pas concerner un partenaire culturel et une structure en même temps",
+                    "Un tarif dérogatoire ne peut pas concerner un partenaire culturel et une entité en même temps",
                     "warning",
                 )
             else:
-                flash("Un tarif dérogatoire ne peut pas concerner un lieu et une structure en même temps", "warning")
+                flash("Un tarif dérogatoire ne peut pas concerner un lieu et une entité en même temps", "warning")
             return False
         return super().validate(extra_validators)
 

--- a/api/src/pcapi/routes/backoffice/external/zendesk_sell/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/external/zendesk_sell/blueprint.py
@@ -33,11 +33,11 @@ def _get_parent_organization_id(venue: offerers_models.Venue) -> int | None:
     except zendesk_sell.ContactFoundMoreThanOneError as e:
         if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
             message = Markup(
-                "Attention : Plusieurs entités parentes possibles ont été trouvées pour ce partenaire culturel dans Zendesk Sell. <br/> <ul>"
+                "Attention : Plusieurs entités juridiques parentes possibles ont été trouvées pour ce partenaire culturel dans Zendesk Sell. <br/> <ul>"
             )
         else:
             message = Markup(
-                "Attention : Plusieurs entités parentes possibles ont été trouvées pour ce lieu dans Zendesk Sell. <br/> <ul>"
+                "Attention : Plusieurs entités juridiques parentes possibles ont été trouvées pour ce lieu dans Zendesk Sell. <br/> <ul>"
             )
         for item in e.items:
             message += Markup(
@@ -59,9 +59,9 @@ def _get_parent_organization_id(venue: offerers_models.Venue) -> int | None:
         return None
     except requests.exceptions.HTTPError as http_error:
         flash(
-            Markup("Une erreur {status_code} s'est produite lors de la recherche de l'entité parente : {error}").format(
-                status_code=str(http_error.response.status_code), error=str(http_error)
-            ),
+            Markup(
+                "Une erreur {status_code} s'est produite lors de la recherche de l'entité juridique parente : {error}"
+            ).format(status_code=str(http_error.response.status_code), error=str(http_error)),
             "warning",
         )
         return None
@@ -81,16 +81,16 @@ def update_offerer(offerer_id: int) -> utils.BackofficeResponse:
 
     if zendesk_sell.is_offerer_only_virtual(offerer):
         if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
-            flash("Cette entité ne gère que des partenaires culturels virtuels", "warning")
+            flash("Cette entité juridique ne gère que des partenaires culturels virtuels", "warning")
         else:
-            flash("Cette entité ne gère que des lieux virtuels", "warning")
+            flash("Cette entité juridique ne gère que des lieux virtuels", "warning")
         return redirect(url, code=303)
 
     try:
         zendesk_offerer_data = zendesk_sell_backend.get_offerer_by_id(offerer)
     except zendesk_sell.ContactFoundMoreThanOneError as e:
         message = Markup(
-            "Plusieurs entités ont été trouvées dans Zendesk Sell, aucune ne peut donc être mise à jour : <br/> <ul>"
+            "Plusieurs entités juridiques ont été trouvées dans Zendesk Sell, aucune ne peut donc être mise à jour : <br/> <ul>"
         )
         for item in e.items:
             message += Markup(
@@ -108,7 +108,7 @@ def update_offerer(offerer_id: int) -> utils.BackofficeResponse:
         flash(Markup(message), "warning")  # pylint: disable=markupsafe-uncontrolled-string
         return redirect(url, code=303)
     except zendesk_sell.ContactNotFoundError:
-        flash("L'entité n'a pas été trouvée dans Zendesk Sell", "warning")
+        flash("L'entité juridique n'a pas été trouvée dans Zendesk Sell", "warning")
         return redirect(url, code=303)
     except requests.exceptions.HTTPError as http_error:
         flash(
@@ -131,7 +131,7 @@ def update_offerer(offerer_id: int) -> utils.BackofficeResponse:
         )
         return redirect(url, code=303)
 
-    flash("L'entité a été mise à jour sur Zendesk Sell", "success")
+    flash("L'entité juridique a été mise à jour sur Zendesk Sell", "success")
     return redirect(url, code=303)
 
 

--- a/api/src/pcapi/routes/backoffice/external/zendesk_sell/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/external/zendesk_sell/blueprint.py
@@ -33,11 +33,11 @@ def _get_parent_organization_id(venue: offerers_models.Venue) -> int | None:
     except zendesk_sell.ContactFoundMoreThanOneError as e:
         if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
             message = Markup(
-                "Attention : Plusieurs structures parentes possibles ont été trouvées pour ce partenaire culturel dans Zendesk Sell. <br/> <ul>"
+                "Attention : Plusieurs entités parentes possibles ont été trouvées pour ce partenaire culturel dans Zendesk Sell. <br/> <ul>"
             )
         else:
             message = Markup(
-                "Attention : Plusieurs structures parentes possibles ont été trouvées pour ce lieu dans Zendesk Sell. <br/> <ul>"
+                "Attention : Plusieurs entités parentes possibles ont été trouvées pour ce lieu dans Zendesk Sell. <br/> <ul>"
             )
         for item in e.items:
             message += Markup(
@@ -59,9 +59,9 @@ def _get_parent_organization_id(venue: offerers_models.Venue) -> int | None:
         return None
     except requests.exceptions.HTTPError as http_error:
         flash(
-            Markup(
-                "Une erreur {status_code} s'est produite lors de la recherche de la structure parente : {error}"
-            ).format(status_code=str(http_error.response.status_code), error=str(http_error)),
+            Markup("Une erreur {status_code} s'est produite lors de la recherche de l'entité parente : {error}").format(
+                status_code=str(http_error.response.status_code), error=str(http_error)
+            ),
             "warning",
         )
         return None
@@ -81,16 +81,16 @@ def update_offerer(offerer_id: int) -> utils.BackofficeResponse:
 
     if zendesk_sell.is_offerer_only_virtual(offerer):
         if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
-            flash("Cette structure ne gère que des partenaires culturels virtuels", "warning")
+            flash("Cette entité ne gère que des partenaires culturels virtuels", "warning")
         else:
-            flash("Cette structure ne gère que des lieux virtuels", "warning")
+            flash("Cette entité ne gère que des lieux virtuels", "warning")
         return redirect(url, code=303)
 
     try:
         zendesk_offerer_data = zendesk_sell_backend.get_offerer_by_id(offerer)
     except zendesk_sell.ContactFoundMoreThanOneError as e:
         message = Markup(
-            "Plusieurs structures ont été trouvées dans Zendesk Sell, aucune ne peut donc être mise à jour : <br/> <ul>"
+            "Plusieurs entités ont été trouvées dans Zendesk Sell, aucune ne peut donc être mise à jour : <br/> <ul>"
         )
         for item in e.items:
             message += Markup(
@@ -108,7 +108,7 @@ def update_offerer(offerer_id: int) -> utils.BackofficeResponse:
         flash(Markup(message), "warning")  # pylint: disable=markupsafe-uncontrolled-string
         return redirect(url, code=303)
     except zendesk_sell.ContactNotFoundError:
-        flash("La structure n'a pas été trouvée dans Zendesk Sell", "warning")
+        flash("L'entité n'a pas été trouvée dans Zendesk Sell", "warning")
         return redirect(url, code=303)
     except requests.exceptions.HTTPError as http_error:
         flash(
@@ -131,7 +131,7 @@ def update_offerer(offerer_id: int) -> utils.BackofficeResponse:
         )
         return redirect(url, code=303)
 
-    flash("La structure a été mise à jour sur Zendesk Sell", "success")
+    flash("L'entité a été mise à jour sur Zendesk Sell", "success")
     return redirect(url, code=303)
 
 

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -369,12 +369,12 @@ def format_booking_cancellation(
         ):
             if author:
                 return Markup(
-                    'Annulée depuis le backoffice par <a class="link-primary" href="{url}">{full_name}</a> pour cause de fermeture de structure'
+                    'Annulée depuis le backoffice par <a class="link-primary" href="{url}">{full_name}</a> pour cause de fermeture d\'entité'
                 ).format(
                     url=url_for("backoffice_web.bo_users.get_bo_user", user_id=author.id),
                     full_name=author.full_name,
                 )
-            return "Annulée depuis le backoffice pour cause de fermeture de structure"
+            return "Annulée depuis le backoffice pour cause de fermeture d'entité"
         case (
             bookings_models.BookingCancellationReasons.REFUSED_BY_INSTITUTE
             | educational_models.CollectiveBookingCancellationReasons.REFUSED_BY_INSTITUTE
@@ -722,7 +722,7 @@ def format_confidence_level_badge_for_venue(venue: offerers_models.Venue) -> str
     if venue.confidenceLevel:
         return format_confidence_level_badge(venue.confidenceLevel)
 
-    return format_confidence_level_badge(venue.managingOfferer.confidenceLevel, show_no_rule=True, info="(structure)")
+    return format_confidence_level_badge(venue.managingOfferer.confidenceLevel, show_no_rule=True, info="(entité)")
 
 
 def format_fraud_check_url(id_check_item: serialization_accounts.IdCheckItemModel) -> str:
@@ -984,7 +984,7 @@ def format_offer_validation_sub_rule_field(sub_rule_field: offers_models.OfferVa
         case offers_models.OfferValidationSubRuleField.ID_VENUE:
             return "Le lieu/partenaire culturel proposant l'offre"  # Remove `lieu/` along with WIP_ENABLE_OFFER_ADDRESS
         case offers_models.OfferValidationSubRuleField.ID_OFFERER:
-            return "La structure proposant l'offre"
+            return "L'entité proposant l'offre"
         case offers_models.OfferValidationSubRuleField.FORMATS_COLLECTIVE_OFFER:
             return "Les formats de l'offre collective"
         case offers_models.OfferValidationSubRuleField.FORMATS_COLLECTIVE_OFFER_TEMPLATE:

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -369,12 +369,12 @@ def format_booking_cancellation(
         ):
             if author:
                 return Markup(
-                    'Annulée depuis le backoffice par <a class="link-primary" href="{url}">{full_name}</a> pour cause de fermeture d\'entité'
+                    'Annulée depuis le backoffice par <a class="link-primary" href="{url}">{full_name}</a> pour cause de fermeture d\'entité juridique'
                 ).format(
                     url=url_for("backoffice_web.bo_users.get_bo_user", user_id=author.id),
                     full_name=author.full_name,
                 )
-            return "Annulée depuis le backoffice pour cause de fermeture d'entité"
+            return "Annulée depuis le backoffice pour cause de fermeture d'entité juridique"
         case (
             bookings_models.BookingCancellationReasons.REFUSED_BY_INSTITUTE
             | educational_models.CollectiveBookingCancellationReasons.REFUSED_BY_INSTITUTE
@@ -722,7 +722,9 @@ def format_confidence_level_badge_for_venue(venue: offerers_models.Venue) -> str
     if venue.confidenceLevel:
         return format_confidence_level_badge(venue.confidenceLevel)
 
-    return format_confidence_level_badge(venue.managingOfferer.confidenceLevel, show_no_rule=True, info="(entité)")
+    return format_confidence_level_badge(
+        venue.managingOfferer.confidenceLevel, show_no_rule=True, info="(entité juridique)"
+    )
 
 
 def format_fraud_check_url(id_check_item: serialization_accounts.IdCheckItemModel) -> str:
@@ -984,7 +986,7 @@ def format_offer_validation_sub_rule_field(sub_rule_field: offers_models.OfferVa
         case offers_models.OfferValidationSubRuleField.ID_VENUE:
             return "Le lieu/partenaire culturel proposant l'offre"  # Remove `lieu/` along with WIP_ENABLE_OFFER_ADDRESS
         case offers_models.OfferValidationSubRuleField.ID_OFFERER:
-            return "L'entité proposant l'offre"
+            return "L'entité juridique proposant l'offre"
         case offers_models.OfferValidationSubRuleField.FORMATS_COLLECTIVE_OFFER:
             return "Les formats de l'offre collective"
         case offers_models.OfferValidationSubRuleField.FORMATS_COLLECTIVE_OFFER_TEMPLATE:

--- a/api/src/pcapi/routes/backoffice/finance/forms.py
+++ b/api/src/pcapi/routes/backoffice/finance/forms.py
@@ -80,7 +80,7 @@ class GetIncidentsSearchForm(forms_utils.PCForm):
     )
 
     offerer = fields.PCTomSelectField(
-        "Structures",
+        "Entités",
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/finance/forms.py
+++ b/api/src/pcapi/routes/backoffice/finance/forms.py
@@ -80,7 +80,7 @@ class GetIncidentsSearchForm(forms_utils.PCForm):
     )
 
     offerer = fields.PCTomSelectField(
-        "Entités",
+        "Entités juridiques",
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/offer_validation_rules/forms.py
+++ b/api/src/pcapi/routes/backoffice/offer_validation_rules/forms.py
@@ -77,7 +77,7 @@ class SearchRuleForm(FlaskForm):
 
     q = fields.PCOptSearchField("Nom de la règle, mots clés")
     offerer = fields.PCTomSelectField(
-        "Structures",
+        "Entités",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -150,7 +150,7 @@ class OfferValidationSubRuleForm(FlaskForm):
         field_list_compatibility=True,
     )
     offerer = fields.PCTomSelectField(
-        "Structure",
+        "Entité",
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/offer_validation_rules/forms.py
+++ b/api/src/pcapi/routes/backoffice/offer_validation_rules/forms.py
@@ -77,7 +77,7 @@ class SearchRuleForm(FlaskForm):
 
     q = fields.PCOptSearchField("Nom de la règle, mots clés")
     offerer = fields.PCTomSelectField(
-        "Entités",
+        "Entités juridiques",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -150,7 +150,7 @@ class OfferValidationSubRuleForm(FlaskForm):
         field_list_compatibility=True,
     )
     offerer = fields.PCTomSelectField(
-        "Entité",
+        "Entité juridique",
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/offerers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offerers/forms.py
@@ -45,7 +45,7 @@ class EditOffererForm(FlaskForm):
         get_label=lambda tag: tag.label or tag.name,
     )
     name = fields.PCStringField(
-        "Nom de l'entité",
+        "Nom de l'entité juridique",
         validators=(
             wtforms.validators.DataRequired("Le nom est obligatoire"),
             wtforms.validators.Length(max=140, message="doit contenir moins de %(max)d caractères"),
@@ -102,7 +102,7 @@ class OffererValidationListForm(utils.PCForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("Nom d'entité, SIREN, code postal, dép., ville, email, nom de compte pro, ID DMS CB")
+    q = fields.PCOptSearchField("Nom, SIREN, code postal, dép., ville, email, nom de compte pro, ID DMS CB")
     regions = fields.PCSelectMultipleField("Régions", choices=get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
         "Tags",
@@ -174,7 +174,9 @@ class UserOffererValidationListForm(utils.PCForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("Nom d'entité, SIREN, code postal, département, ville, email, nom de compte pro")
+    q = fields.PCOptSearchField(
+        "Nom d'entité juridique, SIREN, code postal, département, ville, email, nom de compte pro"
+    )
     regions = fields.PCSelectMultipleField("Régions", choices=get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
         "Tags",
@@ -194,7 +196,8 @@ class UserOffererValidationListForm(utils.PCForm):
         endpoint="backoffice_web.autocomplete_bo_users",
     )
     offerer_status = fields.PCSelectMultipleField(
-        "États de l'entité", choices=utils.choices_from_enum(ValidationStatus, filters.format_validation_status)
+        "États de l'entité juridique",
+        choices=utils.choices_from_enum(ValidationStatus, filters.format_validation_status),
     )
     from_date = fields.PCDateField("Demande à partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Demande jusqu'au", validators=(wtforms.validators.Optional(),))
@@ -228,7 +231,7 @@ class UserOffererValidationListForm(utils.PCForm):
 
 
 class CommentForm(FlaskForm):
-    comment = fields.PCCommentField("Commentaire interne pour l'entité")
+    comment = fields.PCCommentField("Commentaire interne pour l'entité juridique")
 
 
 class OptionalCommentForm(FlaskForm):

--- a/api/src/pcapi/routes/backoffice/offerers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offerers/forms.py
@@ -45,7 +45,7 @@ class EditOffererForm(FlaskForm):
         get_label=lambda tag: tag.label or tag.name,
     )
     name = fields.PCStringField(
-        "Nom de la structure",
+        "Nom de l'entité",
         validators=(
             wtforms.validators.DataRequired("Le nom est obligatoire"),
             wtforms.validators.Length(max=140, message="doit contenir moins de %(max)d caractères"),
@@ -102,9 +102,7 @@ class OffererValidationListForm(utils.PCForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField(
-        "Nom de structure, SIREN, code postal, dép., ville, email, nom de compte pro, ID DMS CB"
-    )
+    q = fields.PCOptSearchField("Nom d'entité, SIREN, code postal, dép., ville, email, nom de compte pro, ID DMS CB")
     regions = fields.PCSelectMultipleField("Régions", choices=get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
         "Tags",
@@ -176,7 +174,7 @@ class UserOffererValidationListForm(utils.PCForm):
     class Meta:
         csrf = False
 
-    q = fields.PCOptSearchField("Nom de structure, SIREN, code postal, département, ville, email, nom de compte pro")
+    q = fields.PCOptSearchField("Nom d'entité, SIREN, code postal, département, ville, email, nom de compte pro")
     regions = fields.PCSelectMultipleField("Régions", choices=get_regions_choices())
     tags = fields.PCQuerySelectMultipleField(
         "Tags",
@@ -196,7 +194,7 @@ class UserOffererValidationListForm(utils.PCForm):
         endpoint="backoffice_web.autocomplete_bo_users",
     )
     offerer_status = fields.PCSelectMultipleField(
-        "États de la structure", choices=utils.choices_from_enum(ValidationStatus, filters.format_validation_status)
+        "États de l'entité", choices=utils.choices_from_enum(ValidationStatus, filters.format_validation_status)
     )
     from_date = fields.PCDateField("Demande à partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Demande jusqu'au", validators=(wtforms.validators.Optional(),))
@@ -230,7 +228,7 @@ class UserOffererValidationListForm(utils.PCForm):
 
 
 class CommentForm(FlaskForm):
-    comment = fields.PCCommentField("Commentaire interne pour la structure")
+    comment = fields.PCCommentField("Commentaire interne pour l'entité")
 
 
 class OptionalCommentForm(FlaskForm):

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -362,10 +362,10 @@ def suspend_offerer(offerer_id: int) -> utils.BackofficeResponse:
             offerers_api.suspend_offerer(offerer, current_user, form.comment.data)
         except offerers_exceptions.CannotSuspendOffererWithBookingsException:
             repository.mark_transaction_as_invalid()
-            flash("Impossible de suspendre une structure juridique pour laquelle il existe des réservations", "warning")
+            flash("Impossible de suspendre une entité pour laquelle il existe des réservations", "warning")
         else:
             flash(
-                Markup("La structure <b>{offerer_name}</b> ({offerer_id}) a été suspendue").format(
+                Markup("L'entité <b>{offerer_name}</b> ({offerer_id}) a été suspendue").format(
                     offerer_name=offerer.name, offerer_id=offerer_id
                 ),
                 "success",
@@ -394,7 +394,7 @@ def unsuspend_offerer(offerer_id: int) -> utils.BackofficeResponse:
     else:
         offerers_api.unsuspend_offerer(offerer, current_user, form.comment.data)
         flash(
-            Markup("La structure <b>{offerer_name}</b> ({offerer_id}) a été réactivée").format(
+            Markup("L'entité <b>{offerer_name}</b> ({offerer_id}) a été réactivée").format(
                 offerer_name=offerer.name, offerer_id=offerer_id
             ),
             "success",
@@ -421,7 +421,7 @@ def delete_offerer(offerer_id: int) -> utils.BackofficeResponse:
         offerers_api.delete_offerer(offerer.id)
     except offerers_exceptions.CannotDeleteOffererWithBookingsException:
         repository.mark_transaction_as_invalid()
-        flash("Impossible de supprimer une structure juridique pour laquelle il existe des réservations", "warning")
+        flash("Impossible de supprimer une entité pour laquelle il existe des réservations", "warning")
         return _self_redirect(offerer.id)
 
     for email in emails:
@@ -433,7 +433,7 @@ def delete_offerer(offerer_id: int) -> utils.BackofficeResponse:
         )
 
     flash(
-        Markup("La structure <b>{offerer_name}</b> ({offerer_id}) a été supprimée").format(
+        Markup("L'entité <b>{offerer_name}</b> ({offerer_id}) a été supprimée").format(
             offerer_name=offerer_name, offerer_id=offerer_id
         ),
         "success",
@@ -693,7 +693,7 @@ def get_delete_user_offerer_form(offerer_id: int, user_offerer_id: int) -> utils
         div_id=f"delete-modal-{user_offerer.id}",  # must be consistent with parameter passed to build_lazy_modal
         title=f"Supprimer le rattachement à {user_offerer.offerer.name.upper()}",
         button_text="Supprimer le rattachement",
-        information="Cette action entraîne la suppression du lien utilisateur/structure et non le rejet. Cette action n’envoie aucun mail à l’acteur culturel.",
+        information="Cette action entraîne la suppression du lien utilisateur/entité et non le rejet. Cette action n’envoie aucun mail à l’acteur culturel.",
     )
 
 
@@ -733,7 +733,7 @@ def delete_user_offerer(offerer_id: int, user_offerer_id: int) -> utils.Backoffi
     offerers_api.delete_offerer_attachment(user_offerer, current_user, form.comment.data)
 
     flash(
-        f"Le rattachement de {user_email} à la structure {offerer_name} a été supprimé",
+        f"Le rattachement de {user_email} à l'entité {offerer_name} a été supprimé",
         "success",
     )
     return _self_redirect(offerer_id, active_tab="users", anchor="offerer_details_frame")
@@ -778,14 +778,14 @@ def add_user_offerer_and_validate(offerer_id: int) -> utils.BackofficeResponse:
 
     if not user:
         repository.mark_transaction_as_invalid()
-        flash("L'ID ne correspond pas à un ancien rattachement à la structure", "warning")
+        flash("L'ID ne correspond pas à un ancien rattachement à l'entité", "warning")
         return _self_redirect(offerer.id, active_tab="users", anchor="offerer_details_frame")
 
     new_user_offerer = offerers_models.UserOfferer(offerer=offerer, user=user, validationStatus=ValidationStatus.NEW)
     offerers_api.validate_offerer_attachment(new_user_offerer, current_user, form.comment.data)
 
     flash(
-        Markup("Le rattachement de <b>{email}</b> à la structure <b>{offerer_name}</b> a été ajouté").format(
+        Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> a été ajouté").format(
             email=user.email, offerer_name=offerer.name
         ),
         "success",

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -362,10 +362,10 @@ def suspend_offerer(offerer_id: int) -> utils.BackofficeResponse:
             offerers_api.suspend_offerer(offerer, current_user, form.comment.data)
         except offerers_exceptions.CannotSuspendOffererWithBookingsException:
             repository.mark_transaction_as_invalid()
-            flash("Impossible de suspendre une entité pour laquelle il existe des réservations", "warning")
+            flash("Impossible de suspendre une entité juridique pour laquelle il existe des réservations", "warning")
         else:
             flash(
-                Markup("L'entité <b>{offerer_name}</b> ({offerer_id}) a été suspendue").format(
+                Markup("L'entité juridique <b>{offerer_name}</b> ({offerer_id}) a été suspendue").format(
                     offerer_name=offerer.name, offerer_id=offerer_id
                 ),
                 "success",
@@ -394,7 +394,7 @@ def unsuspend_offerer(offerer_id: int) -> utils.BackofficeResponse:
     else:
         offerers_api.unsuspend_offerer(offerer, current_user, form.comment.data)
         flash(
-            Markup("L'entité <b>{offerer_name}</b> ({offerer_id}) a été réactivée").format(
+            Markup("L'entité juridique <b>{offerer_name}</b> ({offerer_id}) a été réactivée").format(
                 offerer_name=offerer.name, offerer_id=offerer_id
             ),
             "success",
@@ -421,7 +421,7 @@ def delete_offerer(offerer_id: int) -> utils.BackofficeResponse:
         offerers_api.delete_offerer(offerer.id)
     except offerers_exceptions.CannotDeleteOffererWithBookingsException:
         repository.mark_transaction_as_invalid()
-        flash("Impossible de supprimer une entité pour laquelle il existe des réservations", "warning")
+        flash("Impossible de supprimer une entité juridique pour laquelle il existe des réservations", "warning")
         return _self_redirect(offerer.id)
 
     for email in emails:
@@ -433,7 +433,7 @@ def delete_offerer(offerer_id: int) -> utils.BackofficeResponse:
         )
 
     flash(
-        Markup("L'entité <b>{offerer_name}</b> ({offerer_id}) a été supprimée").format(
+        Markup("L'entité juridique <b>{offerer_name}</b> ({offerer_id}) a été supprimée").format(
             offerer_name=offerer_name, offerer_id=offerer_id
         ),
         "success",
@@ -693,7 +693,7 @@ def get_delete_user_offerer_form(offerer_id: int, user_offerer_id: int) -> utils
         div_id=f"delete-modal-{user_offerer.id}",  # must be consistent with parameter passed to build_lazy_modal
         title=f"Supprimer le rattachement à {user_offerer.offerer.name.upper()}",
         button_text="Supprimer le rattachement",
-        information="Cette action entraîne la suppression du lien utilisateur/entité et non le rejet. Cette action n’envoie aucun mail à l’acteur culturel.",
+        information="Cette action entraîne la suppression du lien utilisateur/entité juridique et non le rejet. Cette action n’envoie aucun mail à l’acteur culturel.",
     )
 
 
@@ -733,7 +733,7 @@ def delete_user_offerer(offerer_id: int, user_offerer_id: int) -> utils.Backoffi
     offerers_api.delete_offerer_attachment(user_offerer, current_user, form.comment.data)
 
     flash(
-        f"Le rattachement de {user_email} à l'entité {offerer_name} a été supprimé",
+        f"Le rattachement de {user_email} à l'entité juridique {offerer_name} a été supprimé",
         "success",
     )
     return _self_redirect(offerer_id, active_tab="users", anchor="offerer_details_frame")
@@ -778,14 +778,14 @@ def add_user_offerer_and_validate(offerer_id: int) -> utils.BackofficeResponse:
 
     if not user:
         repository.mark_transaction_as_invalid()
-        flash("L'ID ne correspond pas à un ancien rattachement à l'entité", "warning")
+        flash("L'ID ne correspond pas à un ancien rattachement à l'entité juridique", "warning")
         return _self_redirect(offerer.id, active_tab="users", anchor="offerer_details_frame")
 
     new_user_offerer = offerers_models.UserOfferer(offerer=offerer, user=user, validationStatus=ValidationStatus.NEW)
     offerers_api.validate_offerer_attachment(new_user_offerer, current_user, form.comment.data)
 
     flash(
-        Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> a été ajouté").format(
+        Markup("Le rattachement de <b>{email}</b> à l'entité juridique <b>{offerer_name}</b> a été ajouté").format(
             email=user.email, offerer_name=offerer.name
         ),
         "success",

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_tag_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_tag_blueprint.py
@@ -97,7 +97,7 @@ def create_offerer_tag() -> utils.BackofficeResponse:
         )
         db.session.add(tag)
         db.session.flush()
-        flash("Le nouveau tag structure a été créé", "success")
+        flash("Le nouveau tag entité a été créé", "success")
 
     except sa.exc.IntegrityError:
         repository.mark_transaction_as_invalid()

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_tag_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_tag_blueprint.py
@@ -97,7 +97,7 @@ def create_offerer_tag() -> utils.BackofficeResponse:
         )
         db.session.add(tag)
         db.session.flush()
-        flash("Le nouveau tag entité a été créé", "success")
+        flash("Le nouveau tag a été créé", "success")
 
     except sa.exc.IntegrityError:
         repository.mark_transaction_as_invalid()

--- a/api/src/pcapi/routes/backoffice/offerers/serialization.py
+++ b/api/src/pcapi/routes/backoffice/offerers/serialization.py
@@ -4,7 +4,7 @@ from pcapi.routes.serialization import BaseModel
 
 class OffererBankInformationStatus(BaseModel):
     """
-    le nombre de lieux dont les infos permettent (ok), ou pas (ko), les remboursements
+    le nombre de partenaires culturels dont les infos permettent (ok), ou pas (ko), les remboursements
     """
 
     ko: int

--- a/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
@@ -125,10 +125,10 @@ def validate_offerer(offerer_id: int) -> utils.BackofficeResponse:
         offerers_api.validate_offerer(offerer, current_user)
     except offerers_exceptions.OffererAlreadyValidatedException:
         repository.mark_transaction_as_invalid()
-        flash(Markup("L'entité <b>{name}</b> est déjà validée").format(name=offerer.name), "warning")
+        flash(Markup("L'entité juridique <b>{name}</b> est déjà validée").format(name=offerer.name), "warning")
         return _redirect_after_offerer_validation_action()
 
-    flash(Markup("L'entité <b>{name}</b> a été validée").format(name=offerer.name), "success")
+    flash(Markup("L'entité juridique <b>{name}</b> a été validée").format(name=offerer.name), "success")
     return _redirect_after_offerer_validation_action()
 
 
@@ -152,8 +152,8 @@ def get_reject_offerer_form(offerer_id: int) -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_web.validation.reject_offerer", offerer_id=offerer.id),
         div_id=f"reject-modal-{offerer.id}",  # must be consistent with parameter passed to build_lazy_modal
-        title=f"Rejeter l'entité {offerer.name.upper()}",
-        button_text="Rejeter l'entité",
+        title=f"Rejeter l'entité juridique {offerer.name.upper()}",
+        button_text="Rejeter l'entité juridique",
     )
 
 
@@ -185,10 +185,10 @@ def reject_offerer(offerer_id: int) -> utils.BackofficeResponse:
         )
     except offerers_exceptions.OffererAlreadyRejectedException:
         repository.mark_transaction_as_invalid()
-        flash(Markup("L'entité <b>{name}</b> est déjà rejetée").format(name=offerer.name), "warning")
+        flash(Markup("L'entité juridique <b>{name}</b> est déjà rejetée").format(name=offerer.name), "warning")
         return _redirect_after_offerer_validation_action()
 
-    flash(Markup("L'entité <b>{name}</b> a été rejetée").format(name=offerer.name), "success")
+    flash(Markup("L'entité juridique <b>{name}</b> a été rejetée").format(name=offerer.name), "success")
     return _redirect_after_offerer_validation_action()
 
 
@@ -215,7 +215,7 @@ def get_offerer_pending_form(offerer_id: int) -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_web.validation.set_offerer_pending", offerer_id=offerer.id),
         div_id=f"pending-modal-{offerer.id}",  # must be consistent with parameter passed to build_lazy_modal
-        title=f"Mettre en attente l'entité {offerer.name.upper()}",
+        title=f"Mettre en attente l'entité juridique {offerer.name.upper()}",
         button_text="Mettre en attente",
     )
 
@@ -248,7 +248,7 @@ def set_offerer_pending(offerer_id: int) -> utils.BackofficeResponse:
         offerer, current_user, comment=form.comment.data, tags_to_add=tags_to_add, tags_to_remove=tags_to_remove
     )
 
-    flash(Markup("L'entité <b>{name}</b> a été mise en attente").format(name=offerer.name), "success")
+    flash(Markup("L'entité juridique <b>{name}</b> a été mise en attente").format(name=offerer.name), "success")
     return _redirect_after_offerer_validation_action()
 
 
@@ -345,12 +345,12 @@ def batch_validate_offerer() -> utils.BackofficeResponse:
     try:
         return _offerer_batch_action(
             offerers_api.validate_offerer,
-            "Les entités sélectionnées ont été validées",
+            "Les entités juridiques sélectionnées ont été validées",
             BatchForm,
         )
     except offerers_exceptions.OffererAlreadyValidatedException:
         repository.mark_transaction_as_invalid()
-        flash("Au moins une des entités a déjà été validée", "warning")
+        flash("Au moins une des entités juridiques a déjà été validée", "warning")
         return _redirect_after_offerer_validation_action()
 
 
@@ -385,8 +385,8 @@ def get_batch_offerer_pending_form() -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_web.validation.batch_set_offerer_pending"),
         div_id="batch-pending-modal",
-        title="Mettre en attente les entités",
-        button_text="Mettre en attente les entités",
+        title="Mettre en attente les entités juridiques",
+        button_text="Mettre en attente les entités juridiques",
     )
 
 
@@ -396,7 +396,7 @@ def get_batch_offerer_pending_form() -> utils.BackofficeResponse:
 def batch_set_offerer_pending() -> utils.BackofficeResponse:
     return _offerer_batch_action(
         offerers_api.set_offerer_pending,
-        "Les entités sélectionnées ont été mises en attente",
+        "Les entités juridiques sélectionnées ont été mises en attente",
         offerer_forms.BatchCommentAndTagOffererForm,
     )
 
@@ -411,8 +411,8 @@ def get_batch_reject_offerer_form() -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_web.validation.batch_reject_offerer"),
         div_id="batch-reject-modal",
-        title="Rejeter les entités",
-        button_text="Rejeter les entités",
+        title="Rejeter les entités juridiques",
+        button_text="Rejeter les entités juridiques",
     )
 
 
@@ -423,12 +423,12 @@ def batch_reject_offerer() -> utils.BackofficeResponse:
     try:
         return _offerer_batch_action(
             offerers_api.reject_offerer,
-            "Les entités sélectionnées ont été rejetées",
+            "Les entités juridiques sélectionnées ont été rejetées",
             offerer_forms.BatchOffererRejectionForm,
         )
     except offerers_exceptions.OffererAlreadyRejectedException:
         repository.mark_transaction_as_invalid()
-        flash("Une des entités a déjà été rejetée", "warning")
+        flash("Une des entités juridiques a déjà été rejetée", "warning")
         return _redirect_after_offerer_validation_action()
 
 
@@ -575,15 +575,15 @@ def validate_user_offerer(user_offerer_id: int) -> utils.BackofficeResponse:
     except offerers_exceptions.UserOffererAlreadyValidatedException:
         repository.mark_transaction_as_invalid()
         flash(
-            Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> est déjà validé").format(
-                email=user_offerer.user.email, offerer_name=user_offerer.offerer.name
-            ),
+            Markup(
+                "Le rattachement de <b>{email}</b> à l'entité juridique <b>{offerer_name}</b> est déjà validé"
+            ).format(email=user_offerer.user.email, offerer_name=user_offerer.offerer.name),
             "warning",
         )
         return _redirect_after_user_offerer_validation_action(user_offerer.offerer.id)
 
     flash(
-        Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> a été validé").format(
+        Markup("Le rattachement de <b>{email}</b> à l'entité juridique <b>{offerer_name}</b> a été validé").format(
             email=user_offerer.user.email, offerer_name=user_offerer.offerer.name
         ),
         "success",
@@ -654,7 +654,7 @@ def reject_user_offerer(user_offerer_id: int) -> utils.BackofficeResponse:
     offerers_api.reject_offerer_attachment(user_offerer, current_user, form.comment.data)
 
     flash(
-        Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> a été rejeté").format(
+        Markup("Le rattachement de <b>{email}</b> à l'entité juridique <b>{offerer_name}</b> a été rejeté").format(
             email=user_offerer.user.email, offerer_name=user_offerer.offerer.name
         ),
         "success",
@@ -694,9 +694,9 @@ def set_user_offerer_pending(user_offerer_id: int) -> utils.BackofficeResponse:
 
     offerers_api.set_offerer_attachment_pending(user_offerer, current_user, form.comment.data)
     flash(
-        Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> a été mis en attente").format(
-            email=user_offerer.user.email, offerer_name=user_offerer.offerer.name
-        ),
+        Markup(
+            "Le rattachement de <b>{email}</b> à l'entité juridique <b>{offerer_name}</b> a été mis en attente"
+        ).format(email=user_offerer.user.email, offerer_name=user_offerer.offerer.name),
         "success",
     )
 

--- a/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
@@ -125,10 +125,10 @@ def validate_offerer(offerer_id: int) -> utils.BackofficeResponse:
         offerers_api.validate_offerer(offerer, current_user)
     except offerers_exceptions.OffererAlreadyValidatedException:
         repository.mark_transaction_as_invalid()
-        flash(Markup("La structure <b>{name}</b> est déjà validée").format(name=offerer.name), "warning")
+        flash(Markup("L'entité <b>{name}</b> est déjà validée").format(name=offerer.name), "warning")
         return _redirect_after_offerer_validation_action()
 
-    flash(Markup("La structure <b>{name}</b> a été validée").format(name=offerer.name), "success")
+    flash(Markup("L'entité <b>{name}</b> a été validée").format(name=offerer.name), "success")
     return _redirect_after_offerer_validation_action()
 
 
@@ -152,8 +152,8 @@ def get_reject_offerer_form(offerer_id: int) -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_web.validation.reject_offerer", offerer_id=offerer.id),
         div_id=f"reject-modal-{offerer.id}",  # must be consistent with parameter passed to build_lazy_modal
-        title=f"Rejeter la structure la structure {offerer.name.upper()}",
-        button_text="Rejeter la structure",
+        title=f"Rejeter l'entité {offerer.name.upper()}",
+        button_text="Rejeter l'entité",
     )
 
 
@@ -185,10 +185,10 @@ def reject_offerer(offerer_id: int) -> utils.BackofficeResponse:
         )
     except offerers_exceptions.OffererAlreadyRejectedException:
         repository.mark_transaction_as_invalid()
-        flash(Markup("La structure <b>{name}</b> est déjà rejetée").format(name=offerer.name), "warning")
+        flash(Markup("L'entité <b>{name}</b> est déjà rejetée").format(name=offerer.name), "warning")
         return _redirect_after_offerer_validation_action()
 
-    flash(Markup("La structure <b>{name}</b> a été rejetée").format(name=offerer.name), "success")
+    flash(Markup("L'entité <b>{name}</b> a été rejetée").format(name=offerer.name), "success")
     return _redirect_after_offerer_validation_action()
 
 
@@ -215,7 +215,7 @@ def get_offerer_pending_form(offerer_id: int) -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_web.validation.set_offerer_pending", offerer_id=offerer.id),
         div_id=f"pending-modal-{offerer.id}",  # must be consistent with parameter passed to build_lazy_modal
-        title=f"Mettre en attente la structure {offerer.name.upper()}",
+        title=f"Mettre en attente l'entité {offerer.name.upper()}",
         button_text="Mettre en attente",
     )
 
@@ -248,7 +248,7 @@ def set_offerer_pending(offerer_id: int) -> utils.BackofficeResponse:
         offerer, current_user, comment=form.comment.data, tags_to_add=tags_to_add, tags_to_remove=tags_to_remove
     )
 
-    flash(Markup("La structure <b>{name}</b> a été mise en attente").format(name=offerer.name), "success")
+    flash(Markup("L'entité <b>{name}</b> a été mise en attente").format(name=offerer.name), "success")
     return _redirect_after_offerer_validation_action()
 
 
@@ -345,12 +345,12 @@ def batch_validate_offerer() -> utils.BackofficeResponse:
     try:
         return _offerer_batch_action(
             offerers_api.validate_offerer,
-            "Les structures sélectionnées ont été validées",
+            "Les entités sélectionnées ont été validées",
             BatchForm,
         )
     except offerers_exceptions.OffererAlreadyValidatedException:
         repository.mark_transaction_as_invalid()
-        flash("Au moins une des structures a déjà été validée", "warning")
+        flash("Au moins une des entités a déjà été validée", "warning")
         return _redirect_after_offerer_validation_action()
 
 
@@ -385,8 +385,8 @@ def get_batch_offerer_pending_form() -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_web.validation.batch_set_offerer_pending"),
         div_id="batch-pending-modal",
-        title="Mettre en attente les structures",
-        button_text="Mettre en attente les structures",
+        title="Mettre en attente les entités",
+        button_text="Mettre en attente les entités",
     )
 
 
@@ -396,7 +396,7 @@ def get_batch_offerer_pending_form() -> utils.BackofficeResponse:
 def batch_set_offerer_pending() -> utils.BackofficeResponse:
     return _offerer_batch_action(
         offerers_api.set_offerer_pending,
-        "Les structures sélectionnées ont été mises en attente",
+        "Les entités sélectionnées ont été mises en attente",
         offerer_forms.BatchCommentAndTagOffererForm,
     )
 
@@ -411,8 +411,8 @@ def get_batch_reject_offerer_form() -> utils.BackofficeResponse:
         form=form,
         dst=url_for("backoffice_web.validation.batch_reject_offerer"),
         div_id="batch-reject-modal",
-        title="Rejeter les structures",
-        button_text="Rejeter les structures",
+        title="Rejeter les entités",
+        button_text="Rejeter les entités",
     )
 
 
@@ -423,12 +423,12 @@ def batch_reject_offerer() -> utils.BackofficeResponse:
     try:
         return _offerer_batch_action(
             offerers_api.reject_offerer,
-            "Les structures sélectionnées ont été rejetées",
+            "Les entités sélectionnées ont été rejetées",
             offerer_forms.BatchOffererRejectionForm,
         )
     except offerers_exceptions.OffererAlreadyRejectedException:
         repository.mark_transaction_as_invalid()
-        flash("Une des structures a déjà été rejetée", "warning")
+        flash("Une des entités a déjà été rejetée", "warning")
         return _redirect_after_offerer_validation_action()
 
 
@@ -575,7 +575,7 @@ def validate_user_offerer(user_offerer_id: int) -> utils.BackofficeResponse:
     except offerers_exceptions.UserOffererAlreadyValidatedException:
         repository.mark_transaction_as_invalid()
         flash(
-            Markup("Le rattachement de <b>{email}</b> à la structure <b>{offerer_name}</b> est déjà validé").format(
+            Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> est déjà validé").format(
                 email=user_offerer.user.email, offerer_name=user_offerer.offerer.name
             ),
             "warning",
@@ -583,7 +583,7 @@ def validate_user_offerer(user_offerer_id: int) -> utils.BackofficeResponse:
         return _redirect_after_user_offerer_validation_action(user_offerer.offerer.id)
 
     flash(
-        Markup("Le rattachement de <b>{email}</b> à la structure <b>{offerer_name}</b> a été validé").format(
+        Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> a été validé").format(
             email=user_offerer.user.email, offerer_name=user_offerer.offerer.name
         ),
         "success",
@@ -654,7 +654,7 @@ def reject_user_offerer(user_offerer_id: int) -> utils.BackofficeResponse:
     offerers_api.reject_offerer_attachment(user_offerer, current_user, form.comment.data)
 
     flash(
-        Markup("Le rattachement de <b>{email}</b> à la structure <b>{offerer_name}</b> a été rejeté").format(
+        Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> a été rejeté").format(
             email=user_offerer.user.email, offerer_name=user_offerer.offerer.name
         ),
         "success",
@@ -694,7 +694,7 @@ def set_user_offerer_pending(user_offerer_id: int) -> utils.BackofficeResponse:
 
     offerers_api.set_offerer_attachment_pending(user_offerer, current_user, form.comment.data)
     flash(
-        Markup("Le rattachement de <b>{email}</b> à la structure <b>{offerer_name}</b> a été mis en attente").format(
+        Markup("Le rattachement de <b>{email}</b> à l'entité <b>{offerer_name}</b> a été mis en attente").format(
             email=user_offerer.user.email, offerer_name=user_offerer.offerer.name
         ),
         "success",

--- a/api/src/pcapi/routes/backoffice/offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offers/forms.py
@@ -58,7 +58,7 @@ class IndividualOffersAlgoliaSearchAttributes(enum.Enum):
     DATE = "Date"
     DEPARTMENT = "Département"
     EAN = "EAN-13"
-    VENUE = "Lieu"
+    VENUE = forms_utils.VenueRenaming("Lieu", "Partenaire culturel")
     REGION = "Région"
     SUBCATEGORY = "Sous-catégorie"
     OFFERER = "Entité"
@@ -456,7 +456,7 @@ class OfferAlgoliaSearchSubForm(forms_utils.PCForm):
         ],
     )
     venue = fields.PCTomSelectField(
-        "Lieux",
+        typing.cast(str, forms_utils.VenueRenaming("Lieux", "Partenaires culturels")),
         multiple=True,
         choices=[],
         validate_choice=False,

--- a/api/src/pcapi/routes/backoffice/offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offers/forms.py
@@ -45,7 +45,7 @@ class IndividualOffersSearchAttributes(enum.Enum):
     PRICE = "Prix"
     PROVIDER = "Fournisseur"
     STATUS = "Statut"
-    OFFERER = "Entité"
+    OFFERER = "Entité juridique"
     TAG = "Tag"
     MUSIC_TYPE_GTL = "Type de musique"
     SHOW_TYPE = "Type de spectacle"
@@ -61,7 +61,7 @@ class IndividualOffersAlgoliaSearchAttributes(enum.Enum):
     VENUE = forms_utils.VenueRenaming("Lieu", "Partenaire culturel")
     REGION = "Région"
     SUBCATEGORY = "Sous-catégorie"
-    OFFERER = "Entité"
+    OFFERER = "Entité juridique"
     PRICE = "Prix"
     SHOW_TYPE = "Type de spectacle"
 
@@ -257,7 +257,7 @@ class OfferAdvancedSearchSubForm(forms_utils.PCForm):
         ],
     )
     offerer = fields.PCTomSelectField(
-        "Entités",
+        "Entités juridiques",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -433,7 +433,7 @@ class OfferAlgoliaSearchSubForm(forms_utils.PCForm):
         field_list_compatibility=True,
     )
     offerer = fields.PCTomSelectField(
-        "Entités",
+        "Entités juridiques",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -547,7 +547,9 @@ class BaseOfferAdvancedSearchForm(GetOffersBaseFields):
 
 class GetOfferAdvancedSearchForm(BaseOfferAdvancedSearchForm):
     form_field_configuration = form_field_configuration
-    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des entités validées", full_row=True)
+    only_validated_offerers = fields.PCSwitchBooleanField(
+        "Uniquement les offres des entités juridiques validées", full_row=True
+    )
 
     def is_empty(self) -> bool:
         empty = not self.only_validated_offerers.data

--- a/api/src/pcapi/routes/backoffice/offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offers/forms.py
@@ -45,7 +45,7 @@ class IndividualOffersSearchAttributes(enum.Enum):
     PRICE = "Prix"
     PROVIDER = "Fournisseur"
     STATUS = "Statut"
-    OFFERER = "Structure"
+    OFFERER = "Entité"
     TAG = "Tag"
     MUSIC_TYPE_GTL = "Type de musique"
     SHOW_TYPE = "Type de spectacle"
@@ -61,7 +61,7 @@ class IndividualOffersAlgoliaSearchAttributes(enum.Enum):
     VENUE = "Lieu"
     REGION = "Région"
     SUBCATEGORY = "Sous-catégorie"
-    OFFERER = "Structure"
+    OFFERER = "Entité"
     PRICE = "Prix"
     SHOW_TYPE = "Type de spectacle"
 
@@ -257,7 +257,7 @@ class OfferAdvancedSearchSubForm(forms_utils.PCForm):
         ],
     )
     offerer = fields.PCTomSelectField(
-        "Structures",
+        "Entités",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -433,7 +433,7 @@ class OfferAlgoliaSearchSubForm(forms_utils.PCForm):
         field_list_compatibility=True,
     )
     offerer = fields.PCTomSelectField(
-        "Structures",
+        "Entités",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -547,9 +547,7 @@ class BaseOfferAdvancedSearchForm(GetOffersBaseFields):
 
 class GetOfferAdvancedSearchForm(BaseOfferAdvancedSearchForm):
     form_field_configuration = form_field_configuration
-    only_validated_offerers = fields.PCSwitchBooleanField(
-        "Uniquement les offres des structures validées", full_row=True
-    )
+    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les offres des entités validées", full_row=True)
 
     def is_empty(self) -> bool:
         empty = not self.only_validated_offerers.data

--- a/api/src/pcapi/routes/backoffice/pro/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro/blueprint.py
@@ -179,13 +179,13 @@ def _render_get_create_offerer_form(form: pro_forms.CreateOffererForm) -> str:
         venue_label = "lieu"
     return render_template(
         "components/turbo/modal_form.html",
-        information=f"Ce formulaire permet de créer une nouvelle structure et le {venue_label} associé dans la base de données. "
-        f"L'Acteur Culturel doit avoir créé son compte utilisateur sur PC Pro et sera ainsi rattaché à la nouvelle structure. ",
+        information=f"Ce formulaire permet de créer une nouvelle entité et le {venue_label} associé dans la base de données. "
+        f"L'Acteur Culturel doit avoir créé son compte utilisateur sur PC Pro et sera ainsi rattaché à la nouvelle entité. ",
         form=form,
         dst=url_for("backoffice_web.pro.create_offerer"),
         div_id="create-offerer-modal",  # must be consistent with parameter passed to build_lazy_modal
-        title="Créer une structure",
-        button_text="Créer la structure",
+        title="Créer une entité",
+        button_text="Créer l'entité",
         data_turbo=True,
     )
 
@@ -248,7 +248,7 @@ def create_offerer() -> utils.BackofficeResponse:
         offerer_creation_info,
         new_onboarding_info,
         author=current_user,
-        comment="Structure créée depuis le backoffice",
+        comment="Entité créée depuis le backoffice",
         ds_dossier_id=form.ds_id.data,
     )
 
@@ -282,11 +282,11 @@ def create_offerer() -> utils.BackofficeResponse:
 
     if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
         flash(
-            Markup("La structure et le partenaire culturel <b>{name}</b> ont été créés").format(name=venue.common_name),
+            Markup("L'entité et le partenaire culturel <b>{name}</b> ont été créés").format(name=venue.common_name),
             "success",
         )
     else:
-        flash(Markup("La structure et le lieu <b>{name}</b> ont été créés").format(name=venue.common_name), "success")
+        flash(Markup("L'entité et le lieu <b>{name}</b> ont été créés").format(name=venue.common_name), "success")
     return redirect(url_for("backoffice_web.offerer.get", offerer_id=user_offerer.offererId), code=303)
 
 
@@ -366,7 +366,7 @@ def _get_user_id_from_offerer_id(offerer_id: int) -> int:
     query = _get_connect_as_base_query().filter(offerers_models.UserOfferer.offererId == offerer_id)
     user_id = _get_best_user_id_for_connect_as(query)
     if not user_id:
-        raise ValueError("Aucun utilisateur approprié n'a été trouvé pour se connecter à cette structure")
+        raise ValueError("Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité")
     return user_id
 
 

--- a/api/src/pcapi/routes/backoffice/pro/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro/blueprint.py
@@ -179,13 +179,13 @@ def _render_get_create_offerer_form(form: pro_forms.CreateOffererForm) -> str:
         venue_label = "lieu"
     return render_template(
         "components/turbo/modal_form.html",
-        information=f"Ce formulaire permet de créer une nouvelle entité et le {venue_label} associé dans la base de données. "
-        f"L'Acteur Culturel doit avoir créé son compte utilisateur sur PC Pro et sera ainsi rattaché à la nouvelle entité. ",
+        information=f"Ce formulaire permet de créer une nouvelle entité juridique et le {venue_label} associé dans la base de données. "
+        f"L'Acteur Culturel doit avoir créé son compte utilisateur sur PC Pro et sera ainsi rattaché à la nouvelle entité juridique. ",
         form=form,
         dst=url_for("backoffice_web.pro.create_offerer"),
         div_id="create-offerer-modal",  # must be consistent with parameter passed to build_lazy_modal
-        title="Créer une entité",
-        button_text="Créer l'entité",
+        title="Créer un partenaire culturel",
+        button_text="Créer l'entité juridique",
         data_turbo=True,
     )
 
@@ -248,7 +248,7 @@ def create_offerer() -> utils.BackofficeResponse:
         offerer_creation_info,
         new_onboarding_info,
         author=current_user,
-        comment="Entité créée depuis le backoffice",
+        comment="Entité juridique créée depuis le backoffice",
         ds_dossier_id=form.ds_id.data,
     )
 
@@ -282,11 +282,16 @@ def create_offerer() -> utils.BackofficeResponse:
 
     if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
         flash(
-            Markup("L'entité et le partenaire culturel <b>{name}</b> ont été créés").format(name=venue.common_name),
+            Markup("L'entité juridique et le partenaire culturel <b>{name}</b> ont été créés").format(
+                name=venue.common_name
+            ),
             "success",
         )
     else:
-        flash(Markup("L'entité et le lieu <b>{name}</b> ont été créés").format(name=venue.common_name), "success")
+        flash(
+            Markup("L'entité juridique et le lieu <b>{name}</b> ont été créés").format(name=venue.common_name),
+            "success",
+        )
     return redirect(url_for("backoffice_web.offerer.get", offerer_id=user_offerer.offererId), code=303)
 
 
@@ -366,7 +371,7 @@ def _get_user_id_from_offerer_id(offerer_id: int) -> int:
     query = _get_connect_as_base_query().filter(offerers_models.UserOfferer.offererId == offerer_id)
     user_id = _get_best_user_id_for_connect_as(query)
     if not user_id:
-        raise ValueError("Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité")
+        raise ValueError("Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité juridique")
     return user_id
 
 

--- a/api/src/pcapi/routes/backoffice/pro/forms.py
+++ b/api/src/pcapi/routes/backoffice/pro/forms.py
@@ -34,7 +34,7 @@ class TypeOptions(enum.Enum):
 def format_search_type_options(type_option: TypeOptions) -> str:
     match type_option:
         case TypeOptions.OFFERER:
-            return "Entité"
+            return "Entité juridique"
         case TypeOptions.VENUE:
             return typing.cast(str, utils.VenueRenaming("Lieu", "Partenaire culturel"))
         case TypeOptions.USER:
@@ -121,7 +121,7 @@ class CreateOffererForm(FlaskForm):
         if siret.data and len(siret.data) == siren_utils.SIRET_LENGTH and siret.data.isnumeric():
             siren = siret.data[:9]
             if find_offerer_by_siren(siren):
-                raise wtforms.validators.ValidationError(f"Une entité existe déjà avec le SIREN {siren}")
+                raise wtforms.validators.ValidationError(f"Une entité juridique existe déjà avec le SIREN {siren}")
 
             try:
                 siret_info = sirene.get_siret(siret.data, raise_if_non_public=False)
@@ -134,7 +134,7 @@ class CreateOffererForm(FlaskForm):
                 raise wtforms.validators.ValidationError(f"L'établissement portant le SIRET {siret.data} est fermé")
             if siret_info.diffusible:
                 raise wtforms.validators.ValidationError(
-                    f"L'établissement portant le SIRET {siret.data} est diffusible, l'acteur culturel peut créer l'entité sur PC Pro"
+                    f"L'établissement portant le SIRET {siret.data} est diffusible, l'acteur culturel peut créer l'entité juridique sur PC Pro"
                 )
             self._siret_info = siret_info
 

--- a/api/src/pcapi/routes/backoffice/pro/forms.py
+++ b/api/src/pcapi/routes/backoffice/pro/forms.py
@@ -34,7 +34,7 @@ class TypeOptions(enum.Enum):
 def format_search_type_options(type_option: TypeOptions) -> str:
     match type_option:
         case TypeOptions.OFFERER:
-            return "Structure"
+            return "Entité"
         case TypeOptions.VENUE:
             return typing.cast(str, utils.VenueRenaming("Lieu", "Partenaire culturel"))
         case TypeOptions.USER:
@@ -121,7 +121,7 @@ class CreateOffererForm(FlaskForm):
         if siret.data and len(siret.data) == siren_utils.SIRET_LENGTH and siret.data.isnumeric():
             siren = siret.data[:9]
             if find_offerer_by_siren(siren):
-                raise wtforms.validators.ValidationError(f"Une structure existe déjà avec le SIREN {siren}")
+                raise wtforms.validators.ValidationError(f"Une entité existe déjà avec le SIREN {siren}")
 
             try:
                 siret_info = sirene.get_siret(siret.data, raise_if_non_public=False)
@@ -134,7 +134,7 @@ class CreateOffererForm(FlaskForm):
                 raise wtforms.validators.ValidationError(f"L'établissement portant le SIRET {siret.data} est fermé")
             if siret_info.diffusible:
                 raise wtforms.validators.ValidationError(
-                    f"L'établissement portant le SIRET {siret.data} est diffusible, l'acteur culturel peut créer la structure sur PC Pro"
+                    f"L'établissement portant le SIRET {siret.data} est diffusible, l'acteur culturel peut créer l'entité sur PC Pro"
                 )
             self._siret_info = siret_info
 

--- a/api/src/pcapi/routes/backoffice/pro_users/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro_users/blueprint.py
@@ -186,7 +186,7 @@ def delete(user_id: int) -> utils.BackofficeResponse:
 
     if not _user_can_be_deleted(user):
         mark_transaction_as_invalid()
-        flash("Le compte est rattaché à une entité", "warning")
+        flash("Le compte est rattaché à une entité juridique", "warning")
         return redirect(url_for("backoffice_web.pro_user.get", user_id=user_id), code=303)
 
     form = pro_users_forms.DeleteProUser()

--- a/api/src/pcapi/routes/backoffice/pro_users/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro_users/blueprint.py
@@ -186,7 +186,7 @@ def delete(user_id: int) -> utils.BackofficeResponse:
 
     if not _user_can_be_deleted(user):
         mark_transaction_as_invalid()
-        flash("Le compte est rattaché à une structure", "warning")
+        flash("Le compte est rattaché à une entité", "warning")
         return redirect(url_for("backoffice_web.pro_user.get", user_id=user_id), code=303)
 
     form = pro_users_forms.DeleteProUser()

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
@@ -51,7 +51,7 @@
                   {{ bank_account.bic }}
                 </p>
                 <p class="mb-1">
-                  <span class="fw-bold">Structure :</span>
+                  <span class="fw-bold">Entité :</span>
                   {{ links.build_offerer_name_to_details_link(bank_account.offerer) }}
                 </p>
               </div>

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
@@ -51,7 +51,7 @@
                   {{ bank_account.bic }}
                 </p>
                 <p class="mb-1">
-                  <span class="fw-bold">Entité :</span>
+                  <span class="fw-bold">Entité juridique :</span>
                   {{ links.build_offerer_name_to_details_link(bank_account.offerer) }}
                 </p>
               </div>

--- a/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
@@ -62,7 +62,7 @@
               <th scope="col">Évènement comptable</th>
               <th scope="col">Date de réservation</th>
               <th scope="col">Date de l'évènement</th>
-              <th scope="col">Structure</th>
+              <th scope="col">Entité</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_bookings/list.html
@@ -62,7 +62,7 @@
               <th scope="col">Évènement comptable</th>
               <th scope="col">Date de réservation</th>
               <th scope="col">Date de l'évènement</th>
-              <th scope="col">Entité</th>
+              <th scope="col">Entité juridique</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -102,7 +102,7 @@
             <div class="col-4">
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Entité :</span> {{ links.build_offerer_name_to_details_link(collective_offer.venue.managingOfferer) }}
+                  <span class="fw-bold">Entité juridique :</span> {{ links.build_offerer_name_to_details_link(collective_offer.venue.managingOfferer) }}
                 </p>
               </div>
               <div class="fs-6">

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -102,7 +102,7 @@
             <div class="col-4">
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Structure :</span> {{ links.build_offerer_name_to_details_link(collective_offer.venue.managingOfferer) }}
+                  <span class="fw-bold">Entité :</span> {{ links.build_offerer_name_to_details_link(collective_offer.venue.managingOfferer) }}
                 </p>
               </div>
               <div class="fs-6">

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
@@ -60,7 +60,7 @@
               </th>
               <th scope="col">Date de l'évènement</th>
               {% if has_permission("PRO_FRAUD_ACTIONS") %}<th scope="col">Tarif</th>{% endif %}
-              <th scope="col">Entité</th>
+              <th scope="col">Entité juridique</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/list.html
@@ -60,7 +60,7 @@
               </th>
               <th scope="col">Date de l'évènement</th>
               {% if has_permission("PRO_FRAUD_ACTIONS") %}<th scope="col">Tarif</th>{% endif %}
-              <th scope="col">Structure</th>
+              <th scope="col">Entité</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/details.html
@@ -65,7 +65,7 @@
             <div class="col-4">
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Entité :</span> {{ links.build_offerer_name_to_details_link(collective_offer_template.venue.managingOfferer) }}
+                  <span class="fw-bold">Entité juridique :</span> {{ links.build_offerer_name_to_details_link(collective_offer_template.venue.managingOfferer) }}
                 </p>
               </div>
               <div class="fs-6">

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/details.html
@@ -65,7 +65,7 @@
             <div class="col-4">
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Structure :</span> {{ links.build_offerer_name_to_details_link(collective_offer_template.venue.managingOfferer) }}
+                  <span class="fw-bold">Entité :</span> {{ links.build_offerer_name_to_details_link(collective_offer_template.venue.managingOfferer) }}
                 </p>
               </div>
               <div class="fs-6">

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
@@ -58,7 +58,7 @@
                   Date de création
                 {% endif %}
               </th>
-              <th scope="col">Entité</th>
+              <th scope="col">Entité juridique</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/list.html
@@ -58,7 +58,7 @@
                   Date de création
                 {% endif %}
               </th>
-              <th scope="col">Structure</th>
+              <th scope="col">Entité</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/components/badges.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/badges.html
@@ -38,7 +38,7 @@
   {{ build_status_badge(offerer, "Nouvelle", "En attente", "Validée", "Rejetée", "Supprimée") }}
 {% endmacro %}
 {% macro build_offerer_badges(offerer) %}
-  <span class="me-1 pb-1 badge rounded-pill text-bg-secondary">Structure</span>
+  <span class="me-1 pb-1 badge rounded-pill text-bg-secondary">Entité</span>
   {{ build_offerer_status_badge(offerer) }}
   {% if not offerer.isActive %}
     <span class="me-1 pb-1 badge rounded-pill text-bg-dark">

--- a/api/src/pcapi/routes/backoffice/templates/components/badges.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/badges.html
@@ -38,7 +38,7 @@
   {{ build_status_badge(offerer, "Nouvelle", "En attente", "Validée", "Rejetée", "Supprimée") }}
 {% endmacro %}
 {% macro build_offerer_badges(offerer) %}
-  <span class="me-1 pb-1 badge rounded-pill text-bg-secondary">Entité</span>
+  <span class="me-1 pb-1 badge rounded-pill text-bg-secondary">Entité juridique</span>
   {{ build_offerer_status_badge(offerer) }}
   {% if not offerer.isActive %}
     <span class="me-1 pb-1 badge rounded-pill text-bg-dark">

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
@@ -13,7 +13,7 @@
     {% endif %}
     <h6 class="card-subtitle mt-4 mb-3 text-muted">Venue ID : {{ row.id }}</h6>
     <h6 class="card-subtitle mb-3 text-muted">{{ row.identifier_name }} : {{ (row.identifier) | empty_string_if_null }}</h6>
-    <h6 class="card-subtitle mb-4 text-muted">Entité : {{ build_offerer_name_to_details_link(row.managingOfferer) }}</h6>
+    <h6 class="card-subtitle mb-4 text-muted">Entité juridique : {{ build_offerer_name_to_details_link(row.managingOfferer) }}</h6>
     <div class="fs-6">
       <p class="mb-1">
         <span class="fw-bold">Email :</span> {{ row.bookingEmail | empty_string_if_null }}

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card_venue.html
@@ -13,7 +13,7 @@
     {% endif %}
     <h6 class="card-subtitle mt-4 mb-3 text-muted">Venue ID : {{ row.id }}</h6>
     <h6 class="card-subtitle mb-3 text-muted">{{ row.identifier_name }} : {{ (row.identifier) | empty_string_if_null }}</h6>
-    <h6 class="card-subtitle mb-4 text-muted">Structure : {{ build_offerer_name_to_details_link(row.managingOfferer) }}</h6>
+    <h6 class="card-subtitle mb-4 text-muted">Entité : {{ build_offerer_name_to_details_link(row.managingOfferer) }}</h6>
     <div class="fs-6">
       <p class="mb-1">
         <span class="fw-bold">Email :</span> {{ row.bookingEmail | empty_string_if_null }}

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
@@ -45,7 +45,7 @@
             <tr>
               <th scope="col"></th>
               <th scope="col">ID règle</th>
-              <th scope="col">Structure</th>
+              <th scope="col">Entité</th>
               <th scope="col">SIREN</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list.html
@@ -45,7 +45,7 @@
             <tr>
               <th scope="col"></th>
               <th scope="col">ID règle</th>
-              <th scope="col">Entité</th>
+              <th scope="col">Entité juridique</th>
               <th scope="col">SIREN</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list/stats.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list/stats.html
@@ -4,7 +4,7 @@
     <div class="card-body">
       <h5 class="fs-2 card-title">{{ stats.by_offerer or 0 }}</h5>
       <p class="card-text fw-light small mb-0">
-        tarifs dérogatoires sur des <b>structures</b>
+        tarifs dérogatoires sur des <b>entités</b>
       </p>
     </div>
   </div>

--- a/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list/stats.html
+++ b/api/src/pcapi/routes/backoffice/templates/custom_reimbursement_rules/list/stats.html
@@ -4,7 +4,7 @@
     <div class="card-body">
       <h5 class="fs-2 card-title">{{ stats.by_offerer or 0 }}</h5>
       <p class="card-text fw-light small mb-0">
-        tarifs dérogatoires sur des <b>entités</b>
+        tarifs dérogatoires sur des <b>entités juridiques</b>
       </p>
     </div>
   </div>

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/list.html
@@ -29,7 +29,7 @@
                 <th scope="col">Type de résa</th>
                 <th scope="col">Nb. Réservation(s)</th>
                 <th scope="col">Montant total</th>
-                <th scope="col">Entité</th>
+                <th scope="col">Entité juridique</th>
                 <th scope="col">
                   {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                     Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/finance/incidents/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/finance/incidents/list.html
@@ -29,7 +29,7 @@
                 <th scope="col">Type de résa</th>
                 <th scope="col">Nb. Réservation(s)</th>
                 <th scope="col">Montant total</th>
-                <th scope="col">Structure</th>
+                <th scope="col">Entité</th>
                 <th scope="col">
                   {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                     Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/home/home.html
+++ b/api/src/pcapi/routes/backoffice/templates/home/home.html
@@ -54,8 +54,8 @@
                 url_for("backoffice_web.collective_offer_template.list_collective_offer_templates", status="PENDING", only_validated_offerers="on", sort="dateCreated", order="desc", limit="1000") ) }}
         {% if conformite_tag_id %}
           {{ stats_card(pending_conformite_offerers_count,
-                    "entité en attente de conformité",
-                    "entités en attente de conformité",
+                    "entité juridique en attente de conformité",
+                    "entités juridiques en attente de conformité",
                     url_for("backoffice_web.validation.list_offerers_to_validate", status=["PENDING"], tags=conformite_tag_id, sort="dateCreated", order="desc") ) }}
         {% endif %}
       </div>

--- a/api/src/pcapi/routes/backoffice/templates/home/home.html
+++ b/api/src/pcapi/routes/backoffice/templates/home/home.html
@@ -54,8 +54,8 @@
                 url_for("backoffice_web.collective_offer_template.list_collective_offer_templates", status="PENDING", only_validated_offerers="on", sort="dateCreated", order="desc", limit="1000") ) }}
         {% if conformite_tag_id %}
           {{ stats_card(pending_conformite_offerers_count,
-                    "structure en attente de conformité",
-                    "structures en attente de conformité",
+                    "entité en attente de conformité",
+                    "entités en attente de conformité",
                     url_for("backoffice_web.validation.list_offerers_to_validate", status=["PENDING"], tags=conformite_tag_id, sort="dateCreated", order="desc") ) }}
         {% endif %}
       </div>

--- a/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
@@ -98,7 +98,7 @@
               <th scope="col">Évènement comptable</th>
               <th scope="col">Date de réservation</th>
               <th scope="col">Date de l'évènement</th>
-              <th scope="col">Entité</th>
+              <th scope="col">Entité juridique</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/individual_bookings/list.html
@@ -98,7 +98,7 @@
               <th scope="col">Évènement comptable</th>
               <th scope="col">Date de réservation</th>
               <th scope="col">Date de l'évènement</th>
-              <th scope="col">Structure</th>
+              <th scope="col">Entité</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
@@ -78,10 +78,10 @@
                 {% call menu_section("Acteurs culturels") %}
                   {% if has_permission("READ_PRO_ENTITY") %}
                     {{ menu_section_item('Liste des acteurs culturels', 'backoffice_web.pro.search_pro') }}
-                    {{ menu_section_item('Structures à valider', 'backoffice_web.validation.list_offerers_to_validate') }}
+                    {{ menu_section_item('Entités à valider', 'backoffice_web.validation.list_offerers_to_validate') }}
                     {{ menu_section_item('Rattachements à valider', 'backoffice_web.validation.list_offerers_attachments_to_validate') }}
                   {% endif %}
-                  {% if has_permission("READ_TAGS") %}{{ menu_section_item('Tags structure', 'backoffice_web.offerer_tag.list_offerer_tags') }}{% endif %}
+                  {% if has_permission("READ_TAGS") %}{{ menu_section_item('Tags entité', 'backoffice_web.offerer_tag.list_offerer_tags') }}{% endif %}
                   {% if has_permission("READ_OFFERS") %}
                     {{ menu_section_item('Offres individuelles', 'backoffice_web.offer.list_offers') }}
                     {{ menu_section_item('Offres collectives', 'backoffice_web.collective_offer.list_collective_offers') }}

--- a/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
+++ b/api/src/pcapi/routes/backoffice/templates/layouts/connected.html
@@ -78,10 +78,12 @@
                 {% call menu_section("Acteurs culturels") %}
                   {% if has_permission("READ_PRO_ENTITY") %}
                     {{ menu_section_item('Liste des acteurs culturels', 'backoffice_web.pro.search_pro') }}
-                    {{ menu_section_item('Entités à valider', 'backoffice_web.validation.list_offerers_to_validate') }}
+                    {{ menu_section_item('Entités juridiques à valider', 'backoffice_web.validation.list_offerers_to_validate') }}
                     {{ menu_section_item('Rattachements à valider', 'backoffice_web.validation.list_offerers_attachments_to_validate') }}
                   {% endif %}
-                  {% if has_permission("READ_TAGS") %}{{ menu_section_item('Tags entité', 'backoffice_web.offerer_tag.list_offerer_tags') }}{% endif %}
+                  {% if has_permission("READ_TAGS") %}
+                    {{ menu_section_item('Tags des entités juridiques', 'backoffice_web.offerer_tag.list_offerer_tags') }}
+                  {% endif %}
                   {% if has_permission("READ_OFFERS") %}
                     {{ menu_section_item('Offres individuelles', 'backoffice_web.offer.list_offers') }}
                     {{ menu_section_item('Offres collectives', 'backoffice_web.collective_offer.list_collective_offers') }}

--- a/api/src/pcapi/routes/backoffice/templates/offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/details.html
@@ -176,7 +176,7 @@
             <div class="col-4">
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Structure :</span> {{ links.build_offerer_name_to_details_link(offer.venue.managingOfferer) }}
+                  <span class="fw-bold">Entité :</span> {{ links.build_offerer_name_to_details_link(offer.venue.managingOfferer) }}
                 </p>
               </div>
               <div class="fs-6">

--- a/api/src/pcapi/routes/backoffice/templates/offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/details.html
@@ -176,7 +176,7 @@
             <div class="col-4">
               <div class="fs-6">
                 <p class="mb-1">
-                  <span class="fw-bold">Entité :</span> {{ links.build_offerer_name_to_details_link(offer.venue.managingOfferer) }}
+                  <span class="fw-bold">Entité juridique :</span> {{ links.build_offerer_name_to_details_link(offer.venue.managingOfferer) }}
                 </p>
               </div>
               <div class="fs-6">

--- a/api/src/pcapi/routes/backoffice/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/list.html
@@ -118,7 +118,7 @@
               </th>
               <th scope="col">Dernière validation</th>
               <th scope="col">Dép.</th>
-              <th scope="col">Structure</th>
+              <th scope="col">Entité</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/offer/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/list.html
@@ -118,7 +118,7 @@
               </th>
               <th scope="col">Dernière validation</th>
               <th scope="col">Dép.</th>
-              <th scope="col">Entité</th>
+              <th scope="col">Entité juridique</th>
               <th scope="col">
                 {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
                   Partenaire culturel

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get.html
@@ -25,25 +25,25 @@
             <div class="d-flex row-reverse justify-content-end flex-grow-1">
               {% if has_permission("MANAGE_PRO_ENTITY") %}
                 {{ build_modal_form("edit-offerer", url_for("backoffice_web.offerer.update_offerer", offerer_id=offerer.id) ,
-                edit_offerer_form, "Modifier les informations", "Modifier les informations de la structure", "Enregistrer") }}
+                edit_offerer_form, "Modifier les informations", "Modifier les informations de l'entité", "Enregistrer") }}
               {% endif %}
               {% if has_permission("ADVANCED_PRO_SUPPORT") %}
                 {{ build_modal_form("generate-api-key", url_for("backoffice_web.offerer.generate_api_key", offerer_id=offerer.id) ,
-                generate_api_key_form, "Générer une clé API", "Générer une clé API pour la structure " + offerer.name, "Confirmer la génération") }}
+                generate_api_key_form, "Générer une clé API", "Générer une clé API pour l'entité " + offerer.name, "Confirmer la génération") }}
               {% endif %}
               {% if has_permission("PRO_FRAUD_ACTIONS") %}
                 {% if offerer.isActive %}
                   {{ build_modal_form("suspend-offerer", url_for("backoffice_web.offerer.suspend_offerer", offerer_id=offerer.id) ,
-                  suspension_form, "Suspendre la structure", "Suspendre la structure", "Confirmer la suspension") }}
+                  suspension_form, "Suspendre l'entité", "Suspendre l'entité", "Confirmer la suspension") }}
                 {% else %}
                   {{ build_modal_form("unsuspend-offerer", url_for("backoffice_web.offerer.unsuspend_offerer", offerer_id=offerer.id) ,
-                  suspension_form, "Réactiver la structure", "Réactiver la structure", "Confirmer la réactivation") }}
+                  suspension_form, "Réactiver l'entité", "Réactiver l'entité", "Confirmer la réactivation") }}
                 {% endif %}
               {% endif %}
               {% if has_permission("DELETE_PRO_ENTITY") %}
-                {% set form_description = "La structure <strong>"|safe + offerer.name + "</strong> ("|safe + offerer.id|string + ") sera définitivement supprimée de la base de données. Veuillez confirmer ce choix." %}
+                {% set form_description = "L'entité <strong>"|safe + offerer.name + "</strong> ("|safe + offerer.id|string + ") sera définitivement supprimée de la base de données. Veuillez confirmer ce choix." %}
                 {{ build_modal_form("delete-offerer", url_for("backoffice_web.offerer.delete_offerer", offerer_id=offerer.id) ,
-                delete_offerer_form, "Supprimer la structure", "Supprimer la structure " + offerer.name,
+                delete_offerer_form, "Supprimer l'entité", "Supprimer l'entité " + offerer.name,
                 "Confirmer", form_description, "bi-trash3-fill") }}
               {% endif %}
             </div>
@@ -75,12 +75,12 @@
             </div>
           {% endif %}
           <p class="card-subtitle text-muted mb-3 h5">
-            Offerer ID : {{ offerer.id }} {{ clipboard.copy_to_clipboard(offerer.id, "Copier l'ID de la structure") }}
+            Offerer ID : {{ offerer.id }} {{ clipboard.copy_to_clipboard(offerer.id, "Copier l'ID de l'entité") }}
           </p>
           <p class="card-subtitle text-muted mb-3 h5">
             {{ offerer.identifier_name }} : {{ links.build_siren_to_external_link(offerer) }}
             {% if offerer.siren %}
-              <span class="ms-1 link-primary">{{ clipboard.copy_to_clipboard(offerer.identifier, "Copier le " + offerer.identifier_name  + " de la structure") }}</span>
+              <span class="ms-1 link-primary">{{ clipboard.copy_to_clipboard(offerer.identifier, "Copier le " + offerer.identifier_name  + " de l'entité") }}</span>
             {% endif %}
           </p>
           <div class="row pt-3">
@@ -148,7 +148,7 @@
                 / {{ bank_information_status.ko }} KO
               </p>
               <p class="mb-1">
-                <span class="fw-bold">Tags structure :</span>
+                <span class="fw-bold">Tags entité :</span>
                 {{ offerer.tags | sort(attribute="label") | format_tag_object_list | safe }}
               </p>
               {% if has_permission("PRO_FRAUD_ACTIONS") %}
@@ -212,7 +212,7 @@
                           {{ zendesk_sell_synchronisation_form.csrf_token }}
                           <div class="modal-header"
                                id="{{ sync_zsell_aria_described_by_id }}">
-                            <h5 class="modal-title">Synchroniser la structure {{ offerer.name }} sur Zendesk Sell</h5>
+                            <h5 class="modal-title">Synchroniser l'entité {{ offerer.name }} sur Zendesk Sell</h5>
                           </div>
                           <div class="modal-body row">
                             <div class="d-flex align-items-center">

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get.html
@@ -25,25 +25,25 @@
             <div class="d-flex row-reverse justify-content-end flex-grow-1">
               {% if has_permission("MANAGE_PRO_ENTITY") %}
                 {{ build_modal_form("edit-offerer", url_for("backoffice_web.offerer.update_offerer", offerer_id=offerer.id) ,
-                edit_offerer_form, "Modifier les informations", "Modifier les informations de l'entité", "Enregistrer") }}
+                edit_offerer_form, "Modifier les informations", "Modifier les informations de l'entité juridique", "Enregistrer") }}
               {% endif %}
               {% if has_permission("ADVANCED_PRO_SUPPORT") %}
                 {{ build_modal_form("generate-api-key", url_for("backoffice_web.offerer.generate_api_key", offerer_id=offerer.id) ,
-                generate_api_key_form, "Générer une clé API", "Générer une clé API pour l'entité " + offerer.name, "Confirmer la génération") }}
+                generate_api_key_form, "Générer une clé API", "Générer une clé API pour l'entité juridique " + offerer.name, "Confirmer la génération") }}
               {% endif %}
               {% if has_permission("PRO_FRAUD_ACTIONS") %}
                 {% if offerer.isActive %}
                   {{ build_modal_form("suspend-offerer", url_for("backoffice_web.offerer.suspend_offerer", offerer_id=offerer.id) ,
-                  suspension_form, "Suspendre l'entité", "Suspendre l'entité", "Confirmer la suspension") }}
+                  suspension_form, "Suspendre l'entité juridique", "Suspendre l'entité juridique", "Confirmer la suspension") }}
                 {% else %}
                   {{ build_modal_form("unsuspend-offerer", url_for("backoffice_web.offerer.unsuspend_offerer", offerer_id=offerer.id) ,
-                  suspension_form, "Réactiver l'entité", "Réactiver l'entité", "Confirmer la réactivation") }}
+                  suspension_form, "Réactiver l'entité juridique", "Réactiver l'entité juridique", "Confirmer la réactivation") }}
                 {% endif %}
               {% endif %}
               {% if has_permission("DELETE_PRO_ENTITY") %}
-                {% set form_description = "L'entité <strong>"|safe + offerer.name + "</strong> ("|safe + offerer.id|string + ") sera définitivement supprimée de la base de données. Veuillez confirmer ce choix." %}
+                {% set form_description = "L'entité juridique <strong>"|safe + offerer.name + "</strong> ("|safe + offerer.id|string + ") sera définitivement supprimée de la base de données. Veuillez confirmer ce choix." %}
                 {{ build_modal_form("delete-offerer", url_for("backoffice_web.offerer.delete_offerer", offerer_id=offerer.id) ,
-                delete_offerer_form, "Supprimer l'entité", "Supprimer l'entité " + offerer.name,
+                delete_offerer_form, "Supprimer l'entité juridique", "Supprimer l'entité juridique " + offerer.name,
                 "Confirmer", form_description, "bi-trash3-fill") }}
               {% endif %}
             </div>
@@ -75,12 +75,12 @@
             </div>
           {% endif %}
           <p class="card-subtitle text-muted mb-3 h5">
-            Offerer ID : {{ offerer.id }} {{ clipboard.copy_to_clipboard(offerer.id, "Copier l'ID de l'entité") }}
+            Offerer ID : {{ offerer.id }} {{ clipboard.copy_to_clipboard(offerer.id, "Copier l'ID de l'entité juridique") }}
           </p>
           <p class="card-subtitle text-muted mb-3 h5">
             {{ offerer.identifier_name }} : {{ links.build_siren_to_external_link(offerer) }}
             {% if offerer.siren %}
-              <span class="ms-1 link-primary">{{ clipboard.copy_to_clipboard(offerer.identifier, "Copier le " + offerer.identifier_name  + " de l'entité") }}</span>
+              <span class="ms-1 link-primary">{{ clipboard.copy_to_clipboard(offerer.identifier, "Copier le " + offerer.identifier_name  + " de l'entité juridique") }}</span>
             {% endif %}
           </p>
           <div class="row pt-3">
@@ -148,7 +148,7 @@
                 / {{ bank_information_status.ko }} KO
               </p>
               <p class="mb-1">
-                <span class="fw-bold">Tags entité :</span>
+                <span class="fw-bold">Tags :</span>
                 {{ offerer.tags | sort(attribute="label") | format_tag_object_list | safe }}
               </p>
               {% if has_permission("PRO_FRAUD_ACTIONS") %}
@@ -212,7 +212,7 @@
                           {{ zendesk_sell_synchronisation_form.csrf_token }}
                           <div class="modal-header"
                                id="{{ sync_zsell_aria_described_by_id }}">
-                            <h5 class="modal-title">Synchroniser l'entité {{ offerer.name }} sur Zendesk Sell</h5>
+                            <h5 class="modal-title">Synchroniser l'entité juridique {{ offerer.name }} sur Zendesk Sell</h5>
                           </div>
                           <div class="modal-body row">
                             <div class="d-flex align-items-center">

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/users.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/users.html
@@ -7,7 +7,7 @@
 {% if has_permission("VALIDATE_OFFERER") %}
   {% if add_user_form %}
     {% set add_pro_user_modal_label_id = random_hash() %}
-    {{ build_modal_form("add-pro-user", add_user_dst, add_user_form, "Récupérer un compte pro rejeté", "Récupérer un compte pro rejeté", "Valider le rattachement", "Veuillez sélectionner le compte pro à rattacher à cette structure") }}
+    {{ build_modal_form("add-pro-user", add_user_dst, add_user_form, "Récupérer un compte pro rejeté", "Récupérer un compte pro rejeté", "Valider le rattachement", "Veuillez sélectionner le compte pro à rattacher à cette entité") }}
   {% else %}
     <button class="btn lead fw-bold mt-2"
             type="button"

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/users.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/users.html
@@ -7,7 +7,7 @@
 {% if has_permission("VALIDATE_OFFERER") %}
   {% if add_user_form %}
     {% set add_pro_user_modal_label_id = random_hash() %}
-    {{ build_modal_form("add-pro-user", add_user_dst, add_user_form, "Récupérer un compte pro rejeté", "Récupérer un compte pro rejeté", "Valider le rattachement", "Veuillez sélectionner le compte pro à rattacher à cette entité") }}
+    {{ build_modal_form("add-pro-user", add_user_dst, add_user_form, "Récupérer un compte pro rejeté", "Récupérer un compte pro rejeté", "Valider le rattachement", "Veuillez sélectionner le compte pro à rattacher à cette entité juridique") }}
   {% else %}
     <button class="btn lead fw-bold mt-2"
             type="button"

--- a/api/src/pcapi/routes/backoffice/templates/offerer/offerer_tag.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/offerer_tag.html
@@ -7,7 +7,7 @@
   {% set edit_offerer_tag_modal_label_id = random_hash() %}
   {% set delete_offerer_tag_modal_label_id = random_hash() %}
   <div class="pt-3 px-5">
-    <h2 class="fw-light">Tags structure</h2>
+    <h2 class="fw-light">Tags entité</h2>
     <div class="mt-4">
       {% call tabs.build_details_tabs_wrapper() %}
         {{ tabs.build_details_tab("tags", "Tags", active_tab == 'tags') }}
@@ -16,7 +16,7 @@
       {% call tabs.build_details_tabs_content_wrapper() %}
         {% call tabs.build_details_tab_content("tags", active_tab == 'tags') %}
           {% if create_tag_form %}
-            {{ build_modal_form("create-offerer-tag", url_for("backoffice_web.offerer_tag.create_offerer_tag") , create_tag_form, "Créer un tag structure", "Créer un tag structure", "Enregistrer") }}
+            {{ build_modal_form("create-offerer-tag", url_for("backoffice_web.offerer_tag.create_offerer_tag") , create_tag_form, "Créer un tag entité", "Créer un tag entité", "Enregistrer") }}
           {% endif %}
           <div>
             <table class="table mb-4">
@@ -47,14 +47,14 @@
                               <li class="dropdown-item p-0">
                                 <a class="btn btn-sm d-block w-100 text-start px-3"
                                    data-bs-toggle="modal"
-                                   data-bs-target=".pc-edit-offerer-tag-modal-{{ offerer_tag.id }}">Modifier le tag structure</a>
+                                   data-bs-target=".pc-edit-offerer-tag-modal-{{ offerer_tag.id }}">Modifier le tag entité</a>
                               </li>
                             {% endif %}
                             {% if delete_tag_form %}
                               <li class="dropdown-item p-0">
                                 <a class="btn btn-sm d-block w-100 text-start px-3"
                                    data-bs-toggle="modal"
-                                   data-bs-target=".pc-delete-offerer-tag-modal-{{ offerer_tag.id }}">Supprimer le tag structure</a>
+                                   data-bs-target=".pc-delete-offerer-tag-modal-{{ offerer_tag.id }}">Supprimer le tag entité</a>
                               </li>
                             {% endif %}
                           </ul>
@@ -104,7 +104,7 @@
                                     <div class="modal-body row">
                                       <p>
                                         Le tag <strong>{{ offerer_tag.label or offerer_tag.name }}</strong> sera définitivement supprimé
-                                        de la base de données et retiré de toutes les structures auxquelles il est associé. Veuillez confirmer ce choix.
+                                        de la base de données et retiré de toutes les entités auxquelles il est associé. Veuillez confirmer ce choix.
                                       </p>
                                       {{ build_form_fields_group(delete_tag_form) }}
                                     </div>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/offerer_tag.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/offerer_tag.html
@@ -7,7 +7,7 @@
   {% set edit_offerer_tag_modal_label_id = random_hash() %}
   {% set delete_offerer_tag_modal_label_id = random_hash() %}
   <div class="pt-3 px-5">
-    <h2 class="fw-light">Tags entité</h2>
+    <h2 class="fw-light">Tags des entités juridiques</h2>
     <div class="mt-4">
       {% call tabs.build_details_tabs_wrapper() %}
         {{ tabs.build_details_tab("tags", "Tags", active_tab == 'tags') }}
@@ -16,7 +16,7 @@
       {% call tabs.build_details_tabs_content_wrapper() %}
         {% call tabs.build_details_tab_content("tags", active_tab == 'tags') %}
           {% if create_tag_form %}
-            {{ build_modal_form("create-offerer-tag", url_for("backoffice_web.offerer_tag.create_offerer_tag") , create_tag_form, "Créer un tag entité", "Créer un tag entité", "Enregistrer") }}
+            {{ build_modal_form("create-offerer-tag", url_for("backoffice_web.offerer_tag.create_offerer_tag") , create_tag_form, "Créer un tag", "Créer un tag", "Enregistrer") }}
           {% endif %}
           <div>
             <table class="table mb-4">
@@ -47,14 +47,14 @@
                               <li class="dropdown-item p-0">
                                 <a class="btn btn-sm d-block w-100 text-start px-3"
                                    data-bs-toggle="modal"
-                                   data-bs-target=".pc-edit-offerer-tag-modal-{{ offerer_tag.id }}">Modifier le tag entité</a>
+                                   data-bs-target=".pc-edit-offerer-tag-modal-{{ offerer_tag.id }}">Modifier le tag</a>
                               </li>
                             {% endif %}
                             {% if delete_tag_form %}
                               <li class="dropdown-item p-0">
                                 <a class="btn btn-sm d-block w-100 text-start px-3"
                                    data-bs-toggle="modal"
-                                   data-bs-target=".pc-delete-offerer-tag-modal-{{ offerer_tag.id }}">Supprimer le tag entité</a>
+                                   data-bs-target=".pc-delete-offerer-tag-modal-{{ offerer_tag.id }}">Supprimer le tag</a>
                               </li>
                             {% endif %}
                           </ul>
@@ -104,7 +104,7 @@
                                     <div class="modal-body row">
                                       <p>
                                         Le tag <strong>{{ offerer_tag.label or offerer_tag.name }}</strong> sera définitivement supprimé
-                                        de la base de données et retiré de toutes les entités auxquelles il est associé. Veuillez confirmer ce choix.
+                                        de la base de données et retiré de toutes les entités juridiques auxquelles il est associé. Veuillez confirmer ce choix.
                                       </p>
                                       {{ build_form_fields_group(delete_tag_form) }}
                                     </div>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/user_offerer_validation.html
@@ -69,7 +69,7 @@
               <th scope="col">Email Compte pro</th>
               <th scope="col">Nom Compte pro</th>
               <th scope="col">État</th>
-              <th scope="col">Tags Entité</th>
+              <th scope="col">Tags Entité juridique</th>
               <th scope="col">
                 <a href="{{ date_created_sort_url }}"
                    class="text-decoration-none"
@@ -78,7 +78,7 @@
                   <i class="bi bi-sort-{{ 'up' if request.args.get("sort") == 'dateCreated' and request.args.get('order') == 'asc' else 'down' }}-alt"></i>
                 </a>
               </th>
-              <th scope="col">Nom Entité</th>
+              <th scope="col">Nom Entité juridique</th>
               <th scope="col">Email Responsable</th>
               <th scope="col">Dernier commentaire</th>
             </tr>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/user_offerer_validation.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/user_offerer_validation.html
@@ -69,7 +69,7 @@
               <th scope="col">Email Compte pro</th>
               <th scope="col">Nom Compte pro</th>
               <th scope="col">État</th>
-              <th scope="col">Tags Structure</th>
+              <th scope="col">Tags Entité</th>
               <th scope="col">
                 <a href="{{ date_created_sort_url }}"
                    class="text-decoration-none"
@@ -78,7 +78,7 @@
                   <i class="bi bi-sort-{{ 'up' if request.args.get("sort") == 'dateCreated' and request.args.get('order') == 'asc' else 'down' }}-alt"></i>
                 </a>
               </th>
-              <th scope="col">Nom Structure</th>
+              <th scope="col">Nom Entité</th>
               <th scope="col">Email Responsable</th>
               <th scope="col">Dernier commentaire</th>
             </tr>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/validation.html
@@ -19,7 +19,7 @@
   <div class="pt-3 px-5 table-container-offerer-validation"
        data-toggle="filters"
        data-toggle-id="offerer-validation">
-    <h2 class="fw-light">Structures à valider</h2>
+    <h2 class="fw-light">Entités à valider</h2>
     <div class="col-2">
       <div class="py-2">
         <button type="submit"
@@ -34,10 +34,10 @@
     </div>
     <div class="d-none filters-container">
       <div class="row px-1">
-        {{ stats_card(stats["NEW"], "nouvelle structure", "nouvelles structures") }}
-        {{ stats_card(stats["PENDING"], "structure en attente", "structures en attente") }}
-        {{ stats_card(stats["VALIDATED"], "structure validée", "structures validées") }}
-        {{ stats_card(stats["REJECTED"], "structure rejetée", "structures rejetées") }}
+        {{ stats_card(stats["NEW"], "nouvelle entité", "nouvelles entités") }}
+        {{ stats_card(stats["PENDING"], "entité en attente", "entités en attente") }}
+        {{ stats_card(stats["VALIDATED"], "entité validée", "entités validées") }}
+        {{ stats_card(stats["REJECTED"], "entité rejetée", "entités rejetées") }}
       </div>
       {{ build_filters_form(form, dst) }}
     </div>
@@ -87,10 +87,10 @@
               {% endif %}
               <th scope="col"></th>
               <th scope="col">ID</th>
-              <th scope="col">Nom de la structure</th>
+              <th scope="col">Nom de l'entité</th>
               <th scope="col">État</th>
               {% if has_validate_permission %}<th scope="col">Top Acteur</th>{% endif %}
-              <th scope="col">Tags structure</th>
+              <th scope="col">Tags entité</th>
               <th scope="col">
                 <a href="{{ date_created_sort_url }}"
                    class="text-decoration-none"
@@ -103,7 +103,7 @@
               <th scope="col">Dernier commentaire</th>
               <th scope="col">SIREN</th>
               <th scope="col">Email</th>
-              <th scope="col">Responsable Structure</th>
+              <th scope="col">Responsable Entité</th>
               <th scope="col">Ville</th>
             </tr>
           </thead>
@@ -209,7 +209,7 @@
           {{ build_lazy_modal(url_for("backoffice_web.validation.get_batch_offerer_pending_form") , "batch-pending-modal", "true") }}
         {% endif %}
       {% else %}
-        Aucune structure ne correspond à la requête
+        Aucune entité ne correspond à la requête
       {% endif %}
     </div>
   </div>

--- a/api/src/pcapi/routes/backoffice/templates/offerer/validation.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/validation.html
@@ -19,7 +19,7 @@
   <div class="pt-3 px-5 table-container-offerer-validation"
        data-toggle="filters"
        data-toggle-id="offerer-validation">
-    <h2 class="fw-light">Entités à valider</h2>
+    <h2 class="fw-light">Entités juridiques à valider</h2>
     <div class="col-2">
       <div class="py-2">
         <button type="submit"
@@ -34,10 +34,10 @@
     </div>
     <div class="d-none filters-container">
       <div class="row px-1">
-        {{ stats_card(stats["NEW"], "nouvelle entité", "nouvelles entités") }}
-        {{ stats_card(stats["PENDING"], "entité en attente", "entités en attente") }}
-        {{ stats_card(stats["VALIDATED"], "entité validée", "entités validées") }}
-        {{ stats_card(stats["REJECTED"], "entité rejetée", "entités rejetées") }}
+        {{ stats_card(stats["NEW"], "nouvelle entité juridique", "nouvelles entités juridiques") }}
+        {{ stats_card(stats["PENDING"], "entité juridique en attente", "entités juridiques en attente") }}
+        {{ stats_card(stats["VALIDATED"], "entité juridique validée", "entités juridiques validées") }}
+        {{ stats_card(stats["REJECTED"], "entité juridique rejetée", "entités juridiques rejetées") }}
       </div>
       {{ build_filters_form(form, dst) }}
     </div>
@@ -87,10 +87,10 @@
               {% endif %}
               <th scope="col"></th>
               <th scope="col">ID</th>
-              <th scope="col">Nom de l'entité</th>
+              <th scope="col">Nom</th>
               <th scope="col">État</th>
               {% if has_validate_permission %}<th scope="col">Top Acteur</th>{% endif %}
-              <th scope="col">Tags entité</th>
+              <th scope="col">Tags</th>
               <th scope="col">
                 <a href="{{ date_created_sort_url }}"
                    class="text-decoration-none"
@@ -103,7 +103,7 @@
               <th scope="col">Dernier commentaire</th>
               <th scope="col">SIREN</th>
               <th scope="col">Email</th>
-              <th scope="col">Responsable Entité</th>
+              <th scope="col">Responsable</th>
               <th scope="col">Ville</th>
             </tr>
           </thead>
@@ -209,7 +209,7 @@
           {{ build_lazy_modal(url_for("backoffice_web.validation.get_batch_offerer_pending_form") , "batch-pending-modal", "true") }}
         {% endif %}
       {% else %}
-        Aucune entité ne correspond à la requête
+        Aucune entité juridique ne correspond à la requête
       {% endif %}
     </div>
   </div>

--- a/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
@@ -14,7 +14,7 @@
           </p>
         {% endif %}
         <p>
-          <span class="fw-bold">Entité :</span> {{ venue.managingOfferer.name }}
+          <span class="fw-bold">Entité juridique :</span> {{ venue.managingOfferer.name }}
         </p>
         <p>
           {% if yearly_revenue is not false %}

--- a/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/move_siret_confirmation.html
@@ -14,7 +14,7 @@
           </p>
         {% endif %}
         <p>
-          <span class="fw-bold">Structure :</span> {{ venue.managingOfferer.name }}
+          <span class="fw-bold">Entité :</span> {{ venue.managingOfferer.name }}
         </p>
         <p>
           {% if yearly_revenue is not false %}

--- a/api/src/pcapi/routes/backoffice/templates/pro/search.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/search.html
@@ -7,12 +7,12 @@
       <button class="btn btn-outline-primary lead fw-bold mt-2"
               data-bs-toggle="modal"
               data-bs-target="#create-offerer-modal"
-              type="button">Créer une structure</button>
+              type="button">Créer une entité</button>
       {{ build_lazy_modal(url_for('backoffice_web.pro.get_create_offerer_form') , "create-offerer-modal") }}
     </div>
   {% endif %}
   {% call build_base_search() %}
-    Retrouve une structure ou un
+    Retrouve une entité ou un
     {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
       partenaire culturel
     {% else %}

--- a/api/src/pcapi/routes/backoffice/templates/pro/search.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro/search.html
@@ -7,12 +7,12 @@
       <button class="btn btn-outline-primary lead fw-bold mt-2"
               data-bs-toggle="modal"
               data-bs-target="#create-offerer-modal"
-              type="button">Créer une entité</button>
+              type="button">Créer un partenaire culturel</button>
       {{ build_lazy_modal(url_for('backoffice_web.pro.get_create_offerer_form') , "create-offerer-modal") }}
     </div>
   {% endif %}
   {% call build_base_search() %}
-    Retrouve une entité ou un
+    Retrouve une entité juridique ou un
     {% if is_feature_active("WIP_ENABLE_OFFER_ADDRESS") %}
       partenaire culturel
     {% else %}

--- a/api/src/pcapi/routes/backoffice/templates/pro_user/get/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro_user/get/details.html
@@ -5,7 +5,7 @@
 <turbo-frame data-turbo="false" id="pro_user_details_frame">
 {% call build_details_tabs_wrapper() %}
   {{ build_details_tab("history", "Historique du compte", active_tab == 'history') }}
-  {{ build_details_tab("user_offerers", "Rattachements aux entités", active_tab == 'user_offerers') }}
+  {{ build_details_tab("user_offerers", "Rattachements aux entités juridiques", active_tab == 'user_offerers') }}
 {% endcall %}
 {% call build_details_tabs_content_wrapper() %}
   {% call build_details_tab_content("history", active_tab == 'history') %}

--- a/api/src/pcapi/routes/backoffice/templates/pro_user/get/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro_user/get/details.html
@@ -5,7 +5,7 @@
 <turbo-frame data-turbo="false" id="pro_user_details_frame">
 {% call build_details_tabs_wrapper() %}
   {{ build_details_tab("history", "Historique du compte", active_tab == 'history') }}
-  {{ build_details_tab("user_offerers", "Rattachements aux structures", active_tab == 'user_offerers') }}
+  {{ build_details_tab("user_offerers", "Rattachements aux entités", active_tab == 'user_offerers') }}
 {% endcall %}
 {% call build_details_tabs_content_wrapper() %}
   {% call build_details_tab_content("history", active_tab == 'history') %}

--- a/api/src/pcapi/routes/backoffice/templates/pro_user/get/details/user_offerer.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro_user/get/details/user_offerer.html
@@ -4,9 +4,9 @@
   <thead>
     <tr>
       <th scope="col"></th>
-      <th scope="col">ID de l'entité</th>
+      <th scope="col">ID de l'entité juridique</th>
       <th scope="col">Statut du rattachement</th>
-      <th scope="col">Statut entité</th>
+      <th scope="col">Statut entité juridique</th>
       <th scope="col">Nom</th>
       <th scope="col">
         SIREN

--- a/api/src/pcapi/routes/backoffice/templates/pro_user/get/details/user_offerer.html
+++ b/api/src/pcapi/routes/backoffice/templates/pro_user/get/details/user_offerer.html
@@ -4,9 +4,9 @@
   <thead>
     <tr>
       <th scope="col"></th>
-      <th scope="col">ID de la structure</th>
+      <th scope="col">ID de l'entité</th>
       <th scope="col">Statut du rattachement</th>
-      <th scope="col">Statut structure</th>
+      <th scope="col">Statut entité</th>
       <th scope="col">Nom</th>
       <th scope="col">
         SIREN

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -203,7 +203,7 @@
                 </p>
               {% endif %}
               <p class="mb-1">
-                <span class="fw-bold">Entité :</span>
+                <span class="fw-bold">Entité juridique :</span>
                 {{ links.build_offerer_name_to_details_link(venue.managingOfferer) }}
               </p>
               {% if venue.contact and venue.contact.website %}

--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -203,7 +203,7 @@
                 </p>
               {% endif %}
               <p class="mb-1">
-                <span class="fw-bold">Structure :</span>
+                <span class="fw-bold">Entité :</span>
                 {{ links.build_offerer_name_to_details_link(venue.managingOfferer) }}
               </p>
               {% if venue.contact and venue.contact.website %}

--- a/api/src/pcapi/routes/backoffice/templates/venue/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/list.html
@@ -63,7 +63,7 @@
               <th scope="col">ID</th>
               <th scope="col">Nom</th>
               <th scope="col">Nom d'usage</th>
-              <th scope="col">Entité</th>
+              <th scope="col">Entité juridique</th>
               <th scope="col">Permanent</th>
               <th scope="col">Label</th>
               <th scope="col">Tags</th>

--- a/api/src/pcapi/routes/backoffice/templates/venue/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/list.html
@@ -63,7 +63,7 @@
               <th scope="col">ID</th>
               <th scope="col">Nom</th>
               <th scope="col">Nom d'usage</th>
-              <th scope="col">Structure</th>
+              <th scope="col">Entité</th>
               <th scope="col">Permanent</th>
               <th scope="col">Label</th>
               <th scope="col">Tags</th>

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -1194,7 +1194,7 @@ def _render_remove_siret_content(
             }
         )
     additional_data = {
-        "Structure": venue.managingOfferer.name,
+        "Entité": venue.managingOfferer.name,
         "Offerer ID": venue.managingOfferer.id,
     }
     if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -1194,7 +1194,7 @@ def _render_remove_siret_content(
             }
         )
     additional_data = {
-        "Entité": venue.managingOfferer.name,
+        "Entité juridique": venue.managingOfferer.name,
         "Offerer ID": venue.managingOfferer.id,
     }
     if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():

--- a/api/src/pcapi/routes/backoffice/venues/forms.py
+++ b/api/src/pcapi/routes/backoffice/venues/forms.py
@@ -112,7 +112,7 @@ class EditVenueForm(EditVirtualVenueForm):
 
             if siret.data[:9] != self.venue.managingOfferer.siren:
                 raise validators.ValidationError(
-                    "Les 9 premiers caractères du SIRET doivent correspondre au SIREN de l'entité"
+                    "Les 9 premiers caractères du SIRET doivent correspondre au SIREN de l'entité juridique"
                 )
 
         return siret
@@ -234,7 +234,7 @@ class GetVenuesListForm(utils.PCForm):
         "Tags", multiple=True, choices=[], validate_choice=False, endpoint="backoffice_web.autocomplete_criteria"
     )
     offerer = fields.PCTomSelectField(
-        "Entités",
+        "Entités juridiques",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -242,7 +242,7 @@ class GetVenuesListForm(utils.PCForm):
     )
     regions = fields.PCSelectMultipleField("Régions", choices=get_regions_choices())
     department = fields.PCSelectMultipleField("Départements", choices=area_choices)
-    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les entités validées")
+    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les entités juridiques validées")
     limit = fields.PCSelectField(
         "Nombre maximum",
         choices=((100, "100"), (500, "500"), (1000, "1000"), (3000, "3000")),

--- a/api/src/pcapi/routes/backoffice/venues/forms.py
+++ b/api/src/pcapi/routes/backoffice/venues/forms.py
@@ -112,7 +112,7 @@ class EditVenueForm(EditVirtualVenueForm):
 
             if siret.data[:9] != self.venue.managingOfferer.siren:
                 raise validators.ValidationError(
-                    "Les 9 premiers caractères du SIRET doivent correspondre au SIREN de la structure"
+                    "Les 9 premiers caractères du SIRET doivent correspondre au SIREN de l'entité"
                 )
 
         return siret
@@ -234,7 +234,7 @@ class GetVenuesListForm(utils.PCForm):
         "Tags", multiple=True, choices=[], validate_choice=False, endpoint="backoffice_web.autocomplete_criteria"
     )
     offerer = fields.PCTomSelectField(
-        "Structures",
+        "Entités",
         multiple=True,
         choices=[],
         validate_choice=False,
@@ -242,7 +242,7 @@ class GetVenuesListForm(utils.PCForm):
     )
     regions = fields.PCSelectMultipleField("Régions", choices=get_regions_choices())
     department = fields.PCSelectMultipleField("Départements", choices=area_choices)
-    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les structures validées")
+    only_validated_offerers = fields.PCSwitchBooleanField("Uniquement les entités validées")
     limit = fields.PCSelectField(
         "Nombre maximum",
         choices=((100, "100"), (500, "500"), (1000, "1000"), (3000, "3000")),

--- a/api/tests/core/finance/test_siret_api.py
+++ b/api/tests/core/finance/test_siret_api.py
@@ -137,7 +137,7 @@ class DeleteSiretTest:
 
         with pytest.raises(siret_api.CheckError) as err:
             siret_api.remove_siret(venue, comment="xxx", new_pricing_point_id=venue.id + 1000, apply_changes=True)
-        assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même structure"
+        assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même entité"
 
     @pytest.mark.usefixtures("clean_database")
     def test_refuse_if_new_pricing_point_has_no_siret(self):
@@ -146,7 +146,7 @@ class DeleteSiretTest:
 
         with pytest.raises(siret_api.CheckError) as err:
             siret_api.remove_siret(venue, comment="xxx", new_pricing_point_id=new_pricing_point.id, apply_changes=True)
-        assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même structure"
+        assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même entité"
 
     @pytest.mark.usefixtures("clean_database")
     def test_refuse_if_new_pricing_point_is_managed_by_another_offerer(self):
@@ -155,4 +155,4 @@ class DeleteSiretTest:
 
         with pytest.raises(siret_api.CheckError) as err:
             siret_api.remove_siret(venue, comment="xxx", new_pricing_point_id=new_pricing_point.id, apply_changes=True)
-        assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même structure"
+        assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même entité"

--- a/api/tests/core/finance/test_siret_api.py
+++ b/api/tests/core/finance/test_siret_api.py
@@ -137,7 +137,10 @@ class DeleteSiretTest:
 
         with pytest.raises(siret_api.CheckError) as err:
             siret_api.remove_siret(venue, comment="xxx", new_pricing_point_id=venue.id + 1000, apply_changes=True)
-        assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même entité"
+        assert (
+            str(err.value)
+            == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même entité juridique"
+        )
 
     @pytest.mark.usefixtures("clean_database")
     def test_refuse_if_new_pricing_point_has_no_siret(self):
@@ -146,7 +149,10 @@ class DeleteSiretTest:
 
         with pytest.raises(siret_api.CheckError) as err:
             siret_api.remove_siret(venue, comment="xxx", new_pricing_point_id=new_pricing_point.id, apply_changes=True)
-        assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même entité"
+        assert (
+            str(err.value)
+            == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même entité juridique"
+        )
 
     @pytest.mark.usefixtures("clean_database")
     def test_refuse_if_new_pricing_point_is_managed_by_another_offerer(self):
@@ -155,4 +161,7 @@ class DeleteSiretTest:
 
         with pytest.raises(siret_api.CheckError) as err:
             siret_api.remove_siret(venue, comment="xxx", new_pricing_point_id=new_pricing_point.id, apply_changes=True)
-        assert str(err.value) == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même entité"
+        assert (
+            str(err.value)
+            == "Le nouveau point de valorisation doit être un lieu avec SIRET sur la même entité juridique"
+        )

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -966,7 +966,7 @@ class DeleteOffererTest:
 
         # Then
         assert exception.value.errors["cannotDeleteOffererWithBookingsException"] == [
-            "Entité non supprimable car elle contient des réservations"
+            "Entité juridique non supprimable car elle contient des réservations"
         ]
         assert offerers_models.Offerer.query.count() == 1
         assert offerers_models.Venue.query.count() == 2
@@ -988,7 +988,7 @@ class DeleteOffererTest:
 
         # Then
         assert exception.value.errors["cannotDeleteOffererWithBookingsException"] == [
-            "Entité non supprimable car elle contient des réservations"
+            "Entité juridique non supprimable car elle contient des réservations"
         ]
         assert offerers_models.Offerer.query.count() == 1
         assert offerers_models.Venue.query.count() == 2
@@ -1654,7 +1654,7 @@ class RejectOffererTest:
         assert action.userId == user.id
         assert action.offererId == offerer.id
         assert action.venueId is None
-        assert action.comment == "Compte pro rejeté suite au rejet de l'entité"
+        assert action.comment == "Compte pro rejeté suite au rejet de l'entité juridique"
 
 
 def test_grant_user_offerer_access():

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -151,7 +151,7 @@ class DeleteVenueTest:
 
         # Then
         assert exception.value.errors["cannotDeleteVenueWithBookingsException"] == [
-            "Lieu non supprimable car il contient des réservations"
+            "Partenaire culturel non supprimable car il contient des réservations"
         ]
         assert offerers_models.Venue.query.count() == 1
         assert offers_models.Stock.query.count() == 1
@@ -168,7 +168,7 @@ class DeleteVenueTest:
 
         # Then
         assert exception.value.errors["cannotDeleteVenueWithBookingsException"] == [
-            "Lieu non supprimable car il contient des réservations"
+            "Partenaire culturel non supprimable car il contient des réservations"
         ]
         assert offerers_models.Venue.query.count() == 1
         assert educational_models.CollectiveStock.query.count() == 1
@@ -185,7 +185,7 @@ class DeleteVenueTest:
 
         # Then
         assert exception.value.errors["cannotDeleteVenueUsedAsPricingPointException"] == [
-            "Lieu non supprimable car il est utilisé comme point de valorisation d'un autre lieu"
+            "Partenaire culturel non supprimable car il est utilisé comme point de valorisation d'un autre partenaire culturel"
         ]
         assert offerers_models.Offerer.query.count() == 1
         assert offerers_models.Venue.query.count() == 2
@@ -242,7 +242,7 @@ class DeleteVenueTest:
 
         # Then
         assert exception.value.errors["cannotDeleteVenueUsedAsReimbursementPointException"] == [
-            "Lieu non supprimable car il est utilisé comme point de remboursement d'un autre lieu"
+            "Partenaire culturel non supprimable car il est utilisé comme point de remboursement d'un autre partenaire culturel"
         ]
         assert offerers_models.Offerer.query.count() == 1
         assert offerers_models.Venue.query.count() == 2
@@ -966,7 +966,7 @@ class DeleteOffererTest:
 
         # Then
         assert exception.value.errors["cannotDeleteOffererWithBookingsException"] == [
-            "Structure juridique non supprimable car elle contient des réservations"
+            "Entité non supprimable car elle contient des réservations"
         ]
         assert offerers_models.Offerer.query.count() == 1
         assert offerers_models.Venue.query.count() == 2
@@ -988,7 +988,7 @@ class DeleteOffererTest:
 
         # Then
         assert exception.value.errors["cannotDeleteOffererWithBookingsException"] == [
-            "Structure juridique non supprimable car elle contient des réservations"
+            "Entité non supprimable car elle contient des réservations"
         ]
         assert offerers_models.Offerer.query.count() == 1
         assert offerers_models.Venue.query.count() == 2
@@ -1654,7 +1654,7 @@ class RejectOffererTest:
         assert action.userId == user.id
         assert action.offererId == offerer.id
         assert action.venueId is None
-        assert action.comment == "Compte pro rejeté suite au rejet de la structure"
+        assert action.comment == "Compte pro rejeté suite au rejet de l'entité"
 
 
 def test_grant_user_offerer_access():

--- a/api/tests/routes/backoffice/admin_test.py
+++ b/api/tests/routes/backoffice/admin_test.py
@@ -549,7 +549,7 @@ class GetBoUserTest(GetEndpointHelper):
             perm_models.Roles.SUPPORT_N2.value,
             perm_models.Roles.SUPPORT_PRO.value,
         ]
-        assert "visualiser une entité, un partenaire culturel ou un compte pro" in " ".join(
+        assert "visualiser une entité juridique, un partenaire culturel ou un compte pro" in " ".join(
             [row["Permissions"] for row in rows]
         )
 

--- a/api/tests/routes/backoffice/admin_test.py
+++ b/api/tests/routes/backoffice/admin_test.py
@@ -549,7 +549,9 @@ class GetBoUserTest(GetEndpointHelper):
             perm_models.Roles.SUPPORT_N2.value,
             perm_models.Roles.SUPPORT_PRO.value,
         ]
-        assert "visualiser une structure, un lieu ou un compte pro" in " ".join([row["Permissions"] for row in rows])
+        assert "visualiser une entité, un partenaire culturel ou un compte pro" in " ".join(
+            [row["Permissions"] for row in rows]
+        )
 
     @pytest.mark.parametrize("user_factory", [users_factories.BeneficiaryGrant18Factory, users_factories.ProFactory])
     def test_get_non_bo_user(self, authenticated_client, user_factory):

--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -164,7 +164,7 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
             f" → {(datetime.date.today() + datetime.timedelta(days=24)).strftime('%d/%m/%Y')}"
             in row["Date de l'évènement"]
         )
-        assert row["Structure"] == collective_bookings[1].offerer.name
+        assert row["Entité"] == collective_bookings[1].offerer.name
         assert row["Lieu"] == collective_bookings[1].venue.name
 
         extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[row_index]
@@ -303,7 +303,7 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
         assert row["Date de l'évènement"].startswith(
             (datetime.date.today() + datetime.timedelta(days=7)).strftime("%d/%m/%Y à ")
         )
-        assert row["Structure"] == collective_bookings[2].offerer.name
+        assert row["Entité"] == collective_bookings[2].offerer.name
         assert row["Lieu"] == collective_bookings[2].venue.name
 
         extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[row_index]

--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -164,7 +164,7 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
             f" → {(datetime.date.today() + datetime.timedelta(days=24)).strftime('%d/%m/%Y')}"
             in row["Date de l'évènement"]
         )
-        assert row["Entité"] == collective_bookings[1].offerer.name
+        assert row["Entité juridique"] == collective_bookings[1].offerer.name
         assert row["Lieu"] == collective_bookings[1].venue.name
 
         extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[row_index]
@@ -303,7 +303,7 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
         assert row["Date de l'évènement"].startswith(
             (datetime.date.today() + datetime.timedelta(days=7)).strftime("%d/%m/%Y à ")
         )
-        assert row["Entité"] == collective_bookings[2].offerer.name
+        assert row["Entité juridique"] == collective_bookings[2].offerer.name
         assert row["Lieu"] == collective_bookings[2].venue.name
 
         extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[row_index]

--- a/api/tests/routes/backoffice/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice/collective_offer_templates_test.py
@@ -85,7 +85,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
         assert rows[0]["État"] == "Validée"
         assert rows[0]["Date de création"] == (datetime.date.today() - datetime.timedelta(days=5)).strftime("%d/%m/%Y")
         assert rows[0]["Formats"] == ", ".join([fmt.value for fmt in collective_offer_templates[0].formats])
-        assert rows[0]["Entité"] == collective_offer_templates[0].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == collective_offer_templates[0].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offer_templates[0].venue.name
         assert rows[0]["Créateur de l'offre"] == collective_offer_templates[0].author.full_name
 
@@ -101,7 +101,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
         assert rows[0]["Nom de l'offre"] == collective_offer_templates[1].name
         assert rows[0]["État"] == "Validée"
         assert rows[0]["Date de création"] == (datetime.date.today() - datetime.timedelta(days=5)).strftime("%d/%m/%Y")
-        assert rows[0]["Entité"] == collective_offer_templates[1].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == collective_offer_templates[1].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offer_templates[1].venue.name
 
     def test_list_offers_by_date(self, authenticated_client, collective_offer_templates):
@@ -246,7 +246,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Entité"] == "Offerer Revue manuelle"
+        assert rows[0]["Entité juridique"] == "Offerer Revue manuelle"
         assert rows[0]["Lieu"] == "Venue"
 
     def test_list_collective_offer_templates_with_venue_confidence_rule(self, client, pro_fraud_admin):
@@ -261,7 +261,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Entité"] == "Offerer"
+        assert rows[0]["Entité juridique"] == "Offerer"
         assert rows[0]["Lieu"] == "Venue Revue manuelle"
 
 
@@ -290,7 +290,7 @@ class GetCollectiveOfferTemplateDetailTest(GetEndpointHelper):
         content_as_text = html_parser.content_as_text(response.data)
         assert f"Date de création : {collectiveOfferTemplate.dateCreated.strftime('%d/%m/%Y')}" in content_as_text
         assert f"Description : {collectiveOfferTemplate.description}" in content_as_text
-        assert f"Entité : {collectiveOfferTemplate.venue.managingOfferer.name}" in content_as_text
+        assert f"Entité juridique : {collectiveOfferTemplate.venue.managingOfferer.name}" in content_as_text
         assert f"Lieu : {collectiveOfferTemplate.venue.name}" in content_as_text
         assert f"Formats : {EacFormat.PROJECTION_AUDIOVISUELLE.value}" in content_as_text
 

--- a/api/tests/routes/backoffice/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice/collective_offer_templates_test.py
@@ -85,7 +85,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
         assert rows[0]["État"] == "Validée"
         assert rows[0]["Date de création"] == (datetime.date.today() - datetime.timedelta(days=5)).strftime("%d/%m/%Y")
         assert rows[0]["Formats"] == ", ".join([fmt.value for fmt in collective_offer_templates[0].formats])
-        assert rows[0]["Structure"] == collective_offer_templates[0].venue.managingOfferer.name
+        assert rows[0]["Entité"] == collective_offer_templates[0].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offer_templates[0].venue.name
         assert rows[0]["Créateur de l'offre"] == collective_offer_templates[0].author.full_name
 
@@ -101,7 +101,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
         assert rows[0]["Nom de l'offre"] == collective_offer_templates[1].name
         assert rows[0]["État"] == "Validée"
         assert rows[0]["Date de création"] == (datetime.date.today() - datetime.timedelta(days=5)).strftime("%d/%m/%Y")
-        assert rows[0]["Structure"] == collective_offer_templates[1].venue.managingOfferer.name
+        assert rows[0]["Entité"] == collective_offer_templates[1].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offer_templates[1].venue.name
 
     def test_list_offers_by_date(self, authenticated_client, collective_offer_templates):
@@ -246,7 +246,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Structure"] == "Offerer Revue manuelle"
+        assert rows[0]["Entité"] == "Offerer Revue manuelle"
         assert rows[0]["Lieu"] == "Venue"
 
     def test_list_collective_offer_templates_with_venue_confidence_rule(self, client, pro_fraud_admin):
@@ -261,7 +261,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Structure"] == "Offerer"
+        assert rows[0]["Entité"] == "Offerer"
         assert rows[0]["Lieu"] == "Venue Revue manuelle"
 
 
@@ -290,7 +290,7 @@ class GetCollectiveOfferTemplateDetailTest(GetEndpointHelper):
         content_as_text = html_parser.content_as_text(response.data)
         assert f"Date de création : {collectiveOfferTemplate.dateCreated.strftime('%d/%m/%Y')}" in content_as_text
         assert f"Description : {collectiveOfferTemplate.description}" in content_as_text
-        assert f"Structure : {collectiveOfferTemplate.venue.managingOfferer.name}" in content_as_text
+        assert f"Entité : {collectiveOfferTemplate.venue.managingOfferer.name}" in content_as_text
         assert f"Lieu : {collectiveOfferTemplate.venue.name}" in content_as_text
         assert f"Formats : {EacFormat.PROJECTION_AUDIOVISUELLE.value}" in content_as_text
 

--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -126,7 +126,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
         )
         assert rows[0]["Tarif"] == "10,10 €"
         assert rows[0]["Formats"] == ", ".join([fmt.value for fmt in collective_offers[0].formats])
-        assert rows[0]["Structure"] == collective_offers[0].venue.managingOfferer.name
+        assert rows[0]["Entité"] == collective_offers[0].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offers[0].venue.name
 
     def test_list_collective_offers_without_fraud_permission(
@@ -169,7 +169,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             == f"{(datetime.date.today() + datetime.timedelta(days=3)).strftime('%d/%m/%Y')} → {(datetime.date.today() + datetime.timedelta(days=24)).strftime('%d/%m/%Y')}"
         )
         assert rows[0]["Tarif"] == "11,00 €"
-        assert rows[0]["Structure"] == collective_offers[1].venue.managingOfferer.name
+        assert rows[0]["Entité"] == collective_offers[1].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offers[1].venue.name
 
     def test_list_collective_offers_by_several_filters(self, authenticated_client, collective_offers):
@@ -728,7 +728,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Structure"] == "Offerer Revue manuelle"
+        assert rows[0]["Entité"] == "Offerer Revue manuelle"
         assert rows[0]["Lieu"] == "Venue"
 
     def test_list_offers_with_venue_confidence_rule(self, client, pro_fraud_admin):
@@ -744,7 +744,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Structure"] == "Offerer"
+        assert rows[0]["Entité"] == "Offerer"
         assert rows[0]["Lieu"] == "Venue Revue manuelle"
 
 

--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -126,7 +126,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
         )
         assert rows[0]["Tarif"] == "10,10 €"
         assert rows[0]["Formats"] == ", ".join([fmt.value for fmt in collective_offers[0].formats])
-        assert rows[0]["Entité"] == collective_offers[0].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == collective_offers[0].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offers[0].venue.name
 
     def test_list_collective_offers_without_fraud_permission(
@@ -169,7 +169,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             == f"{(datetime.date.today() + datetime.timedelta(days=3)).strftime('%d/%m/%Y')} → {(datetime.date.today() + datetime.timedelta(days=24)).strftime('%d/%m/%Y')}"
         )
         assert rows[0]["Tarif"] == "11,00 €"
-        assert rows[0]["Entité"] == collective_offers[1].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == collective_offers[1].venue.managingOfferer.name
         assert rows[0]["Lieu"] == collective_offers[1].venue.name
 
     def test_list_collective_offers_by_several_filters(self, authenticated_client, collective_offers):
@@ -728,7 +728,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Entité"] == "Offerer Revue manuelle"
+        assert rows[0]["Entité juridique"] == "Offerer Revue manuelle"
         assert rows[0]["Lieu"] == "Venue"
 
     def test_list_offers_with_venue_confidence_rule(self, client, pro_fraud_admin):
@@ -744,7 +744,7 @@ class ListCollectiveOffersTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Entité"] == "Offerer"
+        assert rows[0]["Entité juridique"] == "Offerer"
         assert rows[0]["Lieu"] == "Venue Revue manuelle"
 
 

--- a/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
+++ b/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
@@ -59,7 +59,7 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
         rows = sorted(rows, key=lambda row: int(row["ID règle"]))
 
         assert rows[0]["ID règle"] == str(offer_rule.id)
-        assert rows[0]["Entité"] == offer_rule.offer.venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == offer_rule.offer.venue.managingOfferer.name
         assert rows[0]["SIREN"] == offer_rule.offer.venue.managingOfferer.siren
         assert rows[0]["Lieu"] == offer_rule.offer.venue.name
         assert rows[0]["Offre"] == offer_rule.offer.name
@@ -69,7 +69,7 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
         assert rows[0]["Date d'application"] == start.strftime("%d/%m/%Y") + " → ∞"
 
         assert rows[1]["ID règle"] == str(venue_rule.id)
-        assert rows[1]["Entité"] == venue_rule.venue.managingOfferer.name
+        assert rows[1]["Entité juridique"] == venue_rule.venue.managingOfferer.name
         assert rows[1]["SIREN"] == venue_rule.venue.managingOfferer.siren
         assert rows[1]["Lieu"] == f"{venue_rule.venue.name} - {venue_rule.venue.siret}"
         assert rows[1]["Offre"] == ""
@@ -79,7 +79,7 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
         assert rows[1]["Date d'application"] == start.strftime("%d/%m/%Y") + " → ∞"
 
         assert rows[2]["ID règle"] == str(offerer_rule.id)
-        assert rows[2]["Entité"] == offerer_rule.offerer.name
+        assert rows[2]["Entité juridique"] == offerer_rule.offerer.name
         assert rows[2]["SIREN"] == offerer_rule.offerer.siren
         assert rows[2]["Lieu"] == ""
         assert rows[2]["Offre"] == ""
@@ -300,7 +300,7 @@ class CreateCustomReimbursementRuleTest(PostEndpointHelper):
         assert response.status_code == 303
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "Un tarif dérogatoire ne peut pas concerner un lieu et une entité en même temps"
+            == "Un tarif dérogatoire ne peut pas concerner un lieu et une entité juridique en même temps"
         )
 
         assert finance_models.CustomReimbursementRule.query.count() == 0

--- a/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
+++ b/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
@@ -59,7 +59,7 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
         rows = sorted(rows, key=lambda row: int(row["ID règle"]))
 
         assert rows[0]["ID règle"] == str(offer_rule.id)
-        assert rows[0]["Structure"] == offer_rule.offer.venue.managingOfferer.name
+        assert rows[0]["Entité"] == offer_rule.offer.venue.managingOfferer.name
         assert rows[0]["SIREN"] == offer_rule.offer.venue.managingOfferer.siren
         assert rows[0]["Lieu"] == offer_rule.offer.venue.name
         assert rows[0]["Offre"] == offer_rule.offer.name
@@ -69,7 +69,7 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
         assert rows[0]["Date d'application"] == start.strftime("%d/%m/%Y") + " → ∞"
 
         assert rows[1]["ID règle"] == str(venue_rule.id)
-        assert rows[1]["Structure"] == venue_rule.venue.managingOfferer.name
+        assert rows[1]["Entité"] == venue_rule.venue.managingOfferer.name
         assert rows[1]["SIREN"] == venue_rule.venue.managingOfferer.siren
         assert rows[1]["Lieu"] == f"{venue_rule.venue.name} - {venue_rule.venue.siret}"
         assert rows[1]["Offre"] == ""
@@ -79,7 +79,7 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
         assert rows[1]["Date d'application"] == start.strftime("%d/%m/%Y") + " → ∞"
 
         assert rows[2]["ID règle"] == str(offerer_rule.id)
-        assert rows[2]["Structure"] == offerer_rule.offerer.name
+        assert rows[2]["Entité"] == offerer_rule.offerer.name
         assert rows[2]["SIREN"] == offerer_rule.offerer.siren
         assert rows[2]["Lieu"] == ""
         assert rows[2]["Offre"] == ""
@@ -300,7 +300,7 @@ class CreateCustomReimbursementRuleTest(PostEndpointHelper):
         assert response.status_code == 303
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "Un tarif dérogatoire ne peut pas concerner un lieu et une structure en même temps"
+            == "Un tarif dérogatoire ne peut pas concerner un lieu et une entité en même temps"
         )
 
         assert finance_models.CustomReimbursementRule.query.count() == 0

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -176,7 +176,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Individuelle"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[0].booking_finance_incidents))
         assert rows[0]["Montant total"] == "11,00 €"
-        assert rows[0]["Structure"] == incidents[0].venue.managingOfferer.name
+        assert rows[0]["Entité"] == incidents[0].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[0].venue.name
         assert rows[0]["Origine de la demande"] == incidents[0].details["origin"]
 
@@ -196,7 +196,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Individuelle"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[0].booking_finance_incidents))
         assert rows[0]["Montant total"] == "11,00 €"
-        assert rows[0]["Structure"] == incidents[0].venue.managingOfferer.name
+        assert rows[0]["Entité"] == incidents[0].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[0].venue.name
         assert rows[0]["Origine de la demande"] == incidents[0].details["origin"]
 
@@ -225,7 +225,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Collective"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[1].booking_finance_incidents))
         assert rows[0]["Montant total"] == "100,00 €"
-        assert rows[0]["Structure"] == incidents[1].venue.managingOfferer.name
+        assert rows[0]["Entité"] == incidents[1].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[1].venue.name
         assert rows[0]["Origine de la demande"] == incidents[1].details["origin"]
 
@@ -254,7 +254,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Individuelle"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[0].booking_finance_incidents))
         assert rows[0]["Montant total"] == "11,00 €"
-        assert rows[0]["Structure"] == incidents[0].venue.managingOfferer.name
+        assert rows[0]["Entité"] == incidents[0].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[0].venue.name
         assert rows[0]["Origine de la demande"] == incidents[0].details["origin"]
 
@@ -285,7 +285,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Individuelle"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[0].booking_finance_incidents))
         assert rows[0]["Montant total"] == "11,00 €"
-        assert rows[0]["Structure"] == incidents[0].venue.managingOfferer.name
+        assert rows[0]["Entité"] == incidents[0].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[0].venue.name
         assert rows[0]["Origine de la demande"] == incidents[0].details["origin"]
 

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -176,7 +176,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Individuelle"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[0].booking_finance_incidents))
         assert rows[0]["Montant total"] == "11,00 €"
-        assert rows[0]["Entité"] == incidents[0].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == incidents[0].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[0].venue.name
         assert rows[0]["Origine de la demande"] == incidents[0].details["origin"]
 
@@ -196,7 +196,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Individuelle"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[0].booking_finance_incidents))
         assert rows[0]["Montant total"] == "11,00 €"
-        assert rows[0]["Entité"] == incidents[0].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == incidents[0].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[0].venue.name
         assert rows[0]["Origine de la demande"] == incidents[0].details["origin"]
 
@@ -225,7 +225,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Collective"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[1].booking_finance_incidents))
         assert rows[0]["Montant total"] == "100,00 €"
-        assert rows[0]["Entité"] == incidents[1].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == incidents[1].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[1].venue.name
         assert rows[0]["Origine de la demande"] == incidents[1].details["origin"]
 
@@ -254,7 +254,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Individuelle"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[0].booking_finance_incidents))
         assert rows[0]["Montant total"] == "11,00 €"
-        assert rows[0]["Entité"] == incidents[0].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == incidents[0].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[0].venue.name
         assert rows[0]["Origine de la demande"] == incidents[0].details["origin"]
 
@@ -285,7 +285,7 @@ class ListIncidentsTest(GetEndpointHelper):
         assert rows[0]["Type de résa"] == "Individuelle"
         assert rows[0]["Nb. Réservation(s)"] == str(len(incidents[0].booking_finance_incidents))
         assert rows[0]["Montant total"] == "11,00 €"
-        assert rows[0]["Entité"] == incidents[0].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == incidents[0].venue.managingOfferer.name
         assert rows[0]["Porteur de l'offre (lieu)"] == incidents[0].venue.name
         assert rows[0]["Origine de la demande"] == incidents[0].details["origin"]
 

--- a/api/tests/routes/backoffice/home_test.py
+++ b/api/tests/routes/backoffice/home_test.py
@@ -70,7 +70,7 @@ class HomePageTest:
             "3 offres collectives en attente CONSULTER",
             "4 offres collectives vitrine en attente CONSULTER",
         ]
-        # No card for "entité en attente de conformité" because tag "conformité" does not exist
+        # No card for "entité juridique en attente de conformité" because tag "conformité" does not exist
 
     def test_view_home_page_pending_offerers_conformite(self, authenticated_client):
         tag = offerers_factories.OffererTagFactory(name="conformité", label="En attente de conformité")
@@ -92,5 +92,5 @@ class HomePageTest:
             "0 offre individuelle en attente CONSULTER",
             "0 offre collective en attente CONSULTER",
             "0 offre collective vitrine en attente CONSULTER",
-            "1 entité en attente de conformité CONSULTER",
+            "1 entité juridique en attente de conformité CONSULTER",
         ]

--- a/api/tests/routes/backoffice/home_test.py
+++ b/api/tests/routes/backoffice/home_test.py
@@ -70,7 +70,7 @@ class HomePageTest:
             "3 offres collectives en attente CONSULTER",
             "4 offres collectives vitrine en attente CONSULTER",
         ]
-        # No card for "structure en attente de conformité" because tag "conformité" does not exist
+        # No card for "entité en attente de conformité" because tag "conformité" does not exist
 
     def test_view_home_page_pending_offerers_conformite(self, authenticated_client):
         tag = offerers_factories.OffererTagFactory(name="conformité", label="En attente de conformité")
@@ -92,5 +92,5 @@ class HomePageTest:
             "0 offre individuelle en attente CONSULTER",
             "0 offre collective en attente CONSULTER",
             "0 offre collective vitrine en attente CONSULTER",
-            "1 structure en attente de conformité CONSULTER",
+            "1 entité en attente de conformité CONSULTER",
         ]

--- a/api/tests/routes/backoffice/individual_bookings_test.py
+++ b/api/tests/routes/backoffice/individual_bookings_test.py
@@ -150,7 +150,7 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         assert rows[0]["Date de réservation"].startswith(
             (datetime.date.today() - datetime.timedelta(days=4)).strftime("%d/%m/%Y")
         )
-        assert rows[0]["Structure"] == bookings[0].offerer.name
+        assert rows[0]["Entité"] == bookings[0].offerer.name
         assert rows[0]["Lieu"] == bookings[0].venue.name
 
         extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[0]
@@ -288,7 +288,7 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         assert row["Date de réservation"].startswith(
             (datetime.date.today() - datetime.timedelta(days=2)).strftime("%d/%m/%Y à")
         )
-        assert row["Structure"] == bookings[2].offerer.name
+        assert row["Entité"] == bookings[2].offerer.name
         assert row["Lieu"] == bookings[2].venue.name
 
         extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[row_index]

--- a/api/tests/routes/backoffice/individual_bookings_test.py
+++ b/api/tests/routes/backoffice/individual_bookings_test.py
@@ -150,7 +150,7 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         assert rows[0]["Date de réservation"].startswith(
             (datetime.date.today() - datetime.timedelta(days=4)).strftime("%d/%m/%Y")
         )
-        assert rows[0]["Entité"] == bookings[0].offerer.name
+        assert rows[0]["Entité juridique"] == bookings[0].offerer.name
         assert rows[0]["Lieu"] == bookings[0].venue.name
 
         extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[0]
@@ -288,7 +288,7 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         assert row["Date de réservation"].startswith(
             (datetime.date.today() - datetime.timedelta(days=2)).strftime("%d/%m/%Y à")
         )
-        assert row["Entité"] == bookings[2].offerer.name
+        assert row["Entité juridique"] == bookings[2].offerer.name
         assert row["Lieu"] == bookings[2].venue.name
 
         extra_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")[row_index]

--- a/api/tests/routes/backoffice/offer_validation_rules_test.py
+++ b/api/tests/routes/backoffice/offer_validation_rules_test.py
@@ -170,7 +170,7 @@ class ListRulesTest(GetEndpointHelper):
             response = authenticated_client.get(url_for(self.endpoint, offerer=42))
             assert response.status_code == 200
 
-        assert "La structure proposant l'offre est parmi Offerer ID : 42" in html_parser.content_as_text(response.data)
+        assert "L'entité proposant l'offre est parmi Offerer ID : 42" in html_parser.content_as_text(response.data)
 
     def test_search_rule_by_venue(self, authenticated_client):
         venue = offerers_factories.VenueFactory(publicName="Your flowers are beautiful")

--- a/api/tests/routes/backoffice/offer_validation_rules_test.py
+++ b/api/tests/routes/backoffice/offer_validation_rules_test.py
@@ -170,7 +170,9 @@ class ListRulesTest(GetEndpointHelper):
             response = authenticated_client.get(url_for(self.endpoint, offerer=42))
             assert response.status_code == 200
 
-        assert "L'entité proposant l'offre est parmi Offerer ID : 42" in html_parser.content_as_text(response.data)
+        assert "L'entité juridique proposant l'offre est parmi Offerer ID : 42" in html_parser.content_as_text(
+            response.data
+        )
 
     def test_search_rule_by_venue(self, authenticated_client):
         venue = offerers_factories.VenueFactory(publicName="Your flowers are beautiful")

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -112,10 +112,10 @@ class GetOffererTest(GetEndpointHelper):
         assert f"Adresse : {offerer.street} " in content
         assert "Peut créer une offre EAC : Oui" in content
         assert "Présence CB dans les lieux : 0 OK / 0 KO " in content
-        assert "Tags entité : Collectivité Top acteur " in content
+        assert "Tags : Collectivité Top acteur " in content
         assert "Validation des offres : Suivre les règles" in content
         badges = html_parser.extract(response.data, tag="span", class_="badge")
-        assert "Entité" in badges
+        assert "Entité juridique" in badges
         assert "Validée" in badges
         assert "Suspendue" not in badges
 
@@ -399,7 +399,10 @@ class SuspendOffererTest(DeactivateOffererHelper):
         assert response.status_code == 303
         assert response.location == url_for("backoffice_web.offerer.get", offerer_id=offerer.id, _external=True)
         response = authenticated_client.get(response.location)
-        assert html_parser.extract_alert(response.data) == f"L'entité {offerer.name} ({offerer.id}) a été suspendue"
+        assert (
+            html_parser.extract_alert(response.data)
+            == f"L'entité juridique {offerer.name} ({offerer.id}) a été suspendue"
+        )
 
         updated_offerer = offerers_models.Offerer.query.filter_by(id=offerer.id).one()
         assert not updated_offerer.isActive
@@ -421,7 +424,7 @@ class SuspendOffererTest(DeactivateOffererHelper):
         response = authenticated_client.get(response.location)
         assert (
             html_parser.extract_alert(response.data)
-            == "Impossible de suspendre une entité pour laquelle il existe des réservations"
+            == "Impossible de suspendre une entité juridique pour laquelle il existe des réservations"
         )
 
         not_updated_offerer = offerers_models.Offerer.query.filter_by(id=offerer.id).one()
@@ -445,7 +448,10 @@ class UnsuspendOffererTest(ActivateOffererHelper):
         assert response.status_code == 303
         assert response.location == url_for("backoffice_web.offerer.get", offerer_id=offerer.id, _external=True)
         response = authenticated_client.get(response.location)
-        assert html_parser.extract_alert(response.data) == f"L'entité {offerer.name} ({offerer.id}) a été réactivée"
+        assert (
+            html_parser.extract_alert(response.data)
+            == f"L'entité juridique {offerer.name} ({offerer.id}) a été réactivée"
+        )
 
         updated_offerer = offerers_models.Offerer.query.filter_by(id=offerer.id).one()
         assert updated_offerer.isActive
@@ -475,7 +481,7 @@ class DeleteOffererTest(PostEndpointHelper):
         response = authenticated_client.get(expected_url)
         assert (
             html_parser.extract_alert(response.data)
-            == f"L'entité {offerer_to_delete_name} ({offerer_to_delete_id}) a été supprimée"
+            == f"L'entité juridique {offerer_to_delete_name} ({offerer_to_delete_id}) a été supprimée"
         )
 
     def test_cant_delete_offerer_with_bookings(self, legit_user, authenticated_client):
@@ -493,7 +499,7 @@ class DeleteOffererTest(PostEndpointHelper):
         response = authenticated_client.get(expected_url)
         assert (
             html_parser.extract_alert(response.data)
-            == "Impossible de supprimer une entité pour laquelle il existe des réservations"
+            == "Impossible de supprimer une entité juridique pour laquelle il existe des réservations"
         )
 
     def test_no_script_injection_in_offerer_name(self, legit_user, authenticated_client):
@@ -503,7 +509,7 @@ class DeleteOffererTest(PostEndpointHelper):
         assert response.status_code == 303
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == f"L'entité <script>alert('coucou')</script> ({offerer_id}) a été supprimée"
+            == f"L'entité juridique <script>alert('coucou')</script> ({offerer_id}) a été supprimée"
         )
 
 
@@ -1174,7 +1180,7 @@ class GetOffererHistoryTest(GetEndpointHelper):
             authorUser=admin,
             user=user_offerer.user,
             offerer=offerers_factories.UserOffererFactory(user=user_offerer.user).offerer,
-            comment="Commentaire sur une autre entité",
+            comment="Commentaire sur une autre entité juridique",
         )
 
         url = url_for(self.endpoint, offerer_id=user_offerer.offerer.id)
@@ -1185,7 +1191,7 @@ class GetOffererHistoryTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data)
         assert len(rows) == 4
 
-        assert rows[0]["Type"] == "Entité validée"
+        assert rows[0]["Type"] == "Entité juridique validée"
         assert rows[0]["Date/Heure"] == "Le 06/10/2022 à 18h04"  # CET (Paris time)
         assert rows[0]["Commentaire"] == ""
         assert rows[0]["Auteur"] == admin.full_name
@@ -1195,12 +1201,12 @@ class GetOffererHistoryTest(GetEndpointHelper):
         assert rows[1]["Commentaire"] == "Documents reçus"
         assert rows[1]["Auteur"] == legit_user.full_name
 
-        assert rows[2]["Type"] == "Entité mise en attente"
+        assert rows[2]["Type"] == "Entité juridique mise en attente"
         assert rows[2]["Date/Heure"] == "Le 04/10/2022 à 16h02"  # CET (Paris time)
         assert rows[2]["Commentaire"] == "Documents complémentaires demandés"
         assert rows[2]["Auteur"] == admin.full_name
 
-        assert rows[3]["Type"] == "Nouvelle entité"
+        assert rows[3]["Type"] == "Nouvelle entité juridique"
         assert rows[3]["Date/Heure"] == "Le 03/10/2022 à 15h01"  # CET (Paris time)
         assert rows[3]["Commentaire"] == ""
         assert rows[3]["Auteur"] == user_offerer.user.full_name
@@ -1226,7 +1232,7 @@ class GetOffererHistoryTest(GetEndpointHelper):
 
         rows = html_parser.extract_table_rows(response.data)
         assert len(rows) == 1
-        assert rows[0]["Type"] == "Entité rejetée"
+        assert rows[0]["Type"] == "Entité juridique rejetée"
         assert rows[0]["Commentaire"] == "Raison : Non réponse aux questionnaires Relancé 3 fois"
         assert rows[0]["Auteur"] == bo_user.full_name
 
@@ -1948,20 +1954,20 @@ class ListOfferersToValidateTest(GetEndpointHelper):
             rows = html_parser.extract_table_rows(response.data)
             assert len(rows) == 1
             assert rows[0]["ID"] == str(user_offerer.offerer.id)
-            assert rows[0]["Nom de l'entité"] == user_offerer.offerer.name
+            assert rows[0]["Nom"] == user_offerer.offerer.name
             assert rows[0]["État"] == "Nouvelle"
             if top_acteur_column_expected:
                 assert rows[0]["Top Acteur"] == ""  # no text
             else:
                 assert "Top Acteur" not in rows[0]
-            assert tag.label in rows[0]["Tags entité"]
-            assert other_category_tag.label in rows[0]["Tags entité"]
+            assert tag.label in rows[0]["Tags"]
+            assert other_category_tag.label in rows[0]["Tags"]
             assert rows[0]["Date de la demande"] == "03/10/2022"
             assert rows[0]["Documents reçus"] == ""
             assert rows[0]["Dernier commentaire"] == "Houlala"
             assert rows[0]["SIREN"] == user_offerer.offerer.siren
             assert rows[0]["Email"] == user_offerer.user.email
-            assert rows[0]["Responsable Entité"] == user_offerer.user.full_name
+            assert rows[0]["Responsable"] == user_offerer.user.full_name
             assert rows[0]["Ville"] == user_offerer.offerer.city
 
             dms_adage_data = html_parser.extract(response.data, tag="tr", class_="collapse accordion-collapse")
@@ -1986,7 +1992,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
             rows = html_parser.extract_table_rows(response.data)
             assert len(rows) == 1
             assert rows[0]["ID"] == str(user_offerer.offerer.id)
-            assert rows[0]["Nom de l'entité"] == user_offerer.offerer.name
+            assert rows[0]["Nom"] == user_offerer.offerer.name
             assert rows[0]["État"] == "Nouvelle"
             assert rows[0]["Date de la demande"] == "03/10/2022"
             assert rows[0]["Dernier commentaire"] == ""
@@ -2125,7 +2131,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == expected_offerer_names
+            assert {row["Nom"] for row in rows} == expected_offerer_names
 
         @pytest.mark.parametrize(
             "tag_filter, expected_offerer_names",
@@ -2156,7 +2162,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == expected_offerer_names
+            assert {row["Nom"] for row in rows} == expected_offerer_names
 
         def test_list_filtering_by_date(self, authenticated_client):
             # Created before requested range, excluded from results:
@@ -2210,7 +2216,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == {"D"}
+            assert {row["Nom"] for row in rows} == {"D"}
 
         def test_list_search_by_rid7(self, authenticated_client):
             nc_offerer = offerers_factories.NotValidatedCaledonianOffererFactory()
@@ -2223,7 +2229,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == {nc_offerer.name}
+            assert {row["Nom"] for row in rows} == {nc_offerer.name}
 
         @pytest.mark.parametrize("postal_code", ["35400", "35 400"])
         def test_list_search_by_postal_code(self, authenticated_client, offerers_to_be_validated, postal_code):
@@ -2234,7 +2240,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == {"E"}
+            assert {row["Nom"] for row in rows} == {"E"}
 
         def test_list_search_by_department_code(self, authenticated_client, offerers_to_be_validated):
             with assert_num_queries(self.expected_num_queries):
@@ -2244,7 +2250,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == {"A", "E"}
+            assert {row["Nom"] for row in rows} == {"A", "E"}
 
         def test_list_search_by_city(self, authenticated_client, offerers_to_be_validated):
             # Ensure that outerjoin does not cause too many rows returned
@@ -2258,7 +2264,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == {"B", "D"}
+            assert {row["Nom"] for row in rows} == {"B", "D"}
             assert html_parser.extract_pagination_info(response.data) == (1, 1, 2)
 
         @pytest.mark.parametrize("search", ["1", "1234", "123456", "12345678", "12345678912345", "  1234"])
@@ -2284,7 +2290,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == {"B"}
+            assert {row["Nom"] for row in rows} == {"B"}
 
         def test_list_search_by_user_name(self, authenticated_client, offerers_to_be_validated):
             with assert_num_queries(self.expected_num_queries):
@@ -2294,7 +2300,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == {"C"}
+            assert {row["Nom"] for row in rows} == {"C"}
 
         @pytest.mark.parametrize(
             "search_filter, expected_offerer_names",
@@ -2321,7 +2327,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             rows = html_parser.extract_table_rows(response.data)
-            assert {row["Nom de l'entité"] for row in rows} == expected_offerer_names
+            assert {row["Nom"] for row in rows} == expected_offerer_names
 
         @pytest.mark.parametrize(
             "status_filter, expected_status, expected_offerer_names",
@@ -2350,7 +2356,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
 
             if expected_status == 200:
                 rows = html_parser.extract_table_rows(response.data)
-                assert {row["Nom de l'entité"] for row in rows} == expected_offerer_names
+                assert {row["Nom"] for row in rows} == expected_offerer_names
             else:
                 assert html_parser.count_table_rows(response.data) == 0
 
@@ -2467,7 +2473,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
 
             if expected_status == 200:
                 rows = html_parser.extract_table_rows(response.data)
-                assert {row["Nom de l'entité"] for row in rows} == expected_offerer_names
+                assert {row["Nom"] for row in rows} == expected_offerer_names
             else:
                 assert html_parser.count_table_rows(response.data) == 0
 
@@ -2523,10 +2529,10 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             cards = html_parser.extract_cards_text(response.data)
-            assert "3 nouvelles entités" in cards
-            assert "4 entités en attente" in cards
-            assert "1 entité validée" in cards
-            assert "2 entités rejetées" in cards
+            assert "3 nouvelles entités juridiques" in cards
+            assert "4 entités juridiques en attente" in cards
+            assert "1 entité juridique validée" in cards
+            assert "2 entités juridiques rejetées" in cards
 
         def test_no_offerer(self, authenticated_client):
             with assert_num_queries(self.expected_num_queries):
@@ -2534,10 +2540,10 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 assert response.status_code == 200
 
             cards = html_parser.extract_cards_text(response.data)
-            assert "0 nouvelle entité" in cards
-            assert "0 entité en attente" in cards
-            assert "0 entité validée" in cards
-            assert "0 entité rejetée" in cards
+            assert "0 nouvelle entité juridique" in cards
+            assert "0 entité juridique en attente" in cards
+            assert "0 entité juridique validée" in cards
+            assert "0 entité juridique rejetée" in cards
             assert html_parser.count_table_rows(response.data) == 0
 
 
@@ -2594,7 +2600,7 @@ class ValidateOffererTest(ActivateOffererHelper):
 
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == f"L'entité {user_offerer.offerer.name} est déjà validée"
+            == f"L'entité juridique {user_offerer.offerer.name} est déjà validée"
         )
 
 
@@ -2690,7 +2696,7 @@ class RejectOffererTest(DeactivateOffererHelper):
         assert response.status_code == 303
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "L'entité Test est déjà rejetée"
+            == "L'entité juridique Test est déjà rejetée"
         )
 
     def test_cannot_reject_offerer_without_reason(self, authenticated_client):
@@ -2713,7 +2719,7 @@ class RejectOffererTest(DeactivateOffererHelper):
         assert response.status_code == 303
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "L'entité <script>alert('coucou')</script> a été rejetée"
+            == "L'entité juridique <script>alert('coucou')</script> a été rejetée"
         )
 
 
@@ -2943,9 +2949,9 @@ class ListUserOffererToValidateTest(GetEndpointHelper):
         assert rows[0]["Email Compte pro"] == new_user_offerer.user.email
         assert rows[0]["Nom Compte pro"] == new_user_offerer.user.full_name
         assert rows[0]["État"] == "Nouveau"
-        assert rows[0]["Tags Entité"] == offerer_tags[1].label
+        assert rows[0]["Tags Entité juridique"] == offerer_tags[1].label
         assert rows[0]["Date de la demande"] == "03/11/2022"
-        assert rows[0]["Nom Entité"] == owner_user_offerer.offerer.name
+        assert rows[0]["Nom Entité juridique"] == owner_user_offerer.offerer.name
         assert rows[0]["Email Responsable"] == owner_user_offerer.user.email
         assert rows[0]["Dernier commentaire"] == "Bla blabla"
 
@@ -2977,9 +2983,9 @@ class ListUserOffererToValidateTest(GetEndpointHelper):
         assert rows[0]["Email Compte pro"] == new_user_offerer.user.email
         assert rows[0]["Nom Compte pro"] == new_user_offerer.user.full_name
         assert rows[0]["État"] == "Nouveau"
-        assert rows[0]["Tags Entité"] == offerer_tags[2].label
+        assert rows[0]["Tags Entité juridique"] == offerer_tags[2].label
         assert rows[0]["Date de la demande"] == "25/11/2022"
-        assert rows[0]["Nom Entité"] == owner_user_offerer.offerer.name
+        assert rows[0]["Nom Entité juridique"] == owner_user_offerer.offerer.name
         assert rows[0]["Email Responsable"] == owner_user_offerer.user.email
         assert rows[0]["Dernier commentaire"] == ""
 
@@ -3465,7 +3471,7 @@ class AddUserOffererAndValidateTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.headers["location"])
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "L'ID ne correspond pas à un ancien rattachement à l'entité"
+            == "L'ID ne correspond pas à un ancien rattachement à l'entité juridique"
         )
 
         assert offerers_models.UserOfferer.query.count() == 1  # existing before request
@@ -3484,7 +3490,7 @@ class AddUserOffererAndValidateTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.headers["location"])
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "L'ID ne correspond pas à un ancien rattachement à l'entité"
+            == "L'ID ne correspond pas à un ancien rattachement à l'entité juridique"
         )
 
     def test_add_user_empty(self, legit_user, authenticated_client):
@@ -3848,7 +3854,7 @@ class ListOffererTagsTest(GetEndpointHelper):
 
 class CreateTagButtonTest(button_helpers.ButtonHelper):
     needed_permission = perm_models.Permissions.MANAGE_OFFERER_TAG
-    button_label = "Créer un tag entité"
+    button_label = "Créer un tag"
 
     @property
     def path(self):

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -172,7 +172,7 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Date de création"] == (datetime.date.today()).strftime("%d/%m/%Y")
         assert rows[0]["Dernière validation"] == ""
         assert rows[0]["Dép."] == offers[0].venue.departementCode
-        assert rows[0]["Entité"] == offers[0].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == offers[0].venue.managingOfferer.name
         assert rows[0]["Lieu"] == offers[0].venue.name
 
         if stock_data_expected:
@@ -231,7 +231,7 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Date de création"] == (datetime.date.today()).strftime("%d/%m/%Y")
         assert rows[0]["Dernière validation"] == "22/02/2022"
         assert rows[0]["Dép."] == offers[1].venue.departementCode
-        assert rows[0]["Entité"] == offers[1].venue.managingOfferer.name
+        assert rows[0]["Entité juridique"] == offers[1].venue.managingOfferer.name
         assert rows[0]["Lieu"] == offers[1].venue.name
         assert rows[1]["ID"] == str(offers[2].id)
         assert rows[1]["Nom de l'offre"] == offers[2].name
@@ -1220,7 +1220,7 @@ class ListOffersTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Entité"] == "Offerer Revue manuelle"
+        assert rows[0]["Entité juridique"] == "Offerer Revue manuelle"
         assert rows[0]["Lieu"] == "Venue"
 
     def test_list_offers_with_venue_confidence_rule(self, client, pro_fraud_admin):
@@ -1236,7 +1236,7 @@ class ListOffersTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Entité"] == "Offerer"
+        assert rows[0]["Entité juridique"] == "Offerer"
         assert rows[0]["Lieu"] == "Venue Revue manuelle"
 
 
@@ -1869,7 +1869,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert "État : Validée" in card_text
         assert "Score data : 55 " in card_text
         assert "Raison de score faible : Prix Sous-catégorie Description de l'offre " in card_text
-        assert "Entité : Le Petit Rintintin Management" in card_text
+        assert "Entité juridique : Le Petit Rintintin Management" in card_text
         assert "Lieu : Le Petit Rintintin" in card_text
         assert "Utilisateur de la dernière validation" not in card_text
         assert "Date de dernière validation" not in card_text
@@ -1976,7 +1976,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert "Genres : ADVENTURE, ANIMATION, DRAMA " in card_text
         assert "Statut : Épuisée" in card_text
         assert "État : Validée" in card_text
-        assert "Entité : Le Petit Rintintin Management" in card_text
+        assert "Entité juridique : Le Petit Rintintin Management" in card_text
         assert "Lieu : Le Petit Rintintin" in card_text
         assert "Adresse :" not in card_text  # no offererAddress
         assert "Utilisateur de la dernière validation" not in card_text

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -172,7 +172,7 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Date de création"] == (datetime.date.today()).strftime("%d/%m/%Y")
         assert rows[0]["Dernière validation"] == ""
         assert rows[0]["Dép."] == offers[0].venue.departementCode
-        assert rows[0]["Structure"] == offers[0].venue.managingOfferer.name
+        assert rows[0]["Entité"] == offers[0].venue.managingOfferer.name
         assert rows[0]["Lieu"] == offers[0].venue.name
 
         if stock_data_expected:
@@ -231,7 +231,7 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Date de création"] == (datetime.date.today()).strftime("%d/%m/%Y")
         assert rows[0]["Dernière validation"] == "22/02/2022"
         assert rows[0]["Dép."] == offers[1].venue.departementCode
-        assert rows[0]["Structure"] == offers[1].venue.managingOfferer.name
+        assert rows[0]["Entité"] == offers[1].venue.managingOfferer.name
         assert rows[0]["Lieu"] == offers[1].venue.name
         assert rows[1]["ID"] == str(offers[2].id)
         assert rows[1]["Nom de l'offre"] == offers[2].name
@@ -1220,7 +1220,7 @@ class ListOffersTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Structure"] == "Offerer Revue manuelle"
+        assert rows[0]["Entité"] == "Offerer Revue manuelle"
         assert rows[0]["Lieu"] == "Venue"
 
     def test_list_offers_with_venue_confidence_rule(self, client, pro_fraud_admin):
@@ -1236,7 +1236,7 @@ class ListOffersTest(GetEndpointHelper):
             assert response.status_code == 200
 
         rows = html_parser.extract_table_rows(response.data)
-        assert rows[0]["Structure"] == "Offerer"
+        assert rows[0]["Entité"] == "Offerer"
         assert rows[0]["Lieu"] == "Venue Revue manuelle"
 
 
@@ -1869,7 +1869,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert "État : Validée" in card_text
         assert "Score data : 55 " in card_text
         assert "Raison de score faible : Prix Sous-catégorie Description de l'offre " in card_text
-        assert "Structure : Le Petit Rintintin Management" in card_text
+        assert "Entité : Le Petit Rintintin Management" in card_text
         assert "Lieu : Le Petit Rintintin" in card_text
         assert "Utilisateur de la dernière validation" not in card_text
         assert "Date de dernière validation" not in card_text
@@ -1976,7 +1976,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert "Genres : ADVENTURE, ANIMATION, DRAMA " in card_text
         assert "Statut : Épuisée" in card_text
         assert "État : Validée" in card_text
-        assert "Structure : Le Petit Rintintin Management" in card_text
+        assert "Entité : Le Petit Rintintin Management" in card_text
         assert "Lieu : Le Petit Rintintin" in card_text
         assert "Adresse :" not in card_text  # no offererAddress
         assert "Utilisateur de la dernière validation" not in card_text

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -77,7 +77,7 @@ def assert_offerer_equals(result_card_text: str, expected_offerer: offerers_mode
     assert f"SIREN : {expected_offerer.siren} " in result_card_text
     assert f"Ville : {expected_offerer.city}" in result_card_text
     assert f"Code postal : {expected_offerer.postalCode}" in result_card_text
-    assert "Structure " in result_card_text
+    assert "Entité " in result_card_text
     if expected_offerer.isValidated:
         assert " Validée " in result_card_text
     if expected_offerer.isRejected:
@@ -90,7 +90,7 @@ def assert_venue_equals(result_card_text: str, expected_venue: offerers_models.V
     assert f"{expected_venue.name.upper()} " in result_card_text
     assert f"Venue ID : {expected_venue.id} " in result_card_text
     assert f"SIRET : {expected_venue.siret} " in result_card_text
-    assert f"Structure : {expected_venue.managingOfferer.name} " in result_card_text
+    assert f"Entité : {expected_venue.managingOfferer.name} " in result_card_text
     assert f"Email : {expected_venue.bookingEmail} " in result_card_text
     if expected_venue.contact:
         assert f"Tél : {expected_venue.contact.phone_number} " in result_card_text
@@ -827,7 +827,7 @@ class LogsTest:
 
 class CreateOffererButtonTest(button_helpers.ButtonHelper):
     needed_permission = perm_models.Permissions.CREATE_PRO_ENTITY
-    button_label = "Créer une structure"
+    button_label = "Créer une entité"
 
     @property
     def path(self):
@@ -927,7 +927,7 @@ class CreateOffererTest(PostEndpointHelper):
         assert new_offerer_action.offererId == new_offerer.id
         assert new_offerer_action.userId == user.id
         assert new_offerer_action.authorUserId == legit_user.id
-        assert new_offerer_action.comment == "Structure créée depuis le backoffice"
+        assert new_offerer_action.comment == "Entité créée depuis le backoffice"
         assert new_offerer_action.extraData == {
             "target": form_data["target"],
             "venue_type_code": form_data["venue_type_code"],
@@ -1004,7 +1004,7 @@ class CreateOffererTest(PostEndpointHelper):
 
         response = self.post_to_endpoint(authenticated_client, form=form_data)
         assert response.status_code == 400
-        assert html_parser.extract_warnings(response.data) == ["Une structure existe déjà avec le SIREN 900000001"]
+        assert html_parser.extract_warnings(response.data) == ["Une entité existe déjà avec le SIREN 900000001"]
 
     @pytest.mark.parametrize(
         "siret,expected_warning",
@@ -1013,7 +1013,7 @@ class CreateOffererTest(PostEndpointHelper):
             ("90009900000001", "L'établissement portant le SIRET 90009900000001 est fermé"),
             (
                 "12345678900001",
-                "L'établissement portant le SIRET 12345678900001 est diffusible, l'acteur culturel peut créer la structure sur PC Pro",
+                "L'établissement portant le SIRET 12345678900001 est diffusible, l'acteur culturel peut créer l'entité sur PC Pro",
             ),
         ],
     )
@@ -1363,7 +1363,7 @@ class ConnectAsProUserTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.location)
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette structure"
+            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité"
         )
 
     def test_connect_as_offerer_not_found(self, authenticated_client):
@@ -1379,7 +1379,7 @@ class ConnectAsProUserTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.location)
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette structure"
+            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité"
         )
 
     def test_connect_as_offerer_without_active_user(self, authenticated_client):
@@ -1399,7 +1399,7 @@ class ConnectAsProUserTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.location)
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette structure"
+            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité"
         )
 
     @pytest.mark.parametrize(
@@ -1426,7 +1426,7 @@ class ConnectAsProUserTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.location)
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette structure"
+            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité"
         )
 
     def test_connect_as_offerer_user_has_multiple_offerer(self, authenticated_client, legit_user):

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -77,7 +77,7 @@ def assert_offerer_equals(result_card_text: str, expected_offerer: offerers_mode
     assert f"SIREN : {expected_offerer.siren} " in result_card_text
     assert f"Ville : {expected_offerer.city}" in result_card_text
     assert f"Code postal : {expected_offerer.postalCode}" in result_card_text
-    assert "Entité " in result_card_text
+    assert "Entité juridique " in result_card_text
     if expected_offerer.isValidated:
         assert " Validée " in result_card_text
     if expected_offerer.isRejected:
@@ -90,7 +90,7 @@ def assert_venue_equals(result_card_text: str, expected_venue: offerers_models.V
     assert f"{expected_venue.name.upper()} " in result_card_text
     assert f"Venue ID : {expected_venue.id} " in result_card_text
     assert f"SIRET : {expected_venue.siret} " in result_card_text
-    assert f"Entité : {expected_venue.managingOfferer.name} " in result_card_text
+    assert f"Entité juridique : {expected_venue.managingOfferer.name} " in result_card_text
     assert f"Email : {expected_venue.bookingEmail} " in result_card_text
     if expected_venue.contact:
         assert f"Tél : {expected_venue.contact.phone_number} " in result_card_text
@@ -827,7 +827,7 @@ class LogsTest:
 
 class CreateOffererButtonTest(button_helpers.ButtonHelper):
     needed_permission = perm_models.Permissions.CREATE_PRO_ENTITY
-    button_label = "Créer une entité"
+    button_label = "Créer un partenaire culturel"
 
     @property
     def path(self):
@@ -927,7 +927,7 @@ class CreateOffererTest(PostEndpointHelper):
         assert new_offerer_action.offererId == new_offerer.id
         assert new_offerer_action.userId == user.id
         assert new_offerer_action.authorUserId == legit_user.id
-        assert new_offerer_action.comment == "Entité créée depuis le backoffice"
+        assert new_offerer_action.comment == "Entité juridique créée depuis le backoffice"
         assert new_offerer_action.extraData == {
             "target": form_data["target"],
             "venue_type_code": form_data["venue_type_code"],
@@ -1004,7 +1004,9 @@ class CreateOffererTest(PostEndpointHelper):
 
         response = self.post_to_endpoint(authenticated_client, form=form_data)
         assert response.status_code == 400
-        assert html_parser.extract_warnings(response.data) == ["Une entité existe déjà avec le SIREN 900000001"]
+        assert html_parser.extract_warnings(response.data) == [
+            "Une entité juridique existe déjà avec le SIREN 900000001"
+        ]
 
     @pytest.mark.parametrize(
         "siret,expected_warning",
@@ -1013,7 +1015,7 @@ class CreateOffererTest(PostEndpointHelper):
             ("90009900000001", "L'établissement portant le SIRET 90009900000001 est fermé"),
             (
                 "12345678900001",
-                "L'établissement portant le SIRET 12345678900001 est diffusible, l'acteur culturel peut créer l'entité sur PC Pro",
+                "L'établissement portant le SIRET 12345678900001 est diffusible, l'acteur culturel peut créer l'entité juridique sur PC Pro",
             ),
         ],
     )
@@ -1363,7 +1365,7 @@ class ConnectAsProUserTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.location)
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité"
+            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité juridique"
         )
 
     def test_connect_as_offerer_not_found(self, authenticated_client):
@@ -1379,7 +1381,7 @@ class ConnectAsProUserTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.location)
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité"
+            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité juridique"
         )
 
     def test_connect_as_offerer_without_active_user(self, authenticated_client):
@@ -1399,7 +1401,7 @@ class ConnectAsProUserTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.location)
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité"
+            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité juridique"
         )
 
     @pytest.mark.parametrize(
@@ -1426,7 +1428,7 @@ class ConnectAsProUserTest(PostEndpointHelper):
         redirected_response = authenticated_client.get(response.location)
         assert (
             html_parser.extract_alert(redirected_response.data)
-            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité"
+            == "Aucun utilisateur approprié n'a été trouvé pour se connecter à cette entité juridique"
         )
 
     def test_connect_as_offerer_user_has_multiple_offerer(self, authenticated_client, legit_user):

--- a/api/tests/routes/backoffice/pro_users_test.py
+++ b/api/tests/routes/backoffice/pro_users_test.py
@@ -397,15 +397,15 @@ class GetProUserOfferersTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data, parent_class="user_offerers-tab-pane")
         assert len(rows) == 2
 
-        assert rows[0]["ID de la structure"] == str(offerer_1.id)
+        assert rows[0]["ID de l'entité"] == str(offerer_1.id)
         assert rows[0]["Statut du rattachement"] == "Validé"
-        assert rows[0]["Statut structure"] == "Validée"
+        assert rows[0]["Statut entité"] == "Validée"
         assert rows[0]["Nom"] == offerer_1.name
         assert rows[0]["SIREN"] == offerer_1.siren
 
-        assert rows[1]["ID de la structure"] == str(offerer_2.id)
+        assert rows[1]["ID de l'entité"] == str(offerer_2.id)
         assert rows[1]["Statut du rattachement"] == "Nouveau"
-        assert rows[1]["Statut structure"] == "Validée"
+        assert rows[1]["Statut entité"] == "Validée"
         assert rows[1]["Nom"] == offerer_2.name
         assert rows[1]["SIREN"] == offerer_2.siren
 
@@ -421,9 +421,9 @@ class GetProUserOfferersTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data, parent_class="user_offerers-tab-pane")
         assert len(rows) == 1
 
-        assert rows[0]["ID de la structure"] == str(nc_offerer.id)
+        assert rows[0]["ID de l'entité"] == str(nc_offerer.id)
         assert rows[0]["Statut du rattachement"] == "Validé"
-        assert rows[0]["Statut structure"] == "Validée"
+        assert rows[0]["Statut entité"] == "Validée"
         assert rows[0]["Nom"] == nc_offerer.name
         assert rows[0]["SIREN / RID7"] == nc_offerer.rid7
 
@@ -448,8 +448,8 @@ class GetProUserOfferersTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data, parent_class="user_offerers-tab-pane")
         assert len(rows) == 2
 
-        assert rows[0]["Statut structure"] == "Validée"
-        assert rows[1]["Statut structure"] == "En attente"
+        assert rows[0]["Statut entité"] == "Validée"
+        assert rows[1]["Statut entité"] == "En attente"
 
 
 class ValidateProEmailTest(PostEndpointHelper):
@@ -574,7 +574,7 @@ class DeleteProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         assert response.location == url_for("backoffice_web.pro_user.get", user_id=user.id, _external=True)
         redirected_response = authenticated_client.get(response.location)
-        assert html_parser.extract_alert(redirected_response.data) == "Le compte est rattaché à une structure"
+        assert html_parser.extract_alert(redirected_response.data) == "Le compte est rattaché à une entité"
 
         mails_api.delete_contact.assert_not_called()
         DeleteBatchUserAttributesRequest.assert_not_called()

--- a/api/tests/routes/backoffice/pro_users_test.py
+++ b/api/tests/routes/backoffice/pro_users_test.py
@@ -397,15 +397,15 @@ class GetProUserOfferersTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data, parent_class="user_offerers-tab-pane")
         assert len(rows) == 2
 
-        assert rows[0]["ID de l'entité"] == str(offerer_1.id)
+        assert rows[0]["ID de l'entité juridique"] == str(offerer_1.id)
         assert rows[0]["Statut du rattachement"] == "Validé"
-        assert rows[0]["Statut entité"] == "Validée"
+        assert rows[0]["Statut entité juridique"] == "Validée"
         assert rows[0]["Nom"] == offerer_1.name
         assert rows[0]["SIREN"] == offerer_1.siren
 
-        assert rows[1]["ID de l'entité"] == str(offerer_2.id)
+        assert rows[1]["ID de l'entité juridique"] == str(offerer_2.id)
         assert rows[1]["Statut du rattachement"] == "Nouveau"
-        assert rows[1]["Statut entité"] == "Validée"
+        assert rows[1]["Statut entité juridique"] == "Validée"
         assert rows[1]["Nom"] == offerer_2.name
         assert rows[1]["SIREN"] == offerer_2.siren
 
@@ -421,9 +421,9 @@ class GetProUserOfferersTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data, parent_class="user_offerers-tab-pane")
         assert len(rows) == 1
 
-        assert rows[0]["ID de l'entité"] == str(nc_offerer.id)
+        assert rows[0]["ID de l'entité juridique"] == str(nc_offerer.id)
         assert rows[0]["Statut du rattachement"] == "Validé"
-        assert rows[0]["Statut entité"] == "Validée"
+        assert rows[0]["Statut entité juridique"] == "Validée"
         assert rows[0]["Nom"] == nc_offerer.name
         assert rows[0]["SIREN / RID7"] == nc_offerer.rid7
 
@@ -448,8 +448,8 @@ class GetProUserOfferersTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data, parent_class="user_offerers-tab-pane")
         assert len(rows) == 2
 
-        assert rows[0]["Statut entité"] == "Validée"
-        assert rows[1]["Statut entité"] == "En attente"
+        assert rows[0]["Statut entité juridique"] == "Validée"
+        assert rows[1]["Statut entité juridique"] == "En attente"
 
 
 class ValidateProEmailTest(PostEndpointHelper):
@@ -574,7 +574,7 @@ class DeleteProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         assert response.location == url_for("backoffice_web.pro_user.get", user_id=user.id, _external=True)
         redirected_response = authenticated_client.get(response.location)
-        assert html_parser.extract_alert(redirected_response.data) == "Le compte est rattaché à une entité"
+        assert html_parser.extract_alert(redirected_response.data) == "Le compte est rattaché à une entité juridique"
 
         mails_api.delete_contact.assert_not_called()
         DeleteBatchUserAttributesRequest.assert_not_called()

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -126,7 +126,7 @@ class ListVenuesTest(GetEndpointHelper):
         assert int(rows[0]["ID"]) == venues[0].id
         assert rows[0]["Nom"] == venues[0].name
         assert rows[0]["Nom d'usage"] == venues[0].publicName
-        assert rows[0]["Entité"] == venues[0].managingOfferer.name
+        assert rows[0]["Entité juridique"] == venues[0].managingOfferer.name
         assert rows[0]["Permanent"] == "Lieu permanent"
         assert rows[0]["Label"] == venues[0].venueLabel.label
         assert sorted(rows[0]["Tags"].split()) == sorted("Criterion_cinema Criterion_art".split())
@@ -174,7 +174,7 @@ class ListVenuesTest(GetEndpointHelper):
         assert len(rows) == len(matching_venues)
         assert {int(row["ID"]) for row in rows} == {venue.id for venue in matching_venues}
         for row in rows:
-            assert row["Entité"] == offerer.name
+            assert row["Entité juridique"] == offerer.name
 
     def test_list_venues_by_regions(self, authenticated_client, venues):
         venue = offerers_factories.VenueFactory(postalCode="82000")
@@ -269,7 +269,7 @@ class ListVenuesTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data)
         assert len(rows) == 1
         assert rows[0]["ID"] == str(venue.id)
-        assert rows[0]["Entité"] == offerer.name
+        assert rows[0]["Entité juridique"] == offerer.name
 
 
 class GetVenueTest(GetEndpointHelper):
@@ -340,7 +340,7 @@ class GetVenueTest(GetEndpointHelper):
         assert f"Activité principale : {venue.venueTypeCode.value}" in response_text
         assert f"Label : {venue.venueLabel.label} " in response_text
         assert "Type de lieu" not in response_text
-        assert f"Entité : {venue.managingOfferer.name}" in response_text
+        assert f"Entité juridique : {venue.managingOfferer.name}" in response_text
         assert "Site web : https://www.example.com" in response_text
         assert "Validation des offres : Suivre les règles" in response_text
 
@@ -477,8 +477,8 @@ class GetVenueTest(GetEndpointHelper):
     @pytest.mark.parametrize(
         "factory, expected_text",
         [
-            (offerers_factories.WhitelistedOffererConfidenceRuleFactory, "Validation auto (entité)"),
-            (offerers_factories.ManualReviewOffererConfidenceRuleFactory, "Revue manuelle (entité)"),
+            (offerers_factories.WhitelistedOffererConfidenceRuleFactory, "Validation auto (entité juridique)"),
+            (offerers_factories.ManualReviewOffererConfidenceRuleFactory, "Revue manuelle (entité juridique)"),
         ],
     )
     def test_get_venue_with_offerer_confidence_rule(self, authenticated_client, factory, expected_text):
@@ -2866,7 +2866,7 @@ class GetRemoveSiretFormTest(GetEndpointHelper):
         html_parser.assert_no_alert(response.data)
 
         content = html_parser.content_as_text(response.data)
-        assert f"Entité : {offerer.name}" in content
+        assert f"Entité juridique : {offerer.name}" in content
         assert f"Offerer ID : {offerer.id}" in content
         assert f"Lieu : {venue.name}" in content
         assert f"Venue ID : {venue.id}" in content
@@ -2893,7 +2893,10 @@ class GetRemoveSiretFormTest(GetEndpointHelper):
         response = authenticated_client.get(url_for(self.endpoint, venue_id=venue.id))
 
         assert response.status_code == 400
-        assert html_parser.extract_alert(response.data) == "L'entité gérant ce lieu n'a pas d'autre lieu avec SIRET"
+        assert (
+            html_parser.extract_alert(response.data)
+            == "L'entité juridique gérant ce lieu n'a pas d'autre lieu avec SIRET"
+        )
 
     def test_venue_with_high_yearly_revenue(self, authenticated_client):
         venue = offerers_factories.VenueFactory()

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -126,7 +126,7 @@ class ListVenuesTest(GetEndpointHelper):
         assert int(rows[0]["ID"]) == venues[0].id
         assert rows[0]["Nom"] == venues[0].name
         assert rows[0]["Nom d'usage"] == venues[0].publicName
-        assert rows[0]["Structure"] == venues[0].managingOfferer.name
+        assert rows[0]["Entité"] == venues[0].managingOfferer.name
         assert rows[0]["Permanent"] == "Lieu permanent"
         assert rows[0]["Label"] == venues[0].venueLabel.label
         assert sorted(rows[0]["Tags"].split()) == sorted("Criterion_cinema Criterion_art".split())
@@ -174,7 +174,7 @@ class ListVenuesTest(GetEndpointHelper):
         assert len(rows) == len(matching_venues)
         assert {int(row["ID"]) for row in rows} == {venue.id for venue in matching_venues}
         for row in rows:
-            assert row["Structure"] == offerer.name
+            assert row["Entité"] == offerer.name
 
     def test_list_venues_by_regions(self, authenticated_client, venues):
         venue = offerers_factories.VenueFactory(postalCode="82000")
@@ -269,7 +269,7 @@ class ListVenuesTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data)
         assert len(rows) == 1
         assert rows[0]["ID"] == str(venue.id)
-        assert rows[0]["Structure"] == offerer.name
+        assert rows[0]["Entité"] == offerer.name
 
 
 class GetVenueTest(GetEndpointHelper):
@@ -340,7 +340,7 @@ class GetVenueTest(GetEndpointHelper):
         assert f"Activité principale : {venue.venueTypeCode.value}" in response_text
         assert f"Label : {venue.venueLabel.label} " in response_text
         assert "Type de lieu" not in response_text
-        assert f"Structure : {venue.managingOfferer.name}" in response_text
+        assert f"Entité : {venue.managingOfferer.name}" in response_text
         assert "Site web : https://www.example.com" in response_text
         assert "Validation des offres : Suivre les règles" in response_text
 
@@ -477,8 +477,8 @@ class GetVenueTest(GetEndpointHelper):
     @pytest.mark.parametrize(
         "factory, expected_text",
         [
-            (offerers_factories.WhitelistedOffererConfidenceRuleFactory, "Validation auto (structure)"),
-            (offerers_factories.ManualReviewOffererConfidenceRuleFactory, "Revue manuelle (structure)"),
+            (offerers_factories.WhitelistedOffererConfidenceRuleFactory, "Validation auto (entité)"),
+            (offerers_factories.ManualReviewOffererConfidenceRuleFactory, "Revue manuelle (entité)"),
         ],
     )
     def test_get_venue_with_offerer_confidence_rule(self, authenticated_client, factory, expected_text):
@@ -2866,7 +2866,7 @@ class GetRemoveSiretFormTest(GetEndpointHelper):
         html_parser.assert_no_alert(response.data)
 
         content = html_parser.content_as_text(response.data)
-        assert f"Structure : {offerer.name}" in content
+        assert f"Entité : {offerer.name}" in content
         assert f"Offerer ID : {offerer.id}" in content
         assert f"Lieu : {venue.name}" in content
         assert f"Venue ID : {venue.id}" in content

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -2893,7 +2893,7 @@ class GetRemoveSiretFormTest(GetEndpointHelper):
         response = authenticated_client.get(url_for(self.endpoint, venue_id=venue.id))
 
         assert response.status_code == 400
-        assert html_parser.extract_alert(response.data) == "La structure gérant ce lieu n'a pas d'autre lieu avec SIRET"
+        assert html_parser.extract_alert(response.data) == "L'entité gérant ce lieu n'a pas d'autre lieu avec SIRET"
 
     def test_venue_with_high_yearly_revenue(self, authenticated_client):
         venue = offerers_factories.VenueFactory()

--- a/api/tests/routes/backoffice/zendesk_sell_test.py
+++ b/api/tests/routes/backoffice/zendesk_sell_test.py
@@ -52,7 +52,7 @@ class UpdateOffererOnZendeskSellTest(PostEndpointHelper):
         assert response.location == url_for("backoffice_web.offerer.get", offerer_id=offerer.id, _external=True)
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "Cette structure ne gère que des lieux virtuels"
+            == "Cette entité ne gère que des lieux virtuels"
         )
 
         assert not testing.zendesk_sell_requests
@@ -86,7 +86,7 @@ class UpdateOffererOnZendeskSellTest(PostEndpointHelper):
         assert response.location == url_for("backoffice_web.offerer.get", offerer_id=offerer.id, _external=True)
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "Plusieurs structures ont été trouvées dans Zendesk Sell, aucune ne peut donc être mise à jour : "
+            == "Plusieurs entités ont été trouvées dans Zendesk Sell, aucune ne peut donc être mise à jour : "
             f"Identifiant Zendesk Sell : 123, Produit Offerer ID : {offerer.id}, SIREN : {offerer.siren} "
             f"Identifiant Zendesk Sell : 456, Produit Offerer ID : {offerer.id}, SIREN :"
         )
@@ -105,7 +105,7 @@ class UpdateOffererOnZendeskSellTest(PostEndpointHelper):
         assert response.location == url_for("backoffice_web.offerer.get", offerer_id=offerer.id, _external=True)
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "La structure n'a pas été trouvée dans Zendesk Sell"
+            == "L'entité n'a pas été trouvée dans Zendesk Sell"
         )
 
         assert not testing.zendesk_sell_requests
@@ -183,7 +183,7 @@ class UpdateVenueOnZendeskSellTest(PostEndpointHelper):
         assert response.status_code == 303
         assert response.location == url_for("backoffice_web.venue.get", venue_id=venue.id, _external=True)
         assert html_parser.extract_alerts(authenticated_client.get(response.location).data) == [
-            "Attention : Plusieurs structures parentes possibles ont été trouvées pour ce lieu dans Zendesk Sell. "
+            "Attention : Plusieurs entités parentes possibles ont été trouvées pour ce lieu dans Zendesk Sell. "
             f"Identifiant Zendesk Sell : 123, Produit Offerer ID : {venue.managingOffererId}, SIREN : {venue.managingOfferer.siren} "
             f"Identifiant Zendesk Sell : 456, Produit Offerer ID : {venue.managingOffererId}, SIREN :",
             "Le lieu a été mis à jour sur Zendesk Sell",
@@ -212,7 +212,7 @@ class UpdateVenueOnZendeskSellTest(PostEndpointHelper):
         assert response.status_code == 303
         assert response.location == url_for("backoffice_web.venue.get", venue_id=venue.id, _external=True)
         assert html_parser.extract_alerts(authenticated_client.get(response.location).data) == [
-            "Une erreur 500 s'est produite lors de la recherche de la structure parente : test",
+            "Une erreur 500 s'est produite lors de la recherche de l'entité parente : test",
             "Le lieu a été mis à jour sur Zendesk Sell",
         ]
         assert testing.zendesk_sell_requests == [

--- a/api/tests/routes/backoffice/zendesk_sell_test.py
+++ b/api/tests/routes/backoffice/zendesk_sell_test.py
@@ -52,7 +52,7 @@ class UpdateOffererOnZendeskSellTest(PostEndpointHelper):
         assert response.location == url_for("backoffice_web.offerer.get", offerer_id=offerer.id, _external=True)
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "Cette entité ne gère que des lieux virtuels"
+            == "Cette entité juridique ne gère que des lieux virtuels"
         )
 
         assert not testing.zendesk_sell_requests
@@ -86,7 +86,7 @@ class UpdateOffererOnZendeskSellTest(PostEndpointHelper):
         assert response.location == url_for("backoffice_web.offerer.get", offerer_id=offerer.id, _external=True)
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "Plusieurs entités ont été trouvées dans Zendesk Sell, aucune ne peut donc être mise à jour : "
+            == "Plusieurs entités juridiques ont été trouvées dans Zendesk Sell, aucune ne peut donc être mise à jour : "
             f"Identifiant Zendesk Sell : 123, Produit Offerer ID : {offerer.id}, SIREN : {offerer.siren} "
             f"Identifiant Zendesk Sell : 456, Produit Offerer ID : {offerer.id}, SIREN :"
         )
@@ -105,7 +105,7 @@ class UpdateOffererOnZendeskSellTest(PostEndpointHelper):
         assert response.location == url_for("backoffice_web.offerer.get", offerer_id=offerer.id, _external=True)
         assert (
             html_parser.extract_alert(authenticated_client.get(response.location).data)
-            == "L'entité n'a pas été trouvée dans Zendesk Sell"
+            == "L'entité juridique n'a pas été trouvée dans Zendesk Sell"
         )
 
         assert not testing.zendesk_sell_requests
@@ -183,7 +183,7 @@ class UpdateVenueOnZendeskSellTest(PostEndpointHelper):
         assert response.status_code == 303
         assert response.location == url_for("backoffice_web.venue.get", venue_id=venue.id, _external=True)
         assert html_parser.extract_alerts(authenticated_client.get(response.location).data) == [
-            "Attention : Plusieurs entités parentes possibles ont été trouvées pour ce lieu dans Zendesk Sell. "
+            "Attention : Plusieurs entités juridiques parentes possibles ont été trouvées pour ce lieu dans Zendesk Sell. "
             f"Identifiant Zendesk Sell : 123, Produit Offerer ID : {venue.managingOffererId}, SIREN : {venue.managingOfferer.siren} "
             f"Identifiant Zendesk Sell : 456, Produit Offerer ID : {venue.managingOffererId}, SIREN :",
             "Le lieu a été mis à jour sur Zendesk Sell",
@@ -212,7 +212,7 @@ class UpdateVenueOnZendeskSellTest(PostEndpointHelper):
         assert response.status_code == 303
         assert response.location == url_for("backoffice_web.venue.get", venue_id=venue.id, _external=True)
         assert html_parser.extract_alerts(authenticated_client.get(response.location).data) == [
-            "Une erreur 500 s'est produite lors de la recherche de l'entité parente : test",
+            "Une erreur 500 s'est produite lors de la recherche de l'entité juridique parente : test",
             "Le lieu a été mis à jour sur Zendesk Sell",
         ]
         assert testing.zendesk_sell_requests == [


### PR DESCRIPTION
## But de la pull request

Appeler les Offerers "entité juridique" à la place de "structure" dans le BO (sans feature flag)
Tâches non incluses dans cette PR : 
- Modifier les tags sur les Offerers en base de données qui comportent le mot "structure"
- Redresser les données d'historique des actions sur les Offerers qui comportent le mot "structure"

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32908

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
