### PR TITLE
(PC-33041)[API] feat: ext. bookings api: move timeout const to settings

### DIFF
--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -42,7 +42,7 @@ EXTERNAL_BOOKINGS_FF = (
     feature.FeatureToggle.DISABLE_EMS_EXTERNAL_BOOKINGS,
 )
 
-EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS = 12
+EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS = settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS
 
 
 def get_shows_stock(venue_id: int, shows_id: list[int]) -> dict[str, int]:

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -639,3 +639,6 @@ CEGID_URL = secrets_utils.get("CEGID_URL")
 CEGID_USERNAME = secrets_utils.get("CEGID_USERNAME")
 CEGID_PASSWORD = secrets_utils.get("CEGID_PASSWORD")
 CEGID_COMPANY = secrets_utils.get("CEGID_COMPANY")
+
+# External APIs
+EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS = int(os.environ.get("EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS", 10))


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33041

Objectif : ne plus utiliser une constante dans le code pour le temps de _timeout_, mais une variables d'environnement. Ce qui devrait rendre les modifications beaucoup plus simples (et rapides).

La PR côté déploiement est [là](https://github.com/pass-culture/pass-culture-deployment/pull/569).