### PR TITLE
(PC-33129)[API] feat: adding isOnboardinOngoing to /offerer/<id>

### DIFF
--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -104,6 +104,7 @@ class GetOffererResponseModel(BaseModel):
     allowedOnAdage: bool
     hasBankAccountWithPendingCorrections: bool
     isOnboarded: bool
+    isOnboardingOngoing: bool
 
     @classmethod
     def from_orm(cls, row: Row) -> "GetOffererResponseModel":
@@ -135,6 +136,7 @@ class GetOffererResponseModel(BaseModel):
         offerer.hasActiveOffer = row.hasActiveOffer
         offerer.hasBankAccountWithPendingCorrections = row.hasBankAccountWithPendingCorrections
         offerer.isOnboarded = row.isOnboarded
+        offerer.isOnboardingOngoing = row.isOnboardingOngoing
 
         # We would like the response attribute to be called
         # `managedVenues` but we don't want to use the

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -126,6 +126,7 @@ class GetOffererTest:
             "street": offerer.street,
             "allowedOnAdage": offerer.allowedOnAdage,
             "isOnboarded": True,
+            "isOnboardingOngoing": False,
         }
         assert response.json == expected_serialized_offerer
 
@@ -296,6 +297,65 @@ class GetOffererTest:
         assert response.json["hasPendingBankAccount"] is False
         assert response.json["venuesWithNonFreeOffersWithoutBankAccounts"] == []
         assert response.json["hasNonFreeOffer"] is False
+
+    @pytest.mark.parametrize(
+        "has_adage,num_draft_offer,num_approved_offers",
+        [
+            (True, 1, 3),
+            (True, 2, 1),
+            (True, 0, 3),
+            (True, 3, 3),
+            (True, 0, 0),
+            (False, 1, 3),
+            (False, 2, 1),
+            (False, 0, 3),
+            (False, 3, 3),
+            (False, 0, 0),
+        ],
+    )
+    def test_offerer_has_started_on_boarding(self, client, has_adage, num_draft_offer, num_approved_offers):
+        pro = users_factories.ProFactory()
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
+
+        adage_id = None
+        if has_adage:
+            adage_id = "1"
+
+        venue_with_offer = offerers_factories.VenueFactory(managingOfferer=offerer, adageId=adage_id)
+        if num_approved_offers:
+            offers_factories.OfferFactory.create_batch(
+                num_approved_offers, venue=venue_with_offer, validation=offers_models.OfferValidationStatus.APPROVED
+            )
+        if num_draft_offer:
+            offers_factories.OfferFactory.create_batch(
+                num_draft_offer, venue=venue_with_offer, validation=offers_models.OfferValidationStatus.DRAFT
+            )
+
+        offerer_id = offerer.id
+        client = client.with_session_auth(pro.email)
+        num_queries = testing.AUTHENTICATION_QUERIES
+        num_queries += 1  # check user_offerer exists
+        num_queries += 1  # select offerer
+        num_queries += 1  # select api_key
+        num_queries += 1  # select venue
+        num_queries += 1  # check offerer has non free offers
+        num_queries += 1  # select venue_id
+        num_queries += 1  # select offerer_address
+
+        num_queries += 1  # select venues_id with active offers
+        with testing.assert_num_queries(num_queries):
+            response = client.get(f"/offerers/{offerer_id}")
+            assert response.status_code == 200
+
+        assert response.json["managedVenues"][0]["hasCreatedOffer"] is (num_approved_offers > 0)
+        assert response.json["hasValidBankAccount"] is False
+        assert response.json["hasPendingBankAccount"] is False
+        assert response.json["venuesWithNonFreeOffersWithoutBankAccounts"] == []
+        assert response.json["hasNonFreeOffer"] is False
+        assert response.json["isOnboardingOngoing"] is bool(
+            num_draft_offer >= 1 and num_approved_offers == 0 and not has_adage
+        )
 
     def test_offerer_has_inactive_non_free_collective_offer(self, client):
         pro = users_factories.ProFactory()

--- a/pro/src/apiClient/v1/models/GetOffererResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetOffererResponseModel.ts
@@ -19,6 +19,7 @@ export type GetOffererResponseModel = {
   id: number;
   isActive: boolean;
   isOnboarded: boolean;
+  isOnboardingOngoing: boolean;
   isValidated: boolean;
   managedVenues?: Array<GetOffererVenueResponseModel>;
   name: string;

--- a/pro/src/commons/utils/factories/individualApiFactories.ts
+++ b/pro/src/commons/utils/factories/individualApiFactories.ts
@@ -347,6 +347,7 @@ export const defaultGetOffererResponseModel: GetOffererResponseModel = {
   street: 'Fake Address',
   allowedOnAdage: true,
   isOnboarded: true,
+  isOnboardingOngoing: false,
 }
 
 export const defaultGetOffererVenueResponseModel: GetOffererVenueResponseModel =


### PR DESCRIPTION
## But de la pull request
Ajouter un indicateur pour identifier le statut onboarding en cours. 
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33129

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
