### PR TITLE
(PC-33285)[API] feat: check allowed actions when editing collective offer

### DIFF
--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -304,12 +304,15 @@ def cancel_collective_offer_booking(offer_id: int, author_id: int, user_connect_
     if collective_offer is None:
         raise exceptions.CollectiveOfferNotFound()
 
+    if FeatureToggle.ENABLE_COLLECTIVE_NEW_STATUSES.is_active():
+        validation.check_collective_offer_action_is_allowed(
+            collective_offer, educational_models.CollectiveOfferAllowedAction.CAN_CANCEL
+        )
+
     if collective_offer.collectiveStock is None:
         raise exceptions.CollectiveStockNotFound()
 
     collective_stock = collective_offer.collectiveStock
-
-    # Offer is reindexed in the end of this function
     cancelled_booking = _cancel_collective_booking_by_offerer(collective_stock, author_id, user_connect_as)
 
     logger.info(
@@ -372,10 +375,6 @@ def _cancel_collective_booking_by_offerer(
     author_id: int,
     user_connect_as: bool,
 ) -> educational_models.CollectiveBooking:
-    """
-    Cancel booking.
-    Note that this will not reindex the associated offer in Algolia
-    """
     booking_to_cancel: educational_models.CollectiveBooking | None = next(
         (
             collective_booking
@@ -392,11 +391,8 @@ def _cancel_collective_booking_by_offerer(
         cancellation_reason = educational_models.CollectiveBookingCancellationReasons.OFFERER_CONNECT_AS
     else:
         cancellation_reason = educational_models.CollectiveBookingCancellationReasons.OFFERER
-    _cancel_collective_booking(
-        booking_to_cancel,
-        cancellation_reason,
-        author_id,
-    )
+
+    _cancel_collective_booking(booking_to_cancel, cancellation_reason, author_id)
 
     return booking_to_cancel
 

--- a/api/src/pcapi/core/educational/exceptions.py
+++ b/api/src/pcapi/core/educational/exceptions.py
@@ -6,6 +6,8 @@ from pcapi.models.api_errors import ApiErrors
 
 if typing.TYPE_CHECKING:
     from pcapi.core.educational.models import CollectiveBookingStatus
+    from pcapi.core.educational.models import CollectiveOfferAllowedAction
+    from pcapi.core.educational.models import CollectiveOfferTemplateAllowedAction
 
 
 class EducationalInstitutionUnknown(ClientError):
@@ -137,6 +139,18 @@ class EducationalRedcatorCannotBeLinked(Exception):
 
 class CollectiveOfferNotEditable(Exception):
     pass
+
+
+class CollectiveOfferForbiddenAction(Exception):
+    def __init__(self, action: "CollectiveOfferAllowedAction") -> None:
+        self.action = action
+        super().__init__()
+
+
+class CollectiveOfferTemplateForbiddenAction(Exception):
+    def __init__(self, action: "CollectiveOfferTemplateAllowedAction") -> None:
+        self.action = action
+        super().__init__()
 
 
 class CollectiveOfferForbiddenFields(Exception):

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -390,9 +390,23 @@ class ArchivedCollectiveOfferFactory(CollectiveOfferBaseFactory):
 class RejectedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     validation = OfferValidationStatus.REJECTED
 
+    @factory.post_generation
+    def create_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
+        # a rejected offer has a stock because it completed the creation process
+        CollectiveStockFactory(
+            beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=10), collectiveOffer=self
+        )
+
 
 class PendingCollectiveOfferFactory(CollectiveOfferBaseFactory):
     validation = OfferValidationStatus.PENDING
+
+    @factory.post_generation
+    def create_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
+        # a pending offer has a stock because it completed the creation process
+        CollectiveStockFactory(
+            beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=10), collectiveOffer=self
+        )
 
 
 class DraftCollectiveOfferFactory(CollectiveOfferBaseFactory):
@@ -477,10 +491,18 @@ class BookedCollectiveOfferFactory(CollectiveOfferBaseFactory):
         ConfirmedCollectiveBookingFactory(collectiveStock=stock)
 
 
-class EndedCollectiveOfferFactory(CollectiveOfferBaseFactory):
+class EndedNotUsedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_ended_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
         yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        stock = CollectiveStockFactory(beginningDatetime=yesterday, collectiveOffer=self)
+        ConfirmedCollectiveBookingFactory(collectiveStock=stock)
+
+
+class EndedCollectiveOfferFactory(CollectiveOfferBaseFactory):
+    @factory.post_generation
+    def create_ended_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
+        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=3)
         stock = CollectiveStockFactory(beginningDatetime=yesterday, collectiveOffer=self)
         UsedCollectiveBookingFactory(collectiveStock=stock)
 

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1087,12 +1087,19 @@ def get_collective_offer_templates_by_ids_for_adage(offer_ids: typing.Collection
 
 def get_query_for_collective_offers_by_ids_for_user(user: User, ids: typing.Iterable[int]) -> BaseQuery:
     query = educational_models.CollectiveOffer.query
+
     if not user.has_admin_role:
         query = query.join(offerers_models.Venue, educational_models.CollectiveOffer.venue)
         query = query.join(offerers_models.Offerer, offerers_models.Venue.managingOfferer)
         query = query.join(offerers_models.UserOfferer, offerers_models.Offerer.UserOfferers)
         query = query.filter(offerers_models.UserOfferer.userId == user.id, offerers_models.UserOfferer.isValidated)
+
     query = query.filter(educational_models.CollectiveOffer.id.in_(ids))
+    query = query.options(
+        sa.orm.joinedload(educational_models.CollectiveOffer.collectiveStock).joinedload(
+            educational_models.CollectiveStock.collectiveBookings
+        )
+    )
     return query
 
 

--- a/api/src/pcapi/core/educational/validation.py
+++ b/api/src/pcapi/core/educational/validation.py
@@ -146,3 +146,17 @@ def check_if_offer_not_used_or_reimbursed(offer: models.CollectiveOffer) -> None
                 or booking.status is models.CollectiveBookingStatus.REIMBURSED
             ):
                 raise offers_exceptions.OfferUsedOrReimbursedCantBeEdit()
+
+
+def check_collective_offer_action_is_allowed(
+    offer: models.CollectiveOffer, action: models.CollectiveOfferAllowedAction
+) -> None:
+    if action not in offer.allowedActions:
+        raise exceptions.CollectiveOfferForbiddenAction(action=action)
+
+
+def check_collective_offer_template_action_is_allowed(
+    offer: models.CollectiveOfferTemplate, action: models.CollectiveOfferTemplateAllowedAction
+) -> None:
+    if action not in offer.allowedActions:
+        raise exceptions.CollectiveOfferTemplateForbiddenAction(action=action)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -612,6 +612,18 @@ def batch_update_offers(query: BaseQuery, update_fields: dict, send_email_notifi
                 )
 
 
+def archive_collective_offers(
+    offers: list[educational_models.CollectiveOffer], date_archived: datetime.datetime
+) -> None:
+    for offer in offers:
+        educational_validation.check_collective_offer_action_is_allowed(
+            offer, educational_models.CollectiveOfferAllowedAction.CAN_ARCHIVE
+        )
+
+        offer.isActive = False
+        offer.dateArchived = date_archived
+
+
 def batch_update_collective_offers(query: BaseQuery, update_fields: dict) -> None:
     allowed_validation_status = {models.OfferValidationStatus.APPROVED}
     if "dateArchived" in update_fields:

--- a/api/src/pcapi/routes/pro/collective_bookings.py
+++ b/api/src/pcapi/routes/pro/collective_bookings.py
@@ -183,3 +183,7 @@ def cancel_collective_offer_booking(offer_id: int) -> None:
         )
     except collective_exceptions.NoCollectiveBookingToCancel:
         raise ApiErrors({"code": "NO_BOOKING", "message": "This collective offer has no booking to cancel"}, 400)
+    except collective_exceptions.CollectiveOfferForbiddenAction:
+        raise ApiErrors(
+            {"code": "CANCEL_NOT_ALLOWED", "message": "This collective offer status does not allow cancellation"}, 403
+        )

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -16,6 +16,7 @@ from pcapi.core.offers import api as offers_api
 from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.core.offers import validation as offers_validation
 from pcapi.models import db
+from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
 from pcapi.repository import transaction
 from pcapi.routes.apis import private_api
@@ -410,10 +411,20 @@ def patch_collective_offers_archive(
 ) -> None:
     collective_query = educational_api_offer.get_query_for_collective_offers_by_ids_for_user(current_user, body.ids)
 
-    if educational_api_offer.query_has_any_archived(collective_query):
-        raise ApiErrors({"global": ["One of the offers is already archived"]}, status_code=422)
+    if feature.FeatureToggle.ENABLE_COLLECTIVE_NEW_STATUSES.is_active():
+        try:
+            offers_api.archive_collective_offers(offers=collective_query.all(), date_archived=datetime.utcnow())
+        except educational_exceptions.CollectiveOfferForbiddenAction:
+            raise ApiErrors({"global": ["Cette action n'est pas autorisée sur cette offre"]}, status_code=403)
 
-    offers_api.batch_update_collective_offers(collective_query, {"isActive": False, "dateArchived": datetime.utcnow()})
+        db.session.commit()
+    else:
+        if educational_api_offer.query_has_any_archived(collective_query):
+            raise ApiErrors({"global": ["One of the offers is already archived"]}, status_code=422)
+
+        offers_api.batch_update_collective_offers(
+            collective_query, {"isActive": False, "dateArchived": datetime.utcnow()}
+        )
 
 
 @private_api.route("/collective/offers-template/active-status", methods=["PATCH"])
@@ -483,6 +494,8 @@ def patch_collective_offers_educational_institution(
         raise ApiErrors({"educationalInstitution": ["l'institution n'est pas active"]}, status_code=403)
     except educational_exceptions.CollectiveOfferNotEditable:
         raise ApiErrors({"offer": ["L'offre n'est plus modifiable"]}, status_code=403)
+    except educational_exceptions.CollectiveOfferForbiddenAction:
+        raise ApiErrors({"offer": ["Cette action n'est pas autorisée sur cette offre"]}, status_code=403)
     except educational_exceptions.EducationalRedactorNotFound:
         raise ApiErrors({"teacherEmail": ["L'enseignant n'à pas été trouvé dans cet établissement."]}, status_code=404)
     except educational_exceptions.EducationalRedcatorCannotBeLinked:
@@ -825,6 +838,8 @@ def duplicate_collective_offer(
         offer = educational_api_offer.duplicate_offer_and_stock(original_offer=original_offer)
     except educational_exceptions.ValidationFailedOnCollectiveOffer:
         raise ApiErrors({"validation": ["l'offre ne passe pas la validation"]}, status_code=403)
+    except educational_exceptions.CollectiveOfferForbiddenAction:
+        raise ApiErrors({"validation": ["Cette action n'est pas autorisée sur cette offre"]}, status_code=403)
     except educational_exceptions.OffererNotAllowedToDuplicate:
         raise ApiErrors({"offerer": ["la structure n'est pas autorisée à dupliquer l'offre"]}, status_code=403)
     except educational_exceptions.CantGetImageFromUrl:

--- a/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
+++ b/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
@@ -1,10 +1,10 @@
 import pytest
 
-from pcapi.core.educational.factories import CollectiveBookingFactory
-from pcapi.core.educational.factories import CollectiveOfferFactory
-from pcapi.core.educational.models import CollectiveBookingStatus
-import pcapi.core.educational.testing as adage_api_testing
+from pcapi.core.educational import factories
+from pcapi.core.educational import models
+from pcapi.core.educational import testing as adage_api_testing
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 from pcapi.core.token import SecureToken
 from pcapi.core.token.serialization import ConnectAsInternalModel
@@ -13,6 +13,16 @@ from pcapi.routes.adage.v1.serialization.prebooking import serialize_collective_
 
 from tests.conftest import TestClient
 
+
+STATUSES_ALLOWING_CANCEL = (
+    models.CollectiveOfferDisplayedStatus.PREBOOKED,
+    models.CollectiveOfferDisplayedStatus.BOOKED,
+)
+
+STATUSES_NOT_ALLOWING_CANCEL = tuple(
+    set(models.CollectiveOfferDisplayedStatus)
+    - {*STATUSES_ALLOWING_CANCEL, models.CollectiveOfferDisplayedStatus.INACTIVE}
+)
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
@@ -24,8 +34,9 @@ class Returns204Test:
         user = user_factories.UserFactory()
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
-        collective_booking = CollectiveBookingFactory(
-            status=CollectiveBookingStatus.PENDING, collectiveStock__collectiveOffer__venue__managingOfferer=offerer
+        collective_booking = factories.CollectiveBookingFactory(
+            status=models.CollectiveBookingStatus.PENDING,
+            collectiveStock__collectiveOffer__venue__managingOfferer=offerer,
         )
 
         offer_id = collective_booking.collectiveStock.collectiveOffer.id
@@ -33,7 +44,7 @@ class Returns204Test:
         response = client.patch(f"/collective/offers/{offer_id}/cancel_booking")
 
         assert response.status_code == 204
-        assert collective_booking.status == CollectiveBookingStatus.CANCELLED
+        assert collective_booking.status == models.CollectiveBookingStatus.CANCELLED
 
         expected_payload = serialize_collective_booking(collective_booking)
         assert len(adage_api_testing.adage_requests) == 1
@@ -44,8 +55,9 @@ class Returns204Test:
         user = user_factories.ProFactory()
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
-        collective_booking = CollectiveBookingFactory(
-            status=CollectiveBookingStatus.CONFIRMED, collectiveStock__collectiveOffer__venue__managingOfferer=offerer
+        collective_booking = factories.CollectiveBookingFactory(
+            status=models.CollectiveBookingStatus.CONFIRMED,
+            collectiveStock__collectiveOffer__venue__managingOfferer=offerer,
         )
 
         offer_id = collective_booking.collectiveStock.collectiveOffer.id
@@ -53,7 +65,7 @@ class Returns204Test:
         response = client.patch(f"/collective/offers/{offer_id}/cancel_booking")
 
         assert response.status_code == 204
-        assert collective_booking.status == CollectiveBookingStatus.CANCELLED
+        assert collective_booking.status == models.CollectiveBookingStatus.CANCELLED
         assert collective_booking.cancellationUser == user
 
         expected_payload = serialize_collective_booking(collective_booking)
@@ -66,8 +78,9 @@ class Returns204Test:
         admin = user_factories.AdminFactory(email="admin@example.com")
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
-        collective_booking = CollectiveBookingFactory(
-            status=CollectiveBookingStatus.CONFIRMED, collectiveStock__collectiveOffer__venue__managingOfferer=offerer
+        collective_booking = factories.CollectiveBookingFactory(
+            status=models.CollectiveBookingStatus.CONFIRMED,
+            collectiveStock__collectiveOffer__venue__managingOfferer=offerer,
         )
         expected_redirect_link = "https://example.com"
         secure_token = SecureToken(
@@ -86,8 +99,31 @@ class Returns204Test:
         response = client.patch(f"/collective/offers/{offer_id}/cancel_booking")
 
         assert response.status_code == 204
-        assert collective_booking.status == CollectiveBookingStatus.CANCELLED
+        assert collective_booking.status == models.CollectiveBookingStatus.CANCELLED
         assert collective_booking.cancellationUser == admin
+
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", STATUSES_ALLOWING_CANCEL)
+    def test_cancel_allowed_action(self, client, status):
+        offer = factories.create_collective_offer_by_status(status)
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
+
+        client = client.with_session_auth("pro@example.com")
+        response = client.patch(f"/collective/offers/{offer.id}/cancel_booking")
+
+        assert response.status_code == 204
+        assert offer.collectiveStock.collectiveBookings[0].status == models.CollectiveBookingStatus.CANCELLED
+
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    def test_cancel_ended(self, client):
+        offer = factories.EndedNotUsedCollectiveOfferFactory()
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
+
+        client = client.with_session_auth("pro@example.com")
+        response = client.patch(f"/collective/offers/{offer.id}/cancel_booking")
+
+        assert response.status_code == 204
+        assert offer.collectiveStock.collectiveBookings[0].status == models.CollectiveBookingStatus.CANCELLED
 
 
 class Returns404Test:
@@ -112,7 +148,7 @@ class Returns403Test:
         offerer = offerers_factories.OffererFactory()
         offerers_factories.NotValidatedUserOffererFactory(user=user, offerer=offerer)
 
-        offer = CollectiveOfferFactory(venue__managingOfferer=offerer)
+        offer = factories.CollectiveOfferFactory(venue__managingOfferer=offerer)
 
         offer_id = offer.id
         client = client.with_session_auth(user.email)
@@ -124,18 +160,38 @@ class Returns403Test:
         }
         assert len(adage_api_testing.adage_requests) == 0
 
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", STATUSES_NOT_ALLOWING_CANCEL)
+    def test_cancel_unallowed_action(self, client, status):
+        offer = factories.create_collective_offer_by_status(status)
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
+
+        client = client.with_session_auth("pro@example.com")
+        response = client.patch(f"/collective/offers/{offer.id}/cancel_booking")
+
+        assert response.status_code == 403
+        assert response.json == {
+            "code": "CANCEL_NOT_ALLOWED",
+            "message": "This collective offer status does not allow cancellation",
+        }
+
 
 class Returns400Test:
 
     @pytest.mark.parametrize(
-        "status", [CollectiveBookingStatus.CANCELLED, CollectiveBookingStatus.USED, CollectiveBookingStatus.REIMBURSED]
+        "status",
+        [
+            models.CollectiveBookingStatus.CANCELLED,
+            models.CollectiveBookingStatus.USED,
+            models.CollectiveBookingStatus.REIMBURSED,
+        ],
     )
     def test_offer_that_cannot_be_cancelled_because_of_status(self, client: TestClient, status):
         user = user_factories.UserFactory()
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
 
-        educational_booking = CollectiveBookingFactory(
+        educational_booking = factories.CollectiveBookingFactory(
             status=status, collectiveStock__collectiveOffer__venue__managingOfferer=offerer
         )
         offer_id = educational_booking.collectiveStock.collectiveOffer.id

--- a/api/tests/routes/pro/patch_collective_offers_archive_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_archive_test.py
@@ -2,39 +2,50 @@ from datetime import datetime
 
 import pytest
 
-from pcapi.core.educational.factories import CollectiveOfferFactory
-from pcapi.core.educational.factories import create_collective_offer_by_status
-from pcapi.core.educational.models import CollectiveOffer
-from pcapi.core.educational.models import CollectiveOfferDisplayedStatus
-import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.educational import factories
+from pcapi.core.educational import models
+from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
+from pcapi.core.testing import override_features
 from pcapi.models import db
+
+
+STATUSES_NOT_ALLOWING_ARCHIVE = (
+    models.CollectiveOfferDisplayedStatus.PENDING,
+    models.CollectiveOfferDisplayedStatus.PREBOOKED,
+    models.CollectiveOfferDisplayedStatus.BOOKED,
+    models.CollectiveOfferDisplayedStatus.ENDED,
+    models.CollectiveOfferDisplayedStatus.ARCHIVED,
+)
+
+STATUSES_ALLOWING_ARCHIVE = tuple(
+    set(models.CollectiveOfferDisplayedStatus)
+    - {*STATUSES_NOT_ALLOWING_ARCHIVE, models.CollectiveOfferDisplayedStatus.INACTIVE}
+)
 
 
 @pytest.mark.usefixtures("db_session")
 class Returns204Test:
+    num_queries = 1  # authentication
+    num_queries += 1  # load current_user
+    num_queries += 1  # load Feature Flag
+    num_queries += 1  # ensure there is no existing archived offer
+    num_queries += 1  # retrieve all collective_order.ids to batch them in pool for update
+    num_queries += 1  # update dateArchive on collective_offer
+
     def when_archiving_existing_offers(self, client):
-        # Given
-        offer1 = CollectiveOfferFactory()
+        offer1 = factories.CollectiveOfferFactory()
         venue = offer1.venue
-        offer2 = CollectiveOfferFactory(venue=venue)
+        offer2 = factories.CollectiveOfferFactory(venue=venue)
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
         client = client.with_session_auth("pro@example.com")
 
-        # When
         data = {"ids": [offer1.id, offer2.id]}
-
-        # query += 1 authentication
-        # query += 1 load current_user
-        # query += 1 ensure there is no existing archived offer
-        # query += 1 retrieve all collective_order.ids to batch them in pool for update
-        # query += 1 update dateArchive on collective_offer
-        with assert_num_queries(5):
+        with assert_num_queries(self.num_queries):
             response = client.patch("/collective/offers/archive", json=data)
             assert response.status_code == 204
 
-        # Then
         db.session.refresh(offer1)
         assert offer1.isArchived
         assert not offer1.isActive
@@ -43,12 +54,11 @@ class Returns204Test:
         assert not offer2.isActive
 
     def when_archiving_existing_offers_from_other_offerer(self, client):
-        # Given
-        offer = CollectiveOfferFactory()
+        offer = factories.CollectiveOfferFactory()
         venue = offer.venue
         offerer = venue.managingOfferer
 
-        other_offer = CollectiveOfferFactory()
+        other_offer = factories.CollectiveOfferFactory()
         other_venue = other_offer.venue
         other_offerer = other_venue.managingOfferer
 
@@ -58,12 +68,9 @@ class Returns204Test:
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
         client = client.with_session_auth("pro@example.com")
 
-        # When
         data = {"ids": [offer.id, other_offer.id]}
-
         response = client.patch("/collective/offers/archive", json=data)
 
-        # Then
         assert response.status_code == 204
         db.session.refresh(offer)
         assert offer.isArchived
@@ -73,27 +80,18 @@ class Returns204Test:
         assert other_offer.isActive
 
     def when_archiving_draft_offers(self, client):
-        # Given
-        draft_offer = create_collective_offer_by_status(CollectiveOfferDisplayedStatus.DRAFT)
+        draft_offer = factories.create_collective_offer_by_status(models.CollectiveOfferDisplayedStatus.DRAFT)
         venue = draft_offer.venue
-        other_offer = CollectiveOfferFactory(venue=venue)
+        other_offer = factories.CollectiveOfferFactory(venue=venue)
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
         client = client.with_session_auth("pro@example.com")
 
-        # When
         data = {"ids": [draft_offer.id, other_offer.id]}
-
-        # query += 1 authentication
-        # query += 1 load current_user
-        # query += 1 ensure there is no existing archived offer
-        # query += 1 retrieve all collective_order.ids to batch them in pool for update
-        # query += 1 update dateArchive on collective_offer
-        with assert_num_queries(5):
+        with assert_num_queries(self.num_queries):
             response = client.patch("/collective/offers/archive", json=data)
             assert response.status_code == 204
 
-        # Then
         db.session.refresh(draft_offer)
         assert draft_offer.isArchived
         assert not draft_offer.isActive
@@ -102,50 +100,122 @@ class Returns204Test:
         assert not other_offer.isActive
 
     def test_archive_rejected_offer(self, client):
-        # Given
-        offer = create_collective_offer_by_status(CollectiveOfferDisplayedStatus.REJECTED)
+        offer = factories.create_collective_offer_by_status(models.CollectiveOfferDisplayedStatus.REJECTED)
         venue = offer.venue
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
         client = client.with_session_auth("pro@example.com")
 
-        # When
         data = {"ids": [offer.id]}
-
-        # query += 1 authentication
-        # query += 1 load current_user
-        # query += 1 ensure there is no existing archived offer
-        # query += 1 retrieve all collective_order.ids to batch them in pool for update
-        # query += 1 update dateArchive on collective_offer
-        with assert_num_queries(5):
+        with assert_num_queries(self.num_queries):
             response = client.patch("/collective/offers/archive", json=data)
             assert response.status_code == 204
 
-        # Then
         db.session.refresh(offer)
         assert offer.isArchived
         assert not offer.isActive
+
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", STATUSES_ALLOWING_ARCHIVE)
+    def test_archive_offer_allowed_action(self, client, status):
+        offer = factories.create_collective_offer_by_status(status)
+        venue = offer.venue
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
+        client = client.with_session_auth("pro@example.com")
+
+        data = {"ids": [offer.id]}
+        # same queries except "ensure there is no existing archived offer"
+        num_queries = self.num_queries - 1
+        with assert_num_queries(num_queries):
+            response = client.patch("/collective/offers/archive", json=data)
+            assert response.status_code == 204
+
+        db.session.refresh(offer)
+        assert offer.isArchived
+        assert not offer.isActive
+
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", STATUSES_NOT_ALLOWING_ARCHIVE)
+    def test_archive_offer_unallowed_action(self, client, status):
+        offer = factories.create_collective_offer_by_status(status)
+        venue = offer.venue
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
+        client = client.with_session_auth("pro@example.com")
+
+        offer_was_active = offer.isActive
+        offer_was_archived = offer.isArchived
+        data = {"ids": [offer.id]}
+        # same queries except "ensure there is no existing archived offer" and "update dateArchive on collective_offer"
+        num_queries = self.num_queries - 2
+        with assert_num_queries(num_queries):
+            response = client.patch("/collective/offers/archive", json=data)
+            assert response.status_code == 403
+            assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
+
+        db.session.refresh(offer)
+        assert offer.isArchived == offer_was_archived
+        assert offer.isActive == offer_was_active
+
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    def test_archive_offer_ended(self, client):
+        offer = factories.EndedNotUsedCollectiveOfferFactory()
+        venue = offer.venue
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
+        client = client.with_session_auth("pro@example.com")
+
+        data = {"ids": [offer.id]}
+        # same queries except "ensure there is no existing archived offer" and "update dateArchive on collective_offer"
+        num_queries = self.num_queries - 2
+        with assert_num_queries(num_queries):
+            response = client.patch("/collective/offers/archive", json=data)
+            assert response.status_code == 403
+            assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
+
+        db.session.refresh(offer)
+        assert offer.isArchived == False
+        assert offer.isActive == True
+
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    def test_archive_offer_unallowed_action_on_one_offer(self, client):
+        allowed_offer = factories.DraftCollectiveOfferFactory()
+        venue = allowed_offer.venue
+        unallowed_offer = factories.PrebookedCollectiveOfferFactory(venue=venue)
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
+        client = client.with_session_auth("pro@example.com")
+
+        data = {"ids": [allowed_offer.id, unallowed_offer.id]}
+        # same queries except "ensure there is no existing archived offer" and "update dateArchive on collective_offer"
+        num_queries = self.num_queries - 2
+        with assert_num_queries(num_queries):
+            response = client.patch("/collective/offers/archive", json=data)
+            assert response.status_code == 403
+            assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
+
+        db.session.refresh(allowed_offer)
+        db.session.refresh(unallowed_offer)
+        assert not allowed_offer.isArchived
+        assert not unallowed_offer.isArchived
 
 
 @pytest.mark.usefixtures("db_session")
 class Returns422Test:
     def when_archiving_already_archived(self, client):
-        # Given
-        offer_already_archived = CollectiveOfferFactory(isActive=False, dateArchived=datetime.utcnow())
+        offer_already_archived = factories.CollectiveOfferFactory(isActive=False, dateArchived=datetime.utcnow())
         venue = offer_already_archived.venue
-        offer_not_archived = CollectiveOfferFactory(venue=venue)
+        offer_not_archived = factories.CollectiveOfferFactory(venue=venue)
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)
         client = client.with_session_auth("pro@example.com")
 
-        # When
         data = {"ids": [offer_already_archived.id, offer_not_archived.id]}
-
         response = client.patch("/collective/offers/archive", json=data)
 
-        # Then
         assert response.status_code == 422
         assert response.json == {"global": ["One of the offers is already archived"]}
 
-        assert CollectiveOffer.query.get(offer_already_archived.id).isArchived
-        assert not CollectiveOffer.query.get(offer_not_archived.id).isArchived
+        assert models.CollectiveOffer.query.get(offer_already_archived.id).isArchived
+        assert not models.CollectiveOffer.query.get(offer_not_archived.id).isArchived

--- a/api/tests/routes/pro/patch_collective_offers_educational_institution_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_educational_institution_test.py
@@ -2,16 +2,21 @@ from typing import Any
 
 import pytest
 
+from pcapi.core.educational import factories
+from pcapi.core.educational import models
+from pcapi.core.educational import testing as adage_api_testing
 from pcapi.core.educational.adage_backends.serialize import serialize_collective_offer
-from pcapi.core.educational.factories import CollectiveBookingFactory
-from pcapi.core.educational.factories import CollectiveStockFactory
-from pcapi.core.educational.factories import EducationalInstitutionFactory
-from pcapi.core.educational.factories import EducationalRedactorFactory
-from pcapi.core.educational.models import CollectiveBookingStatus
-from pcapi.core.educational.models import CollectiveOffer
-import pcapi.core.educational.testing as adage_api_testing
-import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
+
+
+STATUSES_ALLOWING_EDIT_INSTITUTION = (models.CollectiveOfferDisplayedStatus.DRAFT,)
+
+STATUSES_NOT_ALLOWING_EDIT_INSTITUTION = tuple(
+    set(models.CollectiveOfferDisplayedStatus)
+    - {*STATUSES_ALLOWING_EDIT_INSTITUTION, models.CollectiveOfferDisplayedStatus.INACTIVE}
+)
 
 
 @pytest.mark.usefixtures("db_session")
@@ -19,8 +24,8 @@ from pcapi.core.testing import override_settings
 class Returns200Test:
     def test_create_offer_institution_link(self, client: Any) -> None:
         # Given
-        institution = EducationalInstitutionFactory()
-        stock = CollectiveStockFactory()
+        institution = factories.EducationalInstitutionFactory()
+        stock = factories.CollectiveStockFactory()
         offer = stock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
 
@@ -31,7 +36,7 @@ class Returns200Test:
 
         # Then
         assert response.status_code == 200
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution == institution
 
         expected_payload = serialize_collective_offer(offer)
@@ -40,8 +45,8 @@ class Returns200Test:
 
     def test_create_offer_institution_link_to_teacher(self, client) -> None:
         # Given
-        institution = EducationalInstitutionFactory(institutionId="0470009E")
-        stock = CollectiveStockFactory()
+        institution = factories.EducationalInstitutionFactory(institutionId="0470009E")
+        stock = factories.CollectiveStockFactory()
         offer = stock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
 
@@ -52,20 +57,20 @@ class Returns200Test:
 
         # Then
         assert response.status_code == 200
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution == institution
         assert offer_db.teacher.email == "maria.sklodowska@example.com"
 
     def test_change_offer_institution_link(self, client: Any) -> None:
         # Given
-        institution1 = EducationalInstitutionFactory()
-        stock = CollectiveStockFactory(
+        institution1 = factories.EducationalInstitutionFactory()
+        stock = factories.CollectiveStockFactory(
             collectiveOffer__institution=institution1,
-            collectiveOffer__teacher=EducationalRedactorFactory(),
+            collectiveOffer__teacher=factories.EducationalRedactorFactory(),
         )
         offer = stock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
-        institution2 = EducationalInstitutionFactory()
+        institution2 = factories.EducationalInstitutionFactory()
 
         # When
         client = client.with_session_auth("pro@example.com")
@@ -74,16 +79,16 @@ class Returns200Test:
 
         # Then
         assert response.status_code == 200
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution == institution2
         assert offer_db.teacher is None
 
     def test_delete_offer_institution_link(self, client: Any) -> None:
         # Given
-        institution = EducationalInstitutionFactory()
-        stock = CollectiveStockFactory(
+        institution = factories.EducationalInstitutionFactory()
+        stock = factories.CollectiveStockFactory(
             collectiveOffer__institution=institution,
-            collectiveOffer__teacher=EducationalRedactorFactory(),
+            collectiveOffer__teacher=factories.EducationalRedactorFactory(),
         )
         offer = stock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
@@ -95,11 +100,27 @@ class Returns200Test:
 
         # Then
         assert response.status_code == 200
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution is None
         assert offer_db.teacher is None
 
         assert len(adage_api_testing.adage_requests) == 0
+
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", STATUSES_ALLOWING_EDIT_INSTITUTION)
+    def test_change_institution_allowed_action(self, client, status) -> None:
+        institution1 = factories.EducationalInstitutionFactory()
+        offer = factories.create_collective_offer_by_status(status=status, institution=institution1)
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
+        institution2 = factories.EducationalInstitutionFactory()
+
+        client = client.with_session_auth("pro@example.com")
+        data = {"educationalInstitutionId": institution2.id}
+        response = client.patch(f"/collective/offers/{offer.id}/educational_institution", json=data)
+
+        assert response.status_code == 200
+        offer = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
+        assert offer.institution == institution2
 
 
 @pytest.mark.usefixtures("db_session")
@@ -107,8 +128,8 @@ class Returns200Test:
 class Returns404Test:
     def test_offer_not_found(self, client: Any) -> None:
         # Given
-        institution = EducationalInstitutionFactory()
-        stock = CollectiveStockFactory()
+        institution = factories.EducationalInstitutionFactory()
+        stock = factories.CollectiveStockFactory()
         offer = stock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
 
@@ -119,12 +140,12 @@ class Returns404Test:
 
         # Then
         assert response.status_code == 404
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution is None
 
     def test_institution_not_found(self, client: Any) -> None:
         # Given
-        stock = CollectiveStockFactory()
+        stock = factories.CollectiveStockFactory()
         offer = stock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
 
@@ -135,7 +156,7 @@ class Returns404Test:
 
         # Then
         assert response.status_code == 404
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution is None
 
 
@@ -144,13 +165,13 @@ class Returns404Test:
 class Returns403Test:
     def test_change_institution_on_uneditable_offer_booking_confirmed(self, client: Any) -> None:
         # Given
-        institution1 = EducationalInstitutionFactory()
-        booking = CollectiveBookingFactory(
-            collectiveStock__collectiveOffer__institution=institution1, status=CollectiveBookingStatus.CONFIRMED
+        institution1 = factories.EducationalInstitutionFactory()
+        booking = factories.CollectiveBookingFactory(
+            collectiveStock__collectiveOffer__institution=institution1, status=models.CollectiveBookingStatus.CONFIRMED
         )
         offer = booking.collectiveStock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
-        institution2 = EducationalInstitutionFactory()
+        institution2 = factories.EducationalInstitutionFactory()
 
         # When
         client = client.with_session_auth("pro@example.com")
@@ -159,18 +180,18 @@ class Returns403Test:
 
         # Then
         assert response.status_code == 403
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution == institution1
 
     def test_change_institution_on_uneditable_offer_booking_reimbused(self, client: Any) -> None:
         # Given
-        institution1 = EducationalInstitutionFactory()
-        booking = CollectiveBookingFactory(
-            collectiveStock__collectiveOffer__institution=institution1, status=CollectiveBookingStatus.REIMBURSED
+        institution1 = factories.EducationalInstitutionFactory()
+        booking = factories.CollectiveBookingFactory(
+            collectiveStock__collectiveOffer__institution=institution1, status=models.CollectiveBookingStatus.REIMBURSED
         )
         offer = booking.collectiveStock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
-        institution2 = EducationalInstitutionFactory()
+        institution2 = factories.EducationalInstitutionFactory()
 
         # When
         client = client.with_session_auth("pro@example.com")
@@ -179,18 +200,18 @@ class Returns403Test:
 
         # Then
         assert response.status_code == 403
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution == institution1
 
     def test_change_institution_on_uneditable_offer_booking_used(self, client: Any) -> None:
         # Given
-        institution1 = EducationalInstitutionFactory()
-        booking = CollectiveBookingFactory(
-            collectiveStock__collectiveOffer__institution=institution1, status=CollectiveBookingStatus.USED
+        institution1 = factories.EducationalInstitutionFactory()
+        booking = factories.CollectiveBookingFactory(
+            collectiveStock__collectiveOffer__institution=institution1, status=models.CollectiveBookingStatus.USED
         )
         offer = booking.collectiveStock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
-        institution2 = EducationalInstitutionFactory()
+        institution2 = factories.EducationalInstitutionFactory()
 
         # When
         client = client.with_session_auth("pro@example.com")
@@ -199,13 +220,46 @@ class Returns403Test:
 
         # Then
         assert response.status_code == 403
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution == institution1
+
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", STATUSES_NOT_ALLOWING_EDIT_INSTITUTION)
+    def test_change_institution_unallowed_action(self, client, status) -> None:
+        institution1 = factories.EducationalInstitutionFactory()
+        offer = factories.create_collective_offer_by_status(status=status, institution=institution1)
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
+        institution2 = factories.EducationalInstitutionFactory()
+
+        client = client.with_session_auth("pro@example.com")
+        data = {"educationalInstitutionId": institution2.id}
+        response = client.patch(f"/collective/offers/{offer.id}/educational_institution", json=data)
+
+        assert response.status_code == 403
+        assert response.json == {"offer": ["Cette action n'est pas autorisée sur cette offre"]}
+        offer = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
+        assert offer.institution == institution1
+
+    @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    def test_change_institution_ended(self, client) -> None:
+        institution1 = factories.EducationalInstitutionFactory()
+        offer = factories.EndedNotUsedCollectiveOfferFactory(institution=institution1)
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
+        institution2 = factories.EducationalInstitutionFactory()
+
+        client = client.with_session_auth("pro@example.com")
+        data = {"educationalInstitutionId": institution2.id}
+        response = client.patch(f"/collective/offers/{offer.id}/educational_institution", json=data)
+
+        assert response.status_code == 403
+        assert response.json == {"offer": ["Cette action n'est pas autorisée sur cette offre"]}
+        offer = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
+        assert offer.institution == institution1
 
     def test_add_institution_link_on_pending_offer(self, client: Any) -> None:
         # Given
-        institution = EducationalInstitutionFactory()
-        stock = CollectiveStockFactory(collectiveOffer__validation="PENDING")
+        institution = factories.EducationalInstitutionFactory()
+        stock = factories.CollectiveStockFactory(collectiveOffer__validation="PENDING")
         offer = stock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
 
@@ -216,15 +270,15 @@ class Returns403Test:
 
         # Then
         assert response.status_code == 403
-        offer_db = CollectiveOffer.query.filter(CollectiveOffer.id == offer.id).one()
+        offer_db = models.CollectiveOffer.query.filter(models.CollectiveOffer.id == offer.id).one()
         assert offer_db.institution is None
 
         assert len(adage_api_testing.adage_requests) == 0
 
     def test_offer_institution_link_institution_not_active(self, client: Any) -> None:
         # Given
-        institution = EducationalInstitutionFactory(isActive=False)
-        stock = CollectiveStockFactory()
+        institution = factories.EducationalInstitutionFactory(isActive=False)
+        stock = factories.CollectiveStockFactory()
         offer = stock.collectiveOffer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33285

Partie 1 des actions sur les offres réservables :
- edit institution
- duplicate
- cancel booking
- archive

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
