### PR TITLE
(PC-33148)[API] fix: fixing offer address column in reimbusment csv e…

### DIFF
--- a/api/src/pcapi/core/finance/repository.py
+++ b/api/src/pcapi/core/finance/repository.py
@@ -431,52 +431,79 @@ def _get_collective_reimbursement_details_from_invoices(invoice_ids: list[int]) 
 
 
 def _get_individual_booking_reimbursement_data(query: BaseQuery) -> list[tuple]:
-    return (
+    columns = [
+        bookings_models.Booking.token.label("booking_token"),
+        _truncate_milliseconds(bookings_models.Booking.dateUsed).label("booking_used_date"),
+        bookings_models.Booking.quantity.label("booking_quantity"),
+        bookings_models.Booking.priceCategoryLabel.label("booking_price_category_label"),
+        bookings_models.Booking.amount.label("booking_amount"),
+        offers_models.Offer.name.label("offer_name"),
+        offerers_models.Venue.name.label("venue_name"),
+        offerers_models.Venue.common_name.label("venue_common_name"),  # type: ignore[attr-defined]
+        # Sometimes, a venue has a postal code and a city, but no address, and the offerer's address
+        # is in another city. Now, we only check the postal code to keep either the venue's full address
+        # or the offerer's one
+        sqla.case(
+            (offerers_models.Venue.postalCode.is_not(None), offerers_models.Venue.street),
+            else_=offerers_models.Offerer.street,
+        ).label("venue_address"),
+        sqla.case(
+            (offerers_models.Venue.postalCode.is_not(None), offerers_models.Venue.postalCode),
+            else_=offerers_models.Offerer.postalCode,
+        ).label("venue_postal_code"),
+        sqla.case(
+            (offerers_models.Venue.postalCode.is_not(None), offerers_models.Venue.city),
+            else_=offerers_models.Offerer.city,
+        ).label("venue_city"),
+        offerers_models.Venue.siret.label("venue_siret"),
+        # See note about `amount` in `core/finance/models.py`.
+        (-models.Pricing.amount).label("amount"),
+        models.Pricing.standardRule.label("rule_name"),
+        models.Pricing.customRuleId.label("rule_id"),
+        models.Pricing.collectiveBookingId.label("collective_booking_id"),
+        sqla.cast(models.Invoice.date, sqla.Date).label("invoice_date"),
+        models.Invoice.reference.label("invoice_reference"),
+        models.CashflowBatch.cutoff.label("cashflow_batch_cutoff"),
+        models.CashflowBatch.label.label("cashflow_batch_label"),
+        models.BankAccount.iban.label("iban"),
+        models.BankAccount.label.label("bank_account_label"),
+        sqla.case((models.FinanceEvent.bookingFinanceIncidentId.is_(None), False), else_=True).label("is_incident"),
+    ]
+    query = (
         query.join(models.Pricing.event)
         .join(bookings_models.Booking.offerer)
         .join(bookings_models.Booking.stock)
         .join(offers_models.Stock.offer)
         .join(bookings_models.Booking.venue)
         .order_by(bookings_models.Booking.dateUsed.desc(), bookings_models.Booking.id.desc())
-        .with_entities(
-            bookings_models.Booking.token.label("booking_token"),
-            _truncate_milliseconds(bookings_models.Booking.dateUsed).label("booking_used_date"),
-            bookings_models.Booking.quantity.label("booking_quantity"),
-            bookings_models.Booking.priceCategoryLabel.label("booking_price_category_label"),
-            bookings_models.Booking.amount.label("booking_amount"),
-            offers_models.Offer.name.label("offer_name"),
-            offerers_models.Venue.name.label("venue_name"),
-            offerers_models.Venue.common_name.label("venue_common_name"),  # type: ignore[attr-defined]
-            # Sometimes, a venue has a postal code and a city, but no address, and the offerer's address
-            # is in another city. Now, we only check the postal code to keep either the venue's full address
-            # or the offerer's one
-            sqla.case(
-                (offerers_models.Venue.postalCode.is_not(None), offerers_models.Venue.street),
-                else_=offerers_models.Offerer.street,
-            ).label("venue_address"),
-            sqla.case(
-                (offerers_models.Venue.postalCode.is_not(None), offerers_models.Venue.postalCode),
-                else_=offerers_models.Offerer.postalCode,
-            ).label("venue_postal_code"),
-            sqla.case(
-                (offerers_models.Venue.postalCode.is_not(None), offerers_models.Venue.city),
-                else_=offerers_models.Offerer.city,
-            ).label("venue_city"),
-            offerers_models.Venue.siret.label("venue_siret"),
-            # See note about `amount` in `core/finance/models.py`.
-            (-models.Pricing.amount).label("amount"),
-            models.Pricing.standardRule.label("rule_name"),
-            models.Pricing.customRuleId.label("rule_id"),
-            models.Pricing.collectiveBookingId.label("collective_booking_id"),
-            sqla.cast(models.Invoice.date, sqla.Date).label("invoice_date"),
-            models.Invoice.reference.label("invoice_reference"),
-            models.CashflowBatch.cutoff.label("cashflow_batch_cutoff"),
-            models.CashflowBatch.label.label("cashflow_batch_label"),
-            models.BankAccount.iban.label("iban"),
-            models.BankAccount.label.label("bank_account_label"),
-            sqla.case((models.FinanceEvent.bookingFinanceIncidentId.is_(None), False), else_=True).label("is_incident"),
+    )
+    if FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():
+        sub = sqla.select(
+            offerers_models.OffererAddress.id,
+            geography_models.Address.street,
+            geography_models.Address.postalCode,
+            geography_models.Address.city,
+        ).join_from(
+            offerers_models.OffererAddress,
+            geography_models.Address,
+            offerers_models.OffererAddress.addressId == geography_models.Address.id,
         )
-    ).all()
+        sub_venue = sub.subquery("addresses_venue")
+        sub_offer = sub.subquery("addresses_offer")
+        columns.extend(
+            [
+                sqla_func.coalesce(sub_offer.c.street, sub_venue.c.street).label("address_street"),
+                sqla_func.coalesce(sub_offer.c.postalCode, sub_venue.c.postalCode).label("address_postal_code"),
+                sqla_func.coalesce(sub_offer.c.city, sub_venue.c.city).label("address_city"),
+            ]
+        )
+        query = query.join(sub_venue, sub_venue.c.id == offerers_models.Venue.offererAddressId, isouter=True).join(
+            sub_offer, sub_offer.c.id == offers_models.Offer.offererAddressId, isouter=True
+        )
+    query = query.with_entities(
+        *columns,
+    )
+    return query.all()
 
 
 def _get_individual_reimbursement_details_from_invoices(invoice_ids: list[int]) -> list[tuple]:


### PR DESCRIPTION
…xport from bo

+ fixing collective offer address with FF WIP_ENABLE_OFFER_ADDRESS

## But de la pull request
correction de la colonne "adresse de l'offre" dans l'export des remboursement format csv depuis le bo

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33148

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
