### PR TITLE
(PC-33082)[PRO] fix: Force strong and em html tags bold and italic fo…

### DIFF
--- a/pro/src/styles/global/_layout.scss
+++ b/pro/src/styles/global/_layout.scss
@@ -15,3 +15,11 @@ p,
 textarea {
   @include fonts.body;
 }
+
+strong {
+  @include fonts.body-exergue;
+}
+
+em {
+  @include fonts.body-italic;
+}

--- a/pro/src/styles/mixins/_fonts.scss
+++ b/pro/src/styles/mixins/_fonts.scss
@@ -37,3 +37,8 @@ $caption-line-height: rem.torem(16px);
   font-family: Montserrat-RegularItalic, system-ui, sans-serif;
   font-size: rem.torem(15px);
 }
+
+@mixin body-italic() {
+  font-family: Montserrat-RegularItalic, system-ui, sans-serif;
+  font-size: $body-font-size;
+}


### PR DESCRIPTION
…nts.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33082

**Objectif**
Corriger l'affichage des balises `strong` et `em` pour que la description des offres collectives s'affichent bien respectivement en gras et italique quand on parse le markdown.

Le problème étant que le `font-synthesis: none;` du reset.scss interdit au navigateur d'adapter lui-même le font-style et font-weight des éléments (problème sur Safari et Firefox de [double gras/ double italic](https://www.smashingmagazine.com/2013/02/setting-weights-and-styles-at-font-face-declaration/), présent depuis le changement de fonctionnement des typos DS où chaque typo a un nom unique pour des raisons de compatibilité avec l'app native).

Pour corriger, j'ai créé une nouvelle typo body-italic qui est temporaire d'ici qu'on utilise la typo design system body-italic (dans le DS elle est en 16px contre 15px pour le body actuel c'est pourquoi on peut pas encore l'utiliser).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
