### PR TITLE
(PC-32977)[API] fix: use offer's address geoloc for Algolia's seriali…

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -589,7 +589,7 @@ class AlgoliaBackend(base.SearchBackend):
                 "publicName": venue.publicName,
                 "venue_type": venue.venueTypeCode.name,
             },
-            "_geoloc": position(venue),
+            "_geoloc": position(venue, offer),
         }
 
         if offer.subcategory.category.id == categories.LIVRE.id and gtl:
@@ -785,11 +785,14 @@ class AlgoliaBackend(base.SearchBackend):
         return ids
 
 
-def position(venue: offerers_models.Venue) -> dict[str, float]:
+def position(venue: offerers_models.Venue, offer: offers_models.Offer | None = None) -> dict[str, float]:
     latitude = None
     longitude = None
     if FeatureToggle.WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE.is_active():
-        if venue.offererAddress is not None:
+        if offer and offer.offererAddress:
+            latitude = offer.offererAddress.address.latitude
+            longitude = offer.offererAddress.address.longitude
+        elif venue.offererAddress is not None:
             latitude = venue.offererAddress.address.latitude
             longitude = venue.offererAddress.address.longitude
     else:

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -39,9 +39,19 @@ def test_serialize_offer():
     ).one()
     macro_section = book_macro_section.macroSection.strip()
 
-    offerer_address = offerers_factories.OffererAddressFactory(
+    venue_offerer_address = offerers_factories.OffererAddressFactory(
+        address__departmentCode="75",
+        address__postalCode="75001",
+        address__latitude=geography_factories.DEFAULT_LATITUDE,
+        address__longitude=geography_factories.DEFAULT_TRUNCATED_LONGITUDE,
+    )
+
+    offer_offerer_address = offerers_factories.OffererAddressFactory(
         address__departmentCode="86",
         address__postalCode="86140",
+        address__city="Cernay",
+        address__latitude=-5.01,
+        address__longitude=-6.02,
     )
 
     offer = offers_factories.OfferFactory(
@@ -58,8 +68,9 @@ def test_serialize_offer():
         },
         rankingWeight=2,
         subcategoryId=subcategories.LIVRE_PAPIER.id,
+        offererAddress=offer_offerer_address,
         venue__id=127,
-        venue__offererAddress=offerer_address,
+        venue__offererAddress=venue_offerer_address,
         venue__name="La Moyenne Librairie SA",
         venue__publicName="La Moyenne Librairie",
         venue__venueTypeCode=VenueTypeCode.LIBRARY,
@@ -104,10 +115,10 @@ def test_serialize_offer():
         },
         "venue": {
             "banner_url": offer.venue.bannerUrl,
-            "address": offer.venue.offererAddress.address.street,
-            "city": offer.venue.offererAddress.address.city,
+            "address": offer.offererAddress.address.street,
+            "city": offer.offererAddress.address.city,
             "departmentCode": "86",
-            "postalCode": offer.venue.offererAddress.address.postalCode,
+            "postalCode": offer.offererAddress.address.postalCode,
             "id": offer.venueId,
             "isAudioDisabilityCompliant": False,
             "isMentalDisabilityCompliant": False,
@@ -119,8 +130,8 @@ def test_serialize_offer():
             "isPermanent": True,
         },
         "_geoloc": {
-            "lat": geography_factories.DEFAULT_LATITUDE,
-            "lng": geography_factories.DEFAULT_TRUNCATED_LONGITUDE,
+            "lat": -5.01,
+            "lng": -6.02,
         },
     }
 


### PR DESCRIPTION
…zation

In order to correctly geolocalize an offer in the native application, the offer should be serialized using the offer's offerer address position instead of the venue address position.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
