### PR TITLE
(PC-33284)[API] feat: check allowed actions when editing collective o…

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -491,20 +491,20 @@ class BookedCollectiveOfferFactory(CollectiveOfferBaseFactory):
         ConfirmedCollectiveBookingFactory(collectiveStock=stock)
 
 
-class EndedNotUsedCollectiveOfferFactory(CollectiveOfferBaseFactory):
-    @factory.post_generation
-    def create_ended_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
-        stock = CollectiveStockFactory(beginningDatetime=yesterday, collectiveOffer=self)
-        ConfirmedCollectiveBookingFactory(collectiveStock=stock)
-
-
 class EndedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
-    def create_ended_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+    def booking_is_confirmed(self, _create: bool, booking_is_confirmed: bool = False, **kwargs: typing.Any) -> None:
+        if booking_is_confirmed:
+            yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        else:
+            yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+
         stock = CollectiveStockFactory(beginningDatetime=yesterday, collectiveOffer=self)
-        UsedCollectiveBookingFactory(collectiveStock=stock)
+
+        if booking_is_confirmed:
+            ConfirmedCollectiveBookingFactory(collectiveStock=stock)
+        else:
+            UsedCollectiveBookingFactory(collectiveStock=stock)
 
 
 # Reimbursed offers are relevant only when the FF ENABLE_COLLECTIVE_NEW_STATUSES is active

--- a/api/src/pcapi/core/educational/testing.py
+++ b/api/src/pcapi/core/educational/testing.py
@@ -1,3 +1,4 @@
+from pcapi.core.educational import models
 from pcapi.core.educational.adage_backends.serialize import AdageCollectiveOffer
 from pcapi.core.educational.adage_backends.serialize import AdageCollectiveRequest
 from pcapi.routes.adage.v1.serialization.prebooking import EducationalBookingResponse
@@ -13,3 +14,15 @@ adage_requests: list[dict[str, AdageRequestItem | None]] = []
 def reset_requests() -> None:
     global adage_requests  # pylint: disable=global-statement
     adage_requests = []
+
+
+STATUSES_ALLOWING_EDIT_DETAILS = (
+    models.CollectiveOfferDisplayedStatus.DRAFT,
+    models.CollectiveOfferDisplayedStatus.ACTIVE,
+    models.CollectiveOfferDisplayedStatus.PREBOOKED,
+)
+
+STATUSES_NOT_ALLOWING_EDIT_DETAILS = tuple(
+    set(models.CollectiveOfferDisplayedStatus)
+    - {*STATUSES_ALLOWING_EDIT_DETAILS, models.CollectiveOfferDisplayedStatus.INACTIVE}
+)

--- a/api/tests/core/educational/test_models.py
+++ b/api/tests/core/educational/test_models.py
@@ -747,7 +747,7 @@ class CollectiveOfferAllowedActionsTest:
 
     @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
     def test_get_ended_offer_allowed_actions(self):
-        offer = factories.EndedNotUsedCollectiveOfferFactory()
+        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
 
         assert offer.displayedStatus == CollectiveOfferDisplayedStatus.ENDED
         assert offer.allowedActions == [
@@ -780,7 +780,7 @@ class CollectiveOfferAllowedActionsTest:
 
     @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
     def test_get_offer_ended_allowed_actions_public_api(self):
-        offer = factories.EndedNotUsedCollectiveOfferFactory()
+        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
         offer.provider = providers_factories.ProviderFactory()
 
         assert offer.displayedStatus == CollectiveOfferDisplayedStatus.ENDED

--- a/api/tests/routes/pro/delete_image_collective_offers_test.py
+++ b/api/tests/routes/pro/delete_image_collective_offers_test.py
@@ -4,21 +4,23 @@ from pathlib import Path
 import pytest
 
 from pcapi import settings
-from pcapi.core.educational.factories import CollectiveOfferFactory
-from pcapi.core.educational.models import CollectiveOffer
+from pcapi.core import testing
+from pcapi.core.educational import factories
+from pcapi.core.educational import models
+from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
 
 import tests
 
 
 IMAGES_DIR = Path(tests.__path__[0]) / "files"
-UPLOAD_FOLDER = settings.LOCAL_STORAGE_DIR / CollectiveOffer.FOLDER
+UPLOAD_FOLDER = settings.LOCAL_STORAGE_DIR / models.CollectiveOffer.FOLDER
 
 
 @pytest.mark.usefixtures("db_session")
 class DeleteImageFromFileTest:
     def test_delete_from_file(self, client):
-        offer = CollectiveOfferFactory()
+        offer = factories.CollectiveOfferFactory()
 
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
@@ -49,11 +51,21 @@ class DeleteImageFromFileTest:
         assert response.status_code == 204
         assert (UPLOAD_FOLDER / offer._get_image_storage_id()).exists() is False
 
+    @testing.override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", educational_testing.STATUSES_ALLOWING_EDIT_DETAILS)
+    def test_delete_image_allowed_action(self, client, status):
+        offer = factories.create_collective_offer_by_status(status)
+        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
+
+        response = client.with_session_auth(email="user@example.com").delete(f"/collective/offers/{offer.id}/image")
+
+        assert response.status_code == 204
+
     def test_forbidden_offer(self, client):
         # given
-        offer = CollectiveOfferFactory()
+        offer = factories.CollectiveOfferFactory()
 
-        offer2 = CollectiveOfferFactory()
+        offer2 = factories.CollectiveOfferFactory()
 
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
@@ -65,6 +77,27 @@ class DeleteImageFromFileTest:
 
         # then
         assert response.status_code == 403
+
+    @testing.override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", educational_testing.STATUSES_NOT_ALLOWING_EDIT_DETAILS)
+    def test_delete_image_unallowed_action(self, client, status):
+        offer = factories.create_collective_offer_by_status(status)
+        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
+
+        response = client.with_session_auth(email="user@example.com").delete(f"/collective/offers/{offer.id}/image")
+
+        assert response.status_code == 403
+        assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
+
+    @testing.override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    def test_delete_image_ended(self, client):
+        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
+
+        response = client.with_session_auth(email="user@example.com").delete(f"/collective/offers/{offer.id}/image")
+
+        assert response.status_code == 403
+        assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
 
     def test_not_authentified(self, client):
         # when

--- a/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
+++ b/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
@@ -116,7 +116,7 @@ class Returns204Test:
 
     @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
     def test_cancel_ended(self, client):
-        offer = factories.EndedNotUsedCollectiveOfferFactory()
+        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
 
         client = client.with_session_auth("pro@example.com")

--- a/api/tests/routes/pro/patch_collective_offers_archive_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_archive_test.py
@@ -160,7 +160,7 @@ class Returns204Test:
 
     @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
     def test_archive_offer_ended(self, client):
-        offer = factories.EndedNotUsedCollectiveOfferFactory()
+        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
         venue = offer.venue
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)

--- a/api/tests/routes/pro/patch_collective_offers_educational_institution_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_educational_institution_test.py
@@ -243,7 +243,7 @@ class Returns403Test:
     @override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
     def test_change_institution_ended(self, client) -> None:
         institution1 = factories.EducationalInstitutionFactory()
-        offer = factories.EndedNotUsedCollectiveOfferFactory(institution=institution1)
+        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True, institution=institution1)
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
         institution2 = factories.EducationalInstitutionFactory()
 

--- a/api/tests/routes/pro/patch_collective_stock_test.py
+++ b/api/tests/routes/pro/patch_collective_stock_test.py
@@ -685,10 +685,11 @@ class Return400Test:
 
         stock_id = stock.id
 
-        with assert_num_queries(7):
+        with assert_num_queries(8):
             # query += 1 -> load session
             # query += 1 -> load user
             # query += 1 -> load existing stock
+            # query += 1 -> load FF
             # query += 1 -> ensure the offerer is VALIDATED
             # query += 1 -> check the number of existing stock for the offer id
             # query += 1 -> find education year for start date
@@ -731,10 +732,11 @@ class Return400Test:
 
         stock_id = stock.id
 
-        with assert_num_queries(6):
+        with assert_num_queries(7):
             # query += 1 -> load session
             # query += 1 -> load user
             # query += 1 -> load existing stock
+            # query += 1 -> load FF
             # query += 1 -> ensure the offerer is VALIDATED
             # query += 1 -> check the number of existing stock for the offer id
             # query += 1 -> find education year for start date
@@ -779,10 +781,11 @@ class Return400Test:
 
         stock_id = stock.id
 
-        with assert_num_queries(7):
+        with assert_num_queries(8):
             # query += 1 -> load session
             # query += 1 -> load user
             # query += 1 -> load existing stock
+            # query += 1 -> load FF
             # query += 1 -> ensure the offerer is VALIDATED
             # query += 1 -> check the number of existing stock for the offer id
             # query += 1 -> find education year for start date

--- a/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
+++ b/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
@@ -236,7 +236,7 @@ class Returns200Test:
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
-        offer = educational_factories.EndedNotUsedCollectiveOfferFactory(venue=venue)
+        offer = educational_factories.EndedCollectiveOfferFactory(booking_is_confirmed=True, venue=venue)
 
         response = client.with_session_auth("user@example.com").post(f"/collective/offers/{offer.id}/duplicate")
 

--- a/api/tests/routes/pro/post_image_collective_offers_test.py
+++ b/api/tests/routes/pro/post_image_collective_offers_test.py
@@ -1,0 +1,85 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+from pcapi import settings
+from pcapi.core import testing
+from pcapi.core.educational import factories
+from pcapi.core.educational import models
+from pcapi.core.educational import testing as educational_testing
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.models import db
+
+import tests
+
+
+IMAGES_DIR = Path(tests.__path__[0]) / "files"
+UPLOAD_FOLDER = settings.LOCAL_STORAGE_DIR / models.CollectiveOffer.FOLDER
+
+
+def get_image_data():
+    thumb = (IMAGES_DIR / "mouette_full_size.jpg").read_bytes()
+    return {
+        "credit": "John Do",
+        "thumb": (BytesIO(thumb), "image.jpg"),
+        "croppingRectX": 0.0,
+        "croppingRectY": 0.0,
+        "croppingRectHeight": 0.9,
+        "croppingRectWidth": 0.6,
+    }
+
+
+@pytest.mark.usefixtures("db_session")
+class AttachCollectiveOfferImageTest:
+    def test_attach_offer_image(self, client):
+        offer = factories.CollectiveOfferFactory()
+        assert offer.imageId is None
+        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
+
+        auth_client = client.with_session_auth(email="user@example.com")
+        response = auth_client.post(f"/collective/offers/{offer.id}/image", form=get_image_data())
+
+        assert response.status_code == 200
+        db.session.refresh(offer)
+        assert (UPLOAD_FOLDER / offer._get_image_storage_id()).exists() is True
+        assert offer.imageId is not None
+        assert offer.imageCredit is not None
+        assert offer.imageHasOriginal is not None
+
+    @testing.override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", educational_testing.STATUSES_ALLOWING_EDIT_DETAILS)
+    def test_attach_image_allowed_action(self, client, status):
+        offer = factories.create_collective_offer_by_status(status)
+        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
+
+        auth_client = client.with_session_auth(email="user@example.com")
+        response = auth_client.post(f"/collective/offers/{offer.id}/image", form=get_image_data())
+
+        assert response.status_code == 200
+        assert (UPLOAD_FOLDER / offer._get_image_storage_id()).exists() is True
+
+    @testing.override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    @pytest.mark.parametrize("status", educational_testing.STATUSES_NOT_ALLOWING_EDIT_DETAILS)
+    def test_attach_image_unallowed_action(self, client, status):
+        offer = factories.create_collective_offer_by_status(status)
+        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
+
+        auth_client = client.with_session_auth(email="user@example.com")
+        response = auth_client.post(f"/collective/offers/{offer.id}/image", form=get_image_data())
+
+        assert response.status_code == 403
+        assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
+        assert (UPLOAD_FOLDER / offer._get_image_storage_id()).exists() is False
+
+    @testing.override_features(ENABLE_COLLECTIVE_NEW_STATUSES=True)
+    def test_attach_image_ended(self, client):
+        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
+
+        auth_client = client.with_session_auth(email="user@example.com")
+        response = auth_client.post(f"/collective/offers/{offer.id}/image", form=get_image_data())
+
+        assert response.status_code == 403
+        assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
+        assert (UPLOAD_FOLDER / offer._get_image_storage_id()).exists() is False


### PR DESCRIPTION
…ffer (part 2)

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33284

Partie 2 des actions sur les offres réservables :

edit details
edit dates
edit discount

Voir https://docs.google.com/spreadsheets/d/1_NXxiUGlHPW-P5oeIIpdIiWeJVUKtMy-xRzuyKs-OFQ/edit?gid=0#gid=0

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
