### PR TITLE
(BSR)[API] feat: add educational program update to budget import

### DIFF
--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -73,8 +73,10 @@ def import_deposit_csv(*, path: str, year: int, ministry: str, conflict: str, fi
     CSV format change every time we try to work with it.
     """
     institution_api.import_deposit_institution_csv(
-        path=path, year=year, ministry=ministry, conflict=conflict, final=final, commit=not dry_run
+        path=path, year=year, ministry=ministry, conflict=conflict, final=final, program_name=None
     )
+    if not dry_run:
+        db.session.commit()
 
 
 @blueprint.cli.command("synchronize_venues_from_adage_cultural_partners")

--- a/api/tests/core/educational/api/test_import_deposit_institution_deposit_data.py
+++ b/api/tests/core/educational/api/test_import_deposit_institution_deposit_data.py
@@ -21,7 +21,6 @@ class ImportDepositInstitutionDataTest:
             ministry=educational_models.Ministry.EDUCATION_NATIONALE,
             final=False,
             conflict="crash",
-            commit=True,
         )
 
         institution = educational_models.EducationalInstitution.query.filter_by(institutionId="0470010E").one()
@@ -54,7 +53,6 @@ class ImportDepositInstitutionDataTest:
             ministry=educational_models.Ministry.EDUCATION_NATIONALE,
             final=False,
             conflict="crash",
-            commit=True,
         )
 
         institution = educational_models.EducationalInstitution.query.filter_by(institutionId="0470010E").one()
@@ -87,7 +85,6 @@ class ImportDepositInstitutionDataTest:
                 ministry=educational_models.Ministry.EDUCATION_NATIONALE,
                 final=False,
                 conflict="crash",
-                commit=True,
             )
 
         assert educational_models.EducationalInstitution.query.count() == 0
@@ -110,7 +107,6 @@ class ImportDepositInstitutionDataTest:
             ministry=educational_models.Ministry.EDUCATION_NATIONALE,
             final=False,
             conflict="replace",
-            commit=True,
         )
 
         institution = educational_models.EducationalInstitution.query.filter_by(institutionId="0470010E").one()
@@ -147,7 +143,6 @@ class ImportDepositInstitutionDataTest:
             ministry=educational_models.Ministry.EDUCATION_NATIONALE,
             final=False,
             conflict="keep",
-            commit=True,
         )
 
         institution = educational_models.EducationalInstitution.query.filter_by(institutionId="0470010E").one()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : Ajout de la mise à jour du educational_program lors de l'import des budgets

Une fois ce changement dispo en prod, mettre à jour le script : https://github.com/pass-culture/pass-culture-main/pull/15315

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
