### PR TITLE
(PC-31341)[PRO] feat: Show cancelled filter and status when ff is act…

### DIFF
--- a/pro/src/commons/utils/translate.ts
+++ b/pro/src/commons/utils/translate.ts
@@ -52,6 +52,7 @@ const mapBrowserCollectiveStatusToApi: Record<
   archivee: CollectiveOfferDisplayedStatus.ARCHIVED,
   brouillon: CollectiveOfferDisplayedStatus.DRAFT,
   remboursee: CollectiveOfferDisplayedStatus.REIMBURSED,
+  annulee: CollectiveOfferDisplayedStatus.CANCELLED,
 }
 
 const mapBrowserToApi = (audience: Audience) => ({

--- a/pro/src/components/CollectiveStatusLabel/CollectiveStatusLabel.spec.tsx
+++ b/pro/src/components/CollectiveStatusLabel/CollectiveStatusLabel.spec.tsx
@@ -9,7 +9,6 @@ import { renderWithProviders } from 'commons/utils/renderWithProviders'
 import { CollectiveStatusLabel } from './CollectiveStatusLabel'
 
 interface TestCaseProps {
-  status?: CollectiveOfferStatus
   displayedStatus: CollectiveOfferDisplayedStatus
   expectedLabel: string
 }
@@ -45,15 +44,6 @@ describe('CollectiveStatusLabel', () => {
       expectedLabel: 'expirée',
     },
     {
-      displayedStatus: CollectiveOfferDisplayedStatus.CANCELLED,
-      expectedLabel: 'masquée',
-    },
-    {
-      displayedStatus: CollectiveOfferDisplayedStatus.CANCELLED,
-      status: CollectiveOfferStatus.ACTIVE,
-      expectedLabel: 'publiée',
-    },
-    {
       displayedStatus: CollectiveOfferDisplayedStatus.ARCHIVED,
       expectedLabel: 'archivée',
     },
@@ -73,12 +63,10 @@ describe('CollectiveStatusLabel', () => {
 
   it.each(testCases)(
     'should render %s status',
-    ({ displayedStatus, status, expectedLabel }: TestCaseProps) => {
-      const unrelevantStatus = CollectiveOfferStatus.PENDING
+    ({ displayedStatus, expectedLabel }: TestCaseProps) => {
       renderWithProviders(
         <CollectiveStatusLabel
           offerDisplayedStatus={displayedStatus}
-          offerStatus={status ?? unrelevantStatus}
         />
       )
       expect(screen.getByText(expectedLabel)).toBeInTheDocument()
@@ -86,11 +74,9 @@ describe('CollectiveStatusLabel', () => {
   )
 
   it('should render "remboursée" status when ff is active', () => {
-    const unrelevantStatus = CollectiveOfferStatus.PENDING
     renderWithProviders(
       <CollectiveStatusLabel
         offerDisplayedStatus={CollectiveOfferDisplayedStatus.REIMBURSED}
-        offerStatus={unrelevantStatus}
       />,
       {
         features: ['ENABLE_COLLECTIVE_NEW_STATUSES'],
@@ -100,11 +86,9 @@ describe('CollectiveStatusLabel', () => {
   })
 
   it('should render "non conforme" status when ff is active for REJECTED displayed status', () => {
-    const unrelevantStatus = CollectiveOfferStatus.PENDING
     renderWithProviders(
       <CollectiveStatusLabel
         offerDisplayedStatus={CollectiveOfferDisplayedStatus.REJECTED}
-        offerStatus={unrelevantStatus}
       />,
       {
         features: ['ENABLE_COLLECTIVE_NEW_STATUSES'],
@@ -114,11 +98,9 @@ describe('CollectiveStatusLabel', () => {
   })
 
   it('should render "en pause" status when ff is active for INACTIVE displayed status', () => {
-    const unrelevantStatus = CollectiveOfferStatus.PENDING
     renderWithProviders(
       <CollectiveStatusLabel
         offerDisplayedStatus={CollectiveOfferDisplayedStatus.INACTIVE}
-        offerStatus={unrelevantStatus}
       />,
       {
         features: ['ENABLE_COLLECTIVE_NEW_STATUSES'],
@@ -128,16 +110,26 @@ describe('CollectiveStatusLabel', () => {
   })
 
   it('should render "en instruction" status when ff is active for PENDING displayed status', () => {
-    const unrelevantStatus = CollectiveOfferStatus.PENDING
     renderWithProviders(
       <CollectiveStatusLabel
         offerDisplayedStatus={CollectiveOfferDisplayedStatus.PENDING}
-        offerStatus={unrelevantStatus}
       />,
       {
         features: ['ENABLE_COLLECTIVE_NEW_STATUSES'],
       }
     )
     expect(screen.getByText('en instruction')).toBeInTheDocument()
+  })
+
+  it('should render "annulée" status when the ENABLE_COLLECTIVE_NEW_STATUSES FF is active for a CANCELLED displayed status', () => {
+    renderWithProviders(
+      <CollectiveStatusLabel
+        offerDisplayedStatus={CollectiveOfferDisplayedStatus.CANCELLED}
+      />,
+      {
+        features: ['ENABLE_COLLECTIVE_NEW_STATUSES'],
+      }
+    )
+    expect(screen.getByText('annulée')).toBeInTheDocument()
   })
 })

--- a/pro/src/components/CollectiveStatusLabel/CollectiveStatusLabel.tsx
+++ b/pro/src/components/CollectiveStatusLabel/CollectiveStatusLabel.tsx
@@ -15,17 +15,16 @@ import strokeDoubleCheckIcon from 'icons/stroke-double-check.svg'
 import strokeEuroIcon from 'icons/stroke-euro.svg'
 import strokeHourglassIcon from 'icons/stroke-hourglass.svg'
 import strokeThing from 'icons/stroke-thing.svg'
+import strokeWrongIcon from 'icons/stroke-wrong.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import style from './CollectiveStatusLabel.module.scss'
 
 type CollectiveStatusLabelProps = {
-  offerStatus: CollectiveOfferStatus
   offerDisplayedStatus: CollectiveOfferDisplayedStatus
 }
 
 export const CollectiveStatusLabel = ({
-  offerStatus,
   offerDisplayedStatus,
 }: CollectiveStatusLabelProps) => {
   const areNewStatusesEnabled = useActiveFeature(
@@ -167,31 +166,17 @@ export const CollectiveStatusLabel = ({
         />
       )
     case CollectiveOfferDisplayedStatus.CANCELLED:
-      return offerStatus === CollectiveOfferStatus.ACTIVE ? (
-        <StatusLabel
-          className={style['status-active']}
-          icon={
-            <SvgIcon
-              src={strokeCheckIcon}
-              alt=""
-              className={style['status-label-icon']}
-            />
-          }
-          label="publiée"
+      return <StatusLabel
+      className={style['status-cancelled']}
+      icon={
+        <SvgIcon
+          src={strokeWrongIcon}
+          alt=""
+          className={style['status-label-icon']}
         />
-      ) : (
-        <StatusLabel
-          className={style['status-inactive']}
-          icon={
-            <SvgIcon
-              alt=""
-              src={fullHideIcon}
-              className={style['status-label-icon']}
-            />
-          }
-          label={areNewStatusesEnabled ? 'en pause' : 'masquée'}
-        />
-      )
+      }
+      label="annulée"
+    />
     case CollectiveOfferDisplayedStatus.ARCHIVED:
       return (
         <StatusLabel

--- a/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
+++ b/pro/src/components/OfferEducationalActions/OfferEducationalActions.tsx
@@ -234,7 +234,6 @@ export const OfferEducationalActions = ({
             </>
           )}
           <CollectiveStatusLabel
-            offerStatus={offer.status}
             offerDisplayedStatus={offer.displayedStatus}
           />
         </div>

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -93,7 +93,7 @@ describe('route CollectiveOffers', () => {
 
         await userEvent.click(
           screen.getByText('Statut', {
-            selector: 'span',
+            selector: 'label',
           })
         )
         const list = screen.getByTestId('list')
@@ -130,7 +130,7 @@ describe('route CollectiveOffers', () => {
 
         await userEvent.click(
           screen.getByText('Statut', {
-            selector: 'span',
+            selector: 'label',
           })
         )
         const list = screen.getByTestId('list')
@@ -171,7 +171,7 @@ describe('route CollectiveOffers', () => {
 
         await userEvent.click(
           screen.getByText('Statut', {
-            selector: 'span',
+            selector: 'label',
           })
         )
         const list = screen.getByTestId('list')

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffersQueryParams.spec.tsx
@@ -197,7 +197,7 @@ describe('route CollectiveOffers', () => {
 
       await userEvent.click(
         screen.getByText('Statut', {
-          selector: 'span',
+          selector: 'label',
         })
       )
       const list = screen.getByTestId('list')
@@ -219,7 +219,7 @@ describe('route CollectiveOffers', () => {
 
       await userEvent.click(
         screen.getByText('Statut', {
-          selector: 'span',
+          selector: 'label',
         })
       )
       const list = screen.getByTestId('list')

--- a/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/CollectiveOffersSearchFilters/CollectiveOffersSearchFilters.module.scss
+++ b/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/CollectiveOffersSearchFilters/CollectiveOffersSearchFilters.module.scss
@@ -38,16 +38,6 @@ $status-filter-margin-top: rem.torem(24px);
   margin-bottom: 0;
 }
 
-.status-filter-label {
-  display: flex;
-  align-items: center;
-  gap: rem.torem(8px);
-
-  .status-filter-tag {
-    line-height: 1rem;
-  }
-}
-
 .reset-filters-row {
   flex-direction: column;
 }

--- a/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/CollectiveOffersSearchFilters/CollectiveOffersSearchFilters.tsx
+++ b/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/CollectiveOffersSearchFilters/CollectiveOffersSearchFilters.tsx
@@ -207,6 +207,10 @@ export const CollectiveOffersSearchFilters = ({
             label: 'Remboursée',
             value: CollectiveOfferDisplayedStatus.REIMBURSED,
           },
+          {
+            label: 'Annulée',
+            value: CollectiveOfferDisplayedStatus.CANCELLED,
+          },
         ]
       : []),
   ]
@@ -291,9 +295,7 @@ export const CollectiveOffersSearchFilters = ({
             <SelectAutocomplete
               multi
               name="status"
-              label={
-                <span className={styles['status-filter-label']}>Statut</span>
-              }
+              label="Statut"
               options={statusFilterOptions}
               placeholder="Statuts"
               isOptional

--- a/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/__specs__/CollectiveOffersScreen.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/__specs__/CollectiveOffersScreen.spec.tsx
@@ -546,4 +546,41 @@ describe('CollectiveOffersScreen', () => {
       screen.getByRole('columnheader', { name: 'Structure' })
     ).toBeInTheDocument()
   })
+
+  it('should show the cancelled status option if the ENABLE_COLLECTIVE_NEW_STATUSES FF is active', async () => {
+    renderOffers(
+      {
+        ...props,
+      },
+      { features: ['ENABLE_COLLECTIVE_NEW_STATUSES'] }
+    )
+
+    await userEvent.click(
+      screen.getByRole('combobox', {
+        name: 'Statut',
+      })
+    )
+
+    expect(
+      screen.getByRole('option', { name: 'Annulée' })
+    ).toBeInTheDocument()
+  })
+
+  it('should not show the cancelled status option if the ENABLE_COLLECTIVE_NEW_STATUSES FF is inactive', async () => {
+    renderOffers(
+      {
+        ...props,
+      }
+    )
+
+    await userEvent.click(
+      screen.getByRole('combobox', {
+        name: 'Statut',
+      })
+    )
+
+    expect(
+      screen.queryByRole('option', { name: 'Annulée' })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveOfferStatusCell/CollectiveOfferStatusCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveOfferStatusCell/CollectiveOfferStatusCell.tsx
@@ -19,7 +19,6 @@ export const CollectiveOfferStatusCell = ({
     headers={headers}
   >
     <CollectiveStatusLabel
-      offerStatus={offer.status}
       offerDisplayedStatus={offer.displayedStatus}
     />
   </td>

--- a/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffersScreen/TemplateOffersSearchFilters/TemplateOffersSearchFilters.module.scss
+++ b/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffersScreen/TemplateOffersSearchFilters/TemplateOffersSearchFilters.module.scss
@@ -66,13 +66,6 @@ $status-filter-margin-top: rem.torem(24px);
   margin-bottom: 0;
 }
 
-.status-filter-label {
-  margin-top: $status-filter-margin-top;
-  display: flex;
-  align-items: center;
-  gap: rem.torem(8px);
-}
-
 .reset-filters-row {
   flex-direction: column;
 }

--- a/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffersScreen/TemplateOffersSearchFilters/TemplateOffersSearchFilters.tsx
+++ b/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffersScreen/TemplateOffersSearchFilters/TemplateOffersSearchFilters.tsx
@@ -209,9 +209,7 @@ export const TemplateOffersSearchFilters = ({
           <SelectAutocomplete
             multi
             name="status"
-            label={
-              <span className={styles['status-filter-label']}>Statut</span>
-            }
+            label="Statut"
             options={collectiveFilterStatus}
             placeholder="Statuts"
             isOptional

--- a/pro/src/pages/TemplateCollectiveOffers/__specs__/TemplateCollectiveOffers.spec.tsx
+++ b/pro/src/pages/TemplateCollectiveOffers/__specs__/TemplateCollectiveOffers.spec.tsx
@@ -106,7 +106,7 @@ describe('route TemplateCollectiveOffers', () => {
 
         await userEvent.click(
           screen.getByText('Statut', {
-            selector: 'span',
+            selector: 'label',
           })
         )
         const list = screen.getByTestId('list')
@@ -139,7 +139,7 @@ describe('route TemplateCollectiveOffers', () => {
 
         await userEvent.click(
           screen.getByText('Statut', {
-            selector: 'span',
+            selector: 'label',
           })
         )
         const list = screen.getByTestId('list')
@@ -177,7 +177,7 @@ describe('route TemplateCollectiveOffers', () => {
 
         await userEvent.click(
           screen.getByText('Statut', {
-            selector: 'span',
+            selector: 'label',
           })
         )
         const list = screen.getByTestId('list')

--- a/pro/src/pages/TemplateCollectiveOffers/__specs__/TemplateCollectiveOffersQueryParams.spec.tsx
+++ b/pro/src/pages/TemplateCollectiveOffers/__specs__/TemplateCollectiveOffersQueryParams.spec.tsx
@@ -205,7 +205,7 @@ describe('route TemplateCollectiveOffers', () => {
 
       await userEvent.click(
         screen.getByText('Statut', {
-          selector: 'span',
+          selector: 'label',
         })
       )
       const list = screen.getByTestId('list')
@@ -227,7 +227,7 @@ describe('route TemplateCollectiveOffers', () => {
 
       await userEvent.click(
         screen.getByText('Statut', {
-          selector: 'span',
+          selector: 'label',
         })
       )
       const list = screen.getByTestId('list')


### PR DESCRIPTION
…ive.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31341

**Objectif**
Quand le FF `ENABLE_COLLECTIVE_NEW_STATUSES` est activé, afficher le filtre sur le statut "Annulée" dans le select des filtres collectifs, et afficher le tag "annulée" sur les offres de la liste et dans le header de la page récap des offres.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
