### PR TITLE
(BSR)[API]build: add no-root to proxy build

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -63,7 +63,7 @@ FROM builder-${network_mode} AS builder-dev-proxy
 
 RUN poetry check --lock
 
-RUN REQUESTS_CA_BUNDLE=/cacert.pem PIP_CERT=/cacert.pem CURL_CA_BUNDLE=/cacert.pem poetry install --only dev
+RUN REQUESTS_CA_BUNDLE=/cacert.pem PIP_CERT=/cacert.pem CURL_CA_BUNDLE=/cacert.pem poetry install --only dev --no-root
 
 ########## DEV BUILDER DEFAULT ##########
 


### PR DESCRIPTION
## But de la pull request

En local la commande `pc start-proxy-backend` ne fonctionne pas. Le flag `--no-root` du poetry install n'était pas présent lors du build proxy. Cette PR corrige ça
