### PR TITLE
(PC-33111)[PRO] fix: Makes location fields disabled for pending offers

### DIFF
--- a/pro/src/components/AddressManual/AddressManual.tsx
+++ b/pro/src/components/AddressManual/AddressManual.tsx
@@ -23,7 +23,13 @@ export interface AddressFormValues {
   longitude: string
 }
 
-export const AddressManual = (): JSX.Element => {
+interface AddressManualProps {
+  readOnlyFields?: string[]
+}
+
+export const AddressManual = ({
+  readOnlyFields = [],
+}: AddressManualProps): JSX.Element => {
   const [coords, coordsMeta] = useField<string>('coords')
 
   const formik = useFormikContext<AddressFormValues>()
@@ -53,7 +59,11 @@ export const AddressManual = (): JSX.Element => {
   return (
     <div className={styles['address-manual-wrapper']}>
       <FormLayout.Row>
-        <TextInput label="Adresse postale" name="street" />
+        <TextInput
+          label="Adresse postale"
+          name="street"
+          disabled={readOnlyFields.includes('street')}
+        />
       </FormLayout.Row>
       <FormLayout.Row inline className={styles['inline-fields']}>
         <TextInput
@@ -61,8 +71,14 @@ export const AddressManual = (): JSX.Element => {
           name="postalCode"
           maxLength={5}
           className={styles['field-cp']}
+          disabled={readOnlyFields.includes('postalCode')}
         />
-        <TextInput label="Ville" name="city" className={styles['field-city']} />
+        <TextInput
+          label="Ville"
+          name="city"
+          className={styles['field-city']}
+          disabled={readOnlyFields.includes('city')}
+        />
       </FormLayout.Row>
       <FormLayout.Row>
         <TextInput
@@ -71,6 +87,7 @@ export const AddressManual = (): JSX.Element => {
           onBlur={onCoordsBlur}
           type="text"
           description={`Exemple : 48.853320, 2.348979 ou 48°51'12.0"N 2°20'56.3"E`}
+          disabled={readOnlyFields.includes('coords')}
         />
       </FormLayout.Row>
 

--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/UsefulInformationForm/UsefulInformationForm.tsx
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/UsefulInformationForm/UsefulInformationForm.tsx
@@ -24,7 +24,7 @@ import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 import { Spinner } from 'ui-kit/Spinner/Spinner'
 
 import {
-  DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES,
+  DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES,
   providedTicketWithdrawalTypeRadios,
   ticketSentDateOptions,
   ticketWithdrawalHourOptions,
@@ -99,7 +99,7 @@ export const UsefulInformationForm = ({
   return (
     <>
       {isOfferAddressEnabled && !isVenueVirtual && (
-        <OfferLocation venue={selectedVenue} />
+        <OfferLocation venue={selectedVenue} offer={offer} />
       )}
       <FormLayout.Section title="Retrait de l’offre">
         {displayNoRefundWarning && (
@@ -271,7 +271,7 @@ export const UsefulInformationForm = ({
               if (
                 e.target.checked &&
                 bookingEmail ===
-                  DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES.bookingEmail
+                  DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES.bookingEmail
               ) {
                 await setFieldValue('bookingEmail', venue.bookingEmail ?? email)
               }

--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/__specs__/utils.spec.ts
@@ -3,7 +3,7 @@ import { AccessibilityEnum } from 'commons/core/shared/types'
 import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
 import { OFFER_LOCATION } from 'pages/IndividualOffer/commons/constants'
 
-import { DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES } from '../constants'
+import { DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES } from '../constants'
 import {
   setDefaultInitialValuesFromOffer,
   setFormReadOnlyFields,
@@ -66,7 +66,7 @@ describe('setDefaultInitialValuesFromOffer', () => {
       isNational: true,
       isVenueVirtual: false,
       withdrawalDetails:
-        DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['withdrawalDetails'],
+        DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES['withdrawalDetails'],
       withdrawalDelay: undefined,
       withdrawalType: undefined,
       accessibility: {
@@ -79,7 +79,7 @@ describe('setDefaultInitialValuesFromOffer', () => {
       bookingEmail: '',
       bookingContact: undefined,
       receiveNotificationEmails: false,
-      url: DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['url'],
+      url: DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES['url'],
     }
 
     const result = setDefaultInitialValuesFromOffer({
@@ -104,7 +104,7 @@ describe('setDefaultInitialValuesFromOffer', () => {
       isNational: true,
       isVenueVirtual: false,
       withdrawalDetails:
-        DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['withdrawalDetails'],
+        DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES['withdrawalDetails'],
       withdrawalDelay: undefined,
       withdrawalType: undefined,
       accessibility: {
@@ -117,7 +117,7 @@ describe('setDefaultInitialValuesFromOffer', () => {
       bookingEmail: '',
       bookingContact: undefined,
       receiveNotificationEmails: false,
-      url: DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['url'],
+      url: DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES['url'],
     }
 
     const result = setDefaultInitialValuesFromOffer({
@@ -212,7 +212,7 @@ describe('setFormReadOnlyFields', () => {
     const result = setFormReadOnlyFields(offer)
 
     expect(result).toEqual(
-      Object.keys(DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES)
+      Object.keys(DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES)
     )
   })
 
@@ -224,7 +224,7 @@ describe('setFormReadOnlyFields', () => {
     const result = setFormReadOnlyFields(offer)
 
     expect(result).toEqual(
-      Object.keys(DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES)
+      Object.keys(DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES)
     )
   })
 

--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/constants.ts
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/constants.ts
@@ -4,7 +4,7 @@ import { SUBCATEGORIES_FIELDS_DEFAULT_VALUES } from 'pages/IndividualOffer/Indiv
 
 import { UsefulInformationFormValues } from './types'
 
-export const DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES: UsefulInformationFormValues =
+export const DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES: UsefulInformationFormValues =
   {
     isNational: false,
     bookingContact: '',
@@ -21,6 +21,14 @@ export const DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES: UsefulInformationFormV
       [AccessibilityEnum.MOTOR]: false,
       [AccessibilityEnum.NONE]: false,
     },
+    locationLabel: '',
+    offerLocation: '',
+    addressAutocomplete: '',
+    manuallySetAddress: false,
+    street: '',
+    city: '',
+    postalCode: '',
+    coords: '',
   }
 
 export const ticketWithdrawalTypeRadios = [

--- a/pro/src/components/IndividualOffer/UsefulInformationScreen/utils.ts
+++ b/pro/src/components/IndividualOffer/UsefulInformationScreen/utils.ts
@@ -13,7 +13,7 @@ import { OFFER_LOCATION } from 'pages/IndividualOffer/commons/constants'
 import { FORM_DEFAULT_VALUES } from 'pages/IndividualOffer/IndividualOfferDetailsAndInformations/commons/constants'
 import { computeAddressDisplayName } from 'repository/venuesService'
 
-import { DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES } from './constants'
+import { DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES } from './constants'
 import { UsefulInformationFormValues } from './types'
 
 interface SetDefaultInitialValuesFromOfferProps {
@@ -84,7 +84,7 @@ export function setDefaultInitialValuesFromOffer({
     isNational: offer.isNational,
     withdrawalDetails:
       offer.withdrawalDetails ||
-      DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['withdrawalDetails'],
+      DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES['withdrawalDetails'],
     withdrawalDelay:
       offer.withdrawalDelay === null ? undefined : offer.withdrawalDelay,
     withdrawalType: offer.withdrawalType || undefined,
@@ -98,7 +98,7 @@ export function setDefaultInitialValuesFromOffer({
     bookingEmail: offer.bookingEmail || '',
     bookingContact: offer.bookingContact || undefined,
     receiveNotificationEmails: !!offer.bookingEmail,
-    url: offer.url || DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES['url'],
+    url: offer.url || DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES['url'],
     isVenueVirtual: offer.venue.isVirtual || false,
     ...addressFields,
   }
@@ -109,7 +109,7 @@ export function setFormReadOnlyFields(
 ): string[] {
   const readOnlyField: string[] = []
   if ([OFFER_STATUS_REJECTED, OFFER_STATUS_PENDING].includes(offer.status)) {
-    return Object.keys(DEFAULT_USEFULL_INFORMATION_INTITIAL_VALUES)
+    return Object.keys(DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES)
   }
 
   if (isOfferSynchronized(offer)) {

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetailsAndInformations/components/OfferLocation/OfferLocation.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetailsAndInformations/components/OfferLocation/OfferLocation.tsx
@@ -1,7 +1,10 @@
 import { useField, useFormikContext } from 'formik'
 import React, { useEffect, useState } from 'react'
 
-import { VenueListItemResponseModel } from 'apiClient/v1'
+import {
+  GetIndividualOfferWithAddressResponseModel,
+  VenueListItemResponseModel,
+} from 'apiClient/v1'
 import { resetAddressFields } from 'commons/utils/resetAddressFields'
 import { AddressSelect } from 'components/Address/Address'
 import { AddressManual } from 'components/AddressManual/AddressManual'
@@ -16,13 +19,18 @@ import { ButtonVariant } from 'ui-kit/Button/types'
 import { RadioButton } from 'ui-kit/form/RadioButton/RadioButton'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 
+import { setFormReadOnlyFields } from 'components/IndividualOffer/UsefulInformationScreen/utils'
 import styles from './OfferLocation.module.scss'
 
 interface OfferLocationProps {
   venue: VenueListItemResponseModel | undefined
+  offer: GetIndividualOfferWithAddressResponseModel
 }
 
-export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
+export const OfferLocation = ({
+  venue,
+  offer,
+}: OfferLocationProps): JSX.Element => {
   const formik = useFormikContext<IndividualOfferFormValues>()
 
   const [showOtherAddress, setShowOtherAddress] = useState(
@@ -78,6 +86,8 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
     }
   }
 
+  const readOnlyFields = setFormReadOnlyFields(offer)
+
   const venueAddress = venue?.address
     ? computeAddressDisplayName(venue.address, false)
     : ''
@@ -99,6 +109,7 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
           value={venue?.address?.id_oa.toString() ?? ''}
           required
           onChange={onChangeOfferLocation}
+          disabled={readOnlyFields.includes('offerLocation')}
         />
       </FormLayout.Row>
       <FormLayout.Row className={styles['location-row']}>
@@ -109,6 +120,7 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
           value={OFFER_LOCATION.OTHER_ADDRESS}
           required
           onChange={onChangeOfferLocation}
+          disabled={readOnlyFields.includes('offerLocation')}
         />
       </FormLayout.Row>
 
@@ -119,12 +131,16 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
               label="Intitulé de la localisation"
               name="locationLabel"
               isOptional
+              disabled={readOnlyFields.includes('locationLabel')}
             />
           </FormLayout.Row>
 
           <FormLayout.Row>
             <AddressSelect
-              disabled={manuallySetAddress.value}
+              disabled={
+                manuallySetAddress.value ||
+                readOnlyFields.includes('addressAutocomplete')
+              }
               className={styles['location-field']}
             />
           </FormLayout.Row>
@@ -135,6 +151,7 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
               title="Renseignez l’adresse manuellement"
               icon={manuallySetAddress.value ? fullBackIcon : fullNextIcon}
               onClick={toggleManuallySetAddress}
+              disabled={readOnlyFields.includes('manuallySetAddress')}
             >
               {manuallySetAddress.value ? (
                 <>Revenir à la sélection automatique</>
@@ -143,7 +160,9 @@ export const OfferLocation = ({ venue }: OfferLocationProps): JSX.Element => {
               )}
             </Button>
           </FormLayout.Row>
-          {manuallySetAddress.value && <AddressManual />}
+          {manuallySetAddress.value && (
+            <AddressManual readOnlyFields={readOnlyFields} />
+          )}
         </div>
       )}
     </FormLayout.Section>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33111

Ce ticket corrige la situation où l'on pouvait modifier la localisation d'une offre en attente de validation.
Les champs d'adresse sont désormais désactivés si l'offre est en _pending_.

### Offre à une autre adresse
![image](https://github.com/user-attachments/assets/ae3d29a0-8f9e-4de9-bcaa-280d9c7c79a9)
### Offre avec une adresse manuelle
![image](https://github.com/user-attachments/assets/9866324b-5563-4ce8-aa6d-92f3306a947c)
