### PR TITLE
(PC-33466)[API] fix:prevent CGR synchronisation crash

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -3,6 +3,7 @@ import decimal
 from io import BytesIO
 import logging
 import typing
+import warnings
 
 from PIL import Image
 from PIL import UnidentifiedImageError
@@ -356,6 +357,9 @@ def check_image(
 ) -> None:
     check_image_size(image_as_bytes, max_size)
     try:
+        # to raise an error when PIL warns for a possible decompression bomb
+        # as this warning always lead to the pod being out of memory
+        warnings.simplefilter("error", Image.DecompressionBombWarning)
         image = Image.open(BytesIO(image_as_bytes))
     except UnidentifiedImageError:
         raise exceptions.UnidentifiedImage()


### PR DESCRIPTION
Crash caused by an image with too many pixels

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33466

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
