### PR TITLE
(BSR)[API] test: Add a default value for priceDetail

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -189,6 +189,7 @@ class CollectiveStockFactory(BaseFactory):
     dateModified = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1))
     numberOfTickets = 25
     price = 100
+    priceDetail = factory.LazyAttribute(lambda stock: f"Prix: {stock.price}€ pour {stock.numberOfTickets} tickets")
 
 
 class EducationalYearFactory(BaseFactory):

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -43,7 +43,7 @@ class OfferStockResponse(BaseModel):
     isBookable: bool
     price: int
     numberOfTickets: int | None
-    educationalPriceDetail: str | None
+    priceDetail: str | None = Field(alias="educationalPriceDetail")
 
     _convert_price = validator("price", pre=True, allow_reuse=True)(convert_to_cent)
 

--- a/api/tests/routes/adage_iframe/get_favorites_test.py
+++ b/api/tests/routes/adage_iframe/get_favorites_test.py
@@ -113,7 +113,7 @@ class GetFavoriteOfferTest:
                     "contactPhone": "+33199006328",
                     "durationMinutes": None,
                     "offerId": None,
-                    "educationalPriceDetail": None,
+                    "educationalPriceDetail": stock.priceDetail,
                     "domains": [
                         {"id": stock.collectiveOffer.domains[0].id, "name": stock.collectiveOffer.domains[0].name}
                     ],
@@ -184,7 +184,7 @@ class GetFavoriteOfferTest:
                     "contactUrl": collective_offer_template.contactUrl,
                     "contactForm": collective_offer_template.contactForm.value,
                     "durationMinutes": None,
-                    "educationalPriceDetail": None,
+                    "educationalPriceDetail": collective_offer_template.priceDetail,
                     "offerId": None,
                     "domains": [
                         {

--- a/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
+++ b/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
@@ -146,7 +146,7 @@ class Returns200Test:
                 "bookingLimitDatetime": format_into_utc_date(offer.collectiveStock.bookingLimitDatetime),
                 "price": 100.0,
                 "numberOfTickets": 25,
-                "educationalPriceDetail": None,
+                "educationalPriceDetail": offer.collectiveStock.priceDetail,
                 "isEducationalStockEditable": True,
             },
             "institution": {


### PR DESCRIPTION
## But de la pull request

Ceci permettra de pouvoir modifier une offre sur la sandbox lors des tests un peu plus simplement

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
