### PR TITLE
(BSR)[PRO] feat: use isEditable in collective offer row instead of is…

### DIFF
--- a/pro/src/commons/core/Offers/utils/isOfferDisabled.ts
+++ b/pro/src/commons/core/Offers/utils/isOfferDisabled.ts
@@ -1,14 +1,5 @@
-import { CollectiveOfferStatus, OfferStatus } from 'apiClient/v1'
+import { OfferStatus } from 'apiClient/v1'
 
-// FIXME(anoukhello - 2024-06-21) remove this function for collective offers as it is
-// redundant with the attribute isEditable on collective offer
-export const isOfferDisabled = (
-  status: OfferStatus | CollectiveOfferStatus
-): boolean => {
-  return [
-    OfferStatus.REJECTED,
-    OfferStatus.PENDING,
-    CollectiveOfferStatus.REJECTED,
-    CollectiveOfferStatus.PENDING,
-  ].includes(status)
+export const isOfferDisabled = (status: OfferStatus): boolean => {
+  return [OfferStatus.REJECTED, OfferStatus.PENDING].includes(status)
 }

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveOfferRow.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveOfferRow.tsx
@@ -86,7 +86,7 @@ export const CollectiveOfferRow = ({
         <CheckboxCell
           offerName={offer.name}
           isSelected={isSelected}
-          disabled={isOfferDisabled(offer.status)}
+          disabled={!offer.isEditable}
           selectOffer={() => selectOffer(offer)}
           headers={`${rowId} collective-offer-head-checkbox`}
         />
@@ -96,7 +96,7 @@ export const CollectiveOfferRow = ({
         <ThumbCell
           offer={offer}
           editionOfferLink={editionOfferLink}
-          inactive={isOfferDisabled(offer.status)}
+          inactive={!offer.isEditable}
           headers={`${rowId} collective-offer-head-image`}
         />
 

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
@@ -206,19 +206,19 @@ describe('ollectiveOfferRow', () => {
     })
   })
 
-  const greyedOfferStatusDataSet = [
-    CollectiveOfferStatus.REJECTED,
-    CollectiveOfferStatus.PENDING,
-  ]
-  it.each(greyedOfferStatusDataSet)(
-    'should display the offer greyed when offer is %s',
-    (status) => {
-      props.offer.status = status
-      renderOfferItem(props)
+  it('should display inactive thumb when offer is not editable', () => {
+    props.offer.isEditable = false
+    renderOfferItem(props)
 
-      expect(screen.getByRole('presentation')).toHaveClass('thumb-inactive')
-    }
-  )
+    expect(screen.getByRole('presentation')).toHaveClass('thumb-inactive')
+  })
+
+  it('should display disabled checkbox when offer is not editable', () => {
+    props.offer.isEditable = false
+    renderOfferItem(props)
+
+    expect(screen.getByRole('checkbox')).toBeDisabled()
+  })
 
   const offerStatusDataSet = [
     CollectiveOfferStatus.ACTIVE,


### PR DESCRIPTION
…OfferDisabled

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

L'utilisation de isEditable reste pas mal obsolète, j'ai créé [un ticket ](https://passculture.atlassian.net/browse/PC-33478)côté EAC pour qu'on voit ce qu'on en fait 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
