### PR TITLE
(PC-31818)[API] feat: add bank account sync with external finance backend

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-90128ccd108a (pre) (head)
+58f3ca2882c6 (pre) (head)
 43fee1eab19d (post) (head)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -275,5 +275,6 @@ junit_family = "xunit1"
 markers = [
     "backoffice",
     "features",
+    "settings",
 ]
 requests_mock_case_sensitive = true

--- a/api/src/pcapi/alembic/versions/20241206T150902_58f3ca2882c6_bank_account_cegid_sync.py
+++ b/api/src/pcapi/alembic/versions/20241206T150902_58f3ca2882c6_bank_account_cegid_sync.py
@@ -1,0 +1,22 @@
+"""
+Add `lastCegidSyncDate` field to BankAccount table
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "58f3ca2882c6"
+down_revision = "90128ccd108a"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("bank_account", sa.Column("lastCegidSyncDate", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("bank_account", "lastCegidSyncDate")

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -72,7 +72,6 @@ import pcapi.core.users.models as users_models
 from pcapi.domain import reimbursement
 from pcapi.models import db
 from pcapi.models import feature
-from pcapi.models.feature import FeatureToggle
 from pcapi.repository import is_managed_transaction
 from pcapi.repository import mark_transaction_as_invalid
 from pcapi.repository import on_commit
@@ -2437,9 +2436,9 @@ def _prepare_invoice_context(invoice: models.Invoice, batch: models.CashflowBatc
     period_start, period_end = get_invoice_period(batch.cutoff)
 
     ff_wording = {
-        "venue": "structure" if FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active() else "lieu",
-        "venues": "Structures" if FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active() else "Lieux",
-        "offerer": "Entité juridique" if FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active() else "Structure",
+        "venue": "structure" if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active() else "lieu",
+        "venues": "Structures" if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active() else "Lieux",
+        "offerer": "Entité juridique" if feature.FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active() else "Structure",
     }
 
     return dict(

--- a/api/src/pcapi/core/finance/backend/__init__.py
+++ b/api/src/pcapi/core/finance/backend/__init__.py
@@ -36,6 +36,16 @@ def get_invoice(reference: str) -> dict | None:
     return backend.get_invoice(reference)
 
 
+def get_time_to_sleep_between_two_sync_requests() -> int:
+    backend = _get_backend()
+    return backend.time_to_sleep_between_two_sync_requests
+
+
+def get_backend_name() -> str:
+    backend = _get_backend()
+    return backend.__class__.__name__
+
+
 def _get_backend() -> BaseFinanceBackend:
     backend_class = import_string(settings.FINANCE_BACKEND)
     backend = backend_class()

--- a/api/src/pcapi/core/finance/backend/base.py
+++ b/api/src/pcapi/core/finance/backend/base.py
@@ -17,3 +17,14 @@ class BaseFinanceBackend:
     @property
     def is_configured(self) -> bool:
         raise NotImplementedError()
+
+    @property
+    def is_default(self) -> bool:
+        return False
+
+    @property
+    def time_to_sleep_between_two_sync_requests(self) -> int:
+        """
+        Time in seconds to sleep between two requests to avoid rate limit errors
+        """
+        return 0

--- a/api/src/pcapi/core/finance/backend/cegid.py
+++ b/api/src/pcapi/core/finance/backend/cegid.py
@@ -266,3 +266,8 @@ class CegidFinanceBackend(BaseFinanceBackend):
         if response.status_code == 500 and ("application/json" in response.headers.get("content-type", "")):
             return response.json().get("exceptionType")
         return None
+
+    @property
+    def time_to_sleep_between_two_sync_requests(self) -> int:
+        # In seconds
+        return 10

--- a/api/src/pcapi/core/finance/conf.py
+++ b/api/src/pcapi/core/finance/conf.py
@@ -5,6 +5,10 @@ import pcapi.core.offers.models as offers_models
 from . import models
 
 
+# lock to prevent parallel push of bank accounts
+REDIS_PUSH_BANK_ACCOUNT_LOCK = "pc:finance:push_bank_account_lock"
+REDIS_PUSH_BANK_ACCOUNT_LOCK_TIMEOUT = 86400  # = 60 * 60 * 24 = 24h
+
 # lock to forbid the backoffice any write access to the pricing while the script is running
 REDIS_GENERATE_CASHFLOW_LOCK = "pc:finance:generate_cashflow_lock"
 REDIS_GENERATE_CASHFLOW_LOCK_TIMEOUT = 60 * 60 * 24  # 24h

--- a/api/src/pcapi/core/finance/external.py
+++ b/api/src/pcapi/core/finance/external.py
@@ -1,0 +1,62 @@
+import datetime
+import logging
+import time
+
+from flask import current_app as app
+
+from pcapi.core.finance import backend as finance_backend
+from pcapi.core.finance import conf
+from pcapi.core.finance import models as finance_models
+
+
+logger = logging.getLogger(__name__)
+
+
+def are_cashflows_being_generated() -> bool:
+    return bool(app.redis_client.exists(conf.REDIS_PUSH_BANK_ACCOUNT_LOCK))
+
+
+def push_bank_accounts(count: int) -> None:
+    if bool(app.redis_client.exists(conf.REDIS_PUSH_BANK_ACCOUNT_LOCK)):
+        return
+
+    bank_accounts_query = finance_models.BankAccount.query.filter(
+        finance_models.BankAccount.lastCegidSyncDate.is_(None),
+        finance_models.BankAccount.status == finance_models.BankAccountApplicationStatus.ACCEPTED,
+    ).with_entities(finance_models.BankAccount.id)
+    if count != 0:
+        bank_accounts_query = bank_accounts_query.limit(count)
+
+    bank_accounts = bank_accounts_query.all()
+
+    if not bank_accounts:
+        return
+
+    app.redis_client.set(conf.REDIS_PUSH_BANK_ACCOUNT_LOCK, "1", ex=conf.REDIS_PUSH_BANK_ACCOUNT_LOCK_TIMEOUT)
+
+    try:
+        bank_account_ids = [e[0] for e in bank_accounts]
+        for bank_account_id in bank_account_ids:
+            try:
+                backend_name = finance_backend.get_backend_name()
+                logger.info("Push bank account", extra={"bank_account_id": bank_account_id, "backend": backend_name})
+                finance_backend.push_bank_account(bank_account_id)
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.exception(
+                    "Unable to sync bank account",
+                    extra={
+                        "bank_account_id": bank_account_id,
+                        "exc": str(exc),
+                    },
+                )
+                # Wait until next cron run to continue sync process
+                break
+            else:
+                finance_models.BankAccount.query.filter(finance_models.BankAccount.id == bank_account_id).update(
+                    {"lastCegidSyncDate": datetime.datetime.utcnow()},
+                    synchronize_session=False,
+                )
+                time_to_sleep = finance_backend.get_time_to_sleep_between_two_sync_requests()
+                time.sleep(time_to_sleep)
+    finally:
+        app.redis_client.delete(conf.REDIS_PUSH_BANK_ACCOUNT_LOCK)

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -238,6 +238,7 @@ class BankAccount(PcObject, Base, Model, DeactivableMixin):
         foreign_keys="BankAccountStatusHistory.bankAccountId",
         uselist=True,
     )
+    lastCegidSyncDate = sqla.Column(sqla.DateTime, nullable=True)
 
     @property
     def current_link(self) -> "offerers_models.VenueBankAccountLink | None":

--- a/api/src/pcapi/core/testing.py
+++ b/api/src/pcapi/core/testing.py
@@ -190,6 +190,23 @@ class TestContextDecorator:
         raise TypeError(f"Cannot decorate object {decorated}")
 
 
+class SettingsContext:
+    def __init__(self) -> None:
+        # Use `object.__setattr__` because `__setattr__` method is overriden
+        object.__setattr__(self, "_initial_settings", {})
+
+    def __setattr__(self, attr_name: str, value: typing.Any) -> None:
+        self._initial_settings[attr_name] = getattr(settings, attr_name)
+        setattr(settings, attr_name, value)
+
+    def __getattr__(self, attr_name: str) -> typing.Any:
+        return getattr(settings, attr_name)
+
+    def reset(self) -> None:
+        for attr_name, value in self._initial_settings.items():
+            setattr(settings, attr_name, value)
+
+
 class override_settings(TestContextDecorator):
     """A context manager/function decorator that temporarily changes a
     setting.

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -43,6 +43,9 @@ class FeatureToggle(enum.Enum):
     ENABLE_AUTO_VALIDATION_FOR_EXTERNAL_BOOKING = (
         "Valide automatiquement après 48h les offres issues de l'api billeterie cinéma"
     )
+    ENABLE_BANK_ACCOUNT_SYNC = (
+        "Active la synchronisation des comptes bancaires avec l'outil finance externe (Cegid XRP Flex)"
+    )
     ENABLE_BEAMER = "Active Beamer, le système de notifs du portail pro"
     ENABLE_CDS_IMPLEMENTATION = "Permet la réservation de place de cinéma avec l'API CDS"
     ENABLE_CODIR_OFFERERS_REPORT = "Active le rapport sur les entités juridiques actives pour le CODIR (tourne la nuit)"
@@ -174,6 +177,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.DISPLAY_DMS_REDIRECTION,
     FeatureToggle.EMS_CANCEL_PENDING_EXTERNAL_BOOKING,
     FeatureToggle.ENABLE_AUTO_VALIDATION_FOR_EXTERNAL_BOOKING,
+    FeatureToggle.ENABLE_BANK_ACCOUNT_SYNC,
     FeatureToggle.ENABLE_BEAMER,
     FeatureToggle.ENABLE_CODIR_OFFERERS_REPORT,  # only for production
     FeatureToggle.ENABLE_COLLECTIVE_NEW_STATUSES,

--- a/api/tests/core/finance/conftest.py
+++ b/api/tests/core/finance/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from pcapi.core.finance.backend import dummy as dummy_backend
+
+
+@pytest.fixture(scope="function")
+def clean_dummy_backend_data():
+    yield
+    dummy_backend.clear_invoices()
+    dummy_backend.clear_bank_accounts()

--- a/api/tests/core/finance/test_backends.py
+++ b/api/tests/core/finance/test_backends.py
@@ -15,7 +15,7 @@ from pcapi.core.testing import override_settings
 
 
 pytestmark = [
-    pytest.mark.usefixtures("db_session"),
+    pytest.mark.usefixtures("db_session", "clean_dummy_backend_data"),
 ]
 
 

--- a/api/tests/core/finance/test_external.py
+++ b/api/tests/core/finance/test_external.py
@@ -1,0 +1,57 @@
+import datetime
+from unittest.mock import patch
+
+import pytest
+import time_machine
+
+from pcapi.core.finance import external
+from pcapi.core.finance import factories as finance_factories
+from pcapi.core.finance.backend.dummy import bank_accounts as dummy_bank_accounts
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.testing import override_features
+from pcapi.models import db
+
+
+pytestmark = [
+    pytest.mark.usefixtures("db_session", "clean_dummy_backend_data"),
+    pytest.mark.features(WIP_ENABLE_NEW_FINANCE_WORKFLOW=True, ENABLE_BANK_ACCOUNT_SYNC=True),
+]
+
+
+class ExternalFinanceTest:
+    def test_push_bank_accounts(self):
+        offerer = offerers_factories.OffererFactory(name="Association de coiffeurs", siren="853318459")
+        bank_account = finance_factories.BankAccountFactory(offerer=offerer)
+        assert bank_account.lastCegidSyncDate is None
+
+        now = datetime.datetime.utcnow()
+        with time_machine.travel(now, tick=False):
+            external.push_bank_accounts(10)
+        db.session.flush()
+        db.session.refresh(bank_account)
+        assert bank_account.lastCegidSyncDate == now
+        assert len(dummy_bank_accounts) == 1
+        assert dummy_bank_accounts[0] == bank_account
+
+
+class ExternalFinanceCommandTest:
+    def test_push_bank_accounts_command(self, run_command, mocker):
+        with patch("pcapi.core.finance.external.push_bank_accounts") as push_bank_accounts_mock:
+            run_command("push_bank_accounts", raise_on_error=True)
+
+        assert push_bank_accounts_mock.call_count == 1
+
+    @pytest.mark.parametrize(
+        "enable_new_finance_workflow,enable_bank_account_sync", [(False, True), (True, False), (False, False)]
+    )
+    def test_push_bank_accounts_command_feature_toggle(
+        self, run_command, enable_new_finance_workflow, enable_bank_account_sync
+    ):
+        with override_features(
+            ENABLE_BANK_ACCOUNT_SYNC=enable_bank_account_sync,
+            WIP_ENABLE_NEW_FINANCE_WORKFLOW=enable_new_finance_workflow,
+        ):
+            with patch("pcapi.core.finance.external.push_bank_accounts") as push_bank_accounts_mock:
+                run_command("push_bank_accounts", raise_on_error=True)
+
+        assert push_bank_accounts_mock.call_count == 0


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-31818

Synchronisation des BankAccounts avec l'outil finance externe

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
