### PR TITLE
(BSR)[API] feat: apply `atomic` to public API `providers` endpoints

### DIFF
--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -354,7 +354,8 @@ def update_venue_provider_external_urls(
     )
 
     if is_deletion:
-        repository.delete(venue_provider_external_urls)
+        db.session.delete(venue_provider_external_urls)
+        db.session.flush()
         return
 
     if is_creation:
@@ -372,8 +373,8 @@ def update_venue_provider_external_urls(
     if cancel_external_url != UNCHANGED:
         venue_provider_external_urls.cancelExternalUrl = cancel_external_url
 
-    repository.save(venue_provider_external_urls)
-
+    db.session.add(venue_provider_external_urls)
+    db.session.flush()
     return
 
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/providers.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/providers.py
@@ -2,6 +2,7 @@ from pcapi.core.providers import api as providers_api
 from pcapi.core.providers import exceptions as providers_exceptions
 from pcapi.core.providers import repository as providers_repository
 from pcapi.models import api_errors
+from pcapi.repository import atomic
 from pcapi.routes.public import blueprints
 from pcapi.routes.public import spectree_schemas
 from pcapi.routes.public.documentation_constants import http_responses
@@ -15,6 +16,7 @@ from pcapi.validation.routes.users_authentifications import provider_api_key_req
 
 
 @blueprints.public_api.route("/public/providers/v1/provider", methods=["GET"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
@@ -38,6 +40,7 @@ def get_provider() -> providers_serialization.ProviderResponse:
 
 
 @blueprints.public_api.route("/public/providers/v1/provider", methods=["PATCH"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
@@ -86,6 +89,7 @@ def update_provider(body: providers_serialization.ProviderUpdate) -> providers_s
 
 
 @blueprints.public_api.route("/public/providers/v1/venues/<int:venue_id>", methods=["PATCH"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     on_success_status=204,

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -827,6 +827,7 @@ class UpdateVenueProviderExternalUrlsTest:
         previous_notification_url = venue_provider_external_urls.notificationExternalUrl
 
         api.update_venue_provider_external_urls(venue_provider, booking_external_url=None, cancel_external_url=None)
+        db.session.commit()
 
         # Should have unset ticketing urls
         assert venue_provider_external_urls.bookingExternalUrl == None
@@ -847,6 +848,7 @@ class UpdateVenueProviderExternalUrlsTest:
         api.update_venue_provider_external_urls(
             venue_provider, booking_external_url=None, cancel_external_url=None, notification_external_url=None
         )
+        db.session.commit()
 
         # Should have deleted `venue_provider_external_urls`
         assert venue_provider.externalUrls == None
@@ -868,6 +870,7 @@ class UpdateVenueProviderExternalUrlsTest:
             booking_external_url=None,
             cancel_external_url=None,
         )
+        db.session.commit()
 
         # Should have deleted `venue_provider_external_urls`
         assert venue_provider.externalUrls == None
@@ -889,6 +892,7 @@ class UpdateVenueProviderExternalUrlsTest:
             venue_provider,
             notification_external_url=None,
         )
+        db.session.commit()
 
         # Should have deleted `venue_provider_external_urls`
         assert venue_provider.externalUrls == None

--- a/api/tests/routes/public/helpers.py
+++ b/api/tests/routes/public/helpers.py
@@ -12,6 +12,7 @@ from pcapi.core.offers import models as offers_models
 from pcapi.core.providers import factories as providers_factories
 from pcapi.core.providers import models as providers_models
 from pcapi.models import db
+from pcapi.repository import is_managed_transaction
 
 from tests.conftest import TestClient
 
@@ -23,6 +24,9 @@ class PublicAPIEndpointBaseHelper:
     """
     For Public API endpoints that require authentication
     """
+
+    expected_401_queries_count = 1  # Select API key
+    expected_401_queries_count += 1  # select feature
 
     @property
     def endpoint_url(self):
@@ -70,7 +74,8 @@ class PublicAPIEndpointBaseHelper:
 
         if self.default_path_params:
             url = url.format(**self.default_path_params)
-        with testing.assert_num_queries(2):  # Select API key + select provider
+
+        with testing.assert_num_queries(self.expected_401_queries_count):
             response = client_method(url)
             assert response.status_code == 401
 

--- a/api/tests/routes/public/individual_offers/v1/patch_provider_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_provider_test.py
@@ -15,6 +15,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class PatchProviderTest(PublicAPIEndpointBaseHelper):
     endpoint_url = "/public/providers/v1/provider"
     endpoint_method = "patch"
+    expected_401_queries_count = 3
 
     def test_should_raise_401_because_api_key_is_not_linked_to_provider(self, client: TestClient):
         old_api_key = self.setup_old_api_key()

--- a/api/tests/routes/public/individual_offers/v1/patch_venue_provider_external_urls_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_venue_provider_external_urls_test.py
@@ -15,6 +15,7 @@ class PatchVenueProviderExternalUrlsTest(PublicAPIVenueEndpointHelper):
     endpoint_url = "/public/providers/v1/venues/{venue_id}"
     endpoint_method = "patch"
     default_path_params = {"venue_id": 1}
+    expected_401_queries_count = 3
 
     def test_should_raise_401_because_api_key_is_not_linked_to_provider(self, client: TestClient):
         old_api_key = self.setup_old_api_key()


### PR DESCRIPTION
## But de la pull request

Mettre en place atomic sur les endpoints providers de l'API publique

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
