### PR TITLE
(PC-33725)[API] script: fix some offers' subcategories

### DIFF
--- a/api/src/pcapi/scripts/correct_offer_subcategories/main.sql
+++ b/api/src/pcapi/scripts/correct_offer_subcategories/main.sql
@@ -1,0 +1,12 @@
+update
+    offer
+set
+    "subcategoryId" = 'FESTIVAL_MUSIQUE'
+where
+    id in (
+        281950072,
+        281950144,
+        281950168,
+        281950169,
+        281949052
+    );


### PR DESCRIPTION
Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33725

Corriger la sous-catégorie de certaines offres (qui n'ont pas de remboursement).
