### PR TITLE
(PC-33425)[API] fix: oa filter was not used in patch all active status for…

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -401,6 +401,7 @@ def patch_all_offers_active_status(
         "creation_mode": body.creation_mode,
         "period_beginning_date": body.period_beginning_date,
         "period_ending_date": body.period_ending_date,
+        "offerer_address_id": body.offerer_address_id,
     }
     update_all_offers_active_status_job.delay(filters, body.is_active)
     return offers_serialize.PatchAllOffersActiveStatusResponseModel()

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -173,6 +173,7 @@ class PatchAllOffersActiveStatusBodyModel(BaseModel):
     status: str | None
     period_beginning_date: datetime.date | None
     period_ending_date: datetime.date | None
+    offerer_address_id: int | None
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/workers/update_all_offers_active_status_job.py
+++ b/api/src/pcapi/workers/update_all_offers_active_status_job.py
@@ -13,6 +13,7 @@ def update_all_offers_active_status_job(filters: dict, is_active: bool) -> None:
         status=filters["status"],
         venue_id=filters["venue_id"],
         category_id=filters["category_id"],
+        offerer_address_id=filters["offerer_address_id"],
         name_keywords_or_ean=filters["name_or_ean"],
         creation_mode=filters["creation_mode"],
         period_beginning_date=filters["period_beginning_date"],

--- a/pro/src/apiClient/v1/models/PatchAllOffersActiveStatusBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchAllOffersActiveStatusBodyModel.ts
@@ -7,6 +7,7 @@ export type PatchAllOffersActiveStatusBodyModel = {
   creationMode?: string | null;
   isActive: boolean;
   nameOrIsbn?: string | null;
+  offererAddressId?: number | null;
   offererId?: number | null;
   periodBeginningDate?: string | null;
   periodEndingDate?: string | null;

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
@@ -1,9 +1,10 @@
+import { ReactNode } from 'react'
+
 import { Button } from 'ui-kit/Button/Button'
 
 import collective from './assets/collective.jpeg'
 import individuelle from './assets/individuelle.jpeg'
 import styles from './OnboardingOffersChoicem.module.scss'
-import { ReactNode } from 'react'
 
 interface CardProps {
   imageSrc: string

--- a/pro/src/pages/IndividualOffers/IndividualOffersContainer/IndividualOffersContainer.spec.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffersContainer/IndividualOffersContainer.spec.tsx
@@ -568,8 +568,16 @@ describe('IndividualOffersScreen', () => {
         'Une offre est en cours d’activation, veuillez rafraichir dans quelques instants'
       )
       expect(api.patchAllOffersActiveStatus).toHaveBeenCalledWith({
+        categoryId: null,
+        creationMode: null,
         isActive: true,
+        nameOrIsbn: null,
+        offererAddressId: null,
         offererId: '1',
+        periodBeginningDate: null,
+        periodEndingDate: null,
+        status: null,
+        venueId: null,
       })
     })
 

--- a/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOffersActionsBar/IndividualOffersActionsBar.tsx
@@ -3,7 +3,10 @@ import { useSelector } from 'react-redux'
 import { mutate, useSWRConfig } from 'swr'
 
 import { api } from 'apiClient/api'
-import { OfferStatus } from 'apiClient/v1'
+import {
+  OfferStatus,
+  type PatchAllOffersActiveStatusBodyModel,
+} from 'apiClient/v1'
 import { GET_OFFERS_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { useQuerySearchFilters } from 'commons/core/Offers/hooks/useQuerySearchFilters'
 import { SearchFiltersParams } from 'commons/core/Offers/types'
@@ -75,7 +78,19 @@ const updateIndividualOffersStatus = async (
   apiFilters: SearchFiltersParams,
   areNewStatusesEnabled: boolean
 ) => {
-  const payload = serializeApiFilters(apiFilters)
+  const filters = serializeApiFilters(apiFilters)
+  const payload: PatchAllOffersActiveStatusBodyModel = {
+    categoryId: filters.categoryId ?? null,
+    creationMode: filters.creationMode ?? null,
+    isActive: isActive,
+    nameOrIsbn: filters.nameOrIsbn ?? null,
+    offererId: filters.offererId ?? null,
+    periodBeginningDate: filters.periodBeginningDate ?? null,
+    periodEndingDate: filters.periodEndingDate ?? null,
+    status: filters.status ?? null,
+    venueId: filters.venueId ?? null,
+    offererAddressId: filters.offererAddressId ?? null,
+  }
   const deactivationWording = areNewStatusesEnabled
     ? 'la mise en pause'
     : 'la désactivation'


### PR DESCRIPTION
## But de la pull request

Corriger la prise en compte du filtre sur la localisation dans l'update de masse des offres

[BSR](https://passculture.atlassian.net/browse/PC-33425)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
