### PR TITLE
(BSR)[PRO] test: use beforeEach bc before not used when retry

### DIFF
--- a/pro/cypress/e2e/createAccount.cy.ts
+++ b/pro/cypress/e2e/createAccount.cy.ts
@@ -1,7 +1,7 @@
 import { logAndGoToPage } from '../support/helpers.ts'
 
 describe('Account creation', () => {
-  before(() => {
+  beforeEach(() => {
     cy.visit('/inscription')
     cy.request({
       method: 'GET',

--- a/pro/cypress/e2e/desk.cy.ts
+++ b/pro/cypress/e2e/desk.cy.ts
@@ -5,7 +5,7 @@ import { logAndGoToPage } from '../support/helpers.ts'
 describe('Desk (Guichet) feature', () => {
   let login: string
 
-  before(() => {
+  beforeEach(() => {
     cy.visit('/connexion')
     cy.request({
       method: 'GET',

--- a/pro/cypress/e2e/editDigitalIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/editDigitalIndividualOffer.cy.ts
@@ -6,7 +6,7 @@ describe('Edit digital individual offers', () => {
   let login: string
 
   describe('Display and url modification', () => {
-    before(() => {
+    beforeEach(() => {
       cy.visit('/connexion')
       cy.request({
         method: 'GET',
@@ -84,7 +84,7 @@ describe('Edit digital individual offers', () => {
   })
 
   describe('Modification of date event offer with bookings', () => {
-    before(() => {
+    beforeEach(() => {
       cy.visit('/connexion')
       cy.request({
         method: 'GET',

--- a/pro/cypress/e2e/searchCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/searchCollectiveOffer.cy.ts
@@ -8,7 +8,7 @@ describe('Search collective offers', () => {
   const venueName = 'Mon Lieu'
   const offerName = 'Mon offre collective'
 
-  before(() => {
+  beforeEach(() => {
     cy.visit('/connexion')
     cy.request({
       method: 'GET',


### PR DESCRIPTION
## But de la pull request

Le retry ne pouvait pas fonctionner avec un `before(()`donc on met `beforeEach(()`. Voir https://cloud.cypress.io/projects/rit5sb/runs/1450/overview/1c0ba722-dbcf-4237-b6a9-5cc7d89e065c/replay?att=1&roarHideRunsWithDiffGroupsAndTags=1&ts=1732011458668.2002

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
