### PR TITLE
(BSR) feat: Dockerfile: download digicert certificate

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -152,6 +152,9 @@ RUN pip install \
 
 ENTRYPOINT exec ./entrypoint.sh
 
+RUN cp https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem /usr/local/share/ca-certificates
+RUN update-ca-certificates
+
 ######### CONSOLE #########
 
 FROM lib-dev AS pcapi-console-proxy


### PR DESCRIPTION
## But de la pull request

Ajout d'un certificat digicert au Dockerfile afin que toutes les instances déployées en aient connaissance.
