### PR TITLE
(PC-32767)[BO] feat: add collective offers displayed status in detail…

### DIFF
--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -33,6 +33,7 @@ from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
 from pcapi.domain import show_types
+from pcapi.models import feature as feature_model
 from pcapi.models import offer_mixin
 from pcapi.models import validation_status_mixin
 from pcapi.routes.backoffice.accounts import serialization as serialization_accounts
@@ -488,22 +489,62 @@ def format_offer_validation_status(status: offer_mixin.OfferValidationStatus) ->
 
 def format_offer_status(status: offer_mixin.OfferStatus) -> str:
     match status:
-        case offer_mixin.OfferStatus.DRAFT:
+        case offer_mixin.OfferStatus.DRAFT | offer_mixin.CollectiveOfferStatus.DRAFT:
             return "Brouillon"
-        case offer_mixin.OfferStatus.ACTIVE:
+        case offer_mixin.OfferStatus.ACTIVE | offer_mixin.CollectiveOfferStatus.ACTIVE:
             return "Active"
-        case offer_mixin.OfferStatus.PENDING:
+        case offer_mixin.OfferStatus.PENDING | offer_mixin.CollectiveOfferStatus.PENDING:
             return "Pré-réservée"
-        case offer_mixin.OfferStatus.EXPIRED:
+        case offer_mixin.OfferStatus.EXPIRED | offer_mixin.CollectiveOfferStatus.EXPIRED:
             return "Expirée"
-        case offer_mixin.OfferStatus.REJECTED:
+        case offer_mixin.OfferStatus.REJECTED | offer_mixin.CollectiveOfferStatus.REJECTED:
             return "Rejetée"
-        case offer_mixin.OfferStatus.SOLD_OUT:
+        case offer_mixin.OfferStatus.SOLD_OUT | offer_mixin.CollectiveOfferStatus.SOLD_OUT:
             return "Épuisée"
-        case offer_mixin.OfferStatus.INACTIVE:
+        case offer_mixin.OfferStatus.INACTIVE | offer_mixin.CollectiveOfferStatus.INACTIVE:
             return "Inactive"
+        case offer_mixin.CollectiveOfferStatus.ARCHIVED:
+            return "Archivée"
         case _:
             return status.value
+
+
+def format_collective_offer_displayed_status(
+    displayed_status: educational_models.CollectiveOfferDisplayedStatus,
+) -> str:
+    match displayed_status:
+        case educational_models.CollectiveOfferDisplayedStatus.ACTIVE:
+            return "Publiée"
+        case educational_models.CollectiveOfferDisplayedStatus.PENDING:
+            if feature_model.FeatureToggle.ENABLE_COLLECTIVE_NEW_STATUSES.is_active():
+                return "En instruction"
+            return "En attente"
+        case educational_models.CollectiveOfferDisplayedStatus.REJECTED:
+            if feature_model.FeatureToggle.ENABLE_COLLECTIVE_NEW_STATUSES.is_active():
+                return "Non conforme"
+            return "Refusée"
+        case educational_models.CollectiveOfferDisplayedStatus.PREBOOKED:
+            return "Préréservée"
+        case educational_models.CollectiveOfferDisplayedStatus.BOOKED:
+            return "Réservée"
+        case educational_models.CollectiveOfferDisplayedStatus.INACTIVE:
+            if feature_model.FeatureToggle.ENABLE_COLLECTIVE_NEW_STATUSES.is_active():
+                return "En pause"
+            return "Masquée"
+        case educational_models.CollectiveOfferDisplayedStatus.EXPIRED:
+            return "Expirée"
+        case educational_models.CollectiveOfferDisplayedStatus.ENDED:
+            return "Terminée"
+        case educational_models.CollectiveOfferDisplayedStatus.CANCELLED:
+            return "Annulée"
+        case educational_models.CollectiveOfferDisplayedStatus.REIMBURSED:
+            return "Remboursée"
+        case educational_models.CollectiveOfferDisplayedStatus.ARCHIVED:
+            return "Archivée"
+        case educational_models.CollectiveOfferDisplayedStatus.DRAFT:
+            return "Brouillon"
+        case _:
+            return displayed_status.value
 
 
 def format_offer_category(subcategory_id: str) -> str:
@@ -1395,6 +1436,7 @@ def install_template_filters(app: Flask) -> None:
     app.jinja_env.filters["format_validation_status"] = format_validation_status
     app.jinja_env.filters["format_offer_validation_status"] = format_offer_validation_status
     app.jinja_env.filters["format_offer_status"] = format_offer_status
+    app.jinja_env.filters["format_collective_offer_displayed_status"] = format_collective_offer_displayed_status
     app.jinja_env.filters["format_offer_category"] = format_offer_category
     app.jinja_env.filters["format_offer_subcategory"] = format_offer_subcategory
     app.jinja_env.filters["format_offerer_rejection_reason"] = format_offerer_rejection_reason

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -67,6 +67,9 @@
                   <span class="fw-bold">Statut :</span> {{ collective_offer.status | format_offer_status }}
                 </p>
                 <p class="mb-1">
+                  <span class="fw-bold">Statut PC Pro :</span> {{ collective_offer.displayedStatus | format_collective_offer_displayed_status }}
+                </p>
+                <p class="mb-1">
                   <span class="fw-bold">État :</span> {{ collective_offer.validation | format_offer_validation_status }}
                 </p>
                 {% if collective_offer.lastValidationDate %}

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer_template/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer_template/details.html
@@ -52,6 +52,9 @@
                   <span class="fw-bold">Statut :</span> {{ collective_offer_template.status | format_offer_status }}
                 </p>
                 <p class="mb-1">
+                  <span class="fw-bold">Statut PC Pro :</span> {{ collective_offer_template.displayedStatus | format_collective_offer_displayed_status }}
+                </p>
+                <p class="mb-1">
                   <span class="fw-bold">État :</span> {{ collective_offer_template.validation | format_offer_validation_status }}
                 </p>
                 {% if collective_offer_template.lastValidationAuthor %}

--- a/api/tests/routes/backoffice/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice/collective_offer_templates_test.py
@@ -288,6 +288,8 @@ class GetCollectiveOfferTemplateDetailTest(GetEndpointHelper):
             assert response.status_code == 200
 
         content_as_text = html_parser.content_as_text(response.data)
+        assert "Statut : Active" in content_as_text
+        assert "Statut PC Pro : Publiée" in content_as_text
         assert f"Date de création : {collectiveOfferTemplate.dateCreated.strftime('%d/%m/%Y')}" in content_as_text
         assert f"Description : {collectiveOfferTemplate.description}" in content_as_text
         assert f"Entité juridique : {collectiveOfferTemplate.venue.managingOfferer.name}" in content_as_text

--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -1081,6 +1081,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
             in content_as_text
         )
         assert "Statut : Expirée" in content_as_text
+        assert "Statut PC Pro : Réservée" in content_as_text
         assert "État : Validée" in content_as_text
         assert "Utilisateur de la dernière validation" not in content_as_text
         assert "Date de dernière validation de l’offre" not in content_as_text


### PR DESCRIPTION
…s pages

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32767

Labels récupérées de `pro/src/components/CollectiveStatusLabel/CollectiveStatusLabel.tsx`

Offre réservable
<img width="812" alt="image" src="https://github.com/user-attachments/assets/1ff47057-3796-49ff-a854-98311a4bd69e">

Offre vitrine
<img width="812" alt="image" src="https://github.com/user-attachments/assets/63c3656d-a501-4606-b1f3-bbaee516b757">

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
