### PR TITLE
(PC-33779)[PRO] fix: Adds caret « - » in offer recap for empty OA labels

### DIFF
--- a/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
+++ b/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
@@ -235,7 +235,7 @@ export const OfferSection = ({
               descriptions={[
                 {
                   title: 'Intitulé',
-                  text: offerData.address?.label,
+                  text: offerData.address?.label ?? '-',
                 },
                 {
                   title: 'Adresse',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33779

## Vérifications

- [x] J'ai fait la revue fonctionnelle de mon ticket
