### PR TITLE
(PC-33041)[API] Increase request timeout for external bookings

### DIFF
--- a/api/src/pcapi/connectors/cgr/cgr.py
+++ b/api/src/pcapi/connectors/cgr/cgr.py
@@ -30,7 +30,9 @@ def get_cgr_service_proxy(cinema_url: str, request_timeout: int | None = None) -
 
 
 def get_seances_pass_culture(
-    cinema_details: providers_models.CGRCinemaDetails, allocine_film_id: int = 0
+    cinema_details: providers_models.CGRCinemaDetails,
+    allocine_film_id: int = 0,
+    request_timeout: int | None = None,
 ) -> cgr_serializers.GetSancesPassCultureResponse:
     """
     if allocine_film_id is 0 CGR API will return all future shows
@@ -39,7 +41,7 @@ def get_seances_pass_culture(
     user = settings.CGR_API_USER
     password = decrypt(cinema_details.password)
     cinema_url = cinema_details.cinemaUrl
-    service = get_cgr_service_proxy(cinema_url)
+    service = get_cgr_service_proxy(cinema_url, request_timeout=request_timeout)
     response = service.GetSeancesPassCulture(User=user, mdp=password, IDFilmAllocine=str(allocine_film_id))
     response = json.loads(response)
     _check_response_is_ok(response, "GetSeancesPassCulture")

--- a/api/src/pcapi/connectors/cine_digital_service.py
+++ b/api/src/pcapi/connectors/cine_digital_service.py
@@ -46,9 +46,11 @@ def get_resource(
     cinema_api_token: str | None,
     resource: ResourceCDS,
     path_params: dict[str, Any] | None = None,
+    *,
+    request_timeout: int | None = None,
 ) -> dict | list[dict] | list:
     url = _build_url(api_url, account_id, cinema_api_token, resource, path_params)
-    response = requests.get(url)
+    response = requests.get(url, timeout=request_timeout)
 
     _check_response_is_ok(response, cinema_api_token, f"GET {resource}")
 
@@ -56,11 +58,17 @@ def get_resource(
 
 
 def put_resource(
-    api_url: str, account_id: str, cinema_api_token: str | None, resource: ResourceCDS, body: BaseModel
+    api_url: str,
+    account_id: str,
+    cinema_api_token: str | None,
+    resource: ResourceCDS,
+    body: BaseModel,
+    *,
+    request_timeout: int | None = None,
 ) -> dict | list[dict] | list | None:
     url = _build_url(api_url, account_id, cinema_api_token, resource)
     headers = {"Content-Type": "application/json"}
-    response = requests.put(url, headers=headers, data=body.json(by_alias=True))
+    response = requests.put(url, headers=headers, data=body.json(by_alias=True), timeout=request_timeout)
 
     _check_response_is_ok(response, cinema_api_token, f"PUT {resource}")
 
@@ -71,11 +79,17 @@ def put_resource(
 
 
 def post_resource(
-    api_url: str, account_id: str, cinema_api_token: str | None, resource: ResourceCDS, body: BaseModel
+    api_url: str,
+    account_id: str,
+    cinema_api_token: str | None,
+    resource: ResourceCDS,
+    body: BaseModel,
+    *,
+    request_timeout: int | None = None,
 ) -> dict:
     url = _build_url(api_url, account_id, cinema_api_token, resource)
     headers = {"Content-Type": "application/json"}
-    response = requests.post(url, headers=headers, data=body.json(by_alias=True))
+    response = requests.post(url, headers=headers, data=body.json(by_alias=True), timeout=request_timeout)
 
     _check_response_is_ok(response, cinema_api_token, f"POST {resource}")
 

--- a/api/src/pcapi/connectors/ems.py
+++ b/api/src/pcapi/connectors/ems.py
@@ -95,7 +95,7 @@ class EMSBookingConnector:
     shows_availability_endpoint = "SEANCE"
     cancelation_endpoint = "ANNULATION"
 
-    def do_request(self, endpoint: str, payload: dict) -> requests.Response:
+    def do_request(self, endpoint: str, payload: dict, request_timeout: int | None = None) -> requests.Response:
         """
         Perform the actual request, using mandatory headers
         and hashed payload.
@@ -104,7 +104,7 @@ class EMSBookingConnector:
 
         headers = self._build_headers()
         url = self._build_url(endpoint, payload)
-        return requests.post(url, headers=headers, json=payload)
+        return requests.post(url, headers=headers, json=payload, timeout=request_timeout)
 
     def raise_for_status(self, response: requests.Response) -> None:
         response.raise_for_status()

--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -42,6 +42,8 @@ EXTERNAL_BOOKINGS_FF = (
     feature.FeatureToggle.DISABLE_EMS_EXTERNAL_BOOKINGS,
 )
 
+EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS = 12
+
 
 def get_shows_stock(venue_id: int, shows_id: list[int]) -> dict[str, int]:
     client = _get_external_bookings_client_api(venue_id)
@@ -127,6 +129,7 @@ def book_event_ticket(
         json=json_payload,
         hmac=hmac_signature,
         headers={"Content-Type": "application/json"},
+        timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
     )
     _check_external_booking_response_is_ok(response)
 
@@ -214,7 +217,13 @@ def cancel_event_ticket(
     if venue_provider and venue_provider.externalUrls and venue_provider.externalUrls.cancelExternalUrl:
         cancel_url = venue_provider.externalUrls.cancelExternalUrl
 
-    response = requests.post(cancel_url, json=json_payload, headers=headers, hmac=hmac_signature)
+    response = requests.post(
+        cancel_url,
+        json=json_payload,
+        headers=headers,
+        hmac=hmac_signature,
+        timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
+    )
     _check_external_booking_response_is_ok(response)
 
     try:

--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -83,13 +83,15 @@ def _get_external_bookings_client_api(venue_id: int) -> external_bookings_models
             cds_cinema_details = providers_repository.get_cds_cinema_details(cinema_id)
             cinema_api_token = cds_cinema_details.cinemaApiToken
             account_id = cds_cinema_details.accountId
-            return CineDigitalServiceAPI(cinema_id, account_id, api_url, cinema_api_token)
+            return CineDigitalServiceAPI(
+                cinema_id, account_id, api_url, cinema_api_token, request_timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS
+            )
         case "BoostStocks":
-            return BoostClientAPI(cinema_id)
+            return BoostClientAPI(cinema_id, request_timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS)
         case "CGRStocks":
-            return CGRClientAPI(cinema_id)
+            return CGRClientAPI(cinema_id, request_timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS)
         case "EMSStocks":
-            return EMSClientAPI(cinema_id)
+            return EMSClientAPI(cinema_id, request_timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS)
         case _:
             raise ValueError(f"Unknown Provider: {cinema_venue_provider.provider.localClass}")
 

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -66,7 +66,12 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             sale_cancel_items.append(sale_cancel_item)
 
         sale_cancel = boost_serializers.SaleCancel(sales=sale_cancel_items)
-        boost.put_resource(self.cinema_id, boost.ResourceBoost.CANCEL_ORDER_SALE, sale_cancel)
+        boost.put_resource(
+            self.cinema_id,
+            boost.ResourceBoost.CANCEL_ORDER_SALE,
+            sale_cancel,
+            request_timeout=self.request_timeout,
+        )
 
     def book_ticket(
         self, show_id: int, booking: bookings_models.Booking, beneficiary: users_models.User
@@ -81,11 +86,21 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
         sale_body = boost_serializers.SaleRequest(
             codePayment=constants.BOOST_PASS_CULTURE_CODE_PAYMENT, basketItems=basket_items, idsBeforeSale=None
         )
-        sale_preparation_response = boost.post_resource(self.cinema_id, boost.ResourceBoost.COMPLETE_SALE, sale_body)
+        sale_preparation_response = boost.post_resource(
+            self.cinema_id,
+            boost.ResourceBoost.COMPLETE_SALE,
+            sale_body,
+            request_timeout=self.request_timeout,
+        )
         sale_preparation = parse_obj_as(boost_serializers.SalePreparationResponse, sale_preparation_response)
 
         sale_body.idsBeforeSale = str(sale_preparation.data[0].id)
-        sale_response = boost.post_resource(self.cinema_id, boost.ResourceBoost.COMPLETE_SALE, sale_body)
+        sale_response = boost.post_resource(
+            self.cinema_id,
+            boost.ResourceBoost.COMPLETE_SALE,
+            sale_body,
+            request_timeout=self.request_timeout,
+        )
         sale_confirmation_response = parse_obj_as(boost_serializers.SaleConfirmationResponse, sale_response)
         add_to_queue(
             bookings_constants.REDIS_EXTERNAL_BOOKINGS_NAME,
@@ -174,6 +189,7 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             self.cinema_id,
             boost.ResourceBoost.SHOWTIME,
             pattern_values={"id": showtime_id},
+            request_timeout=self.request_timeout,
         )
         showtime_details = parse_obj_as(boost_serializers.ShowTimeDetails, json_data)
         return showtime_details.data

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -149,7 +149,13 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
                 params["per_page"] = per_page
             else:
                 params = {"page": current_page, "per_page": per_page}
-            json_data = boost.get_resource(self.cinema_id, resource, params=params, pattern_values=pattern_values)
+            json_data = boost.get_resource(
+                self.cinema_id,
+                resource,
+                params=params,
+                pattern_values=pattern_values,
+                request_timeout=self.request_timeout,
+            )
             collection = parse_obj_as(collection_class, json_data)
             items.extend(collection.data)
             total_pages = collection.totalPages

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -32,8 +32,16 @@ CDS_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%f%z"
 
 
 class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
-    def __init__(self, cinema_id: str, account_id: str, api_url: str, cinema_api_token: str | None):
-        super().__init__(cinema_id=cinema_id)
+    def __init__(
+        self,
+        cinema_id: str,
+        account_id: str,
+        api_url: str,
+        cinema_api_token: str | None,
+        *,
+        request_timeout: int | None = None,
+    ):
+        super().__init__(cinema_id=cinema_id, request_timeout=request_timeout)
         if not cinema_api_token:
             raise ValueError(f"Missing token for {cinema_id}")
         self.token = cinema_api_token
@@ -81,7 +89,9 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
         )
 
     def get_show(self, show_id: int) -> cds_serializers.ShowCDS:
-        data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.SHOWS)
+        data = get_resource(
+            self.api_url, self.account_id, self.token, ResourceCDS.SHOWS, request_timeout=self.request_timeout
+        )
         shows = parse_obj_as(list[cds_serializers.ShowCDS], data)
         for show in shows:
             if show.id == show_id:
@@ -108,7 +118,13 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
             return bytes()
 
     def get_voucher_payment_type(self) -> cds_serializers.PaymentTypeCDS:
-        data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.PAYMENT_TYPE)
+        data = get_resource(
+            self.api_url,
+            self.account_id,
+            self.token,
+            ResourceCDS.PAYMENT_TYPE,
+            request_timeout=self.request_timeout,
+        )
         payment_types = parse_obj_as(list[cds_serializers.PaymentTypeCDS], data)
         for payment_type in payment_types:
             if payment_type.internal_code == cds_constants.VOUCHER_PAYMENT_TYPE_CDS:
@@ -121,7 +137,13 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
 
     @lru_cache
     def get_pc_voucher_types(self) -> list[cds_serializers.VoucherTypeCDS]:
-        data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.VOUCHER_TYPE)
+        data = get_resource(
+            self.api_url,
+            self.account_id,
+            self.token,
+            ResourceCDS.VOUCHER_TYPE,
+            request_timeout=self.request_timeout,
+        )
         voucher_types = parse_obj_as(list[cds_serializers.VoucherTypeCDS], data)
         return [
             voucher_type
@@ -130,7 +152,13 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
         ]
 
     def get_screen(self, screen_id: int) -> cds_serializers.ScreenCDS:
-        data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.SCREENS)
+        data = get_resource(
+            self.api_url,
+            self.account_id,
+            self.token,
+            ResourceCDS.SCREENS,
+            request_timeout=self.request_timeout,
+        )
         screens = parse_obj_as(list[cds_serializers.ScreenCDS], data)
 
         for screen in screens:
@@ -231,7 +259,14 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
             barcodes_int.append(int(barcode))
 
         cancel_body = cds_serializers.CancelBookingCDS(barcodes=barcodes_int, paiement_type_id=paiement_type_id)  # type: ignore[call-arg]
-        api_response = put_resource(self.api_url, self.account_id, self.token, ResourceCDS.CANCEL_BOOKING, cancel_body)
+        api_response = put_resource(
+            self.api_url,
+            self.account_id,
+            self.token,
+            ResourceCDS.CANCEL_BOOKING,
+            cancel_body,
+            request_timeout=self.request_timeout,
+        )
 
         if api_response:
             cancel_errors = parse_obj_as(cds_serializers.CancelBookingsErrorsCDS, api_response)
@@ -267,7 +302,12 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
         )
 
         json_response = post_resource(
-            self.api_url, self.account_id, self.token, ResourceCDS.CREATE_TRANSACTION, create_transaction_body
+            self.api_url,
+            self.account_id,
+            self.token,
+            ResourceCDS.CREATE_TRANSACTION,
+            create_transaction_body,
+            request_timeout=self.request_timeout,
         )
         create_transaction_response = parse_obj_as(cds_serializers.CreateTransactionResponseCDS, json_response)
 

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -58,7 +58,13 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
         lru_cache is a feature in Python that can significantly improve the performance of functions
         by caching their results based on their input arguments, thus avoiding costly recomputations.
         """
-        data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.CINEMAS)
+        data = get_resource(
+            self.api_url,
+            self.account_id,
+            self.token,
+            ResourceCDS.CINEMAS,
+            request_timeout=self.request_timeout,
+        )
         cinemas = parse_obj_as(list[cds_serializers.CinemaCDS], data)
         for cinema in cinemas:
             if cinema.id == self.cinema_id:
@@ -72,7 +78,13 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
         key_template=constants.CDS_SHOWTIMES_STOCKS_CACHE_KEY, expire=cds_constants.CDS_SHOWTIMES_STOCKS_CACHE_TIMEOUT
     )
     def get_shows_remaining_places(self, show_ids: list[int]) -> str:
-        data = get_resource(self.api_url, self.account_id, self.token, ResourceCDS.SHOWS)
+        data = get_resource(
+            self.api_url,
+            self.account_id,
+            self.token,
+            ResourceCDS.SHOWS,
+            request_timeout=self.request_timeout,
+        )
         shows = parse_obj_as(list[cds_serializers.ShowCDS], data)
         if self.get_internet_sale_gauge_active():
             return json.dumps({show.id: show.internet_remaining_place for show in shows if show.id in show_ids})

--- a/api/src/pcapi/core/external_bookings/cgr/client.py
+++ b/api/src/pcapi/core/external_bookings/cgr/client.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
-    def __init__(self, cinema_id: str):
-        super().__init__(cinema_id=cinema_id)
+    def __init__(self, cinema_id: str, request_timeout: None | int = None):
+        super().__init__(cinema_id=cinema_id, request_timeout=request_timeout)
         self.cgr_cinema_details = get_cgr_cinema_details(cinema_id)
 
     def get_films(self) -> list[cgr_serializers.Film]:
@@ -64,7 +64,11 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             pToken=booking.token,
             pDateLimiteAnnul=booking.cancellationLimitDate.isoformat(),
         )
-        response = reservation_pass_culture(self.cgr_cinema_details, book_show_body)
+        response = reservation_pass_culture(
+            self.cgr_cinema_details,
+            book_show_body,
+            request_timeout=self.request_timeout,
+        )
         logger.info(
             "Booked CGR Ticket",
             extra={
@@ -106,7 +110,7 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
         barcodes_set = set(barcodes)
         for barcode in barcodes_set:
             logger.info("Cancelling CGR external booking", extra={"barcode": barcode, "cinema_id": self.cinema_id})
-            annulation_pass_culture(self.cgr_cinema_details, barcode)
+            annulation_pass_culture(self.cgr_cinema_details, barcode, request_timeout=self.request_timeout)
             logger.info("CGR Booking Cancelled", extra={"barcode": barcode})
 
     def get_shows_remaining_places(self, shows_id: list[int]) -> dict[str, int]:

--- a/api/src/pcapi/core/external_bookings/cgr/client.py
+++ b/api/src/pcapi/core/external_bookings/cgr/client.py
@@ -35,7 +35,11 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
     )
     def get_film_showtimes_stocks(self, film_id: str) -> str:
         logger.info("Fetching CGR showtimes", extra={"cinema_id": self.cinema_id})
-        response = get_seances_pass_culture(self.cgr_cinema_details, allocine_film_id=int(film_id))
+        response = get_seances_pass_culture(
+            self.cgr_cinema_details,
+            allocine_film_id=int(film_id),
+            request_timeout=self.request_timeout,
+        )
 
         try:
             film = response.ObjetRetour.Films[0]

--- a/api/src/pcapi/core/external_bookings/ems/client.py
+++ b/api/src/pcapi/core/external_bookings/ems/client.py
@@ -147,7 +147,11 @@ class EMSClientAPI(external_bookings_models.ExternalBookingsClientAPI):
     )
     def get_film_showtimes_stocks(self, film_id: str) -> str:
         payload = ems_serializers.AvailableShowsRequest(num_cine=self.cinema_id, id_film=film_id)
-        response = self.connector.do_request(self.connector.shows_availability_endpoint, payload.dict())
+        response = self.connector.do_request(
+            self.connector.shows_availability_endpoint,
+            payload.dict(),
+            request_timeout=self.request_timeout,
+        )
         try:
             self.connector.raise_for_status(response)
         except ExternalBookingSoldOutError:

--- a/api/src/pcapi/core/external_bookings/models.py
+++ b/api/src/pcapi/core/external_bookings/models.py
@@ -28,8 +28,9 @@ class Movie:
 
 
 class ExternalBookingsClientAPI:
-    def __init__(self, cinema_id: str) -> None:
+    def __init__(self, cinema_id: str, request_timeout: None | int = None) -> None:
         self.cinema_id = cinema_id
+        self.request_timeout = request_timeout
 
     # Fixme (yacine, 2022-12-19) remove this method from ExternalBookingsClientAPI. Unlike CDS, on Boost API
     #  we can't get shows remaining places from list of shows ids

--- a/api/tests/connectors/api_cine_digital_service_test.py
+++ b/api/tests/connectors/api_cine_digital_service_test.py
@@ -64,10 +64,10 @@ class CineDigitalServiceGetResourceTest:
         request_get.return_value = response_return_value
 
         # When
-        json_data = get_resource(api_url, cinema_id, token, resource)
+        json_data = get_resource(api_url, cinema_id, token, resource, request_timeout=14)
 
         # Then
-        request_get.assert_called_once_with("https://test_id.test_url/tariffs?api_token=test_token")
+        request_get.assert_called_once_with("https://test_id.test_url/tariffs?api_token=test_token", timeout=14)
         assert json_data == shows_json
 
     @mock.patch("pcapi.connectors.cine_digital_service.requests.get")
@@ -81,9 +81,9 @@ class CineDigitalServiceGetResourceTest:
         request_get.return_value = mock.MagicMock(status_code=400, reason="the test token test_token is wrong")
 
         with pytest.raises(cds_exceptions.CineDigitalServiceAPIException) as exc_info:
-            get_resource(api_url, cinema_id, token, resource)
+            get_resource(api_url, cinema_id, token, resource, request_timeout=14)
 
-        request_get.assert_called_once_with("https://test_id.test_url/tariffs?api_token=test_token")
+        request_get.assert_called_once_with("https://test_id.test_url/tariffs?api_token=test_token", timeout=14)
 
         assert isinstance(exc_info.value, cds_exceptions.CineDigitalServiceAPIException)
         assert token not in str(exc_info.value)
@@ -100,9 +100,9 @@ class CineDigitalServiceGetResourceTest:
         request_get.return_value = mock.MagicMock(status_code=200)
 
         # When
-        get_resource(api_url, cinema_id, token, resource, path_params)
+        get_resource(api_url, cinema_id, token, resource, path_params, request_timeout=14)
         # Then
-        request_get.assert_called_once_with("https://test_id.test_url/shows/1/seatmap?api_token=test_token")
+        request_get.assert_called_once_with("https://test_id.test_url/shows/1/seatmap?api_token=test_token", timeout=14)
 
 
 class CineDigitalServicePutResourceTest:
@@ -122,13 +122,14 @@ class CineDigitalServicePutResourceTest:
         request_put.return_value = response_return_value
 
         # When
-        json_data = put_resource(api_url, cinema_id, token, resource, body)
+        json_data = put_resource(api_url, cinema_id, token, resource, body, request_timeout=14)
 
         # Then
         request_put.assert_called_once_with(
             "https://test_id.test_url/transaction/cancel?api_token=test_token",
             headers={"Content-Type": "application/json"},
             data='{"barcodes": [111111111111], "paiementtypeid": 5}',
+            timeout=14,
         )
         assert json_data == response_json
 

--- a/api/tests/connectors/cgr/api_cgr_test.py
+++ b/api/tests/connectors/cgr/api_cgr_test.py
@@ -64,7 +64,10 @@ class CGRGetSeancesPassCultureTest:
         )
         cgr_cinema_details = providers_factories.CGRCinemaDetailsFactory(cinemaUrl="http://example.com/web_service")
 
-        result = get_seances_pass_culture(cinema_details=cgr_cinema_details)
+        result = get_seances_pass_culture(cinema_details=cgr_cinema_details, request_timeout=14)
+
+        assert requests_mock.request_history[-1].method == "POST"
+        assert requests_mock.request_history[-1].timeout == 14
 
         assert result.CodeErreur == 0
         assert result.IntituleErreur == ""

--- a/api/tests/core/external_bookings/boost/test_client.py
+++ b/api/tests/core/external_bookings/boost/test_client.py
@@ -70,8 +70,14 @@ class GetShowtimesTest:
             f"https://cinema-0.example.com/api/showtimes/between/{start_date.strftime('%Y-%m-%d')}/{end_date}?paymentMethod=external%3Acredit%3Apassculture&hideFullReservation=1&page=2&per_page=2",
             json=fixtures.ShowtimesWithPaymentMethodFilterEndpointResponse.PAGE_2_JSON_DATA,
         )
-        boost = boost_client.BoostClientAPI(cinema_str_id)
+        boost = boost_client.BoostClientAPI(cinema_str_id, request_timeout=14)
         showtimes = boost.get_showtimes(per_page=2, start_date=start_date, interval_days=10)
+
+        assert requests_mock.request_history[-1].method == "GET"
+        assert requests_mock.request_history[-1].timeout == 14
+        assert requests_mock.request_history[-2].method == "GET"
+        assert requests_mock.request_history[-2].timeout == 14
+
         assert len(showtimes) == 3
         assert showtimes[0].id == 15971
         assert showtimes[0].numberSeatsRemaining == 147
@@ -114,8 +120,11 @@ class GetShowtimesTest:
             "https://cinema-0.example.com/api/showtimes/between/2022-10-10/2022-10-20?film=207&paymentMethod=external:credit:passculture&hideFullReservation=1&page=1&per_page=2",
             json=fixtures.ShowtimesWithFilmIdAndPaymentMethodFilterEndpointResponse.PAGE_1_JSON_DATA,
         )
-        boost = boost_client.BoostClientAPI(cinema_str_id)
+        boost = boost_client.BoostClientAPI(cinema_str_id, request_timeout=14)
         showtimes = boost.get_showtimes(per_page=2, start_date=date.date(2022, 10, 10), interval_days=10, film=207)
+
+        assert requests_mock.request_history[-1].method == "GET"
+        assert requests_mock.request_history[-1].timeout == 14
 
         assert len(showtimes) == 2
         assert showtimes[0].id == 16277

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -135,11 +135,12 @@ class CineDigitalServiceGetShowTest:
             account_id="accountid_test",
             cinema_api_token="token_test",
             api_url="apiUrl_test/",
+            request_timeout=14,
         )
         show = cine_digital_service.get_show(2)
 
         # then
-        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource)
+        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource, request_timeout=14)
 
         assert show.id == 2
 
@@ -886,14 +887,24 @@ class CineDigitalServiceCancelBookingTest:
             id=12, internal_code="VCH", is_active=True
         )
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id",
+            account_id="accountid_test",
+            cinema_api_token="token_test",
+            api_url="test_url",
+            request_timeout=12,
         )
 
         # When
-        try:
-            cine_digital_service.cancel_booking(["3107362853729", "1312079646868"])
-        except cds_exceptions.CineDigitalServiceAPIException:
-            assert False, "Should not raise exception"
+
+        cine_digital_service.cancel_booking(["3107362853729", "1312079646868"])
+        mocked_put_resource.assert_called_with(
+            "test_url",
+            "accountid_test",
+            "token_test",
+            ResourceCDS.CANCEL_BOOKING,
+            cds_serializers.CancelBookingCDS(barcodes=[3107362853729, 1312079646868], paiement_type_id=12),
+            request_timeout=12,
+        )
 
     @patch("pcapi.core.external_bookings.cds.client.put_resource")
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_voucher_payment_type")
@@ -1090,7 +1101,11 @@ class CineDigitalServiceBookTicketTest:
         mocked_post_resource.return_value = json_create_transaction
 
         cine_digital_service = CineDigitalServiceAPI(
-            cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test", api_url="test_url"
+            cinema_id="test_id",
+            account_id="accountid_test",
+            cinema_api_token="token_test",
+            api_url="test_url",
+            request_timeout=12,
         )
 
         tickets = cine_digital_service.book_ticket(show_id=14, booking=booking, beneficiary=beneficiary)

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -303,17 +303,16 @@ class CineDigitalServiceGetShowsRemainingPlacesTest:
         ]
         mocked_get_resource.return_value = json_shows
 
-        # when
         cine_digital_service = CineDigitalServiceAPI(
             cinema_id="cinemaid_test",
             account_id="accountid_test",
             cinema_api_token="token_test",
             api_url="apiUrl_test/",
+            request_timeout=14,
         )
         shows_remaining_places = cine_digital_service.get_shows_remaining_places([2, 3])
 
-        # then
-        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource)
+        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource, request_timeout=14)
 
         assert shows_remaining_places == {"2": 30, "3": 100}
 
@@ -325,7 +324,6 @@ class CineDigitalServiceGetShowsRemainingPlacesTest:
     def test_should_return_shows_id_with_corresponding_remaining_places(
         self, mocked_internet_sale_gauge_active, mocked_get_resource
     ):
-        # Given
         account_id = "accountid_test"
         token = "token_test"
         api_url = "apiUrl_test/"
@@ -389,17 +387,16 @@ class CineDigitalServiceGetShowsRemainingPlacesTest:
         ]
         mocked_get_resource.return_value = json_shows
 
-        # when
         cine_digital_service = CineDigitalServiceAPI(
             cinema_id="cinemaid_test",
             account_id="accountid_test",
             cinema_api_token="token_test",
             api_url="apiUrl_test/",
+            request_timeout=14,
         )
         shows_remaining_places = cine_digital_service.get_shows_remaining_places([2, 3])
 
-        # then
-        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource)
+        mocked_get_resource.assert_called_once_with(api_url, account_id, token, resource, request_timeout=14)
 
         assert shows_remaining_places == {"2": 88, "3": 88}
 

--- a/api/tests/core/external_bookings/cgr/test_client.py
+++ b/api/tests/core/external_bookings/cgr/test_client.py
@@ -32,9 +32,11 @@ class BookTicketTest:
             "http://cgr-cinema-0.example.com/web_service",
             text=fixtures.cgr_reservation_response_template(fixtures.ONE_TICKET_RESPONSE),
         )
-        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_id)
+        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_id, request_timeout=12)
         tickets = cgr.book_ticket(show_id=177182, booking=booking, beneficiary=beneficiary)
 
+        assert requests_mock.request_history[-1].method == "POST"
+        assert requests_mock.request_history[-1].timeout == 12
         assert len(tickets) == 1
         assert tickets[0].barcode == "CINE999508637111"
         assert tickets[0].seat_number == "D8"
@@ -71,9 +73,11 @@ class BookTicketTest:
             text=fixtures.cgr_reservation_response_template(fixtures.ONE_TICKET_RESPONSE_WITHOUT_PLACEMENT),
         )
 
-        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_id)
+        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_id, request_timeout=12)
         tickets = cgr.book_ticket(show_id=177182, booking=booking, beneficiary=beneficiary)
 
+        assert requests_mock.request_history[-1].method == "POST"
+        assert requests_mock.request_history[-1].timeout == 12
         assert len(tickets) == 1
         assert tickets[0].barcode == "CINE999508637111"
         assert not tickets[0].seat_number
@@ -104,9 +108,11 @@ class BookTicketTest:
             text=fixtures.cgr_reservation_response_template(fixtures.TWO_TICKETS_RESPONSE),
         )
 
-        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_id)
+        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_id, request_timeout=12)
         tickets = cgr.book_ticket(show_id=177182, booking=booking, beneficiary=beneficiary)
 
+        assert requests_mock.request_history[-1].method == "POST"
+        assert requests_mock.request_history[-1].timeout == 12
         assert len(tickets) == 2
         assert tickets[0].barcode == "CINE999508637111"
         assert tickets[0].seat_number == "F7"
@@ -140,9 +146,11 @@ class BookTicketTest:
             text=fixtures.cgr_reservation_response_template(fixtures.TWO_TICKETS_RESPONSE_WITHOUT_PLACEMENT),
         )
 
-        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_id)
+        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_id, request_timeout=12)
         tickets = cgr.book_ticket(show_id=177182, booking=booking, beneficiary=beneficiary)
 
+        assert requests_mock.request_history[-1].method == "POST"
+        assert requests_mock.request_history[-1].timeout == 12
         assert len(tickets) == 2
         assert tickets[0].barcode == "CINE999508637111"
         assert not tickets[0].seat_number
@@ -172,12 +180,12 @@ class CancelBookingTest:
             text=fixtures.cgr_annulation_response_template(),
         )
 
-        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_str_id)
-        try:
-            cgr.cancel_booking(barcodes=["CINE-123456789"])
-        except CGRAPIException:
-            assert False, "Should not raise exception"
+        cgr = cgr_client.CGRClientAPI(cinema_id=cinema_str_id, request_timeout=12)
 
+        cgr.cancel_booking(barcodes=["CINE-123456789"])
+
+        assert requests_mock.request_history[-1].method == "POST"
+        assert requests_mock.request_history[-1].timeout == 12
         assert post_adapter.call_count == 1
         assert "<pQrCode>CINE-123456789</pQrCode>" in post_adapter.last_request.text
 

--- a/api/tests/core/external_bookings/ems/test_client.py
+++ b/api/tests/core/external_bookings/ems/test_client.py
@@ -208,8 +208,10 @@ class EMSGetFilmShowtimesStocksTest:
         url_matcher = re.compile("https://fake_url.com/SEANCE/*")
         requests_mock.post(url=url_matcher, json=response_json)
 
-        client = EMSClientAPI(cinema_id=cinema_id)
+        client = EMSClientAPI(cinema_id=cinema_id, request_timeout=14)
         stocks = client.get_film_showtimes_stocks("12345")
 
+        assert requests_mock.request_history[-1].method == "POST"
+        assert requests_mock.request_history[-1].timeout == 14
         assert len(stocks) == 2
         assert stocks == {"999000111": 100, "998880001": 100}

--- a/api/tests/core/external_bookings/ems/test_client.py
+++ b/api/tests/core/external_bookings/ems/test_client.py
@@ -73,9 +73,11 @@ class EMSBookTicketTest:
 
         requests_mock.post(url, json=expected_data, headers={"Source": settings.EMS_API_BOOKING_HEADER})
 
-        client = EMSClientAPI(cinema_id=cinema_id)
+        client = EMSClientAPI(cinema_id=cinema_id, request_timeout=12)
         ticket = client.book_ticket(show_id="999700079979", booking=booking, beneficiary=beneficiary)
 
+        assert requests_mock.request_history[-1].method == "POST"
+        assert requests_mock.request_history[-1].timeout == 12
         assert len(ticket) == 1
         ticket = ticket.pop()
         assert ticket.barcode == "000000144659"
@@ -140,9 +142,11 @@ class EMSBookTicketTest:
 
         requests_mock.post(url, json=expected_data, headers={"Source": settings.EMS_API_BOOKING_HEADER})
 
-        client = EMSClientAPI(cinema_id=cinema_id)
+        client = EMSClientAPI(cinema_id=cinema_id, request_timeout=12)
         tickets = client.book_ticket(show_id="999700079979", booking=booking, beneficiary=beneficiary)
 
+        assert requests_mock.request_history[-1].method == "POST"
+        assert requests_mock.request_history[-1].timeout == 12
         assert len(tickets) == 2
         assert tickets[0].barcode == "000000144659"
         assert tickets[0].seat_number == ""

--- a/api/tests/core/external_bookings/test_api.py
+++ b/api/tests/core/external_bookings/test_api.py
@@ -7,6 +7,7 @@ import pytest
 
 import pcapi.core.bookings.factories as bookings_factories
 from pcapi.core.bookings.utils import generate_hmac_signature
+from pcapi.core.external_bookings.api import EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS
 from pcapi.core.external_bookings.api import _get_external_bookings_client_api
 from pcapi.core.external_bookings.api import book_event_ticket
 from pcapi.core.external_bookings.api import cancel_event_ticket
@@ -187,6 +188,7 @@ class BookEventTicketTest:
             json=expected_json_string,
             hmac=expected_hmac_signature,
             headers={"Content-Type": "application/json"},
+            timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
         )
         assert remaining_quantity == 12
         assert [ticket.barcode for ticket in tickets] == ["1234567AJSQ", "1234567AJSA"]
@@ -322,6 +324,7 @@ class BookEventTicketTest:
             json=expected_json_string,
             hmac=expected_hmac_signature,
             headers={"Content-Type": "application/json"},
+            timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
         )
 
     @patch("pcapi.core.external_bookings.api.requests.post")
@@ -525,6 +528,7 @@ class CancelEventTicketTest:
             json=expected_json_string,
             hmac=expected_hmac_signature,
             headers={"Content-Type": "application/json"},
+            timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
         )
 
     @patch("pcapi.core.external_bookings.api.requests.post")
@@ -572,6 +576,7 @@ class CancelEventTicketTest:
             json=expected_json_string,
             hmac=expected_hmac_signature,
             headers={"Content-Type": "application/json"},
+            timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
         )
 
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33041

Ce qui est fait dans cette PR  : 
- Ajout d'une constante `EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS` au niveau de `external_bookings/api.py`
- Modification de la classe abstraite `ExternalBookingsClientAPI` et de toutes classes enfants (`EMSClientAPI`, `CGRClientAPI`, `CineDigitalServiceAPI`, `BoostClientAPI`) : 
    - Ajout de l'attribut `request_timeout`, défini à l'initialisation de la classe
    - Transmission de l'attribut `request_timeout` aux requêtes effectuées à partir des connecteurs (pour surcharger le timeout par défaut défini [`REQUEST_TIMEOUT_IN_SECOND`](https://github.com/pass-culture/pass-culture-main/blob/tcoudray-pass/PC-33041-increase-timeout/api/src/pcapi/utils/requests.py#L40))
- Modification des méthodes `external_bookings_api.book_event_ticket` et `external_bookings_api.cancel_event_ticket` pour utiliser `EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS` comme valeur de timeout dans les requêtes (et non la valeur par défaut [`REQUEST_TIMEOUT_IN_SECOND`](https://github.com/pass-culture/pass-culture-main/blob/tcoudray-pass/PC-33041-increase-timeout/api/src/pcapi/utils/requests.py#L40))

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
