### PR TITLE
(PC-32107)[API] fix: do not compare naive and aware datetimes when co…

### DIFF
--- a/api/src/pcapi/core/educational/api/stock.py
+++ b/api/src/pcapi/core/educational/api/stock.py
@@ -266,6 +266,12 @@ def _update_educational_booking_educational_year_id(
 def _update_educational_booking_cancellation_limit_date(
     booking: educational_models.CollectiveBooking, new_beginning_datetime: datetime.datetime
 ) -> None:
+    # if the input date has a timezone (resp. does not have one), we need to compare it with an aware datetime (resp. a naive datetime)
+    now = (
+        datetime.datetime.utcnow()
+        if new_beginning_datetime.tzinfo is None
+        else datetime.datetime.now(datetime.timezone.utc)  # pylint: disable=datetime-now
+    )
     booking.cancellationLimitDate = educational_utils.compute_educational_booking_cancellation_limit_date(
-        new_beginning_datetime, datetime.datetime.utcnow()
+        new_beginning_datetime, now
     )


### PR DESCRIPTION
…mputing cancellation limit date

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32107

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
