### PR TITLE
(PC-33820)[PRO] style: Prevent collaborators email statuses to be bro…

### DIFF
--- a/pro/src/pages/Collaborators/Collaborators.module.scss
+++ b/pro/src/pages/Collaborators/Collaborators.module.scss
@@ -49,30 +49,11 @@
 
   .members-container {
     margin-bottom: rem.torem(24px);
-    max-width: 100%;
-    position: relative;
-
-    &::before {
-      content: "";
-      position: absolute;
-      display: block;
-      width: rem.torem(45px);
-      top: 0;
-      right: 0;
-      bottom: 0;
-      z-index: 2;
-      box-shadow: inset rem.torem(-45px) 0 rem.torem(15px) rem.torem(-30px)
-        white;
-    }
-
-    .members-inner {
-      overflow-x: auto;
-    }
   }
 
   .members-list {
     border-collapse: separate;
-    min-width: rem.torem(365px);
+    width: 100%;
 
     th {
       @include fonts.body-accent-xs;
@@ -97,13 +78,11 @@
 }
 
 .member-email {
-  display: flex;
-  word-break: keep-all;
+  word-break: break-word;
 }
 
 .member-status {
-  width: rem.torem(90px);
-  word-break: keep-all;
+  white-space: nowrap;
 }
 
 .display-all-members-button {

--- a/pro/src/pages/Collaborators/Collaborators.tsx
+++ b/pro/src/pages/Collaborators/Collaborators.tsx
@@ -3,9 +3,8 @@
 // Component only for display (sub-components already tested)
 
 import { Form, FormikProvider, useFormik } from 'formik'
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
-import { useLocation } from 'react-router-dom'
 import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
@@ -27,7 +26,6 @@ import { EmailSpellCheckInput } from 'ui-kit/form/EmailSpellCheckInput/EmailSpel
 
 import styles from './Collaborators.module.scss'
 
-const SECTION_ID = '#attachment-invitations-section'
 const SUCCESS_MESSAGE = "L'invitation a bien été envoyée."
 const ERROR_MESSAGE = 'Une erreur est survenue lors de l’envoi de l’invitation.'
 
@@ -35,7 +33,6 @@ export const Collaborators = (): JSX.Element | null => {
   const offererId = useSelector(selectCurrentOffererId)
 
   const { logEvent } = useAnalytics()
-  const location = useLocation()
   const notify = useNotification()
   const [isLoading, setIsLoading] = useState(false)
   const [displayAllMembers, setDisplayAllMembers] = useState(false)
@@ -84,15 +81,6 @@ export const Collaborators = (): JSX.Element | null => {
     validateOnChange: false,
   })
 
-  const shouldScrollToSection = location.hash === SECTION_ID
-  const scrollToSection = useCallback((node: HTMLElement) => {
-    if (shouldScrollToSection) {
-      setTimeout(() => {
-        node.scrollIntoView()
-      }, 200)
-    }
-  }, [])
-
   const MAX_COLLABORATORS = 10
 
   if (!offererId) {
@@ -103,7 +91,7 @@ export const Collaborators = (): JSX.Element | null => {
     <Layout>
       <h1 className={styles['title']}>Collaborateurs</h1>
 
-      <section className={styles['section']} ref={scrollToSection}>
+      <section className={styles['section']}>
         <h2 className={styles['main-list-title']}>Liste des collaborateurs</h2>
 
         {members.length > 0 && (


### PR DESCRIPTION
…ken into two lines.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33820

**Objectif**
Ne pas faire passer le statut "En attente" sur 2 lignes quand l'adresse email est longue. Au passage j'ai supprimé le scroll horizontal pour favoriser de voir toutes les informations à tout moment.

**Vue de la table à différentes largeurs d'écran :**
<img width="852" alt="Capture d’écran 2025-01-07 à 14 52 50" src="https://github.com/user-attachments/assets/f3ade660-c64b-4823-a8df-de2fe02eac63" />
<img width="550" alt="Capture d’écran 2025-01-07 à 14 52 58" src="https://github.com/user-attachments/assets/650b04ec-f30a-4032-adb8-2543ba39a92b" />
<img width="288" alt="Capture d’écran 2025-01-07 à 14 53 19" src="https://github.com/user-attachments/assets/51006721-d782-4902-98ae-c3630ab681f2" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
