### PR TITLE
(BSR)[API] fix: add some missing fields in collective offers in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -536,6 +536,7 @@ def create_offers_booking_with_different_displayed_status(
             startDatetime=beginning_datetime,
             endDatetime=end_datetime,
             bookingLimitDatetime=booking_limit_datetime,
+            priceDetail="Some details",
         )
 
         if booking_factory:
@@ -594,6 +595,7 @@ def create_offer_templates_with_different_displayed_status(
             venue=next(venue_iterator),
             educational_domains=[next(domains_iterator)],
             bookingEmails=["toto@totoland.com"],
+            formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
         )
 
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : Sur les offres collectives de la sandbox ajoutées pour tester les statuts, il manque le champ "priceDetail" du stock et "formats" des offres vitrine.
Ces champs étant obligatoires sur le front, en l'état ça bloque la modification des offres.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
