### PR TITLE
(PC-33430)[PRO] feat: Remove unused line-heights and align line-heigh…

### DIFF
--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.module.scss
@@ -15,7 +15,6 @@
   &-step-title-disabled {
     @include fonts.body-exergue;
 
-    line-height: rem.torem(20px);
     color: var(--color-grey-dark);
   }
 

--- a/pro/src/components/Bookings/BookingsRecapTable/Filters/Filters.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/Filters/Filters.module.scss
@@ -41,7 +41,6 @@
 .bs-filter-button {
   background-color: transparent;
   border: none;
-  line-height: rem.torem(20px);
   vertical-align: middle;
 }
 
@@ -49,7 +48,6 @@
   @include fonts.caption;
 
   color: var(--color-black);
-  line-height: rem.torem(20px);
   min-height: rem.torem(60px);
   padding: rem.torem(14px);
   vertical-align: middle;

--- a/pro/src/components/Bookings/PreFilters/PreFilters.module.scss
+++ b/pro/src/components/Bookings/PreFilters/PreFilters.module.scss
@@ -75,7 +75,6 @@
   @include fonts.body;
 
   color: var(--color-error-light);
-  line-height: rem.torem(16px);
   text-align: center;
 }
 

--- a/pro/src/components/IndividualOffer/SummaryScreen/SummaryScreen.module.scss
+++ b/pro/src/components/IndividualOffer/SummaryScreen/SummaryScreen.module.scss
@@ -10,7 +10,6 @@
 }
 
 .offer-creation-preview-title {
-  line-height: rem.torem(22px);
   margin-bottom: rem.torem(16px);
   display: flex;
 

--- a/pro/src/components/Newsletter/Newsletter.module.scss
+++ b/pro/src/components/Newsletter/Newsletter.module.scss
@@ -34,10 +34,6 @@
     padding-right: rem.torem(16px);
     min-height: rem.torem(53px);
 
-    // We use "em" here because em is based on element font-size
-    // and we want line-height to grow together with font-size
-    line-height: 1.25em;
-
     @media (min-width: size.$tablet) {
       padding-right: 20%;
     }

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscoveryBanner/AdageDiscoveryBanner.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/AdageDiscoveryBanner/AdageDiscoveryBanner.module.scss
@@ -15,7 +15,6 @@
     margin: 0;
     color: var(--color-white);
     text-align: center;
-    line-height: normal;
     position: relative;
     z-index: 1;
 

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
@@ -105,7 +105,6 @@ $offer-image-width: rem.torem(216px);
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   overflow: hidden;
-  line-height: rem.torem(20px);
   margin-bottom: rem.torem(16px);
 }
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/AdageButtonFilter/AdageButtonFilter.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/AdageButtonFilter/AdageButtonFilter.module.scss
@@ -19,8 +19,6 @@
 
   &-is-active {
     @include fonts.button;
-
-    line-height: rem.torem(20px);
   }
 
   &-selected {

--- a/pro/src/pages/Errors/Unavailable/Unavailable.module.scss
+++ b/pro/src/pages/Errors/Unavailable/Unavailable.module.scss
@@ -17,7 +17,6 @@
     @include fonts-design-system.title1;
 
     color: var(--color-white);
-    line-height: normal;
     margin: rem.torem(32px) 0 rem.torem(16px);
   }
 

--- a/pro/src/pages/VenueCreation/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
+++ b/pro/src/pages/VenueCreation/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
@@ -15,7 +15,6 @@
   &-step-title-disabled {
     @include fonts.body-exergue;
 
-    line-height: rem.torem(20px);
     color: var(--color-grey-dark);
   }
 

--- a/pro/src/ui-kit/Tag/Tag.module.scss
+++ b/pro/src/ui-kit/Tag/Tag.module.scss
@@ -63,7 +63,6 @@
     padding: 0 rem.torem(4px);
     color: var(--color-accent);
     border: 1px solid var(--color-accent);
-    line-height: rem.torem(20px);
   }
 
   &.light-green {

--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectedValuesTags/SelectedValuesTags.module.scss
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectedValuesTags/SelectedValuesTags.module.scss
@@ -18,7 +18,6 @@
   background-color: var(--color-grey-light);
   color: var(--color-black);
   display: inline-flex;
-  line-height: rem.torem(16px);
   padding: 0 rem.torem(4px) rem.torem(1px) rem.torem(4px);
 
   &:hover {
@@ -29,7 +28,6 @@
     @include fonts.caption;
 
     cursor: pointer;
-    line-height: rem.torem(16px);
     background: none;
     border: none;
     display: flex;

--- a/pro/src/ui-kit/form/TextArea/TextArea.module.scss
+++ b/pro/src/ui-kit/form/TextArea/TextArea.module.scss
@@ -4,7 +4,6 @@
 .text-area {
   @include forms.input-theme;
 
-  $line-height: 1.3;
   $padding: 16px;
 
   display: block;

--- a/pro/src/ui-kit/form/TextInput/TextInput.module.scss
+++ b/pro/src/ui-kit/form/TextInput/TextInput.module.scss
@@ -6,7 +6,6 @@
     display: flex;
     align-items: center;
     min-height: rem.torem(40px);
-    line-height: 1.3;
   }
 
   &-group {
@@ -19,4 +18,3 @@
     }
   }
 }
-

--- a/pro/src/ui-kit/form/shared/FieldError/FieldError.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldError/FieldError.module.scss
@@ -16,6 +16,5 @@
 
   &-text {
     white-space: pre-wrap;
-    line-height: rem.torem(16px);
   }
 }

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
@@ -85,9 +85,6 @@ $icon-size: rem.torem(20px);
   display: flex;
   align-items: center;
 
-  // Reset button styles
-  line-height: 0;
-
   &-container {
     position: absolute;
     border-radius: 50%;

--- a/pro/src/ui-kit/form/shared/FieldSuccess/FieldSuccess.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldSuccess/FieldSuccess.module.scss
@@ -17,6 +17,5 @@
 
   &-text {
     white-space: pre-wrap;
-    line-height: rem.torem(18px);
   }
 }


### PR DESCRIPTION
…ts on typo line-height.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33430

Clean de quelques `line-height` supplémentaires qui n'ont pas d'effet ou qui devraient être la lien-height par défaut.

2 des plus grosses modifs : 
- Le tag nouveau avant/après
<img width="624" alt="Capture d’écran 2024-12-04 à 15 09 37" src="https://github.com/user-attachments/assets/43934f2d-651a-44a5-8fc8-adee97aa068f">
<img width="595" alt="Capture d’écran 2024-12-04 à 15 09 43" src="https://github.com/user-attachments/assets/686e93cc-0edf-4202-82d5-8fd65dfee2bb">


- Le texte de la page d'erreur avant/après
<img width="529" alt="Capture d’écran 2024-12-04 à 17 10 55" src="https://github.com/user-attachments/assets/6de82c09-bfce-4fc5-91d0-e955e79a9ea9">
<img width="492" alt="Capture d’écran 2024-12-04 à 17 11 19" src="https://github.com/user-attachments/assets/138f28e2-79fa-4e0f-a025-fc0e6cf2b6c1">


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
