### PR TITLE
(PC-32360)[PRO] feat: Display edition buttons on collective recap bas…

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/CollectiveOfferSummary/CollectiveOfferSummary.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/CollectiveOfferSummary/CollectiveOfferSummary.spec.tsx
@@ -1,7 +1,13 @@
 import { screen, waitForElementToBeRemoved } from '@testing-library/react'
 import { expect } from 'vitest'
 
-import { EacFormat, OfferContactFormEnum } from 'apiClient/v1'
+import {
+  CollectiveOfferAllowedAction,
+  CollectiveOfferStatus,
+  CollectiveOfferTemplateAllowedAction,
+  EacFormat,
+  OfferContactFormEnum,
+} from 'apiClient/v1'
 import {
   getCollectiveOfferFactory,
   getCollectiveOfferTemplateFactory,
@@ -156,6 +162,173 @@ describe('CollectiveOfferSummary', () => {
     expect(
       screen.queryByRole('link', { name: 'Modifier' })
     ).not.toBeInTheDocument()
+  })
+
+  it('should display the edition button when the FF ENABLE_COLLECTIVE_NEW_STATUSES is disabled and the offer is template', async () => {
+    renderCollectiveOfferSummary({
+      ...props,
+      offer: getCollectiveOfferTemplateFactory(),
+      offerEditLink: '123',
+    })
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getByRole('link', { name: 'Modifier' })).toBeInTheDocument()
+  })
+
+  it('should display the edition buttons when the FF ENABLE_COLLECTIVE_NEW_STATUSES is disabled and the offer is not archived', async () => {
+    renderCollectiveOfferSummary({
+      ...props,
+      offer: getCollectiveOfferFactory({
+        status: CollectiveOfferStatus.ACTIVE,
+      }),
+      offerEditLink: '123',
+      stockEditLink: '234',
+      visibilityEditLink: '345',
+    })
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getAllByRole('link', { name: 'Modifier' })).toHaveLength(3)
+  })
+
+  it('should display the edition buttons when the FF ENABLE_COLLECTIVE_NEW_STATUSES is enabled the template offer can be edited', async () => {
+    renderCollectiveOfferSummary(
+      {
+        ...props,
+        offer: getCollectiveOfferTemplateFactory({
+          allowedActions: [
+            CollectiveOfferTemplateAllowedAction.CAN_EDIT_DETAILS,
+          ],
+        }),
+        offerEditLink: '123',
+      },
+      { features: ['ENABLE_COLLECTIVE_NEW_STATUSES'] }
+    )
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getByRole('link', { name: 'Modifier' })).toBeInTheDocument()
+  })
+
+  it('should not display the edition buttons when the FF ENABLE_COLLECTIVE_NEW_STATUSES is enabled the template offer cannot be edited', async () => {
+    renderCollectiveOfferSummary(
+      {
+        ...props,
+        offer: getCollectiveOfferTemplateFactory({
+          allowedActions: [CollectiveOfferTemplateAllowedAction.CAN_ARCHIVE],
+        }),
+        offerEditLink: '123',
+      },
+      { features: ['ENABLE_COLLECTIVE_NEW_STATUSES'] }
+    )
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(
+      screen.queryByRole('link', { name: 'Modifier' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not display the edition buttons when the FF ENABLE_COLLECTIVE_NEW_STATUSES is enabled the bookable offer cannot be edited', async () => {
+    renderCollectiveOfferSummary(
+      {
+        ...props,
+        offer: getCollectiveOfferFactory({
+          allowedActions: [CollectiveOfferAllowedAction.CAN_ARCHIVE],
+        }),
+        offerEditLink: '123',
+      },
+      { features: ['ENABLE_COLLECTIVE_NEW_STATUSES'] }
+    )
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(
+      screen.queryByRole('link', { name: 'Modifier' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should display one edition button when the FF ENABLE_COLLECTIVE_NEW_STATUSES is enabled and the offer description is editable', async () => {
+    renderCollectiveOfferSummary(
+      {
+        ...props,
+        offer: getCollectiveOfferFactory({
+          allowedActions: [CollectiveOfferAllowedAction.CAN_EDIT_DETAILS],
+        }),
+        offerEditLink: '123',
+      },
+      { features: ['ENABLE_COLLECTIVE_NEW_STATUSES'] }
+    )
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.queryByRole('link', { name: 'Modifier' })).toBeInTheDocument()
+  })
+
+  it('should display two edition buttons when the FF ENABLE_COLLECTIVE_NEW_STATUSES is enabled and the offer description and price are editable', async () => {
+    renderCollectiveOfferSummary(
+      {
+        ...props,
+        offer: getCollectiveOfferFactory({
+          allowedActions: [
+            CollectiveOfferAllowedAction.CAN_EDIT_DETAILS,
+            CollectiveOfferAllowedAction.CAN_EDIT_DISCOUNT,
+          ],
+        }),
+        offerEditLink: '123',
+        stockEditLink: '234',
+      },
+      { features: ['ENABLE_COLLECTIVE_NEW_STATUSES'] }
+    )
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getAllByRole('link', { name: 'Modifier' })).toHaveLength(2)
+  })
+
+  it('should display two edition buttons when the FF ENABLE_COLLECTIVE_NEW_STATUSES is enabled and the offer description and dates are editable', async () => {
+    renderCollectiveOfferSummary(
+      {
+        ...props,
+        offer: getCollectiveOfferFactory({
+          allowedActions: [
+            CollectiveOfferAllowedAction.CAN_EDIT_DETAILS,
+            CollectiveOfferAllowedAction.CAN_EDIT_DATES,
+          ],
+        }),
+        offerEditLink: '123',
+        stockEditLink: '234',
+      },
+      { features: ['ENABLE_COLLECTIVE_NEW_STATUSES'] }
+    )
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getAllByRole('link', { name: 'Modifier' })).toHaveLength(2)
+  })
+
+  it('should display three edition buttons when the FF ENABLE_COLLECTIVE_NEW_STATUSES is enabled and the offer description, dates and institution are editable', async () => {
+    renderCollectiveOfferSummary(
+      {
+        ...props,
+        offer: getCollectiveOfferFactory({
+          allowedActions: [
+            CollectiveOfferAllowedAction.CAN_EDIT_DETAILS,
+            CollectiveOfferAllowedAction.CAN_EDIT_DATES,
+            CollectiveOfferAllowedAction.CAN_EDIT_INSTITUTION,
+          ],
+        }),
+        offerEditLink: '123',
+        stockEditLink: '234',
+        visibilityEditLink: '345',
+      },
+      { features: ['ENABLE_COLLECTIVE_NEW_STATUSES'] }
+    )
+
+    await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+
+    expect(screen.getAllByRole('link', { name: 'Modifier' })).toHaveLength(3)
   })
 
   describe('OA feature flag', () => {


### PR DESCRIPTION
…ed on allowed actions and status FF.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32360

**Objectif**
Afficher les boutons "Modifier" du récap d'une offre collective en fonction des `allowedActions` de l'offre et de l'activation du FF `ENABLE_COLLECTIVE_NEW_STATUSES`.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
