### PR TITLE
(BSR)[PRO] test: fix errors when creation offers

### DIFF
--- a/pro/cypress/e2e/createCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/createCollectiveOffer.cy.ts
@@ -5,7 +5,7 @@ import {
 
 describe('Create collective offers', () => {
   let login: string
-  let offerDraft: { "name": string, "venueName": string }
+  let offerDraft: { name: string; venueName: string }
   const newOfferName = 'Ma nouvelle offre collective créée'
   const venueName = 'Mon Lieu 1'
 
@@ -113,14 +113,23 @@ describe('Create collective offers', () => {
     const expectedResults = [
       ['', '', 'Titre', 'Lieu', 'Établissement', 'Statut'],
       ['', '', newOfferName, venueName, 'COLLEGE 123', 'brouillon'],
-      ['', '', offerDraft.name, offerDraft.venueName, 'DE LA TOUR', 'brouillon'],
+      [
+        '',
+        '',
+        offerDraft.name,
+        offerDraft.venueName,
+        'DE LA TOUR',
+        'brouillon',
+      ],
     ]
 
     expectOffersOrBookingsAreFound(expectedResults)
 
     cy.stepLog({ message: 'I want to change my offer to published status' })
 
-    cy.findByRole('link', { name: newOfferName }).click()
+    cy.findAllByTestId('offer-item-row')
+      .eq(0)
+      .within(() => cy.get('a[title*="' + newOfferName + '"]').click())
 
     cy.wait('@educationalOfferers')
 

--- a/pro/cypress/e2e/createIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/createIndividualOffer.cy.ts
@@ -1,14 +1,14 @@
 import {
   interceptSearch5Adresses,
   sessionLogInAndGoToPage,
-  expectOffersOrBookingsAreFound
+  expectOffersOrBookingsAreFound,
 } from '../support/helpers.ts'
 
 describe('Create individual offers', () => {
   let login: string
   let venueName: string
   const stock = '42'
-  
+
   before(() => {
     cy.wrap(Cypress.session.clearAllSavedSessions())
     cy.visit('/connexion')
@@ -308,9 +308,9 @@ describe('Create individual offers', () => {
 
     cy.stepLog({ message: 'my new physical offer should be displayed' })
     const expectedNewResults = [
-      ['', '', '', 'Lieu', 'Stocks', 'Statut', ''],
-      ['', '', offerTitle , venueName, stock, 'publiée'],
-      []
+      ['', "Nom de l'offre", 'Lieu', 'Stocks', 'Statut', ''],
+      ['', offerTitle, venueName, stock, 'publiée'],
+      [],
     ]
 
     expectOffersOrBookingsAreFound(expectedNewResults)


### PR DESCRIPTION
## But de la pull request

Corrige les derniers échecs depuis ce matin

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
