### PR TITLE
(PC-33110)[PRO] fix: Makes offer location field disabled for synchronized offers

### DIFF
--- a/pro/src/pages/IndividualOffer/commons/constants.ts
+++ b/pro/src/pages/IndividualOffer/commons/constants.ts
@@ -18,6 +18,7 @@ export const SUBCATEGORIES_FIELDS_DEFAULT_VALUES = {
 }
 
 const OFFER_LOCATION_DEFAULT_VALUES = {
+  offerLocation: '',
   locationLabel: '',
   manuallySetAddress: false,
   street: '',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33110

Empêche la modification du champs "Localisation de l’offre" sur une offre synchronisée.
