### PR TITLE
(PC-33476)[PRO] feat: Remove todo message and inexistant FF.

### DIFF
--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.tsx
@@ -59,7 +59,6 @@ function sortInvoices(
           : compareAsc(new Date(b.date), new Date(a.date))
       )
 
-    // TODO : remove me when removing WIP_ENABLE_FINANCE_INCIDENT
     case InvoicesOrderedBy.REIMBURSEMENT_POINT_NAME:
       return [...invoices].sort((a, b) =>
         sortingMode === SortingMode.ASC
@@ -93,6 +92,7 @@ function sortInvoices(
           : b.cashflowLabels[0].localeCompare(a.cashflowLabels[0])
       )
 
+    case null:
     default:
       return invoices
   }

--- a/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/ReimbursementInvoices.spec.tsx
@@ -139,7 +139,7 @@ describe('reimbursementsWithFilters', () => {
     expect(screen.getByText(/75,00/)).toBeInTheDocument()
   })
 
-  it('should display new invoice table if FF WIP_ENABLE_FINANCE_INCIDENT is enable', async () => {
+  it('should display the invoice table', async () => {
     vi.spyOn(api, 'getInvoicesV2').mockResolvedValue([
       {
         reference: 'J123456789',
@@ -159,9 +159,7 @@ describe('reimbursementsWithFilters', () => {
       },
     ])
 
-    renderReimbursementsInvoices({
-      features: ['WIP_ENABLE_FINANCE_INCIDENT'],
-    })
+    renderReimbursementsInvoices()
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
     expect(
@@ -236,9 +234,7 @@ describe('reimbursementsWithFilters', () => {
   })
 
   it('should contain sort informations for a11y', async () => {
-    renderReimbursementsInvoices({
-      features: ['WIP_ENABLE_FINANCE_INCIDENT'],
-    })
+    renderReimbursementsInvoices()
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 
@@ -324,9 +320,7 @@ describe('reimbursementsWithFilters', () => {
     ])
     vi.spyOn(api, 'getReimbursementsCsvV2')
 
-    renderReimbursementsInvoices({
-      features: ['WIP_ENABLE_FINANCE_INCIDENT'],
-    })
+    renderReimbursementsInvoices()
 
     await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33476

**Objectif**
Suppression d'un message de TODO qui propose de supprimer un cas de tri de la table des justificatifs de remboursement. Comme le FF n'existe déjà plus mais que le tri existe encore, je propsoe de laisser le tri même si le message de TODO propose de l'enlever.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
