### PR TITLE
(PC-33423)[API] feat: add status isActive to headline_offer

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 f8588023c126 (pre) (head)
-4c53718279e7 (post) (head)
+4c3be4ff5274 (post) (head)

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 f8588023c126 (pre) (head)
-b18478ab2ea8 (post) (head)
+4c53718279e7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20241220T091708_4c53718279e7_drop_headline_offer_unicity_constraints.py
+++ b/api/src/pcapi/alembic/versions/20241220T091708_4c53718279e7_drop_headline_offer_unicity_constraints.py
@@ -1,0 +1,77 @@
+"""
+Drop headline offer unicity constraints on offer and venue
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "4c53718279e7"
+down_revision = "b18478ab2ea8"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_headline_offer_offerId",
+            table_name="headline_offer",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.create_index(
+            op.f("ix_headline_offer_offerId"),
+            "headline_offer",
+            ["offerId"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.drop_index(
+            "ix_headline_offer_venueId",
+            table_name="headline_offer",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.create_index(
+            op.f("ix_headline_offer_venueId"),
+            "headline_offer",
+            ["venueId"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            op.f("ix_headline_offer_venueId"),
+            table_name="headline_offer",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.create_index(
+            "ix_headline_offer_venueId",
+            "headline_offer",
+            ["venueId"],
+            unique=True,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.drop_index(
+            op.f("ix_headline_offer_offerId"),
+            table_name="headline_offer",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.create_index(
+            "ix_headline_offer_offerId",
+            "headline_offer",
+            ["offerId"],
+            unique=True,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )

--- a/api/src/pcapi/alembic/versions/20241220T095131_4c3be4ff5274_add_timespan_on_headline_offer.py
+++ b/api/src/pcapi/alembic/versions/20241220T095131_4c3be4ff5274_add_timespan_on_headline_offer.py
@@ -1,0 +1,42 @@
+"""
+add timespan on headline_offer table
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "4c3be4ff5274"
+down_revision = "4c53718279e7"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute('ALTER TABLE headline_offer DROP COLUMN IF EXISTS "dateUpdated"')
+    op.execute('ALTER TABLE headline_offer DROP COLUMN IF EXISTS "dateCreated"')
+
+    op.execute('ALTER TABLE headline_offer ADD COLUMN IF NOT EXISTS "timespan" TSRANGE NOT NULL')
+
+    op.execute("ALTER TABLE headline_offer DROP CONSTRAINT IF EXISTS exclude_offer_timespan")
+    op.execute(
+        'ALTER TABLE headline_offer ADD CONSTRAINT exclude_offer_timespan EXCLUDE USING gist ("offerId" WITH =, timespan WITH &&)'
+    )
+
+    op.execute("ALTER TABLE headline_offer DROP CONSTRAINT IF EXISTS exclude_venue_timespan")
+    op.execute(
+        'ALTER TABLE headline_offer ADD CONSTRAINT exclude_venue_timespan EXCLUDE USING gist ("venueId" WITH =, timespan WITH &&)'
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE headline_offer DROP CONSTRAINT IF EXISTS exclude_offer_timespan")
+    op.execute("ALTER TABLE headline_offer DROP CONSTRAINT IF EXISTS exclude_venue_timespan")
+    op.execute('ALTER TABLE headline_offer DROP COLUMN IF EXISTS "timespan"')
+    op.execute(
+        'ALTER TABLE headline_offer ADD COLUMN IF NOT EXISTS "dateCreated" TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now()'
+    )
+    op.execute(
+        'ALTER TABLE headline_offer ADD COLUMN IF NOT EXISTS "dateUpdated" TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now()'
+    )

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -726,7 +726,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
 
     @property
     def has_headline_offer(self) -> bool:
-        return bool(self.headlineOffers)
+        return any(headline_offer.isActive for headline_offer in self.headlineOffers)
 
 
 class GooglePlacesInfo(PcObject, Base, Model):

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -886,18 +886,16 @@ def get_offerer_address_of_offerer(offerer_id: int, offerer_address_id: int) -> 
 
 def get_offerer_headline_offer(offerer_id: int) -> offers_models.Offer | None:
     try:
-        # FIXME: ogeber: when offers will be able to have several headline offers, and unicity of the headline
-        # offer will be on its active status, change this query and add a filter on active headline offer only
         offer = (
             offers_models.Offer.query.join(models.Venue, offers_models.Offer.venueId == models.Venue.id)
             .join(models.Offerer, models.Venue.managingOffererId == models.Offerer.id)
             .join(offers_models.HeadlineOffer, offers_models.HeadlineOffer.offerId == offers_models.Offer.id)
             .options(
-                sqla_orm.contains_eager(offers_models.Offer.headlineOffer),
+                sqla_orm.contains_eager(offers_models.Offer.headlineOffers),
                 sqla_orm.joinedload(offers_models.Offer.mediations),
                 sqla_orm.joinedload(offers_models.Offer.product).joinedload(offers_models.Product.productMediations),
             )
-            .filter(models.Offerer.id == offerer_id)
+            .filter(models.Offerer.id == offerer_id, offers_models.HeadlineOffer.isActive == True)
             .one_or_none()
         )
 

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -700,6 +700,14 @@ def activate_future_offers(publication_date: datetime.datetime | None = None) ->
     batch_update_offers(query, {"isActive": True})
 
 
+def set_upper_timespan_of_inactive_headline_offers() -> None:
+    inactive_headline_offers = offers_repository.get_inactive_headline_offers()
+    for headline_offer in inactive_headline_offers:
+        headline_offer.timespan = db_utils.make_timerange(headline_offer.timespan.lower, datetime.datetime.utcnow())
+
+    db.session.commit()
+
+
 def make_offer_headline(offer: models.Offer) -> models.HeadlineOffer:
     if offer.status != OfferStatus.ACTIVE:
         raise exceptions.InactiveOfferCanNotBeHeadline()

--- a/api/src/pcapi/core/offers/commands.py
+++ b/api/src/pcapi/core/offers/commands.py
@@ -10,3 +10,9 @@ blueprint = Blueprint(__name__, __name__)
 @log_cron_with_transaction
 def activate_future_offers() -> None:
     offers_api.activate_future_offers()
+
+
+@blueprint.cli.command("set_upper_timespan_of_inactive_headline_offers")
+@log_cron_with_transaction
+def set_upper_timespan_of_inactive_headline_offers() -> None:
+    offers_api.set_upper_timespan_of_inactive_headline_offers()

--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -378,3 +378,18 @@ class AllNullContactRequestDataError(CollectiveOfferContactRequestError):
 class UrlandFormBothSetError(CollectiveOfferContactRequestError):
     msg = "Url and form can not both be used"
     fields = "url,form"
+
+
+class InactiveOfferCanNotBeHeadline(Exception):
+    def __init__(self) -> None:
+        super().__init__("headlineOffer", "This offer is inactive and can not be made headline")
+
+
+class OfferHasAlreadyAnActiveHeadlineOffer(Exception):
+    def __init__(self) -> None:
+        super().__init__("headlineOffer", "This offer is already an active headline offer")
+
+
+class VenueHasAlreadyAnActiveHeadlineOffer(Exception):
+    def __init__(self) -> None:
+        super().__init__("headlineOffer", "This venue has already an active headline offer")

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -268,6 +268,10 @@ class HeadlineOfferFactory(BaseFactory):
     class Meta:
         model = models.HeadlineOffer
 
+    offer = factory.SubFactory(OfferFactory)
+    venue = factory.SelfAttribute("offer.venue")
+    timespan = (datetime.datetime.utcnow(),)
+
 
 class PriceCategoryLabelFactory(BaseFactory):
     class Meta:

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -217,11 +217,6 @@ class OfferFactory(BaseFactory):
 
         return super()._create(model_class, *args, **kwargs)
 
-    @factory.post_generation
-    def is_headline_offer(self, create: bool, is_headline_offer: bool = False, **kwargs: typing.Any) -> None:
-        if is_headline_offer:
-            HeadlineOfferFactory(offer=self, venue=self.venue)
-
 
 class ArtistProductLinkFactory(BaseFactory):
     class Meta:

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -517,10 +517,10 @@ class HeadlineOffer(PcObject, Base, Model):
     __tablename__ = "headline_offer"
 
     offerId: int = sa.Column(
-        sa.BigInteger, sa.ForeignKey("offer.id", ondelete="CASCADE"), nullable=False, index=True, unique=True
+        sa.BigInteger, sa.ForeignKey("offer.id", ondelete="CASCADE"), nullable=False, index=True, unique=False
     )
-    offer: sa_orm.Mapped["Offer"] = sa_orm.relationship("Offer", back_populates="headlineOffer")
-    venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), nullable=False, index=True, unique=True)
+    offer: sa_orm.Mapped["Offer"] = sa_orm.relationship("Offer", back_populates="headlineOffers")
+    venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), nullable=False, index=True, unique=False)
     venue: sa_orm.Mapped["Venue"] = sa_orm.relationship("Venue", back_populates="headlineOffers")
 
     dateCreated: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
@@ -614,8 +614,8 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     reactions: list["Reaction"] = sa.orm.relationship(
         "Reaction", back_populates="offer", uselist=True, cascade="all, delete-orphan", passive_deletes=True
     )
-    headlineOffer: sa_orm.Mapped["HeadlineOffer"] = sa_orm.relationship(
-        "HeadlineOffer", back_populates="offer", uselist=False
+    headlineOffers: sa_orm.Mapped[list["HeadlineOffer"]] = sa_orm.relationship(
+        "HeadlineOffer", back_populates="offer", uselist=True, cascade="all, delete-orphan", passive_deletes=True
     )
 
     sa.Index("idx_offer_trgm_name", name, postgresql_using="gin")

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -108,7 +108,7 @@ def get_capped_offers_for_filters(
                 models.Offer.extraData,
                 models.Offer.lastProviderId,
                 models.Offer.offererAddressId,
-            ).joinedload(models.Offer.headlineOffer)
+            ).joinedload(models.Offer.headlineOffers)
         )
         .options(
             sa_orm.joinedload(models.Offer.venue)
@@ -207,6 +207,16 @@ def get_offers_data_from_top_offers(top_offers: list[dict]) -> list[dict]:
                 models.Mediation.dateCreated,
                 models.Mediation.thumbCount,
                 models.Mediation.credit,
+            )
+        )
+        .options(sa_orm.joinedload(models.Offer.headlineOffers))
+        .options(
+            sa_orm.joinedload(models.Offer.stocks).load_only(
+                models.Stock.quantity,
+                models.Stock.isSoftDeleted,
+                models.Stock.beginningDatetime,
+                models.Stock.dnBookedQuantity,
+                models.Stock.bookingLimitDatetime,
             )
         )
         .options(
@@ -1140,7 +1150,7 @@ def get_offer_by_id(offer_id: int, load_options: OFFER_LOAD_OPTIONS = ()) -> mod
         if "product" in load_options:
             query = query.options(sa_orm.joinedload(models.Offer.product).joinedload(models.Product.productMediations))
         if "headline_offer" in load_options:
-            query = query.options(sa_orm.joinedload(models.Offer.headlineOffer))
+            query = query.options(sa_orm.joinedload(models.Offer.headlineOffers))
         if "price_category" in load_options:
             query = query.options(
                 sa_orm.joinedload(models.Offer.priceCategories).joinedload(models.PriceCategory.priceCategoryLabel)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
@@ -23,6 +23,9 @@ from pcapi.sandboxes.scripts.creators.industrial.create_industrial_eac_data impo
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_event_occurrences import *
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_event_offers import *
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_event_stocks import *
+from pcapi.sandboxes.scripts.creators.industrial.create_industrial_headline_offers import (
+    create_industrial_headline_offers,
+)
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_incidents import create_industrial_incidents
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_individual_offerers import (
     create_industrial_individual_offerers,
@@ -101,6 +104,8 @@ def save_industrial_sandbox() -> None:
     create_industrial_thing_stocks(thing_offers_by_name)
 
     create_industrial_mediations(offers_by_name)
+
+    create_industrial_headline_offers(offers_by_name)
 
     criteria_by_name = create_industrial_criteria()
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_offers.py
@@ -34,7 +34,6 @@ def create_industrial_event_offers(
             continue
 
         event_venue = event_venues[0]
-        headline_offer_limit_per_offerer = 1
 
         for venue_event_index in range(0, EVENTS_PER_OFFERER_WITH_PHYSICAL_VENUE):
             event_subcategory_index = (venue_event_index + event_index) % len(event_subcategories)
@@ -59,11 +58,8 @@ def create_industrial_event_offers(
                 ),
                 isActive=is_active,
                 isDuo=is_duo,
-                is_headline_offer=bool(headline_offer_limit_per_offerer and not event_venue.has_headline_offer),
             )
             offer_index += 1
-            # FIXME : 6.12.2024 ogeber : decrement headline_offer_limit_per_offerer (limit 0) if original limit is > 1
-            headline_offer_limit_per_offerer = 0
 
         event_index += EVENTS_PER_OFFERER_WITH_PHYSICAL_VENUE
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_headline_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_headline_offers.py
@@ -1,0 +1,37 @@
+import logging
+
+import pcapi.core.offers.factories as offers_factories
+from pcapi.core.offers.models import Offer
+from pcapi.models.offer_mixin import OfferStatus
+
+
+logger = logging.getLogger(__name__)
+
+HEADLINE_OFFER_LIMIT_PER_OFFERER = 1
+
+
+def create_industrial_headline_offers(offers_by_name: dict[str, Offer]) -> None:
+    logger.info("create_industrial_headline_offers")
+
+    headline_offer_limit_per_offerer = {}
+    offerers = {offer.venue.managingOfferer.name: offer.venue.managingOfferer for offer in offers_by_name.values()}
+    for offerer_name in offerers.keys():
+        headline_offer_limit_per_offerer[offerer_name] = HEADLINE_OFFER_LIMIT_PER_OFFERER
+
+    headline_offers_by_name = {}
+    for offer_name, offer in offers_by_name.items():
+        offerer_name = offer.venue.managingOfferer.name
+        if (
+            headline_offer_limit_per_offerer[offerer_name]
+            and offer.status == OfferStatus.ACTIVE
+            and not offer.venue.has_headline_offer
+        ):
+            headline_offers_by_name[offer_name] = offers_factories.HeadlineOfferFactory(offer=offer, venue=offer.venue)
+
+            headline_offer_limit_per_offerer[offerer_name] = (
+                headline_offer_limit_per_offerer[offerer_name] - 1
+                if headline_offer_limit_per_offerer[offerer_name] > 0
+                else headline_offer_limit_per_offerer[offerer_name]
+            )
+
+    logger.info("created %d headline offers", len(headline_offers_by_name))

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_thing_offers.py
@@ -34,8 +34,6 @@ def create_industrial_thing_offers(
         physical_venue_name = virtual_venue.name.replace(" (Offre numérique)", "")
         physical_venue = venues_by_name.get(physical_venue_name)
 
-        headline_offer_limit_per_offerer = 1
-
         for venue_thing_index in range(0, THINGS_PER_OFFERER):
             thing_venue = None
             subcategory_index = (venue_thing_index + thing_index) % len(thing_subcategories)
@@ -65,12 +63,9 @@ def create_industrial_thing_offers(
                 url="http://example.com" if subcategory.is_online_only else None,
                 idAtProvider=str(id_at_provider),
                 extraData=offers_factories.build_extra_data_from_subcategory(subcategory.id, set_all_fields=False),
-                is_headline_offer=bool(headline_offer_limit_per_offerer and not thing_venue.has_headline_offer),
             )
             offer_index += 1
             id_at_provider += 1
-            # FIXME : 6.12.2024 ogeber : decrement headline_offer_limit_per_offerer (limit 0) if original limit is > 1
-            headline_offer_limit_per_offerer = 0
 
         thing_index += THINGS_PER_OFFERER
 

--- a/api/tests/core/offerers/test_repository.py
+++ b/api/tests/core/offerers/test_repository.py
@@ -276,6 +276,7 @@ class GetOffererAddressesTest:
 class GetOffererHeadlineOfferTest:
     def test_return_headline_offer(self):
         offer = offers_factories.OfferFactory()
+        offers_factories.StockFactory(offer=offer)
         offers_factories.HeadlineOfferFactory(offer=offer, venue=offer.venue)
 
         headline_offer = repository.get_offerer_headline_offer(offer.venue.managingOffererId)
@@ -287,7 +288,9 @@ class GetOffererHeadlineOfferTest:
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         other_venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offer = offers_factories.OfferFactory(venue=venue)
+        offers_factories.StockFactory(offer=offer)
         other_offer = offers_factories.OfferFactory(venue=other_venue)
+        offers_factories.StockFactory(offer=other_offer)
         offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
         offers_factories.HeadlineOfferFactory(offer=other_offer, venue=other_venue)
 

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -1,6 +1,8 @@
 import datetime
 
 import pytest
+from sqlalchemy import exc
+import time_machine
 
 import pcapi.core.bookings.constants as bookings_constants
 import pcapi.core.bookings.factories as bookings_factories
@@ -695,3 +697,55 @@ class OfferfullAddressTest:
         )
         offer = factories.OfferFactory(offererAddress=oa)
         assert offer.fullAddress == expected_full_address
+
+
+class HeadlineOfferTest:
+    today = datetime.datetime.utcnow()
+    tomorrow = today + datetime.timedelta(days=1)
+    day_after_tomorrow = today + datetime.timedelta(days=2)
+    next_month = today + datetime.timedelta(days=30)
+
+    def test_headline_offer_is_active(self):
+        offer = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=offer)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, timespan=(self.today, None))
+        assert headline_offer.isActive
+
+    def test_headline_offer_with_ending_time_in_the_future_is_active(self):
+        offer = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=offer)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, timespan=(self.today, self.day_after_tomorrow))
+        assert headline_offer.isActive
+
+    def test_headline_offer_is_not_active(self):
+        offer = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=offer)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, timespan=(self.today, self.day_after_tomorrow))
+        with time_machine.travel(self.next_month):
+            assert not headline_offer.isActive
+
+    @pytest.mark.parametrize(
+        "timespan,overlaping_timespan",
+        [
+            ((today, None), (tomorrow, None)),
+            ((today, None), (tomorrow, next_month)),
+            ((today, day_after_tomorrow), (tomorrow, None)),
+            ((today, day_after_tomorrow), (tomorrow, next_month)),
+        ],
+    )
+    def test_unicity_headline_offer(self, timespan, overlaping_timespan):
+        offer = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=offer)
+        factories.HeadlineOfferFactory(offer=offer, timespan=timespan)
+        with pytest.raises(exc.IntegrityError):
+            factories.HeadlineOfferFactory(offer=offer, timespan=overlaping_timespan)
+
+    def test_unicity_headline_offer_by_venue(self):
+        venue = offerers_factories.VenueFactory()
+        offer = factories.OfferFactory(isActive=True, venue=venue)
+        another_offer_on_the_same_venue = factories.OfferFactory(isActive=True, venue=venue)
+        factories.StockFactory(offer=offer)
+        factories.StockFactory(offer=another_offer_on_the_same_venue)
+        factories.HeadlineOfferFactory(offer=offer)
+        with pytest.raises(exc.IntegrityError):
+            factories.HeadlineOfferFactory(offer=another_offer_on_the_same_venue)

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -2588,3 +2588,83 @@ class GetOfferPriceCategoriesFiltersTest:
 
         # Then
         assert len(price_categories.all()) == 0
+
+
+@pytest.mark.usefixtures("db_session")
+class GetHeadlineOfferFiltersTest:
+    def test_get_headline_offer_basic(self):
+        offer = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=offer)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer)
+
+        headline_offer_query_result = repository.get_active_headline_offer(offer.id)
+        assert headline_offer_query_result == headline_offer
+
+    def test_get_only_active_headline_offer(self):
+        offer = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=offer)
+        creation_time = datetime.datetime.utcnow() - datetime.timedelta(days=20)
+        finished_timespan = (creation_time, creation_time + datetime.timedelta(days=10))
+        headline_offer = factories.HeadlineOfferFactory(offer=offer)
+        factories.HeadlineOfferFactory(offer=offer, timespan=finished_timespan)
+
+        headline_offer_query_result = repository.get_active_headline_offer(offer.id)
+        assert headline_offer_query_result == headline_offer
+
+    def test_get_specific_offer_active_headline_offer(self):
+        offer = factories.OfferFactory(isActive=True)
+        offer_on_another_venue = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=offer)
+        factories.StockFactory(offer=offer_on_another_venue)
+        factories.HeadlineOfferFactory(offer=offer)
+        factories.HeadlineOfferFactory(offer=offer_on_another_venue)
+
+        headline_offer_query_result = repository.get_active_headline_offer(offer.id)
+        assert headline_offer_query_result.offer == offer
+
+    def test_should_return_no_inactive_headline_offer(self):
+        offer = factories.OfferFactory(isActive=False)
+        factories.StockFactory(offer=offer)
+        factories.HeadlineOfferFactory(offer=offer)
+        creation_time = datetime.datetime.utcnow() - datetime.timedelta(days=20)
+        finished_timespan = (creation_time, creation_time + datetime.timedelta(days=10))
+        factories.HeadlineOfferFactory(offer=offer, timespan=finished_timespan)
+
+        headline_offer_query_result = repository.get_active_headline_offer(offer.id)
+        assert headline_offer_query_result == None
+
+    def test_get_inactive_headline_offers_basic(self):
+        inactive_offer = factories.OfferFactory(isActive=False)
+        inactive_offer_headline_offer = factories.HeadlineOfferFactory(offer=inactive_offer)
+
+        active_offer = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=active_offer)
+        active_offer_headline_offer = factories.HeadlineOfferFactory(offer=active_offer)
+
+        finished_timespan = (
+            datetime.datetime.utcnow() - datetime.timedelta(days=20),
+            datetime.datetime.utcnow() - datetime.timedelta(days=10),
+        )
+        already_inactive_offer_headline_offer = factories.HeadlineOfferFactory(
+            offer=active_offer, timespan=finished_timespan
+        )
+
+        another_active_offer = factories.OfferFactory(isActive=True)
+        timespan_finishing_in_the_future = (
+            datetime.datetime.utcnow() - datetime.timedelta(days=3),
+            datetime.datetime.utcnow() + datetime.timedelta(days=3),
+        )
+        soon_to_be_inactive_timespan = factories.HeadlineOfferFactory(
+            offer=another_active_offer, timespan=timespan_finishing_in_the_future
+        )
+
+        headline_offer_query_result = repository.get_inactive_headline_offers()
+        assert headline_offer_query_result == [inactive_offer_headline_offer]
+
+    def test_get_inactive_headline_offers_empty_result(self):
+        offer = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=offer)
+        factories.HeadlineOfferFactory(offer=offer)
+
+        headline_offer_query_result = repository.get_inactive_headline_offers()
+        assert headline_offer_query_result == []

--- a/api/tests/routes/native/v1/offerers_test.py
+++ b/api/tests/routes/native/v1/offerers_test.py
@@ -211,6 +211,7 @@ class OffererHeadlineOfferTest:
         offerer = user_offerer.offerer
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offer = offers_factories.OfferFactory(venue=venue)
+        offers_factories.StockFactory(offer=offer)
         offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
 
         client = client.with_session_auth(email=pro.email)

--- a/api/tests/routes/pro/get_offerer_headline_offer_test.py
+++ b/api/tests/routes/pro/get_offerer_headline_offer_test.py
@@ -24,6 +24,7 @@ class Return200Test:
         offerer = user_offerer.offerer
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offer = offers_factories.OfferFactory(venue=venue)
+        offers_factories.StockFactory(offer=offer)
         offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
         client = client.with_session_auth(email=pro.email)
         offerer_id = offerer.id
@@ -52,6 +53,7 @@ class Return200Test:
         offers_factories.ProductMediationFactory(product=product, imageType=TiteliveImageType.VERSO)
 
         offer = offers_factories.OfferFactory(venue=venue, product=product)
+        offers_factories.StockFactory(offer=offer)
         offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
         client = client.with_session_auth(email=pro.email)
         offerer_id = offerer.id
@@ -91,9 +93,11 @@ class Return400Test:
         offerer = user_offerer.offerer
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offer = offers_factories.OfferFactory(venue=venue)
+        offers_factories.StockFactory(offer=offer)
         offers_factories.HeadlineOfferFactory(offer=offer, venue=venue)
         other_venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         other_offer = offers_factories.OfferFactory(venue=other_venue)
+        offers_factories.StockFactory(offer=other_offer)
         offers_factories.HeadlineOfferFactory(offer=other_offer, venue=other_venue)
         client = client.with_session_auth(email=pro.email)
         offerer_id = offerer.id

--- a/api/tests/routes/pro/get_offerer_stats_test.py
+++ b/api/tests/routes/pro/get_offerer_stats_test.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 import time_machine
 
@@ -25,7 +27,10 @@ class OffererStatsTest:
         offer_2 = offers_factories.OfferFactory(venue__managingOffererId=offerer.id)
         mediation = offers_factories.MediationFactory(offer=offer_2)
         offer_3 = offers_factories.OfferFactory(venue__managingOffererId=offerer.id)
-        offers_factories.HeadlineOfferFactory(offer=offer_2, venue=offer_2.venue)
+        offers_factories.StockFactory(offer=offer_2)
+        offers_factories.HeadlineOfferFactory(
+            offer=offer_2, venue=offer_2.venue, timespan=(datetime.datetime.utcnow(),)
+        )
 
         offerers_factories.OffererStatsFactory(
             offerer=offerer,
@@ -73,8 +78,7 @@ class OffererStatsTest:
         queries = testing.AUTHENTICATION_QUERIES
         queries += 1  # check user_offerer exists
         queries += 1  # select offerer_stats
-        queries += 1  # select offers with images
-        queries += 3  # determine if headline offers
+        queries += 1  # select offers with images, join on headline offer & stocks
         with testing.assert_num_queries(queries):
             response = client.get(f"/offerers/{offerer_id}/stats")
             assert response.status_code == 200


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33423
commit 1 : retirer les contraintes d'unicité sur les offres & venues (pour préparer la suite)
commit 2: ajouter un timespan et des contraintes d'unicité sur l'overlap du timespan par offre et venue
commit 3: mettre à jour la fin du timespan si une offre n'est plus active (sera ajoutée à la crontab)
commit 4: mise à jour de la sandbox pour avoir des offres à la une valide
commit 5: mise à jour des routes GET offerer / headline_offer (PRO + NATIF)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
