### PR TITLE
(BSR)[API] chore: clean achievements on sandbox reset

### DIFF
--- a/api/src/pcapi/repository/clean_database.py
+++ b/api/src/pcapi/repository/clean_database.py
@@ -3,6 +3,7 @@ import typing
 import flask_sqlalchemy
 
 from pcapi import settings
+from pcapi.core.achievements import models as achievements_models
 import pcapi.core.bookings.models as bookings_models
 from pcapi.core.chronicles import models as chronicles_models
 import pcapi.core.criteria.models as criteria_models
@@ -28,6 +29,7 @@ from pcapi.models.feature import install_feature_flags
 # Order of table to clean matters because of foreign key constraints
 # They will be deleted in this order
 tables_to_clean: list[flask_sqlalchemy.Model] = [
+    achievements_models.Achievement,
     chronicles_models.ProductChronicle,
     chronicles_models.OfferChronicle,
     chronicles_models.Chronicle,


### PR DESCRIPTION
## But de la pull request

BSR: rajout du truncate de la table achievement dans le reset de la sandbox

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
