### PR TITLE
(PC-33349)[PRO] fix: The app preview should not display the venue det…

### DIFF
--- a/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
+++ b/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
@@ -232,6 +232,7 @@ export const OfferSection = ({
         {!offerData.isVenueVirtual && isOfferAddressEnabled && (
           <SummarySubSection title="Localisation de l’offre">
             <SummaryDescriptionList
+              listDataTestId="localisation-offer-details"
               descriptions={[
                 {
                   title: 'Intitulé',

--- a/pro/src/components/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
+++ b/pro/src/components/IndividualOffer/SummaryScreen/__specs__/SummaryScreen.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { addDays, format } from 'date-fns'
 import { generatePath, Route, Routes } from 'react-router-dom'
@@ -662,6 +662,39 @@ describe('Summary', () => {
       // Both present in <VenueDetails /> and <SummaryScreen /> components
       expect(screen.getAllByText('mon adresse')).toHaveLength(2)
       expect(screen.getAllByText('ma street 1 ma ville')).toHaveLength(2)
+    })
+
+    it('should render component with new sections and empty address data', async () => {
+      vi.spyOn(api, 'getOfferer').mockResolvedValue(
+        defaultGetOffererResponseModel
+      )
+      customContext.offer = getIndividualOfferFactory({
+        isEvent: true,
+        address: null,
+      })
+
+      renderSummary(
+        customContext,
+        generatePath(
+          getIndividualOfferPath({
+            step: OFFER_WIZARD_STEP_IDS.SUMMARY,
+            mode: OFFER_WIZARD_MODE.CREATION,
+          }),
+          { offerId: 'AA' }
+        ),
+        { features: ['WIP_ENABLE_OFFER_ADDRESS'] }
+      )
+
+      expect(await screen.findByText(/Structure/)).toBeInTheDocument()
+      expect(
+        await screen.findByText('Localisation de l’offre')
+      ).toBeInTheDocument()
+
+      expect(
+        within(screen.getByTestId('localisation-offer-details')).getAllByText(
+          '-'
+        )
+      ).toHaveLength(2)
     })
   })
 

--- a/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.tsx
+++ b/pro/src/components/OfferAppPreview/VenueDetails/VenueDetails.tsx
@@ -2,6 +2,7 @@ import {
   AddressResponseIsLinkedToVenueModel,
   GetOfferVenueResponseModel,
 } from 'apiClient/v1'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { computeAddressDisplayName } from 'repository/venuesService'
 
 import style from './VenueDetails.module.scss'
@@ -17,18 +18,35 @@ export const VenueDetails = ({
   address,
   withdrawalDetails,
 }: VenueDetailsProps): JSX.Element => {
-  const { street, postalCode, city } = address || venue
+  const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
 
-  const label = address ? address.label || '' : venue.publicName || venue.name
+  function computeAddress() {
+    let venueAddressString = '-'
+    let label = '-'
 
-  const venueAddressString = computeAddressDisplayName(
-    {
-      street,
-      postalCode: postalCode || '',
-      city: city || '',
-    },
-    false
-  )
+    if (!isOfferAddressEnabled) {
+      label = venue.publicName || venue.name
+      venueAddressString = [label, venue.street, venue.postalCode, venue.city]
+        .filter((str) => Boolean(str))
+        .join(' - ')
+    } else if (address) {
+      const { street, postalCode, city } = address
+
+      label = address.label || '-'
+
+      venueAddressString = computeAddressDisplayName(
+        {
+          street,
+          postalCode: postalCode || '',
+          city: city || '',
+        },
+        false
+      )
+    }
+    return { label, venueAddressString }
+  }
+
+  const { label, venueAddressString } = computeAddress()
 
   return (
     <div className={style['venue-details']}>


### PR DESCRIPTION
…ails.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33349

- Ne pas afficher l'adresse de la venue si pas d'OA.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
