### PR TITLE
(PC-33385)[API]  feat: routes get offerer headline offer

### DIFF
--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -77,6 +77,10 @@ class OffererAddressCreationError(Exception):
     pass
 
 
+class TooManyHeadlineOffersForOfferer(Exception):
+    pass
+
+
 class CannotSuspendOffererWithBookingsException(ClientError):
     def __init__(self) -> None:
         super().__init__(

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -50,6 +50,8 @@ from pcapi.connectors.big_query.queries.offerer_stats import TopOffersData
 from pcapi.core.educational import models as educational_models
 import pcapi.core.finance.models as finance_models
 from pcapi.core.geography import models as geography_models
+from pcapi.core.offerers.schemas import BannerMetaModel
+from pcapi.core.offerers.schemas import VenueTypeCode
 from pcapi.models import Base
 from pcapi.models import Model
 from pcapi.models import db
@@ -60,8 +62,6 @@ from pcapi.models.has_address_mixin import HasAddressMixin
 from pcapi.models.has_thumb_mixin import HasThumbMixin
 from pcapi.models.pc_object import PcObject
 from pcapi.models.validation_status_mixin import ValidationStatusMixin
-from pcapi.routes.native.v1.serialization.offerers import BannerMetaModel
-from pcapi.routes.native.v1.serialization.offerers import VenueTypeCode
 from pcapi.utils import crypto
 from pcapi.utils import regions as regions_utils
 from pcapi.utils import siren as siren_utils

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -882,3 +882,25 @@ def get_offerer_address_of_offerer(offerer_id: int, offerer_address_id: int) -> 
         )
         .one_or_none()
     )
+
+
+def get_offerer_headline_offer(offerer_id: int) -> offers_models.Offer | None:
+    try:
+        # FIXME: ogeber: when offers will be able to have several headline offers, and unicity of the headline
+        # offer will be on its active status, change this query and add a filter on active headline offer only
+        offer = (
+            offers_models.Offer.query.join(models.Venue, offers_models.Offer.venueId == models.Venue.id)
+            .join(models.Offerer, models.Venue.managingOffererId == models.Offerer.id)
+            .join(offers_models.HeadlineOffer, offers_models.HeadlineOffer.offerId == offers_models.Offer.id)
+            .options(
+                sqla_orm.contains_eager(offers_models.Offer.headlineOffer),
+                sqla_orm.joinedload(offers_models.Offer.mediations),
+                sqla_orm.joinedload(offers_models.Offer.product).joinedload(offers_models.Product.productMediations),
+            )
+            .filter(models.Offerer.id == offerer_id)
+            .one_or_none()
+        )
+
+    except sqla_orm.exc.MultipleResultsFound:
+        raise exceptions.TooManyHeadlineOffersForOfferer
+    return offer

--- a/api/src/pcapi/core/offerers/schemas.py
+++ b/api/src/pcapi/core/offerers/schemas.py
@@ -1,3 +1,4 @@
+import enum
 import re
 import typing
 
@@ -119,3 +120,55 @@ class AddressBodyModel(BaseModel):
     postalCode: VenuePostalCode
     street: VenueAddress
     isManualEdition: bool = False
+
+
+class BannerMetaModel(typing.TypedDict, total=False):
+    image_credit: VenueImageCredit | None
+    image_credit_url: str | None
+    is_from_google: bool
+
+
+class VenueTypeCode(enum.Enum):
+    ADMINISTRATIVE = "Lieu administratif"
+    ARTISTIC_COURSE = "Cours et pratique artistiques"
+    BOOKSTORE = "Librairie"
+    CONCERT_HALL = "Musique - Salle de concerts"
+    CREATIVE_ARTS_STORE = "Magasin arts créatifs"
+    CULTURAL_CENTRE = "Centre culturel"
+    DIGITAL = "Offre numérique"
+    DISTRIBUTION_STORE = "Magasin de distribution de produits culturels"
+    FESTIVAL = "Festival"
+    GAMES = "Jeux / Jeux vidéos"
+    LIBRARY = "Bibliothèque ou médiathèque"
+    MOVIE = "Cinéma - Salle de projections"
+    MUSEUM = "Musée"
+    MUSICAL_INSTRUMENT_STORE = "Musique - Magasin d’instruments"
+    OTHER = "Autre"
+    PATRIMONY_TOURISM = "Patrimoine et tourisme"
+    PERFORMING_ARTS = "Spectacle vivant"
+    RECORD_STORE = "Musique - Disquaire"
+    SCIENTIFIC_CULTURE = "Culture scientifique"
+    TRAVELING_CINEMA = "Cinéma itinérant"
+    VISUAL_ARTS = "Arts visuels, arts plastiques et galeries"
+
+    # These methods are used by pydantic in order to return the enum name and validate the value
+    # instead of returning the enum directly.
+    @classmethod
+    def __get_validators__(cls) -> typing.Iterator[typing.Callable]:
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: str | enum.Enum) -> str:
+        if isinstance(value, enum.Enum):
+            value = value.name
+
+        if not hasattr(cls, value):
+            raise ValueError(f"{value}: invalide")
+
+        return value
+
+
+VenueTypeCodeKey = enum.Enum(  # type: ignore[misc]
+    "VenueTypeCodeKey",
+    {code.name: code.name for code in VenueTypeCode},
+)

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -18,6 +18,7 @@ import pcapi.core.educational.api.national_program as np_api
 from pcapi.core.finance import repository as finance_repository
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.repository import find_venue_by_id
+from pcapi.core.offerers.schemas import VenueTypeCode
 from pcapi.core.offers import exceptions
 from pcapi.core.offers import models
 from pcapi.core.offers import repository
@@ -27,7 +28,6 @@ from pcapi.domain import show_types
 from pcapi.models import api_errors
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_mixin import OfferValidationStatus
-from pcapi.routes.native.v1.serialization.offerers import VenueTypeCode
 from pcapi.routes.serialization import stock_serialize as serialization
 from pcapi.utils import date
 

--- a/api/src/pcapi/routes/native/v1/offerers.py
+++ b/api/src/pcapi/routes/native/v1/offerers.py
@@ -1,6 +1,8 @@
 from flask import abort
 
 from pcapi.core.offerers.models import Venue
+import pcapi.core.offerers.repository as offerers_repository
+from pcapi.repository import atomic
 from pcapi.serialization.decorator import spectree_serialize
 
 from .. import blueprint
@@ -16,3 +18,17 @@ def get_venue(venue_id: int) -> serializers.VenueResponse:
         abort(404)
 
     return serializers.VenueResponse.from_orm(venue)
+
+
+@blueprint.native_route("/offerer/<int:offerer_id>/headline-offer", methods=["GET"])
+@atomic()
+@spectree_serialize(
+    response_model=serializers.OffererHeadLineOfferResponseModel, api=blueprint.api, on_error_statuses=[404]
+)
+def get_offerer_headline_offer(
+    offerer_id: int,
+) -> serializers.OffererHeadLineOfferResponseModel:
+    offerer_headline_offer = offerers_repository.get_offerer_headline_offer(offerer_id)
+    if not offerer_headline_offer:
+        abort(404)
+    return serializers.OffererHeadLineOfferResponseModel.from_orm(offerer_headline_offer)

--- a/api/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -4,6 +4,7 @@ import typing
 import pydantic.v1 as pydantic_v1
 
 from pcapi.core.offerers import schemas as offerers_schemas
+from pcapi.core.offers import models as offers_models
 from pcapi.core.subscription.phone_validation import exceptions as phone_validation_exceptions
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import base
@@ -66,3 +67,12 @@ class VenueResponse(base.BaseVenueResponse):
 
     class Config:
         getter_dict = VenueResponseGetterDict
+
+
+class OffererHeadLineOfferResponseModel(BaseModel):
+    id: int
+    name: str
+    image: offers_models.OfferImage | None
+
+    class Config:
+        orm_mode = True

--- a/api/src/pcapi/routes/native/v1/serialization/offerers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offerers.py
@@ -1,4 +1,3 @@
-import enum
 import logging
 import typing
 
@@ -12,58 +11,6 @@ from pcapi.utils import phone_number as phone_number_utils
 
 
 logger = logging.getLogger(__name__)
-
-
-class VenueTypeCode(enum.Enum):
-    ADMINISTRATIVE = "Lieu administratif"
-    ARTISTIC_COURSE = "Cours et pratique artistiques"
-    BOOKSTORE = "Librairie"
-    CONCERT_HALL = "Musique - Salle de concerts"
-    CREATIVE_ARTS_STORE = "Magasin arts créatifs"
-    CULTURAL_CENTRE = "Centre culturel"
-    DIGITAL = "Offre numérique"
-    DISTRIBUTION_STORE = "Magasin de distribution de produits culturels"
-    FESTIVAL = "Festival"
-    GAMES = "Jeux / Jeux vidéos"
-    LIBRARY = "Bibliothèque ou médiathèque"
-    MOVIE = "Cinéma - Salle de projections"
-    MUSEUM = "Musée"
-    MUSICAL_INSTRUMENT_STORE = "Musique - Magasin d’instruments"
-    OTHER = "Autre"
-    PATRIMONY_TOURISM = "Patrimoine et tourisme"
-    PERFORMING_ARTS = "Spectacle vivant"
-    RECORD_STORE = "Musique - Disquaire"
-    SCIENTIFIC_CULTURE = "Culture scientifique"
-    TRAVELING_CINEMA = "Cinéma itinérant"
-    VISUAL_ARTS = "Arts visuels, arts plastiques et galeries"
-
-    # These methods are used by pydantic in order to return the enum name and validate the value
-    # instead of returning the enum directly.
-    @classmethod
-    def __get_validators__(cls) -> typing.Iterator[typing.Callable]:
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, value: str | enum.Enum) -> str:
-        if isinstance(value, enum.Enum):
-            value = value.name
-
-        if not hasattr(cls, value):
-            raise ValueError(f"{value}: invalide")
-
-        return value
-
-
-VenueTypeCodeKey = enum.Enum(  # type: ignore[misc]
-    "VenueTypeCodeKey",
-    {code.name: code.name for code in VenueTypeCode},
-)
-
-
-class BannerMetaModel(typing.TypedDict, total=False):
-    image_credit: offerers_schemas.VenueImageCredit | None
-    image_credit_url: str | None
-    is_from_google: bool
 
 
 class VenueAccessibilityModel(BaseModel):
@@ -112,8 +59,8 @@ class VenueResponse(base.BaseVenueResponse):
     id: int
     address: str | None
     accessibility: VenueAccessibilityModel
-    venueTypeCode: VenueTypeCodeKey
-    bannerMeta: BannerMetaModel | None
+    venueTypeCode: offerers_schemas.VenueTypeCodeKey
+    bannerMeta: offerers_schemas.BannerMetaModel | None
     timezone: str
     contact: VenueContactModel | None
 

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -415,3 +415,12 @@ class OffererAddressResponseModel(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class OffererHeadLineOfferResponseModel(BaseModel):
+    id: int
+    name: str
+    image: offers_models.OfferImage | None
+
+    class Config:
+        orm_mode = True

--- a/api/tests/core/offerers/test_repository.py
+++ b/api/tests/core/offerers/test_repository.py
@@ -271,3 +271,32 @@ class GetOffererAddressesTest:
         results = query.all()
         assert len(results) == 2
         assert {r.id for r in results} == {offerer_address_with_one_offer.id, offerer_address_with_two_offers.id}
+
+
+class GetOffererHeadlineOfferTest:
+    def test_return_headline_offer(self):
+        offer = offers_factories.OfferFactory()
+        offers_factories.HeadlineOfferFactory(offer=offer, venue=offer.venue)
+
+        headline_offer = repository.get_offerer_headline_offer(offer.venue.managingOffererId)
+
+        assert headline_offer.id == offer.id
+
+    def test_shoud_not_return_several_headline_offer(self):
+        offerer = offerers_factories.OffererFactory()
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        other_venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        offer = offers_factories.OfferFactory(venue=venue)
+        other_offer = offers_factories.OfferFactory(venue=other_venue)
+        offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
+        offers_factories.HeadlineOfferFactory(offer=other_offer, venue=other_venue)
+
+        with pytest.raises(exceptions.TooManyHeadlineOffersForOfferer):
+            repository.get_offerer_headline_offer(offerer.id)
+
+    def test_returns_no_headline_offer(self):
+        offerer = offerers_factories.OffererFactory()
+
+        headline_offer = repository.get_offerer_headline_offer(offerer.id)
+
+        assert headline_offer == None

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -11,6 +11,7 @@ from pcapi.core.educational.models import StudentLevels
 import pcapi.core.geography.factories as geography_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
+from pcapi.core.offerers.schemas import VenueTypeCode
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
 from pcapi.core.providers.constants import BookFormat
@@ -18,7 +19,6 @@ from pcapi.core.search.backends import algolia
 from pcapi.core.testing import override_features
 from pcapi.core.testing import override_settings
 from pcapi.routes.adage_iframe.serialization.offers import OfferAddressType
-from pcapi.routes.native.v1.serialization.offerers import VenueTypeCode
 from pcapi.utils.human_ids import humanize
 
 

--- a/api/tests/routes/native/openapi_test.py
+++ b/api/tests/routes/native/openapi_test.py
@@ -1331,6 +1331,23 @@ def test_public_api(client):
                     "title": "OfferExtraDataResponse",
                     "type": "object",
                 },
+                "OfferImage": {
+                    "properties": {
+                        "credit": {
+                            "title": "Credit",
+                            "type": "string",
+                        },
+                        "url": {
+                            "title": "Url",
+                            "type": "string",
+                        },
+                    },
+                    "required": [
+                        "url",
+                    ],
+                    "title": "OfferImage",
+                    "type": "object",
+                },
                 "OfferImageResponse": {
                     "properties": {
                         "credit": {"nullable": True, "title": "Credit", "type": "string"},
@@ -1607,6 +1624,32 @@ def test_public_api(client):
                     },
                     "required": ["id", "offerer", "name", "coordinates", "isPermanent", "timezone"],
                     "title": "OfferVenueResponse",
+                    "type": "object",
+                },
+                "OffererHeadLineOfferResponseModel": {
+                    "properties": {
+                        "id": {
+                            "title": "Id",
+                            "type": "integer",
+                        },
+                        "image": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/OfferImage",
+                                },
+                            ],
+                            "nullable": True,
+                        },
+                        "name": {
+                            "title": "Name",
+                            "type": "string",
+                        },
+                    },
+                    "required": [
+                        "id",
+                        "name",
+                    ],
+                    "title": "OffererHeadLineOfferResponseModel",
                     "type": "object",
                 },
                 "OffersStocksRequest": {
@@ -3710,6 +3753,54 @@ def test_public_api(client):
                     "summary": "report_offer <POST>",
                     "tags": [],
                 }
+            },
+            "/native/v1/offerer/{offerer_id}/headline-offer": {
+                "get": {
+                    "description": "",
+                    "operationId": "get__native_v1_offerer_{offerer_id}_headline-offer",
+                    "parameters": [
+                        {
+                            "description": "",
+                            "in": "path",
+                            "name": "offerer_id",
+                            "required": True,
+                            "schema": {
+                                "format": "int32",
+                                "type": "integer",
+                            },
+                        },
+                    ],
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/OffererHeadLineOfferResponseModel",
+                                    },
+                                },
+                            },
+                            "description": "OK",
+                        },
+                        "403": {
+                            "description": "Forbidden",
+                        },
+                        "404": {
+                            "description": "Not Found",
+                        },
+                        "422": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/ValidationError",
+                                    },
+                                },
+                            },
+                            "description": "Unprocessable Entity",
+                        },
+                    },
+                    "summary": "get_offerer_headline_offer <GET>",
+                    "tags": [],
+                },
             },
             "/native/v1/offers/reports": {
                 "get": {

--- a/api/tests/routes/native/v1/offerers_test.py
+++ b/api/tests/routes/native/v1/offerers_test.py
@@ -1,8 +1,10 @@
 import pytest
 
 from pcapi.connectors.acceslibre import ExpectedFieldsEnum as acceslibre_enum
+from pcapi.core import testing
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offerers.models import VenueTypeCode
+import pcapi.core.offers.factories as offers_factories
 from pcapi.core.testing import assert_num_queries
 
 
@@ -196,3 +198,38 @@ class VenuesTest:
         with assert_num_queries(self.expected_num_queries):
             response = client.get(f"/native/v1/venue/{venue_id}")
             assert response.status_code == 200
+
+
+class OffererHeadlineOfferTest:
+    num_queries = testing.AUTHENTICATION_QUERIES
+    num_queries += 1  # check user_offerer
+    num_queries += 1  # get headline offer
+
+    def test_get_offerer_headline_offer_success(self, client):
+        user_offerer = offerers_factories.UserOffererFactory()
+        pro = user_offerer.user
+        offerer = user_offerer.offerer
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        offer = offers_factories.OfferFactory(venue=venue)
+        offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
+
+        client = client.with_session_auth(email=pro.email)
+        with assert_num_queries(self.num_queries):
+            response = client.get(f"/offerers/{offerer.id}/headline-offer")
+
+        assert response.status_code == 200
+        assert response.json == {
+            "name": offer.name,
+            "id": offer.id,
+            "image": offer.image,
+        }
+
+    def test_get_offerer_headline_offer_not_found(self, client):
+        user_offerer = offerers_factories.UserOffererFactory()
+        pro = user_offerer.user
+        offerer = user_offerer.offerer
+
+        client = client.with_session_auth(email=pro.email)
+        with assert_num_queries(self.num_queries + 1):  # +1 for atomic rollback
+            response = client.get(f"/offerers/{offerer.id}/headline-offer")
+            assert response.status_code == 404

--- a/api/tests/routes/pro/get_offerer_headline_offer_test.py
+++ b/api/tests/routes/pro/get_offerer_headline_offer_test.py
@@ -1,0 +1,103 @@
+import pytest
+
+from pcapi.core import testing
+from pcapi.core.categories import subcategories_v2
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.offers.models import GcuCompatibilityType
+from pcapi.core.offers.models import TiteliveImageType
+from pcapi.core.testing import assert_num_queries
+from pcapi.core.users import factories as users_factories
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class Return200Test:
+    num_queries = testing.AUTHENTICATION_QUERIES
+    num_queries += 1  # check user_offerer exists
+    num_queries += 1  # select offer that is headline
+
+    def test_get_offerer_headline_offer_success(self, client):
+        user_offerer = offerers_factories.UserOffererFactory()
+        pro = user_offerer.user
+        offerer = user_offerer.offerer
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        offer = offers_factories.OfferFactory(venue=venue)
+        offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
+        client = client.with_session_auth(email=pro.email)
+        offerer_id = offerer.id
+        with assert_num_queries(self.num_queries):
+            response = client.get(f"/offerers/{offerer_id}/headline-offer")
+
+        assert response.status_code == 200
+        assert response.json == {
+            "name": offer.name,
+            "id": offer.id,
+            "image": offer.image,
+        }
+
+    def test_get_offerer_headline_offer_with_product_mediations(self, client):
+        user_offerer = offerers_factories.UserOffererFactory()
+        pro = user_offerer.user
+        offerer = user_offerer.offerer
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        product = offers_factories.ProductFactory(
+            name="Les Héritiers",
+            description="Les étudiants et la culture",
+            subcategoryId=subcategories_v2.LIVRE_PAPIER.id,
+            gcuCompatibilityType=GcuCompatibilityType.COMPATIBLE,
+        )
+        offers_factories.ProductMediationFactory(product=product, imageType=TiteliveImageType.RECTO)
+        offers_factories.ProductMediationFactory(product=product, imageType=TiteliveImageType.VERSO)
+
+        offer = offers_factories.OfferFactory(venue=venue, product=product)
+        offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
+        client = client.with_session_auth(email=pro.email)
+        offerer_id = offerer.id
+        with assert_num_queries(self.num_queries):
+            response = client.get(f"/offerers/{offerer_id}/headline-offer")
+            assert response.status_code == 200
+
+
+class Return400Test:
+    num_queries = testing.AUTHENTICATION_QUERIES
+    num_queries += 1  # check user_offerer
+    num_queries += 1  # get headline offer
+    num_queries += 1  # rollback (atomic)
+
+    def test_access_by_unauthorized_pro_user(self, client):
+        pro = users_factories.ProFactory()
+        offerer = offerers_factories.OffererFactory()
+        client = client.with_session_auth(email=pro.email)
+        offerer_id = offerer.id
+        with assert_num_queries(self.num_queries - 1):  # unauthorized, so no query to headline offer made
+            response = client.get(f"/offerers/{offerer_id}/headline-offer")
+            assert response.status_code == 403
+
+    def test_get_offerer_headline_offer_not_found(self, client):
+        user_offerer = offerers_factories.UserOffererFactory()
+        pro = user_offerer.user
+        offerer = user_offerer.offerer
+        client = client.with_session_auth(email=pro.email)
+        offerer_id = offerer.id
+        with assert_num_queries(self.num_queries):
+            response = client.get(f"/offerers/{offerer_id}/headline-offer")
+            assert response.status_code == 404
+
+    def test_with_multiple_headline_offer_on_one_offerer_should_fail(self, client):
+        user_offerer = offerers_factories.UserOffererFactory()
+        pro = user_offerer.user
+        offerer = user_offerer.offerer
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        offer = offers_factories.OfferFactory(venue=venue)
+        offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
+        other_venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+        other_offer = offers_factories.OfferFactory(venue=other_venue)
+        offers_factories.HeadlineOfferFactory(offer=other_offer, venue=other_venue)
+        client = client.with_session_auth(email=pro.email)
+        offerer_id = offerer.id
+        with assert_num_queries(self.num_queries):
+            response = client.get(f"/offerers/{offerer_id}/headline-offer")
+            assert response.status_code == 404
+            assert response.json == {"global": "Une entité juridique ne peut avoir qu’une seule offre à la une"}

--- a/api/tests/routes/pro/patch_draft_offer_test.py
+++ b/api/tests/routes/pro/patch_draft_offer_test.py
@@ -7,6 +7,7 @@ from pcapi.connectors import api_adresse
 from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.geography import models as geography_models
 import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.offerers.schemas import VenueTypeCode
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import OfferStatus
@@ -14,7 +15,6 @@ import pcapi.core.providers.factories as providers_factories
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
-from pcapi.routes.native.v1.serialization.offerers import VenueTypeCode
 from pcapi.utils.date import format_into_utc_date
 
 

--- a/api/tests/routes/pro/post_draft_offer_test.py
+++ b/api/tests/routes/pro/post_draft_offer_test.py
@@ -2,11 +2,11 @@ import pytest
 
 from pcapi.core.categories import subcategories_v2 as subcategories
 import pcapi.core.offerers.factories as offerers_factories
+from pcapi.core.offerers.schemas import VenueTypeCode
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import Offer
 from pcapi.core.testing import override_features
 import pcapi.core.users.factories as users_factories
-from pcapi.routes.native.v1.serialization.offerers import VenueTypeCode
 
 
 @pytest.mark.usefixtures("db_session")

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -180,6 +180,7 @@ export type { OfferDomain } from './models/OfferDomain';
 export type { OffererAddressRequestModel } from './models/OffererAddressRequestModel';
 export type { OffererAddressResponseModel } from './models/OffererAddressResponseModel';
 export type { OffererApiKey } from './models/OffererApiKey';
+export type { OffererHeadLineOfferResponseModel } from './models/OffererHeadLineOfferResponseModel';
 export { OffererMemberStatus } from './models/OffererMemberStatus';
 export type { OffererStatsDataModel } from './models/OffererStatsDataModel';
 export type { OffererStatsResponseModel } from './models/OffererStatsResponseModel';

--- a/pro/src/apiClient/v1/models/OffererHeadLineOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/OffererHeadLineOfferResponseModel.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { OfferImage } from './OfferImage';
+export type OffererHeadLineOfferResponseModel = {
+  id: number;
+  image?: OfferImage | null;
+  name: string;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -72,6 +72,7 @@ import type { LoginUserBodyModel } from '../models/LoginUserBodyModel';
 import type { NewPasswordBodyModel } from '../models/NewPasswordBodyModel';
 import type { OffererAddressRequestModel } from '../models/OffererAddressRequestModel';
 import type { OffererAddressResponseModel } from '../models/OffererAddressResponseModel';
+import type { OffererHeadLineOfferResponseModel } from '../models/OffererHeadLineOfferResponseModel';
 import type { OffererStatsResponseModel } from '../models/OffererStatsResponseModel';
 import type { OfferStatus } from '../models/OfferStatus';
 import type { PatchAllOffersActiveStatusBodyModel } from '../models/PatchAllOffersActiveStatusBodyModel';
@@ -1494,6 +1495,27 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'GET',
       url: '/offerers/{offerer_id}/dashboard',
+      path: {
+        'offerer_id': offererId,
+      },
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
+   * get_offerer_headline_offer <GET>
+   * @param offererId
+   * @returns OffererHeadLineOfferResponseModel OK
+   * @throws ApiError
+   */
+  public getOffererHeadlineOffer(
+    offererId: number,
+  ): CancelablePromise<OffererHeadLineOfferResponseModel> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/offerers/{offerer_id}/headline-offer',
       path: {
         'offerer_id': offererId,
       },


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33385

- création des deux routes
- dépacement de `BannerMetaModel` et `VenueTypeCode` pour résoudre un import circulaire

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
