### PR TITLE
(PC-33722)[API] fix: rm current_user as a parameter inside public route

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -1,6 +1,5 @@
 import copy
 
-from flask_login import current_user
 import sqlalchemy as sqla
 
 from pcapi import repository
@@ -595,7 +594,7 @@ def delete_event_stock(event_id: int, stock_id: int) -> None:
     if not stock_to_delete:
         raise api_errors.ApiErrors({"stock_id": ["No stock could be found"]}, status_code=404)
     try:
-        offers_api.delete_stock(stock_to_delete, current_user)
+        offers_api.delete_stock(stock_to_delete)
     except offers_exceptions.OfferEditionBaseException as error:
         raise api_errors.ApiErrors(error.errors, status_code=400)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33722

Bug : impossible d'annuler le stock d'un événement via l'API publique si celui-ci a au moins une réservation.

Fix : ne pas utiliser `current_user` dans l'API publique puisqu'il renvoie un objet représentant un utilisateur anonyme (logique, puisqu'elle n'utilise pas flask login) ce qui créé quelques étincelles au moment de mettre à jour la réservation ("`cancellationUserId` doit être un entier").
