### PR TITLE
Revert "(PC-32716)[PRO] refactor: Replace obsolete util function by a standard one"

### DIFF
--- a/pro/src/commons/utils/__specs__/findLastIndex.spec.ts
+++ b/pro/src/commons/utils/__specs__/findLastIndex.spec.ts
@@ -1,0 +1,40 @@
+import { findLastIndex } from '../findLastIndex'
+
+describe('findLastIndex', () => {
+  it('should return last index when it satisfies the condition', () => {
+    const testArray = [
+      { index: 0, isTrue: true },
+      { index: 1, isTrue: true },
+      { index: 2, isTrue: true },
+      { index: 3, isTrue: true },
+    ]
+    const anotherArray = [
+      { index: 0, isTrue: true },
+      { index: 1, isTrue: true },
+      { index: 2, isTrue: false },
+      { index: 3, isTrue: false },
+    ]
+
+    const expectedIndex = findLastIndex(testArray, (elem) => elem.isTrue)
+    const anotherExpectedIndex = findLastIndex(
+      anotherArray,
+      (elem) => elem.isTrue
+    )
+
+    expect(expectedIndex).toBe(testArray[3].index)
+    expect(anotherExpectedIndex).toBe(anotherArray[1].index)
+  })
+
+  it('should return -1 when no element satisfies the condition', () => {
+    const testArray = [
+      { id: 0, isTrue: false },
+      { id: 1, isTrue: false },
+      { id: 2, isTrue: false },
+      { id: 3, isTrue: false },
+    ]
+
+    const expectedIndex = findLastIndex(testArray, (elem) => elem.isTrue)
+
+    expect(expectedIndex).toBe(-1)
+  })
+})

--- a/pro/src/commons/utils/findLastIndex.ts
+++ b/pro/src/commons/utils/findLastIndex.ts
@@ -1,0 +1,12 @@
+export function findLastIndex<T>(
+  array: Array<T>,
+  predicate: (value: T) => boolean
+): number {
+  let l = array.length
+  while (l--) {
+    if (predicate(array[l])) {
+      return l
+    }
+  }
+  return -1
+}

--- a/pro/src/components/Stepper/Stepper.tsx
+++ b/pro/src/components/Stepper/Stepper.tsx
@@ -1,6 +1,7 @@
 import cn from 'classnames'
 import React, { useLayoutEffect, useRef, useState } from 'react'
 
+import { findLastIndex } from 'commons/utils/findLastIndex'
 import { StepContent } from 'components/Stepper/StepContent'
 
 import styles from './Stepper.module.scss'
@@ -35,7 +36,7 @@ export const Stepper = ({
   const [stepperWidth, setStepperWidth] = useState(0)
 
   const lastStepIndex = steps.length - 1
-  const lastLineToActivate = steps.findLastIndex((step: Step) => !!step.url)
+  const lastLineToActivate = findLastIndex(steps, (step: Step) => !!step.url)
 
   useLayoutEffect(() => {
     //  Before the first render, get the list total width


### PR DESCRIPTION
This reverts commit 2a6844d089cf40fe4e544d0e1de0a9fcd073dfd4.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32983

Il semblerait que la suppression de cette fonction provoque de nombreuses erreurs sur de vieux navigateurs n'ayant pas implémentés nativement la fonction "findLastIndex".

Cette PR fait-donc un revert du commit pour récupérer la fonction de polyfill pour "findLastIndex".
