### PR TITLE
(BSR)[PRO] test: expect shows real comparison

### DIFF
--- a/pro/cypress/support/helpers.ts
+++ b/pro/cypress/support/helpers.ts
@@ -46,8 +46,7 @@ export function expectOffersOrBookingsAreFound(
               .eq(column)
               .then((cellValue) => {
                 if (lineArray[column].length) {
-                  let isAMatch: boolean = cellValue.text().includes(lineArray[column])
-                  expect(isAMatch).to.be.true
+                  expect(cellValue.text()).to.include(lineArray[column])
                 }
               })
           }
@@ -118,7 +117,6 @@ export function sessionLogInAndGoToPage(
   })
   cy.visit(path)
 }
-
 
 /**
  * Checks that the homepage is loaded and displayed


### PR DESCRIPTION
## But de la pull request

On faisait précédemment (changé dans cette [PR](https://github.com/pass-culture/pass-culture-main/pull/15501/files#diff-d96f7a1a0c58a137f1a785b46eeed8b3f60819a9df05182efab9fb93c140d86d)) un `expect(truc).to.be.true` alors qu'on compare les valeurs de tableau affiché avec ce qu'on attend.

Voilà les logs dans Cypress
![CleanShot 2024-12-16 at 16 22 43@2x](https://github.com/user-attachments/assets/259eeaa9-2ae7-4567-b904-fb5e9b703a7c)



J'ai remis pour qu'on voit bien ce qu'ils se passe, notamment en cas d'erreur.
![CleanShot 2024-12-16 at 16 18 56@2x](https://github.com/user-attachments/assets/4f4c5921-89cd-4e6d-82e6-b8c485a560f5)



## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
