### PR TITLE
(PC-33379)[PRO] fix: Validate email validity in collective contact on…

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/validationSchema.ts
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/validationSchema.ts
@@ -122,19 +122,18 @@ export function getOfferEducationalValidationSchema(
           'Veuillez entrer un numéro de téléphone valide, exemple : 612345678',
         test: isPhoneValid,
       }),
-    email: yup
-      .string()
-      .when(['contactOptions', 'isTemplate'], {
-        is: (
-          contactOptions: OfferEducationalFormValues['contactOptions'],
-          isTemplate: boolean
-        ) => !isTemplate || contactOptions?.email,
-        then: (schema) =>
-          schema.required('Veuillez renseigner une adresse email'),
-      })
-      .email(
-        'Veuillez renseigner une adresse email valide, exemple : mail@exemple.com'
-      ),
+    email: yup.string().when(['contactOptions', 'isTemplate'], {
+      is: (
+        contactOptions: OfferEducationalFormValues['contactOptions'],
+        isTemplate: boolean
+      ) => !isTemplate || contactOptions?.email,
+      then: (schema) =>
+        schema
+          .required('Veuillez renseigner une adresse email')
+          .email(
+            'Veuillez renseigner une adresse email valide, exemple : mail@exemple.com'
+          ),
+    }),
     contactUrl: yup.string().when(['contactOptions', 'contactFormType'], {
       is: (
         contactOptions: OfferEducationalFormValues['contactOptions'],


### PR DESCRIPTION
…ly when email field visible.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33379

**Objectif**
Ne pas bloquer la validation du formulaire de création d'offre collective vitrine quand un email invalide a été entré dans la section contact ->  "Par Email", mais que la case "Par Email" a été décochée.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
