### PR TITLE
(PC-33067)[API] refactor: use atomic decorator on native GET routes

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 import datetime
 from decimal import Decimal
 import enum
+from functools import partial
 from io import BytesIO
 import itertools
 import logging
@@ -65,6 +66,7 @@ from pcapi.models.api_errors import ApiErrors
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.notifications import push as push_api
 from pcapi.repository import is_managed_transaction
+from pcapi.repository import on_commit
 from pcapi.repository import repository
 from pcapi.repository import transaction
 from pcapi.routes.serialization import users as users_serialization
@@ -208,7 +210,7 @@ def create_account(
         external_attributes_api.update_external_user(user)
 
     if not user.isEmailValidated and send_activation_mail:
-        request_email_confirmation(user)
+        on_commit(partial(request_email_confirmation, user))
 
     return user
 

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -229,6 +229,7 @@ def get_email_update_token_expiration_date(user: users_models.User) -> serialize
 
 @blueprint.native_route("/account", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api, on_error_statuses=[400])
+@atomic()
 def create_account(body: serializers.AccountRequest) -> None:
     if FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA.is_active():
         try:

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
     api=blueprint.api,
 )
 @authenticated_and_active_user_required
+@atomic()
 def get_user_profile(user: users_models.User) -> serializers.UserProfileResponse:
     return serializers.UserProfileResponse.from_orm(user)
 

--- a/api/src/pcapi/routes/native/v1/banner.py
+++ b/api/src/pcapi/routes/native/v1/banner.py
@@ -4,6 +4,7 @@ import pcapi.core.banner.api as banner_api
 from pcapi.core.fraud import models as fraud_models
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.users import models as users_models
+from pcapi.repository import atomic
 from pcapi.routes.native import blueprint
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.routes.native.v1.serialization import banner as serializers
@@ -13,6 +14,7 @@ from pcapi.serialization.decorator import spectree_serialize
 @blueprint.native_route("/banner", methods=["GET"])
 @spectree_serialize(on_success_status=200, api=blueprint.api, response_model=serializers.BannerResponse)
 @authenticated_and_active_user_required
+@atomic()
 def get_banner(user: users_models.User, query: serializers.BannerQueryParams) -> serializers.BannerResponse | None:
     joined_user = (
         users_models.User.query.filter_by(id=user.id)

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -11,6 +11,7 @@ from pcapi.core.offers.models import Stock
 from pcapi.core.providers.exceptions import InactiveProvider
 from pcapi.core.users.models import User
 from pcapi.models.api_errors import ApiErrors
+from pcapi.repository import atomic
 from pcapi.repository import repository
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.routes.native.v1.serialization.bookings import BookOfferRequest
@@ -105,6 +106,7 @@ def book_offer(user: User, body: BookOfferRequest) -> BookOfferResponse:
 @blueprint.native_route("/bookings", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=BookingsResponse)
 @authenticated_and_active_user_required
+@atomic()
 def get_bookings(user: User) -> BookingsResponse:
     individual_bookings = bookings_api.get_individual_bookings(user)
     ended_bookings, ongoing_bookings = bookings_api.classify_and_sort_bookings(individual_bookings)

--- a/api/src/pcapi/routes/native/v1/cultural_survey.py
+++ b/api/src/pcapi/routes/native/v1/cultural_survey.py
@@ -4,6 +4,7 @@ import logging
 from pcapi.core.cultural_survey import cultural_survey
 from pcapi.core.external.attributes.api import update_external_user
 from pcapi.core.users import models as users_models
+from pcapi.repository import atomic
 from pcapi.repository import transaction
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
     api=blueprint.api,
 )
 @authenticated_and_active_user_required
+@atomic()
 def get_cultural_survey_questions(user: users_models.User) -> serializers.CulturalSurveyQuestionsResponse:
     return serializers.CulturalSurveyQuestionsResponse(
         questions=cultural_survey.ALL_CULTURAL_SURVEY_QUESTIONS,

--- a/api/src/pcapi/routes/native/v1/favorites.py
+++ b/api/src/pcapi/routes/native/v1/favorites.py
@@ -181,6 +181,7 @@ def get_favorites_for(user: User, favorite_id: int | None = None) -> list[Favori
 @blueprint.native_route("/me/favorites", methods=["GET"])
 @spectree_serialize(response_model=serializers.PaginatedFavoritesResponse, api=blueprint.api)
 @authenticated_and_active_user_required
+@atomic()
 def get_favorites(user: User) -> serializers.PaginatedFavoritesResponse:
     favorites = get_favorites_for(user)
 

--- a/api/src/pcapi/routes/native/v1/favorites.py
+++ b/api/src/pcapi/routes/native/v1/favorites.py
@@ -25,6 +25,7 @@ from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ResourceNotFoundError
+from pcapi.repository import atomic
 from pcapi.repository import transaction
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
@@ -81,6 +82,7 @@ def _fill_favorite_offer(
 @blueprint.native_route("/me/favorites/count", methods=["GET"])
 @spectree_serialize(response_model=serializers.FavoritesCountResponse, api=blueprint.api)
 @authenticated_and_active_user_required
+@atomic()
 def get_favorites_count(user: User) -> serializers.FavoritesCountResponse:
     return serializers.FavoritesCountResponse(count=Favorite.query.filter_by(user=user).count())
 

--- a/api/src/pcapi/routes/native/v1/offerers.py
+++ b/api/src/pcapi/routes/native/v1/offerers.py
@@ -12,6 +12,7 @@ from .serialization import offerers as serializers
 # It will break the WebApp v2 proxy in case of endpoint modification. Read https://github.com/pass-culture/pass-culture-app-native/pull/2808/files#r844891000
 @blueprint.native_route("/venue/<int:venue_id>", methods=["GET"])
 @spectree_serialize(response_model=serializers.VenueResponse, api=blueprint.api, on_error_statuses=[404])
+@atomic()
 def get_venue(venue_id: int) -> serializers.VenueResponse:
     venue = Venue.query.get_or_404(venue_id)
     if not venue.isPermanent:

--- a/api/src/pcapi/routes/native/v1/offers.py
+++ b/api/src/pcapi/routes/native/v1/offers.py
@@ -97,6 +97,7 @@ def report_offer(user: User, offer_id: int, body: serializers.OfferReportRequest
 @blueprint.native_route("/offer/report/reasons", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=serializers.OfferReportReasons)
 @authenticated_and_active_user_required
+@atomic()
 def report_offer_reasons(user: User) -> serializers.OfferReportReasons:
     return serializers.OfferReportReasons(reasons=Reason.get_full_meta())
 
@@ -104,6 +105,7 @@ def report_offer_reasons(user: User) -> serializers.OfferReportReasons:
 @blueprint.native_route("/offers/reports", methods=["GET"])
 @spectree_serialize(on_success_status=200, api=blueprint.api, response_model=serializers.UserReportedOffersResponse)
 @authenticated_and_active_user_required
+@atomic()
 def user_reported_offers(user: User) -> serializers.UserReportedOffersResponse:
     return serializers.UserReportedOffersResponse(reportedOffers=user.reported_offers)  # type: ignore[call-arg]
 
@@ -111,6 +113,7 @@ def user_reported_offers(user: User) -> serializers.UserReportedOffersResponse:
 @blueprint.native_route("/send_offer_webapp_link_by_email/<int:offer_id>", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
 @authenticated_and_active_user_required
+@atomic()
 def send_offer_app_link(user: User, offer_id: int) -> None:
     """
     On iOS native app, users cannot book numeric offers with price > 0, so
@@ -127,6 +130,7 @@ def send_offer_app_link(user: User, offer_id: int) -> None:
 @blueprint.native_route("/send_offer_link_by_push/<int:offer_id>", methods=["POST"])
 @spectree_serialize(on_success_status=204, api=blueprint.api)
 @authenticated_and_active_user_required
+@atomic()
 def send_offer_link_by_push(user: User, offer_id: int) -> None:
     offer = Offer.query.get_or_404(offer_id)
     if offer.validation != OfferValidationStatus.APPROVED:
@@ -136,6 +140,7 @@ def send_offer_link_by_push(user: User, offer_id: int) -> None:
 
 @blueprint.native_route("/subcategories/v2", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=subcategories_v2_serializers.SubcategoriesResponseModelv2)
+@atomic()
 def get_subcategories_v2() -> subcategories_v2_serializers.SubcategoriesResponseModelv2:
     return subcategories_v2_serializers.SubcategoriesResponseModelv2(
         subcategories=[
@@ -163,6 +168,7 @@ def get_subcategories_v2() -> subcategories_v2_serializers.SubcategoriesResponse
 
 @blueprint.native_route("/categories", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=subcategories_v2_serializers.CategoriesResponseModel)
+@atomic()
 def get_categories() -> subcategories_v2_serializers.CategoriesResponseModel:
     return subcategories_v2_serializers.CategoriesResponseModel(
         categories=[

--- a/api/src/pcapi/routes/native/v1/reaction.py
+++ b/api/src/pcapi/routes/native/v1/reaction.py
@@ -24,6 +24,7 @@ def post_reaction(user: users_models.User, body: serialization.PostReactionReque
 @blueprint.native_route("/reaction/available", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=serialization.GetAvailableReactionsResponse)
 @authenticated_and_active_user_required
+@atomic()
 def get_available_reactions(user: users_models.User) -> serialization.GetAvailableReactionsResponse:
     booking_with_available_reactions = reactions_api.get_bookings_with_available_reactions(user.id)
 

--- a/api/src/pcapi/routes/native/v1/recommendation.py
+++ b/api/src/pcapi/routes/native/v1/recommendation.py
@@ -4,6 +4,7 @@ import pcapi.connectors.recommendation as recommendation_api
 import pcapi.core.users.models as users_models
 import pcapi.core.users.repository as users_repository
 from pcapi.models.api_errors import ApiErrors
+from pcapi.repository import atomic
 from pcapi.routes.native import blueprint
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
@@ -14,6 +15,7 @@ from .serialization import recommendation as serializers
 @blueprint.native_route("/recommendation/similar_offers/<int:offer_id>", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=serializers.SimilarOffersResponse)
 @flask_jwt_extended.jwt_required(optional=True)
+@atomic()
 def similar_offers(
     offer_id: int,
     query: serializers.SimilarOffersRequestQuery,

--- a/api/src/pcapi/routes/native/v1/settings.py
+++ b/api/src/pcapi/routes/native/v1/settings.py
@@ -1,5 +1,6 @@
 from pcapi.core.users import constants
 from pcapi.models.feature import FeatureToggle
+from pcapi.repository import atomic
 from pcapi.repository import feature_queries
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.settings import OBJECT_STORAGE_URL
@@ -19,6 +20,7 @@ def _get_features(*requested_features: FeatureToggle) -> dict[FeatureToggle, boo
 
 @blueprint.native_route("/settings", methods=["GET"])
 @spectree_serialize(api=blueprint.api, response_model=serializers.SettingsResponse)
+@atomic()
 def get_settings() -> serializers.SettingsResponse:
     features = _get_features(
         FeatureToggle.DISPLAY_DMS_REDIRECTION,

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -13,6 +13,7 @@ from pcapi.core.subscription import profile_options
 from pcapi.core.subscription.ubble import api as ubble_subscription_api
 from pcapi.core.users import models as users_models
 from pcapi.models import api_errors
+from pcapi.repository import atomic
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils import requests as requests_utils
@@ -32,6 +33,7 @@ logger = logging.getLogger(__name__)
     deprecated=True,
 )
 @authenticated_and_active_user_required
+@atomic()
 def next_subscription_step(
     user: users_models.User,
 ) -> serializers.NextSubscriptionStepResponse | None:
@@ -61,6 +63,7 @@ def next_subscription_step(
     deprecated=True,
 )
 @authenticated_and_active_user_required
+@atomic()
 def get_subscription_stepper_deprecated(user: users_models.User) -> serializers.SubscriptionStepperResponse:
     user_subscription_state = subscription_api.get_user_subscription_state(user)
     stepper_header = subscription_api.get_stepper_title_and_subtitle(user, user_subscription_state)
@@ -95,6 +98,7 @@ def get_subscription_stepper_deprecated(user: users_models.User) -> serializers.
     api=blueprint.api,
 )
 @authenticated_and_active_user_required
+@atomic()
 def get_subscription_stepper(user: users_models.User) -> serializers.SubscriptionStepperResponseV2:
     user_subscription_state = subscription_api.get_user_subscription_state(user)
     stepper_header = subscription_api.get_stepper_title_and_subtitle(user, user_subscription_state)
@@ -123,6 +127,7 @@ def get_subscription_stepper(user: users_models.User) -> serializers.Subscriptio
 @blueprint.native_route("/subscription/profile", methods=["GET"])
 @spectree_serialize(on_success_status=200, on_error_statuses=[404], api=blueprint.api)
 @authenticated_and_active_user_required
+@atomic()
 def get_profile(user: users_models.User) -> serializers.ProfileResponse | None:
     if (profile_data := subscription_api.get_profile_data(user)) is not None:
         try:
@@ -161,6 +166,7 @@ def complete_profile(user: users_models.User, body: serializers.ProfileUpdateReq
     api=blueprint.api,
 )
 @authenticated_and_active_user_required
+@atomic()
 def get_activity_types(user: users_models.User) -> serializers.ActivityTypesResponse:
     activities = [serializers.ActivityResponseModel.from_orm(activity) for activity in profile_options.ALL_ACTIVITIES]
     middle_school = serializers.ActivityResponseModel.from_orm(profile_options.MIDDLE_SCHOOL_STUDENT)

--- a/api/src/pcapi/routes/native/v2/account.py
+++ b/api/src/pcapi/routes/native/v2/account.py
@@ -22,6 +22,7 @@ from .serialization import account as serializers
 @blueprint.native_route("/profile/email_update/status", version="v2", methods=["GET"])
 @spectree_serialize(on_success_status=200, api=blueprint.api, response_model=serializers.EmailUpdateStatusResponse)
 @authenticated_and_active_user_required
+@atomic()
 def get_email_update_status(user: users_models.User) -> serializers.EmailUpdateStatusResponse:
     latest_email_update_event = email_repository.get_email_update_latest_event(user)
     if not latest_email_update_event:

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -477,7 +477,6 @@ class AccountCreationTest:
         expected_num_queries += 1  # user
         expected_num_queries += 1  # user
         expected_num_queries += 1  # user (insert)
-        expected_num_queries += 1  # user
         expected_num_queries += 1  # bookings
         expected_num_queries += 1  # favorites
         expected_num_queries += 1  # deposit
@@ -1518,7 +1517,9 @@ class GetEMailUpdateStatusTest:
         user = users_factories.UserFactory(email=self.old_email)
 
         client = client.with_token(user.email)
-        expected_num_queries = 2  # user + user_email_history
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # user_email_history
+        expected_num_queries += 1  # atomic rollback to savepoint
         with assert_num_queries(expected_num_queries):
             response = client.get("/native/v1/profile/email_update/status")
             assert response.status_code == 404
@@ -2684,6 +2685,7 @@ class GetAccountSuspendedDateTest:
             client.with_token(email=user.email)
 
             expected_num_queries = 2  # user + action_history
+            expected_num_queries += 1  # atomic rollback to savepoint
             with assert_num_queries(expected_num_queries):
                 response = client.get("/native/v1/account/suspension_date")
                 assert response.status_code == 403

--- a/api/tests/routes/native/v1/offerers_test.py
+++ b/api/tests/routes/native/v1/offerers_test.py
@@ -171,12 +171,16 @@ class VenuesTest:
     def test_get_non_permanent_venue(self, client):
         venue = offerers_factories.VenueFactory(isPermanent=False)
         venue_id = venue.id
-        with assert_num_queries(1):  # venue
+        num_queries = 1  # venue
+        num_queries += 1  # atomic rollback to savepoint
+        with assert_num_queries(num_queries):
             response = client.get(f"/native/v1/venue/{venue_id}")
             assert response.status_code == 404
 
     def test_get_non_existing_venue(self, client):
-        with assert_num_queries(1):  # venue
+        num_queries = 1  # venue
+        num_queries += 1  # atomic rollback to savepoint
+        with assert_num_queries(num_queries):
             response = client.get("/native/v1/venue/123456789")
             assert response.status_code == 404
 

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -1345,7 +1345,9 @@ class GetProfileTest:
         user = users_factories.BeneficiaryGrant18Factory()
 
         client.with_token(user.email)
-        with assert_num_queries(self.expected_num_queries):
+        num_queries = self.expected_num_queries
+        num_queries += 1  # atomic rollback to savepoint
+        with assert_num_queries(num_queries):
             response = client.get("/native/v1/subscription/profile")
             assert response.status_code == 404
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33067
Partie a priori triviale de l'ajout d'`atomic` sur les routes natives

Notion de suivi d'avancement: https://www.notion.so/passcultureapp/Retirer-flask-pytest-sqlalchemy-2a4bbf96d0ab43de843d0ace3652c619?pvs=4#4925eebc677d4e368724d5007a3dd9a7
