### PR TITLE
(PC-32112)[PRO] invoicetable: csv: 24 rows selected max

### DIFF
--- a/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
+++ b/api/src/pcapi/routes/serialization/reimbursement_csv_serialize.py
@@ -7,6 +7,7 @@ import typing
 from typing import Callable
 from typing import Iterable
 
+from pydantic.v1 import ConstrainedList
 from pydantic.v1 import validator
 from pydantic.v1.main import BaseModel
 import pytz
@@ -300,8 +301,15 @@ class ReimbursementCsvQueryModel(BaseModel):
     reimbursementPeriodEndingDate: str | None
 
 
+class InvoiceList(ConstrainedList):
+    __args__ = (str,)  # required by pydantic
+    item_type = str
+    unique_items = True
+    max_items = 24
+
+
 class ReimbursementCsvByInvoicesModel(BaseModel):
-    invoicesReferences: list[str]
+    invoicesReferences: InvoiceList
 
     @validator("invoicesReferences", pre=True)
     def ensure_invoices_references_is_list(cls, v: list[str] | str) -> list[str]:

--- a/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
+++ b/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 from io import StringIO
+import string
 
 import pytest
 
@@ -245,3 +246,15 @@ def test_return_only_searched_invoice(client):
     assert reader.fieldnames == ReimbursementDetails.CSV_HEADER
     rows = list(reader)
     assert len(rows) == 1
+
+
+def test_too_many_invoices_searched_returns_an_error(client):
+    pro = users_factories.ProFactory()
+
+    client = client.with_session_auth(pro.email)
+    references = "invoicesReferences=" + "&invoicesReferences=".join(list(string.ascii_letters))
+
+    response = client.get(f"/v2/reimbursements/csv?{references}")
+
+    assert response.status_code == 400
+    assert response.json == {"invoicesReferences": ["ensure this value has at most 24 items"]}

--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
@@ -144,6 +144,12 @@ export const InvoiceTable = ({ invoices }: InvoiceTableProps) => {
   }
 
   async function downloadCSVFiles(references: string[]) {
+    if (references.length > 24) {
+      notify.error(
+        'Vous ne pouvez pas télécharger plus de 24 documents en une fois.'
+      )
+      return
+    }
     try {
       logEvent(Events.CLICKED_INVOICES_DOWNLOAD, {
         fileType: 'details',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32112

Limiter le nombre de csv de détails de remboursements à 24: un utilisateur ne peut pas sélectionner plus de 24 remboursements à la fois.

Cette limite existe pour le téléchargement des justificatifs (sur la même page) mais pas pour les csv. Un utilisateur pouvait donc sélectionner plus de cent (par exemple) remboursements et demander les csv de détails, ce qui peut générer des requêtes beaucoup trop lourdes au niveau de la base de données (et donc un timeout ensuite).
