### PR TITLE
(PC-33803)[PRO] fix: Width of day checkboxes.

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventCreation/DayCheckbox.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/DayCheckbox.module.scss
@@ -4,7 +4,11 @@
 
 $checkbox-size: rem.torem(40px);
 
-.checkbox input {
+.day-checkbox {
+  width: auto;
+}
+
+.day-checkbox-input {
   position: relative;
   width: $checkbox-size;
   height: $checkbox-size;

--- a/pro/src/components/IndividualOffer/StocksEventCreation/DayCheckbox.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/DayCheckbox.tsx
@@ -23,7 +23,8 @@ export const DayCheckbox = ({
       label={undefined}
       {...field}
       {...inputProps}
-      className={styles['checkbox']}
+      className={styles['day-checkbox']}
+      inputClassName={styles['day-checkbox-input']}
       aria-label={label}
       data-letter={letter}
     />


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33803

**Objectif**
Corriger l'affichage des `DayCheckbox` dans le form d'édition des jours d'ouverture d'un lieu.

Avant/après : 
<img width="470" alt="Capture d’écran 2025-01-06 à 16 39 12" src="https://github.com/user-attachments/assets/9a76761f-c66c-4c60-a701-5db7fc7b0bc0" />
<img width="382" alt="Capture d’écran 2025-01-06 à 16 38 57" src="https://github.com/user-attachments/assets/befb8518-ac21-448f-a018-7641682117c0" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
