### PR TITLE
(BSR)[PRO] test: check download pdf reimbursement details

### DIFF
--- a/pro/cypress/e2e/financialManagement.cy.ts
+++ b/pro/cypress/e2e/financialManagement.cy.ts
@@ -133,13 +133,22 @@ describe('Financial Management - messages, links to external help page, reimburs
         })
       })
 
-      cy.stepLog({ message: 'I download reimbursement details' })
+      cy.stepLog({ message: 'I download reimbursement details in csv' })
       cy.findByTestId('dropdown-menu-trigger').click()
       cy.findByText(/Télécharger le détail des réservations/).click()
 
-      cy.stepLog({ message: 'I can see the reimbursement details' })
-      const filename = `${Cypress.config('downloadsFolder')}/remboursements_pass_culture.csv`
-      cy.readFile(filename, { timeout: 15000 }).should('not.be.empty')
+      cy.stepLog({ message: 'I can see the reimbursement details in csv' })
+      const filenameCSV = `${Cypress.config('downloadsFolder')}/remboursements_pass_culture.csv`
+      cy.readFile(filenameCSV, { timeout: 15000 }).should('not.be.empty')
+
+      cy.stepLog({ message: 'I download reimbursement details in pdf' })
+      cy.findByTestId('dropdown-menu-trigger').click()
+      cy.findByText(/Télécharger le justificatif comptable/).click()
+
+      cy.stepLog({ message: 'I can see the reimbursement details in pdf' })
+      // Nok working, no pdf file
+      // const filenamePDF = `${Cypress.config('downloadsFolder')}/remboursements_pass_culture.pdf`
+      // cy.readFile(filenamePDF, { timeout: 15000 }).should('not.be.empty')
     })
   })
 


### PR DESCRIPTION
## But de la pull request

Ne marche pas sur l'étape `I can see the reimbursement details in pdf`, le pdf téléchargé ne peut être récupéré. Voir avec @ataib-pass et @fseguin-pass avec qui on en discute

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
