### PR TITLE
(PC-32880)[PRO] feat: Ajout saisie d’adresse manuelle sur le parcours d’inscription de l’offerer+venue

### DIFF
--- a/api/src/pcapi/routes/backoffice/pro/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro/blueprint.py
@@ -19,6 +19,7 @@ from pcapi.core.finance import models as finance_models
 from pcapi.core.mails import transactional as transactional_mails
 from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offerers import schemas as offerers_schemas
 from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.token import SecureToken
@@ -251,19 +252,23 @@ def create_offerer() -> utils.BackofficeResponse:
         comment="Entité juridique créée depuis le backoffice",
         ds_dossier_id=form.ds_id.data,
     )
-
-    venue_creation_info = venues_serialize.PostVenueBodyModel(
-        siret=form.siret_info.siret,  # type: ignore[arg-type]
-        street=address.street,  # type: ignore[arg-type]
-        banId=city_info.id,  # type: ignore[arg-type]
-        bookingEmail=pro_user.email,  # type: ignore[arg-type]
-        city=address.city,  # type: ignore[arg-type]
+    address_body_model = offerers_schemas.AddressBodyModel(
+        street=offerers_schemas.VenueAddress(address.street),
+        city=offerers_schemas.VenueCity(address.city),
+        postalCode=offerers_schemas.VenuePostalCode(postal_code),
         latitude=city_info.latitude,
         longitude=city_info.longitude,
+        banId=city_info.id,
+        label=None,
+    )
+
+    venue_creation_info = venues_serialize.PostVenueBodyModel(
+        address=address_body_model,
+        siret=offerers_schemas.VenueSiret(form.siret_info.siret),
+        bookingEmail=offerers_schemas.VenueBookingEmail(pro_user.email),
         managingOffererId=user_offerer.offererId,
-        name=form.public_name.data,
-        publicName=form.public_name.data,
-        postalCode=postal_code,  # type: ignore[arg-type]
+        name=offerers_schemas.VenueName(form.public_name.data),
+        publicName=offerers_schemas.VenuePublicName(form.public_name.data),
         venueLabelId=None,
         venueTypeCode=form.venue_type_code.data,
         withdrawalDetails=None,

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -15,6 +15,7 @@ from pcapi.core.external import subcategory_suggestion
 from pcapi.core.offerers import exceptions as offerers_exceptions
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers import repository as offerers_repository
+import pcapi.core.offerers.api as offerers_api
 from pcapi.core.offers import exceptions
 from pcapi.core.offers import models
 from pcapi.core.offers import schemas as offers_schemas
@@ -319,7 +320,9 @@ def post_offer(body: offers_serialize.PostOfferBodyModel) -> offers_serialize.Ge
     )
     offerer_address: offerers_models.OffererAddress | None = None
     offerer_address = (
-        offers_api.get_offerer_address_from_address(venue, body.address) if body.address else venue.offererAddress
+        offerers_api.get_offerer_address_from_address(venue.managingOffererId, body.address)
+        if body.address
+        else venue.offererAddress
     )
     rest.check_user_has_access_to_offerer(current_user, venue.managingOffererId)
     try:

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -9,6 +9,7 @@ from sqlalchemy.engine import Row
 import sqlalchemy.orm as sqla_orm
 
 from pcapi import settings
+from pcapi.core.offerers import schemas as offerers_schemas
 import pcapi.core.offerers.models as offerers_models
 from pcapi.core.offerers.models import Target
 import pcapi.core.offerers.repository as offerers_repository
@@ -254,19 +255,14 @@ class CreateOffererQueryModel(BaseModel):
 
 
 class SaveNewOnboardingDataQueryModel(BaseModel):
-    banId: str | None
-    city: str
     createVenueWithoutSiret: bool = False
-    latitude: float
-    longitude: float
-    postalCode: str
     publicName: str | None
     siret: str
-    street: str | None
     target: Target
     venueTypeCode: str
     webPresence: str
     token: str
+    address: offerers_schemas.AddressBodyModel
 
     class Config:
         extra = "forbid"

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -1,6 +1,4 @@
 from datetime import datetime
-from decimal import Decimal
-from decimal import InvalidOperation
 import enum
 from io import BytesIO
 import typing
@@ -32,10 +30,6 @@ from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.image_conversion import CropParam
 from pcapi.utils.image_conversion import CropParams
-
-
-MAX_LONGITUDE = 180
-MAX_LATITUDE = 90
 
 
 class DMSApplicationstatus(enum.Enum):
@@ -72,17 +66,12 @@ class DMSApplicationForEAC(BaseModel):
 
 
 class PostVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
-    street: offerers_schemas.VenueAddress
-    banId: offerers_schemas.VenueBanId | None
+    address: offerers_schemas.AddressBodyModel
     bookingEmail: offerers_schemas.VenueBookingEmail
-    city: offerers_schemas.VenueCity
     comment: offerers_schemas.VenueComment | None
-    latitude: float
-    longitude: float
     managingOffererId: int
     name: offerers_schemas.VenueName
     publicName: offerers_schemas.VenuePublicName | None
-    postalCode: offerers_schemas.VenuePostalCode
     siret: offerers_schemas.VenueSiret | None
     venueLabelId: int | None
     venueTypeCode: str
@@ -92,28 +81,6 @@ class PostVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
 
     class Config:
         extra = "forbid"
-
-    @validator("latitude", pre=True)
-    @classmethod
-    def validate_latitude(cls, raw_latitude: str) -> str:
-        try:
-            latitude = Decimal(raw_latitude)
-        except InvalidOperation:
-            raise ValueError("Format incorrect")
-        if not -MAX_LATITUDE < latitude < MAX_LATITUDE:
-            raise ValueError("La latitude doit être comprise entre -90.0 et +90.0")
-        return raw_latitude
-
-    @validator("longitude", pre=True)
-    @classmethod
-    def validate_longitude(cls, raw_longitude: str) -> str:
-        try:
-            longitude = Decimal(raw_longitude)
-        except InvalidOperation:
-            raise ValueError("Format incorrect")
-        if not -MAX_LONGITUDE < longitude < MAX_LONGITUDE:
-            raise ValueError("La longitude doit être comprise entre -180.0 et +180.0")
-        return raw_longitude
 
     @validator("siret", always=True)
     @classmethod

--- a/api/src/pcapi/scripts/beneficiary/import_test_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_test_users.py
@@ -135,9 +135,9 @@ def _create_pro_user(row: dict) -> User:
         comment="Validée automatiquement par le script de création",
     )
 
-# Most of offerers are not validated on staging without this commit() - TODO: is this related to atomic? oa?
+    # Most of offerers are not validated on staging without this commit() - TODO: is this related to atomic? oa?
     db.session.commit()
-    
+
     address = offerers_schemas.AddressBodyModel(
         street=offerers_schemas.VenueAddress(offerer_creation_info.street),
         city=offerers_schemas.VenueCity(offerer_creation_info.city),

--- a/api/src/pcapi/scripts/beneficiary/import_test_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_test_users.py
@@ -135,21 +135,26 @@ def _create_pro_user(row: dict) -> User:
         comment="Validée automatiquement par le script de création",
     )
 
-    # Most of offerers are not validated on staging without this commit() - TODO: is this related to atomic? oa?
+# Most of offerers are not validated on staging without this commit() - TODO: is this related to atomic? oa?
     db.session.commit()
-
-    venue_creation_info = venues_serialize.PostVenueBodyModel(
+    
+    address = offerers_schemas.AddressBodyModel(
         street=offerers_schemas.VenueAddress(offerer_creation_info.street),
-        banId=offerers_schemas.VenueBanId("75101_2259_00001"),  # 1 place de la Concorde
-        bookingEmail=offerers_schemas.VenueBookingEmail(user.email),
         city=offerers_schemas.VenueCity(offerer_creation_info.city),
-        comment=None,
+        postalCode=offerers_schemas.VenuePostalCode(offerer_creation_info.postalCode),
         latitude=gps[0],
         longitude=gps[1],
+        banId=offerers_schemas.VenueBanId("75101_2259_00001"),  # 1 place de la Concorde
+        label=None,
+    )
+
+    venue_creation_info = venues_serialize.PostVenueBodyModel(
+        address=address,
+        bookingEmail=offerers_schemas.VenueBookingEmail(user.email),
+        comment=None,
         managingOffererId=offerer.id,
         name=offerers_schemas.VenueName(f'Structure {row["Prénom"]} {row["Nom"]}'),
         publicName=None,
-        postalCode=offerers_schemas.VenuePostalCode(offerer_creation_info.postalCode),
         siret=offerers_schemas.VenueSiret(siret),
         venueLabelId=None,
         venueTypeCode=offerers_models.VenueTypeCode.ADMINISTRATIVE.name,

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -513,7 +513,11 @@ class CreateOffererTest:
         gen_offerer_tags()
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="777084112", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="777084112",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
 
         # When
@@ -547,7 +551,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
 
         # When
@@ -562,7 +570,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
         offerer = offerers_factories.OffererFactory(siren=offerer_informations.siren)
 
@@ -592,7 +604,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
         offerer = offerers_factories.NotValidatedOffererFactory(
             siren=offerer_informations.siren, validationStatus=ValidationStatus.PENDING
@@ -615,7 +631,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
         offerer = offerers_factories.RejectedOffererFactory(
             name="Rejected Offerer",
@@ -656,7 +676,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
         offerer = offerers_factories.RejectedOffererFactory(
             name="Rejected Offerer",
@@ -687,7 +711,13 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
+            latitude=48,
+            longitude=2,
         )
         offerer = offerers_factories.RejectedOffererFactory(
             name="Rejected Offerer",
@@ -718,7 +748,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
         offerer = offerers_factories.OffererFactory(siren=offerer_informations.siren)
         offerers_factories.RejectedUserOffererFactory(user=user, offerer=offerer)
@@ -745,7 +779,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
         offerer = offerers_factories.OffererFactory(siren=offerer_informations.siren)
         offerers_factories.RejectedUserOffererFactory(user=user, offerer=offerer)
@@ -777,7 +815,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.NonAttachedProFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
 
         # When
@@ -804,7 +846,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="418166096", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="418166096",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
         offerer = offerers_factories.OffererFactory(siren=offerer_informations.siren)
         offerers_factories.DeletedUserOffererFactory(user=user, offerer=offerer)
@@ -831,7 +877,11 @@ class CreateOffererTest:
         # Given
         user = users_factories.UserFactory()
         offerer_informations = offerers_serialize.CreateOffererQueryModel(
-            name="Test Offerer", siren="777084112", address="123 rue de Paris", postalCode="93100", city="Montreuil"
+            name="Test Offerer",
+            siren="777084112",
+            address="123 rue de Paris",
+            postalCode="93100",
+            city="Montreuil",
         )
 
         # When
@@ -1971,15 +2021,18 @@ class CreateFromOnboardingDataTest:
         self, create_venue_without_siret: bool
     ) -> offerers_serialize.SaveNewOnboardingDataQueryModel:
         return offerers_serialize.SaveNewOnboardingDataQueryModel(
-            banId="75101_9575_00003",
-            city="Paris",
-            createVenueWithoutSiret=create_venue_without_siret,
-            latitude=2.30829,
-            longitude=48.87171,
-            postalCode="75001",
-            publicName="Nom public de mon lieu",
+            address=offerers_schemas.AddressBodyModel(
+                label="",
+                banId="75101_9575_00003",
+                city=offerers_schemas.VenueCity("Paris"),
+                latitude=2.30829,
+                longitude=48.87171,
+                postalCode=offerers_schemas.VenuePostalCode("75001"),
+                street=offerers_schemas.VenueAddress("3 RUE DE VALOIS"),
+            ),
             siret="85331845900031",
-            street="3 RUE DE VALOIS",
+            publicName="Nom public de mon lieu",
+            createVenueWithoutSiret=create_venue_without_siret,
             target=offerers_models.Target.INDIVIDUAL,
             venueTypeCode=offerers_models.VenueTypeCode.MOVIE.name,
             webPresence="https://www.example.com, https://instagram.com/example, https://mastodon.social/@example",
@@ -2205,7 +2258,7 @@ class CreateFromOnboardingDataTest:
         user = users_factories.UserFactory(email="pro@example.com")
         user.add_non_attached_pro_role()
         onboarding_data = self.get_onboarding_data(create_venue_without_siret=False)
-        onboarding_data.street = None
+        onboarding_data.address.street = ""
 
         created_user_offerer = offerers_api.create_from_onboarding_data(user, onboarding_data)
 
@@ -2213,7 +2266,7 @@ class CreateFromOnboardingDataTest:
         created_offerer = created_user_offerer.offerer
         assert created_offerer.name == "MINISTERE DE LA CULTURE"
         assert created_offerer.siren == "853318459"
-        assert created_offerer.street is None
+        assert not created_offerer.street
         assert created_offerer.city == "Paris"
         assert created_offerer.postalCode == "75001"
         # 1 virtual Venue + 1 Venue with siret have been created
@@ -2229,7 +2282,7 @@ class CreateFromOnboardingDataTest:
         user = users_factories.UserFactory(email="pro@example.com")
         user.add_non_attached_pro_role()
         onboarding_data = self.get_onboarding_data(create_venue_without_siret=False)
-        onboarding_data.banId = None
+        onboarding_data.address.banId = None
 
         created_user_offerer = offerers_api.create_from_onboarding_data(user, onboarding_data)
 

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -83,12 +83,14 @@ def test_new_offerer_auto_tagging(db_session, ape_code, expected_tag):
 class CreateVenueTest:
     def base_data(self, offerer):
         return {
-            "street": "rue du test",
-            "city": "Paris",
-            "postalCode": "75002",
-            "banId": "75113_1834_00007",
-            "latitude": 1,
-            "longitude": 1,
+            "address": {
+                "street": "rue du test",
+                "city": "Paris",
+                "postalCode": "75002",
+                "banId": "75113_1834_00007",
+                "latitude": 1,
+                "longitude": 1,
+            },
             "managingOffererId": offerer.id,
             "name": "La Venue",
             "venueTypeCode": "VISUAL_ARTS",

--- a/api/tests/routes/pro/post_offerer_test.py
+++ b/api/tests/routes/pro/post_offerer_test.py
@@ -30,6 +30,8 @@ def test_create_virtual_venue(client):
         "address": "123 rue de Paris",
         "postalCode": "93100",
         "city": "Montreuil",
+        "latitude": 48,
+        "longitude": 2,
     }
 
     # when
@@ -54,6 +56,8 @@ def test_returned_data(client):
         "address": "123 rue de Paris",
         "postalCode": "93100",
         "city": "Montreuil",
+        "latitude": 48,
+        "longitude": 2,
     }
 
     client = client.with_session_auth(pro.email)
@@ -76,6 +80,8 @@ def test_user_cant_create_same_offerer_twice(client):
         "address": "123 rue de Paris",
         "postalCode": "93100",
         "city": "Montreuil",
+        "latitude": 48,
+        "longitude": 2,
     }
 
     client = client.with_session_auth(pro.email)
@@ -99,7 +105,14 @@ def test_when_no_address_is_provided(client):
     pro = users_factories.ProFactory(
         lastConnectionDate=datetime.utcnow(),
     )
-    body = {"name": "Test Offerer", "siren": "418166096", "postalCode": "93100", "city": "Montreuil"}
+    body = {
+        "name": "Test Offerer",
+        "siren": "418166096",
+        "postalCode": "93100",
+        "city": "Montreuil",
+        "latitude": 48,
+        "longitude": 2,
+    }
 
     # when
     client = client.with_session_auth(pro.email)
@@ -120,6 +133,8 @@ def test_use_offerer_name_retrieved_from_sirene_api(client):
         "address": "123 rue de Paris",
         "postalCode": "93100",
         "city": "Montreuil",
+        "latitude": 48,
+        "longitude": 2,
     }
     client = client.with_session_auth(pro.email)
     response = client.post("/offerers", json=body)
@@ -139,6 +154,8 @@ def test_current_user_has_access_to_created_offerer(client):
         "address": "123 rue de Paris",
         "postalCode": "93100",
         "city": "Montreuil",
+        "latitude": 48,
+        "longitude": 2,
     }
 
     # when
@@ -162,6 +179,8 @@ def test_new_user_offerer_has_validation_status_new(client):
         "street": offerer.street,
         "postalCode": offerer.postalCode,
         "city": offerer.city,
+        "latitude": 48,
+        "longitude": 2,
     }
 
     # when
@@ -185,6 +204,8 @@ def test_create_offerer_action_is_logged(client):
         "address": "123 rue de Paris",
         "postalCode": "93100",
         "city": "Montreuil",
+        "latitude": 48,
+        "longitude": 2,
     }
 
     # when
@@ -219,6 +240,8 @@ def test_with_inactive_siren(requests_mock, client):
         "address": "123 rue de Paris",
         "postalCode": "93100",
         "city": "Montreuil",
+        "latitude": 48,
+        "longitude": 2,
     }
 
     client = client.with_session_auth(user.email)
@@ -249,6 +272,8 @@ def test_saint_martin_offerer_creation_without_postal_code_is_successfull(reques
         "postalCode": "",
         "siren": siren,
         "apeCode": "94.99Z",
+        "latitude": 48,
+        "longitude": 2,
     }
 
     client = client.with_session_auth(user.email)

--- a/api/tests/routes/pro/post_save_new_onboarding_data_test.py
+++ b/api/tests/routes/pro/post_save_new_onboarding_data_test.py
@@ -2,7 +2,9 @@ from unittest.mock import patch
 
 import pytest
 
+from pcapi.connectors.api_adresse import AddressInfo
 from pcapi.connectors.entreprise import exceptions as sirene_exceptions
+from pcapi.core.geography import models as geography_models
 from pcapi.core.history import models as history_models
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.users.factories as users_factories
@@ -13,15 +15,17 @@ from tests.connectors import sirene_test_data
 pytestmark = pytest.mark.usefixtures("db_session")
 
 REQUEST_BODY = {
-    "city": "Paris",
-    "banId": "75101_9575_00003",
-    "createVenueWithoutSiret": False,
-    "latitude": 2.30829,
-    "longitude": 48.87171,
-    "postalCode": "75001",
-    "publicName": "Pass Culture",
+    "address": {
+        "city": "Paris",
+        "banId": "75101_9575_00003",
+        "latitude": 2.30829,
+        "longitude": 48.87171,
+        "postalCode": "75001",
+        "street": "3 RUE DE VALOIS",
+    },
     "siret": "85331845900031",
-    "street": "3 RUE DE VALOIS",
+    "publicName": "Pass Culture",
+    "createVenueWithoutSiret": False,
     "target": "INDIVIDUAL",
     "venueTypeCode": "MOVIE",
     "webPresence": "https://www.example.com, https://instagram.com/example, https://mastodon.social/@example",
@@ -30,7 +34,21 @@ REQUEST_BODY = {
 
 
 class Returns200Test:
-    def test_nominal(self, client):
+    @patch(
+        "pcapi.connectors.api_adresse.TestingBackend.get_single_address_result",
+        return_value=AddressInfo(
+            id="75101_9575_00003",
+            label="3 Rue de Valois 75001 Paris",
+            postcode="75001",
+            citycode="75056",
+            score=0.9651727272727272,
+            latitude=48.87171,
+            longitude=2.308289,
+            city="Paris",
+            street="3 Rue de Valois",
+        ),
+    )
+    def test_nominal(self, mocked_get_address, client):
         user = users_factories.UserFactory(email="pro@example.com")
 
         client = client.with_session_auth(user.email)
@@ -75,6 +93,83 @@ class Returns200Test:
         assert len(created_venue.action_history) == 1
         assert created_venue.action_history[0].actionType == history_models.ActionType.VENUE_CREATED
         assert created_venue.action_history[0].authorUser == user
+
+        mocked_get_address.assert_called_once()
+
+        address = geography_models.Address.query.one()
+        assert created_venue.offererAddress.addressId == address.id
+        assert address.street == "3 Rue de Valois"
+        assert address.city == REQUEST_BODY["address"]["city"]
+        assert address.isManualEdition is False
+
+    @patch(
+        "pcapi.connectors.api_adresse.TestingBackend.get_municipality_centroid",
+        return_value=AddressInfo(
+            id="75101",
+            label="Paris",
+            postcode="75001",
+            citycode="75056",
+            score=0.9651727272727272,
+            latitude=48.87171,
+            longitude=2.308289,
+            city="Paris",
+            street=None,
+        ),
+    )
+    def test_nominal_case_with_manually_edited_address(self, mocked_get_centroid, client):
+        user = users_factories.UserFactory(email="pro@example.com")
+
+        client = client.with_session_auth(user.email)
+        data = {**REQUEST_BODY}
+        data["address"]["isManualEdition"] = True
+        response = client.post("/offerers/new", json=REQUEST_BODY)
+
+        assert response.status_code == 201
+        created_offerer = offerers_models.Offerer.query.one()
+        assert created_offerer.street == "3 RUE DE VALOIS"
+        assert created_offerer.city == "Paris"
+        assert created_offerer.name == "MINISTERE DE LA CULTURE"
+        assert not created_offerer.isValidated
+        assert created_offerer.postalCode == "75001"
+        created_venue = offerers_models.Venue.query.filter(offerers_models.Venue.isVirtual.is_(False)).one()
+        assert created_venue.street == "3 RUE DE VALOIS"
+        assert created_venue.bookingEmail == "pro@example.com"
+        assert created_venue.city == "Paris"
+        assert created_venue.audioDisabilityCompliant is None
+        assert created_venue.mentalDisabilityCompliant is None
+        assert created_venue.motorDisabilityCompliant is None
+        assert created_venue.visualDisabilityCompliant is None
+        assert created_venue.comment is None
+        assert created_venue.departementCode == "75"
+        assert created_venue.name == "MINISTERE DE LA CULTURE"
+        assert created_venue.postalCode == "75001"
+        assert created_venue.publicName == "Pass Culture"
+        assert created_venue.siret == "85331845900031"
+        assert created_venue.venueTypeCode == offerers_models.VenueTypeCode.MOVIE
+        assert created_venue.withdrawalDetails is None
+        assert created_venue.adageId is None
+        assert created_venue.adageInscriptionDate is None
+
+        assert len(created_venue.adage_addresses) == 1
+        adage_addr = created_venue.adage_addresses[0]
+
+        assert adage_addr.venueId == created_venue.id
+        assert adage_addr.adageId == created_venue.adageId
+        assert adage_addr.adageInscriptionDate == created_venue.adageInscriptionDate
+
+        assert len(created_offerer.action_history) == 1
+        assert created_offerer.action_history[0].actionType == history_models.ActionType.OFFERER_NEW
+        assert created_offerer.action_history[0].authorUser == user
+        assert len(created_venue.action_history) == 1
+        assert created_venue.action_history[0].actionType == history_models.ActionType.VENUE_CREATED
+        assert created_venue.action_history[0].authorUser == user
+
+        address = geography_models.Address.query.one()
+        assert created_venue.offererAddress.addressId == address.id
+        assert address.street == REQUEST_BODY["address"]["street"]
+        assert address.city == REQUEST_BODY["address"]["city"]
+        assert address.isManualEdition is True
+        mocked_get_centroid.assert_called_once()
 
     def test_returns_public_information_only(self, client):
         user = users_factories.UserFactory(email="pro@example.com")

--- a/api/tests/routes/pro/post_venue_test.py
+++ b/api/tests/routes/pro/post_venue_test.py
@@ -1,13 +1,16 @@
 from datetime import datetime
 import pathlib
+from unittest.mock import patch
 
 import pytest
 
+from pcapi.connectors.api_adresse import AddressInfo
 from pcapi.core import testing
 from pcapi.core.external.zendesk_sell_backends import testing as zendesk_testing
 from pcapi.core.geography import models as geography_models
 from pcapi.core.history import models as history_models
 from pcapi.core.offerers import models
+from pcapi.core.offerers import models as offerers_models
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offerers.models import Venue
 from pcapi.core.users import testing as external_testing
@@ -62,15 +65,17 @@ def create_valid_venue_data(user=None):
     venue_label = offerers_factories.VenueLabelFactory(label="CAC - Centre d'art contemporain d'intérêt national")
 
     return {
+        "address": {
+            "street": "Chemin de Chaniaux 48250 Laveyrune",
+            "postalCode": "48250",
+            "city": "Laveyrune",
+            "latitude": 44.626322,
+            "longitude": 3.893166,
+        },
         "name": "MINISTERE DE LA CULTURE",
         "siret": f"{user_offerer.offerer.siren}10045",
-        "street": "Chemin de Chaniaux 48250 Laveyrune",
-        "postalCode": "48250",
         "bookingEmail": "toto@example.com",
-        "city": "Laveyrune",
         "managingOffererId": user_offerer.offerer.id,
-        "latitude": 44.626322,
-        "longitude": 3.893166,
         "publicName": "Ma venue publique",
         "venueTypeCode": "BOOKSTORE",
         "venueLabelId": venue_label.id,
@@ -211,35 +216,29 @@ class Returns400Test:
         user = ProFactory()
         venue_data = create_valid_venue_data(user)
 
-        venue_data = {
-            **venue_data,
-            "latitude": -98.82387,
-            "longitude": "112°3534",
-        }
+        venue_data["address"]["latitude"] = -98.82387
+        venue_data["address"]["longitude"] = "112°3534"
 
         client = client.with_session_auth(email=user.email)
         response = client.post("/venues", json=venue_data)
 
         assert response.status_code == 400
-        assert response.json["latitude"] == ["La latitude doit être comprise entre -90.0 et +90.0"]
-        assert response.json["longitude"] == ["Format incorrect"]
+        assert response.json["address.latitude"] == ["La latitude doit être comprise entre -90.0 et +90.0"]
+        assert response.json["address.longitude"] == ["Format incorrect"]
 
     def test_longitude_out_of_range_and_latitude_wrong_format(self, client):
         user = ProFactory()
 
         venue_data = create_valid_venue_data(user)
-        venue_data = {
-            **venue_data,
-            "latitude": "76°8237",
-            "longitude": 210.43251,
-        }
+        venue_data["address"]["latitude"] = "76°8237"
+        venue_data["address"]["longitude"] = 210.43251
 
         client = client.with_session_auth(email=user.email)
         response = client.post("/venues", json=venue_data)
 
         assert response.status_code == 400
-        assert response.json["longitude"] == ["La longitude doit être comprise entre -180.0 et +180.0"]
-        assert response.json["latitude"] == ["Format incorrect"]
+        assert response.json["address.longitude"] == ["La longitude doit être comprise entre -180.0 et +180.0"]
+        assert response.json["address.latitude"] == ["Format incorrect"]
 
     def test_mandatory_accessibility_fields(self, client):
         user = ProFactory()

--- a/pro/src/apiClient/v1/models/AddressBodyModel.ts
+++ b/pro/src/apiClient/v1/models/AddressBodyModel.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export type AddressBodyModel = {
+  banId?: string | null;
   city: string;
   isManualEdition?: boolean;
   isVenueAddress?: boolean;

--- a/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostVenueBodyModel.ts
@@ -2,25 +2,21 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AddressBodyModel } from './AddressBodyModel';
 import type { VenueContactModel } from './VenueContactModel';
 export type PostVenueBodyModel = {
+  address: AddressBodyModel;
   audioDisabilityCompliant?: boolean | null;
-  banId?: string | null;
   bookingEmail: string;
-  city: string;
   comment?: string | null;
   contact?: VenueContactModel | null;
   description?: string | null;
-  latitude: number;
-  longitude: number;
   managingOffererId: number;
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name: string;
-  postalCode: string;
   publicName?: string | null;
   siret?: string | null;
-  street: string;
   venueLabelId?: number | null;
   venueTypeCode: string;
   visualDisabilityCompliant?: boolean | null;

--- a/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
+++ b/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
@@ -2,17 +2,13 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AddressBodyModel } from './AddressBodyModel';
 import type { Target } from './Target';
 export type SaveNewOnboardingDataQueryModel = {
-  banId?: string | null;
-  city: string;
+  address: AddressBodyModel;
   createVenueWithoutSiret?: boolean;
-  latitude: number;
-  longitude: number;
-  postalCode: string;
   publicName?: string | null;
   siret: string;
-  street?: string | null;
   target: Target;
   token: string;
   venueTypeCode: string;

--- a/pro/src/components/Address/constants.ts
+++ b/pro/src/components/Address/constants.ts
@@ -7,6 +7,8 @@ export const DEFAULT_ADDRESS_FORM_VALUES = {
   longitude: 0,
   street: '',
   postalCode: '',
+  coords: '',
+  manuallySetAddress: false,
 }
 
 export const DEBOUNCE_TIME_BEFORE_REQUEST = 400

--- a/pro/src/components/Address/types.ts
+++ b/pro/src/components/Address/types.ts
@@ -5,4 +5,5 @@ export interface Address {
   postalCode: string
   street: string
   banId: string | null
+  manuallySetAddress?: boolean
 }

--- a/pro/src/components/Address/validationSchema.ts
+++ b/pro/src/components/Address/validationSchema.ts
@@ -1,7 +1,37 @@
 import * as yup from 'yup'
 
+import { checkCoords } from 'commons/utils/coords'
+
 export const validationSchema = {
-  addressAutocomplete: yup
+  addressAutocomplete: yup.string().when(['manuallySetAddress'], {
+    is: (manuallySetAddress: boolean) => !manuallySetAddress,
+    then: (schema) =>
+      schema.required(
+        'Veuillez sélectionner une adresse parmi les suggestions'
+      ),
+  }),
+  street: yup
     .string()
-    .required('Veuillez sélectionner une adresse parmi les suggestions'),
+    .trim()
+    .required('Veuillez renseigner une adresse postale'),
+  postalCode: yup
+    .string()
+    .trim()
+    .required('Veuillez renseigner un code postal')
+    .min(5, 'Veuillez renseigner un code postal valide')
+    .max(5, 'Veuillez renseigner un code postal valide'),
+
+  city: yup.string().trim().required('Veuillez renseigner une ville'),
+  coords: yup
+    .string()
+    .trim()
+    .when(['manuallySetAddress'], {
+      is: (manuallySetAddress: boolean) => manuallySetAddress,
+      then: (schema) =>
+        schema
+          .required('Veuillez renseigner les coordonnées GPS')
+          .test('coords', 'Veuillez respecter le format attendu', (value) =>
+            checkCoords(value)
+          ),
+    }),
 }

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
@@ -1,6 +1,15 @@
+import { useField, useFormikContext } from 'formik'
+
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
+import { resetAddressFields } from 'commons/utils/resetAddressFields'
 import { AddressSelect } from 'components/Address/Address'
 import { Address } from 'components/Address/types'
+import { AddressManual } from 'components/AddressManual/AddressManual'
 import { FormLayout } from 'components/FormLayout/FormLayout'
+import fullBackIcon from 'icons/full-back.svg'
+import fullNextIcon from 'icons/full-next.svg'
+import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant } from 'ui-kit/Button/types'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 
 import { OffererFormValues } from '../Offerer/OffererForm'
@@ -14,9 +23,25 @@ export interface OffererAuthenticationFormValues
   publicName: string
   addressAutocomplete: string
   'search-addressAutocomplete': string
+  coords: string
+  manuallySetAddress: boolean
 }
 
 export const OffererAuthenticationForm = (): JSX.Element => {
+  const formik = useFormikContext<OffererAuthenticationFormValues>()
+  const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
+
+  const [manuallySetAddress, , { setValue: setManuallySetAddress }] =
+    useField('manuallySetAddress')
+
+  const toggleManuallySetAddress = async () => {
+    const isAddressManual = !manuallySetAddress.value
+    await setManuallySetAddress(isAddressManual)
+    if (isAddressManual) {
+      await resetAddressFields({ formik })
+    }
+  }
+
   return (
     <FormLayout.Section>
       <h1 className={styles['title']}>Identification</h1>
@@ -33,7 +58,25 @@ export const OffererAuthenticationForm = (): JSX.Element => {
         <AddressSelect
           description="À modifier si l’adresse postale de votre structure est différente de la raison sociale."
           suggestionLimit={5}
+          disabled={manuallySetAddress.value}
         />
+        {isOfferAddressEnabled && (
+          <>
+            <Button
+              variant={ButtonVariant.QUATERNARY}
+              title="Renseignez l’adresse manuellement"
+              icon={manuallySetAddress.value ? fullBackIcon : fullNextIcon}
+              onClick={toggleManuallySetAddress}
+            >
+              {manuallySetAddress.value ? (
+                <>Revenir à la sélection automatique</>
+              ) : (
+                <>Vous ne trouvez pas votre adresse ?</>
+              )}
+            </Button>
+            {manuallySetAddress.value && <AddressManual />}
+          </>
+        )}
       </FormLayout.Row>
     </FormLayout.Section>
   )

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
@@ -23,8 +23,8 @@ export interface OffererAuthenticationFormValues
   publicName: string
   addressAutocomplete: string
   'search-addressAutocomplete': string
-  coords: string
-  manuallySetAddress: boolean
+  coords?: string
+  manuallySetAddress?: boolean
 }
 
 export const OffererAuthenticationForm = (): JSX.Element => {

--- a/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
@@ -69,7 +69,7 @@ fetchMock.mockResponse(
   { status: 200 }
 )
 
-const renderOffererAuthentiationScreen = (
+const renderOffererAuthenticationScreen = (
   contextValue: SignupJourneyContextValues
 ) => {
   return renderWithProviders(
@@ -98,6 +98,7 @@ const renderOffererAuthentiationScreen = (
     }
   )
 }
+
 describe('screens:SignupJourney::OffererAuthentication', () => {
   let contextValue: SignupJourneyContextValues
   beforeEach(() => {
@@ -120,7 +121,7 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
   })
 
   it('should render component', async () => {
-    renderOffererAuthentiationScreen(contextValue)
+    renderOffererAuthenticationScreen(contextValue)
 
     expect(
       await screen.findByText(
@@ -154,7 +155,7 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
   })
 
   it('should display activity screen on submit', async () => {
-    renderOffererAuthentiationScreen(contextValue)
+    renderOffererAuthenticationScreen(contextValue)
     expect(await screen.findByText('Identification')).toBeInTheDocument()
     await userEvent.click(
       screen.getByRole('button', { name: 'Étape suivante' })
@@ -163,7 +164,7 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
   })
 
   it('should display offerer screen on submit', async () => {
-    renderOffererAuthentiationScreen(contextValue)
+    renderOffererAuthenticationScreen(contextValue)
     expect(await screen.findByText('Identification')).toBeInTheDocument()
     await userEvent.click(screen.getByRole('button', { name: 'Retour' }))
     expect(screen.getByText('Offerer screen')).toBeInTheDocument()
@@ -171,7 +172,7 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
 
   it('should redirect to offerer screen if there is no offerer siret', () => {
     contextValue.offerer = DEFAULT_OFFERER_FORM_VALUES
-    renderOffererAuthentiationScreen(contextValue)
+    renderOffererAuthenticationScreen(contextValue)
     expect(screen.queryByText('Identification')).not.toBeInTheDocument()
     expect(screen.getByText('Offerer screen')).toBeInTheDocument()
   })
@@ -181,7 +182,7 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
       ...DEFAULT_OFFERER_FORM_VALUES,
       siret: '12345678933333',
     }
-    renderOffererAuthentiationScreen(contextValue)
+    renderOffererAuthenticationScreen(contextValue)
     expect(screen.queryByText('Identification')).not.toBeInTheDocument()
     expect(screen.getByText('Offerer screen')).toBeInTheDocument()
   })

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
-import { SaveNewOnboardingDataQueryModel, Target } from 'apiClient/v1'
+import { SaveNewOnboardingDataQueryModel, Target, AddressBodyModel } from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { GET_VENUE_TYPES_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { DEFAULT_ACTIVITY_VALUES } from 'commons/context/SignupJourneyContext/constants'
@@ -94,12 +94,14 @@ export const Validation = (): JSX.Element => {
           /* istanbul ignore next: the form validation already handles this */
           activity.targetCustomer ?? Target.EDUCATIONAL,
         createVenueWithoutSiret: offerer.createVenueWithoutSiret ?? false,
-        banId: offerer.banId,
-        longitude: offerer.longitude ?? 0,
-        latitude: offerer.latitude ?? 0,
-        city: offerer.city,
-        postalCode: offerer.postalCode,
-        street: offerer.street,
+        address: {
+          banId: offerer.banId,
+          longitude: offerer.longitude ?? 0,
+          latitude: offerer.latitude ?? 0,
+          city: offerer.city,
+          postalCode: offerer.postalCode,
+          street: offerer.street,
+        },
         token,
       }
 

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
-import { SaveNewOnboardingDataQueryModel, Target, AddressBodyModel } from 'apiClient/v1'
+import { SaveNewOnboardingDataQueryModel, Target } from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { GET_VENUE_TYPES_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { DEFAULT_ACTIVITY_VALUES } from 'commons/context/SignupJourneyContext/constants'
@@ -14,6 +14,7 @@ import {
   RECAPTCHA_ERROR,
   RECAPTCHA_ERROR_MESSAGE,
 } from 'commons/core/shared/constants'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useCurrentUser } from 'commons/hooks/useCurrentUser'
 import { useInitReCaptcha } from 'commons/hooks/useInitReCaptcha'
 import { useNotification } from 'commons/hooks/useNotification'
@@ -37,6 +38,7 @@ export const Validation = (): JSX.Element => {
   const { logEvent } = useAnalytics()
   const notify = useNotification()
   const navigate = useNavigate()
+  const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
   const { activity, offerer } = useSignupJourneyContext()
   useInitReCaptcha()
 
@@ -101,6 +103,9 @@ export const Validation = (): JSX.Element => {
           city: offerer.city,
           postalCode: offerer.postalCode,
           street: offerer.street,
+          ...(isOfferAddressEnabled && {
+            isManualEdition: offerer.manuallySetAddress,
+          }),
         },
         token,
       }

--- a/pro/src/components/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
@@ -234,12 +234,14 @@ describe('ValidationScreen', () => {
           webPresence: 'url1, url2',
           target: Target.EDUCATIONAL,
           createVenueWithoutSiret: false,
-          street: '3 Rue de Valois',
-          banId: '75118_5995_00043',
-          city: 'Paris',
-          latitude: 0,
-          longitude: 0,
-          postalCode: '75001',
+          address: {
+            street: '3 Rue de Valois',
+            banId: '75118_5995_00043',
+            city: 'Paris',
+            latitude: 0,
+            longitude: 0,
+            postalCode: '75001',
+          },
           token: 'token',
         })
       }

--- a/pro/src/pages/VenueCreation/serializers.ts
+++ b/pro/src/pages/VenueCreation/serializers.ts
@@ -9,18 +9,12 @@ export const serializePostVenueBodyModel = (
 ): PostVenueBodyModel => {
   const payload: PostVenueBodyModel = {
     audioDisabilityCompliant: formValues.accessibility.audio,
-    banId: formValues.banId,
     bookingEmail: formValues.bookingEmail,
-    city: formValues.city,
     comment: formValues.comment,
-    latitude: formValues.latitude,
-    longitude: formValues.longitude,
     mentalDisabilityCompliant: formValues.accessibility.mental,
     motorDisabilityCompliant: formValues.accessibility.motor,
     name: formValues.name,
-    postalCode: formValues.postalCode,
     publicName: formValues.publicName,
-    street: formValues.street,
     siret: unhumanizeSiret(formValues.siret),
     venueTypeCode: formValues.venueType,
     visualDisabilityCompliant: formValues.accessibility.visual,
@@ -32,6 +26,14 @@ export const serializePostVenueBodyModel = (
     },
     venueLabelId: null,
     managingOffererId: offererId,
+    address: {
+      banId: formValues.banId,
+      city: formValues.city,
+      latitude: formValues.latitude,
+      longitude: formValues.longitude,
+      postalCode: formValues.postalCode,
+      street: formValues.street
+    }
   }
 
   if (hideSiret) {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32880

Ajout de la saisie d’adresse manuelle lors de l'inscription d'une nouvelle structure à l'entité juridique

<img src="https://github.com/user-attachments/assets/a5326756-79e1-4f0c-a083-6f75e2a508e0" width="300">


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
