### PR TITLE
(BSR)[PRO] test: fix flaky adage when favorite too quick

### DIFF
--- a/pro/cypress/e2e/adage.cy.ts
+++ b/pro/cypress/e2e/adage.cy.ts
@@ -190,6 +190,10 @@ describe('ADAGE discovery', () => {
       method: 'POST',
       url: '/adage-iframe/logs/fav-offer/',
     }).as('fav-offer')
+    cy.intercept({
+      method: 'POST',
+      url: '/adage-iframe/logs/catalog-view',
+    }).as('catalogView')
   })
 
   it('It should put an offer in favorite', () => {
@@ -197,8 +201,9 @@ describe('ADAGE discovery', () => {
     const adageToken = Cypress.env('adageToken')
 
     cy.visit(`/adage-iframe/recherche?token=${adageToken}`)
-
+    cy.wait('@catalogView').its('response.statusCode').should('eq', 204)
     cy.findAllByTestId('spinner').should('not.exist')
+    cy.findByTestId('offer-listitem').contains('Mon offre collective')
 
     cy.stepLog({ message: 'I add first offer to favorites' })
     cy.findByText(offerName).parent().click()


### PR DESCRIPTION
## But de la pull request

La mise en favori se faisait trop tôt, il est préférable d'attendre le chargement de la page (quelques cas [flaky](https://cloud.cypress.io/projects/rit5sb/analytics/flaky-tests?att=1&branches=%5B%5D&browsers=%5B%5D&chartRangeMostCommonErrors=%5B%5D&chartRangeSlowestTests=%5B%5D&chartRangeTopFailures=%5B%5D&committers=%5B%5D&cypressVersions=%5B%5D&flaky=%5B%5D&operatingSystems=%5B%5D&replayTestId=e1b3136a-3374-40fa-871f-3623478e83a7&runGroups=%5B%5D&specFiles=%5B%5D&status=%5B%7B%22label%22%3A%22Passed%22%2C%22value%22%3A%22PASSED%22%7D%2C%7B%22label%22%3A%22Failed%22%2C%22value%22%3A%22FAILED%22%7D%5D&tags=%5B%5D&tagsMatch=ANY&timeInterval=WEEK&timeRange=%7B%22startDate%22%3A%222024-11-13%22%2C%22endDate%22%3A%222024-11-20%22%7D&ts=1732106982088&viewBy=TEST_CASE) sur master aboutissant à un message `Une erreur s'est produite`)

![CleanShot 2024-11-20 at 15 47 02@2x](https://github.com/user-attachments/assets/bc71b7e5-26c1-4829-af34-982fc51cbd18)


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
