### PR TITLE
(BSR) [API] Apply `catch_cinema_provider_request_timeout` to cinema API client

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -415,6 +415,9 @@ def _book_cinema_external_ticket(booking: Booking, stock: Stock, beneficiary: Us
     except external_bookings_exceptions.ExternalBookingSoldOutError as exc:
         logger.exception("Could not book this offer as it's sold out.")
         raise exc
+    except external_bookings_exceptions.ExternalBookingTimeoutException as exc:
+        logger.exception("Could not book this offer as the request timed out.")
+        raise exc
     except Exception as exc:
         logger.exception("Could not book external ticket: %s", exc)
         raise external_bookings_exceptions.ExternalBookingException

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -40,6 +40,7 @@ import pcapi.core.external_bookings.api as external_bookings_api
 from pcapi.core.external_bookings.boost.exceptions import BoostAPIException
 from pcapi.core.external_bookings.cds.exceptions import CineDigitalServiceAPIException
 from pcapi.core.external_bookings.cgr.exceptions import CGRAPIException
+from pcapi.core.external_bookings.exceptions import ExternalBookingTimeoutException
 from pcapi.core.finance import api as finance_api
 from pcapi.core.finance import models as finance_models
 import pcapi.core.finance.conf as finance_conf
@@ -1441,7 +1442,13 @@ def update_stock_quantity_to_match_cinema_venue_provider_remaining_places(offer:
 
     try:
         shows_remaining_places = get_shows_remaining_places_from_provider(venue_provider.provider.localClass, offer)
-    except (EMSAPIException, BoostAPIException, CineDigitalServiceAPIException, CGRAPIException) as e:
+    except (
+        EMSAPIException,
+        BoostAPIException,
+        CineDigitalServiceAPIException,
+        CGRAPIException,
+        ExternalBookingTimeoutException,
+    ) as e:
         # If we can't retrieve the stocks from the provider, we stop here to avoid breaking the code following this function
         # This is not ideal, I believe this function should be called on its own, or asynchronously
         # However this means frontend code (probably) so this temporarily fixes crashes for end users

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -93,6 +93,8 @@ def book_offer(user: User, body: BookOfferRequest) -> BookOfferResponse:
             extra={"offer_id": stock.offer.id, "provider_id": stock.offer.lastProviderId},
         )
         raise ApiErrors({"code": "CINEMA_PROVIDER_BOOKING_FAILED"})
+    except external_bookings_exceptions.ExternalBookingTimeoutException:
+        raise ApiErrors({"code": "PROVIDER_RESPONSE_TIMEOUT"})
     except external_bookings_exceptions.ExternalBookingSoldOutError:
         raise ApiErrors({"code": "PROVIDER_STOCK_SOLD_OUT"})
     except external_bookings_exceptions.ExternalBookingNotEnoughSeatsError:

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -589,7 +589,7 @@ class BookOfferTest:
             url = EMSBookingConnector()._build_url("VENTE", payload)
             booking_adapter = requests_mock.post(url=re.compile(rf"{url}"), exc=exception)
 
-            with pytest.raises(external_bookings_exceptions.ExternalBookingException):
+            with pytest.raises(external_bookings_exceptions.ExternalBookingTimeoutException):
                 api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
 
             assert not Booking.query.all()
@@ -700,7 +700,7 @@ class BookOfferTest:
             url = EMSBookingConnector()._build_url("VENTE", payload)
             booking_adapter = requests_mock.post(url=re.compile(rf"{url}"), exc=exception)
 
-            with pytest.raises(external_bookings_exceptions.ExternalBookingException):
+            with pytest.raises(external_bookings_exceptions.ExternalBookingTimeoutException):
                 api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
 
             assert not Booking.query.all()
@@ -781,7 +781,7 @@ class BookOfferTest:
             url = EMSBookingConnector()._build_url("VENTE", payload)
             booking_adapter = requests_mock.post(url=re.compile(rf"{url}"), exc=exception)
 
-            with pytest.raises(external_bookings_exceptions.ExternalBookingException):
+            with pytest.raises(external_bookings_exceptions.ExternalBookingTimeoutException):
                 api.book_offer(beneficiary=beneficiary, stock_id=stock.id, quantity=1)
 
             assert not Booking.query.all()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
