### PR TITLE
(BSR)[PRO] test: add collaborator test and clean_email_list

### DIFF
--- a/api/src/pcapi/routes/internal/e2e.py
+++ b/api/src/pcapi/routes/internal/e2e.py
@@ -42,13 +42,20 @@ def get_sandbox(module_name, getter_name):  # type: ignore [no-untyped-def]
         raise errors
 
 
+# The next endpoints must only be used with EMAIL_BACKEND set to `pcapi.core.mails.backends.testing.TestingBackend`
+# otherwise the outbox will be empty
+# The next endpoints is only available if ENABLE_TEST_ROUTES is set to 1
+@private_api.route("/sandboxes/clear_email_list", methods=["GET"])
+def clear_email_list():  # type: ignore [no-untyped-def]
+    if len(mails_testing.outbox) != 0:
+        mails_testing.outbox.clear()
+    return "Outbox cleared"
+
+
 @private_api.route("/sandboxes/get_unique_email", methods=["GET"])
 def get_unique_email():  # type: ignore [no-untyped-def]
-    # This endpoint must only be used with EMAIL_BACKEND set to `pcapi.core.mails.backends.testing.TestingBackend`
-    # otherwise the outbox will be empty
-    # This endpoint is only available if ENABLE_TEST_ROUTES is set to 1
     delay = 0
-    while len(mails_testing.outbox) != 1 and delay <= 60:
+    while len(mails_testing.outbox) == 0 and delay <= 60:
         time.sleep(5)
         delay += 5
     return mails_testing.outbox[0]

--- a/pro/cypress/e2e/collaborator.cy.ts
+++ b/pro/cypress/e2e/collaborator.cy.ts
@@ -1,0 +1,55 @@
+import { logAndGoToPage } from '../support/helpers.ts'
+
+describe('Collaborator list feature', () => {
+  let login: string
+
+  before(() => {
+    cy.visit('/connexion')
+    cy.request({
+      method: 'GET',
+      url: 'http://localhost:5001/sandboxes/pro/create_regular_pro_user',
+    }).then((response) => {
+      login = response.body.user.email
+    })
+
+    cy.request({
+      method: 'GET',
+      url: 'http://localhost:5001/sandboxes/clear_email_list',
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+    })
+  })
+
+  it('I can add a new collaborator and he receives an email invitation', () => {
+    const randomEmail = `collaborator${Math.random()}@example.com`
+    logAndGoToPage(login, '/')
+
+    cy.stepLog({ message: 'open collaborator Page' })
+    cy.findAllByText('Collaborateurs').click()
+
+    cy.stepLog({ message: 'add a collaborator in the list' })
+    cy.findByText('Ajouter un collaborateur').click()
+    cy.findByLabelText('Adresse email *').type(randomEmail)
+    cy.findByText('Inviter').click()
+
+    cy.stepLog({ message: 'check notification about invitation sent' })
+    cy.findAllByTestId('global-notification-success').should(
+      'contain',
+      `L'invitation a bien été envoyée.`
+    )
+
+    cy.stepLog({ message: 'check login validated and new collaborator waiting status' })
+    cy.contains(randomEmail).next().should('have.text', 'En attente')
+    cy.contains(login).next().should('have.text', 'Validé')
+
+    cy.stepLog({ message: 'check email received by email' })
+    cy.request({
+      method: 'GET',
+      url: 'http://localhost:5001/sandboxes/get_unique_email',
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      expect(response.body.To).to.eq(randomEmail)
+      expect(response.body.params.OFFERER_NAME).to.contain('Le Petit Rintintin Management')
+    })
+  })
+})

--- a/pro/cypress/e2e/createAccount.cy.ts
+++ b/pro/cypress/e2e/createAccount.cy.ts
@@ -1,10 +1,18 @@
 import { logAndGoToPage } from '../support/helpers.ts'
 
 describe('Account creation', () => {
+  before(() => {
+    cy.visit('/inscription')
+    cy.request({
+      method: 'GET',
+      url: 'http://localhost:5001/sandboxes/clear_email_list',
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+    })
+  })
+
   it('I should be able to create an account', () => {
     const randomEmail = `jean${Math.random()}@example.com`
-    cy.visit('/inscription')
-
     cy.stepLog({
       message: 'I fill required information in create account form',
     })


### PR DESCRIPTION
## But de la pull request

Nouveau test pour ajouter un collaborateur (ligne 67 du [fichier](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98))

J'ai aussi ajouté une route pour vider l'outbox de mails (en cas de retry) ce qui permet de récupérer un seul email dans la suite du test et bien vérifier que c'est celui-ci qu'on attendait

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
