### PR TITLE
(PC-33122)[PRO] fix: auto-redirect old stats url to new one

### DIFF
--- a/pro/src/pages/OffererStats/OffererStats/OffererStatsScreen.tsx
+++ b/pro/src/pages/OffererStats/OffererStats/OffererStatsScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
+import { Navigate } from 'react-router-dom'
 
 import { api } from 'apiClient/api'
 import { SelectOption } from 'commons/custom_types/form'
@@ -14,11 +15,21 @@ import styles from './OffererStatsScreen.module.scss'
 
 export const OffererStatsScreen = () => {
   const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
+  const isOffererStatsV2Active = useActiveFeature('WIP_OFFERER_STATS_V2')
   const targetOffererId = useSelector(selectCurrentOffererId)
 
   const [iframeUrl, setIframeUrl] = useState('')
   const [selectedVenueId, setSelectedVenueId] = useState('all')
   const [venueOptions, setVenueOptions] = useState<SelectOption[]>([])
+
+  if (isOffererStatsV2Active) {
+    return <Navigate
+      to='/remboursements/revenus'
+      replace={true}
+      relative="path"
+    />
+  }
+
   const ALL_VENUES_OPTION = {
     value: 'all',
     label: isOfferAddressEnabled ? 'Tous' : 'Tous les lieux',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33122

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
