### PR TITLE
(PC-33026)[PRO] fix: use last typings for Income page

### DIFF
--- a/pro/src/commons/utils/factories/statisticsFactories.ts
+++ b/pro/src/commons/utils/factories/statisticsFactories.ts
@@ -7,7 +7,10 @@ export const statisticsFactory = ({
   collectiveAndIndividualRevenueYear = '2024',
 }): StatisticsModel => {
   const incomeByYear = {
-    ...(emptyYear && {[emptyYear]: {}}),
+    ...(emptyYear && {[emptyYear]: {
+      revenue: null,
+      expectedRevenue: null,
+    }}),
     ...(individualRevenueOnlyYear && {
       [individualRevenueOnlyYear]: {
         revenue: {

--- a/pro/src/pages/Reimbursements/Income/Income.spec.tsx
+++ b/pro/src/pages/Reimbursements/Income/Income.spec.tsx
@@ -334,22 +334,22 @@ describe('Income', () => {
         for (const t of incomeTypes) {
           await waitFor(() => {
             const incomeResults = income[t]
-            const { total, individual, collective } = incomeResults
-
-            if (isCollectiveAndIndividualRevenue(incomeResults)) {
-              expect(screen.getByText(toFloatStr(total))).toBeInTheDocument()
-              expect(
-                screen.getByText(toFloatStr(individual))
-              ).toBeInTheDocument()
-              expect(
-                screen.getByText(toFloatStr(collective))
-              ).toBeInTheDocument()
-            } else if (isCollectiveRevenue(incomeResults)) {
-              expect(
-                screen.getByText(toFloatStr(collective))
-              ).toBeInTheDocument()
-            } else {
-              expect(screen.getByText(toFloatStr(individual))).toBeInTheDocument()
+            if (incomeResults) {
+              if (isCollectiveAndIndividualRevenue(incomeResults)) {
+                expect(screen.getByText(toFloatStr(incomeResults.total))).toBeInTheDocument()
+                expect(
+                  screen.getByText(toFloatStr(incomeResults.individual))
+                ).toBeInTheDocument()
+                expect(
+                  screen.getByText(toFloatStr(incomeResults.collective))
+                ).toBeInTheDocument()
+              } else if (isCollectiveRevenue(incomeResults)) {
+                expect(
+                  screen.getByText(toFloatStr(incomeResults.collective))
+                ).toBeInTheDocument()
+              } else {
+                expect(screen.getByText(toFloatStr(incomeResults.individual))).toBeInTheDocument()
+              }
             }
           })
         }
@@ -364,7 +364,7 @@ describe('Income', () => {
       await waitFor(() => screen.getAllByText(LABELS.incomeResultsLabel))
 
       const emptyYear = Object.keys(MOCK_DATA.incomeByYear).find(
-        year => Object.keys(MOCK_DATA.incomeByYear[year]).length === 0
+        year => MOCK_DATA.incomeByYear[year].revenue === null && MOCK_DATA.incomeByYear[year].expectedRevenue === null
       )
       await userEvent.click(
         screen.getByRole('button', {

--- a/pro/src/pages/Reimbursements/Income/Income.tsx
+++ b/pro/src/pages/Reimbursements/Income/Income.tsx
@@ -1,12 +1,12 @@
-import isEqual from 'lodash.isequal'
 import classnames from 'classnames'
-import { useState, useEffect, useRef } from 'react'
 import { FormikProvider, useFormik } from 'formik'
+import isEqual from 'lodash.isequal'
+import { useState, useEffect, useRef } from 'react'
 import * as yup from 'yup'
 
 import { FormLayout } from 'components/FormLayout/FormLayout'
-import { Spinner } from 'ui-kit/Spinner/Spinner'
 import { SelectAutocomplete } from 'ui-kit/form/SelectAutoComplete/SelectAutocomplete'
+import { Spinner } from 'ui-kit/Spinner/Spinner'
 
 import { useVenues, useIncome } from './hooks'
 import styles from './Income.module.scss'
@@ -89,7 +89,7 @@ export const Income = () => {
   } = useIncome(debouncedSelectedVenues)
   const finalActiveYear = activeYear || years[0]
   const activeYearIncome = incomeByYear?.[finalActiveYear] || {}
-  const activeYearHasData = Object.keys(activeYearIncome).length > 0
+  const activeYearHasData = activeYearIncome.revenue || activeYearIncome.expectedRevenue
 
   useEffect(() => {
     if (hasSingleVenue && incomeDataReady && firstYearFilterRef.current) {
@@ -190,14 +190,14 @@ export const Income = () => {
                   <IncomeNoData type="income-year" />
                 ) : (
                   <div className={styles['income-results']}>
-                    <IncomeResultsBox
+                    {activeYearIncome.revenue && <IncomeResultsBox
                       type="revenue"
                       income={activeYearIncome.revenue}
-                    />
-                    <IncomeResultsBox
+                    />}
+                    {activeYearIncome.expectedRevenue && <IncomeResultsBox
                       type="expectedRevenue"
                       income={activeYearIncome.expectedRevenue}
-                    />
+                    />}
                   </div>
                 )}
               </>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33026

## Objectifs
- Followup de la tâche côté frontend, pour faire suite aux changements de typage d'api. 
- Sans cette PR, le type check est cassé ! 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
