### PR TITLE
(PC-33167)[PRO] test: add more tests for collective search

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/getters/pro.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/pro.py
@@ -216,12 +216,50 @@ def create_pro_user_with_collective_offers() -> dict:
     pro_user = users_factories.ProFactory()
     offerer = offerers_factories.OffererFactory()
     offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-    venue = offerers_factories.VenueFactory(name="Mon Lieu", managingOfferer=offerer, isPermanent=True)
+    venue1 = offerers_factories.CollectiveVenueFactory(name="Mon Lieu 1", managingOfferer=offerer)
+    venue2 = offerers_factories.CollectiveVenueFactory(name="Mon Lieu 2", managingOfferer=offerer)
     offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
 
     educational_factories.CollectiveOfferTemplateFactory(
-        name="Mon offre collective",
-        venue=venue,
+        name="Mon offre collective publiée vitrine",
+        venue=venue1,
+        subcategoryId=subcategories.CONCERT.id,
+        formats=[subcategories.EacFormat.CONCERT],
+    )
+
+    educational_factories.CollectiveStockFactory(
+        collectiveOffer__name="Mon offre collective publiée réservable",
+        collectiveOffer__venue=venue1,
+        collectiveOffer__subcategoryId=subcategories.CONCERT.id,
+        collectiveOffer__formats=[subcategories.EacFormat.CONCERT],
+        beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(weeks=2),
+        endDatetime=datetime.datetime.utcnow() + datetime.timedelta(weeks=2),
+    )
+
+    educational_factories.DraftCollectiveOfferFactory(
+        name="Mon offre collective en brouillon réservable",
+        venue=venue1,
+        subcategoryId=subcategories.CONCERT.id,
+        formats=[subcategories.EacFormat.REPRESENTATION],
+    )
+
+    educational_factories.PendingCollectiveOfferFactory(
+        name="Mon offre collective en instruction réservable",
+        venue=venue2,
+        subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
+        formats=[subcategories.EacFormat.REPRESENTATION],
+    )
+
+    educational_factories.RejectedCollectiveOfferFactory(
+        name="Mon offre collective non conforme réservable",
+        venue=venue2,
+        subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
+        formats=[subcategories.EacFormat.REPRESENTATION],
+    )
+
+    educational_factories.ArchivedCollectiveOfferFactory(
+        name="Mon offre collective archivée réservable",
+        venue=venue2,
         subcategoryId=subcategories.SEANCE_CINE.id,
         formats=[subcategories.EacFormat.PROJECTION_AUDIOVISUELLE],
     )

--- a/pro/cypress/e2e/searchCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/searchCollectiveOffer.cy.ts
@@ -1,3 +1,5 @@
+import { addWeeks, format } from 'date-fns'
+
 import {
   expectOffersOrBookingsAreFound,
   logAndGoToPage,
@@ -5,10 +7,17 @@ import {
 
 describe('Search collective offers', () => {
   let login: string
-  const venueName = 'Mon Lieu'
-  const offerName = 'Mon offre collective'
+  const venueName1 = 'Mon Lieu 1'
+  const venueName2 = 'Mon Lieu 2'
+  const offerNameArchived = 'Mon offre collective archivée réservable'
+  const offerNamePublished = 'Mon offre collective publiée réservable'
+  const offerNamePublishedTemplate = 'Mon offre collective publiée vitrine'
+  const offerNameDraft = 'Mon offre collective en brouillon réservable'
+  const offerNameNotConform = 'Mon offre collective non conforme réservable'
+  const offerNameInInstruction = 'Mon offre collective en instruction réservable'
+  const formatName = 'Concert'
 
-  beforeEach(() => {
+  before(() => {
     cy.visit('/connexion')
     cy.request({
       method: 'GET',
@@ -16,20 +25,247 @@ describe('Search collective offers', () => {
     }).then((response) => {
       login = response.body.user.email
     })
+    cy.setFeatureFlags([
+      { name: 'ENABLE_COLLECTIVE_NEW_STATUSES', isActive: true },
+    ])
+  })
+
+  beforeEach(() => {
+    logAndGoToPage(login, '/accueil')
+
     cy.intercept({ method: 'GET', url: '/collective/offers*' }).as(
       'collectiveOffers'
     )
+    cy.intercept({ method: 'GET', url: '/venues?offererId*' }).as(
+      'venuesOffererId'
+    )
+    cy.visit('/offres/collectives')
+    cy.wait(['@collectiveOffers', '@venuesOffererId'])
+    cy.findAllByTestId('spinner').should('not.exist')
   })
 
-  it('I should be able to search with several filters and see expected results', () => {
-    logAndGoToPage(login, '/offres/collectives')
-    cy.wait('@collectiveOffers')
+  it(`I should be able to search with a name "${offerNamePublished}" and see expected results`, () => {
+    cy.stepLog({
+      message: 'I search with the name "' + offerNamePublished + '"',
+    })
+    cy.findByPlaceholderText('Rechercher par nom d’offre').type(
+      offerNamePublished
+    )
 
-    cy.stepLog({ message: 'I select "Mon Lieu" in "Lieu"' })
-    cy.findByLabelText('Lieu').select(venueName)
+    cy.stepLog({ message: 'I validate my filters' })
+    cy.findByText('Rechercher').click()
+    cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
 
-    cy.stepLog({ message: 'I select "Projection audiovisuelle" in "Format"' })
-    cy.findByLabelText('Format').select('Projection audiovisuelle')
+    cy.stepLog({ message: '1 result should be displayed' })
+    const expectedResults = [
+      ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
+      [
+        '',
+        '',
+        offerNamePublished,
+        venueName1,
+        'Tous les établissements',
+        'publiée',
+      ],
+    ]
+
+    expectOffersOrBookingsAreFound(expectedResults)
+  })
+
+  it(`I should be able to search with a lieu "${venueName2}" and see expected results`, () => {
+    cy.stepLog({ message: 'I search with the place "' + venueName2 + '"' })
+    cy.findByLabelText('Lieu').select(venueName2)
+
+    cy.stepLog({ message: 'I validate my filters' })
+    cy.findByText('Rechercher').click()
+    cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+
+    cy.stepLog({ message: '3 results should be displayed' })
+    const expectedResults = [
+      ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
+      [
+        '',
+        '',
+        offerNameNotConform,
+        venueName2,
+        'Tous les établissements',
+        'non conforme',
+      ],
+      [
+        '',
+        '',
+        offerNameInInstruction,
+        venueName2,
+        'Tous les établissements',
+        'en instruction',
+      ],
+      [
+        '',
+        '',
+        offerNameArchived,
+        venueName2,
+        'Tous les établissements',
+        'archivée',
+      ],
+    ]
+
+    expectOffersOrBookingsAreFound(expectedResults)
+  })
+
+  it(`I should be able to search with a format "${formatName}" and see expected results`, () => {
+    cy.stepLog({ message: 'I search with the Format "' + formatName + '"' })
+    cy.findByLabelText('Format').select(formatName)
+
+    cy.stepLog({ message: 'I validate my filters' })
+    cy.findByText('Rechercher').click()
+    cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+
+    cy.stepLog({ message: '2 results should be displayed' })
+    const expectedResults = [
+      ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
+      [
+        '',
+        '',
+        offerNamePublished,
+        venueName1,
+        'Tous les établissements',
+        'publiée',
+      ],
+      [
+        '',
+        '',
+        offerNamePublishedTemplate,
+        venueName1,
+        'Tous les établissements',
+        'publiée',
+      ],
+    ]
+
+    expectOffersOrBookingsAreFound(expectedResults)
+  })
+
+  it(`I should be able to search with a Type "Offre réservable" and see expected results`, () => {
+    cy.stepLog({ message: 'I search with the Type "Offre réservable"' })
+    cy.findByLabelText('Type de l’offre').select('Offre réservable')
+
+    cy.stepLog({ message: 'I validate my filters' })
+    cy.findByText('Rechercher').click()
+    cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+
+    cy.stepLog({ message: '5 results should be displayed' })
+    const expectedResults = [
+      ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
+      [
+        '',
+        '',
+        offerNameArchived,
+        venueName2,
+        'Tous les établissements',
+        'archivée',
+      ],
+      [
+        '',
+        '',
+        offerNameNotConform,
+        venueName2,
+        'Tous les établissements',
+        'non conforme',
+      ],
+      [
+        '',
+        '',
+        offerNameInInstruction,
+        venueName2,
+        'Tous les établissements',
+        'en instruction',
+      ],
+      [
+        '',
+        '',
+        offerNameDraft,
+        venueName1,
+        'Tous les établissements',
+        'brouillon',
+      ],
+      [
+        '',
+        '',
+        offerNamePublished,
+        venueName1,
+        'Tous les établissements',
+        'publiée',
+      ],
+    ]
+
+    expectOffersOrBookingsAreFound(expectedResults)
+  })
+
+  it(`I should be able to search with a Date and see expected results`, () => {
+    cy.stepLog({ message: 'I select a date in 2 weeks' })
+    const dateSearch = format(addWeeks(new Date(), 2), 'yyyy-MM-dd')
+    cy.findByLabelText('Début de la période').type(dateSearch)
+    cy.findByLabelText('Fin de la période').type(dateSearch)
+
+    cy.stepLog({ message: 'I validate my filters' })
+    cy.findByText('Rechercher').click()
+    cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+
+    cy.stepLog({ message: '1 result should be displayed' })
+    const expectedResults = [
+      ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
+      [
+        '',
+        '',
+        offerNamePublished,
+        venueName1,
+        'Tous les établissements',
+        'publiée',
+      ],
+    ]
+
+    expectOffersOrBookingsAreFound(expectedResults)
+  })
+
+  it('I should be able to search with a status "En instruction" and see expected results', () => {
+    cy.stepLog({ message: 'I search with status "En instruction"' })
+    cy.get('#search-status').click()
+    cy.get('#list-status').find('#option-display-PENDING').click()
+    cy.findByText('Offres collectives').click()
+
+    cy.stepLog({ message: 'I validate my filters' })
+    cy.findByText('Rechercher').click()
+    cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+
+    cy.stepLog({ message: '1 result should be displayed' })
+    const expectedResults = [
+      ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
+      [
+        '',
+        '',
+        offerNameInInstruction,
+        venueName2,
+        'Tous les établissements',
+        'en instruction',
+      ],
+    ]
+
+    expectOffersOrBookingsAreFound(expectedResults)
+  })
+
+  it('I should be able to search with several filters and see expected results, then reinit filters', () => {
+    cy.stepLog({ message: 'I select ' + venueName1 + ' in "Lieu"' })
+    cy.findByLabelText('Lieu').select(venueName1)
+
+    cy.stepLog({ message: 'I select "Représentation" in "Format"' })
+    cy.findByLabelText('Format').select('Représentation')
+
+    cy.stepLog({ message: 'I search with the name "brouillon"' })
+    cy.findByPlaceholderText('Rechercher par nom d’offre').type('brouillon')
+
+    cy.stepLog({ message: 'I search with status "Brouillon"' })
+    cy.get('#search-status').click()
+    cy.get('#list-status').find('#option-display-DRAFT').click()
+    cy.findByText('Offres collectives').click()
 
     cy.stepLog({ message: 'I validate my collective filters' })
     cy.findByText('Rechercher').click()
@@ -37,12 +273,91 @@ describe('Search collective offers', () => {
 
     cy.stepLog({ message: '1 result should be displayed' })
     const expectedResults = [
-      ['', '', 'Titre', 'Lieu', 'Établissement', 'Status'],
-      ['', '', offerName, venueName, 'Tous les établissements', 'publiée'],
+      ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
+      [
+        '',
+        '',
+        offerNameDraft,
+        venueName1,
+        'Tous les établissements',
+        'brouillon',
+      ],
     ]
 
-    cy.findAllByTestId('offer-item-row').should('have.length', 1)
-
     expectOffersOrBookingsAreFound(expectedResults)
+
+    cy.stepLog({ message: 'I reset all filters' })
+    cy.findByText('Réinitialiser les filtres').click()
+
+    cy.stepLog({ message: 'All filters are empty' })
+    cy.findByPlaceholderText('Rechercher par nom d’offre').should('be.empty')
+    cy.get('#search-status').should('be.empty')
+    cy.findByTestId('wrapper-lieu').within(() => {
+      cy.get('select').invoke('val').should('eq', 'all')
+    })
+    cy.findByTestId('wrapper-format').within(() => {
+      cy.get('select').invoke('val').should('eq', 'all')
+    })
+    cy.findByTestId('wrapper-collectiveOfferType').within(() => {
+      cy.get('select').invoke('val').should('eq', 'all')
+    })
+    cy.findByTestId('wrapper-search-status').within(() => {
+      cy.get('select').invoke('val').should('be.empty')
+    })
+
+    cy.stepLog({ message: '6 results should be displayed' })
+    const expectedResults2 = [
+      ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
+      [
+        '',
+        '',
+        offerNameNotConform,
+        venueName2,
+        'Tous les établissements',
+        'non conforme',
+      ],
+      [
+        '',
+        '',
+        offerNameInInstruction,
+        venueName2,
+        'Tous les établissements',
+        'en instruction',
+      ],
+      [
+        '',
+        '',
+        offerNameDraft,
+        venueName1,
+        'Tous les établissements',
+        'brouillon',
+      ],
+      [
+        '',
+        '',
+        offerNamePublished,
+        venueName1,
+        'Tous les établissements',
+        'publiée',
+      ],
+      [
+        '',
+        '',
+        offerNamePublishedTemplate,
+        venueName1,
+        'Tous les établissements',
+        'publiée',
+      ],
+      [
+        '',
+        '',
+        offerNameArchived,
+        venueName2,
+        'Tous les établissements',
+        'archivée',
+      ],
+    ]
+
+    expectOffersOrBookingsAreFound(expectedResults2)
   })
 })

--- a/pro/cypress/e2e/searchIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/searchIndividualOffer.cy.ts
@@ -48,8 +48,6 @@ describe('Search individual offers', () => {
       ['', '', offerName1, venueName, '1 000', 'publiée'],
     ]
 
-    cy.findAllByTestId('offer-item-row').should('have.length', 1)
-
     expectOffersOrBookingsAreFound(expectedResults)
   })
 
@@ -73,8 +71,6 @@ describe('Search individual offers', () => {
       ['', '', offerName2 + ean, venueName, '1 000', 'publiée'],
     ]
 
-    cy.findAllByTestId('offer-item-row').should('have.length', 1)
-
     expectOffersOrBookingsAreFound(expectedResults)
   })
 
@@ -93,8 +89,6 @@ describe('Search individual offers', () => {
       ['', '', 'Titre', 'Lieu', 'Stocks', 'Status'],
       ['', '', offerName3, venueName, '1 000', 'publiée'],
     ]
-
-    cy.findAllByTestId('offer-item-row').should('have.length', 1)
 
     expectOffersOrBookingsAreFound(expectedResults)
   })
@@ -122,8 +116,6 @@ describe('Search individual offers', () => {
       ['', '', offerName1, venueName, '1 000', 'publiée'],
     ]
 
-    cy.findAllByTestId('offer-item-row').should('have.length', 6)
-
     expectOffersOrBookingsAreFound(expectedResults)
   })
 
@@ -144,8 +136,6 @@ describe('Search individual offers', () => {
       ['', '', 'Titre', 'Lieu', 'Stocks', 'Status'],
       ['', '', offerName4, venueName, '1 000', 'publiée'],
     ]
-
-    cy.findAllByTestId('offer-item-row').should('have.length', 1)
 
     expectOffersOrBookingsAreFound(expectedResults)
   })
@@ -184,8 +174,6 @@ describe('Search individual offers', () => {
       ['', '', offerName5, venueName, '1 000', 'publiée'],
     ]
 
-    cy.findAllByTestId('offer-item-row').should('have.length', 2)
-
     expectOffersOrBookingsAreFound(expectedResults)
 
     cy.stepLog({ message: 'I reset all filters' })
@@ -221,8 +209,6 @@ describe('Search individual offers', () => {
       ['', '', offerName2, venueName, '1 000', 'publiée'],
       ['', '', offerName1, venueName, '1 000', 'publiée'],
     ]
-
-    cy.findAllByTestId('offer-item-row').should('have.length', 7)
 
     expectOffersOrBookingsAreFound(expectedResults2)
   })

--- a/pro/cypress/support/helpers.ts
+++ b/pro/cypress/support/helpers.ts
@@ -17,6 +17,8 @@ export function expectOffersOrBookingsAreFound(
 
   cy.contains(regexExpectedCount)
 
+  cy.findAllByTestId('offer-item-row').should('have.length', expectedLength)
+
   for (let rowLine = 0; rowLine < expectedLength; rowLine++) {
     const lineArray = expectedResults[rowLine + 1]
 


### PR DESCRIPTION
(PC-33167)[PRO] test: add more tests for collective search

## But de la pull request

Ajoute un cas de filtre de recherche d'offre collective:
- par nom
- par lieu
- par format
- par type
- par date
- par status
et la réinitialisation des filtres dans une recherche combinée

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
