### PR TITLE
(PC-33121)[PRO] fix: Create component with own state for each managed…

### DIFF
--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.module.scss
@@ -47,21 +47,6 @@ $banner-height: rem.torem(124px);
     }
   }
 
-  &-checkbox-button {
-    margin: 0;
-  }
-
-  &-checkbox-container {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: rem.torem(24px);
-
-    &:last-child {
-      margin-bottom: 0;
-    }
-  }
-
   &-actions {
     display: flex;
     justify-content: flex-end;

--- a/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/LinkVenuesDialog.tsx
@@ -14,15 +14,14 @@ import { pluralizeString } from 'commons/utils/pluralize'
 import { Callout } from 'components/Callout/Callout'
 import { CalloutVariant } from 'components/Callout/types'
 import { ConfirmDialog } from 'components/Dialog/ConfirmDialog/ConfirmDialog'
-import fullEditIcon from 'icons/full-edit.svg'
 import strokeWarningIcon from 'icons/stroke-warning.svg'
 import { Button } from 'ui-kit/Button/Button'
-import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
+import { ButtonVariant } from 'ui-kit/Button/types'
 import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
 import { BaseCheckbox } from 'ui-kit/form/shared/BaseCheckbox/BaseCheckbox'
 
 import styles from './LinkVenuesDialog.module.scss'
-import { PricingPointDialog } from './PricingPointDialog/PricingPointDialog'
+import { ManadgedVenueItem } from './ManagedVenueItem/ManagedVenueItem'
 
 interface LinkVenuesDialogProps {
   offererId: number
@@ -42,9 +41,6 @@ export const LinkVenuesDialog = ({
   const [showDiscardChangesDialog, setShowDiscardChangesDialog] =
     useState<boolean>(false)
   const [showUnlinkVenuesDialog, setShowUnlinkVenuesDialog] =
-    useState<boolean>(false)
-  const [selectedVenue, setSelectedVenue] = useState<ManagedVenues | null>(null)
-  const [isPricingPointDialogOpen, setIsPricingPointDialogOpen] =
     useState<boolean>(false)
 
   const availableManagedVenuesIds = managedVenues
@@ -105,23 +101,12 @@ export const LinkVenuesDialog = ({
       }
     },
   })
-
-  function handleVenueChange(event: any) {
-    if (event.target.checked) {
-      setSelectedVenuesIds([...selectedVenuesIds, parseInt(event.target.value)])
-    } else {
-      setSelectedVenuesIds(
-        selectedVenuesIds.filter(
-          (venueId) => venueId !== parseInt(event.target.value)
-        )
-      )
-    }
-  }
-
-  const venuesForPricingPoint = managedVenues.filter((x) => Boolean(x.siret))
   const hasVenuesWithoutPricingPoint = managedVenues.some(
     (venue) => !venue.hasPricingPoint
   )
+
+  const venuesForPricingPoint = managedVenues.filter((x) => Boolean(x.siret))
+
   return (
     <>
       <DialogBuilder
@@ -198,54 +183,17 @@ export const LinkVenuesDialog = ({
 
                 {managedVenues.map((venue) => {
                   return (
-                    <div
+                    <ManadgedVenueItem
+                      venue={venue}
                       key={venue.id}
-                      className={styles['dialog-checkbox-container']}
-                    >
-                      <BaseCheckbox
-                        disabled={
-                          (Boolean(venue.bankAccountId) &&
-                            venue.bankAccountId !== selectedBankAccount.id) ||
-                          !venue.hasPricingPoint
-                        }
-                        label={venue.commonName}
-                        name={venue.id.toString()}
-                        value={venue.id}
-                        checked={selectedVenuesIds.indexOf(venue.id) >= 0}
-                        onChange={handleVenueChange}
-                      />
-                      {!venue.hasPricingPoint && (
-                        <DialogBuilder
-                          open={isPricingPointDialogOpen}
-                          onOpenChange={setIsPricingPointDialogOpen}
-                          trigger={
-                            <Button
-                              variant={ButtonVariant.QUATERNARY}
-                              icon={fullEditIcon}
-                              iconPosition={IconPositionEnum.LEFT}
-                              onClick={() => {
-                                setSelectedVenue(venue)
-                              }}
-                              className={styles['dialog-checkbox-button']}
-                            >
-                              Sélectionner un SIRET
-                            </Button>
-                          }
-                        >
-                          <PricingPointDialog
-                            selectedVenue={selectedVenue}
-                            venues={venuesForPricingPoint}
-                            closeDialog={() => {
-                              setSelectedVenue(null)
-                              setIsPricingPointDialogOpen(false)
-                            }}
-                            updateVenuePricingPoint={
-                              updateBankAccountVenuePricingPoint
-                            }
-                          />
-                        </DialogBuilder>
-                      )}
-                    </div>
+                      updateBankAccountVenuePricingPoint={
+                        updateBankAccountVenuePricingPoint
+                      }
+                      selectedBankAccount={selectedBankAccount}
+                      selectedVenuesIds={selectedVenuesIds}
+                      setSelectedVenuesIds={setSelectedVenuesIds}
+                      venuesForPricingPoint={venuesForPricingPoint}
+                    />
                   )
                 })}
               </div>

--- a/pro/src/pages/Reimbursements/BankInformations/ManagedVenueItem/ManagedVenueItem.module.scss
+++ b/pro/src/pages/Reimbursements/BankInformations/ManagedVenueItem/ManagedVenueItem.module.scss
@@ -1,0 +1,16 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.dialog-checkbox-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: rem.torem(24px);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.dialog-checkbox-button {
+  margin: 0;
+}

--- a/pro/src/pages/Reimbursements/BankInformations/ManagedVenueItem/ManagedVenueItem.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/ManagedVenueItem/ManagedVenueItem.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+
+import { BankAccountResponseModel, ManagedVenues } from 'apiClient/v1'
+import fullEditIcon from 'icons/full-edit.svg'
+import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
+import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
+import { BaseCheckbox } from 'ui-kit/form/shared/BaseCheckbox/BaseCheckbox'
+
+import { PricingPointDialog } from '../PricingPointDialog/PricingPointDialog'
+
+import styles from './ManagedVenueItem.module.scss'
+
+type ManadgedVenueItemProps = {
+  venue: ManagedVenues
+  updateBankAccountVenuePricingPoint: (venueId: number) => void
+  selectedBankAccount: BankAccountResponseModel
+  selectedVenuesIds: number[]
+  setSelectedVenuesIds: (ids: number[]) => void
+  venuesForPricingPoint: ManagedVenues[]
+}
+
+export function ManadgedVenueItem({
+  venue,
+  updateBankAccountVenuePricingPoint,
+  selectedBankAccount,
+  selectedVenuesIds,
+  setSelectedVenuesIds,
+  venuesForPricingPoint,
+}: ManadgedVenueItemProps) {
+  const [selectedVenue, setSelectedVenue] = useState<ManagedVenues | null>(null)
+  const [isPricingPointDialogOpen, setIsPricingPointDialogOpen] =
+    useState<boolean>(false)
+
+  function handleVenueChange(event: any) {
+    if (event.target.checked) {
+      setSelectedVenuesIds([...selectedVenuesIds, parseInt(event.target.value)])
+    } else {
+      setSelectedVenuesIds(
+        selectedVenuesIds.filter(
+          (venueId) => venueId !== parseInt(event.target.value)
+        )
+      )
+    }
+  }
+
+  return (
+    <div className={styles['dialog-checkbox-container']}>
+      <BaseCheckbox
+        disabled={
+          (Boolean(venue.bankAccountId) &&
+            venue.bankAccountId !== selectedBankAccount.id) ||
+          !venue.hasPricingPoint
+        }
+        label={venue.commonName}
+        name={venue.id.toString()}
+        value={venue.id}
+        checked={selectedVenuesIds.indexOf(venue.id) >= 0}
+        onChange={handleVenueChange}
+      />
+      {!venue.hasPricingPoint && (
+        <DialogBuilder
+          open={isPricingPointDialogOpen}
+          onOpenChange={setIsPricingPointDialogOpen}
+          trigger={
+            <Button
+              variant={ButtonVariant.QUATERNARY}
+              icon={fullEditIcon}
+              iconPosition={IconPositionEnum.LEFT}
+              onClick={() => {
+                setSelectedVenue(venue)
+              }}
+              className={styles['dialog-checkbox-button']}
+            >
+              Sélectionner un SIRET
+            </Button>
+          }
+        >
+          <PricingPointDialog
+            selectedVenue={selectedVenue}
+            venues={venuesForPricingPoint}
+            closeDialog={() => {
+              setSelectedVenue(null)
+              setIsPricingPointDialogOpen(false)
+            }}
+            updateVenuePricingPoint={updateBankAccountVenuePricingPoint}
+          />
+        </DialogBuilder>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
… venue in pricing point dialog.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33121

**Objectif**
Ne pas avoir de bug graphique quand on ouvre le dialog Pricing point (au clic sur "Sélectionner un siret").
Le problème apparait quand il y a un grand nombre de venues (50-100). Pour chacune d'entre elle un sous dialog pricing point est créé. Ces sous-dialog sont "controllés" càd que leur ouverture/fermeture est gérée à l'extérieur des dialogs (pour pouvoir le fermer uniquement après que le formulaire de validation interne ait eu le temps de submit).

Le fait que tous ces dialogs sont controllés par le même state `isPricingPointDialogOpen` semble poser problème, quand il change, ça re-déclenche le render (et peut-être autre chose en interne de radix-ui (?)) de tous les dialogs (ce qui crée l'artefact).

Pour corriger, j'ai créé un sous-composant `ManagedVenueItem.tsx` pour que chaque manadged venue gère son propre state `isPricingPointDialogOpen`, et que le changement de state ne re-trigger pas tt le monde.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
