### PR TITLE
(PC-33410)[API] fix: Prevent crash on PATCH /offer when address exist

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 f8588023c126 (pre) (head)
-4c3be4ff5274 (post) (head)
+f512de569bde (post) (head)

--- a/api/src/pcapi/alembic/versions/20241220T090811_f512de569bde_drop_ix_partial_unique_address_per_street_and_insee_code_address_table.py
+++ b/api/src/pcapi/alembic/versions/20241220T090811_f512de569bde_drop_ix_partial_unique_address_per_street_and_insee_code_address_table.py
@@ -1,0 +1,36 @@
+"""Drop ix_partial_unique_address_per_street_and_insee_code index on Address table
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "f512de569bde"
+down_revision = "4c3be4ff5274"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_partial_unique_address_per_street_and_insee_code",
+            table_name="address",
+            postgresql_where='((street IS NOT NULL) AND ("inseeCode" IS NOT NULL) AND ("isManualEdition" IS NOT TRUE))',
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_partial_unique_address_per_street_and_insee_code",
+            "address",
+            ["street", "inseeCode"],
+            unique=True,
+            postgresql_where='((street IS NOT NULL) AND ("inseeCode" IS NOT NULL) AND ("isManualEdition" IS NOT TRUE))',
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )

--- a/api/src/pcapi/core/geography/models.py
+++ b/api/src/pcapi/core/geography/models.py
@@ -46,13 +46,6 @@ class Address(PcObject, Base, Model):
 
     __table_args__ = (
         sa.Index(
-            "ix_partial_unique_address_per_street_and_insee_code",
-            "street",
-            "inseeCode",
-            unique=True,
-            postgresql_where=sa.and_(street.is_not(None), inseeCode.is_not(None), isManualEdition.is_not(True)),
-        ),
-        sa.Index(
             # FIXME (dramelet, 14-10-2024)
             # Our current version of sqlalchemy (1.4) doesn't handle
             # the option `nulls_not_distinct` from postgresql dialect

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -6,7 +6,6 @@ import decimal
 import functools
 import itertools
 import logging
-import math
 from math import ceil
 import re
 import secrets
@@ -2820,20 +2819,6 @@ def get_or_create_address(location_data: LocationData, is_manual_edition: bool =
                 ),
             ),
         ).one()
-        if not math.isclose(float(address.latitude), float(latitude), rel_tol=0.00001) or not math.isclose(
-            float(address.longitude), float(longitude), rel_tol=0.00001
-        ):
-            logger.error(
-                "Unique constraint over street and inseeCode matched different coordinates",
-                extra={
-                    "address_id": address.id,
-                    "incoming_banId": ban_id,
-                    "address_latitude": address.latitude,
-                    "address_longitude": address.longitude,
-                    "incoming_latitude": latitude,
-                    "incoming_longitude": longitude,
-                },
-            )
 
     return address
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2804,20 +2804,13 @@ def get_or_create_address(location_data: LocationData, is_manual_edition: bool =
 
     if address is None:
         address = geography_models.Address.query.filter(
-            geography_models.Address.street == street,
+            geography_models.Address.banId == ban_id,
             geography_models.Address.inseeCode == insee_code,
-            sa.or_(
-                geography_models.Address.isManualEdition.is_not(True),  # false or null
-                sa.and_(
-                    geography_models.Address.banId == ban_id,
-                    geography_models.Address.inseeCode == insee_code,
-                    geography_models.Address.street == street,
-                    geography_models.Address.postalCode == postal_code,
-                    geography_models.Address.city == city,
-                    geography_models.Address.latitude == latitude,
-                    geography_models.Address.longitude == longitude,
-                ),
-            ),
+            geography_models.Address.street == street,
+            geography_models.Address.postalCode == postal_code,
+            geography_models.Address.city == city,
+            geography_models.Address.latitude == latitude,
+            geography_models.Address.longitude == longitude,
         ).one()
 
     return address

--- a/api/src/pcapi/core/offerers/schemas.py
+++ b/api/src/pcapi/core/offerers/schemas.py
@@ -113,13 +113,19 @@ class VenueWithdrawalDetails(pydantic_v1.ConstrainedStr):
 
 class AddressBodyModel(BaseModel):
     isVenueAddress: bool = False
+    isManualEdition: bool = False
     city: VenueCity
     label: str | None
     latitude: float | str
     longitude: float | str
     postalCode: VenuePostalCode
     street: VenueAddress
-    isManualEdition: bool = False
+
+    @validator("city")
+    def title_city_when_manually_edited(cls, city: str, values: dict) -> str:
+        if values["isManualEdition"] is True:
+            return city.title()
+        return city
 
 
 class BannerMetaModel(typing.TypedDict, total=False):

--- a/api/tests/core/geography/test_models.py
+++ b/api/tests/core/geography/test_models.py
@@ -21,6 +21,7 @@ class AddressModelsTest:
             # We can't use a duplicate AddressFactory here because of `sqlalchemy_get_or_create`
             db.session.add(
                 Address(
+                    banId="75102_7560_00001",
                     street="89 Rue de la Boétie",
                     postalCode="75008",
                     inseeCode="75056",


### PR DESCRIPTION
with isManualEdition at True and False

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33410

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
