### PR TITLE
(PC-32898)[PRO] fix: refresh after actions in individual offers

### DIFF
--- a/pro/src/pages/Offers/OffersRoute.tsx
+++ b/pro/src/pages/Offers/OffersRoute.tsx
@@ -31,6 +31,7 @@ import {
 import { Spinner } from 'ui-kit/Spinner/Spinner'
 
 import { IndividualOffersScreen } from './components/IndividualOffersScreen/IndividualOffersScreen'
+import { computeIndividualApiFilters } from './utils/computeIndividualApiFilters'
 
 export const GET_OFFERS_QUERY_KEY = 'listOffers'
 
@@ -88,13 +89,11 @@ export const OffersRoute = (): JSX.Element => {
   //  Admin users are not allowed to check all offers at once or to use the status filter for performance reasons. Unless there is a venue or offerer filter active.
   const isRestrictedAsAdmin = currentUser.isAdmin && !isFilterByVenueOrOfferer
 
-  const apiFilters: SearchFiltersParams = {
-    ...DEFAULT_SEARCH_FILTERS,
-    ...urlSearchFilters,
-    ...(isRestrictedAsAdmin ? { status: ALL_STATUS } : {}),
-    ...{ offererId: selectedOffererId?.toString() ?? '' },
-  }
-  delete apiFilters.page
+  const apiFilters = computeIndividualApiFilters(
+    urlSearchFilters,
+    selectedOffererId?.toString(),
+    isRestrictedAsAdmin
+  )
 
   const offersQuery = useSWR([GET_OFFERS_QUERY_KEY, apiFilters], () => {
     const {

--- a/pro/src/pages/Offers/OffersTable/Cells/DeleteDraftCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/DeleteDraftCell.tsx
@@ -21,12 +21,20 @@ import { computeDeletionSuccessMessage } from 'pages/Offers/utils/computeDeletio
 import { ListIconButton } from 'ui-kit/ListIconButton/ListIconButton'
 
 import styles from './Cells.module.scss'
+import { computeIndividualApiFilters } from 'pages/Offers/utils/computeIndividualApiFilters'
+import { selectCurrentOffererId } from 'commons/store/user/selectors'
+import { useSelector } from 'react-redux'
 
 interface DeleteDraftOffersProps {
   offer: ListOffersOfferResponseModel
+  isRestrictedAsAdmin: boolean
 }
 
-export const DeleteDraftCell = ({ offer }: DeleteDraftOffersProps) => {
+export const DeleteDraftCell = ({
+  offer,
+  isRestrictedAsAdmin,
+}: DeleteDraftOffersProps) => {
+  const selectedOffererId = useSelector(selectCurrentOffererId)?.toString()
   const urlSearchFilters = useQuerySearchFilters()
   const { mutate } = useSWRConfig()
   const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false)
@@ -37,11 +45,11 @@ export const DeleteDraftCell = ({ offer }: DeleteDraftOffersProps) => {
     setIsConfirmDialogOpen(false)
   }, [])
 
-  const apiFilters = {
-    ...DEFAULT_SEARCH_FILTERS,
-    ...urlSearchFilters,
-  }
-  delete apiFilters.page
+  const apiFilters = computeIndividualApiFilters(
+    urlSearchFilters,
+    selectedOffererId?.toString(),
+    isRestrictedAsAdmin
+  )
 
   const onConfirmDeleteDraftOffer = async () => {
     try {

--- a/pro/src/pages/Offers/OffersTable/Cells/IndividualActionsCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/IndividualActionsCell.tsx
@@ -12,12 +12,14 @@ interface IndividualActionsCellsProps {
   offer: ListOffersOfferResponseModel
   editionOfferLink: string
   editionStockLink: string
+  isRestrictedAsAdmin: boolean
 }
 
 export const IndividualActionsCells = ({
   offer,
   editionOfferLink,
   editionStockLink,
+  isRestrictedAsAdmin,
 }: IndividualActionsCellsProps) => {
   return (
     <td
@@ -28,7 +30,10 @@ export const IndividualActionsCells = ({
     >
       <div className={styles['actions-column-container']}>
         {offer.status === OFFER_STATUS_DRAFT ? (
-          <DeleteDraftCell offer={offer} />
+          <DeleteDraftCell
+            offer={offer}
+            isRestrictedAsAdmin={isRestrictedAsAdmin}
+          />
         ) : (
           <EditStocksCell offer={offer} editionStockLink={editionStockLink} />
         )}

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOfferRow/IndividualOfferRow.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOfferRow/IndividualOfferRow.tsx
@@ -25,6 +25,7 @@ export type IndividualOfferRowProps = {
   offer: ListOffersOfferResponseModel
   selectOffer: (offer: ListOffersOfferResponseModel) => void
   isFirstRow: boolean
+  isRestrictedAsAdmin: boolean
 }
 
 export const IndividualOfferRow = ({
@@ -32,6 +33,7 @@ export const IndividualOfferRow = ({
   isSelected,
   selectOffer,
   isFirstRow,
+  isRestrictedAsAdmin,
 }: IndividualOfferRowProps) => {
   const offerAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
 
@@ -82,6 +84,7 @@ export const IndividualOfferRow = ({
         offer={offer}
         editionOfferLink={editionOfferLink}
         editionStockLink={editionStockLink}
+        isRestrictedAsAdmin={isRestrictedAsAdmin}
       />
     </tr>
   )

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOfferRow/__specs__/IndividualOfferRow.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOfferRow/__specs__/IndividualOfferRow.spec.tsx
@@ -67,6 +67,7 @@ describe('IndividualOfferRow', () => {
       selectOffer: vi.fn(),
       isSelected: false,
       isFirstRow: true,
+      isRestrictedAsAdmin: false,
     }
   })
 

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
@@ -3,7 +3,6 @@ import { mutate, useSWRConfig } from 'swr'
 
 import { api } from 'apiClient/api'
 import { OfferStatus } from 'apiClient/v1'
-import { DEFAULT_SEARCH_FILTERS } from 'commons/core/Offers/constants'
 import { useQuerySearchFilters } from 'commons/core/Offers/hooks/useQuerySearchFilters'
 import { SearchFiltersParams } from 'commons/core/Offers/types'
 import { serializeApiFilters } from 'commons/core/Offers/utils/serializer'
@@ -24,6 +23,9 @@ import { computeSelectedOffersLabel } from '../../../utils/computeSelectedOffers
 
 import { DeleteConfirmDialog } from './DeleteConfirmDialog'
 import { IndividualDeactivationConfirmDialog } from './IndividualDeactivationConfirmDialog'
+import { selectCurrentOffererId } from 'commons/store/user/selectors'
+import { useSelector } from 'react-redux'
+import { computeIndividualApiFilters } from 'pages/Offers/utils/computeIndividualApiFilters'
 
 export type IndividualOffersActionsBarProps = {
   areAllOffersSelected: boolean
@@ -34,6 +36,7 @@ export type IndividualOffersActionsBarProps = {
   canDelete: boolean
   canPublish: boolean
   canDeactivate: boolean
+  isRestrictedAsAdmin: boolean
 }
 
 const computeAllActivationSuccessMessage = (nbSelectedOffers: number) => {
@@ -119,7 +122,6 @@ const updateIndividualOffersStatus = async (
       )
     }
   }
-
   await mutate([GET_OFFERS_QUERY_KEY, apiFilters])
 }
 
@@ -132,9 +134,11 @@ export const IndividualOffersActionsBar = ({
   canDelete,
   canPublish,
   canDeactivate,
+  isRestrictedAsAdmin,
 }: IndividualOffersActionsBarProps): JSX.Element => {
   const urlSearchFilters = useQuerySearchFilters()
   const { mutate } = useSWRConfig()
+  const selectedOffererId = useSelector(selectCurrentOffererId)?.toString()
 
   const notify = useNotification()
   const [isDeactivationDialogOpen, setIsDeactivationDialogOpen] =
@@ -144,11 +148,11 @@ export const IndividualOffersActionsBar = ({
     'ENABLE_COLLECTIVE_NEW_STATUSES'
   )
 
-  const apiFilters = {
-    ...DEFAULT_SEARCH_FILTERS,
-    ...urlSearchFilters,
-  }
-  delete apiFilters.page
+  const apiFilters = computeIndividualApiFilters(
+    urlSearchFilters,
+    selectedOffererId,
+    isRestrictedAsAdmin
+  )
 
   const handleClose = () => {
     clearSelectedOffers()

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/__specs__/IndividualOffersActionsBar.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/__specs__/IndividualOffersActionsBar.spec.tsx
@@ -51,6 +51,7 @@ describe('ActionsBar', () => {
       clearSelectedOffers: vi.fn(),
       toggleSelectAllCheckboxes: vi.fn(),
       areAllOffersSelected: false,
+      isRestrictedAsAdmin: false,
     }
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
       logEvent: mockLogEvent,

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTable.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTable.tsx
@@ -112,6 +112,7 @@ export const IndividualOffersTable = ({
                   offers={currentPageOffersSubset}
                   selectOffer={setSelectedOffer}
                   selectedOffers={selectedOffers}
+                  isRestrictedAsAdmin={isRestrictedAsAdmin}
                 />
               </table>
             </>

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTableBody/IndividualOffersTableBody.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersTableBody/IndividualOffersTableBody.tsx
@@ -9,12 +9,14 @@ type IndividualOffersTableBodyProps = {
   offers: ListOffersOfferResponseModel[]
   selectOffer: (offer: ListOffersOfferResponseModel) => void
   selectedOffers: ListOffersOfferResponseModel[]
+  isRestrictedAsAdmin: boolean
 }
 
 export const IndividualOffersTableBody = ({
   offers,
   selectOffer,
   selectedOffers,
+  isRestrictedAsAdmin,
 }: IndividualOffersTableBodyProps) => {
   return (
     <tbody className={styles['individual-tbody']}>
@@ -30,6 +32,7 @@ export const IndividualOffersTableBody = ({
             offer={offer}
             selectOffer={selectOffer}
             isFirstRow={index === 0}
+            isRestrictedAsAdmin={isRestrictedAsAdmin}
           />
         )
       })}

--- a/pro/src/pages/Offers/components/IndividualOffersScreen/IndividualOffersScreen.tsx
+++ b/pro/src/pages/Offers/components/IndividualOffersScreen/IndividualOffersScreen.tsx
@@ -184,6 +184,7 @@ export const IndividualOffersScreen = ({
                 canDelete={canDelete}
                 canDeactivate={canDeactivate}
                 canPublish={canPublish}
+                isRestrictedAsAdmin={Boolean(isRestrictedAsAdmin)}
               />
             )}
           </div>

--- a/pro/src/pages/Offers/utils/computeIndividualApiFilters.ts
+++ b/pro/src/pages/Offers/utils/computeIndividualApiFilters.ts
@@ -1,0 +1,20 @@
+import {
+  ALL_STATUS,
+  DEFAULT_SEARCH_FILTERS,
+} from 'commons/core/Offers/constants'
+import { SearchFiltersParams } from 'commons/core/Offers/types'
+
+export function computeIndividualApiFilters(
+  urlSearchFilters: SearchFiltersParams,
+  selectedOffererId?: string | null,
+  isRestrictedAsAdmin?: boolean
+): SearchFiltersParams {
+  const apiFilters: SearchFiltersParams = {
+    ...DEFAULT_SEARCH_FILTERS,
+    ...urlSearchFilters,
+    ...(isRestrictedAsAdmin ? { status: ALL_STATUS } : {}),
+    ...{ offererId: selectedOffererId?.toString() ?? '' },
+  }
+  delete apiFilters.page
+  return apiFilters
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32898

Les offres n'étaient plus raffraichies après une action parce que les apiFilters n'étaient plus identiques
j'ai donc créé une fonction pour centraliser leur gestion

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
