### PR TITLE
(BSR)[API] fix: recreate invalid index ix_user_email_domain

### DIFF
--- a/api/src/pcapi/scripts/recreate_ix_user_email_domain/main.sql
+++ b/api/src/pcapi/scripts/recreate_ix_user_email_domain/main.sql
@@ -1,0 +1,15 @@
+-- One time script to recreate an index reported as invalid
+-- Sentry issue: https://sentry.passculture.team/organizations/sentry/issues/1477809/?environment=production&project=5
+
+DROP INDEX CONCURRENTLY IF EXISTS "ix_user_email_domain";
+
+SET SESSION statement_timeout='300s';
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_user_email_domain" ON public."user" USING btree (email_domain(email));
+SET SESSION statement_timeout=60000;  -- restore value set in helm/pcapi/production/values-configmaps.yaml:
+
+-- Print invalid indexes to check in logs that the index is now valid
+SELECT relname
+FROM pg_class,
+    pg_index
+WHERE pg_index.indisvalid = false
+    AND pg_index.indexrelid = pg_class.oid;


### PR DESCRIPTION
## But de la pull request

Recréation de l'index invalide ix_user_email_domain

https://sentry.passculture.team/organizations/sentry/discover/api:efa26950af944010a22e2fc079e1391c/

Inspiré de :  https://github.com/pass-culture/pass-culture-main/pull/15494

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
