### PR TITLE
(PC-33000)[PRO] feat: add 'focus:visible' on back to nav link, only display when connected + aria-live to announce page titles

### DIFF
--- a/pro/cypress/e2e/adageConfirmation.cy.ts
+++ b/pro/cypress/e2e/adageConfirmation.cy.ts
@@ -68,7 +68,7 @@ import {
         cy.get('#list-status').find('#option-display-PREBOOKED').click()
 
         // We click outside the filter to close it
-        cy.findByText('Offres collectives').click()
+        cy.findByRole('heading', { name: 'Offres collectives' }).click()
 
         cy.stepLog({ message: 'I validate my filters' })
         cy.findByText('Rechercher').click()
@@ -116,7 +116,7 @@ import {
         cy.get('#list-status').find('#option-display-BOOKED').click()
 
         // We click outside the filter to close it
-        cy.findByText('Offres collectives').click()
+        cy.findByRole('heading', { name: 'Offres collectives' }).click()
 
         cy.stepLog({ message: 'I validate my filters' })
 

--- a/pro/cypress/e2e/createCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/createCollectiveOffer.cy.ts
@@ -105,8 +105,8 @@ describe('Create collective offers', () => {
 
     cy.get('#search-status').click()
     cy.get('#list-status').find('#option-display-DRAFT').click()
-    cy.findByText('Offres collectives').click()
-
+    // We click outside the filter to close it
+    cy.findByRole('heading', { name: 'Offres collectives' }).click()
     cy.findByText('Rechercher').click()
     cy.wait('@collectiveOffers')
 

--- a/pro/cypress/e2e/searchCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/searchCollectiveOffer.cy.ts
@@ -155,7 +155,8 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: 'I search with status "En instruction"' })
     cy.get('#search-status').click()
     cy.get('#list-status').find('#option-display-PENDING').click()
-    cy.findByText('Offres collectives').click()
+    // We click outside the filter to close it
+    cy.findByRole('heading', { name: 'Offres collectives' }).click()
 
     cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
@@ -183,7 +184,8 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: 'I search with status "Brouillon"' })
     cy.get('#search-status').click()
     cy.get('#list-status').find('#option-display-DRAFT').click()
-    cy.findByText('Offres collectives').click()
+    // We click outside the filter to close it
+    cy.findByRole('heading', { name: 'Offres collectives' }).click()
 
     cy.stepLog({ message: 'I validate my collective filters' })
     cy.findByText('Rechercher').click()

--- a/pro/src/Root.tsx
+++ b/pro/src/Root.tsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux'
 import { AppRouter } from 'app/AppRouter/AppRouter'
 import { createStore } from 'commons/store/store'
 import { StoreProvider } from 'commons/store/StoreProvider/StoreProvider'
+import { PageTitleAnnouncer } from 'components/PageTitleAnnouncer/PageTitleAnnouncer'
 
 interface RootProps {
   isAdageIframe: boolean
@@ -16,6 +17,7 @@ export const Root = ({ isAdageIframe }: RootProps): JSX.Element => {
     <Provider store={store}>
       <StoreProvider isAdageIframe={isAdageIframe}>
         <AppRouter />
+        <PageTitleAnnouncer />
       </StoreProvider>
     </Provider>
   )

--- a/pro/src/app/App/hook/__specs__/usePageTitle.spec.tsx
+++ b/pro/src/app/App/hook/__specs__/usePageTitle.spec.tsx
@@ -4,6 +4,7 @@ import { Route, Routes } from 'react-router'
 import { Link } from 'react-router-dom'
 
 import { renderWithProviders } from 'commons/utils/renderWithProviders'
+import { PageTitleAnnouncer } from 'components/PageTitleAnnouncer/PageTitleAnnouncer'
 
 import { usePageTitle } from '../usePageTitle'
 
@@ -14,45 +15,48 @@ const PageTitle = (): null => {
 
 const renderusePageTitleRoutes = (url = '/accueil') => {
   renderWithProviders(
-    <Routes>
-      <Route
-        path="/accueil"
-        element={
-          <>
-            <PageTitle />
-            <span>Main page</span>
-            <Link to="/guichet">Guichet</Link>
-          </>
-        }
-      />
-      <Route
-        path="/guichet"
-        element={
-          <>
-            <PageTitle />
-            <span>Guichet page</span>
-          </>
-        }
-      />
-      <Route
-        path="/parcours-inscription"
-        element={
-          <>
-            <PageTitle />
-            <span>Welcome signupJourney page</span>
-          </>
-        }
-      />
-      <Route
-        path="/parcours-inscription/structure"
-        element={
-          <>
-            <PageTitle />
-            <span>Structure page</span>
-          </>
-        }
-      />
-    </Routes>,
+    <>
+      <Routes>
+        <Route
+          path="/accueil"
+          element={
+            <>
+              <PageTitle />
+              <span>Main page</span>
+              <Link to="/guichet">Guichet</Link>
+            </>
+          }
+        />
+        <Route
+          path="/guichet"
+          element={
+            <>
+              <PageTitle />
+              <span>Guichet page</span>
+            </>
+          }
+        />
+        <Route
+          path="/parcours-inscription"
+          element={
+            <>
+              <PageTitle />
+              <span>Welcome signupJourney page</span>
+            </>
+          }
+        />
+        <Route
+          path="/parcours-inscription/structure"
+          element={
+            <>
+              <PageTitle />
+              <span>Structure page</span>
+            </>
+          }
+        />
+      </Routes>
+      <PageTitleAnnouncer />
+    </>,
     { initialRouterEntries: [url] }
   )
 }
@@ -69,5 +73,12 @@ describe('usePageTitle', () => {
     renderusePageTitleRoutes()
     await userEvent.click(screen.getByRole('link', { name: 'Guichet' }))
     expect(document.title).toEqual('Guichet - pass Culture Pro')
+  })
+
+  it('should update aria pane name announcer region when user navigates to another page', async () => {
+    renderusePageTitleRoutes()
+    await userEvent.click(screen.getByRole('link', { name: 'Guichet' }))
+    const pageTitleAnnouncer = screen.getByTestId('page-title-announcer')
+    expect(pageTitleAnnouncer).toHaveTextContent('Guichet')
   })
 })

--- a/pro/src/app/App/hook/usePageTitle.ts
+++ b/pro/src/app/App/hook/usePageTitle.ts
@@ -13,5 +13,10 @@ export const usePageTitle = (): LocationListener | void => {
     document.title = currentRoute
       ? `${currentRoute.title} - pass Culture Pro`
       : 'pass Culture Pro'
+
+    const pageTitleAnnouncer = document.getElementById('page-title-announcer')
+    if (pageTitleAnnouncer) {
+      pageTitleAnnouncer.textContent = currentRoute?.title || 'pass Culture Pro'
+    }
   }, [location])
 }

--- a/pro/src/app/App/layout/Layout.module.scss
+++ b/pro/src/app/App/layout/Layout.module.scss
@@ -153,29 +153,20 @@ $connect-as-header-height: rem.torem(52px);
   }
 }
 
-.main-heading-wrapper {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-bottom: rem.torem(32px);
-}
-
 .main-heading {
-  @include fonts-design-system.title1;
-}
+  &-wrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: rem.torem(32px);
+  }
 
-.back-to-nav-link {
-  margin-left: rem.torem(16px);
-  opacity: 0;
-  height: rem.torem(24px);
-  width: rem.torem(24px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  &-title {
+    @include fonts-design-system.title1;
+  }
 
-  &:active,
-  &:focus {
-    opacity: 1;
+  &-back-to-nav-link {
+    margin-left: rem.torem(16px);
   }
 }
 

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -41,17 +41,18 @@ export const Layout = ({
   const navPanel = useRef<HTMLDivElement>(null)
 
   const isMobileScreen = useMediaQuery('(max-width: 46.5rem)')
+  const isConnected = !!currentUser
 
   const shouldDisplayUserReview =
     layout !== 'funnel' && layout !== 'onboarding' && layout !== 'logged-out'
 
-  const mainHeaing = mainHeading && (
+  const mainHeadingWrapper = mainHeading && (
     <div className={styles['main-heading-wrapper']}>
       <h1 className={styles['main-heading-title']}>{mainHeading}</h1>
-      <BackToNavLink
+      {isConnected && <BackToNavLink
         isMobileScreen={isMobileScreen}
         className={styles['main-heading-back-to-nav-link']}
-      />
+      />}
     </div>
   )
 
@@ -140,7 +141,7 @@ export const Layout = ({
               <main id="content">
                 {layout === 'funnel' || layout === 'onboarding' ? (
                   <>
-                    {mainHeaing}
+                    {mainHeadingWrapper}
                     {children}
                   </>
                 ) : (
@@ -151,7 +152,7 @@ export const Layout = ({
                         layout === 'logged-out' && mainHeading,
                     })}
                   >
-                    {mainHeaing}
+                    {mainHeadingWrapper}
                     {children}
                   </div>
                 )}

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -4,11 +4,11 @@ import { useSelector } from 'react-redux'
 
 import { useMediaQuery } from 'commons/hooks/useMediaQuery'
 import { selectCurrentUser } from 'commons/store/user/selectors'
+import { BackToNavLink } from 'components/BackToNavLink/BackToNavLink'
 import { Footer } from 'components/Footer/Footer'
 import { Header } from 'components/Header/Header'
 import { SkipLinks } from 'components/SkipLinks/SkipLinks'
 import { UserReview } from 'components/UserReview/UserReview'
-import fullGoTop from 'icons/full-go-top.svg'
 import fullInfoIcon from 'icons/full-info.svg'
 import logoPassCultureProFullIcon from 'icons/logo-pass-culture-pro-full.svg'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
@@ -47,18 +47,11 @@ export const Layout = ({
 
   const mainHeaing = mainHeading && (
     <div className={styles['main-heading-wrapper']}>
-      <h1 className={styles['main-heading']}>{mainHeading}</h1>
-      <a
-        id="back-to-nav-link"
-        href={isMobileScreen ? '#header-nav-toggle' : '#lateral-panel'}
-        className={styles['back-to-nav-link']}
-      >
-        <SvgIcon
-          src={fullGoTop}
-          alt="Revenir à la barre de navigation"
-          width="20"
-        />
-      </a>
+      <h1 className={styles['main-heading-title']}>{mainHeading}</h1>
+      <BackToNavLink
+        isMobileScreen={isMobileScreen}
+        className={styles['main-heading-back-to-nav-link']}
+      />
     </div>
   )
 

--- a/pro/src/app/App/layout/__specs__/Layout.spec.tsx
+++ b/pro/src/app/App/layout/__specs__/Layout.spec.tsx
@@ -8,15 +8,25 @@ import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
 import { Layout, LayoutProps } from '../Layout'
 
-const renderLayout = (
+const LABELS = {
+  backToNavLink: /Revenir à la barre de navigation/,
+}
+
+type LayoutTestProps = Partial<LayoutProps> & {
+  isConnected?: boolean
+  isImpersonated?: boolean
+}
+
+const renderLayout = ({
   isImpersonated = false,
-  layoutProps: LayoutProps = {}
-) => {
-  renderWithProviders(<Layout {...layoutProps} />, {
+  isConnected = true,
+  ...props
+}: LayoutTestProps = {}) => {
+  renderWithProviders(<Layout {...props} />, isConnected ? {
     user: sharedCurrentUserFactory({
       isImpersonated,
     }),
-  })
+  }: {})
 }
 
 describe('Layout', () => {
@@ -48,6 +58,7 @@ describe('Layout', () => {
 
         expect(screen.getByLabelText('Fermer')).toHaveFocus()
       })
+
       it('should trap focus when side nav is open', async () => {
         await userEvent.click(screen.getByLabelText('Menu'))
 
@@ -61,8 +72,29 @@ describe('Layout', () => {
     })
   })
 
+  describe('about main heading & back to nav link', () => {
+    it('should render a main heading when provided', () => {
+      const mainHeading = 'Home'
+      renderLayout({ mainHeading })
+
+      expect(screen.getByRole('heading', { name: mainHeading })).toBeInTheDocument()
+    })
+
+    it('should render a back to nav link when a main heading is provided and when user is connected', () => {
+      renderLayout({ mainHeading: 'Home', isConnected: true })
+
+      expect(screen.getByRole('link', { name: LABELS.backToNavLink })).toBeInTheDocument()
+    })
+
+    it('should not render a back to nav link when not connected', () => {
+      renderLayout({  mainHeading: 'Home', isConnected: false })
+
+      expect(screen.queryByRole('link', { name: LABELS.backToNavLink })).not.toBeInTheDocument()
+    })
+  })
+
   it('should render connect as banner if user has isImpersonated value is true', () => {
-    renderLayout(true)
+    renderLayout({ isImpersonated: true })
 
     expect(
       screen.getByText('Vous êtes connecté en tant que :')
@@ -77,13 +109,13 @@ describe('Layout', () => {
     })
 
     it('should not display footer is "showFooter" is false', () => {
-      renderLayout(false, { showFooter: false })
+      renderLayout({ isImpersonated: false, showFooter: false })
 
       expect(screen.queryByTestId('app-footer')).not.toBeInTheDocument()
     })
 
     it('should not display footer by default if layout is "funnel"', () => {
-      renderLayout(false, { layout: 'funnel' })
+      renderLayout({ isImpersonated: false, layout: 'funnel' })
 
       expect(screen.queryByTestId('app-footer')).not.toBeInTheDocument()
     })

--- a/pro/src/components/BackToNavLink/BackToNavLink.module.scss
+++ b/pro/src/components/BackToNavLink/BackToNavLink.module.scss
@@ -4,6 +4,7 @@
   opacity: 0;
   height: rem.torem(24px);
   width: rem.torem(24px);
+  min-width: rem.torem(24px);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/pro/src/components/BackToNavLink/BackToNavLink.module.scss
+++ b/pro/src/components/BackToNavLink/BackToNavLink.module.scss
@@ -1,0 +1,14 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.back-to-nav-link {
+  opacity: 0;
+  height: rem.torem(24px);
+  width: rem.torem(24px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:focus-visible {
+    opacity: 1;
+  }
+}

--- a/pro/src/components/BackToNavLink/BackToNavLink.tsx
+++ b/pro/src/components/BackToNavLink/BackToNavLink.tsx
@@ -1,0 +1,33 @@
+import classnames from 'classnames'
+
+import fullGoTop from 'icons/full-go-top.svg'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+
+import styles from './BackToNavLink.module.scss'
+
+interface BackToNavLinkProps {
+  isMobileScreen?: boolean
+  className?: string
+}
+
+export const BackToNavLink = ({
+  isMobileScreen,
+  className,
+}: BackToNavLinkProps): JSX.Element => {
+  return (
+    <a
+      id="back-to-nav-link"
+      href={isMobileScreen ? '#header-nav-toggle' : '#lateral-panel'}
+      className={classnames(
+        className,
+        styles['back-to-nav-link']
+      )}
+    >
+      <SvgIcon
+        src={fullGoTop}
+        alt="Revenir à la barre de navigation"
+        width="20"
+      />
+    </a>
+  )
+}

--- a/pro/src/components/PageTitleAnnouncer/PageTitleAnnouncer.module.scss
+++ b/pro/src/components/PageTitleAnnouncer/PageTitleAnnouncer.module.scss
@@ -1,0 +1,5 @@
+@use "styles/mixins/_a11y.scss" as a11y;
+
+.visually-hidden {
+  @include a11y.visually-hidden;
+}

--- a/pro/src/components/PageTitleAnnouncer/PageTitleAnnouncer.tsx
+++ b/pro/src/components/PageTitleAnnouncer/PageTitleAnnouncer.tsx
@@ -1,9 +1,11 @@
+import styles from './PageTitleAnnouncer.module.scss'
+
 export const PageTitleAnnouncer = (): JSX.Element => {
   return (
     <div
       id="page-title-announcer"
       aria-live="assertive"
-      className="visually-hidden"
+      className={styles['visually-hidden']}
       data-testid="page-title-announcer"
     />
   )

--- a/pro/src/components/PageTitleAnnouncer/PageTitleAnnouncer.tsx
+++ b/pro/src/components/PageTitleAnnouncer/PageTitleAnnouncer.tsx
@@ -1,0 +1,10 @@
+export const PageTitleAnnouncer = (): JSX.Element => {
+  return (
+    <div
+      id="page-title-announcer"
+      aria-live="assertive"
+      className="visually-hidden"
+      data-testid="page-title-announcer"
+    />
+  )
+}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33000

## Objectifs
- [x]  Ajout de l’aria-live pour annoncer la redirection des pages.
- [x]  Passage du lien “back-to-nav” en :focus-visible de façon à ce qu’il ne soit visible qu’en navigation clavier.
- [x]  Afficher le lien “Revenir à la navigation principale” qu’en vue connectée.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~
- [ ] J'ai fait la revue fonctionnelle de mon ticket
