### PR TITLE
(BSR)[PRO] test: wait for all collaborator page before adding a new one

### DIFF
--- a/pro/cypress/e2e/collaborator.cy.ts
+++ b/pro/cypress/e2e/collaborator.cy.ts
@@ -3,7 +3,7 @@ import { logAndGoToPage } from '../support/helpers.ts'
 describe('Collaborator list feature', () => {
   let login: string
 
-  before(() => {
+  beforeEach(() => {
     cy.visit('/connexion')
     cy.request({
       method: 'GET',
@@ -24,8 +24,12 @@ describe('Collaborator list feature', () => {
     const randomEmail = `collaborator${Math.random()}@example.com`
     logAndGoToPage(login, '/')
 
-    cy.stepLog({ message: 'open collaborator Page' })
+    cy.stepLog({ message: 'open collaborator page' })
     cy.findAllByText('Collaborateurs').click()
+
+    cy.stepLog({ message: 'wait for collaborator page display' })
+    cy.url().should('include', '/collaborateurs')
+    cy.contains(login)
 
     cy.stepLog({ message: 'add a collaborator in the list' })
     cy.findByText('Ajouter un collaborateur').click()
@@ -38,7 +42,9 @@ describe('Collaborator list feature', () => {
       `L'invitation a bien été envoyée.`
     )
 
-    cy.stepLog({ message: 'check login validated and new collaborator waiting status' })
+    cy.stepLog({
+      message: 'check login validated and new collaborator waiting status',
+    })
     cy.contains(randomEmail).next().should('have.text', 'En attente')
     cy.contains(login).next().should('have.text', 'Validé')
 
@@ -49,7 +55,9 @@ describe('Collaborator list feature', () => {
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.To).to.eq(randomEmail)
-      expect(response.body.params.OFFERER_NAME).to.contain('Le Petit Rintintin Management')
+      expect(response.body.params.OFFERER_NAME).to.contain(
+        'Le Petit Rintintin Management'
+      )
     })
   })
 })


### PR DESCRIPTION
## But de la pull request

Corrige quelques échecs uniquement observés sur master après merge: on attend l'affichage du compte courant dans la liste des collaborateurs avant d'en rajouter un nouveau

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
