### PR TITLE
(BSR)[PRO] test: add some JSDoc for commands and helper functions

### DIFF
--- a/pro/cypress/support/commands.ts
+++ b/pro/cypress/support/commands.ts
@@ -69,8 +69,6 @@ Cypress.Commands.add('getFakeAdageToken', () => {
   })
 })
 
-// See https://github.com/cypress-io/cypress/issues/1570#issuecomment-891244917
-// Workaround bc onChange not triggered for an input type='range' rendered by React
 Cypress.Commands.add(
   'setSliderValue',
   { prevSubject: 'element' },
@@ -87,13 +85,13 @@ Cypress.Commands.add(
   }
 )
 
-// Workaround to format log. See https://github.com/cypress-io/cypress/issues/2134
-// and https://github.com/cypress-io/cypress/issues/2134#issuecomment-1692593562
-
 /**
  *  Helper function to convert hex colors to rgb
+ *  Workaround to format log
  * @param {string} hex - hex color
  * @returns {string}
+ * @see https://github.com/cypress-io/cypress/issues/2134
+ * @see https://github.com/cypress-io/cypress/issues/2134#issuecomment-1692593562
  *
  * @example
  * // returns "255 255 255"
@@ -140,14 +138,6 @@ export function createCustomLog() {
     ` // @ts-expect-error: Object is possibly 'null'.
   Cypress.$(window.top.document.head).append(logStyle)
 }
-
-/**
- * Print in Cypress UI/Cloud a message with a formatted style
- * @param {string} log.message - The content of the message.
- *
- * @example
- * cy.stepLog({ message: 'I do this' })
- */
 
 Cypress.Commands.add('stepLog', ({ message }) => {
   createCustomLog()

--- a/pro/cypress/support/index.d.ts
+++ b/pro/cypress/support/index.d.ts
@@ -1,15 +1,58 @@
 declare namespace Cypress {
   interface Chainable {
+    /**
+     * Activate or disable a feature flag
+     * 
+     * @param {Feature[]} features - An array of `Feature` objects to be updated.
+     * Each `Feature` object contains a name and an activation state (`isActive`).
+     * @example 
+     * cy.setFeatureFlags([ { name: 'ENABLE_COLLECTIVE_NEW_STATUSES', isActive: true }])
+     */
     setFeatureFlags(features: Feature[]): Chainable
 
+    
+    /**
+     * This function creates a fake adage token which is set as an environment variable `adageToken`
+     *
+     * @example 
+     * cy.getFakeAdageToken()
+     * const adageToken = Cypress.env('adageToken')
+     * cy.visit(`/adage-iframe/recherche?token=${adageToken}`)
+     */
     getFakeAdageToken(): Chainable
 
+    
+    /**
+     * Set the slider value of an input of type `range`.
+     * Workaround because onChange not triggered for an input type='range' rendered by React
+     *
+     * @param {number} value
+     * @see https://github.com/cypress-io/cypress/issues/1570#issuecomment-891244917
+     * @example 
+     * cy.get('input[type=range]').setSliderValue(1.7)
+     */
     setSliderValue(value: number): Chainable<void>
 
+    
+    /**
+     * Adds a log in Cypress Cloud and Cypress UI. Usefull to make scenario list of commands more understandable
+     *
+     * @params {{ message: string }} string containing the
+     * @example 
+     * cy.stepLog({message: 'I want to create an offer'})
+     */
     stepLog(params: { message: string }): Chainable
   }
 }
 
+/**
+ * This interface is used to set Feature Flags with a name and a boolean if needs to be activated or not
+ *
+ * @interface
+ *
+ * @property {string} name - name of the Feature Flag
+ * @property {boolean} isActive - to activate (true) or not (falst)
+ */
 interface Feature {
   name: string
   isActive: boolean


### PR DESCRIPTION
## But de la pull request

Ajoute de la JSDoc pour les helper et nouvelles `Cypress.Commands` créées

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
