### PR TITLE
(PC-32893)[PRO] fix: Remove the gap between adage header active tab l…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.module.scss
@@ -33,7 +33,7 @@
   .adage-header-budget {
     border-left: 1px solid var(--color-grey-medium);
     border-top: none;
-    padding-left: 0 0 0 rem.torem(32px);
+    padding: 0 0 0 rem.torem(32px);
     width: unset;
 
     &-link {


### PR DESCRIPTION
…ine and bottom header line.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32893

**Objectif**
Corriger l'espace entre le bas du header ADAGE et la barre de l'onglet actif.

Avant/Après 
<img width="674" alt="Capture d’écran 2024-11-07 à 10 06 56" src="https://github.com/user-attachments/assets/04160045-d061-4633-8a0f-96e094c53a3e">
<img width="725" alt="Capture d’écran 2024-12-03 à 14 04 11" src="https://github.com/user-attachments/assets/694bfc0c-cc34-44c2-bd12-7e3518eb8bc0">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
