### PR TITLE
(BSR)[API] fix: sentry alert is useless in case Zendesk Sell server is not reachable

### DIFF
--- a/api/src/pcapi/core/external/zendesk_sell_backends/zendesk_sell.py
+++ b/api/src/pcapi/core/external/zendesk_sell_backends/zendesk_sell.py
@@ -266,7 +266,12 @@ class ZendeskSellReadOnlyBackend(BaseBackend):
             case _:
                 raise ValueError("Unsupported method")
         if not response.ok:
-            logger.error(
+            if response.status_code in (502, 503, 504):
+                # No need for Sentry alert in case of timeout or server unavailable, we can't fix anything
+                log_function = logger.warning
+            else:
+                log_function = logger.error
+            log_function(
                 "Error %s while calling Zendesk Sell API",
                 response.status_code,
                 extra={


### PR DESCRIPTION
## But de la pull request

Inutile de m'alerter sur Sentry quand une requête à Zendesk Sell finit en timeout.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
