### PR TITLE
(BSR)[API] chore : do not log some external calls

### DIFF
--- a/api/src/pcapi/connectors/acceslibre.py
+++ b/api/src/pcapi/connectors/acceslibre.py
@@ -527,7 +527,7 @@ class AcceslibreBackend(BaseBackend):
     def _fetch_request(
         url: str, headers: dict | None = None, params: dict[str, str | int] | None = None
     ) -> requests.Response:
-        return requests.get(url, headers=headers, params=params, timeout=ACCESLIBRE_REQUEST_TIMEOUT)
+        return requests.get(url, headers=headers, params=params, timeout=ACCESLIBRE_REQUEST_TIMEOUT, log_info=False)
 
     def _send_request(
         self,

--- a/api/src/pcapi/connectors/api_recaptcha.py
+++ b/api/src/pcapi/connectors/api_recaptcha.py
@@ -27,7 +27,7 @@ class InvalidRecaptchaTokenException(ApiErrors):
 def get_token_validation_and_score(token: str, secret: str) -> dict:
     params = {"secret": secret, "response": token}
     try:
-        api_response = requests.post(settings.RECAPTCHA_API_URL, data=params)
+        api_response = requests.post(settings.RECAPTCHA_API_URL, data=params, log_info=False)
         api_response.raise_for_status()
         json_response = api_response.json()
     except requests.exceptions.RequestException as exc:

--- a/api/src/pcapi/connectors/recommendation.py
+++ b/api/src/pcapi/connectors/recommendation.py
@@ -78,10 +78,12 @@ class HttpBackend:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", urllib_execptions.InsecureRequestWarning)
                 if method == "get":
-                    response = requests.get(url, params=params, disable_synchronous_retry=True, verify=False)
+                    response = requests.get(
+                        url, params=params, disable_synchronous_retry=True, verify=False, log_info=False
+                    )
                 elif method == "post":
                     response = requests.post(
-                        url, params=params, json=body, disable_synchronous_retry=True, verify=False
+                        url, params=params, json=body, disable_synchronous_retry=True, verify=False, log_info=False
                     )
                 else:
                     raise ValueError(f"Unexpected method: {method}")

--- a/api/src/pcapi/core/external/compliance_backends/compliance.py
+++ b/api/src/pcapi/core/external/compliance_backends/compliance.py
@@ -27,6 +27,7 @@ class ComplianceBackend(BaseBackend):
                     "accept": "application/json",
                 },
                 json=data,
+                log_info=False,
             )
 
         except requests.exceptions.RequestException as exc:

--- a/api/src/pcapi/core/monkeypatches.py
+++ b/api/src/pcapi/core/monkeypatches.py
@@ -1,4 +1,3 @@
-import time
 import typing
 
 import sib_api_v3_sdk.rest
@@ -19,7 +18,6 @@ def custom_restclient_request(
     """Wrapper around ``RESTClientObject.request()`` from SendindBlue SDK
     that sets a default timeout and logs the request.
     """
-    start = time.perf_counter()
     if kwargs.get("_request_timeout") is None:
         kwargs["_request_timeout"] = SENDINBLUE_REQUEST_TIMEOUT
     try:
@@ -35,15 +33,6 @@ def custom_restclient_request(
             },
         )
         raise
-    elapsed = time.perf_counter() - start
-    logger.info(
-        "External service called",
-        extra={
-            "url": url,
-            "statusCode": response.status,
-            "duration": elapsed,
-        },
-    )
     return response
 
 

--- a/api/tests/connectors/api_recaptcha_test.py
+++ b/api/tests/connectors/api_recaptcha_test.py
@@ -40,7 +40,9 @@ class GetTokenValidationAndScoreTest:
 
         # Then
         request_post.assert_called_once_with(
-            settings.RECAPTCHA_API_URL, data={"secret": "recaptcha-secret", "response": token}
+            settings.RECAPTCHA_API_URL,
+            data={"secret": "recaptcha-secret", "response": token},
+            log_info=False,
         )
 
     @override_settings(RECAPTCHA_SECRET="recaptcha-secret")


### PR DESCRIPTION
## But de la pull request
Do not log calls to some external services. Impacted services : 
- Reco API (logs are exists on passculture-data-prod project)
- Compliance API (logs exists on passculture-data-prod project)
- Brevo (for this calls, only the URL and the timing is displayed. I don't really see how this can be useful)
- Reptcha (likewise)
- AccesLibre (likewise)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
