### PR TITLE
(BSR) test: use timedelta instead of replace in a test

### DIFF
--- a/api/tests/routes/pro/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/post_collective_offers_template_test.py
@@ -199,7 +199,7 @@ class Returns200Test:
         assert response.status_code == 201
         offer = CollectiveOfferTemplate.query.filter_by(id=response.json["id"]).one()
         assert offer.dateRange.lower == now
-        assert offer.dateRange.upper == now.replace(second=now.second + 1)
+        assert offer.dateRange.upper == now + timedelta(seconds=1)
 
 
 class Returns403Test:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : utiliser timedelta plutôt que replace pour ne pas planter 1 seconde sur 60

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
