### PR TITLE
(PC-33269)[PRO] fix: Adds condition to check if an address isn't undefined

### DIFF
--- a/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
+++ b/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
@@ -234,7 +234,9 @@ export const OfferSection = ({
                 },
                 {
                   title: 'Adresse',
-                  text: computeAddressDisplayName(offerData.address!, false),
+                  text: offerData.address
+                    ? computeAddressDisplayName(offerData.address, false)
+                    : '-',
                 },
               ]}
             />


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33269

Il semblerait que l'erreur se produise suite à une not-null assertion sur `offerData.address!`

Une valeur "undefined" peut alors potentiellement arriver en argument de "computeAddressDisplayName" et provoquer l'erreur.
