### PR TITLE
(BSR)[API] fix: Fixed flaky test offerer already has offer with ean

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -663,9 +663,12 @@ def check_product_cgu_and_offerer(
             },
             status_code=422,
         )
-    if len([venue for venue in offerer.managedVenues if venue.isVirtual is False]) == 1:
+    not_virtual_venues = [venue for venue in offerer.managedVenues if venue.isVirtual is False]
+    # Context give only the offerer, not the specific venue on wich the offer is created.
+    # We can only check the existence of an offer with this EAN if the offerer has one venue.
+    if len(not_virtual_venues) == 1:
         try:
-            check_ean_does_not_exist(ean, offerer.managedVenues[0])
+            check_ean_does_not_exist(ean, not_virtual_venues[0])
         except exceptions.OfferAlreadyExists:
             raise api_errors.ApiErrors(
                 errors={"ean": ["Une offre avec cet EAN existe déjà. Vous pouvez la retrouver dans l'onglet Offres."]},


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

Correction d'un bug découvert grâce à un test flaky. Dans le check permettant de vérifier si un offerer avec une seule venue physique ne possède pas déjà une offre avec un certain EAN, nous avions un faux positif de temps en temps.

Le test permet de créer un offerer avec une venue physique avec une offre avec EAN, une autre virtuelle sans offre.
La condition permettait de vérifier que l'offerer n'avait qu'une seule venue physique mais `offerer.managedVenues[0]` retourne la venue virtuelle dans certain cas (ordre de création de la venue ?). Aucune offre avec EAN n'existant sur cette venue virtuelle, nous avons un faux positif.

Je remplace `offerer.managedVenues` par la liste d'un élément contenant la venue physique

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
