### PR TITLE
(BSR)[PRO] test: check emails for pre-booked, booked and canceled collective offers

### DIFF
--- a/pro/cypress/e2e/adageConfirmation.cy.ts
+++ b/pro/cypress/e2e/adageConfirmation.cy.ts
@@ -3,27 +3,30 @@ import {
   expectOffersOrBookingsAreFound,
   logInAndGoToPage,
 } from '../support/helpers.ts'
-  
-  describe('Adage confirmation', () => {
-    let login: string
-    let offer: { id: number, name: string, venueName: string }
-    let stock: { startDatetime: string}
-    let providerApiKey: string
-  
-    beforeEach(() => {
-      cy.visit('/connexion')
-      cy.request({
+
+describe('Adage confirmation', () => {
+  let login: string
+  let offer: { id: number; name: string; venueName: string }
+  let stock: { startDatetime: string }
+  let providerApiKey: string
+  const email1 = 'collectiveofferfactory+booking@example.com'
+  const email2 = 'collectiveofferfactory+booking@example2.com'
+
+  beforeEach(() => {
+    cy.visit('/connexion')
+    cy.request({
+      method: 'GET',
+      url: 'http://localhost:5001/sandboxes/pro/create_pro_user_with_active_collective_offer',
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      login = response.body.user.email
+      offer = response.body.offer
+      stock = response.body.stock
+      providerApiKey = response.body.providerApiKey
+      cy.intercept({
         method: 'GET',
-        url: 'http://localhost:5001/sandboxes/pro/create_pro_user_with_active_collective_offer',
-      }).then((response) => {
-        login = response.body.user.email
-        offer = response.body.offer
-        stock = response.body.stock
-        providerApiKey = response.body.providerApiKey
-      })
-      cy.intercept({ method: 'GET', url: '/collective/offers?offererId=1' }).as(
-        'collectiveOffers'
-      )
+        url: `/collective/offers?offererId=${offer.id}`,
+      }).as('collectiveOffers')
       cy.intercept({
         method: 'GET',
         url: '/collective/offers?offererId=1&status=BOOKED',
@@ -32,119 +35,249 @@ import {
         method: 'GET',
         url: '/collective/offers?offererId=1&status=PREBOOKED',
       }).as('collectiveOffersPREBOOKED')
-      cy.intercept({ method: 'GET', url: '/collective/offers/1' }).as(
+      cy.intercept({ method: 'GET', url: `/collective/offers/${offer.id}` }).as(
         'collectiveOfferDetails'
       )
-    })
-  
-    it('I should be able to search with several filters and see expected results', () => {
-      logInAndGoToPage(login, '/offres/collectives')
-      cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
-
-      cy.stepLog({ message: 'I click on the offer' })
-
-      cy.findAllByTestId('offer-item-row').find('a').contains(offer.name).click()
-
-      cy.wait('@collectiveOfferDetails')
-      cy.stepLog({ message: 'I check that the offer is published' })
-      cy.contains("Récapitulatif")
-      cy.contains('publiée')
-
-      cy.visit('/offres/collectives')
-
-      cy.stepLog({ message: 'Mock the Adage pré-confirmation from the teacher' })
       cy.request({
-        method: 'POST',
-        url: `http://localhost:5001/v2/collective/adage_mock/offer/${offer.id}/book`,
-        headers: {
-          'Authorization': `Bearer ${providerApiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: {}
+        method: 'GET',
+        url: 'http://localhost:5001/sandboxes/clear_email_list',
       }).then((response) => {
-        const { bookingId } = response.body
-
-        cy.stepLog({ message: `The offer is now prebooked with a booking id ${bookingId}` })
-
-        cy.stepLog({ message: 'I search with status "PREBOOKED"' })
-        cy.get('#search-status').click()
-        cy.get('#list-status').find('#option-display-PREBOOKED').click()
-
-        // We click outside the filter to close it
-        cy.findByRole('heading', { name: 'Offres collectives' }).click()
-
-        cy.stepLog({ message: 'I validate my filters' })
-        cy.findByText('Rechercher').click()
-        cy.wait('@collectiveOffersPREBOOKED')
-          .its('response.statusCode')
-          .should('eq', 200)
-
-        let expectedResults = [
-          ['', '', '', 'Titre', 'Date de l’évènement', 'Lieu', 'Établissement', 'Statut'],
-          [
-            '',
-            '',
-            '',
-            offer.name,
-            collectiveFormatEventDate(stock.startDatetime),
-            offer.venueName,
-            'DE LA TOUR',
-            'préréservée',
-          ],
-        ]
-    
-        expectOffersOrBookingsAreFound(expectedResults)
-
-        cy.stepLog({ message: 'Mock the Adage confirmation from the headmaster' })
-        cy.request({
-          method: 'POST',
-          url: `http://localhost:5001/v2/collective/adage_mock/bookings/${bookingId}/confirm`,
-          headers: {
-            'Authorization': `Bearer ${providerApiKey}`,
-            'Content-Type': 'application/json',
-          },
-          body: {}
-        })
-
-        cy.stepLog({ message: 'The offer is now confirmed' })
-
-        cy.stepLog({ message: 'I reset all filters' })
-        cy.findByText('Réinitialiser les filtres').click()
-
-        cy.stepLog({ message: 'Status filter is empty' })
-        cy.findByTestId('wrapper-search-status').within(() => {
-          cy.get('select').invoke('val').should('be.empty')
-        })
-
-        cy.stepLog({ message: 'I search with status "BOOKED"' })
-        cy.get('#search-status').click()
-        cy.get('#list-status').find('#option-display-BOOKED').click()
-
-        // We click outside the filter to close it
-        cy.findByRole('heading', { name: 'Offres collectives' }).click()
-
-        cy.stepLog({ message: 'I validate my filters' })
-
-        cy.findByText('Rechercher').click()
-        cy.wait('@collectiveOffersBOOKED')
-          .its('response.statusCode')
-          .should('eq', 200)
-
-        expectedResults = [
-          ['', 'Titre',  'Date de l’évènement', 'Lieu', 'Établissement', 'Statut'],
-          [
-            '',
-            '',
-            '',
-            offer.name,
-            collectiveFormatEventDate(stock.startDatetime),
-            offer.venueName,
-            'DE LA TOUR',
-            'réservée',
-          ],
-        ]
-    
-        expectOffersOrBookingsAreFound(expectedResults)
+        expect(response.status).to.eq(200)
       })
     })
+    cy.setFeatureFlags([
+      { name: 'ENABLE_COLLECTIVE_NEW_STATUSES', isActive: true },
+    ])
   })
+
+  it('I should be able to search with several filters and see expected results', () => {
+    logInAndGoToPage(login, '/offres/collectives')
+    cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+
+    cy.stepLog({ message: 'I click on the offer' })
+
+    cy.findAllByTestId('offer-item-row').find('a').contains(offer.name).click()
+
+    cy.wait('@collectiveOfferDetails')
+    cy.stepLog({ message: 'I check that the offer is published' })
+    cy.contains('Récapitulatif')
+    cy.contains('publiée')
+
+    cy.visit('/offres/collectives')
+
+    cy.stepLog({ message: 'Mock the Adage pre-booked from the teacher' })
+    cy.request({
+      method: 'POST',
+      url: `http://localhost:5001/v2/collective/adage_mock/offer/${offer.id}/book`,
+      headers: {
+        Authorization: `Bearer ${providerApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: {},
+    }).then((response) => {
+      expect(response.status).to.eq(200)
+      const { bookingId } = response.body
+
+      cy.stepLog({
+        message: `The offer is now prebooked with a booking ID ${bookingId}`,
+      })
+
+      cy.stepLog({ message: 'Check email received with booking ID' })
+      cy.request({
+        method: 'GET',
+        url: 'http://localhost:5001/sandboxes/get_unique_email',
+        timeout: 60000,
+      }).then((response) => {
+        expect(response.status).to.eq(200)
+        expect(response.body.To).to.eq(email1 + ', ' + email2)
+        expect(response.body.params.BOOKING_ID).to.eq(bookingId)
+      })
+
+      cy.stepLog({ message: 'I search with status "PREBOOKED"' })
+      cy.get('#search-status').click()
+      cy.get('#list-status').find('#option-display-PREBOOKED').click()
+
+      // We click outside the filter to close it
+      cy.findByLabelText('Statut').click()
+
+      cy.stepLog({ message: 'I validate my filters' })
+      cy.findByText('Rechercher').click({ force: true })
+      cy.wait('@collectiveOffersPREBOOKED')
+        .its('response.statusCode')
+        .should('eq', 200)
+
+      let expectedResults = [
+        [
+          '',
+          '',
+          '',
+          'Titre',
+          'Date de l’évènement',
+          'Lieu',
+          'Établissement',
+          'Statut',
+        ],
+        [
+          '',
+          '',
+          '',
+          offer.name,
+          collectiveFormatEventDate(stock.startDatetime),
+          offer.venueName,
+          'DE LA TOUR',
+          'préréservée',
+        ],
+      ]
+
+      expectOffersOrBookingsAreFound(expectedResults)
+
+      cy.request({
+        method: 'GET',
+        url: 'http://localhost:5001/sandboxes/clear_email_list',
+      }).then((response) => {
+        expect(response.status).to.eq(200)
+      })
+
+      cy.stepLog({ message: 'Mock the Adage confirmation from the headmaster' })
+      cy.request({
+        method: 'POST',
+        url: `http://localhost:5001/v2/collective/adage_mock/bookings/${bookingId}/confirm`,
+        headers: {
+          Authorization: `Bearer ${providerApiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: {},
+      }).then((response) => {
+        expect(response.status).to.eq(204)
+      })
+
+      cy.stepLog({ message: 'The offer is now confirmed' })
+
+      cy.stepLog({
+        message: 'Check email received with a To, a Bcc and booking ID',
+      })
+      cy.request({
+        method: 'GET',
+        url: 'http://localhost:5001/sandboxes/get_unique_email',
+        timeout: 60000,
+      }).then((response) => {
+        expect(response.status).to.eq(200)
+        expect(response.body.To).to.eq(email1)
+        expect(response.body.Bcc).to.eq(email2)
+        expect(response.body.params.BOOKING_ID).to.eq(bookingId)
+      })
+
+      cy.stepLog({ message: 'I reset all filters' })
+      cy.findByText('Réinitialiser les filtres').click()
+
+      cy.stepLog({ message: 'Status filter is empty' })
+      cy.findByTestId('wrapper-search-status').within(() => {
+        cy.get('select').invoke('val').should('be.empty')
+      })
+
+      cy.stepLog({ message: 'I search with status "BOOKED"' })
+      cy.get('#search-status').click()
+      cy.get('#list-status').find('#option-display-BOOKED').click()
+
+      // We click outside the filter to close it
+      cy.findByLabelText('Statut').click()
+
+      cy.stepLog({ message: 'I validate my filters' })
+
+      cy.findByText('Rechercher').click({ force: true })
+      cy.wait('@collectiveOffersBOOKED')
+        .its('response.statusCode')
+        .should('eq', 200)
+
+      expectedResults = [
+        [
+          '',
+          '',
+          '',
+          'Titre',
+          'Date de l’évènement',
+          'Lieu',
+          'Établissement',
+          'Statut',
+        ],
+        [
+          '',
+          '',
+          '',
+          offer.name,
+          collectiveFormatEventDate(stock.startDatetime),
+          offer.venueName,
+          'DE LA TOUR',
+          'réservée',
+        ],
+      ]
+
+      expectOffersOrBookingsAreFound(expectedResults)
+
+      cy.stepLog({ message: 'I reset all filters' })
+      cy.findByText('Réinitialiser les filtres').click()
+
+      cy.stepLog({ message: 'Status filter is empty' })
+      cy.findByTestId('wrapper-search-status').within(() => {
+        cy.get('select').invoke('val').should('be.empty')
+      })
+
+      cy.request({
+        method: 'GET',
+        url: 'http://localhost:5001/sandboxes/clear_email_list',
+      }).then((response) => {
+        expect(response.status).to.eq(200)
+      })
+
+      cy.stepLog({ message: 'I cancel the booking' })
+      cy.get('button[title="Action"]').click()
+      cy.findByText('Annuler la réservation').click()
+      cy.findByTestId('confirm-dialog-button-confirm').click()
+
+      cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+
+      cy.findAllByTestId('global-notification-success').should(
+        'contain',
+        'Vous avez annulé la réservation de cette offre. Elle n’est donc plus visible sur ADAGE.'
+      )
+
+      cy.stepLog({ message: 'Check email received with a To and Bcc' })
+      cy.request({
+        method: 'GET',
+        url: 'http://localhost:5001/sandboxes/get_unique_email',
+        timeout: 60000,
+      }).then((response) => {
+        expect(response.status).to.eq(200)
+        expect(response.body.To).to.eq(email1)
+        expect(response.body.Bcc).to.eq(email2)
+      })
+
+      cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
+      cy.stepLog({ message: 'Offer is now canceled' })
+      cy.contains('annulée')
+      expectedResults = [
+        [
+          '',
+          '',
+          '',
+          'Titre',
+          "Date de l'événement",
+          'Lieu',
+          'Établissement',
+          'Statut',
+        ],
+        [
+          '',
+          '',
+          '',
+          offer.name,
+          collectiveFormatEventDate(stock.startDatetime),
+          offer.venueName,
+          'DE LA TOUR',
+          'annulée',
+        ],
+      ]
+      expectOffersOrBookingsAreFound(expectedResults)
+    })
+  })
+})

--- a/pro/cypress/e2e/collaborator.cy.ts
+++ b/pro/cypress/e2e/collaborator.cy.ts
@@ -53,7 +53,7 @@ describe('Collaborator list feature', () => {
       .should('have.text', 'En attente')
     cy.contains(login).next().should('have.text', 'Validé')
 
-    cy.stepLog({ message: 'check email received by email' })
+    cy.stepLog({ message: 'check email received' })
     cy.request({
       method: 'GET',
       url: 'http://localhost:5001/sandboxes/get_unique_email',


### PR DESCRIPTION
## But de la pull request

Lignes 232, 233 et 234 du cahier de test 
pour tester la bonne réception des mails de pré-réservation, réservation et annulation de réservation

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
