### PR TITLE
(PC-33846)[PRO] feat: add target blank for url in description and mai…

### DIFF
--- a/pro/src/components/Markdown/Markdown.module.scss
+++ b/pro/src/components/Markdown/Markdown.module.scss
@@ -1,0 +1,8 @@
+.markdown-link {
+    font-family: var(--font-semi-bold-family);
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+

--- a/pro/src/components/Markdown/Markdown.tsx
+++ b/pro/src/components/Markdown/Markdown.tsx
@@ -1,4 +1,5 @@
 import DOMPurify from 'dompurify'
+import styles from './Markdown.module.scss'
 
 const BOLD_REGEXP = /\*\*(.*?)\*\*/gim
 const ITALIC_REGEXP = /_(.*?)_/gim
@@ -11,7 +12,7 @@ function markdownToHtml(markdown: string) {
   markdown = markdown.replace(ITALIC_REGEXP, '<em>$1</em>')
   markdown = markdown.replace(URL_REGEXP, (url) => {
     const href = url.match('^https?://') ? url : `https://${url}`
-    return `<a href="${href}" rel="noreferrer">${url}</a>`
+    return `<a class="${styles['markdown-link']}" href="${href}" rel="noreferrer" target="_blank">${url}</a>`
   })
   return markdown.replace(EMAIL_REGEXP, (email) => {
     return `<a href="mailto:${email}">${email}</a>`
@@ -21,7 +22,7 @@ function markdownToHtml(markdown: string) {
 export const Markdown = ({ markdownText }: { markdownText: string }) => {
   const html = DOMPurify.sanitize(markdownToHtml(markdownText), {
     ALLOWED_TAGS: ['strong', 'em', 'a'],
-    ALLOWED_ATTR: ['href', 'target', 'rel'],
+    ALLOWED_ATTR: ['href', 'target', 'rel', 'class'],
   })
   return <span dangerouslySetInnerHTML={{ __html: html }} />
 }

--- a/pro/src/components/Markdown/__specs__/Markdown.spec.tsx
+++ b/pro/src/components/Markdown/__specs__/Markdown.spec.tsx
@@ -24,14 +24,14 @@ describe('Markdown', () => {
   it('should render urls with <a> tag', () => {
     const component = renderMarkdown('https://example.com')
     expect(component.container.innerHTML).toContain(
-      '<span><a rel="noreferrer" href="https://example.com">https://example.com</a></span>'
+      '<span><a target="_blank" rel="noreferrer" href="https://example.com" class="markdown-link">https://example.com</a></span>'
     )
   })
 
   it('should render urls without http prefix with <a> tag', () => {
     const component = renderMarkdown('www.example.com')
     expect(component.container.innerHTML).toContain(
-      '<span><a rel="noreferrer" href="https://www.example.com">www.example.com</a></span>'
+      '<span><a target="_blank" rel="noreferrer" href="https://www.example.com" class="markdown-link">www.example.com</a></span>'
     )
   })
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.module.scss
@@ -99,3 +99,11 @@
   background-image: none;
   background-color: var(--color-grey-light);
 }
+
+a[href^="mailto:"] {
+  font-family: var(--font-semi-bold-family);
+
+  &:hover {
+  text-decoration: underline;
+  }
+}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
@@ -96,7 +96,7 @@ export const RequestFormDialog = ({
 
   const getDescriptionElement = () => {
     if (contactEmail && !contactPhone && !contactUrl && !contactForm) {
-      return renderContactElement('par mail', contactEmail)
+      return renderContactElement('par mail', contactEmail, 'mail')
     }
     if (!contactEmail && contactPhone && !contactUrl && !contactForm) {
       return renderContactElement('par téléphone', contactPhone)
@@ -119,13 +119,23 @@ export const RequestFormDialog = ({
 
   const renderContactElement = (
     description: string,
-    value: string | null | undefined
+    value: string | null | undefined,
+    type?: string
   ) => (
     <div>
       <span className={styles['form-description']}>
         Il vous propose de le faire {description} :
       </span>
-      <span className={styles['form-description-text-contact']}>{value}</span>
+      {type === 'mail' ? (
+        <a
+          href={`mailto:${value}`}
+          className={styles['form-description-text-contact']}
+        >
+          {value}
+        </a>
+      ) : (
+        <span className={styles['form-description-text-contact']}>{value}</span>
+      )}
     </div>
   )
 
@@ -143,9 +153,12 @@ export const RequestFormDialog = ({
         {contactEmail && (
           <li>
             par mail :{' '}
-            <span className={styles['form-description-text-value']}>
+            <a
+              href={`mailto:${contactEmail}`}
+              className={styles['form-description-text-value']}
+            >
               {contactEmail}
-            </span>
+            </a>
           </li>
         )}
         {contactPhone && (


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33846

Ajouter l'attribut tareget="_blank" pour les liens qui sont écrit dans le champ description d'une offre collective pour ouvrir le lien sur un nouvel onglet lorsqu'un utilisateur clique dessus depuis adage (le problème remonté était que le lien s'ouvrait dans l'iframe et les CSP bloqué la redirection)

Ajouter mailto pour les mails dans la modal de contact sur adage

## Vérifications

- [x] J'ai écrit les tests nécessaires