### PR TITLE
(PC-33426)[PRO] fix: cannot change date when offer is active or prebo…

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/OfferEducationalStock/OfferEducationalStock.tsx
@@ -97,7 +97,7 @@ export const OfferEducationalStock = <
   
   const canEditDiscount = areCollectiveNewStatusesEnabled ? isActionAllowedOnCollectiveOffer(offer, CollectiveOfferAllowedAction.CAN_EDIT_DISCOUNT) : !disablePriceAndParticipantInputs
 
-  const canEditDates = areCollectiveNewStatusesEnabled ? isActionAllowedOnCollectiveOffer(offer, CollectiveOfferAllowedAction.CAN_EDIT_DATES) : mode === Mode.CREATION
+  const canEditDates = areCollectiveNewStatusesEnabled ? isActionAllowedOnCollectiveOffer(offer, CollectiveOfferAllowedAction.CAN_EDIT_DATES) : mode !== Mode.READ_ONLY
 
   const postForm = async (values: OfferEducationalStockFormValues) => {
     setIsLoading(true)

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/OfferEducationalStock/__specs__/OfferEducationalStock.spec.tsx
@@ -212,6 +212,24 @@ it('should display saved information in the action bar', () => {
   expect(screen.getByText('Enregistrer et continuer')).toBeInTheDocument()
 })
 
+it('should not disable start datetime, end datetime and event time inputs when form access is edition', () => {
+  const testProps: OfferEducationalStockProps = {
+    ...defaultProps,
+    mode: Mode.EDITION,
+    offer: getCollectiveOfferFactory(),
+  }
+
+  renderWithProviders(<OfferEducationalStock {...testProps} />)
+
+  const startDatetimeInput = screen.getByLabelText('Date de début *')
+  const endDatetimeInput = screen.getByLabelText('Date de fin *')
+  const eventTimeInput = screen.getByLabelText('Horaire *')
+
+  expect(startDatetimeInput).not.toBeDisabled()
+  expect(endDatetimeInput).not.toBeDisabled()
+  expect(eventTimeInput).not.toBeDisabled()
+})
+
 it('should not disable description, price and places when allowedAction CAN_EDIT_DISCOUNT exist and FF ENABLE_COLLECTIVE_NEW_STATUSES enable ', () => {
   const testProps: OfferEducationalStockProps = {
     ...defaultProps,


### PR DESCRIPTION
…oked

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33426

Lorsque le FF des statuts est désactivé, il n'était plus possible de changer les dates d'une offre collectives en statut publiée ou préréservée.

Dans la condition, on autorisait seulement en mode création la possibilité de changer les dates/horaires alors que l'on peut aussi le faire en édition

## Vérifications

- [x] J'ai écrit les tests nécessaires