### PR TITLE
(PC-33581)[BO] fix: timeout when filtering by email domain

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-741084b8cec2 (pre) (head)
-ffc1d7402c8a (post) (head)
+1343aeafc182 (pre) (head)
+9803f6ec13df (post) (head)

--- a/api/src/pcapi/alembic/versions/20241213T125457_1343aeafc182_create_function_email_domain.py
+++ b/api/src/pcapi/alembic/versions/20241213T125457_1343aeafc182_create_function_email_domain.py
@@ -1,0 +1,32 @@
+"""create SQL function: email_domain
+"""
+
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "1343aeafc182"
+down_revision = "741084b8cec2"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE OR REPLACE FUNCTION public.email_domain(text)
+                RETURNS text
+                LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT AS
+            $$
+                SELECT substring($1 from '@(.*)$')
+            $$
+            ;
+            """
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("""DROP FUNCTION IF EXISTS public.email_domain;""")

--- a/api/src/pcapi/alembic/versions/20241213T130718_9803f6ec13df_create_index_user_email_domain.py
+++ b/api/src/pcapi/alembic/versions/20241213T130718_9803f6ec13df_create_index_user_email_domain.py
@@ -1,0 +1,38 @@
+"""Create index: email_domain(user.email)
+"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "9803f6ec13df"
+down_revision = "ffc1d7402c8a"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Tested on staging: 58 seconds
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS
+            "ix_user_email_domain" ON public."user"
+            USING btree (email_domain(email));
+            """
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            index_name="ix_user_email_domain",
+            table_name="user",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -227,6 +227,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
             sa.func.immutable_unaccent(firstName + " " + lastName),
             postgresql_using="gin",
         ),
+        sa.Index("ix_user_email_domain", sa.func.email_domain(email)),
     )
 
     def __init__(self, **kwargs: typing.Any) -> None:

--- a/api/src/pcapi/routes/backoffice/fraud/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/fraud/blueprint.py
@@ -74,7 +74,7 @@ def _filter_non_pro_by_domain_name_query(domain_name: str) -> BaseQuery:
         sa.not_(users_models.User.isActive.is_(False)),
         sa.not_(users_models.User.has_pro_role),
         sa.not_(users_models.User.has_non_attached_pro_role),
-        users_models.User.email.like(f"%@{domain_name.lower()}"),
+        sa.func.email_domain(users_models.User.email) == domain_name.lower(),
     )
 
 
@@ -92,7 +92,7 @@ def _list_untouched_pro_accounts(domain_name: str) -> list[str]:
             users_models.User.has_pro_role,
             users_models.User.has_non_attached_pro_role,
         ),
-        users_models.User.email.like(f"%@{domain_name.lower()}"),
+        sa.func.email_domain(users_models.User.email) == domain_name.lower(),
     ).options(sa.orm.load_only(users_models.User.id, users_models.User.email))
 
     return sorted(query, key=attrgetter("email"))


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-33581

```
pcapi-staging> explain analyze select email from "user" where email like '%@passculture.app';
+-------------------------------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                                                  |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Gather  (cost=1000.56..591798.83 rows=744 width=28) (actual time=0.543..27953.140 rows=679 loops=1)                                                         |
|   Workers Planned: 2                                                                                                                                        |
|   Workers Launched: 2                                                                                                                                       |
|   ->  Parallel Index Only Scan using user_email_key on "user"  (cost=0.56..590724.43 rows=310 width=28) (actual time=18592.306..27941.509 rows=226 loops=3) |
|         Filter: ((email)::text ~~ '%@passculture.app'::text)                                                                                                |
|         Rows Removed by Filter: 2478735                                                                                                                     |
|         Heap Fetches: 41944                                                                                                                                 |
| Planning Time: 0.200 ms                                                                                                                                     |
| Execution Time: 27953.274 ms                                                                                                                                |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN 9
Time: 27.966s (27 seconds), executed in: 27.958s (27 seconds)


pcapi-staging> explain analyze select email from "user" where email_domain(email) = 'passculture.app';
+-------------------------------------------------------------------------------------------------------------------------------------+
| QUERY PLAN                                                                                                                          |
|-------------------------------------------------------------------------------------------------------------------------------------|
| Bitmap Heap Scan on "user"  (cost=420.61..122692.41 rows=37184 width=28) (actual time=0.210..1.045 rows=679 loops=1)                |
|   Recheck Cond: ("substring"((email)::text, '@(.*)$'::text) = 'passculture.app'::text)                                              |
|   Heap Blocks: exact=606                                                                                                            |
|   ->  Bitmap Index Scan on ix_user_email_domain  (cost=0.00..411.31 rows=37184 width=0) (actual time=0.109..0.110 rows=679 loops=1) |
|         Index Cond: ("substring"((email)::text, '@(.*)$'::text) = 'passculture.app'::text)                                          |
| Planning Time: 1.127 ms                                                                                                             |
| Execution Time: 1.189 ms                                                                                                            |
+-------------------------------------------------------------------------------------------------------------------------------------+
EXPLAIN 7
Time: 0.015s
```



## Vérifications

- [x] J'ai vérifié l'absence de régression en exécutant les tests existants
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
