### PR TITLE
(PC-33538)[API] fix: limit index_offers_in_algolia_by_offer

### DIFF
--- a/api/src/pcapi/core/search/backends/algolia.py
+++ b/api/src/pcapi/core/search/backends/algolia.py
@@ -359,6 +359,9 @@ class AlgoliaBackend(base.SearchBackend):
             return True
 
     def index_offers(self, offers: abc.Collection[offers_models.Offer], last_30_days_bookings: dict[int, int]) -> None:
+        # Warning: if you ever need to alter the DB, please make sure you take into account that
+        # the calling function index_offers_in_queue does a rollback to remove any reading lock
+        # during processing.
         if not offers:
             return
         objects = [self.serialize_offer(offer, last_30_days_bookings.get(offer.id) or 0) for offer in offers]


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-33538

This is a far from perfect fix but hopefully should help. It does limit the time during which read locks are kept by the index_offers_in_algolia_by_offer cron.
Although it does not write anything in the DB by the time of this commit, it does read offers though and does not close its transaction untill all the offers are sent to Algolia.
This has kept read lock for very long times (60+ minutes). By rollbacking, this commit should release the locks on a regular basis. Commit may not work as we use savepoints for subtransactions and commiting the savepoint will only move the read locks into the transaction whereas the rollback should remove them. However, it probably will not be enough as each subtransaction may last around 60 seconds.
Ideally, the read should be done and the subtransaction rollbacked immediatly *before* serialization and sending data to Algolia.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
