### PR TITLE
(BSR)[PRO] cleanup after eslint update

### DIFF
--- a/pro/eslint.config.mjs
+++ b/pro/eslint.config.mjs
@@ -141,11 +141,11 @@ export default [
       '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-unnecessary-condition': 'error',
+      'require-await': 'error',
 
       // TODO turn into error
       'react-hooks/rules-of-hooks': 'warn',
       '@typescript-eslint/switch-exhaustiveness-check': 'warn',
-      'require-await': 'warn',
       'react-hooks/exhaustive-deps': 'warn',
 
       'react/self-closing-comp': [

--- a/pro/eslint.config.mjs
+++ b/pro/eslint.config.mjs
@@ -140,9 +140,9 @@ export default [
       '@typescript-eslint/no-unnecessary-type-arguments': 'error',
       '@typescript-eslint/no-unnecessary-boolean-literal-compare': 'error',
       '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'error',
 
       // TODO turn into error
-      '@typescript-eslint/no-unnecessary-condition': 'warn',
       'react-hooks/rules-of-hooks': 'warn',
       '@typescript-eslint/switch-exhaustiveness-check': 'warn',
       'require-await': 'warn',

--- a/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/__specs__/CollectiveActionsCells.spec.tsx
@@ -461,16 +461,16 @@ describe('CollectiveActionsCells', () => {
       {
         offer: collectiveOfferFactory({
           isShowcase: false,
-          allowedActions: [
-            CollectiveOfferAllowedAction.CAN_CANCEL,
-          ],
+          allowedActions: [CollectiveOfferAllowedAction.CAN_CANCEL],
         }),
-      }, ['ENABLE_COLLECTIVE_NEW_STATUSES'])
+      },
+      ['ENABLE_COLLECTIVE_NEW_STATUSES']
+    )
 
-      await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByTitle('Action'))
 
-      expect(screen.getByText('Annuler la réservation')).toBeInTheDocument()
-    })
+    expect(screen.getByText('Annuler la réservation')).toBeInTheDocument()
+  })
 
   it('should allow to hide template offer when the ENABLE_COLLECTIVE_NEW_STATUSES FF is enabled', async () => {
     renderCollectiveActionsCell(
@@ -496,7 +496,7 @@ describe('CollectiveActionsCells', () => {
     )
   })
 
-  it('should not show cancel button when ENABLE_COLLECTIVE_NEW_STATUSES and offer has not CAN_CANCEL allowed action', async () => {
+  it('should not show cancel button when ENABLE_COLLECTIVE_NEW_STATUSES and offer has not CAN_CANCEL allowed action', () => {
     renderCollectiveActionsCell(
       {
         offer: collectiveOfferFactory({
@@ -507,7 +507,7 @@ describe('CollectiveActionsCells', () => {
       ['ENABLE_COLLECTIVE_NEW_STATUSES']
     )
 
-      expect(screen.queryByText('Annuler la réservation')).not.toBeInTheDocument()
+    expect(screen.queryByText('Annuler la réservation')).not.toBeInTheDocument()
   })
 
   it('should allow to publish template offer when the ENABLE_COLLECTIVE_NEW_STATUSES FF is enabled', async () => {

--- a/pro/src/ui-kit/form/QuantityInput/QuantityInput.spec.tsx
+++ b/pro/src/ui-kit/form/QuantityInput/QuantityInput.spec.tsx
@@ -4,7 +4,10 @@ import { Formik } from 'formik'
 
 import { QuantityInput, QuantityInputProps } from './QuantityInput'
 
-const renderQuantityInput = (props: QuantityInputProps, initialQuantity: number | string = '') => {
+const renderQuantityInput = (
+  props: QuantityInputProps,
+  initialQuantity: number | string = ''
+) => {
   return render(
     <Formik initialValues={{ quantity: initialQuantity }} onSubmit={() => {}}>
       <QuantityInput {...props} />
@@ -76,7 +79,7 @@ describe('QuantityInput', () => {
     expect(checkbox).toBeChecked()
   })
 
-  it('should check the checkbox initially when the input value is an empty string', async () => {
+  it('should check the checkbox initially when the input value is an empty string', () => {
     renderQuantityInput({}, '')
 
     let input = screen.getByRole('spinbutton', { name: LABELS.input })
@@ -86,7 +89,7 @@ describe('QuantityInput', () => {
     expect(checkbox).toBeChecked()
   })
 
-  it('should uncheck the checkbox when the input value is set', async () => {
+  it('should uncheck the checkbox when the input value is set', () => {
     renderQuantityInput({}, '1')
 
     let input = screen.getByRole('spinbutton', { name: LABELS.input })


### PR DESCRIPTION
## But de la pull request

Poursuite du cleanup suite à la migration eslint, fix des alertes suivantes : 
```
      '@typescript-eslint/no-unnecessary-condition': 'error',
      'require-await': 'error',
```
## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
