### PR TITLE
(BSR)[API] test: dump/restore on staging: clear action_history.jsonData only when it contains sensitive information

### DIFF
--- a/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
+++ b/api/src/pcapi/scripts/rebuild_staging/anonymize.sql
@@ -163,10 +163,15 @@ SET
     "newDomainEmail" = 'anonymized.email'
 ;
 
--- Keep those which doesn't contain personal data
+-- Keep those which do not contain personal data
 UPDATE action_history
 SET "jsonData" = '{}'
-WHERE "ruleId" is null and "financeIncidentId" is null
+WHERE "actionType" IN (
+  'INFO_MODIFIED',
+  'OFFERER_NEW',
+  'USER_OFFERER_NEW',
+  'FRAUD_INFO_MODIFIED'
+)
 ;
 
 -- We probably should anonymize `offer.bookingEmail`


### PR DESCRIPTION
## But de la pull request

Des informations incomplètes étaient affichées dans le backoffice (exemple : modification d'un rôle du BO sans préciser le rôle) à cause de l'anonymisation du dump/restore qui efface trop d'infos. Proposition : ne le faire que pour les actions qui peuvent contenir des informations personnelles ou sensibles.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
