### PR TITLE
(PC-32970)[API] chore: deactivate admin session on pro interface

### DIFF
--- a/api/src/pcapi/scripts/deactivate_admin_user/main.py
+++ b/api/src/pcapi/scripts/deactivate_admin_user/main.py
@@ -1,0 +1,19 @@
+from pcapi.app import app
+from pcapi.core.users import models
+from pcapi.models import db
+
+
+def deactivate_admin_user_session() -> None:
+    admin_users = models.User.query.filter(models.User.roles.contains([models.UserRole.ADMIN]))
+    admin_users_ids = set()
+
+    for admin in admin_users:
+        admin_users_ids.add(admin.id)
+
+    models.UserSession.query.filter(models.UserSession.userId.in_(admin_users_ids)).delete()
+    db.session.commit()
+
+
+if __name__ == "__main__":
+    with app.app_context():
+        deactivate_admin_user_session()


### PR DESCRIPTION
## But de la pull request

### ⚠️ Ne sera pas mergée ! Sera runnée dans un job console !

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32970

On avait bloqué la possibilité de connecter au portail pro la semaine dernière. Ce ticket a pour vocation de désactiver les sessions d'admins qui se seraient connectés avant le changement et resteraient connectés grâce à leur session.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
