### PR TITLE
(PC-32800)[PRO] fix: Box button double outline on focus.

### DIFF
--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -204,21 +204,6 @@
         var(--color-medium-shadow);
     }
 
-    &:focus-visible {
-      &:not(.button-disabled) {
-        position: relative;
-
-        &::before {
-          display: block;
-          content: "";
-          position: absolute;
-          inset: rem.torem(-4px);
-          border: 1px solid var(--color-input-text-color);
-          border-radius: rem.torem(8px);
-        }
-      }
-    }
-
     .button-arrow-content {
       flex-grow: 1;
       text-align: left;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32800

**Objectif**
Ne pas avoir 2 outlines sur le bouton de type Box au focus.

Avant/Après
<img width="924" alt="Capture d’écran 2024-11-04 à 13 25 51" src="https://github.com/user-attachments/assets/8604224e-3378-46da-833c-ecc951205f38">
<img width="396" alt="Capture d’écran 2024-12-03 à 14 22 03" src="https://github.com/user-attachments/assets/12d70f45-3026-451d-a6d0-73894db6e0b6">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
