### PR TITLE
(PC-32974)[API] fix: broken date filters on offer's page

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -324,15 +324,10 @@ def get_offers_by_filters(
         )
         target_timezone: sa.orm.Mapped[typing.Any] | sa.sql.functions.Function = offerers_models.Venue.timezone
         if FeatureToggle.WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE.is_active():
-            stock_query = (
-                stock_query.join(offers_model.Offer)
-                .outerjoin(
-                    offerers_models.OffererAddress,
-                    offer_alias.offererAddressId == offerers_models.OffererAddress.id,
-                    isouter=True,
-                )
-                .join(geography_models.Address, offerers_models.OffererAddress.addressId == geography_models.Address.id)
-            )
+            stock_query = stock_query.outerjoin(
+                offerers_models.OffererAddress,
+                offer_alias.offererAddressId == offerers_models.OffererAddress.id,
+            ).join(geography_models.Address, offerers_models.OffererAddress.addressId == geography_models.Address.id)
             target_timezone = sa.func.coalesce(geography_models.Address.timezone, offerers_models.Venue.timezone)
         if period_beginning_date is not None:
             stock_query = stock_query.filter(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32974

The join on Offer broke things since it missed the filters on it because there was already an alias used on offer.
It looks like the second join got all the stocks all the time, making the filters on date useless.

The test did not detect it because it was only making sure the offers were OK within the time range but was not checking if the offers were correctly ignored when outside the time range.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
