### PR TITLE
(PC-33367)[BO] fix: do not make login crash when CSRF token expired

### DIFF
--- a/api/tests/routes/backoffice/auth_test.py
+++ b/api/tests/routes/backoffice/auth_test.py
@@ -1,6 +1,7 @@
 import logging
 from unittest.mock import patch
 
+from authlib.integrations.base_client import MismatchingStateError
 from flask import url_for
 import pytest
 
@@ -136,6 +137,15 @@ class AuthorizePageTest:
         assert response.status_code == 302
         assert response.location == url_for("backoffice_web.user_not_found", _external=True)
         assert "Failed authentication attempt" in caplog.messages
+
+    @patch("pcapi.routes.backoffice.auth.backoffice_oauth.google.authorize_access_token")
+    def test_csrf_token_expired(self, mock_authorize_access_token, client):
+        mock_authorize_access_token.side_effect = MismatchingStateError()
+
+        response = client.get(url_for("backoffice_web.authorize"))
+
+        assert response.status_code == 302
+        assert response.location == url_for("backoffice_web.login", _external=True)
 
 
 class LogoutTest(PostEndpointWithoutPermissionHelper):


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-33367

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
