### PR TITLE
(PC-33137)[PRO] fix: reset image in indiv. offer creation form when EAN is cleared

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.spec.tsx
@@ -46,7 +46,7 @@ const EanSearchWrappedWithFormik = ({
   initialEan = '',
   eanSubmitError = '',
   onEanSearch = vi.fn(),
-  resetForm = vi.fn(),
+  onEanReset = vi.fn(),
 }: DetailsEanSearchTestProps): JSX.Element => {
   const formik = useFormik({
     initialValues: {
@@ -72,7 +72,7 @@ const EanSearchWrappedWithFormik = ({
         initialEan={initialEan}
         eanSubmitError={eanSubmitError}
         onEanSearch={onEanSearch}
-        resetForm={resetForm}
+        onEanReset={onEanReset}
       />
     </FormikProvider>
   )
@@ -217,11 +217,11 @@ describe('DetailsEanSearch', () => {
       })
 
       it('should clear the form when the clear button is clicked', async () => {
-        const resetForm = vi.fn()
+        const onEanReset = vi.fn()
         renderDetailsEanSearch({
           isDirtyDraftOffer: true,
           wasEanSearchPerformedSuccessfully: true,
-          resetForm,
+          onEanReset,
         })
 
         const clearButton = screen.getByRole('button', {
@@ -231,7 +231,7 @@ describe('DetailsEanSearch', () => {
         expect(clearButton).toBeInTheDocument()
 
         await userEvent.click(clearButton)
-        expect(resetForm.mock.calls.length).toBe(1)
+        expect(onEanReset.mock.calls.length).toBe(1)
       })
 
       it('should display an error message if POST API ends with an EAN err', () => {

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.tsx
@@ -24,7 +24,7 @@ export type DetailsEanSearchProps = {
   initialEan?: string
   eanSubmitError?: string
   onEanSearch: (ean: string, product: Product) => Promise<void>
-  resetForm: () => void
+  onEanReset: () => void
 }
 
 export const DetailsEanSearch = ({
@@ -34,7 +34,7 @@ export const DetailsEanSearch = ({
   initialEan,
   eanSubmitError,
   onEanSearch,
-  resetForm,
+  onEanReset,
 }: DetailsEanSearchProps): JSX.Element => {
   const selectedOffererId = useSelector(selectCurrentOffererId)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -101,7 +101,7 @@ export const DetailsEanSearch = ({
 
   const onEanClear = () => {
     formik.resetForm()
-    resetForm()
+    onEanReset()
     setWasCleared(true)
   }
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreen.tsx
@@ -281,6 +281,11 @@ export const IndividualOfferDetailsScreen = ({
     })
   }
 
+  const onEanReset = () => {
+    setImageOffer(undefined)
+    formik.resetForm()
+  }
+
   return (
     <>
       <FormLayout.MandatoryInfo />
@@ -292,7 +297,7 @@ export const IndividualOfferDetailsScreen = ({
           initialEan={offer?.extraData?.ean}
           eanSubmitError={formik.status === 'apiError' ? formik.errors.ean : ''}
           onEanSearch={onEanSearch}
-          resetForm={formik.resetForm}
+          onEanReset={onEanReset}
         />
       )}
       {isEanSearchCalloutAloneDisplayed && <EanSearchCallout />}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33137

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
