### PR TITLE
BSR refacto csv de remboursement

### DIFF
--- a/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
@@ -157,11 +157,14 @@ def download_reimbursement_details(bank_account_id: int) -> utils.BackofficeResp
         return redirect(
             request.referrer or url_for("backoffice_web.bank_account.get", bank_account_id=bank_account_id), code=303
         )
-
+    offerer_id = finance_models.BankAccount.query.get(bank_account_id).offererId
     invoices = finance_models.Invoice.query.filter(finance_models.Invoice.id.in_(form.object_ids_list)).all()
     reimbursement_details = [
         reimbursement_csv_serialize.ReimbursementDetails(details)
-        for details in finance_repository.find_all_invoices_finance_details([invoice.id for invoice in invoices])
+        for details in finance_repository.find_offerer_payments(
+            offerer_id = offerer_id,
+            bank_account_id=bank_account_id, invoices_references=[invoice.reference for invoice in invoices]
+        )
     ]
     export_data = reimbursement_csv_serialize.generate_reimbursement_details_csv(reimbursement_details)
     export_date = datetime.utcnow().strftime("%Y-%m-%d-%H-%M")


### PR DESCRIPTION
## But de la pull request

Uniformiser les export de csv de remboursement entre pro et bo. 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
