### PR TITLE
(PC-33696)[BO] feat: add filter responses by status in special operation details page

### DIFF
--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -1519,18 +1519,35 @@ def format_finance_incident_type(incident_kind: finance_models.IncidentType) -> 
             return incident_kind.value
 
 
-def format_special_event_response_status(response_status: operations_models.SpecialEventResponseStatus) -> str:
+def format_special_event_response_status_str(response_status: operations_models.SpecialEventResponseStatus) -> str:
     match response_status:
         case operations_models.SpecialEventResponseStatus.NEW:
-            return Markup('<span class="badge text-bg-info">Nouvelle</span>')
+            return "Nouvelle"
         case operations_models.SpecialEventResponseStatus.VALIDATED:
-            return Markup('<span class="badge text-bg-success">Retenue</span>')
+            return "Retenue"
         case operations_models.SpecialEventResponseStatus.REJECTED:
-            return Markup('<span class="badge text-bg-danger">Rejetée</span>')
+            return "Rejetée"
         case operations_models.SpecialEventResponseStatus.PRESELECTED:
-            return Markup('<span class="badge border border-success text-success">Préselectionnée</span>')
+            return "Préselectionnée"
         case _:
             return response_status.value
+
+
+def format_special_event_response_status(response_status: operations_models.SpecialEventResponseStatus) -> str:
+    response_status_str = format_special_event_response_status_str(response_status)
+    match response_status:
+        case operations_models.SpecialEventResponseStatus.NEW:
+            return Markup('<span class="badge text-bg-info">{status}</span>').format(status=response_status_str)
+        case operations_models.SpecialEventResponseStatus.VALIDATED:
+            return Markup('<span class="badge text-bg-success">{status}</span>').format(status=response_status_str)
+        case operations_models.SpecialEventResponseStatus.REJECTED:
+            return Markup('<span class="badge text-bg-danger">{status}</span>').format(status=response_status_str)
+        case operations_models.SpecialEventResponseStatus.PRESELECTED:
+            return Markup('<span class="badge border border-success text-success">{status}</span>').format(
+                status=response_status_str
+            )
+        case _:
+            return response_status_str
 
 
 def field_list_get_number_from_name(field_name: str) -> str:

--- a/api/src/pcapi/routes/backoffice/operations/forms.py
+++ b/api/src/pcapi/routes/backoffice/operations/forms.py
@@ -4,6 +4,8 @@ from urllib.parse import urlparse
 from flask_wtf import FlaskForm
 import wtforms
 
+from pcapi.core.operations import models
+from pcapi.routes.backoffice.filters import format_special_event_response_status_str
 from pcapi.routes.backoffice.forms import fields
 from pcapi.routes.backoffice.forms import utils
 
@@ -55,3 +57,17 @@ class CreateSpecialEventForm(FlaskForm):
             if not re.match(RE_TYPEFORM_ID, typeform_id.data):
                 raise wtforms.validators.ValidationError("Le format n'est pas reconnu")
         return typeform_id
+
+
+class OperationResponseForm(utils.PCForm):
+    class Meta:
+        csrf = False
+
+    response_status = fields.PCSelectMultipleField(
+        "État de la candidature",
+        choices=utils.choices_from_enum(
+            enum_cls=models.SpecialEventResponseStatus,
+            formatter=format_special_event_response_status_str,
+        ),
+        coerce=models.SpecialEventResponseStatus,
+    )

--- a/api/src/pcapi/routes/backoffice/templates/operations/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/operations/details.html
@@ -1,4 +1,5 @@
 {% import "components/links.html" as links %}
+{% from "components/forms.html" import build_filters_form with context %}
 {% from "components/presentation/details/tabs.html" import build_details_tab %}
 {% from "components/presentation/details/tabs.html" import build_details_tabs_wrapper %}
 {% from "components/presentation/details/tabs.html" import build_details_tab_content %}
@@ -46,6 +47,9 @@
         {% endcall %}
         {% call build_details_tabs_content_wrapper() %}
           {% call build_details_tab_content("responses", active_tab == 'responses') %}
+            <div class="px-3">
+              <div class="filters">{{ build_filters_form(response_form, dst_response) }}</div>
+            </div>
             <table class="table mb-4 my-4">
               <thead>
                 <tr>
@@ -129,7 +133,7 @@
                       {% for question in special_event.questions | sort(attribute='id') %}
                         <span class="fw-bold">{{ question.title }}</span>
                         <br />
-                        {{ row.full_answers.get(question.id|string) | empty_string_if_null }}
+                        {{ (row.full_answers or {}).get(question.id|string) | empty_string_if_null }}
                         <br />
                         <br />
                       {% endfor %}


### PR DESCRIPTION
## But de la pull request

Ajout d'un filtre par état de la candidature dans la page d'une opération spéciale :

<img width="1267" alt="Capture d’écran 2025-01-06 à 16 34 04" src="https://github.com/user-attachments/assets/1874ea15-81dc-41be-ae77-b7831e6b723c" />

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33696

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
