### PR TITLE
(PC-33366)[API] fix: make job retryable when receiving random 403 from Compliance API

### DIFF
--- a/api/src/pcapi/core/external/compliance_backends/compliance.py
+++ b/api/src/pcapi/core/external/compliance_backends/compliance.py
@@ -40,7 +40,9 @@ class ComplianceBackend(BaseBackend):
                     "Connection to Compliance API was refused",
                     extra={"status_code": api_response.status_code},
                 )
-                raise requests.ExternalAPIException(is_retryable=False)
+                # FIXME (prouzet, 2024-11-29) We experience random HTTP 403 errors (1 to 5 every day), so make them
+                #  retryable until the issue is fixed on data team side. Sentry issue: 1613833
+                raise requests.ExternalAPIException(is_retryable=(api_response.status_code == 403))
             if api_response.status_code == 422:
                 error_data = {"status_code": api_response.status_code}
                 try:


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-33366

Retenter pour ne pas omettre les infos dans l'offre en cas d'erreur aléatoire de l'API Compliance.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
