### PR TITLE
(BSR)[PRO] test: how to use cypress e2e in README

### DIFF
--- a/pro/cypress/README.md
+++ b/pro/cypress/README.md
@@ -1,6 +1,61 @@
+# Exécution des tests e2e Cypress avec le Pass Culture
+
+Pour exécuter les tests, vous avez besoin de la stack lancée en local et **aucune donnée dans la sandbox** (les données utiles pour chacun des cas de test sont créés à l'exécution de chacun d'entre eux).
+
+## Stack Pass Culture Pro dans Docker
+Le plus simple est de lancer l’application `pro` avec `docker-compose`. Cela permet de lancer en une commande les containers `pc-nginx`, `pc-backoffice`, `pc-api`, `pc-postgres-pytest`, `pc-postgres` et `pc-redis` 
+
+Pour cela, avec une version node récente, dans le répertoire [`pass-culture`](https://github.com/pass-culture/pass-culture-main) :
+
+Dans un premier terminal:
+```
+pass-culture-main % ./pc symlink
+pass-culture-main % pc install
+pass-culture-main % docker-compose -f docker-compose-backend.yml up -d
+pass-culture-main % pc start-pro
+```
+Et c’est tout. Il ne faut pas peupler la sandbox, elle doit rester vide et les données seront créées par la Factory lors de l’exécution.
+
+## Lancer les tests avec l'interface Cypress
+Pour lancer les tests avec l'interface Cypress et ainsi avoir la possibilité de revenir sur l'exécution sans marquer de points d'arrêts, il faut lancer la commande suivante depuis le répertoire `pro` dans un second terminal:
+```
+pro % yarn test:e2e
+```
+puis sélectionner le fichier `.cy.ts` à exécuter dans l'interface ou choisir de tout lancer (voir l'[open mode](https://docs.cypress.io/app/core-concepts/open-mode])).
+
+## Lancer les tests sans l'interface Cypress
+Sans l'interface Cypress, et donc en ligne de commande, il faut exécuter la commande suivante depuis le répertoire `pro`:
+```
+pro % yarn test:bdd
+```
+
+Pour ne lancer qu'un seul fichier de test `.cy.ts` on peut le sélectionner avec l'option `--spec` dans cette commande:
+```
+pro % npx cypress run --e2e --browser chrome --config-file cypress/cypress.config.ts --spec cypress/e2e/adageConfirmation.cy.ts
+```
+
+# Données générées - Data Factory
+Nous n'utilisons plus les données de la sandbox industrial et générons nos propres données avec des routes Factory.
+
+De nouvelles routes `api` sont créées par les devs. Voir par exemple
+```
+api/src/pcapi/sandboxes/scripts/getters/pro_01_create_pro_user.py
+```
+qu’il suffit d’appeler ainsi dans les tests auto dans son test e2e en récupérant les données.
+
+Exemple:
+```typescript
+cy.request(
+    'http://localhost:5001/sanboxes/pro_01_create_pro_user/create_pro_user_with_venue_bank_account_and_userofferer'
+  ).then((response) => {
+    expect(response.status).to.eq(200)
+    user_email = response.body.user.email
+  })
+  ```
+
 # Bonnes pratiques
 
-## Comment attendre
+## Comment attendre ?
 
 Les mauvaises implémentations de codes d'attentes sont les principales sources d'instabilité (flakiness) dans les tests E2E, soyez vigilants ! Les mauvaises pratiques sont :
 

--- a/pro/cypress/e2e/README.md
+++ b/pro/cypress/e2e/README.md
@@ -1,4 +1,4 @@
-# Guidelines Gherkin
+# Guidelines
 
 ## Dois-je écrire ce test ?
 
@@ -12,9 +12,9 @@ Comme dit dans le titre, ne réécrivez pas un test (ou une assertion) qui exist
 
 ## Ecrivez de beaux scénarios que tout le monde aura envie de lire
 
-### Nommez vos features et scénarios de manière à ce qu'on sache exactement ce qu'ils vont faire
+### Nommez vos it('') de manière à ce qu'on sache exactement ce qu'ils vont faire
 
-En lisant votre feature et votre scénario on devrait savoir immédiatement ce que ça teste. Pour trouver l'inspiration, on pourra par exemple utiliser une tournure à la Friends : "Celui où..."
+En lisant votre cas de test on devrait savoir immédiatement ce que ça teste. Pour trouver l'inspiration, on pourra par exemple utiliser une tournure à la Friends : "Celui où..."
 
 ### Faites le plus court possible
 
@@ -28,11 +28,11 @@ Exemple de tests qui respectent bien ces deux règles : les scénarios Adage.
 
 ### Seule et unique exception aux deux points précédents
 
-la seule exception tolérée dans le contexte Pass Culture sera le cas des parcours (workflow) nominaux (happy path) et critiques: ce que souhaite faire l'utilisateur et qui ne doit jamais casser. Dans ces cas spécifiques, il vaut mieux un parcours de bout en bout que des petits scénarios découpés de façon artificielle et couteuse en préconditions (mocks par exemple).
+La seule exception tolérée dans le contexte Pass Culture sera le cas des parcours (workflow) nominaux (happy path) et critiques: ce que souhaite faire l'utilisateur et qui ne doit jamais casser. Dans ces cas spécifiques, il vaut mieux un parcours de bout en bout que des petits scénarios découpés de façon artificielle et couteuse en préconditions (mocks par exemple).
 
 ### Ne décrivez pas l'interface utilisateur (UI)
 
-votre scénario ne devrait pas parler de l'interface (boutons, liens, etc.). Vous devriez parler de l'intention de l'utlisateur plutôt que de ses interactions.
+Votre scénario ne devrait pas parler de l'interface (boutons, liens, etc.). Vous devriez parler de l'intention de l'utlisateur plutôt que de ses interactions.
 
 _Ex:_ `I click on "Plus Tard" link in confirmation popin`_, devrait plutôt ressembler à :_ `I skip offer creation`
 


### PR DESCRIPTION
## But de la pull request

D'où viennent les données ? Data factory ? Comment lancer Cypress ?
+ il était encore fait référence à Gherkin et aux features/scenario dans la guideline du `cypress/e2e/README` 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
