### PR TITLE
(PC-33130)[PRO] feat: do not display loader when changing partner page

### DIFF
--- a/pro/src/pages/VenueEdition/VenueEdition.tsx
+++ b/pro/src/pages/VenueEdition/VenueEdition.tsx
@@ -61,10 +61,8 @@ export const VenueEdition = (): JSX.Element | null => {
   }
 
   if (
-    venueQuery.isLoading ||
     venueTypesQuery.isLoading ||
     offererQuery.isLoading ||
-    !venue ||
     !offerer ||
     !venueTypes
   ) {
@@ -80,16 +78,16 @@ export const VenueEdition = (): JSX.Element | null => {
       key: 'individual',
       label: 'Pour le grand public',
       url: generatePath('/structures/:offererId/lieux/:venueId', {
-        offererId: String(venue.managingOfferer.id),
-        venueId: String(venue.id),
+        offererId: String(venue?.managingOfferer.id),
+        venueId: String(venue?.id),
       }),
     },
     {
       key: 'collective',
       label: 'Pour les enseignants',
       url: generatePath('/structures/:offererId/lieux/:venueId/collectif', {
-        offererId: String(venue.managingOfferer.id),
-        venueId: String(venue.id),
+        offererId: String(venue?.managingOfferer.id),
+        venueId: String(venue?.id),
       }),
     },
   ]
@@ -109,7 +107,7 @@ export const VenueEdition = (): JSX.Element | null => {
   const titleText =
     activeStep === 'collective'
       ? 'Page dans ADAGE'
-      : !venue.isPermanent
+      : !venue?.isPermanent
         ? 'Page adresse'
         : 'Page sur l’application'
 
@@ -118,7 +116,7 @@ export const VenueEdition = (): JSX.Element | null => {
       <div>
         <FormLayout>
           <h1 className={styles['header']}>{titleText}</h1>
-          {venuesOptions.length > 1 && venue.isPermanent && (
+          {venuesOptions.length > 1 && venue?.isPermanent && (
             <>
               <FormLayout.Row>
                 <FieldLayout
@@ -143,14 +141,16 @@ export const VenueEdition = (): JSX.Element | null => {
             </>
           )}
         </FormLayout>
-        <VenueEditionHeader
-          venue={venue}
-          offerer={offerer}
-          venueTypes={venueTypes}
-          key={venueId}
-        />
+        {venue && (
+          <VenueEditionHeader
+            venue={venue}
+            offerer={offerer}
+            venueTypes={venueTypes}
+            key={venueId}
+          />
+        )}
 
-        {!venue.isPermanent && (
+        {!venue?.isPermanent && (
           <Tabs
             tabs={tabs}
             selectedKey={activeStep}
@@ -163,7 +163,12 @@ export const VenueEdition = (): JSX.Element | null => {
             path="collectif/*"
             element={<CollectiveDataEdition venue={venue} />}
           />
-          <Route path="*" element={<VenueEditionFormScreen venue={venue} />} />
+          {venue && (
+            <Route
+              path="*"
+              element={<VenueEditionFormScreen venue={venue} />}
+            />
+          )}
         </Routes>
       </div>
     </Layout>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33130

Le produit préfère l'affichage sans loader

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
