### PR TITLE
(PC-32794)[PRO] fix: show a generic cancellation reason instead of th…

### DIFF
--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.tsx
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.tsx
@@ -41,11 +41,8 @@ const cancellationReasonTitle = (
       return 'Vous avez annulé la réservation'
     case CollectiveBookingCancellationReasons.EXPIRED:
       return 'Annulé automatiquement'
-    case CollectiveBookingCancellationReasons.FRAUD:
-    case CollectiveBookingCancellationReasons.BACKOFFICE:
-      return 'Le pass Culture a annulé la réservation'
     default:
-      throw new Error('Invalid cancellation reason')
+      return 'Le pass Culture a annulé la réservation'
   }
 }
 

--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/__specs__/CollectiveTimeLine.spec.tsx
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/__specs__/CollectiveTimeLine.spec.tsx
@@ -149,6 +149,23 @@ describe('collective timeline', () => {
     ).toBeInTheDocument()
   })
 
+  it('should return defautl cancellation message when reason is unknown', () => {
+    const bookingRecap = collectiveBookingFactory({
+      bookingStatus: BOOKING_STATUS.CANCELLED,
+      bookingConfirmationDate: null,
+      bookingConfirmationLimitDate: '01/01/2023',
+      bookingCancellationReason: 'UNKNOWN_CANCELLATION_REASON' as CollectiveBookingCancellationReasons,
+      bookingStatusHistory: [
+        { date: new Date().toISOString(), status: BOOKING_STATUS.PENDING },
+        { date: new Date().toISOString(), status: BOOKING_STATUS.CANCELLED },
+      ],
+    })
+    renderCollectiveTimeLine(bookingRecap, bookingDetails)
+    expect(
+      screen.getByText('Le pass Culture a annulé la réservation')
+    ).toBeInTheDocument()
+  })
+
   it('should log event when clicking modify booking limit date', async () => {
     const mockLogEvent = vi.fn()
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({


### PR DESCRIPTION
…rowing an error on collective booking

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32794

Afficher un message générique d'annulation "la pass Culture a annulé votre réservation" plutôt qu'afficher une page d'erreur quand la CancellationReason est inconnue

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
