### PR TITLE
(PC-32886)[PRO] fix: in offer we cannot change to price step in edition

### DIFF
--- a/pro/src/components/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.tsx
+++ b/pro/src/components/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.tsx
@@ -36,11 +36,13 @@ export const IndivualOfferLayout = ({
   const shouldDisplayActionOnStatus =
     mode !== OFFER_WIZARD_MODE.CREATION && offer && withStepper
 
+  // This is used to not be able to go to next step in creation mode
   const isUsefulInformationSubmitted =
-    localStorageAvailable() &&
-    !!localStorage.getItem(
-      `${LOCAL_STORAGE_USEFUL_INFORMATION_SUBMITTED}_${offer?.id}`
-    )
+    (localStorageAvailable() &&
+      !!localStorage.getItem(
+        `${LOCAL_STORAGE_USEFUL_INFORMATION_SUBMITTED}_${offer?.id}`
+      )) ||
+    mode !== OFFER_WIZARD_MODE.CREATION
 
   return (
     <>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32886

les données de la sandbox sont bien incohérentes → il s’agit d’une offre publiée sans price_categories / tarif ce qui bloque le passage à l'étape suivante
or on ne peut pas supprimer les price categories en édition donc ce cas ne peut actuellement pas se produire

Cependant comme c’est une feature qu’on pourrait développer un jour nous avons proposé un correctif

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
