### PR TITLE
(BSR)[API] fix: don't crash on collect only with BO non-BO tests

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -648,7 +648,8 @@ def pytest_collection_finish(session):
         session.config.rootdir / dir in Path(item.fspath).parents for dir in backoffice_dirs for item in session.items
     ]
     if any(matches) and not all(matches):
-        pytest.exit("You can not run backoffice tests with non backoffice tests")
+        if not session.config.option.collectonly:
+            pytest.exit("You can not run backoffice tests with non backoffice tests")
     if all(matches):
         session.config.option.markexpr = "backoffice"
 


### PR DESCRIPTION
## But de la pull request

BSR: pytest should not exit with failure when it collects only the tests even if the tests are mixed with BO / non-BO routes

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
