### PR TITLE
(PC-32969)[PRO] feat: Handle default value for offer location

### DIFF
--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/UsefulInformationScreen.tsx
@@ -99,7 +99,7 @@ export const UsefulInformationScreen = ({
       ])
 
       const hasAddressChanged = someFormFieldsChanged([
-        'offerlocation',
+        'offerLocation',
         'search-addressAutocomplete',
         'street',
         'postalCode',

--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
@@ -183,7 +183,7 @@ describe('setDefaultInitialValuesFromOffer', () => {
       receiveNotificationEmails: true,
       url: 'http://example.com',
 
-      offerlocation: OFFER_LOCATION.OTHER_ADDRESS,
+      offerLocation: OFFER_LOCATION.OTHER_ADDRESS,
       manuallySetAddress: true,
       'search-addressAutocomplete': addressAutocomplete,
       addressAutocomplete,

--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/types.ts
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/types.ts
@@ -14,7 +14,7 @@ export type UsefulInformationFormValues = {
   isVenueVirtual?: boolean
   bookingContact?: string
 
-  offerlocation?: string | undefined
+  offerLocation?: string | undefined
   manuallySetAddress?: boolean
   'search-addressAutocomplete'?: string
   addressAutocomplete?: string

--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/utils.ts
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/utils.ts
@@ -20,6 +20,7 @@ interface SetDefaultInitialValuesFromOfferProps {
   offer: GetIndividualOfferWithAddressResponseModel
   selectedVenue?: VenueListItemResponseModel | undefined
 }
+
 export function setDefaultInitialValuesFromOffer({
   offer,
   selectedVenue = undefined,
@@ -44,14 +45,14 @@ export function setDefaultInitialValuesFromOffer({
     // If the venue's OA selected at step 1 is the same than the one we have saved in offer draft,
     //  then set this OA id in formik field (so it will be checked by default)
     //  Else, we can assume it's an "other" address
-    const offerlocation =
+    const offerLocation =
       selectedVenue?.address &&
       selectedVenue.address.id_oa === offer.address.id_oa
         ? offer.address.id_oa
         : OFFER_LOCATION.OTHER_ADDRESS
 
     addressFields = {
-      offerlocation: String(offerlocation),
+      offerLocation: String(offerLocation),
       manuallySetAddress: offer.address.isManualEdition,
       'search-addressAutocomplete': addressAutocomplete,
       addressAutocomplete,
@@ -63,6 +64,18 @@ export function setDefaultInitialValuesFromOffer({
       city: offer.address.city,
       latitude: String(offer.address.latitude),
       longitude: String(offer.address.longitude),
+    }
+  } else if (selectedVenue && selectedVenue.address) {
+    addressFields = {
+      offerLocation: String(selectedVenue.address.id_oa),
+      coords: `${selectedVenue.address.latitude}, ${selectedVenue.address.longitude}`,
+      banId: selectedVenue.address.banId,
+      locationLabel: selectedVenue.address.label ?? '',
+      street: selectedVenue.address.street,
+      postalCode: selectedVenue.address.postalCode,
+      city: selectedVenue.address.city,
+      latitude: String(selectedVenue.address.latitude),
+      longitude: String(selectedVenue.address.longitude),
     }
   }
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetailsAndInformations/components/OfferLocation/OfferLocation.module.scss
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetailsAndInformations/components/OfferLocation/OfferLocation.module.scss
@@ -1,7 +1,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
 
-.offerlocation-wrapper {
+.offer-location-wrapper {
   .infotext {
     @include fonts.body;
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetailsAndInformations/components/OfferLocation/OfferLocation.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetailsAndInformations/components/OfferLocation/OfferLocation.tsx
@@ -14,7 +14,6 @@ import { computeAddressDisplayName } from 'repository/venuesService'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { RadioButton } from 'ui-kit/form/RadioButton/RadioButton'
-import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 
 import styles from './OfferLocation.module.scss'
@@ -27,12 +26,12 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
   const formik = useFormikContext<IndividualOfferFormValues>()
 
   const [showOtherAddress, setShowOtherAddress] = useState(
-    formik.values.offerlocation === OFFER_LOCATION.OTHER_ADDRESS
+    formik.values.offerLocation === OFFER_LOCATION.OTHER_ADDRESS
   )
 
   useEffect(() => {
-    setShowOtherAddress(formik.values.offerlocation === 'other')
-  }, [formik.values.offerlocation])
+    setShowOtherAddress(formik.values.offerLocation === 'other')
+  }, [formik.values.offerLocation])
 
   const [manuallySetAddress, , { setValue: setManuallySetAddress }] =
     useField('manuallySetAddress')
@@ -84,12 +83,10 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
     : ''
   const venueFullText = `${venue?.publicName || venue?.name} – ${venueAddress}`
 
-  const [, offerlocationMeta] = useField<string>('offerlocation')
-
   return (
     <FormLayout.Section
       title="Localisation de l’offre"
-      className={styles['offerlocation-wrapper']}
+      className={styles['offer-location-wrapper']}
     >
       <p className={styles['infotext']}>
         Il s’agit de l’adresse à laquelle les jeunes devront se présenter.
@@ -98,7 +95,7 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
         <RadioButton
           withBorder
           label={venueFullText}
-          name="offerlocation"
+          name="offerLocation"
           value={venue?.address?.id_oa.toString() ?? ''}
           required
           onChange={onChangeOfferLocation}
@@ -108,15 +105,12 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
         <RadioButton
           withBorder
           label="À une autre adresse"
-          name="offerlocation"
+          name="offerLocation"
           value={OFFER_LOCATION.OTHER_ADDRESS}
           required
           onChange={onChangeOfferLocation}
         />
       </FormLayout.Row>
-      {offerlocationMeta.error && !offerlocationMeta.value && (
-        <FieldError name="offerlocation">{offerlocationMeta.error}</FieldError>
-      )}
 
       {showOtherAddress && (
         <div className={styles['other-address-wrapper']}>

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetailsAndInformations/components/OfferLocation/validationSchema.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetailsAndInformations/components/OfferLocation/validationSchema.ts
@@ -4,7 +4,7 @@ import { checkCoords } from 'commons/utils/coords'
 import { OFFER_LOCATION } from 'pages/IndividualOffer/commons/constants'
 
 const locationSchema = {
-  offerlocation: yup
+  offerLocation: yup
     .string()
     .trim()
     .when('isVenueVirtual', {
@@ -14,7 +14,7 @@ const locationSchema = {
   addressAutocomplete: yup
     .string()
     .trim()
-    .when(['offerlocation', 'manuallySetAddress', 'isVenueVirtual'], {
+    .when(['offerLocation', 'manuallySetAddress', 'isVenueVirtual'], {
       is: (
         offerLocation: string,
         manuallySetAddress: boolean,
@@ -31,7 +31,7 @@ const locationSchema = {
   street: yup
     .string()
     .trim()
-    .when(['offerlocation', 'isVenueVirtual'], {
+    .when(['offerLocation', 'isVenueVirtual'], {
       is: (offerLocation: string, isVenueVirtual: boolean) =>
         !isVenueVirtual && offerLocation === OFFER_LOCATION.OTHER_ADDRESS,
       then: (schema) =>
@@ -40,7 +40,7 @@ const locationSchema = {
   postalCode: yup
     .string()
     .trim()
-    .when(['offerlocation', 'isVenueVirtual'], {
+    .when(['offerLocation', 'isVenueVirtual'], {
       is: (offerLocation: string, isVenueVirtual: boolean) =>
         !isVenueVirtual && offerLocation === OFFER_LOCATION.OTHER_ADDRESS,
       then: (schema) => schema.required('Veuillez renseigner un code postal'),
@@ -48,7 +48,7 @@ const locationSchema = {
   city: yup
     .string()
     .trim()
-    .when(['offerlocation', 'isVenueVirtual'], {
+    .when(['offerLocation', 'isVenueVirtual'], {
       is: (offerLocation: string, isVenueVirtual: boolean) =>
         !isVenueVirtual && offerLocation === OFFER_LOCATION.OTHER_ADDRESS,
       then: (schema) => schema.required('Veuillez renseigner une ville'),
@@ -56,7 +56,7 @@ const locationSchema = {
   coords: yup
     .string()
     .trim()
-    .when(['offerlocation', 'manuallySetAddress', 'isVenueVirtual'], {
+    .when(['offerLocation', 'manuallySetAddress', 'isVenueVirtual'], {
       is: (
         offerLocation: string,
         manuallySetAddress: boolean,

--- a/pro/src/pages/IndividualOffer/commons/__specs__/serializers.spec.ts
+++ b/pro/src/pages/IndividualOffer/commons/__specs__/serializers.spec.ts
@@ -1,16 +1,12 @@
 /* istanbul ignore file: DEBT, TO FIX */
 
-import { PatchOfferBodyModel, PostOfferBodyModel } from 'apiClient/v1'
-import { AccessibilityEnum } from 'commons/core/shared/types'
-import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
-import { OFFER_LOCATION } from 'pages/IndividualOffer/commons/constants'
-import { IndividualOfferFormValues } from 'pages/IndividualOffer/commons/types'
+import { PatchOfferBodyModel, PostOfferBodyModel } from "apiClient/v1";
+import { AccessibilityEnum } from "commons/core/shared/types";
+import { getIndividualOfferFactory } from "commons/utils/factories/individualApiFactories";
+import { OFFER_LOCATION } from "pages/IndividualOffer/commons/constants";
+import { IndividualOfferFormValues } from "pages/IndividualOffer/commons/types";
 
-import {
-  serializeDurationMinutes,
-  serializeExtraData,
-  serializePatchOffer,
-} from '../serializePatchOffer'
+import { serializeDurationMinutes, serializeExtraData, serializePatchOffer } from "../serializePatchOffer";
 
 describe('test updateIndividualOffer::serializers', () => {
   it('test serializeDurationMinutes', () => {
@@ -97,7 +93,7 @@ describe('test updateIndividualOffer::serializers', () => {
         street: '3 Rue de Valois',
         locationLabel: 'Ville lumière',
         manuallySetAddress: false,
-        offerlocation: OFFER_LOCATION.OTHER_ADDRESS,
+        offerLocation: OFFER_LOCATION.OTHER_ADDRESS,
       }
       patchBody = {
         audioDisabilityCompliant: true,
@@ -185,7 +181,7 @@ describe('test updateIndividualOffer::serializers', () => {
     it('should send isVenueAddress flag set to true when user select the venue location', () => {
       formValues = {
         ...formValues,
-        offerlocation: '1', // any ID that represents the venue OA location
+        offerLocation: '1', // any ID that represents the venue OA location
       }
       patchBody = {
         ...patchBody,
@@ -205,7 +201,7 @@ describe('test updateIndividualOffer::serializers', () => {
     it('should send isVenueAddress flag set to false when user select another location (WIP_ENABLE_OFFER_ADDRESS)', () => {
       formValues = {
         ...formValues,
-        offerlocation: OFFER_LOCATION.OTHER_ADDRESS, // user choosed to set another address
+        offerLocation: OFFER_LOCATION.OTHER_ADDRESS, // user choosed to set another address
       }
       patchBody = {
         ...patchBody,
@@ -226,7 +222,7 @@ describe('test updateIndividualOffer::serializers', () => {
         ...formValues,
         locationLabel: '',
         manuallySetAddress: false,
-        offerlocation: OFFER_LOCATION.OTHER_ADDRESS,
+        offerLocation: OFFER_LOCATION.OTHER_ADDRESS,
       }
       patchBody = {
         ...patchBody,

--- a/pro/src/pages/IndividualOffer/commons/serializePatchOffer.ts
+++ b/pro/src/pages/IndividualOffer/commons/serializePatchOffer.ts
@@ -47,6 +47,7 @@ export const serializeDurationMinutes = (
 
   return minutes + hours * 60
 }
+
 interface SerializePatchOffer {
   offer: GetIndividualOfferResponseModel
   formValues: Partial<IndividualOfferFormValues>
@@ -99,7 +100,7 @@ export const serializePatchOffer = ({
         label: sentValues.locationLabel,
         isManualEdition: sentValues.manuallySetAddress,
         isVenueAddress:
-          sentValues.offerlocation === OFFER_LOCATION.OTHER_ADDRESS
+          sentValues.offerLocation === OFFER_LOCATION.OTHER_ADDRESS
             ? false
             : true,
       },

--- a/pro/src/pages/IndividualOffer/commons/types.ts
+++ b/pro/src/pages/IndividualOffer/commons/types.ts
@@ -1,6 +1,6 @@
 import { WithdrawalTypeEnum } from 'apiClient/v1'
 import { AccessibilityFormValues } from 'commons/core/shared/types'
-import { type AddressFormValues } from 'components/AddressManual/AddressManual' // We makes "AddressFormValues" partial because the individual offer form may not have address fields (e.g. if it's a virtual offer)
+import { type AddressFormValues } from 'components/AddressManual/AddressManual'
 
 // We makes "AddressFormValues" partial because the individual offer form may not have address fields (e.g. if it's a virtual offer)
 export interface IndividualOfferFormValues extends Partial<AddressFormValues> {

--- a/pro/src/pages/IndividualOffer/commons/types.ts
+++ b/pro/src/pages/IndividualOffer/commons/types.ts
@@ -1,6 +1,6 @@
 import { WithdrawalTypeEnum } from 'apiClient/v1'
 import { AccessibilityFormValues } from 'commons/core/shared/types'
-import { type AddressFormValues } from 'components/AddressManual/AddressManual'
+import { type AddressFormValues } from 'components/AddressManual/AddressManual' // We makes "AddressFormValues" partial because the individual offer form may not have address fields (e.g. if it's a virtual offer)
 
 // We makes "AddressFormValues" partial because the individual offer form may not have address fields (e.g. if it's a virtual offer)
 export interface IndividualOfferFormValues extends Partial<AddressFormValues> {
@@ -35,7 +35,7 @@ export interface IndividualOfferFormValues extends Partial<AddressFormValues> {
   url: string
   isVenueVirtual?: boolean
   bookingContact?: string
-  offerlocation?: string | undefined
+  offerLocation?: string | undefined
   locationLabel?: string | null
   manuallySetAddress?: boolean
 }

--- a/pro/src/pages/Offers/OffersTable/Cells/AddressCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/AddressCell.tsx
@@ -8,7 +8,7 @@ import styles from './Cells.module.scss'
 export function AddressCell({
   address,
 }: {
-  address: AddressResponseIsLinkedToVenueModel
+  address: AddressResponseIsLinkedToVenueModel | null | undefined
 }) {
   return (
     <td
@@ -17,7 +17,7 @@ export function AddressCell({
         styles['venue-column']
       )}
     >
-      {computeAddressDisplayName(address)}
+      {address && computeAddressDisplayName(address)}
     </td>
   )
 }

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOfferRow/IndividualOfferRow.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOfferRow/IndividualOfferRow.tsx
@@ -68,7 +68,7 @@ export const IndividualOfferRow = ({
 
       <OfferNameCell offer={offer} editionOfferLink={editionOfferLink} />
 
-      {offerAddressEnabled && offer.address ? (
+      {offerAddressEnabled ? (
         <AddressCell address={offer.address} />
       ) : (
         <OfferVenueCell venue={offer.venue} />


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32969

- The venue address is the default value
- Do not display the venue address for offers without one.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
