### PR TITLE
(PC-33242)[BO] feat: add batch actions on responses in operation details page

### DIFF
--- a/api/src/pcapi/routes/backoffice/forms/empty.py
+++ b/api/src/pcapi/routes/backoffice/forms/empty.py
@@ -18,4 +18,6 @@ class BatchForm(FlaskForm):
 
     @property
     def object_ids_list(self) -> list[int]:
-        return [int(id) for id in self.object_ids.data.split(",")]
+        object_ids_str = self.object_ids.data or ""
+        object_ids_str_list = [id_str for id_str in object_ids_str.split(",") if id_str]
+        return [int(id) for id in object_ids_str_list]

--- a/api/src/pcapi/routes/backoffice/templates/operations/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/operations/details.html
@@ -50,9 +50,44 @@
             <div class="px-3">
               <div class="filters">{{ build_filters_form(response_form, dst_response) }}</div>
             </div>
-            <table class="table mb-4 my-4">
+            <div class="d-flex flex-row-reverse">
+              <div class="align-self-center flex-row-reverse"
+                   data-toggle="pc-batch-confirm-btn-group"
+                   data-toggle-id="table-container-operation-responses-btn-group"
+                   data-pc-table-multi-select-id="table-operation-responses-multiselect"
+                   data-input-ids-name="object_ids">
+                <button disabled
+                        type="button"
+                        class="btn btn-outline-primary"
+                        data-modal-selector="#batch-validate-response-modal"
+                        data-mode="fetch"
+                        data-fetch-url="{{ url_for('backoffice_web.operations.get_batch_validate_responses_form', special_event_id=special_event.id) }}"
+                        data-use-confirmation-modal="true">Retenir</button>
+                <button disabled
+                        type="button"
+                        class="btn btn-outline-primary"
+                        data-modal-selector="#batch-preselect-response-modal"
+                        data-mode="fetch"
+                        data-fetch-url="{{ url_for('backoffice_web.operations.get_batch_preselect_responses_form', special_event_id=special_event.id) }}"
+                        data-use-confirmation-modal="true">Présélectionner</button>
+                <button disabled
+                        type="button"
+                        class="btn btn-outline-primary"
+                        data-modal-selector="#batch-reject-response-modal"
+                        data-mode="fetch"
+                        data-fetch-url="{{ url_for('backoffice_web.operations.get_batch_reject_responses_form', special_event_id=special_event.id) }}"
+                        data-use-confirmation-modal="true">Rejeter</button>
+              </div>
+            </div>
+            <table class="table mb-4 my-4"
+                   data-table-multi-select-id="table-operation-responses-multiselect">
               <thead>
                 <tr>
+                  <th scope="col">
+                    <input type="checkbox"
+                           class="form-check-input"
+                           name="pc-table-multi-select-check-all" />
+                  </th>
                   <th scope="col"></th>
                   <th scope="col">Candidat</th>
                   <th scope="col">Email</th>
@@ -67,6 +102,12 @@
                 {% for row in response_rows %}
                   {% set response = row.SpecialEventResponse %}
                   <tr>
+                    <td>
+                      <input type="checkbox"
+                             class="form-check-input"
+                             name="pc-table-multi-select-check-{{ response.id }}"
+                             data-id="{{ response.id }}" />
+                    </td>
                     <td>
                       <div class="dropdown">
                         <button type="button"
@@ -94,7 +135,7 @@
                                     method="post">
                                 {{ csrf_token }}
                                 <button type="submit"
-                                        class="btn btn-sm d-block w-100 text-start px-3">Préselectionner la candidature</button>
+                                        class="btn btn-sm d-block w-100 text-start px-3">Présélectionner la candidature</button>
                               </form>
                             </li>
                           {% endif %}
@@ -142,6 +183,9 @@
                 {% endfor %}
               </tbody>
             </table>
+            {{ build_lazy_modal(url_for("backoffice_web.operations.get_batch_validate_responses_form", special_event_id=special_event.id) , "batch-validate-response-modal", "eager") }}
+            {{ build_lazy_modal(url_for("backoffice_web.operations.get_batch_preselect_responses_form", special_event_id=special_event.id) , "batch-preselect-response-modal", "eager") }}
+            {{ build_lazy_modal(url_for("backoffice_web.operations.get_batch_reject_responses_form", special_event_id=special_event.id) , "batch-reject-response-modal", "eager") }}
           {% endcall %}
         {% endcall %}
       </div>


### PR DESCRIPTION
## But de la pull request

Ajout des actions batch sur les candidatures dans la page d'une opération spéciale :

<img width="1241" alt="Capture d’écran 2025-01-10 à 14 46 11" src="https://github.com/user-attachments/assets/47bd3b0b-79ac-4d34-bed7-5a4ecd5baa2b" />

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33242

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
