### PR TITLE
(PC-33413)[PRO] fix: Dont display expiration banner when the offer is…

### DIFF
--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveOfferRow.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveOfferRow.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames'
 
 import {
+  CollectiveOfferDisplayedStatus,
   CollectiveOfferResponseModel,
-  CollectiveOfferStatus,
 } from 'apiClient/v1'
 import { CollectiveSearchFiltersParams } from 'commons/core/Offers/types'
 import { isOfferDisabled } from 'commons/core/Offers/utils/isOfferDisabled'
@@ -32,9 +32,8 @@ function isCollectiveOfferActiveOrPreBooked(
   offer: CollectiveOfferResponseModel
 ) {
   return (
-    offer.status === CollectiveOfferStatus.ACTIVE ||
-    (offer.status === CollectiveOfferStatus.SOLD_OUT &&
-      offer.booking?.booking_status === 'PENDING')
+    offer.displayedStatus === CollectiveOfferDisplayedStatus.ACTIVE ||
+    offer.displayedStatus === CollectiveOfferDisplayedStatus.PREBOOKED
   )
 }
 
@@ -64,7 +63,7 @@ export const CollectiveOfferRow = ({
     isCollectiveOffersExpirationEnabled &&
     !offer.isShowcase &&
     isCollectiveOfferActiveOrPreBooked(offer) &&
-    bookingLimitDate
+    !!bookingLimitDate
 
   return (
     <>

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/ExpirationCell/ExpirationCell.spec.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/ExpirationCell/ExpirationCell.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 
 import {
+  CollectiveOfferDisplayedStatus,
   CollectiveOfferResponseModel,
   CollectiveOfferStatus,
 } from 'apiClient/v1'
@@ -64,7 +65,7 @@ describe('ExpirationCell', () => {
   it('should display a banner saying that the offer needs to be booked if it is already pre-booked', () => {
     const offerExpiring = {
       ...offer,
-      status: CollectiveOfferStatus.SOLD_OUT,
+      displayedStatus: CollectiveOfferDisplayedStatus.PREBOOKED,
     }
     offerExpiring.booking = { booking_status: 'PENDING', id: 1 }
     const today = new Date()

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/ExpirationCell/ExpirationCell.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/ExpirationCell/ExpirationCell.tsx
@@ -2,8 +2,8 @@ import classNames from 'classnames'
 import { differenceInCalendarDays, format } from 'date-fns'
 
 import {
+  CollectiveOfferDisplayedStatus,
   CollectiveOfferResponseModel,
-  CollectiveOfferStatus,
 } from 'apiClient/v1'
 import { FORMAT_DD_MM_YYYY, toDateStrippedOfTimezone } from 'commons/utils/date'
 import { pluralize } from 'commons/utils/pluralize'
@@ -50,7 +50,7 @@ export function ExpirationCell({
           )}
           <div className={styles['banner-expiration-waiting']}>
             <SvgIcon alt="" src={fullWaitIcon} width="16" /> En attente de{' '}
-            {offer.status === CollectiveOfferStatus.ACTIVE
+            {offer.displayedStatus === CollectiveOfferDisplayedStatus.ACTIVE
               ? 'préréservation par l’enseignant'
               : 'réservation par le chef d’établissement'}
           </div>

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
@@ -5,6 +5,7 @@ import { api } from 'apiClient/api'
 import {
   ApiError,
   CollectiveBookingStatus,
+  CollectiveOfferDisplayedStatus,
   CollectiveOfferResponseModel,
   CollectiveOfferStatus,
   ListOffersStockResponseModel,
@@ -439,7 +440,7 @@ describe('ollectiveOfferRow', () => {
 
   it('should display a expiration row if the bookable offer is active, and if the FF ENABLE_COLLECTIVE_OFFERS_EXPIRATION is enabled', () => {
     props.offer = collectiveOfferFactory({
-      status: CollectiveOfferStatus.ACTIVE,
+      displayedStatus: CollectiveOfferDisplayedStatus.ACTIVE,
       stocks: [
         {
           hasBookingLimitDatetimePassed: false,
@@ -460,7 +461,7 @@ describe('ollectiveOfferRow', () => {
 
   it('should display a expiration row if the bookable offer is pre-booked, and if the FF ENABLE_COLLECTIVE_OFFERS_EXPIRATION is enabled', () => {
     props.offer = collectiveOfferFactory({
-      status: CollectiveOfferStatus.SOLD_OUT,
+      displayedStatus: CollectiveOfferDisplayedStatus.PREBOOKED,
       stocks: [
         {
           hasBookingLimitDatetimePassed: false,
@@ -482,7 +483,7 @@ describe('ollectiveOfferRow', () => {
 
   it('should not display a expiration row if the FF ENABLE_COLLECTIVE_OFFERS_EXPIRATION is disabled', () => {
     props.offer = collectiveOfferFactory({
-      status: CollectiveOfferStatus.ACTIVE,
+      displayedStatus: CollectiveOfferDisplayedStatus.ACTIVE,
       stocks: [
         {
           hasBookingLimitDatetimePassed: false,
@@ -501,12 +502,31 @@ describe('ollectiveOfferRow', () => {
 
   it('should not display a expiration row if the offer has no booking limit', () => {
     props.offer = collectiveOfferFactory({
-      status: CollectiveOfferStatus.ACTIVE,
+      displayedStatus: CollectiveOfferDisplayedStatus.ACTIVE,
       stocks: [
         {
           hasBookingLimitDatetimePassed: false,
           remainingQuantity: 1,
           bookingLimitDatetime: undefined,
+        },
+      ],
+    })
+
+    renderOfferItem(props)
+
+    expect(
+      screen.queryByText('En attente de préréservation par l’enseignant')
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not display a expiration row if the offer was cancelled', () => {
+    props.offer = collectiveOfferFactory({
+      displayedStatus: CollectiveOfferDisplayedStatus.CANCELLED,
+      stocks: [
+        {
+          hasBookingLimitDatetimePassed: false,
+          remainingQuantity: 1,
+          bookingLimitDatetime: getToday().toISOString(),
         },
       ],
     })


### PR DESCRIPTION
… cancelled.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33413

**Objectif**
Ne pas afficher la bannière indiquant que l'offre est en attente de préréservation si elle a été annulée.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
