### PR TITLE
(BSR)[PRO] test: add new signup test case with known offerer and unknown venue

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/getters/pro.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/pro.py
@@ -20,6 +20,13 @@ def create_new_pro_user() -> dict:
 def create_new_pro_user_and_offerer() -> dict:
     pro_user = users_factories.ProFactory()
     offerer = offerers_factories.OffererFactory()
+    offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
+    return {"user": get_pro_user_helper(pro_user), "siren": offerer.siren}
+
+
+def create_new_pro_user_and_offerer_with_venue() -> dict:
+    pro_user = users_factories.ProFactory()
+    offerer = offerers_factories.OffererFactory()
     venue = offerers_factories.VenueFactory(managingOfferer=offerer, isPermanent=True)
     offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
     return {"user": get_pro_user_helper(pro_user), "siret": venue.siret}


### PR DESCRIPTION
## But de la pull request

Dernier cas de signup manquant: nouvelle venue avec structure existante.
J'ai aussi réorganisé le titres Mocha dans le but de bien rendre visible ce qui est testé dans chacun des 4 cas.

![CleanShot 2024-11-28 at 17 38 17@2x](https://github.com/user-attachments/assets/5766fd9a-f045-4fd1-baf2-73d72cdf9393)



## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
