### PR TITLE
(PC-32833)[PRO] fix: Display no offers template when therer are no of…

### DIFF
--- a/pro/src/commons/core/Offers/utils/hasSearchFilters.ts
+++ b/pro/src/commons/core/Offers/utils/hasSearchFilters.ts
@@ -7,12 +7,10 @@ export const hasSearchFilters = (
     searchFilters
   ) as (keyof SearchFiltersParams)[]
 ): boolean => {
-  return filterNames
-    .map(
-      (filterName) =>
-        searchFilters[filterName] !== { ...DEFAULT_SEARCH_FILTERS }[filterName]
-    )
-    .includes(true)
+  return filterNames.some(
+    (filterName) =>
+      searchFilters[filterName] !== { ...DEFAULT_SEARCH_FILTERS }[filterName]
+  )
 }
 
 export const hasCollectiveSearchFilters = (
@@ -22,10 +20,8 @@ export const hasCollectiveSearchFilters = (
     searchFilters
   ) as (keyof CollectiveSearchFiltersParams)[]
 ): boolean => {
-  return filterNames
-    .map(
-      (filterName) =>
-        searchFilters[filterName] !== { ...defaultFilters }[filterName]
-    )
-    .includes(true)
+  return filterNames.some(
+    (filterName) =>
+      searchFilters[filterName] !== { ...defaultFilters }[filterName]
+  )
 }

--- a/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/CollectiveOffersScreen.tsx
+++ b/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/CollectiveOffersScreen.tsx
@@ -80,7 +80,10 @@ export const CollectiveOffersScreen = ({
   const userHasNoOffers =
     !isLoading &&
     !hasOffers &&
-    !hasCollectiveSearchFilters(urlSearchFilters, defaultCollectiveFilters)
+    !hasCollectiveSearchFilters(
+      { ...urlSearchFilters, offererId: 'all' },
+      { ...defaultCollectiveFilters, offererId: 'all' }
+    )
 
   const areAllOffersSelected =
     selectedOffers.length > 0 &&


### PR DESCRIPTION
…fers on the structure.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32833

**Objectif**
Ne pas prendre en compte la valeur de l'offerer dans la comparaison des filtres appliqués pour l'affichage du composant indiquant qu'il n'y a pas d'offres sur l'offerer.

@ahello-pass @smokhtari-pass Le champ de l'offererId sélectionné est pas vraiment un filtre de recherche (en tout cas plus maintenant). Est-ce qu'il faudrait pas le retirer de notre modèle de filtres ? 🤔 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
