### PR TITLE
(PC-33084)[API] feat: improve bookings fetching strategy

### DIFF
--- a/api/src/pcapi/core/bookings/utils.py
+++ b/api/src/pcapi/core/bookings/utils.py
@@ -1,10 +1,14 @@
+from datetime import date
 from datetime import datetime
+from datetime import time
 from datetime import timedelta
 from hashlib import sha256
 import hmac
 import typing
+from zoneinfo import ZoneInfo
 
 from dateutil import tz
+import pytz
 
 from pcapi import settings
 from pcapi.core.categories import subcategories_v2 as subcategories
@@ -96,3 +100,19 @@ def get_cooldown_datetime_by_subcategories(sub_category_id: str) -> datetime:
             else 0
         )
     )
+
+
+def convert_date_period_to_utc_datetime_period(
+    date_period: tuple[date, date],
+    timezone: str,
+) -> tuple[datetime, datetime]:
+    start_date, end_date = date_period
+
+    # if dates aren't chronologically ordered
+    if date_period[0] > date_period[1]:
+        end_date, start_date = date_period
+
+    start_datetime = datetime.combine(start_date, time(hour=0, minute=0, second=0), tzinfo=ZoneInfo(timezone))
+    end_datetime = datetime.combine(end_date, time(hour=23, minute=59, second=59), tzinfo=ZoneInfo(timezone))
+
+    return (start_datetime.astimezone(pytz.utc), end_datetime.astimezone(pytz.utc))

--- a/api/tests/core/bookings/test_utils.py
+++ b/api/tests/core/bookings/test_utils.py
@@ -2,6 +2,7 @@ import datetime
 import importlib
 
 import pytest
+import pytz
 import time_machine
 
 import pcapi.core.bookings.utils as utils
@@ -38,3 +39,29 @@ def test_get_cooldown_datetime_by_subcategories_env():
         subcategory_id = subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id
         cooldown_datetime = datetime.datetime(2025, 2, 1, 12, 29, 26)
         assert utils.get_cooldown_datetime_by_subcategories(subcategory_id) == cooldown_datetime
+
+
+@pytest.mark.parametrize(
+    "date_period, timezone, expected_result",
+    [
+        (
+            [datetime.date(2024, 12, 11), datetime.date(2024, 12, 12)],
+            "Europe/Paris",
+            (
+                datetime.datetime(2024, 12, 10, 23, 0, 0, tzinfo=pytz.utc),
+                datetime.datetime(2024, 12, 12, 22, 59, 59, tzinfo=pytz.utc),
+            ),
+        ),
+        (  # dates not ordered
+            [datetime.date(2024, 12, 25), datetime.date(2024, 12, 4)],
+            "Europe/Paris",
+            (
+                datetime.datetime(2024, 12, 3, 23, 0, 0, tzinfo=pytz.utc),
+                datetime.datetime(2024, 12, 25, 22, 59, 59, tzinfo=pytz.utc),
+            ),
+        ),
+    ],
+)
+def test_convert_date_period_to_utc_datetime_period(date_period, timezone, expected_result):
+    result = utils.convert_date_period_to_utc_datetime_period(date_period, timezone)
+    assert result == expected_result

--- a/api/tests/routes/pro/get_all_bookings_test.py
+++ b/api/tests/routes/pro/get_all_bookings_test.py
@@ -12,7 +12,6 @@ from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.external_bookings.factories import ExternalBookingFactory
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
-from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
@@ -138,6 +137,9 @@ class GetAllBookingsTest:
 class Returns200Test:
     expected_num_queries = 1  # Fetch the session
     expected_num_queries += 1  # Fetch the user
+    # the user timezones query is duplicated for better readability
+    expected_num_queries += 1  # Fetch user timezones (for the count)
+    expected_num_queries += 1  # Fetch user timezones (for the query)
     expected_num_queries += 1  # CTE built over booking, stock and external_booking
     expected_num_queries += 1  # 4.external_booking
     expected_num_queries += 1  # 5. check if WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE is active
@@ -174,9 +176,8 @@ class Returns200Test:
 
         client = client.with_session_auth(pro_user.email)
         with assert_num_queries(self.expected_num_queries):
-            with assert_no_duplicated_queries():
-                response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked")
-                assert response.status_code == 200
+            response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked")
+            assert response.status_code == 200
 
         expected_bookings_recap = [
             {
@@ -258,10 +259,9 @@ class Returns200Test:
 
         client = client.with_session_auth(pro_user.email)
         with assert_num_queries(self.expected_num_queries):
-            with assert_no_duplicated_queries():
-                response = client.get(
-                    f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked&eventDate={requested_date}"
-                )
+            response = client.get(
+                f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked&eventDate={requested_date}"
+            )
 
         assert response.status_code == 200
         assert len(response.json["bookingsRecap"]) == 1
@@ -282,11 +282,10 @@ class Returns200Test:
 
         client = client.with_session_auth(pro_user.email)
         with assert_num_queries(self.expected_num_queries):
-            with assert_no_duplicated_queries():
-                response = client.get(
-                    "/bookings/pro?bookingPeriodBeginningDate=%s&bookingPeriodEndingDate=%s&bookingStatusFilter=booked"
-                    % (booking_period_beginning_date, booking_period_ending_date)
-                )
+            response = client.get(
+                "/bookings/pro?bookingPeriodBeginningDate=%s&bookingPeriodEndingDate=%s&bookingStatusFilter=booked"
+                % (booking_period_beginning_date, booking_period_ending_date)
+            )
 
         assert response.status_code == 200
         assert len(response.json["bookingsRecap"]) == 1
@@ -310,8 +309,7 @@ class Returns200Test:
 
         # when
         client = client.with_session_auth(pro_user.email)
-        expected_num_queries = 5  # user + session + SELECT DISTINCT booking + bookingToken + check WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE is active
-        with assert_num_queries(expected_num_queries):
+        with assert_num_queries(self.expected_num_queries):
             response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}")
             assert response.status_code == 200
 
@@ -349,9 +347,8 @@ class Returns200Test:
 
         client = client.with_session_auth(pro_user.email)
         with assert_num_queries(self.expected_num_queries):
-            with assert_no_duplicated_queries():
-                response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked")
-                assert response.status_code == 200
+            response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked")
+            assert response.status_code == 200
 
         expected_bookings_recap = [
             {
@@ -433,10 +430,9 @@ class Returns200Test:
 
         client = client.with_session_auth(pro_user.email)
         with assert_num_queries(self.expected_num_queries):
-            with assert_no_duplicated_queries():
-                response = client.get(
-                    f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked&eventDate={requested_date}"
-                )
+            response = client.get(
+                f"/bookings/pro?{BOOKING_PERIOD_PARAMS}&bookingStatusFilter=booked&eventDate={requested_date}"
+            )
 
         assert response.status_code == 200
         assert len(response.json["bookingsRecap"]) == 1
@@ -457,11 +453,10 @@ class Returns200Test:
 
         client = client.with_session_auth(pro_user.email)
         with assert_num_queries(self.expected_num_queries):
-            with assert_no_duplicated_queries():
-                response = client.get(
-                    "/bookings/pro?bookingPeriodBeginningDate=%s&bookingPeriodEndingDate=%s&bookingStatusFilter=booked"
-                    % (booking_period_beginning_date, booking_period_ending_date)
-                )
+            response = client.get(
+                "/bookings/pro?bookingPeriodBeginningDate=%s&bookingPeriodEndingDate=%s&bookingStatusFilter=booked"
+                % (booking_period_beginning_date, booking_period_ending_date)
+            )
 
         assert response.status_code == 200
         assert len(response.json["bookingsRecap"]) == 1
@@ -487,8 +482,7 @@ class Returns200Test:
 
         # when
         client = client.with_session_auth(pro_user.email)
-        expected_num_queries = 5  # user + session + SELECT DISTINCT booking + bookingToken + check WIP_USE_OFFERER_ADDRESS_AS_DATA_SOURCE is active
-        with assert_num_queries(expected_num_queries):
+        with assert_num_queries(self.expected_num_queries):
             response = client.get(f"/bookings/pro?{BOOKING_PERIOD_PARAMS}")
             assert response.status_code == 200
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-33084

Actuellement le téléchargement des réservations pour les grosses structures (type FNAC ou Cultura) ne fonctionne plus car la requête SQL prend trop de temps.

Le but de cette PR est d'améliorer les performances de la requête SQL en changeant notre stratégie concernant le filtrage par date. 

Plutôt que de faire :
```sql
WHERE
  -- Transformation 2: Cast de la datetime en date
  CAST(
  -- Transformation 1: Calcul de la date dans la timezone du booking
    timezone(
        coalesce(address.timezone, address_2.timezone, venue.timezone),
        timezone('UTC', booking."dateCreated")
    ) 
    AS DATE) BETWEEN SYMMETRIC '2024-11-28' AND '2024-12-03'
```

Faire plutôt (pour tirer au maximum profit des index sur les dates): 

```sql
WHERE
    (coalesce(address.timezone, address_2.timezone, venue.timezone) = "Europe/Paris"
    -- Pas de cast ce qui permet d'exploiter le fait qu'il y a un index sur `dateCreated`
    -- '2024-10-28' et '2024-11-03' heure de Paris transformées en leur équivalent en datetime UTC
    AND booking."dateCreated" BETWEEN SYMMETRIC '2024-10-27 23:00:00' AND '2024-11-03 22:59:59')

/* si les bookings sont sur plusieurs timezones (par exemple ici "Europe/Paris" et "America/Cayenne")*/
WHERE
    (coalesce(address.timezone, address_2.timezone, venue.timezone) = "Europe/Paris"
    -- '2024-10-28' et '2024-11-03' heure de Paris transformées en leur équivalent en datetime UTC
    AND booking."dateCreated" BETWEEN SYMMETRIC '2024-10-27 23:00:00' AND '2024-11-03 22:59:59')
OR
    (coalesce(address.timezone, address_2.timezone, venue.timezone) = "America/Cayenne"
    -- '2024-10-28' et '2024-11-03' heure de Cayenne transformées en leur équivalent en datetime UTC
    AND booking."dateCreated" BETWEEN SYMMETRIC '2024-10-28 03:00:00' AND '2024-11-04 02:59:59')
```

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
