### PR TITLE
(PC-33613)[PRO] fix: Dont dl the search-insights lib automatically.

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -22,7 +22,10 @@ import { useDispatch } from 'react-redux'
 
 import { SuggestionType } from 'apiClient/adage'
 import { apiAdage } from 'apiClient/api'
-import { setAdagePageSaved, setAdageQuery } from 'commons/store/adageFilter/reducer'
+import {
+  setAdagePageSaved,
+  setAdageQuery,
+} from 'commons/store/adageFilter/reducer'
 import {
   ALGOLIA_API_KEY,
   ALGOLIA_APP_ID,
@@ -270,7 +273,6 @@ export const Autocomplete = ({
         KeyboardEvent
       >({
         initialState: instantSearchUiState,
-        insights: true,
         openOnFocus: true,
         onStateChange: ({ state }) => {
           setInstantSearchUiState(state)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33613

**Objectif**
Désactiver le téléchargement automatique de la lib `search-insight` au moment de l'initialisation de l'autocomplete algolia. La lib search-insight est déjà dans nos dépendances.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
