### PR TITLE
(PC-33220)[API] fix: missing offer_id in data log

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -244,6 +244,7 @@ def create_draft_offer(
         product=product,
     )
     db.session.add(offer)
+    db.session.flush()
 
     if body.call_id:
         logger.info(

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1423,6 +1423,24 @@ class CreateDraftOfferTest:
         with pytest.raises(exceptions.OffererVirtualVenueNotFound):
             api.create_draft_offer(body, venue=venue)
 
+    @override_features(WIP_SUGGESTED_SUBCATEGORIES=True)
+    def test_create_offer_sends_complete_log_to_data(self, caplog):
+        venue = offerers_factories.VenueFactory(isVirtual=False)
+        body = offers_schemas.PostDraftOfferBodyModel(
+            name="L'esclave et Violette",
+            subcategoryId="LIVRE_PAPIER",
+            venueId=venue.id,
+            callId="123e4567-e89b-12d3-a456-426614174000",
+        )
+        with caplog.at_level(logging.INFO):
+            offer = api.create_draft_offer(body, venue=venue)
+            assert caplog.records[0].message == "Offer Categorisation Data API"
+            assert caplog.records[0].technical_message_id == "offer_categorisation"
+            assert caplog.records[0].extra["analyticsSource"] == "app-pro"
+            assert caplog.records[0].extra["offer_id"] == offer.id
+            assert caplog.records[0].extra["offer_data_api_call_id"] == "123e4567-e89b-12d3-a456-426614174000"
+            assert caplog.records[0].extra["offer_subcategory"] == offer.subcategoryId
+
 
 @pytest.mark.usefixtures("db_session")
 class UpdateDraftOfferTest:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33389

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
