### PR TITLE
(PC-33757)[API] fix: add missing params to some pro email data

### DIFF
--- a/api/src/pcapi/core/mails/transactional/pro/offerer_attachment_invitation.py
+++ b/api/src/pcapi/core/mails/transactional/pro/offerer_attachment_invitation.py
@@ -12,7 +12,11 @@ def retrieve_data_for_offerer_attachment_invitation_new_user(
     offerer: offerers_models.Offerer,
 ) -> models.TransactionalEmailData:
     return models.TransactionalEmailData(
-        template=TransactionalEmail.OFFERER_ATTACHMENT_INVITATION_NEW_USER.value, params={"OFFERER_NAME": offerer.name}
+        template=TransactionalEmail.OFFERER_ATTACHMENT_INVITATION_NEW_USER.value,
+        params={
+            "OFFERER_NAME": offerer.name,
+            "REGISTRATION_LINK": f"{settings.PRO_URL}/inscription",
+        },
     )
 
 
@@ -21,7 +25,7 @@ def retrieve_data_for_offerer_attachment_invitation_existing_user_with_validated
 ) -> models.TransactionalEmailData:
     return models.TransactionalEmailData(
         template=TransactionalEmail.OFFERER_ATTACHMENT_INVITATION_EXISTING_VALIDATED_USER_EMAIL.value,
-        params={"OFFERER_NAME": offerer.name},
+        params={"OFFERER_NAME": offerer.name, "JOIN_LINK": settings.PRO_URL},
     )
 
 

--- a/api/tests/core/mails/transactional/pro/offerer_attachment_invitation_test.py
+++ b/api/tests/core/mails/transactional/pro/offerer_attachment_invitation_test.py
@@ -2,6 +2,7 @@ import dataclasses
 
 import pytest
 
+from pcapi import settings
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.mails.transactional.pro.offerer_attachment_invitation as oai
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
@@ -18,7 +19,10 @@ class ProOffererAttachmentInvitationTest:
         mail_data = oai.retrieve_data_for_offerer_attachment_invitation_new_user(offerer)
 
         assert mail_data.template == TransactionalEmail.OFFERER_ATTACHMENT_INVITATION_NEW_USER.value
-        assert mail_data.params == {"OFFERER_NAME": "Le Théâtre SAS"}
+        assert mail_data.params == {
+            "OFFERER_NAME": "Le Théâtre SAS",
+            "REGISTRATION_LINK": f"{settings.PRO_URL}/inscription",
+        }
 
     def test_email_data_existing_validated_user(self):
         offerer = offerers_factories.OffererFactory(name="Le Théâtre SAS")
@@ -28,7 +32,7 @@ class ProOffererAttachmentInvitationTest:
         assert (
             mail_data.template == TransactionalEmail.OFFERER_ATTACHMENT_INVITATION_EXISTING_VALIDATED_USER_EMAIL.value
         )
-        assert mail_data.params == {"OFFERER_NAME": "Le Théâtre SAS"}
+        assert mail_data.params == {"OFFERER_NAME": "Le Théâtre SAS", "JOIN_LINK": settings.PRO_URL}
 
     @pytest.mark.settings(PRO_URL="http://pcpro.com")
     def test_email_data_existing_not_validated_user(self):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33757

Ajout de deux paramètres manquants aux données de templates à envoyer à Brevo.
Des liens en durs (vers testing, les joies des hackatons) sont utilisés jusqu'ici. Une fois cette PR fusionnée, on pourra mettre à jour les templates sur Brevo.
