### PR TITLE
(BSR) fix: use timedelta in test instead of replace

### DIFF
--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -248,7 +248,7 @@ class Returns200Test:
 
         updated_offer = CollectiveOfferTemplate.query.filter(CollectiveOfferTemplate.id == offer.id).one()
         assert updated_offer.dateRange.lower == now
-        assert updated_offer.dateRange.upper == now.replace(second=now.second + 1)
+        assert updated_offer.dateRange.upper == now + timedelta(seconds=1)
 
     def test_contact_form_both_null_form_and_url(self, client):
         offer_ctx = build_offer_context()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : utiliser timedelta plutôt que replace pour ne pas faire d'erreur quand on tombe sur la seconde 59 (pas d'chance)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
