### PR TITLE
(BSR)[PRO] test: loading /collaborateurs page too soon caused flakyness

### DIFF
--- a/pro/cypress/e2e/collaborator.cy.ts
+++ b/pro/cypress/e2e/collaborator.cy.ts
@@ -22,7 +22,7 @@ describe('Collaborator list feature', () => {
 
   it('I can add a new collaborator and he receives an email invitation', () => {
     const randomEmail = `collaborator${Math.random()}@example.com`
-    logAndGoToPage(login, '/')
+    logAndGoToPage(login, '/accueil')
 
     cy.stepLog({ message: 'open collaborator page' })
     cy.findAllByText('Collaborateurs').click()
@@ -30,7 +30,7 @@ describe('Collaborator list feature', () => {
     cy.stepLog({ message: 'wait for collaborator page display' })
     cy.url().should('include', '/collaborateurs')
     cy.findAllByTestId('spinner').should('not.exist')
-    cy.contains(login, { timeout: 60000 })
+    cy.contains(login)
 
     cy.stepLog({ message: 'add a collaborator in the list' })
     cy.findByText('Ajouter un collaborateur').click()
@@ -47,7 +47,7 @@ describe('Collaborator list feature', () => {
       message: 'check login validated and new collaborator waiting status',
     })
     cy.findAllByTestId('spinner').should('not.exist')
-    cy.contains(randomEmail, { timeout: 60000 })
+    cy.contains(randomEmail)
       .next()
       .should('have.text', 'En attente')
     cy.contains(login).next().should('have.text', 'Validé')


### PR DESCRIPTION
## But de la pull request

Le timeout de 60" précédemment ajouté était inutile et n'a pas résolu le flakyness (difficile à reproduire en local). Le problème semble dû au fait d'afficher la page `/collaborateurs` directement au login, on passe donc par l'affichage de la page `accueil` avant d'ouvrir `/collaborateurs` et ça semble mieux!

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
