### PR TITLE
(BSR)[PRO] test: wait authenticate after visit adage iframe

### DIFF
--- a/pro/cypress/support/commands.ts
+++ b/pro/cypress/support/commands.ts
@@ -65,7 +65,7 @@ Cypress.Commands.add('getFakeAdageToken', () => {
     method: 'GET',
     url: 'http://localhost:5001/adage-iframe/testing/token',
   }).then((response) => {
-    Cypress.env('adageToken', response.body.token)
+    return cy.wrap(response.body.token)
   })
 })
 

--- a/pro/cypress/support/index.d.ts
+++ b/pro/cypress/support/index.d.ts
@@ -12,11 +12,11 @@ declare namespace Cypress {
 
     
     /**
-     * This function creates a fake adage token which is set as an environment variable `adageToken`
-     *
-     * @example 
-     * cy.getFakeAdageToken()
-     * const adageToken = Cypress.env('adageToken')
+     * This function creates a fake adage token, and returns it as a string
+     * 
+     * @returns a string of the fake adage token
+     * @example
+     * cy.getFakeAdageToken().then((value) => { adageToken = value })
      * cy.visit(`/adage-iframe/recherche?token=${adageToken}`)
      */
     getFakeAdageToken(): Chainable


### PR DESCRIPTION
## But de la pull request

Il arrive que les tests adage soient flaky, j'ajoute ici une attente sur le `GET /adage-iframe/authenticate`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
