### PR TITLE
(BSR)[PRO] test: timeout 60 secs for request to get email

### DIFF
--- a/pro/cypress/e2e/collaborator.cy.ts
+++ b/pro/cypress/e2e/collaborator.cy.ts
@@ -57,6 +57,7 @@ describe('Collaborator list feature', () => {
     cy.request({
       method: 'GET',
       url: 'http://localhost:5001/sandboxes/get_unique_email',
+      timeout: 60000
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.To).to.eq(randomEmail)

--- a/pro/cypress/e2e/createAccount.cy.ts
+++ b/pro/cypress/e2e/createAccount.cy.ts
@@ -37,7 +37,7 @@ describe('Account creation', () => {
     cy.request({
       method: 'GET',
       url: 'http://localhost:5001/sandboxes/get_unique_email',
-      // failOnStatusCode: false,
+      timeout: 60000
     }).then((response) => {
       expect(response.status).to.eq(200)
       expect(response.body.To).to.eq(randomEmail)


### PR DESCRIPTION
## But de la pull request

Dans la route `get_unique_email` de `e2e.py` on lit la file d'attente d'email pendant 60 secondes max, il faut donc que le timeout dans l'appel depuis les tests e2e soit le même

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
