### PR TITLE
(PC-33741)[PRO] fix: Load the offerer when logging in.

### DIFF
--- a/pro/src/pages/SignIn/SignIn.tsx
+++ b/pro/src/pages/SignIn/SignIn.tsx
@@ -9,11 +9,17 @@ import { Layout } from 'app/App/layout/Layout'
 import {
   RECAPTCHA_ERROR,
   RECAPTCHA_ERROR_MESSAGE,
+  SAVED_OFFERER_ID_KEY,
 } from 'commons/core/shared/constants'
 import { useInitReCaptcha } from 'commons/hooks/useInitReCaptcha'
 import { useNotification } from 'commons/hooks/useNotification'
 import { useRedirectLoggedUser } from 'commons/hooks/useRedirectLoggedUser'
+import {
+  updateOffererNames,
+  updateSelectedOffererId,
+} from 'commons/store/offerer/reducer'
 import { updateUser } from 'commons/store/user/reducer'
+import { localStorageAvailable } from 'commons/utils/localStorageAvailable'
 import { getReCaptchaToken } from 'commons/utils/recaptcha'
 
 import { SIGNIN_FORM_DEFAULT_VALUES } from './constants'
@@ -65,6 +71,25 @@ export const SignIn = (): JSX.Element => {
         password,
         captchaToken,
       })
+
+      const offerers = await api.listOfferersNames()
+      const firstOffererId = offerers.offerersNames[0]?.id
+
+      if (firstOffererId) {
+        dispatch(updateOffererNames(offerers.offerersNames))
+
+        if (localStorageAvailable()) {
+          const savedOffererId = localStorage.getItem(SAVED_OFFERER_ID_KEY)
+          dispatch(
+            updateSelectedOffererId(
+              savedOffererId ? Number(savedOffererId) : firstOffererId
+            )
+          )
+        } else {
+          dispatch(updateSelectedOffererId(firstOffererId))
+        }
+      }
+
       dispatch(updateUser(user))
       setshouldRedirect(true)
     } catch (error) {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33741

**Objectif**
Lors du login, ajouter la mise à jour dans le store de l'offerer de l'utilisateur. Sans ça, si le store est initialisé alors que l'utilisateur n'est pas connecté, l'offerer n'est jamais ajouté au store et la page d'accueil est vide.

Voir la description du ticket pour la reproduction du bug.

@abouabdallaoui-pass  Je pense que c'est depuis [le commit d'ajout du store de l'offerer](https://github.com/pass-culture/pass-culture-main/commit/fcd8d3d95b7f020f5ca0f60821f7c2de03f3746e). J'ai fait de mon mieux pour corriger rapidement, mais ce serait top si tu pouvais jeter un oeil. Aussi est-ce que pour éviter les multiples appels sur `offerers/names` on pourrait mettres les offerers dispo dans le store ?

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
