### PR TITLE
(PC-30786)[PRO] feat: use CAN_CANCEL action to show collective booking cancel button when FF is on

### DIFF
--- a/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/CollectiveActionsCells.tsx
@@ -279,6 +279,16 @@ export const CollectiveActionsCells = ({
       !offer.isPublicApi &&
       offer.status !== CollectiveOfferStatus.ARCHIVED
 
+  const isBookingCancellable =
+    areCollectiveNewStatusesEnabled ?
+      isActionAllowedOnCollectiveOffer(offer,CollectiveOfferAllowedAction.CAN_CANCEL)
+      : offer.status === CollectiveOfferStatus.SOLD_OUT &&
+        offer.booking &&
+        (offer.booking.booking_status ===
+          CollectiveBookingStatus.PENDING ||
+          offer.booking.booking_status ===
+            CollectiveBookingStatus.CONFIRMED)
+
   return (
     <td
       className={cn(styles['offers-table-cell'], styles['actions-column'])}
@@ -375,12 +385,7 @@ export const CollectiveActionsCells = ({
                     </ButtonLink>
                   </DropdownMenu.Item>
                 )}
-                {offer.status === CollectiveOfferStatus.SOLD_OUT &&
-                  offer.booking &&
-                  (offer.booking.booking_status ===
-                    CollectiveBookingStatus.PENDING ||
-                    offer.booking.booking_status ===
-                      CollectiveBookingStatus.CONFIRMED) && (
+                {isBookingCancellable && (
                     <>
                       <DropdownMenu.Separator
                         className={cn(

--- a/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
@@ -452,4 +452,38 @@ describe('CollectiveActionsCells', () => {
 
     expect(screen.queryByText('Modifier')).not.toBeInTheDocument()
   })
+
+  it('should show cancel button when ENABLE_COLLECTIVE_NEW_STATUSES and offer has CAN_CANCEL allowed action', async () => {
+    renderCollectiveActionsCell(
+      {
+        offer: collectiveOfferFactory({
+          isShowcase: false,
+          allowedActions: [
+            CollectiveOfferAllowedAction.CAN_CANCEL,
+          ],
+        }),
+      },
+      ['ENABLE_COLLECTIVE_NEW_STATUSES']
+    )
+
+    await userEvent.click(screen.getByTitle('Action'))
+
+    expect(screen.getByText('Annuler la réservation')).toBeInTheDocument()
+  })
+
+  it('should not show cancel button when ENABLE_COLLECTIVE_NEW_STATUSES and offer has not CAN_CANCEL allowed action', async () => {
+    renderCollectiveActionsCell(
+      {
+        offer: collectiveOfferFactory({
+          isShowcase: false,
+          allowedActions: [],
+        }),
+      },
+      ['ENABLE_COLLECTIVE_NEW_STATUSES']
+    )
+
+    await userEvent.click(screen.getByTitle('Action'))
+
+    expect(screen.queryByText('Annuler la réservation')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-30786

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
