### PR TITLE
(PC-33989)[API] fix: prevent call to harvestr when `userComment` is emply

### DIFF
--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -341,16 +341,17 @@ def submit_user_review(body: users_serializers.SubmitReviewRequestModel) -> None
 
     check_user_has_access_to_offerer(current_user, body.offererId)
 
-    harvestr.create_message(
-        title=f"Retour - {body.pageTitle}",
-        content=body.userComment,
-        requester=harvestr.HaverstrRequester(
-            name=current_user.full_name,
-            externalUid=str(current_user.id),
-            email=current_user.email,
-        ),
-        labels=["AC", f"location: {body.location}"],
-    )
+    if body.userComment:
+        harvestr.create_message(
+            title=f"Retour - {body.pageTitle}",
+            content=body.userComment,
+            requester=harvestr.HaverstrRequester(
+                name=current_user.full_name,
+                externalUid=str(current_user.id),
+                email=current_user.email,
+            ),
+            labels=["AC", f"location: {body.location}"],
+        )
 
     logger.info(
         "User submitting review",


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-33989

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
