### PR TITLE
(PC-33676)[PRO] fix: Dont set all opening hours to closed when editin…

### DIFF
--- a/pro/src/commons/utils/factories/collectiveApiFactories.ts
+++ b/pro/src/commons/utils/factories/collectiveApiFactories.ts
@@ -322,6 +322,7 @@ export const defaultGetVenue: GetVenueResponseModel = {
   timezone: 'Europe/Paris',
   venueTypeCode: VenueTypeCode.CENTRE_CULTUREL,
   visualDisabilityCompliant: true,
+  openingHours: null,
 }
 
 export const defaultGetCollectiveOfferRequest: GetCollectiveOfferRequestResponseModel =

--- a/pro/src/pages/VenueEdition/OpeningHoursForm/HourLine.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursForm/HourLine.tsx
@@ -21,7 +21,7 @@ export function HourLine({ day }: HourLineProps) {
   const { setFieldValue, values, setFieldTouched } =
     useFormikContext<VenueEditionFormValues>()
   const [isFullLineDisplayed, setIsFullLineDisplayed] = useState(
-    Boolean(values[day].afternoonStartingHour)
+    Boolean(values[day]?.afternoonStartingHour)
   )
 
   async function removeAfternoon() {
@@ -68,7 +68,7 @@ export function HourLine({ day }: HourLineProps) {
               isLabelHidden
               hideFooter
               className={styles['time-picker']}
-              min={values[day].morningStartingHour}
+              min={values[day]?.morningStartingHour}
             />
           </span>
         </td>
@@ -104,7 +104,7 @@ export function HourLine({ day }: HourLineProps) {
               isLabelHidden
               hideFooter
               className={styles['time-picker']}
-              min={values[day].morningEndingHour}
+              min={values[day]?.morningEndingHour}
             />
           </td>
           <td className={styles['hour-cell']}>
@@ -116,7 +116,7 @@ export function HourLine({ day }: HourLineProps) {
                 isLabelHidden
                 hideFooter
                 className={styles['time-picker']}
-                min={values[day].afternoonStartingHour}
+                min={values[day]?.afternoonStartingHour}
               />
             </span>
           </td>

--- a/pro/src/pages/VenueEdition/OpeningHoursForm/__specs__/OpeningHoursForm.spec.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursForm/__specs__/OpeningHoursForm.spec.tsx
@@ -83,41 +83,6 @@ describe('OpeningHoursForm', () => {
           morningStartingHour: '08:00',
           isAfternoonOpen: true,
         },
-        saturday: {
-          afternoonEndingHour: '',
-          afternoonStartingHour: '',
-          morningEndingHour: '',
-          morningStartingHour: '',
-          isAfternoonOpen: false,
-        },
-        sunday: {
-          afternoonEndingHour: '',
-          afternoonStartingHour: '',
-          morningEndingHour: '',
-          morningStartingHour: '',
-          isAfternoonOpen: false,
-        },
-        thursday: {
-          afternoonEndingHour: '',
-          afternoonStartingHour: '',
-          morningEndingHour: '',
-          morningStartingHour: '',
-          isAfternoonOpen: false,
-        },
-        tuesday: {
-          afternoonEndingHour: '',
-          afternoonStartingHour: '',
-          morningEndingHour: '',
-          morningStartingHour: '',
-          isAfternoonOpen: false,
-        },
-        wednesday: {
-          afternoonEndingHour: '',
-          afternoonStartingHour: '',
-          morningEndingHour: '',
-          morningStartingHour: '',
-          isAfternoonOpen: false,
-        },
       }),
       expect.anything()
     )

--- a/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
@@ -30,8 +30,9 @@ export function OpeningHoursReadOnly({ openingHours }: OpeningHours) {
         shouldShowDivider={false}
       >
         <p>
-          Vous n’avez pas renseigné d’horaire d’ouverture. Votre établissement
-          est indiqué comme fermé sur l’application.
+          {openingHours === null
+            ? 'Non renseigné'
+            : `Vous n’avez pas renseigné d’horaire d’ouverture. Votre établissement est indiqué comme fermé sur l’application.`}
         </p>
       </SummarySubSection>
     )

--- a/pro/src/pages/VenueEdition/VenueEditionForm.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionForm.tsx
@@ -48,7 +48,11 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
     try {
       await api.editVenue(
         venue.id,
-        serializeEditVenueBodyModel(values, !venue.siret)
+        serializeEditVenueBodyModel(
+          values,
+          !venue.siret,
+          venue.openingHours !== null
+        )
       )
 
       await mutate([GET_VENUE_QUERY_KEY, String(venue.id)])

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionFormScreen.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionFormScreen.spec.tsx
@@ -316,4 +316,48 @@ describe('VenueFormScreen', () => {
       ).toBeInTheDocument()
     })
   })
+
+  it('should not send opening hours if the filed was not filled, and if there were no opening hours already added previously', async () => {
+    const editVenueSpy = vi.spyOn(api, 'editVenue')
+
+    renderForm({ ...baseVenue, openingHours: null })
+
+    await userEvent.click(screen.getByText(/Enregistrer/))
+
+    expect(editVenueSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ openingHours: null })
+    )
+  })
+
+  it('should send opening hours if the filed was not filled, but the openingHours already existed', async () => {
+    const editVenueSpy = vi.spyOn(api, 'editVenue')
+
+    renderForm({
+      ...baseVenue,
+      openingHours: {
+        MONDAY: [
+          { open: '09:00', close: '12:00' },
+          { open: '13:00', close: '18:00' },
+        ],
+      },
+    })
+
+    await userEvent.click(screen.getByText(/Enregistrer/))
+
+    expect(editVenueSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        openingHours: expect.arrayContaining([
+          {
+            weekday: 'monday',
+            timespan: [
+              ['09:00', '12:00'],
+              ['13:00', '18:00'],
+            ],
+          },
+        ]),
+      })
+    )
+  })
 })

--- a/pro/src/pages/VenueEdition/__specs__/serializers.spec.ts
+++ b/pro/src/pages/VenueEdition/__specs__/serializers.spec.ts
@@ -1,0 +1,56 @@
+import { defaultGetVenue } from 'commons/utils/factories/collectiveApiFactories'
+
+import { serializeEditVenueBodyModel } from '../serializers'
+import { setInitialFormValues } from '../setInitialFormValues'
+
+describe('Venue edition payload serializer', () => {
+  it('should serialize a venue payload with no openingHours', () => {
+    const initialFormValues = setInitialFormValues({
+      ...defaultGetVenue,
+      openingHours: null,
+    })
+    expect(serializeEditVenueBodyModel(initialFormValues, true, false)).toEqual(
+      expect.objectContaining({ openingHours: null })
+    )
+  })
+
+  it('should serialize a venue payload with openingHours', () => {
+    const initialFormValues = setInitialFormValues({
+      ...defaultGetVenue,
+      openingHours: {
+        MONDAY: [
+          { open: '01:00', close: '09:00' },
+          { open: '10:00', close: '11:00' },
+        ],
+      },
+    })
+    expect(serializeEditVenueBodyModel(initialFormValues, true, false)).toEqual(
+      expect.objectContaining({
+        openingHours: expect.arrayContaining([
+          {
+            weekday: 'monday',
+            timespan: [
+              ['01:00', '09:00'],
+              ['10:00', '11:00'],
+            ],
+          },
+          { weekday: 'tuesday', timespan: [] },
+        ]),
+      })
+    )
+  })
+
+  it('should serialize a venue payload with no opening hours and that has never had opening hours before', () => {
+    const initialFormValues = setInitialFormValues({
+      ...defaultGetVenue,
+      openingHours: null,
+    })
+    expect(serializeEditVenueBodyModel(initialFormValues, true, true)).toEqual(
+      expect.objectContaining({
+        openingHours: expect.arrayContaining([
+          { weekday: 'tuesday', timespan: [] },
+        ]),
+      })
+    )
+  })
+})

--- a/pro/src/pages/VenueEdition/setInitialFormValues.ts
+++ b/pro/src/pages/VenueEdition/setInitialFormValues.ts
@@ -36,17 +36,8 @@ function buildOpeningHoursValues(
     Boolean(dateAndHour[1])
   )
 
-  if (!openingHours || openingHours.length === 0) {
-    return {
-      days: [],
-      monday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
-      wednesday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
-      tuesday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
-      thursday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
-      friday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
-      saturday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
-      sunday: { ...DEFAULT_INTITIAL_OPENING_HOURS },
-    }
+  if (!openingHours) {
+    return { days: [] }
   }
   const days = filledDays.map((dateAndHour) =>
     dateAndHour[0].toLowerCase()

--- a/pro/src/pages/VenueEdition/types.ts
+++ b/pro/src/pages/VenueEdition/types.ts
@@ -16,13 +16,13 @@ export interface VenueEditionFormValues {
   phoneNumber: string | null
   webSite: string | null
   days: Day[]
-  monday: DayValues
-  tuesday: DayValues
-  wednesday: DayValues
-  thursday: DayValues
-  friday: DayValues
-  saturday: DayValues
-  sunday: DayValues
+  monday?: DayValues
+  tuesday?: DayValues
+  wednesday?: DayValues
+  thursday?: DayValues
+  friday?: DayValues
+  saturday?: DayValues
+  sunday?: DayValues
 }
 
 export type Day =


### PR DESCRIPTION
…g a venue with no opening hours.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33676

**Objectif**
Ne pas envoyer des openingHours avec des jours sans valeur d'ouverture quand on met à jour une venue qui n'a pas encore d'openingHour.

L'api des heures d'ouverture a pas été prévue pour gérer la différence entre "fermé" et "horaires d'ouverture non renseignées" lors d'une modif du lieu (on ne peut pas PATCH avec des valeurs d'ouverture `null`). L'api est à revoir, cette PR est juste un petit hack pour qu'au moins on ne set pas systématiquement les heures d'ouverture à "fermé" quand on update qqchose dans le lieu.


## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
