### PR TITLE
PC-33480 - Delete pullrequests deployments on schedule

### DIFF
--- a/.github/workflows/dev_on_schedule_delete_pullrequest_deployments.yml
+++ b/.github/workflows/dev_on_schedule_delete_pullrequest_deployments.yml
@@ -1,0 +1,75 @@
+name: "2 [on_schedule] Delete pullrequest deployments"
+
+on:
+  schedule:
+    - cron: "0 */1 * * *"
+
+permissions: write-all
+
+jobs:
+  delete-pullrequest-deployment:
+    name: "Delete PR deployment"
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4.2.1
+      - name: "Authentification to Google"
+        uses: 'google-github-actions/auth@v2'
+        with:
+          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+      # Get github api token
+      - name: "Get secrets (github)"
+        id: 'get-github-token'
+        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        with:
+          secrets: |-
+            API_TOKEN_GITHUB:passculture-metier-ehp/passculture-main-sa-access-token
+
+      # Checkout rendered-manifests repository
+      - uses: actions/checkout@v4.2.1
+        with:
+          repository: pass-culture/rendered-manifests
+          token: ${{ steps.get-github-token.outputs.API_TOKEN_GITHUB }}
+          path: ./rendered-manifests
+          ref: 'pcapi/pullrequests'
+
+      - name: "Connect to cluster"
+        uses: pass-culture/common-workflows/actions/teleport-connect@teleport-connect/v0.1.0
+        with:
+          teleport_proxy: teleport.ehp.passculture.team:443
+          teleport_kubernetes_cluster: passculture-metier-ehp
+
+      - name: "Delete PR deployments"
+        run: |
+          set +e
+          git config --global user.email "PassCulture-SA@passculture.team"
+          git config --global user.name "PassCulture-SA"
+          cd ./rendered-manifests
+          # Look for deployments older than 4 hours by looking at pcapi-pr namespaces created prior that delay
+          pullrequests_ids=$(kubectl get ns -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | awk '{if ($1 ~ "pcapi-pr") print $0}' | awk '$2 <= "'$(date -d'now-4 hours' -Ins --utc | sed 's/+0000/Z/')'" { print $1 }' | cut -d "-" -f3)
+
+          files_modified=false
+          for id in $pullrequests_ids; do
+            [[ -d "pcapi-pr-$id" ]] && { git rm -r pcapi-pr-$id; files_modified=true; } || echo "path pcapi-pr-$id does not exist"
+            [[ -d "postgresql-pr-$id" ]] && { git rm -r postgresql-pr-$id; files_modified=true; } || echo "path postgresql-pr-$id does not exist"
+            [[ -d "redis-pr-$id" ]] && { git rm -r redis-pr-$id; files_modified=true; } || echo "path redis-pr-$id does not exist"
+          done
+          if [ "$files_modified" = true ]; then
+            git add .
+            git commit -m "Scheduled delete of pullrequests deployments"
+            git push
+          fi
+
+          for id in $pullrequests_ids; do
+            while true; do
+              kubectl get application -n argocd | grep $id
+              [[ $? -eq 0 ]] && sleep 5 || break
+            done
+            # Check for PR namespace and delete it
+            kubectl get ns pcapi-pr-$id
+            [[ $? -eq 0 ]] && kubectl delete ns pcapi-pr-$id || echo "namespace pcapi-pr-$id does not exist"
+          done


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33480

Delete pullrequests deployments on schedule :
- Runs every hour
- Get deployments older than 4 hours by looking for namespaces pcapi-pr-* created older than 4 hours and retrieves PR ids
- Delete matching folders ids in rendered-manifests/pcapi/pullrequests
- Finally delete matching namespaces 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
