### PR TITLE
(PC-33444)[BO] fix: fix display of custom reimbursment rules when a v…

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -126,9 +126,9 @@
 {% endmacro %}
 {% macro build_venue_name_to_pc_pro_link(venue, public_name=true, siret=false) %}
   {% if venue.isVirtual %}
-    {{ build_connect_as_pseudo_link(venue.id, "venue", "/accueil?structure="~venue.managingOffererId~"&from-bo=true", (((public_name and venue.publicName) or venue.name) + ((" - " + venue.siret) if siret else "")), "link-primary") }}
+    {{ build_connect_as_pseudo_link(venue.id, "venue", "/accueil?structure="~venue.managingOffererId~"&from-bo=true", (((public_name and venue.publicName) or venue.name) + ((" - " + venue.siret) if (siret and venue.siret) else "")), "link-primary") }}
   {% else %}
-    {{ build_connect_as_pseudo_link(venue.id, "venue", "/structures/"~venue.managingOffererId~"/lieux/"~venue.id~"", (((public_name and venue.publicName) or venue.name) + ((" - " + venue.siret) if siret else "")), "link-primary") }}
+    {{ build_connect_as_pseudo_link(venue.id, "venue", "/structures/"~venue.managingOffererId~"/lieux/"~venue.id~"", (((public_name and venue.publicName) or venue.name) + ((" - " + venue.siret) if (siret and venue.siret) else "")), "link-primary") }}
   {% endif %}
 {% endmacro %}
 {% macro build_venue_parameters_name_to_pc_pro_link(venue) %}

--- a/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
+++ b/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
@@ -183,6 +183,17 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
         assert html_parser.count_table_rows(response.data) == 25  # extra data in second row for each booking
         assert "Il y a plus de 25 résultats dans la base de données" in html_parser.extract_alert(response.data)
 
+    def test_display_list_even_if_rule_on_venue_without_siret(self, authenticated_client):
+        venue = offerers_factories.VenueFactory()
+        finance_factories.CustomReimbursementRuleFactory(venue=venue)
+        venue.comment = "comment"
+        venue.siret = None
+        db.session.flush()
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url_for(self.endpoint, limit=25))
+            assert response.status_code == 200
+
 
 class GetCreateCustomReimbursementRuleFormTest(GetEndpointHelper):
     endpoint = "backoffice_web.reimbursement_rules.get_create_custom_reimbursement_rule_form"


### PR DESCRIPTION
…enue has no siret

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33444

![image](https://github.com/user-attachments/assets/77b3fd33-c154-4adc-9a6c-bb3ac6118676)


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
