### PR TITLE
(PC-32895)[PRO] fix: Dont hide the multiselect border

### DIFF
--- a/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
+++ b/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
@@ -24,9 +24,6 @@
 
 .search-input {
   @include forms.input-theme;
-
-  border: none;
-
   @include forms.input-theme-nested;
 }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32895

**Objectif**
Supprimer le style qui retire la bordure de l'input de recherche des composants de filtre d'ADAGE.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
