### PR TITLE
(PC-32982)[PRO] fix: align QuantityInput mins with formik validation rules + avoid null/undefined init values

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
@@ -364,6 +364,7 @@ export const RecurrenceForm = ({
                           className={styles['quantity-input']}
                           hideFooter
                           isOptional
+                          min={1}
                         />
                         <Select
                           label="Tarif"

--- a/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
@@ -88,7 +88,7 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
   // validation is tested in getValidationSchema
   // and it's not possible as is to test it here
   /* istanbul ignore next: DEBT, TO FIX */
-  const minQuantity = stocks.length > 0 ? stocks[0].bookingsQuantity : null
+  const minQuantity = stocks.length > 0 ? stocks[0].bookingsQuantity : 0
   const isDisabled = isOfferDisabled(offer.status)
   const useOffererAddressAsDataSourceEnabled = useActiveFeature(
     'WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE'
@@ -395,6 +395,7 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
                 className={styles['field-layout-xsmall']}
                 classNameFooter={styles['field-layout-footer']}
                 isOptional
+                min={minQuantity}
               />
               {mode === OFFER_WIZARD_MODE.EDITION && stocks.length > 0 && (
                 <>

--- a/pro/src/components/IndividualOffer/StocksThing/__specs__/validationSchema.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksThing/__specs__/validationSchema.spec.tsx
@@ -10,26 +10,26 @@ describe('validationSchema', () => {
     description: string
     formValues: Partial<StockThingFormValues>
     expectedErrors: string[]
-    minQuantity: null | number
+    minQuantity: number
   }[] = [
     {
       description: 'valid form',
       formValues: stockThingFormValuesFactory(),
       expectedErrors: [],
-      minQuantity: null,
+      minQuantity: 0,
     },
     {
       description: 'need price',
       formValues: {},
       expectedErrors: ['Veuillez renseigner un prix'],
-      minQuantity: null,
+      minQuantity: 0,
     },
 
     {
       description: 'price above 300',
       formValues: { price: 300.01 },
       expectedErrors: ['Veuillez renseigner un prix inférieur à 300€'],
-      minQuantity: null,
+      minQuantity: 0,
     },
     {
       description: 'bad quantity',

--- a/pro/src/components/IndividualOffer/StocksThing/utils/__specs__/buildInitialValues.spec.ts
+++ b/pro/src/components/IndividualOffer/StocksThing/utils/__specs__/buildInitialValues.spec.ts
@@ -77,7 +77,7 @@ describe('StockThingForm::utils::buildInitialValues', () => {
       stockId: 1,
       remainingQuantity: 'unlimited',
       bookingsQuantity: '20',
-      quantity: null,
+      quantity: '',
       bookingLimitDatetime: '',
       price: 12,
       isDuo: true,

--- a/pro/src/components/IndividualOffer/StocksThing/utils/buildInitialValues.ts
+++ b/pro/src/components/IndividualOffer/StocksThing/utils/buildInitialValues.ts
@@ -24,7 +24,7 @@ export const buildInitialValues = (
     stockId: stocks[0].id,
     remainingQuantity: stocks[0].remainingQuantity?.toString() || 'unlimited',
     bookingsQuantity: stocks[0].bookingsQuantity.toString(),
-    quantity: stocks[0].quantity === undefined ? '' : stocks[0].quantity,
+    quantity: (stocks[0].quantity === undefined || stocks[0].quantity === null) ? '' : stocks[0].quantity,
     bookingLimitDatetime: stocks[0].bookingLimitDatetime
       ? format(
           getLocalDepartementDateTimeFromUtc(

--- a/pro/src/components/IndividualOffer/StocksThing/validationSchema.ts
+++ b/pro/src/components/IndividualOffer/StocksThing/validationSchema.ts
@@ -7,7 +7,7 @@ export const MAX_STOCKS_QUANTITY = 1000000
 export const getValidationSchema = (
   mode: OFFER_WIZARD_MODE,
   /* istanbul ignore next: DEBT, TO FIX */
-  minQuantity: number | null = null
+  minQuantity: number
 ) => {
   const validationSchema = {
     price: yup
@@ -29,7 +29,8 @@ export const getValidationSchema = (
     activationCodes: yup.array(),
     isDuo: yup.boolean(),
   }
-  if (minQuantity !== null) {
+
+  if (minQuantity !== 0) {
     validationSchema.quantity = validationSchema.quantity.min(
       minQuantity,
       'Quantité trop faible'

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.spec.tsx
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.spec.tsx
@@ -4,9 +4,9 @@ import { Formik } from 'formik'
 
 import { QuantityInput, QuantityInputProps } from './QuantityInput'
 
-const renderQuantityInput = (props: QuantityInputProps) => {
+const renderQuantityInput = (props: QuantityInputProps, initialQuantity: number | string = '') => {
   return render(
-    <Formik initialValues={{ quantity: '' }} onSubmit={() => {}}>
+    <Formik initialValues={{ quantity: initialQuantity }} onSubmit={() => {}}>
       <QuantityInput {...props} />
     </Formik>
   )
@@ -66,8 +66,29 @@ describe('QuantityInput', () => {
     expect(checkbox).toBeChecked()
   })
 
-  it('should move focus to the input when the checkbox is unchecked and init the input with 1', async () => {
-    renderQuantityInput({})
+  it('should check the checkbox initially when the input value is an empty string', async () => {
+    renderQuantityInput({}, '')
+
+    let input = screen.getByRole('spinbutton', { name: LABELS.input })
+    let checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
+
+    expect(input).toHaveValue(null)
+    expect(checkbox).toBeChecked()
+  })
+
+  it('should uncheck the checkbox when the input value is set', async () => {
+    renderQuantityInput({}, '1')
+
+    let input = screen.getByRole('spinbutton', { name: LABELS.input })
+    let checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
+
+    expect(input).toHaveValue(1)
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it('should move focus to the input when the checkbox is unchecked and init the input with the minimum', async () => {
+    const min = 10
+    renderQuantityInput({ min })
 
     const input = screen.getByRole('spinbutton', { name: LABELS.input })
     const checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
@@ -75,6 +96,6 @@ describe('QuantityInput', () => {
     await userEvent.click(checkbox)
     expect(checkbox).not.toBeChecked()
     expect(input).toHaveFocus()
-    expect(input).toHaveValue(1)
+    expect(input).toHaveValue(min)
   })
 })

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.tsx
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.tsx
@@ -35,6 +35,11 @@ export type QuantityInputProps = Pick<
    * This is to support custom logic when the quantity changes.
    */
   onChange?: (quantity: Quantity) => void
+  /**
+   * The minimum value allowed for the quantity.
+   * Make sure it matches formik validation schema.
+   */
+  min?: Quantity
 }
 
 export const QuantityInput = ({
@@ -48,16 +53,17 @@ export const QuantityInput = ({
   smallLabel,
   hideFooter,
   isOptional,
+  min = 0,
 }: QuantityInputProps) => {
   const quantityRef = useRef<HTMLInputElement>(null)
   const unlimitedRef = useRef<HTMLInputElement>(null)
 
   const [field] = useField(name)
   const { setFieldValue } = useFormikContext()
-  const [isUnlimited, setIsUnlimited] = useState(!field.value)
+  const [isUnlimited, setIsUnlimited] = useState(field.value === '')
 
   useEffect(() => {
-    setIsUnlimited(!field.value)
+    setIsUnlimited(field.value === '')
   }, [field.value])
 
   useEffect(() => {
@@ -70,15 +76,15 @@ export const QuantityInput = ({
   }, [isUnlimited])
 
   const onQuantityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newQuantity = parseInt(event.target.value)
-    onChange?.(newQuantity)
+    const nextValue = event.target.value ? parseInt(event.target.value) : ''
+    onChange?.(nextValue)
   }
 
   const onCheckboxChange = async () => {
     const nextIsUnlimitedState = !isUnlimited
     setIsUnlimited(nextIsUnlimitedState)
 
-    let nextFieldValue: Quantity = 1
+    let nextFieldValue: Quantity = min
     if (nextIsUnlimitedState) {
       // If the checkbox is going to be checked,
       // we need to clear the quantity field as an empty
@@ -106,7 +112,7 @@ export const QuantityInput = ({
         hasDecimal={false}
         className={className}
         classNameFooter={classNameFooter}
-        min={1}
+        min={min}
         max={1_000_000}
         isLabelHidden={isLabelHidden}
         hideFooter={hideFooter}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32982

## Modifications
- [x]  Correctif initialisation du composant avec une valeur de field nulle → ne doit toujours être que string (empty ou portant un nombre) ou number.
- [x]  Initialisation du composant à illimité lorsque la valeur est à empty string.
- [x]  La valeur 0 est désormais autorisée en fonction du min défini.
Par défaut, le min du composant est à 0.
Dans le cas du RecurrenceForm, il est à 1.
Dans le cas de StockThing et en édition, il ne peut pas être inférieur au nombre de réservations.
Il correspond dans tous les cas à ce qui est contrôlé dans les schémas de validation Formik.
- [x]  Lorsque Illimité est décoché manuellement, le champ est réinitialisé au min.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
