### PR TITLE
(PC-32979)[API] fix: 'ValueError: second must be in 0..59' in get_non_empty_date_time_range

### DIFF
--- a/api/src/pcapi/core/educational/utils.py
+++ b/api/src/pcapi/core/educational/utils.py
@@ -87,7 +87,7 @@ def get_non_empty_date_time_range(start: datetime, end: datetime) -> DateTimeRan
     """
 
     if start == end:
-        new_end = end.replace(second=end.second + 1)
+        new_end = end + timedelta(seconds=1)
     else:
         new_end = end
 

--- a/api/tests/core/educational/test_utils.py
+++ b/api/tests/core/educational/test_utils.py
@@ -62,3 +62,22 @@ class HashUserEmailTest:
 
         # Then
         assert result == "f0e2a21bcf499cbc713c47d8f034d66e90a99f9ffcfe96466c9971dfdc5c9816"
+
+
+class GetNonEmptyDateTimeRangeTest:
+    def test_get_non_empty_datetime_range(self) -> None:
+        start = datetime(2024, 12, 24, 23, 59, 59)
+        end = datetime(2024, 12, 25, 23, 59, 59)
+
+        result = utils.get_non_empty_date_time_range(start, end)
+
+        assert result.lower == start
+        assert result.upper == end
+
+    def test_get_non_empty_datetime_range_ends_when_starts(self) -> None:
+        start = datetime(2024, 12, 24, 23, 59, 59)
+
+        result = utils.get_non_empty_date_time_range(start, start)
+
+        assert result.lower == start
+        assert result.upper == datetime(2024, 12, 25, 0, 0, 0)


### PR DESCRIPTION
## But de la pull request

Exception liée au ticket Jira qui n'est actuellement déployé que sur testing : https://passculture.atlassian.net/browse/PC-32979

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
