### PR TITLE
(PC-33006)[API] fix: handle error: price cat edit: reject/pend offer

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -605,12 +605,17 @@ def post_price_categories(
                     status_code=400,
                 )
             data = price_category_to_edit.dict(exclude_unset=True)
-            offers_api.edit_price_category(
-                offer,
-                price_category=existing_price_categories_by_id[data["id"]],
-                label=data.get("label", offers_api.UNCHANGED),
-                price=data.get("price", offers_api.UNCHANGED),
-            )
+            try:
+                offers_api.edit_price_category(
+                    offer,
+                    price_category=existing_price_categories_by_id[data["id"]],
+                    label=data.get("label", offers_api.UNCHANGED),
+                    price=data.get("price", offers_api.UNCHANGED),
+                )
+            except exceptions.RejectedOrPendingOfferNotEditable:
+                raise api_errors.ApiErrors(
+                    {"offer": ["Offer is not editable (because rejected or pending)"]}, status_code=400
+                )
 
     return offers_serialize.GetIndividualOfferResponseModel.from_orm(offer)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33006

Fix : lorsqu'un client essayait d'éditer le prix d'une offre rejetée ou en brouillon, une erreur était générée mais pas gérée.
Correction : gérer cette erreur et informer le client que cette opération n'est pas possible.
