### PR TITLE
(PC-33558)[BO] fix: avoid Sentry alert when no GTL ID, already notifi…

### DIFF
--- a/api/src/pcapi/connectors/titelive.py
+++ b/api/src/pcapi/connectors/titelive.py
@@ -192,7 +192,7 @@ def get_new_product_from_ean13(ean: str) -> offers_models.Product:
         # EAN without GTL exist (DVD, ...), ex: 3597660004235
         core_logging.log_for_supervision(
             logger,
-            logging.ERROR,
+            logging.WARNING,
             "Titelive get_new_product_from_ean13: External error:",
             extra={
                 "alert": "Titelive API no gtl_id",


### PR DESCRIPTION
…ed in flash message

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-33558

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
