### PR TITLE
(BSR)[PRO] test: share data from backend route retrieved in e2e code

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/getters/pro.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/pro.py
@@ -40,11 +40,11 @@ def create_regular_pro_user() -> dict:
     pro_user = users_factories.ProFactory()
     offerer = offerers_factories.OffererFactory()
     offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
-    offerers_factories.VenueFactory(name="Mon Lieu", managingOfferer=offerer, isPermanent=True)
+    venue = offerers_factories.VenueFactory(name="Mon Lieu", managingOfferer=offerer, isPermanent=True)
     offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
     offerers_factories.VenueLabelFactory(label="Musée de France")
 
-    return {"user": get_pro_user_helper(pro_user), "siren": offerer.siren}
+    return {"user": get_pro_user_helper(pro_user), "siren": offerer.siren, "venueName": venue.name}
 
 
 def create_pro_user_with_bookings() -> dict:
@@ -56,13 +56,31 @@ def create_pro_user_with_bookings() -> dict:
     stock = offers_factories.StockFactory(offer__venue=venue)
     stock_event = offers_factories.EventStockFactory(offer__venue=venue)
 
-    bookings_factories.BookingFactory(token="2XTM3W", stock=stock, status=bookings_models.BookingStatus.CONFIRMED)
-    bookings_factories.BookingFactory(token="TOSOON", stock=stock_event, status=bookings_models.BookingStatus.CONFIRMED)
-    bookings_factories.BookingFactory(token="XUSEDX", stock=stock, status=bookings_models.BookingStatus.USED)
-    bookings_factories.BookingFactory(token="CANCEL", stock=stock, status=bookings_models.BookingStatus.CANCELLED)
-    bookings_factories.BookingFactory(token="REIMBU", stock=stock, status=bookings_models.BookingStatus.REIMBURSED)
-    bookings_factories.BookingFactory(token="OTHERX")
-    return {"user": get_pro_user_helper(pro_user)}
+    bookingConfirmed = bookings_factories.BookingFactory(
+        token="2XTM3W", stock=stock, status=bookings_models.BookingStatus.CONFIRMED
+    )
+    bookingTooSoon = bookings_factories.BookingFactory(
+        token="TOSOON", stock=stock_event, status=bookings_models.BookingStatus.CONFIRMED
+    )
+    bookingUsed = bookings_factories.BookingFactory(
+        token="XUSEDX", stock=stock, status=bookings_models.BookingStatus.USED
+    )
+    bookingCanceled = bookings_factories.BookingFactory(
+        token="CANCEL", stock=stock, status=bookings_models.BookingStatus.CANCELLED
+    )
+    bookingReimbursed = bookings_factories.BookingFactory(
+        token="REIMBU", stock=stock, status=bookings_models.BookingStatus.REIMBURSED
+    )
+    bookingOtherX = bookings_factories.BookingFactory(token="OTHERX")
+    return {
+        "user": get_pro_user_helper(pro_user),
+        "tokenConfirmed": bookingConfirmed.token,
+        "tokenTooSoon": bookingTooSoon.token,
+        "tokenUsed": bookingUsed.token,
+        "tokenCanceled": bookingCanceled.token,
+        "tokenReimbursed": bookingReimbursed.token,
+        "tokenOther": bookingOtherX.token,
+    }
 
 
 def create_regular_pro_user_with_virtual_offer() -> dict:
@@ -143,7 +161,7 @@ def create_adage_environment() -> dict:
         type=educational_models.PlaylistType.NEW_OFFER,
         institution=educational_institution,
     )
-    educational_factories.PlaylistFactory(
+    newOfferer = educational_factories.PlaylistFactory(
         distanceInKm=50,
         collective_offer_template=offer,
         type=educational_models.PlaylistType.NEW_OFFERER,
@@ -163,7 +181,7 @@ def create_adage_environment() -> dict:
     )
 
     # offer result by algolia are mocked in e2e test
-    return {"offerId": offer.id}
+    return {"offerId": offer.id, "offerName": offer.name, "venueName": newOfferer.venue.name}
 
 
 def create_pro_user_with_individual_offers() -> dict:
@@ -208,12 +226,22 @@ def create_pro_user_with_individual_offers() -> dict:
         subcategoryId=subcategories.LIVRE_PAPIER.id,
     )
     offers_factories.StockFactory(offer=offer6)
-    offers_factories.ThingOfferFactory(
+    offer7 = offers_factories.ThingOfferFactory(
         venue=venue,
         name="Une offre épuisée",
         subcategoryId=subcategories.LIVRE_PAPIER.id,
     )
-    return {"user": get_pro_user_helper(pro_user)}
+    return {
+        "user": get_pro_user_helper(pro_user),
+        "venue": {"name": venue.name},
+        "offer1": {"name": offer1.name},
+        "offer2": {"name": offer2.name},
+        "offer3": {"name": offer3.name},
+        "offer4": {"name": offer4.name},
+        "offer5": {"name": offer5.name},
+        "offer6": {"name": offer6.name},
+        "offer7": {"name": offer7.name},
+    }
 
 
 def create_pro_user_with_collective_offers() -> dict:
@@ -224,14 +252,14 @@ def create_pro_user_with_collective_offers() -> dict:
     venue2 = offerers_factories.CollectiveVenueFactory(name="Mon Lieu 2", managingOfferer=offerer)
     offerers_factories.VirtualVenueFactory(managingOfferer=offerer)
 
-    educational_factories.CollectiveOfferTemplateFactory(
+    offerPublishedTemplate = educational_factories.CollectiveOfferTemplateFactory(
         name="Mon offre collective publiée vitrine",
         venue=venue1,
         subcategoryId=subcategories.CONCERT.id,
         formats=[subcategories.EacFormat.CONCERT],
     )
 
-    educational_factories.CollectiveStockFactory(
+    offerPublished = educational_factories.CollectiveStockFactory(
         collectiveOffer__name="Mon offre collective publiée réservable",
         collectiveOffer__venue=venue1,
         collectiveOffer__subcategoryId=subcategories.CONCERT.id,
@@ -240,28 +268,28 @@ def create_pro_user_with_collective_offers() -> dict:
         endDatetime=datetime.datetime.utcnow() + datetime.timedelta(weeks=2),
     )
 
-    educational_factories.DraftCollectiveOfferFactory(
+    offerDraft = educational_factories.DraftCollectiveOfferFactory(
         name="Mon offre collective en brouillon réservable",
         venue=venue1,
         subcategoryId=subcategories.CONCERT.id,
         formats=[subcategories.EacFormat.REPRESENTATION],
     )
 
-    educational_factories.PendingCollectiveOfferFactory(
+    offerInInstruction = educational_factories.PendingCollectiveOfferFactory(
         name="Mon offre collective en instruction réservable",
         venue=venue2,
         subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
         formats=[subcategories.EacFormat.REPRESENTATION],
     )
 
-    educational_factories.RejectedCollectiveOfferFactory(
+    offerNotConform = educational_factories.RejectedCollectiveOfferFactory(
         name="Mon offre collective non conforme réservable",
         venue=venue2,
         subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
         formats=[subcategories.EacFormat.REPRESENTATION],
     )
 
-    educational_factories.ArchivedCollectiveOfferFactory(
+    offerArchived = educational_factories.ArchivedCollectiveOfferFactory(
         name="Mon offre collective archivée réservable",
         venue=venue2,
         subcategoryId=subcategories.SEANCE_CINE.id,
@@ -279,7 +307,30 @@ def create_pro_user_with_collective_offers() -> dict:
     educational_factories.EducationalYearFactory()
     educational_factories.EducationalInstitutionFactory(name="COLLEGE 123")
 
-    return {"user": get_pro_user_helper(pro_user)}
+    return {
+        "user": get_pro_user_helper(pro_user),
+        "offerPublishedTemplate": {
+            "name": offerPublishedTemplate.name,
+            "venueName": offerPublishedTemplate.venue.name,
+        },
+        "offerPublished": {
+            "name": offerPublished.collectiveOffer.name,
+            "venueName": offerPublished.collectiveOffer.venue.name,
+        },
+        "offerDraft": {
+            "name": offerDraft.name,
+            "venueName": offerDraft.venue.name,
+        },
+        "offerInInstruction": {
+            "name": offerInInstruction.name,
+            "venueName": offerInInstruction.venue.name,
+        },
+        "offerNotConform": {
+            "name": offerNotConform.name,
+            "venueName": offerNotConform.venue.name,
+        },
+        "offerArchived": {"name": offerArchived.name, "venueName": offerArchived.venue.name},
+    }
 
 
 def create_pro_user_with_active_collective_offer() -> dict:

--- a/pro/cypress/e2e/adage.cy.ts
+++ b/pro/cypress/e2e/adage.cy.ts
@@ -1,7 +1,8 @@
 describe('ADAGE discovery', () => {
   let offerId: number
-  const offerName = 'Mon offre collective'
   let adageToken: string
+  let offerName: string
+  let venueName: string
 
   beforeEach(() => {
     cy.stepLog({ message: 'I go to adage login page with valid token' })
@@ -14,6 +15,8 @@ describe('ADAGE discovery', () => {
       url: 'http://localhost:5001/sandboxes/pro/create_adage_environment',
     }).then((response) => {
       offerId = response.body.offerId
+      offerName = response.body.offerName
+      venueName = response.body.venueName
     })
     cy.intercept(
       'GET',
@@ -214,7 +217,7 @@ describe('ADAGE discovery', () => {
       }
     })
     cy.findAllByTestId('spinner').should('not.exist')
-    cy.findByTestId('offer-listitem').contains('Mon offre collective')
+    cy.findByTestId('offer-listitem').contains(offerName)
 
     cy.stepLog({ message: 'I add first offer to favorites' })
     cy.findByText(offerName).parent().click()
@@ -276,7 +279,7 @@ describe('ADAGE discovery', () => {
     cy.wait('@authenticate').its('response.statusCode').should('eq', 200)
 
     cy.stepLog({ message: 'I click on venue' })
-    cy.findByText('Mon lieu collectif').parent().click()
+    cy.findByText(venueName).parent().click()
 
     cy.stepLog({
       message: 'the iframe search page should be displayed correctly',
@@ -289,7 +292,7 @@ describe('ADAGE discovery', () => {
     )
 
     cy.stepLog({ message: 'Venue filter should be there' })
-    cy.findByText('Lieu : Mon lieu collectif').should('be.visible')
+    cy.findByText(`Lieu : ${venueName}`).should('be.visible')
   })
 
   it('It should redirect to search page with filtered domain on click in domain card', () => {
@@ -318,7 +321,7 @@ describe('ADAGE discovery', () => {
     cy.wait('@authenticate').its('response.statusCode').should('eq', 200)
 
     cy.stepLog({ message: 'I click on venue' })
-    cy.findByText('Mon lieu collectif').parent().click()
+    cy.findByText(venueName).parent().click()
 
     cy.stepLog({
       message: 'the iframe search page should be displayed correctly',
@@ -331,12 +334,12 @@ describe('ADAGE discovery', () => {
     )
 
     cy.stepLog({ message: 'I go back to search page' })
-    cy.findByText('Lieu : Mon lieu collectif').should('be.visible')
+    cy.findByText(`Lieu : ${venueName}`).should('be.visible')
     cy.findByRole('link', { name: 'Découvrir' }).click()
     cy.findByRole('link', { name: 'Rechercher' }).click()
 
     cy.stepLog({ message: 'The filter has disappear' })
-    cy.findByText('Lieu : Mon lieu collectif').should('not.exist')
+    cy.findByText(`Lieu : ${venueName}`).should('not.exist')
   })
 
   it('It should not keep filter venue after page change', () => {
@@ -344,7 +347,7 @@ describe('ADAGE discovery', () => {
     cy.wait('@authenticate').its('response.statusCode').should('eq', 200)
 
     cy.stepLog({ message: 'I click on venue' })
-    cy.findByText('Mon lieu collectif').parent().click()
+    cy.findByText(venueName).parent().click()
 
     cy.stepLog({
       message: 'the iframe search page should be displayed correctly',
@@ -357,12 +360,12 @@ describe('ADAGE discovery', () => {
     )
 
     cy.stepLog({ message: 'I go back to search page' })
-    cy.findByText('Lieu : Mon lieu collectif').should('be.visible')
+    cy.findByText(`Lieu : ${venueName}`).should('be.visible')
     cy.findByRole('link', { name: 'Découvrir' }).click()
     cy.findByRole('link', { name: 'Rechercher' }).click()
 
     cy.stepLog({ message: 'The filter has disappear' })
-    cy.findByText('Lieu : Mon lieu collectif').should('not.exist')
+    cy.findByText(`Lieu : ${venueName}`).should('not.exist')
   })
 
   it('It should save view type in search page', () => {
@@ -411,7 +414,7 @@ describe('ADAGE discovery', () => {
     cy.wait('@authenticate').its('response.statusCode').should('eq', 200)
 
     cy.stepLog({ message: 'I choose my filters' })
-    cy.findByText('Mon lieu collectif').parent().click()
+    cy.findByText(venueName).parent().click()
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(500) // Click on "Domaine artistique" is too fast waiting api is not enough
@@ -436,7 +439,7 @@ describe('ADAGE discovery', () => {
     cy.findByRole('button', { name: 'Domaine artistique (1)' }).click()
     cy.findByLabelText('Danse').should('be.checked')
 
-    cy.findByText('Lieu : Mon lieu collectif').should('be.visible')
+    cy.findByText(`Lieu : ${venueName}`).should('be.visible')
   })
 
   it('It should save page when navigating the iframe', () => {

--- a/pro/cypress/e2e/createCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/createCollectiveOffer.cy.ts
@@ -5,7 +5,8 @@ import {
 
 describe('Create collective offers', () => {
   let login: string
-  const offerName = 'Mon offre collective en brouillon'
+  let offerDraft: { "name": string, "venueName": string }
+  const newOfferName = 'Ma nouvelle offre collective créée'
   const venueName = 'Mon Lieu 1'
 
   beforeEach(() => {
@@ -15,6 +16,7 @@ describe('Create collective offers', () => {
       url: 'http://localhost:5001/sandboxes/pro/create_pro_user_with_collective_offers',
     }).then((response) => {
       login = response.body.user.email
+      offerDraft = response.body.offerDraft
     })
     cy.intercept(
       'GET',
@@ -62,7 +64,7 @@ describe('Create collective offers', () => {
     cy.get('#list-formats').find('#option-display-Concert').click()
     cy.findByText('Type d’offre').click()
 
-    cy.findByLabelText('Titre de l’offre *').type(offerName)
+    cy.findByLabelText('Titre de l’offre *').type(newOfferName)
     cy.findByLabelText('Description *').type('Bookable draft offer')
     cy.findByText('Collège - 6e').click()
     cy.findByLabelText('Email *').type('example@passculture.app')
@@ -110,15 +112,15 @@ describe('Create collective offers', () => {
 
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      ['', '', offerName, venueName, 'COLLEGE 123', 'brouillon'],
-      [],
+      ['', '', newOfferName, venueName, 'COLLEGE 123', 'brouillon'],
+      ['', '', offerDraft.name, offerDraft.venueName, 'DE LA TOUR', 'brouillon'],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults)
 
     cy.stepLog({ message: 'I want to change my offer to published status' })
 
-    cy.findByRole('link', { name: offerName }).click()
+    cy.findByRole('link', { name: newOfferName }).click()
 
     cy.wait('@educationalOfferers')
 
@@ -130,13 +132,12 @@ describe('Create collective offers', () => {
 
     cy.url().should('contain', '/offres/collectives')
 
-    cy.findByPlaceholderText('Rechercher par nom d’offre').type(offerName)
+    cy.findByPlaceholderText('Rechercher par nom d’offre').type(newOfferName)
     cy.findByText('Rechercher').click()
 
     const expectedNewResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      ['', '', offerName, venueName, 'COLLEGE 123', 'publiée'],
-      [],
+      ['', '', newOfferName, venueName, 'COLLEGE 123', 'publiée'],
     ]
 
     expectOffersOrBookingsAreFound(expectedNewResults)

--- a/pro/cypress/e2e/createIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/createIndividualOffer.cy.ts
@@ -1,10 +1,13 @@
 import {
   interceptSearch5Adresses,
   sessionLogInAndGoToPage,
+  expectOffersOrBookingsAreFound
 } from '../support/helpers.ts'
 
 describe('Create individual offers', () => {
   let login: string
+  let venueName: string
+  const stock = '42'
   
   before(() => {
     cy.wrap(Cypress.session.clearAllSavedSessions())
@@ -14,6 +17,7 @@ describe('Create individual offers', () => {
       url: 'http://localhost:5001/sandboxes/pro/create_regular_pro_user',
     }).then((response) => {
       login = response.body.user.email
+      venueName = response.body.venueName
     })
     cy.setFeatureFlags([{ name: 'WIP_ENABLE_OFFER_ADDRESS', isActive: false }])
   })
@@ -276,7 +280,7 @@ describe('Create individual offers', () => {
     cy.stepLog({ message: 'I fill in stocks' })
     cy.get('#price').type('42')
     cy.get('#bookingLimitDatetime').type('2042-05-03')
-    cy.get('#quantity').type('42')
+    cy.get('#quantity').type(stock)
 
     cy.stepLog({ message: 'I validate stocks step' })
     cy.findByText('Enregistrer et continuer').click()
@@ -303,7 +307,13 @@ describe('Create individual offers', () => {
     })
 
     cy.stepLog({ message: 'my new physical offer should be displayed' })
-    cy.contains('H2G2 Le Guide du voyageur galactique')
+    const expectedNewResults = [
+      ['', '', '', 'Lieu', 'Stocks', 'Statut', ''],
+      ['', '', offerTitle , venueName, stock, 'publiée'],
+      []
+    ]
+
+    expectOffersOrBookingsAreFound(expectedNewResults)
     cy.get('@ean').then((ean) => {
       cy.contains(ean.toString())
     })

--- a/pro/cypress/e2e/desk.cy.ts
+++ b/pro/cypress/e2e/desk.cy.ts
@@ -4,6 +4,12 @@ import { sessionLogInAndGoToPage } from '../support/helpers.ts'
 
 describe('Desk (Guichet) feature', () => {
   let login: string
+  let tokenConfirmed: string
+  let tokenTooSoon: string
+  let tokenUsed: string
+  let tokenCanceled: string
+  let tokenReimbursed: string
+  let tokenOther: string
 
   before(() => {
     cy.wrap(Cypress.session.clearAllSavedSessions())
@@ -13,6 +19,12 @@ describe('Desk (Guichet) feature', () => {
       url: 'http://localhost:5001/sandboxes/pro/create_pro_user_with_bookings',
     }).then((response) => {
       login = response.body.user.email
+      tokenConfirmed = response.body.tokenConfirmed
+      tokenTooSoon = response.body.tokenTooSoon
+      tokenUsed = response.body.tokenUsed
+      tokenCanceled = response.body.tokenCanceled
+      tokenReimbursed = response.body.tokenReimbursed
+      tokenOther = response.body.tokenOther
     })
   })
 
@@ -43,9 +55,9 @@ describe('Desk (Guichet) feature', () => {
     })
   })
 
-  it('I should be able to validate a countermark', () => {
-    cy.stepLog({ message: 'I add this countermark "2XTM3W"' })
-    cy.findByLabelText('Contremarque').type('2XTM3W')
+  it('I should be able to validate a valid countermark', () => {
+    cy.stepLog({ message: `I add a valid countermark ${tokenConfirmed}` })
+    cy.findByLabelText('Contremarque').type(tokenConfirmed)
 
     cy.stepLog({ message: 'I validate the countermark' })
     cy.findByText('Coupon vérifié, cliquez sur "Valider" pour enregistrer')
@@ -68,8 +80,8 @@ describe('Desk (Guichet) feature', () => {
   })
 
   it('It should decline an event countermark more than 48h before', () => {
-    cy.stepLog({ message: 'I add this countermark "TOSOON"' })
-    cy.findByLabelText('Contremarque').type('TOSOON')
+    cy.stepLog({ message: `I add this countermark "${tokenTooSoon}"` })
+    cy.findByLabelText('Contremarque').type(tokenTooSoon)
 
     cy.stepLog({ message: 'the countermark is rejected as invalid' })
     const date = format(addDays(new Date(), 2), 'dd/MM/yyyy')
@@ -83,8 +95,8 @@ describe('Desk (Guichet) feature', () => {
   })
 
   it('I should be able to invalidate an already used countermark', () => {
-    cy.stepLog({ message: 'I add this countermark "XUSEDX"' })
-    cy.findByLabelText('Contremarque').type('XUSEDX')
+    cy.stepLog({ message: `I add this countermark "${tokenUsed}"` })
+    cy.findByLabelText('Contremarque').type(tokenUsed)
     cy.findByText(/Cette contremarque a été validée./)
 
     cy.stepLog({ message: 'I invalidate the countermark' })
@@ -96,8 +108,8 @@ describe('Desk (Guichet) feature', () => {
   })
 
   it('I should not be able to validate another pro countermark', () => {
-    cy.stepLog({ message: 'I add this countermark "OTHERX"' })
-    cy.findByLabelText('Contremarque').type('OTHERX')
+    cy.stepLog({ message: `I add this countermark "${tokenOther}"` })
+    cy.findByLabelText('Contremarque').type(tokenOther)
 
     cy.stepLog({ message: 'I cannot validate the countermark' })
     cy.findByText('Valider la contremarque').should('be.disabled')
@@ -107,8 +119,8 @@ describe('Desk (Guichet) feature', () => {
   })
 
   it('I should not be able to validate a cancelled countermark', () => {
-    cy.stepLog({ message: 'I add this countermark "CANCEL"' })
-    cy.findByLabelText('Contremarque').type('CANCEL')
+    cy.stepLog({ message: `I add this countermark "${tokenCanceled}"` })
+    cy.findByLabelText('Contremarque').type(tokenCanceled)
 
     cy.stepLog({ message: 'I validate the countermark' })
     cy.findByText('Valider la contremarque').should('be.disabled')
@@ -116,8 +128,8 @@ describe('Desk (Guichet) feature', () => {
   })
 
   it('I should not be able to validate a reimbursed countermark', () => {
-    cy.stepLog({ message: 'I add this countermark "REIMBU"' })
-    cy.findByLabelText('Contremarque').type('REIMBU')
+    cy.stepLog({ message: `I add this countermark "${tokenReimbursed}"` })
+    cy.findByLabelText('Contremarque').type(tokenReimbursed)
 
     cy.stepLog({ message: 'I validate the countermark' })
     cy.findByText('Valider la contremarque').should('be.disabled')

--- a/pro/cypress/e2e/searchCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/searchCollectiveOffer.cy.ts
@@ -7,14 +7,13 @@ import {
 
 describe('Search collective offers', () => {
   let login: string
-  const venueName1 = 'Mon Lieu 1'
-  const venueName2 = 'Mon Lieu 2'
-  const offerNameArchived = 'Mon offre collective archivée réservable'
-  const offerNamePublished = 'Mon offre collective publiée réservable'
-  const offerNamePublishedTemplate = 'Mon offre collective publiée vitrine'
-  const offerNameDraft = 'Mon offre collective en brouillon réservable'
-  const offerNameNotConform = 'Mon offre collective non conforme réservable'
-  const offerNameInInstruction = 'Mon offre collective en instruction réservable'
+  let offerPublishedTemplate: { "name": string, "venueName": string }
+  let offerPublished: { "name": string, "venueName": string }
+  let offerDraft: { "name": string, "venueName": string }
+  let offerInInstruction: { "name": string, "venueName": string }
+  let offerNotConform: { "name": string, "venueName": string }
+  let offerArchived: { "name": string, "venueName": string }
+
   const formatName = 'Concert'
 
   before(() => {
@@ -24,6 +23,12 @@ describe('Search collective offers', () => {
       url: 'http://localhost:5001/sandboxes/pro/create_pro_user_with_collective_offers',
     }).then((response) => {
       login = response.body.user.email
+      offerPublishedTemplate = response.body.offerPublishedTemplate
+      offerPublished = response.body.offerPublished
+      offerDraft = response.body.offerDraft
+      offerInInstruction = response.body.offerInInstruction
+      offerNotConform = response.body.offerNotConform
+      offerArchived = response.body.offerArchived
     })
     cy.setFeatureFlags([
       { name: 'ENABLE_COLLECTIVE_NEW_STATUSES', isActive: true },
@@ -31,7 +36,11 @@ describe('Search collective offers', () => {
   })
 
   beforeEach(() => {
-    sessionLogInAndGoToPage('Session search collective offer', login, '/accueil')
+    sessionLogInAndGoToPage(
+      'Session search collective offer',
+      login,
+      '/accueil'
+    )
 
     cy.intercept({ method: 'GET', url: '/collective/offers*' }).as(
       'collectiveOffers'
@@ -44,12 +53,12 @@ describe('Search collective offers', () => {
     cy.findAllByTestId('spinner').should('not.exist')
   })
 
-  it(`I should be able to search with a name "${offerNamePublished}" and see expected results`, () => {
+  it(`I should be able to search with a name and see expected results`, () => {
     cy.stepLog({
-      message: 'I search with the name "' + offerNamePublished + '"',
+      message: 'I search with the name "' + offerPublished.name + '"',
     })
     cy.findByPlaceholderText('Rechercher par nom d’offre').type(
-      offerNamePublished
+      offerPublished.name
     )
 
     cy.stepLog({ message: 'I validate my filters' })
@@ -59,22 +68,15 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: '1 result should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      [
-        '',
-        '',
-        offerNamePublished,
-        venueName1,
-        '',
-        'publiée',
-      ],
+      ['', '', offerPublished.name, offerPublished.venueName, '', 'publiée'],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults)
   })
 
-  it(`I should be able to search with a lieu "${venueName2}" and see expected results`, () => {
-    cy.stepLog({ message: 'I search with the place "' + venueName2 + '"' })
-    cy.findByLabelText('Lieu').select(venueName2)
+  it(`I should be able to search with a lieu and see expected results`, () => {
+    cy.stepLog({ message: 'I search with the place "' + offerArchived.venueName + '"' })
+    cy.findByLabelText('Lieu').select(offerArchived.venueName)
 
     cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
@@ -83,30 +85,9 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: '3 results should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      [
-        '',
-        '',
-        offerNameNotConform,
-        venueName2,
-        '',
-        'non conforme',
-      ],
-      [
-        '',
-        '',
-        offerNameInInstruction,
-        venueName2,
-        '',
-        'en instruction',
-      ],
-      [
-        '',
-        '',
-        offerNameArchived,
-        venueName2,
-        '',
-        'archivée',
-      ],
+      ['', '', offerNotConform.name, offerNotConform.venueName, '', 'non conforme'],
+      ['', '', offerInInstruction.name, offerInInstruction.venueName, '', 'en instruction'],
+      ['', '', offerArchived.name, offerArchived.venueName, '', 'archivée'],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults)
@@ -123,22 +104,8 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: '2 results should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      [
-        '',
-        '',
-        offerNamePublished,
-        venueName1,
-        '',
-        'publiée',
-      ],
-      [
-        '',
-        '',
-        offerNamePublishedTemplate,
-        venueName1,
-        '',
-        'publiée',
-      ],
+      ['', '', offerPublished.name, offerPublished.venueName, '', 'publiée'],
+      ['', '', offerPublishedTemplate.name, offerPublishedTemplate.venueName, '', 'publiée'],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults)
@@ -155,46 +122,11 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: '5 results should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      [
-        '',
-        '',
-        offerNameArchived,
-        venueName2,
-        '',
-        'archivée',
-      ],
-      [
-        '',
-        '',
-        offerNameNotConform,
-        venueName2,
-        '',
-        'non conforme',
-      ],
-      [
-        '',
-        '',
-        offerNameInInstruction,
-        venueName2,
-        '',
-        'en instruction',
-      ],
-      [
-        '',
-        '',
-        offerNameDraft,
-        venueName1,
-        '',
-        'brouillon',
-      ],
-      [
-        '',
-        '',
-        offerNamePublished,
-        venueName1,
-        '',
-        'publiée',
-      ],
+      ['', '', offerArchived.name, offerArchived.venueName, '', 'archivée'],
+      ['', '', offerNotConform.name, offerNotConform.venueName, '', 'non conforme'],
+      ['', '', offerInInstruction.name, offerInInstruction.venueName, '', 'en instruction'],
+      ['', '', offerDraft.name, offerDraft.venueName, '', 'brouillon'],
+      ['', '', offerPublished.name, offerPublished.venueName, '', 'publiée'],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults)
@@ -213,14 +145,7 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: '1 result should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      [
-        '',
-        '',
-        offerNamePublished,
-        venueName1,
-        '',
-        'publiée',
-      ],
+      ['', '', offerPublished.name, offerPublished.venueName, '', 'publiée'],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults)
@@ -239,22 +164,15 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: '1 result should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      [
-        '',
-        '',
-        offerNameInInstruction,
-        venueName2,
-        '',
-        'en instruction',
-      ],
+      ['', '', offerInInstruction.name, offerInInstruction.venueName, '', 'en instruction'],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults)
   })
 
   it('I should be able to search with several filters and see expected results, then reinit filters', () => {
-    cy.stepLog({ message: 'I select ' + venueName1 + ' in "Lieu"' })
-    cy.findByLabelText('Lieu').select(venueName1)
+    cy.stepLog({ message: 'I select ' + offerDraft.venueName + ' in "Lieu"' })
+    cy.findByLabelText('Lieu').select(offerDraft.venueName)
 
     cy.stepLog({ message: 'I select "Représentation" in "Format"' })
     cy.findByLabelText('Format').select('Représentation')
@@ -274,14 +192,7 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: '1 result should be displayed' })
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      [
-        '',
-        '',
-        offerNameDraft,
-        venueName1,
-        '',
-        'brouillon',
-      ],
+      ['', '', offerDraft.name, offerDraft.venueName, '', 'brouillon'],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults)
@@ -308,54 +219,12 @@ describe('Search collective offers', () => {
     cy.stepLog({ message: '6 results should be displayed' })
     const expectedResults2 = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
-      [
-        '',
-        '',
-        offerNameNotConform,
-        venueName2,
-        '',
-        'non conforme',
-      ],
-      [
-        '',
-        '',
-        offerNameInInstruction,
-        venueName2,
-        '',
-        'en instruction',
-      ],
-      [
-        '',
-        '',
-        offerNameDraft,
-        venueName1,
-        '',
-        'brouillon',
-      ],
-      [
-        '',
-        '',
-        offerNamePublished,
-        venueName1,
-        '',
-        'publiée',
-      ],
-      [
-        '',
-        '',
-        offerNamePublishedTemplate,
-        venueName1,
-        '',
-        'publiée',
-      ],
-      [
-        '',
-        '',
-        offerNameArchived,
-        venueName2,
-        '',
-        'archivée',
-      ],
+      ['', '', offerNotConform.name, offerNotConform.venueName, '', 'non conforme'],
+      ['', '', offerInInstruction.name, offerInInstruction.venueName, '', 'en instruction'],
+      ['', '', offerDraft.name, offerDraft.venueName, '', 'brouillon'],
+      ['', '', offerPublished.name, offerPublished.venueName, '', 'publiée'],
+      ['', '', offerPublishedTemplate.name, offerPublishedTemplate.venueName, '', 'publiée'],
+      ['', '', offerArchived.name, offerArchived.venueName, '', 'archivée'],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults2)

--- a/pro/cypress/e2e/searchIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/searchIndividualOffer.cy.ts
@@ -7,14 +7,14 @@ import {
 
 describe('Search individual offers', () => {
   let login: string
-  const venueName = 'Mon Lieu'
-  const offerName1 = 'Une super offre'
-  const offerName2 = 'Une offre avec ean'
-  const offerName3 = 'Une flûte traversière'
-  const offerName4 = "Un concert d'electro inoubliable"
-  const offerName5 = 'Une autre offre incroyable'
-  const offerName6 = 'Encore une offre incroyable'
-  const offerName7 = 'Une offre épuisée'
+  let venueName: string
+  let offerName1: string
+  let offerName2: string
+  let offerName3: string
+  let offerName4: string
+  let offerName5: string
+  let offerName6: string
+  let offerName7: string
 
   before(() => {
     cy.wrap(Cypress.session.clearAllSavedSessions())
@@ -24,6 +24,14 @@ describe('Search individual offers', () => {
       url: 'http://localhost:5001/sandboxes/pro/create_pro_user_with_individual_offers',
     }).then((response) => {
       login = response.body.user.email
+      venueName = response.body.venue.name
+      offerName1 = response.body.offer1.name
+      offerName2 = response.body.offer2.name
+      offerName3 = response.body.offer3.name
+      offerName4 = response.body.offer4.name
+      offerName5 = response.body.offer5.name
+      offerName6 = response.body.offer6.name
+      offerName7 = response.body.offer7.name
     })
   })
 
@@ -77,7 +85,11 @@ describe('Search individual offers', () => {
 
   it('I should be able to search with "Catégorie" filter and see expected results', () => {
     cy.stepLog({ message: 'I select "Instrument de musique" in "Catégorie"' })
-    cy.findByLabelText('Catégorie').select('Instrument de musique')
+
+    cy.findByTestId('wrapper-categorie').within(() => {
+      cy.findByLabelText('Catégorie').select('Instrument de musique')
+      cy.get('#categorie').should('have.value', 'INSTRUMENT')
+    })
 
     cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
@@ -94,8 +106,10 @@ describe('Search individual offers', () => {
 
   it('I should be able to search by offer status and see expected results', () => {
     cy.stepLog({ message: 'I select "Publiée" in offer status' })
+
     cy.findByTestId('wrapper-status').within(() => {
-      cy.get('select').select('Publiée')
+      cy.findByLabelText('Statut').select('Publiée')
+      cy.get('#status').should('have.value', 'ACTIVE')
     })
 
     cy.stepLog({ message: 'I validate my filters' })

--- a/pro/cypress/support/helpers.ts
+++ b/pro/cypress/support/helpers.ts
@@ -45,12 +45,9 @@ export function expectOffersOrBookingsAreFound(
             cy.wrap($elt)
               .eq(column)
               .then((cellValue) => {
-                if (cellValue.text().length && lineArray[column].length) {
-                  return cy
-                    .wrap(cellValue)
-                    .should('contain.text', lineArray[column])
-                } else {
-                  return true
+                if (lineArray[column].length) {
+                  let isAMatch: boolean = cellValue.text().includes(lineArray[column])
+                  expect(isAMatch).to.be.true
                 }
               })
           }


### PR DESCRIPTION
## But de la pull request

On utilise maintenant le contenu des datas générées (nom d'offre, de venue...) plutôt que copier les labels côté back et front e2e
C'était une suggestion de @abouabdallaoui-pass [ici](https://github.com/pass-culture/pass-culture-main/pull/15238#discussion_r1867247669)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
