### PR TITLE
(PC-31872)[BO] feat: Use only the two first gtl_id digits to format music type on offer's BO

### DIFF
--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -806,7 +806,11 @@ def format_modified_info_values(modified_info: typing.Any, name: str | None = No
 
 def format_music_gtl_id(music_gtl_id: str) -> str:
     return next(
-        (music_genre.label for music_genre in categories.TITELIVE_MUSIC_TYPES if music_genre.gtl_id == music_gtl_id),
+        (
+            music_genre.label
+            for music_genre in categories.TITELIVE_MUSIC_TYPES
+            if music_genre.gtl_id[:2] == music_gtl_id[:2]
+        ),
         f"Gtl inconnu [{music_gtl_id}]",
     )
 

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -1843,11 +1843,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
     def test_get_detail_offer(self, authenticated_client):
         offer = offers_factories.OfferFactory(
             withdrawalDetails="Demander à la caisse",
-            extraData={
-                "ean": "1234567891234",
-                "author": "Author",
-                "editeur": "Editor",
-            },
+            extraData={"ean": "1234567891234", "author": "Author", "editeur": "Editor", "gtl_id": "08010000"},
         )
         offers_factories.OfferComplianceFactory(
             offer=offer,
@@ -1865,6 +1861,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert f"Offer ID : {offer.id}" in card_text
         assert "Catégorie : Films, vidéos" in card_text
         assert "Sous-catégorie : Support physique (DVD, Blu-ray...)" in card_text
+        assert "Type de musique : Alternatif" in card_text
         assert "Statut : Épuisée" in card_text
         assert "État : Validée" in card_text
         assert "Score data : 55 " in card_text


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31872

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
