### PR TITLE
Pc 33526 rework radio group box

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
@@ -19,6 +19,7 @@ import { DatePicker } from 'ui-kit/form/DatePicker/DatePicker'
 import { QuantityInput } from 'ui-kit/form/QuantityInput/QuantityInput'
 import { RadioButton } from 'ui-kit/form/RadioButton/RadioButton'
 import { Select } from 'ui-kit/form/Select/Select'
+import { RadioVariant } from 'ui-kit/form/shared/BaseRadio/BaseRadio'
 import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 import { TimePicker } from 'ui-kit/form/TimePicker/TimePicker'
@@ -148,7 +149,7 @@ export const RecurrenceForm = ({
                 label="Une seule fois"
                 name="recurrenceType"
                 value={RecurrenceType.UNIQUE}
-                withBorder
+                variant={RadioVariant.BOX}
                 onChange={onRecurrenceTypeChange}
               />
 
@@ -156,7 +157,7 @@ export const RecurrenceForm = ({
                 label="Tous les jours"
                 name="recurrenceType"
                 value={RecurrenceType.DAILY}
-                withBorder
+                variant={RadioVariant.BOX}
                 onChange={onRecurrenceTypeChange}
               />
 
@@ -164,7 +165,7 @@ export const RecurrenceForm = ({
                 label="Toutes les semaines"
                 name="recurrenceType"
                 value={RecurrenceType.WEEKLY}
-                withBorder
+                variant={RadioVariant.BOX}
                 onChange={onRecurrenceTypeChange}
               />
 
@@ -172,7 +173,7 @@ export const RecurrenceForm = ({
                 label="Tous les mois"
                 name="recurrenceType"
                 value={RecurrenceType.MONTHLY}
-                withBorder
+                variant={RadioVariant.BOX}
                 onChange={onRecurrenceTypeChange}
               />
             </div>

--- a/pro/src/components/IndividualOffer/SummaryScreen/EventPublicationForm/EventPublicationForm.tsx
+++ b/pro/src/components/IndividualOffer/SummaryScreen/EventPublicationForm/EventPublicationForm.tsx
@@ -6,6 +6,7 @@ import { Divider } from 'ui-kit/Divider/Divider'
 import { DatePicker } from 'ui-kit/form/DatePicker/DatePicker'
 import { RadioButton } from 'ui-kit/form/RadioButton/RadioButton'
 import { Select } from 'ui-kit/form/Select/Select'
+import { RadioVariant } from 'ui-kit/form/shared/BaseRadio/BaseRadio'
 import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 
 import styles from './EventPublicationForm.module.scss'
@@ -62,14 +63,14 @@ export const EventPublicationForm = () => {
                 label="Tout de suite"
                 name="publicationMode"
                 value="now"
-                withBorder
+                variant={RadioVariant.BOX}
               />
 
               <RadioButton
                 label="À une date et heure précise"
                 name="publicationMode"
                 value="later"
-                withBorder
+                variant={RadioVariant.BOX}
               />
             </div>
           </FormLayout.Row>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.module.scss
@@ -46,6 +46,10 @@
 
   &-evenement {
     @include fonts.body;
+
+    legend {
+      color: var(--color-grey-dark);
+    }
   }
 }
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.module.scss
@@ -47,6 +47,8 @@
   &-evenement {
     @include fonts.body;
 
+    margin-bottom: rem.torem(24px);
+
     legend {
       color: var(--color-grey-dark);
     }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.tsx
@@ -184,6 +184,7 @@ export const OfferFilters = ({
                     group={adressTypeRadios}
                     className={styles['filter-container-evenement']}
                     name="eventAddressType"
+                    legend="Choisir un type d'intervention"
                   />
                 </ModalFilterLayout>
               </AdageButtonFilter>

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormDates/FormDates.module.scss
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormDates/FormDates.module.scss
@@ -1,7 +1,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .banner {
-  margin-bottom: rem.torem(16px);
+  margin: rem.torem(16px) 0;
 }
 
 .container {

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormDates/FormDates.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormDates/FormDates.tsx
@@ -9,6 +9,7 @@ import { Callout } from 'ui-kit/Callout/Callout'
 import { CalloutVariant } from 'ui-kit/Callout/types'
 import { DatePicker } from 'ui-kit/form/DatePicker/DatePicker'
 import { RadioGroup } from 'ui-kit/form/RadioGroup/RadioGroup'
+import { RadioVariant } from 'ui-kit/form/shared/BaseRadio/BaseRadio'
 import { TimePicker } from 'ui-kit/form/TimePicker/TimePicker'
 
 import styles from './FormDates.module.scss'
@@ -57,7 +58,7 @@ export const FormDates = ({
             value: 'specific_dates',
           },
         ]}
-        withBorder
+        variant={RadioVariant.BOX}
         legend="Quand votre offre peut-elle avoir lieu ?"
         name="datesType"
       />

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
@@ -155,7 +155,7 @@ export const FormPracticalInformation = ({
           : 'Lieu de l’événement'
       }
     >
-      <FormLayout.Row>
+      <FormLayout.Row className={styles['address-radio-group']}>
         <RadioGroup
           group={adressTypeRadios}
           legend="Adresse où se déroulera l’évènement :"

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/OfferEducationalForm.module.scss
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/OfferEducationalForm.module.scss
@@ -26,3 +26,7 @@
 .banner-space {
   margin-bottom: rem.torem(16px);
 }
+
+.address-radio-group {
+  margin-bottom: rem.torem(24px);
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/SuggestedSubcategories/SuggestedSubcategories.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/SuggestedSubcategories/SuggestedSubcategories.tsx
@@ -18,6 +18,7 @@ import {
 } from 'pages/IndividualOffer/IndividualOfferDetails/commons/utils'
 import { RadioButton } from 'ui-kit/form/RadioButton/RadioButton'
 import { Select } from 'ui-kit/form/Select/Select'
+import { RadioVariant } from 'ui-kit/form/shared/BaseRadio/BaseRadio'
 import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 
 import styles from './SuggestedSubcategories.module.scss'
@@ -120,7 +121,7 @@ export function SuggestedSubcategories({
         name="suggestedSubcategory"
         value={id}
         key={id}
-        withBorder
+        variant={RadioVariant.BOX}
         onChange={onRadioButtonChange}
       />
     )

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/OfferLocation/OfferLocation.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/OfferLocation/OfferLocation.tsx
@@ -17,6 +17,7 @@ import { computeAddressDisplayName } from 'repository/venuesService'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { RadioButton } from 'ui-kit/form/RadioButton/RadioButton'
+import { RadioVariant } from 'ui-kit/form/shared/BaseRadio/BaseRadio'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 
 import { setFormReadOnlyFields } from '../../commons/utils'
@@ -104,7 +105,7 @@ export const OfferLocation = ({
       </p>
       <FormLayout.Row className={styles['location-row']}>
         <RadioButton
-          withBorder
+          variant={RadioVariant.BOX}
           label={venueFullText}
           name="offerLocation"
           value={venue?.address?.id_oa.toString() ?? ''}
@@ -115,7 +116,7 @@ export const OfferLocation = ({
       </FormLayout.Row>
       <FormLayout.Row className={styles['location-row']}>
         <RadioButton
-          withBorder
+          variant={RadioVariant.BOX}
           label="À une autre adresse"
           name="offerLocation"
           value={OFFER_LOCATION.OTHER_ADDRESS}

--- a/pro/src/pages/IndividualOffer/IndividualOfferSummary/IndividualOfferBookings/components/DownloadBookingsModal/DownloadBookingsModal.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferSummary/IndividualOfferBookings/components/DownloadBookingsModal/DownloadBookingsModal.tsx
@@ -96,7 +96,6 @@ export const DownloadBookingsModal = ({
             name="bookings-date-select"
             checked={selectedDate === eventDate}
             className={style['bookings-date-radio']}
-            withBorder={false}
             label={
               <div className={style['radio-label']}>
                 <abbr

--- a/pro/src/ui-kit/form/IconRadioGroup/IconRadioGroup.stories.tsx
+++ b/pro/src/ui-kit/form/IconRadioGroup/IconRadioGroup.stories.tsx
@@ -21,22 +21,6 @@ export default {
   ],
 }
 
-const defaultArgs = {
-  name: 'question',
-  legend: 'This is the legend',
-  group: [
-    {
-      label: 'Oui',
-      value: `question1`,
-    },
-    {
-      label: 'Non',
-      value: `question2`,
-    },
-  ],
-  withBorder: false,
-}
-
 export const Default = {
   args: {
     name: 'question',

--- a/pro/src/ui-kit/form/RadioButton/RadioButton.stories.tsx
+++ b/pro/src/ui-kit/form/RadioButton/RadioButton.stories.tsx
@@ -3,6 +3,8 @@ import { Formik } from 'formik'
 
 import logoPassCultureIcon from 'icons/logo-pass-culture.svg'
 
+import { RadioVariant } from '../shared/BaseRadio/BaseRadio'
+
 import { RadioButton } from './RadioButton'
 
 export default {
@@ -26,7 +28,7 @@ export const Default: StoryObj<typeof RadioButton> = {
 }
 export const WithBorder: StoryObj<typeof RadioButton> = {
   args: {
-    withBorder: true,
+    variant: RadioVariant.BOX,
     label: 'Male',
   },
 }

--- a/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
+++ b/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames'
 import { useField } from 'formik'
 import React, { useCallback } from 'react'
 
-import { BaseRadio } from '../shared/BaseRadio/BaseRadio'
+import { BaseRadio, RadioVariant } from '../shared/BaseRadio/BaseRadio'
 
 /**
  * Props for the RadioButton component.
@@ -24,9 +24,9 @@ interface RadioButtonProps
    */
   value: string
   /**
-   * Whether to add a border around the radio button.
+   * Variant of styles of the radio input.
    */
-  withBorder?: boolean
+  variant?: RadioVariant
   /**
    * Whether the radio button has an error.
    */
@@ -58,7 +58,7 @@ interface RadioButtonProps
  *   name="gender"
  *   label="Male"
  *   value="male"
- *   withBorder={true}
+ *   variant={RadioVariant.BOX}
  * />
  *
  * @accessibility
@@ -71,7 +71,7 @@ export const RadioButton = ({
   name,
   label,
   value,
-  withBorder,
+  variant,
   className,
   hasError,
   onChange,
@@ -100,7 +100,7 @@ export const RadioButton = ({
       className={cn(className)}
       checked={field.checked}
       hasError={hasError}
-      withBorder={withBorder}
+      variant={variant}
       onChange={(e) => onCustomChange(e)}
       ariaDescribedBy={ariaDescribedBy}
       childrenOnChecked={childrenOnChecked}

--- a/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
+++ b/pro/src/ui-kit/form/RadioButton/RadioButton.tsx
@@ -32,13 +32,13 @@ interface RadioButtonProps
    */
   hasError?: boolean
   /**
-   * Whether the radio button should take up the full width of the container.
-   */
-  fullWidth?: boolean
-  /**
    * ARIA attribute to describe the element the radio button is associated with.
    */
   ariaDescribedBy?: string
+  /**
+   * Inner content that appears under the radio button when it is checked.
+   */
+  childrenOnChecked?: JSX.Element
 }
 
 /**
@@ -72,11 +72,11 @@ export const RadioButton = ({
   label,
   value,
   withBorder,
-  fullWidth,
   className,
   hasError,
   onChange,
   ariaDescribedBy,
+  childrenOnChecked,
 }: RadioButtonProps): JSX.Element => {
   const [field] = useField({ name, value, type: 'radio' })
 
@@ -101,9 +101,9 @@ export const RadioButton = ({
       checked={field.checked}
       hasError={hasError}
       withBorder={withBorder}
-      fullWidth={fullWidth}
       onChange={(e) => onCustomChange(e)}
       ariaDescribedBy={ariaDescribedBy}
+      childrenOnChecked={childrenOnChecked}
     />
   )
 }

--- a/pro/src/ui-kit/form/RadioGroup/RadioGroup.module.scss
+++ b/pro/src/ui-kit/form/RadioGroup/RadioGroup.module.scss
@@ -4,12 +4,4 @@
   &-item:not(:last-of-type) {
     margin-bottom: rem.torem(8px);
   }
-
-  &-horizontal {
-    display: flex;
-
-    .radio-group-item {
-      margin-right: rem.torem(16px);
-    }
-  }
 }

--- a/pro/src/ui-kit/form/RadioGroup/RadioGroup.stories.tsx
+++ b/pro/src/ui-kit/form/RadioGroup/RadioGroup.stories.tsx
@@ -1,6 +1,8 @@
 import { Formik } from 'formik'
 
-import { Direction, RadioGroup } from './RadioGroup'
+import { RadioVariant } from '../shared/BaseRadio/BaseRadio'
+
+import { RadioGroup, RadioGroupProps } from './RadioGroup'
 
 export default {
   title: 'ui-kit/forms/RadioGroup',
@@ -9,7 +11,10 @@ export default {
     (Story: any) => (
       <Formik
         initialValues={{
-          question: {},
+          ['name']: 'option1',
+          ['name 3']: 'option1',
+          ['name 4']: 'option02',
+          ['name 5']: 'option3',
         }}
         onSubmit={() => {}}
       >
@@ -21,18 +26,17 @@ export default {
   ],
 }
 
-const defaultArgs = {
-  name: 'question',
-  legend: 'This is the legend',
-  direction: Direction.VERTICAL,
+const defaultArgs: RadioGroupProps = {
+  name: 'name',
+  legend: 'Choisir une option',
   group: [
     {
-      label: 'Oui',
-      value: `question1`,
+      label: 'Option 1',
+      value: `option1`,
     },
     {
-      label: 'Non',
-      value: `question2`,
+      label: 'Option 2',
+      value: `option2`,
     },
   ],
   withBorder: false,
@@ -42,16 +46,69 @@ export const Default = {
   args: defaultArgs,
 }
 
+export const Disabled = {
+  args: { ...defaultArgs, variant: RadioVariant.BOX, disabled: true },
+}
+
 export const WithBorder = {
   args: {
     ...defaultArgs,
     withBorder: true,
+    name: 'name 2',
   },
 }
 
-export const Horizontal = {
+export const WithChildren = {
   args: {
     ...defaultArgs,
-    direction: Direction.HORIZONTAL,
+    withBorder: true,
+    group: defaultArgs.group.map((g, i) => ({
+      ...g,
+      childrenOnChecked: (
+        <RadioGroup
+          legend="Choisir une sous-option"
+          name="name 4"
+          variant={RadioVariant.BOX}
+          group={[
+            { label: `Sous-option ${i + 1} 1`, value: `option${i}1` },
+            { label: `Sous-option ${i + 1} 2`, value: `option${i}2` },
+          ]}
+        />
+      ),
+    })),
+    name: 'name 3',
+  },
+}
+
+export const InnerRadioGroupWithNoLegend = {
+  args: {
+    ...defaultArgs,
+    variant: RadioVariant.BOX,
+    name: 'name 5',
+    group: [
+      {
+        label: <span id="my-id-1">Option 1</span>,
+        value: 'option1',
+      },
+      {
+        label: <span id="my-id-2">Option 2</span>,
+        value: 'option2',
+      },
+      {
+        label: <span id="my-id-3">Option 3</span>,
+        value: 'option3',
+        childrenOnChecked: (
+          <RadioGroup
+            name="subgroup"
+            describedBy="my-id-3"
+            variant={RadioVariant.BOX}
+            group={[
+              { label: 'Sous-option 1', value: 'sub-option-1' },
+              { label: 'Sous-option 2', value: 'sub-option-2' },
+            ]}
+          />
+        ),
+      },
+    ],
   },
 }

--- a/pro/src/ui-kit/form/RadioGroup/RadioGroup.stories.tsx
+++ b/pro/src/ui-kit/form/RadioGroup/RadioGroup.stories.tsx
@@ -39,7 +39,6 @@ const defaultArgs: RadioGroupProps = {
       value: `option2`,
     },
   ],
-  withBorder: false,
 }
 
 export const Default = {
@@ -53,7 +52,7 @@ export const Disabled = {
 export const WithBorder = {
   args: {
     ...defaultArgs,
-    withBorder: true,
+    variant: RadioVariant.BOX,
     name: 'name 2',
   },
 }
@@ -61,7 +60,7 @@ export const WithBorder = {
 export const WithChildren = {
   args: {
     ...defaultArgs,
-    withBorder: true,
+    variant: RadioVariant.BOX,
     group: defaultArgs.group.map((g, i) => ({
       ...g,
       childrenOnChecked: (

--- a/pro/src/ui-kit/form/RadioGroup/RadioGroup.tsx
+++ b/pro/src/ui-kit/form/RadioGroup/RadioGroup.tsx
@@ -2,6 +2,7 @@ import cn from 'classnames'
 import { useField } from 'formik'
 
 import { RadioButton } from '../RadioButton/RadioButton'
+import { RadioVariant } from '../shared/BaseRadio/BaseRadio'
 import { FieldSetLayout } from '../shared/FieldSetLayout/FieldSetLayout'
 
 import styles from './RadioGroup.module.scss'
@@ -50,9 +51,9 @@ export type RadioGroupProps = RequireAtLeastOne<
      */
     className?: string
     /**
-     * Whether to add a border around each radio button.
+     * Variant of the radio inputs styles within the group.
      */
-    withBorder?: boolean
+    variant?: RadioVariant.BOX
     /**
      * Callback function to handle changes in the radio group.
      */
@@ -91,7 +92,7 @@ export const RadioGroup = ({
   legend,
   describedBy,
   className,
-  withBorder,
+  variant,
   onChange,
 }: RadioGroupProps): JSX.Element => {
   const [, meta] = useField({ name })
@@ -115,7 +116,7 @@ export const RadioGroup = ({
             label={item.label}
             name={name}
             value={item.value}
-            withBorder={withBorder}
+            variant={variant}
             hasError={hasError}
             onChange={onChange}
             {...(hasError ? { ariaDescribedBy: `error-${name}` } : {})}

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
@@ -83,7 +83,7 @@
   }
 }
 
-.radio.with-border {
+.radio.box-variant {
   border: rem.torem(1px) solid var(--color-grey-dark);
   border-radius: rem.torem(8px);
   padding: 0 0 0 rem.torem(16px);

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
@@ -3,9 +3,8 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .base-radio {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  cursor: pointer;
 
   &-label {
     line-height: rem.torem(16px);
@@ -22,36 +21,24 @@
     text-decoration: underline;
   }
 
-  &:focus-within {
-    outline: rem.torem(1px) solid var(--color-input-text-color);
-    outline-offset: rem.torem(4px);
-    border-radius: rem.torem(4px);
-  }
-
   &-input {
+    display: flex;
+    align-items: center;
     height: rem.torem(20px);
+    min-width: rem.torem(20px);
     width: rem.torem(20px);
     border: rem.torem(2px) solid var(--color-grey-dark);
     border-radius: 50%;
     background-color: var(--color-white);
-    flex: 0 0 auto;
     margin-right: rem.torem(8px);
     appearance: none;
     outline: none;
     cursor: pointer;
-    transition:
-      border 150ms ease,
-      background 150ms ease,
-      box-shadow 150ms ease;
-
-    &:hover,
-    &:focus-visible {
-      border-color: var(--color-secondary-light);
-    }
 
     &:disabled {
       cursor: default;
       border-color: var(--color-input-border-color-disabled);
+      background-color: transparent;
     }
 
     &.has-error {
@@ -59,40 +46,26 @@
     }
 
     &:checked {
+      box-shadow: inset 0 0 0 rem.torem(3px) var(--color-white);
       border-color: var(--color-secondary-light);
-      background: radial-gradient(
-        var(--color-secondary-light) 0%,
-        var(--color-secondary-light) 40%,
-        transparent 50%,
-        transparent
-      );
+      background-color: var(--color-secondary-light);
 
       &:disabled {
-        box-shadow: inset 0 0 0 rem.torem(2px) var(--color-white);
-        border-color: var(--color-input-border-color-disabled);
-        background: radial-gradient(
-          var(--color-input-border-color-disabled) 0%,
-          var(--color-input-border-color-disabled) 40%,
-          transparent 50%,
-          transparent
-        );
+        box-shadow: inset 0 0 0 rem.torem(3px) var(--color-grey-light);
+        border-color: var(--color-grey-semi-dark);
+        background-color: var(--color-grey-semi-dark);
       }
 
       &.has-error {
-        box-shadow: inset 0 0 0 rem.torem(2px) var(--color-white);
+        box-shadow: inset 0 0 0 rem.torem(3px) var(--color-white);
         border-color: var(--color-input-border-color-error);
-        background: radial-gradient(
-          var(--color-input-border-color-error) 0%,
-          var(--color-input-border-color-error) 40%,
-          transparent 50%,
-          transparent
-        );
+        background-color: var(--color-input-border-color-error);
       }
     }
   }
 }
 
-.with-border {
+.radio.with-border {
   border: rem.torem(1px) solid var(--color-grey-dark);
   border-radius: rem.torem(8px);
   padding: 0 0 0 rem.torem(16px);
@@ -108,35 +81,35 @@
 
   &:hover {
     box-shadow: forms.$input-hover-shadow;
-    cursor: pointer;
   }
 
-  .is-disabled {
-    border: none;
+  &.is-checked {
+    border-color: var(--color-secondary-light);
+    background-color: var(--color-background-secondary);
+  }
+
+  &.has-error {
+    border-color: var(--color-input-border-color-error);
+    background-color: var(--color-background-error);
+  }
+
+  &.is-disabled {
+    border-color: var(--color-input-border-color-disabled);
     background-color: var(--color-grey-light);
     color: var(--color-grey-dark);
-
-    &:focus-within {
-      outline: none;
-    }
 
     &:hover {
       box-shadow: none;
     }
   }
+}
 
-  &-checked {
-    border: rem.torem(2px) solid var(--color-secondary-light);
-    background-color: var(--color-background-secondary);
-
-    .base-radio-label {
-      @include fonts.body-exergue;
-
-      padding: rem.torem(16px) rem.torem(16px) rem.torem(16px) 0;
-    }
+.radio.has-children {
+  &.is-checked:not(.is-disabled) {
+    background: none;
   }
 }
 
-.full-width {
-  width: 100%;
+.base-radio-children-on-checked {
+  padding: 0 rem.torem(16px) rem.torem(16px) 0;
 }

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
@@ -65,6 +65,24 @@
   }
 }
 
+.radio:focus-within {
+  outline: rem.torem(1px) solid var(--color-black);
+  outline-offset: rem.torem(4px);
+  border-radius: rem.torem(8px);
+}
+
+@supports selector(:has(*)) {
+  .radio:focus-within {
+    outline: none;
+  }
+
+  .radio:has(.base-radio-input:focus-visible) {
+    outline: rem.torem(1px) solid var(--color-black);
+    outline-offset: rem.torem(4px);
+    border-radius: rem.torem(8px);
+  }
+}
+
 .radio.with-border {
   border: rem.torem(1px) solid var(--color-grey-dark);
   border-radius: rem.torem(8px);
@@ -72,11 +90,6 @@
 
   .base-radio-label {
     padding: rem.torem(16px) rem.torem(16px) rem.torem(16px) 0;
-  }
-
-  &:focus-within {
-    outline: rem.torem(1px) solid var(--color-black);
-    outline-offset: rem.torem(4px);
   }
 
   &:hover {

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.spec.tsx
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.spec.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+
+import { BaseRadio, BaseRadioProps } from './BaseRadio'
+
+const props: BaseRadioProps = {
+  label: 'My radio input label',
+  checked: true,
+  onChange: () => {},
+}
+
+describe('BaseRadio', () => {
+  it('should display a radio input', () => {
+    render(<BaseRadio {...props} />)
+
+    expect(
+      screen.getByRole('radio', { name: 'My radio input label' })
+    ).toBeInTheDocument()
+  })
+
+  it('should display an invalid radio input', () => {
+    render(<BaseRadio {...props} hasError />)
+
+    expect(
+      screen.getByRole('radio', { name: 'My radio input label' })
+    ).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('should display radio input children when the input is checked', () => {
+    render(<BaseRadio {...props} childrenOnChecked={<div>My children</div>} />)
+
+    expect(screen.getByText('My children')).toBeInTheDocument()
+  })
+
+  it('should not display radio input children when the input is unchecked', () => {
+    render(
+      <BaseRadio
+        {...props}
+        childrenOnChecked={<div>My children</div>}
+        checked={false}
+      />
+    )
+
+    expect(screen.queryByText('My children')).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.stories.tsx
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.stories.tsx
@@ -25,3 +25,16 @@ export const WithBorder: StoryObj<typeof BaseRadio> = {
     withBorder: true,
   },
 }
+
+export const WithChildren: StoryObj<typeof BaseRadio> = {
+  args: {
+    label: 'radio label',
+    hasError: false,
+    disabled: false,
+    checked: true,
+    withBorder: true,
+    childrenOnChecked: (
+      <div>Sub content displayed when the radio input is selected.</div>
+    ),
+  },
+}

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.stories.tsx
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.stories.tsx
@@ -1,6 +1,6 @@
 import type { StoryObj } from '@storybook/react'
 
-import { BaseRadio } from './BaseRadio'
+import { BaseRadio, RadioVariant } from './BaseRadio'
 
 export default {
   title: 'ui-kit/forms/shared/BaseRadio',
@@ -22,7 +22,7 @@ export const WithBorder: StoryObj<typeof BaseRadio> = {
     hasError: false,
     disabled: false,
     checked: false,
-    withBorder: true,
+    variant: RadioVariant.BOX,
   },
 }
 
@@ -32,7 +32,7 @@ export const WithChildren: StoryObj<typeof BaseRadio> = {
     hasError: false,
     disabled: false,
     checked: true,
-    withBorder: true,
+    variant: RadioVariant.BOX,
     childrenOnChecked: (
       <div>Sub content displayed when the radio input is selected.</div>
     ),

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
@@ -3,12 +3,17 @@ import React, { useId } from 'react'
 
 import styles from './BaseRadio.module.scss'
 
+export enum RadioVariant {
+  DEFAULT = 'DEFAULT',
+  BOX = 'BOX',
+}
+
 interface BaseRadioProps
   extends Partial<React.InputHTMLAttributes<HTMLInputElement>> {
   label: string | JSX.Element
   hasError?: boolean
   className?: string
-  withBorder?: boolean
+  variant?: RadioVariant
   ariaDescribedBy?: string
   childrenOnChecked?: JSX.Element
 }
@@ -17,9 +22,9 @@ export const BaseRadio = ({
   label,
   hasError,
   className,
-  withBorder = false,
   ariaDescribedBy,
   childrenOnChecked,
+  variant = RadioVariant.DEFAULT,
   ...props
 }: BaseRadioProps): JSX.Element => {
   const id = useId()
@@ -28,7 +33,7 @@ export const BaseRadio = ({
   return (
     <div
       className={cn(styles['radio'], {
-        [styles[`with-border`]]: withBorder,
+        [styles[`box-variant`]]: variant === RadioVariant.BOX,
         [styles[`has-children`]]: childrenOnChecked,
         [styles[`is-checked`]]: props.checked,
         [styles[`is-disabled`]]: props.disabled,

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
@@ -9,8 +9,8 @@ interface BaseRadioProps
   hasError?: boolean
   className?: string
   withBorder?: boolean
-  fullWidth?: boolean
   ariaDescribedBy?: string
+  childrenOnChecked?: JSX.Element
 }
 
 export const BaseRadio = ({
@@ -18,39 +18,53 @@ export const BaseRadio = ({
   hasError,
   className,
   withBorder = false,
-  fullWidth = false,
   ariaDescribedBy,
+  childrenOnChecked,
   ...props
 }: BaseRadioProps): JSX.Element => {
   const id = useId()
+  const childrenContainerId = useId()
 
   return (
     <div
-      className={cn(
-        styles['base-radio'],
-        {
-          [styles[`with-border`]]: withBorder,
-          [styles[`is-disabled`]]: props.disabled,
-          [styles[`full-width`]]: fullWidth,
-          [styles[`with-border-checked`]]:
-            withBorder && props.checked && !props.disabled,
-        },
-        className
-      )}
+      className={cn(styles['radio'], {
+        [styles[`with-border`]]: withBorder,
+        [styles[`has-children`]]: childrenOnChecked,
+        [styles[`is-checked`]]: props.checked,
+        [styles[`is-disabled`]]: props.disabled,
+        [styles[`has-error`]]: hasError,
+      })}
     >
-      <input
-        type="radio"
-        {...props}
-        className={cn(styles[`base-radio-input`], {
-          [styles['has-error']]: hasError,
-        })}
-        {...(ariaDescribedBy ? { 'aria-describedby': ariaDescribedBy } : {})}
-        aria-invalid={hasError}
-        id={id}
-      />
-      <label htmlFor={id} className={cn(styles['base-radio-label'])}>
-        {label}
-      </label>
+      <div
+        className={cn(
+          styles['base-radio'],
+          {
+            [styles[`is-disabled`]]: props.disabled,
+          },
+          className
+        )}
+      >
+        <input
+          type="radio"
+          {...props}
+          className={cn(styles[`base-radio-input`], {
+            [styles['has-error']]: hasError,
+          })}
+          {...(ariaDescribedBy ? { 'aria-describedby': ariaDescribedBy } : {})}
+          aria-invalid={hasError}
+          id={id}
+        />
+        <label htmlFor={id} className={styles['base-radio-label']}>
+          {label}
+        </label>
+      </div>
+      <div id={childrenContainerId}>
+        {childrenOnChecked && props.checked && (
+          <div className={styles['base-radio-children-on-checked']}>
+            {childrenOnChecked}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.tsx
@@ -8,7 +8,7 @@ export enum RadioVariant {
   BOX = 'BOX',
 }
 
-interface BaseRadioProps
+export interface BaseRadioProps
   extends Partial<React.InputHTMLAttributes<HTMLInputElement>> {
   label: string | JSX.Element
   hasError?: boolean

--- a/pro/src/ui-kit/form/shared/FieldSetLayout/FieldSetLayout.tsx
+++ b/pro/src/ui-kit/form/shared/FieldSetLayout/FieldSetLayout.tsx
@@ -28,6 +28,7 @@ export const FieldSetLayout = ({
   isOptional = false,
   ariaDescribedBy,
 }: FieldSetLayoutProps): JSX.Element => {
+  const showError = Boolean(error) || !hideFooter
   return (
     <fieldset
       className={cn(styles['fieldset-layout'], className)}
@@ -42,7 +43,7 @@ export const FieldSetLayout = ({
         </legend>
       )}
       <div>{children}</div>
-      {!hideFooter && (
+      {showError && (
         <div className={styles['fieldset-layout-error']}>
           {!!error && <FieldError name={name}>{error}</FieldError>}
         </div>

--- a/pro/src/ui-kit/form/shared/FieldSetLayout/FieldSetLayout.tsx
+++ b/pro/src/ui-kit/form/shared/FieldSetLayout/FieldSetLayout.tsx
@@ -14,6 +14,7 @@ interface FieldSetLayoutProps {
   hideFooter?: boolean
   dataTestId?: string
   isOptional?: boolean
+  ariaDescribedBy?: string
 }
 
 export const FieldSetLayout = ({
@@ -25,12 +26,14 @@ export const FieldSetLayout = ({
   hideFooter = false,
   dataTestId,
   isOptional = false,
+  ariaDescribedBy,
 }: FieldSetLayoutProps): JSX.Element => {
   return (
     <fieldset
       className={cn(styles['fieldset-layout'], className)}
       data-testid={dataTestId}
       aria-required={!isOptional}
+      aria-describedby={ariaDescribedBy}
     >
       {legend && (
         <legend className={styles['fieldset-layout-legend']}>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33526

**Objectif**
- Donner la possibilité au `RadioGroup` d'avoir une section qui s'affiche sous les options quand elles sont sélectionnées.
- Revue des styles disabled du `BaseRadio` pour coller à [ce design](https://www.figma.com/design/z4Hs7lbjyI0gi8O9wxSgJb/Am%C3%A9lio-offre-vitrine?node-id=6503-9072&t=O0MJER3bjqoT86NT-4).
- La props `legend` ou `describedBy` rendues obligatoires.

<img width="1007" alt="Capture d’écran 2024-12-20 à 16 01 56" src="https://github.com/user-attachments/assets/69d04f9a-1b1e-428f-9206-234989e10b0a" />
<img width="1044" alt="Capture d’écran 2024-12-20 à 15 57 51" src="https://github.com/user-attachments/assets/91976c27-bc05-495d-8e49-cf565b88a79e" />


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
