### PR TITLE
(BSR)[PRO] test: more specific waits for adage confirmation

### DIFF
--- a/pro/cypress/e2e/adageConfirmation.cy.ts
+++ b/pro/cypress/e2e/adageConfirmation.cy.ts
@@ -18,17 +18,25 @@ import {
         offer = response.body.offer
         providerApiKey = response.body.providerApiKey
       })
-      cy.intercept({ method: 'GET', url: '/collective/offers*' }).as(
+      cy.intercept({ method: 'GET', url: '/collective/offers?offererId=1' }).as(
         'collectiveOffers'
       )
-      cy.intercept({ method: 'GET', url: /\/collective\/offers\/[1-9]+/ }).as(
+      cy.intercept({
+        method: 'GET',
+        url: '/collective/offers?offererId=1&status=BOOKED',
+      }).as('collectiveOffersBOOKED')
+      cy.intercept({
+        method: 'GET',
+        url: '/collective/offers?offererId=1&status=PREBOOKED',
+      }).as('collectiveOffersPREBOOKED')
+      cy.intercept({ method: 'GET', url: '/collective/offers/1' }).as(
         'collectiveOfferDetails'
       )
     })
   
     it('I should be able to search with several filters and see expected results', () => {
       logInAndGoToPage(login, '/offres/collectives')
-      cy.wait('@collectiveOffers')
+      cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
 
       cy.stepLog({ message: 'I click on the offer' })
 
@@ -64,7 +72,9 @@ import {
 
         cy.stepLog({ message: 'I validate my filters' })
         cy.findByText('Rechercher').click()
-        cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+        cy.wait('@collectiveOffersPREBOOKED')
+          .its('response.statusCode')
+          .should('eq', 200)
 
         let expectedResults = [
           ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
@@ -111,7 +121,9 @@ import {
         cy.stepLog({ message: 'I validate my filters' })
 
         cy.findByText('Rechercher').click()
-        cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+        cy.wait('@collectiveOffersBOOKED')
+          .its('response.statusCode')
+          .should('eq', 200)
 
         expectedResults = [
           ['', 'Titre', 'Lieu', 'Établissement', 'Statut'],


### PR DESCRIPTION
## But de la pull request

Test adage confirmation flaky, j'ai ici précisé les intercept plus précisément pour qu'ils ne soient pas détectés plusieurs fois.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
