### PR TITLE
(BSR)[PRO] fix: csp clickjacking

### DIFF
--- a/pro/firebase.json
+++ b/pro/firebase.json
@@ -13,6 +13,10 @@
         "source": "**",
         "headers": [
           {
+            "key": "Content-Security-Policy",
+            "value": "frame-ancestors 'self' https://bv.ac-versailles.fr https://adage-pr.phm.education.gouv.fr https://adage-pp.hp.in.phm.education.gouv.fr https://adage-qp.hp.in.phm.education.gouv.fr https://adage-pr.in.phm.education.gouv.fr"
+          },
+          {
             "key": "Content-Security-Policy-Report-Only",
             "value": "style-src 'self' https://app.getbeamer.com 'unsafe-inline'; img-src 'self' blob: data: https://*.getbeamer.com https://storage.googleapis.com https://www.googletagmanager.com; object-src 'none'; frame-src https://*.getbeamer.com https://www.google.com https://data-analytics.passculture.team; script-src 'self' 'nonce-recaptcha' https://www.gstatic.com https://*.getbeamer.com https://*.hotjar.com https://www.googletagmanager.com https://firebaseinstallations.googleapis.com https://firebaseremoteconfig.googleapis.com https://api-adresse.data.gouv.fr https://*.hotjar.io; connect-src 'self' https://*.algolianet.com https://www.googletagmanager.com https://www.google-analytics.com wss://ws.hotjar.com https://*.hotjar.com https://*.hotjar.io https://api-adresse.data.gouv.fr https://storage.googleapis.com https://backend.getbeamer.com https://firebaseremoteconfig.googleapis.com https://firebase.googleapis.com https://firebaseinstallations.googleapis.com https://sentry.passculture.team https://backend.integration.passculture.pro https://backend.testing.passculture.team https://backend.staging.passculture.team https://backend.passculture.pro https://region1.google-analytics.com https://*.algolia.net https://insights.algolia.io; base-uri; report-uri https://sentry.passculture.team/api/2/security/?sentry_key=50f5694849704813b4154c5868b73365;"
           }


### PR DESCRIPTION
Ajout de frame-ancestors dans les CSP

PR pour fix les attaques de type clickjacking -> on autorise seulement les urls listés à afficher notre iframe sur leurs site, les autres non listées auront un message d'erreur fourni par le navigateur (si vous avez une idée d'autres lien qui utiliserait le portail pro dans une iframe, ajoutez le en commentaire pour qu'on puisse l'ajouter)