### PR TITLE
(PC-33133)[PRO] feat: harmonize publish action in offers

### DIFF
--- a/pro/src/pages/Offers/OffersTable/Cells/DeleteDraftCell.tsx
+++ b/pro/src/pages/Offers/OffersTable/Cells/DeleteDraftCell.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react'
+import { useSelector } from 'react-redux'
 import { useSWRConfig } from 'swr'
 
 import { api } from 'apiClient/api'
@@ -11,18 +12,16 @@ import {
 } from 'commons/core/FirebaseEvents/constants'
 import { useQuerySearchFilters } from 'commons/core/Offers/hooks/useQuerySearchFilters'
 import { useNotification } from 'commons/hooks/useNotification'
+import { selectCurrentOffererId } from 'commons/store/user/selectors'
 import { ConfirmDialog } from 'components/Dialog/ConfirmDialog/ConfirmDialog'
 import fullTrashIcon from 'icons/full-trash.svg'
 import strokeTrashIcon from 'icons/stroke-trash.svg'
 import { GET_OFFERS_QUERY_KEY } from 'pages/Offers/OffersRoute'
 import { computeDeletionErrorMessage } from 'pages/Offers/utils/computeDeletionErrorMessage'
 import { computeDeletionSuccessMessage } from 'pages/Offers/utils/computeDeletionSuccessMessage'
-import { ListIconButton } from 'ui-kit/ListIconButton/ListIconButton'
-
-import styles from 'styles/components/Cells.module.scss'
 import { computeIndividualApiFilters } from 'pages/Offers/utils/computeIndividualApiFilters'
-import { selectCurrentOffererId } from 'commons/store/user/selectors'
-import { useSelector } from 'react-redux'
+import styles from 'styles/components/Cells.module.scss'
+import { ListIconButton } from 'ui-kit/ListIconButton/ListIconButton'
 
 interface DeleteDraftOffersProps {
   offer: ListOffersOfferResponseModel

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useSelector } from 'react-redux'
 import { mutate, useSWRConfig } from 'swr'
 
 import { api } from 'apiClient/api'
@@ -8,6 +9,7 @@ import { SearchFiltersParams } from 'commons/core/Offers/types'
 import { serializeApiFilters } from 'commons/core/Offers/utils/serializer'
 import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useNotification } from 'commons/hooks/useNotification'
+import { selectCurrentOffererId } from 'commons/store/user/selectors'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { computeActivationSuccessMessage } from 'components/OffersTable/utils/computeActivationSuccessMessage'
 import { computeSelectedOffersLabel } from 'components/OffersTable/utils/computeSelectedOffersLabel'
@@ -17,22 +19,19 @@ import fullValidateIcon from 'icons/full-validate.svg'
 import { GET_OFFERS_QUERY_KEY } from 'pages/Offers/OffersRoute'
 import { computeDeletionErrorMessage } from 'pages/Offers/utils/computeDeletionErrorMessage'
 import { computeDeletionSuccessMessage } from 'pages/Offers/utils/computeDeletionSuccessMessage'
+import { computeIndividualApiFilters } from 'pages/Offers/utils/computeIndividualApiFilters'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
 
 import { DeleteConfirmDialog } from './DeleteConfirmDialog'
 import { IndividualDeactivationConfirmDialog } from './IndividualDeactivationConfirmDialog'
-import { selectCurrentOffererId } from 'commons/store/user/selectors'
-import { useSelector } from 'react-redux'
-import { computeIndividualApiFilters } from 'pages/Offers/utils/computeIndividualApiFilters'
 
 export type IndividualOffersActionsBarProps = {
   areAllOffersSelected: boolean
   clearSelectedOffers: () => void
   selectedOffers: { id: number; status: OfferStatus }[]
   toggleSelectAllCheckboxes: () => void
-  getUpdateOffersStatusMessage: (selectedOfferIds: number[]) => string
   canDelete: boolean
   canPublish: boolean
   canDeactivate: boolean
@@ -130,7 +129,6 @@ export const IndividualOffersActionsBar = ({
   clearSelectedOffers,
   toggleSelectAllCheckboxes,
   areAllOffersSelected,
-  getUpdateOffersStatusMessage,
   canDelete,
   canPublish,
   canDeactivate,
@@ -183,14 +181,7 @@ export const IndividualOffersActionsBar = ({
   }
 
   const handleActivate = async () => {
-    const updateOfferStatusMessage = getUpdateOffersStatusMessage(
-      selectedOffers.map((offer) => offer.id)
-    )
-    if (!updateOfferStatusMessage) {
-      await handleUpdateOffersStatus(true)
-    } else {
-      notify.error(updateOfferStatusMessage)
-    }
+    await handleUpdateOffersStatus(true)
   }
 
   const handleDeactivateOffers = async () => {

--- a/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/__specs__/IndividualOffersActionsBar.spec.tsx
+++ b/pro/src/pages/Offers/OffersTable/IndividualOffersTable/IndividualOffersActionsBar/__specs__/IndividualOffersActionsBar.spec.tsx
@@ -32,7 +32,6 @@ vi.mock('apiClient/api', () => ({
 }))
 
 const mockLogEvent = vi.fn()
-const mockGetUpdateOffersStatusMessage = vi.fn()
 
 describe('ActionsBar', () => {
   let props: IndividualOffersActionsBarProps
@@ -43,7 +42,6 @@ describe('ActionsBar', () => {
 
   beforeEach(() => {
     props = {
-      getUpdateOffersStatusMessage: mockGetUpdateOffersStatusMessage,
       canDelete: true,
       canPublish: true,
       canDeactivate: true,
@@ -120,24 +118,6 @@ describe('ActionsBar', () => {
     expect(props.clearSelectedOffers).toHaveBeenCalledTimes(1)
     expect(
       screen.getByText('2 offres ont bien été publiées')
-    ).toBeInTheDocument()
-  })
-
-  it('should not activate offers when a draft is selected', async () => {
-    mockGetUpdateOffersStatusMessage.mockReturnValueOnce(
-      'Vous ne pouvez pas publier des brouillons depuis cette liste'
-    )
-
-    renderActionsBar(props)
-
-    await userEvent.click(screen.getByText('Publier'))
-
-    expect(api.patchOffersActiveStatus).not.toHaveBeenCalled()
-    expect(props.clearSelectedOffers).not.toHaveBeenCalled()
-    expect(
-      screen.getByText(
-        'Vous ne pouvez pas publier des brouillons depuis cette liste'
-      )
     ).toBeInTheDocument()
   })
 

--- a/pro/src/pages/Offers/components/IndividualOffersScreen/IndividualOffersScreen.tsx
+++ b/pro/src/pages/Offers/components/IndividualOffersScreen/IndividualOffersScreen.tsx
@@ -96,16 +96,6 @@ export const IndividualOffersScreen = ({
     applyUrlFiltersAndRedirect({ ...filters, page: DEFAULT_PAGE })
   }
 
-  const getUpdateOffersStatusMessage = (tmpSelectedOfferIds: number[]) => {
-    const selectedOffers = offers.filter((offer) =>
-      tmpSelectedOfferIds.includes(offer.id)
-    )
-    if (selectedOffers.some((offer) => offer.status === OFFER_STATUS_DRAFT)) {
-      return 'Vous ne pouvez pas publier des brouillons depuis cette liste'
-    }
-    return ''
-  }
-
   function onSetSelectedOffer(offer: ListOffersOfferResponseModel) {
     const matchingOffer = selectedOffers.find((selectedOffer) =>
       isSameOffer(offer, selectedOffer)
@@ -180,7 +170,6 @@ export const IndividualOffersScreen = ({
                   status: offer.status,
                 }))}
                 toggleSelectAllCheckboxes={toggleSelectAllCheckboxes}
-                getUpdateOffersStatusMessage={getUpdateOffersStatusMessage}
                 canDelete={canDelete}
                 canDeactivate={canDeactivate}
                 canPublish={canPublish}

--- a/pro/src/pages/Offers/components/IndividualOffersScreen/__specs__/IndividualOffersScreen.spec.tsx
+++ b/pro/src/pages/Offers/components/IndividualOffersScreen/__specs__/IndividualOffersScreen.spec.tsx
@@ -101,6 +101,7 @@ vi.mock('apiClient/api', () => ({
   api: {
     listOfferersNames: vi.fn().mockReturnValue({}),
     deleteDraftOffers: vi.fn(),
+    patchAllOffersActiveStatus: vi.fn(),
   },
 }))
 
@@ -539,14 +540,14 @@ describe('IndividualOffersScreen', () => {
   })
 
   describe('on click on select all offers checkbox', () => {
-    it('should display display error message when trying to activate draft offers', async () => {
+    it('should activate only inactive offers when trying to activate draft or active offers', async () => {
       const offers = [
         listOffersOfferFactory({
           isActive: false,
           status: OfferStatus.DRAFT,
         }),
         listOffersOfferFactory({
-          isActive: false,
+          isActive: true,
           status: OfferStatus.ACTIVE,
         }),
         listOffersOfferFactory({
@@ -563,9 +564,13 @@ describe('IndividualOffersScreen', () => {
       await userEvent.click(screen.getByLabelText('Tout sélectionner'))
       await userEvent.click(screen.getByText('Publier'))
 
-      expect(mockNotifyError).toHaveBeenCalledWith(
-        'Vous ne pouvez pas publier des brouillons depuis cette liste'
+      expect(mockNotifyPending).toHaveBeenCalledWith(
+        'Une offre est en cours d’activation, veuillez rafraichir dans quelques instants'
       )
+      expect(api.patchAllOffersActiveStatus).toHaveBeenCalledWith({
+        isActive: true,
+        offererId: '1',
+      })
     })
 
     it('should check all validated offers checkboxes', async () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33133

La vérification sur les offres brouillons étaient inutile, le back s'en charge et l'appel au back était de toute manière identique
en le retirant les trois actions/boutons se comportent de la même manière

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
