### PR TITLE
(BSR)[PRO] test: increase timeout in collaborateur list

### DIFF
--- a/pro/cypress/e2e/collaborator.cy.ts
+++ b/pro/cypress/e2e/collaborator.cy.ts
@@ -29,7 +29,8 @@ describe('Collaborator list feature', () => {
 
     cy.stepLog({ message: 'wait for collaborator page display' })
     cy.url().should('include', '/collaborateurs')
-    cy.contains(login)
+    cy.findAllByTestId('spinner').should('not.exist')
+    cy.contains(login, { timeout: 60000 })
 
     cy.stepLog({ message: 'add a collaborator in the list' })
     cy.findByText('Ajouter un collaborateur').click()
@@ -45,7 +46,10 @@ describe('Collaborator list feature', () => {
     cy.stepLog({
       message: 'check login validated and new collaborator waiting status',
     })
-    cy.contains(randomEmail).next().should('have.text', 'En attente')
+    cy.findAllByTestId('spinner').should('not.exist')
+    cy.contains(randomEmail, { timeout: 60000 })
+      .next()
+      .should('have.text', 'En attente')
     cy.contains(login).next().should('have.text', 'Validé')
 
     cy.stepLog({ message: 'check email received by email' })


### PR DESCRIPTION
## But de la pull request

Timeout et spinner pour l'affichage de la liste des collaborateurs qui traine parfois et rend le test flaky

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
