### PR TITLE
(BSR)[API] feat: add a dry run option to import_deposit_csv command

### DIFF
--- a/api/src/pcapi/core/educational/api/institution.py
+++ b/api/src/pcapi/core/educational/api/institution.py
@@ -54,11 +54,13 @@ def search_educational_institution(
 
 
 def import_deposit_institution_data(
+    *,
     data: dict[str, Decimal],
     educational_year: educational_models.EducationalYear,
     ministry: educational_models.Ministry,
     final: bool,
     conflict: str,
+    commit: bool,
 ) -> None:
     adage_institutions = {
         i.uai: i for i in adage_client.get_adage_educational_institutions(ansco=educational_year.adageId)
@@ -123,7 +125,8 @@ def import_deposit_institution_data(
             )
             db.session.add(deposit)
 
-    db.session.commit()
+    if commit:
+        db.session.commit()
 
 
 def get_current_year_remaining_credit(institution: educational_models.EducationalInstitution) -> Decimal:

--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -68,7 +68,8 @@ def generate_fake_adage_token(readonly: bool) -> None:
     help="Overide previous ministry if needed.",
 )
 @click.option("--final", type=bool, is_flag=True, default=False, help="Flag deposits as final.")
-def import_deposit_csv(path: str, year: int, ministry: str, conflict: str, final: bool) -> None:
+@click.option("--dry-run", type=bool, default=True, help="Do not commit the changes.")
+def import_deposit_csv(*, path: str, year: int, ministry: str, conflict: str, final: bool, dry_run: bool) -> None:
     """
     import CSV deposits and update institution according to adage data.
 
@@ -116,6 +117,7 @@ def import_deposit_csv(path: str, year: int, ministry: str, conflict: str, final
             ministry=educational_models.Ministry[ministry],
             conflict=conflict,
             final=final,
+            commit=not dry_run,
         )
 
 

--- a/api/tests/core/educational/api/test_import_deposit_institution_deposit_data.py
+++ b/api/tests/core/educational/api/test_import_deposit_institution_deposit_data.py
@@ -21,6 +21,7 @@ class ImportDepositInstitutionDataTest:
             ministry=educational_models.Ministry.EDUCATION_NATIONALE,
             final=False,
             conflict="crash",
+            commit=True,
         )
 
         institution = educational_models.EducationalInstitution.query.filter_by(institutionId="0470010E").one()
@@ -53,6 +54,7 @@ class ImportDepositInstitutionDataTest:
             ministry=educational_models.Ministry.EDUCATION_NATIONALE,
             final=False,
             conflict="crash",
+            commit=True,
         )
 
         institution = educational_models.EducationalInstitution.query.filter_by(institutionId="0470010E").one()
@@ -84,6 +86,7 @@ class ImportDepositInstitutionDataTest:
             ministry=educational_models.Ministry.EDUCATION_NATIONALE,
             final=False,
             conflict="crash",
+            commit=True,
         )
 
         assert educational_models.EducationalInstitution.query.count() == 0
@@ -105,6 +108,7 @@ class ImportDepositInstitutionDataTest:
             ministry=educational_models.Ministry.EDUCATION_NATIONALE,
             final=False,
             conflict="replace",
+            commit=True,
         )
 
         institution = educational_models.EducationalInstitution.query.filter_by(institutionId="0470010E").one()
@@ -141,6 +145,7 @@ class ImportDepositInstitutionDataTest:
             ministry=educational_models.Ministry.EDUCATION_NATIONALE,
             final=False,
             conflict="keep",
+            commit=True,
         )
 
         institution = educational_models.EducationalInstitution.query.filter_by(institutionId="0470010E").one()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : ajout d'un paramètre pour pouvoir lancer `import_deposit_csv` en dry-run

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
