### PR TITLE
(BSR)[API] feat: tone down log level to error in user anonymisation

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1524,7 +1524,7 @@ def anonymize_user(user: models.User, *, author: models.User | None = None, forc
         try:
             iris = get_iris_from_address(address=user.address, postcode=user.postalCode)
         except (api_adresse.AdresseApiException, api_adresse.InvalidFormatException) as exc:
-            logger.exception("Could not anonymize user", extra={"user_id": user.id, "exc": str(exc)})
+            logger.error("Could not anonymize user", extra={"user_id": user.id, "exc": str(exc)})
             return False
 
         if not iris and not force:
@@ -1535,10 +1535,10 @@ def anonymize_user(user: models.User, *, author: models.User | None = None, forc
     except ExternalAPIException as exc:
         # If is_retryable it is a real error. If this flag is False then it means the email is unknown for brevo.
         if exc.is_retryable:
-            logger.exception("Could not anonymize user", extra={"user_id": user.id, "exc": str(exc)})
+            logger.error("Could not anonymize user", extra={"user_id": user.id, "exc": str(exc)})
             return False
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.exception("Could not anonymize user", extra={"user_id": user.id, "exc": str(exc)})
+        logger.error("Could not anonymize user", extra={"user_id": user.id, "exc": str(exc)})
         return False
 
     for beneficiary_fraud_check in user.beneficiaryFraudChecks:


### PR DESCRIPTION
## But de la pull request

abaisse le log level a error dans l'anonymisation des users

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
