### PR TITLE
(PC-34011)[PRO] feat: UI fixes to fix new typos mis-alignments.

### DIFF
--- a/pro/cypress/e2e/adageConfirmation.cy.ts
+++ b/pro/cypress/e2e/adageConfirmation.cy.ts
@@ -230,7 +230,7 @@ describe('Adage confirmation', () => {
       })
 
       cy.stepLog({ message: 'I cancel the booking' })
-      cy.get('button[title="Action"]').click()
+      cy.findByRole('button', { name: 'Voir les actions' }).click()
       cy.findByText('Annuler la réservation').click()
       cy.findByTestId('confirm-dialog-button-confirm').click()
 

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveActionsCells/CollectiveActionsCells.spec.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveActionsCells/CollectiveActionsCells.spec.tsx
@@ -119,7 +119,7 @@ describe('CollectiveActionsCells', () => {
       }),
     })
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     const archiveOfferButton = screen.getByText('Archiver')
     await userEvent.click(archiveOfferButton)
@@ -150,7 +150,7 @@ describe('CollectiveActionsCells', () => {
       isSelected: true,
     })
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     const archiveOfferButton = screen.getByText('Archiver')
     await userEvent.click(archiveOfferButton)
@@ -175,14 +175,14 @@ describe('CollectiveActionsCells', () => {
       }),
     })
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     expect(
       screen.queryByText('Créer une offre réservable')
     ).not.toBeInTheDocument()
   })
 
-  it('should not display duplicate button for pending template offer', async () => {
+  it('should not display duplicate button for pending template offer', () => {
     renderCollectiveActionsCell({
       offer: collectiveOfferFactory({
         isShowcase: true,
@@ -190,11 +190,7 @@ describe('CollectiveActionsCells', () => {
       }),
     })
 
-    await userEvent.click(screen.getByTitle('Action'))
-
-    expect(
-      screen.queryByText('Créer une offre réservable')
-    ).not.toBeInTheDocument()
+    expect(screen.queryByText('Voir les actions')).not.toBeInTheDocument()
   })
 
   it('should not display duplicate button for draft bookable offer', async () => {
@@ -204,7 +200,7 @@ describe('CollectiveActionsCells', () => {
       }),
     })
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     expect(screen.queryByText('Dupliquer')).not.toBeInTheDocument()
   })
@@ -216,7 +212,7 @@ describe('CollectiveActionsCells', () => {
       }),
     })
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     expect(screen.getByText('Créer une offre réservable')).toBeInTheDocument()
   })
@@ -224,7 +220,7 @@ describe('CollectiveActionsCells', () => {
   it('should display duplicate button for draft bookable offer', async () => {
     renderCollectiveActionsCell()
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     expect(screen.getByText('Dupliquer')).toBeInTheDocument()
   })
@@ -244,7 +240,7 @@ describe('CollectiveActionsCells', () => {
         }),
       })
 
-      await userEvent.click(screen.getByTitle('Action'))
+      await userEvent.click(screen.getByText('Voir les actions'))
       await userEvent.click(screen.getByText('Dupliquer'))
       expect(notifyError).toBeCalledWith(
         'Une erreur est survenue lors de la récupération de votre offre'
@@ -268,7 +264,7 @@ describe('CollectiveActionsCells', () => {
         }),
       })
 
-      await userEvent.click(screen.getByTitle('Action'))
+      await userEvent.click(screen.getByText('Voir les actions'))
       await userEvent.click(screen.getByText('Dupliquer'))
       expect(api.duplicateCollectiveOffer).toBeCalledWith(200)
       expect(fetchMock).toHaveBeenCalledWith('https://http.cat/201')
@@ -299,7 +295,7 @@ describe('CollectiveActionsCells', () => {
         }),
       })
 
-      await userEvent.click(screen.getByTitle('Action'))
+      await userEvent.click(screen.getByText('Voir les actions'))
       await userEvent.click(screen.getByText('Dupliquer'))
       expect(mockLogEvent).toHaveBeenCalledTimes(1)
       expect(mockLogEvent).toHaveBeenNthCalledWith(
@@ -333,7 +329,7 @@ describe('CollectiveActionsCells', () => {
         }),
       })
 
-      await userEvent.click(screen.getByTitle('Action'))
+      await userEvent.click(screen.getByText('Voir les actions'))
       await userEvent.click(screen.getByText('Créer une offre réservable'))
       expect(api.createCollectiveOffer).toBeCalledWith({
         audioDisabilityCompliant: false,
@@ -388,7 +384,7 @@ describe('CollectiveActionsCells', () => {
       ['ENABLE_COLLECTIVE_NEW_STATUSES']
     )
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     expect(screen.getByText('Modifier')).toBeInTheDocument()
   })
@@ -404,7 +400,7 @@ describe('CollectiveActionsCells', () => {
       ['ENABLE_COLLECTIVE_NEW_STATUSES']
     )
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     expect(screen.queryByText('Modifier')).not.toBeInTheDocument()
   })
@@ -446,7 +442,7 @@ describe('CollectiveActionsCells', () => {
         ['ENABLE_COLLECTIVE_NEW_STATUSES']
       )
 
-      await userEvent.click(screen.getByTitle('Action'))
+      await userEvent.click(screen.getByText('Voir les actions'))
 
       expect(screen.getByText('Modifier')).toBeInTheDocument()
     }
@@ -466,7 +462,7 @@ describe('CollectiveActionsCells', () => {
       ['ENABLE_COLLECTIVE_NEW_STATUSES']
     )
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     expect(screen.queryByText('Modifier')).not.toBeInTheDocument()
   })
@@ -482,7 +478,7 @@ describe('CollectiveActionsCells', () => {
       ['ENABLE_COLLECTIVE_NEW_STATUSES']
     )
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     expect(screen.getByText('Annuler la réservation')).toBeInTheDocument()
   })
@@ -498,7 +494,7 @@ describe('CollectiveActionsCells', () => {
       ['ENABLE_COLLECTIVE_NEW_STATUSES']
     )
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     await userEvent.click(
       screen.getByRole('button', {
@@ -538,7 +534,7 @@ describe('CollectiveActionsCells', () => {
       ['ENABLE_COLLECTIVE_NEW_STATUSES']
     )
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     await userEvent.click(
       screen.getByRole('button', {

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveActionsCells/CollectiveActionsCells.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveActionsCells/CollectiveActionsCells.tsx
@@ -54,7 +54,7 @@ import styles from 'styles/components/Cells.module.scss'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
-import { ListIconButton } from 'ui-kit/ListIconButton/ListIconButton'
+import { DropdownMenuWrapper } from 'ui-kit/DropdownMenuWrapper/DropdownMenuWrapper'
 
 import { BookingLinkCell } from './BookingLinkCell'
 import { DuplicateOfferDialog } from './DuplicateOfferDialog/DuplicateOfferDialog'
@@ -353,7 +353,11 @@ export const CollectiveActionsCells = ({
   return (
     <td
       role="cell"
-      className={cn(styles['offers-table-cell'], styles['actions-column'], className)}
+      className={cn(
+        styles['offers-table-cell'],
+        styles['actions-column'],
+        className
+      )}
       headers={`${rowId} ${CELLS_DEFINITIONS.ACTIONS.id}`}
     >
       <div className={styles['actions-column-container']}>
@@ -367,159 +371,141 @@ export const CollectiveActionsCells = ({
               offerId={offer.id}
             />
           )}
-        <DropdownMenu.Root modal={false}>
-          <DropdownMenu.Trigger className={styles['dropdown-button']} asChild>
-            <ListIconButton
-              icon={fullThreeDotsIcon}
-              title="Action"
-              className={noActionsAllowed ? styles['dropdown-button-hide'] : ''}
-            >
-              Voir les actions
-            </ListIconButton>
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content className={styles['pop-in']} align="start">
-              <div className={styles['menu']}>
-                {(offer.status === CollectiveOfferStatus.SOLD_OUT ||
-                  offer.status === CollectiveOfferStatus.EXPIRED) &&
-                  offer.booking && (
-                    <>
-                      <DropdownMenu.Item
-                        className={styles['menu-item']}
-                        asChild
-                      >
-                        <ButtonLink
-                          to={bookingLink}
-                          icon={fullNextIcon}
-                          onClick={() =>
-                            logEvent(
-                              CollectiveBookingsEvents.CLICKED_SEE_COLLECTIVE_BOOKING,
-                              {
-                                from: location.pathname,
-                                offerId: offer.id,
-                                offerType: 'collective',
-                                offererId: selectedOffererId?.toString(),
-                              }
-                            )
-                          }
-                        >
-                          Voir la{' '}
-                          {offer.booking.booking_status ===
-                          CollectiveBookingStatus.PENDING
-                            ? 'préréservation'
-                            : 'réservation'}
-                        </ButtonLink>
-                      </DropdownMenu.Item>
-                      <DropdownMenu.Separator
-                        className={cn(
-                          styles['separator'],
-                          styles['tablet-only']
-                        )}
-                      />
-                    </>
-                  )}
-                {canDuplicateOffer && (
-                  <DropdownMenu.Item
-                    className={styles['menu-item']}
-                    onSelect={handleCreateOfferClick}
-                  >
-                    <Button icon={fullCopyIcon} variant={ButtonVariant.TERNARY}>
-                      Dupliquer
-                    </Button>
-                  </DropdownMenu.Item>
-                )}
-                {canCreateBookableOffer && (
-                  <DropdownMenu.Item
-                    className={styles['menu-item']}
-                    onSelect={handleCreateOfferClick}
-                  >
-                    <Button icon={fullPlusIcon} variant={ButtonVariant.TERNARY}>
-                      Créer une offre réservable
-                    </Button>
-                  </DropdownMenu.Item>
-                )}
-                {canEditOffer && (
+        {!noActionsAllowed && (
+          <DropdownMenuWrapper
+            title="Voir les actions"
+            triggerIcon={fullThreeDotsIcon}
+            triggerTooltip
+          >
+            {(offer.status === CollectiveOfferStatus.SOLD_OUT ||
+              offer.status === CollectiveOfferStatus.EXPIRED) &&
+              offer.booking && (
+                <>
                   <DropdownMenu.Item className={styles['menu-item']} asChild>
                     <ButtonLink
-                      to={editionOfferLink}
-                      icon={fullPenIcon}
-                      className={styles['button']}
-                      onClick={handleEditOfferClick}
+                      to={bookingLink}
+                      icon={fullNextIcon}
+                      onClick={() =>
+                        logEvent(
+                          CollectiveBookingsEvents.CLICKED_SEE_COLLECTIVE_BOOKING,
+                          {
+                            from: location.pathname,
+                            offerId: offer.id,
+                            offerType: 'collective',
+                            offererId: selectedOffererId?.toString(),
+                          }
+                        )
+                      }
                     >
-                      Modifier
+                      Voir la{' '}
+                      {offer.booking.booking_status ===
+                      CollectiveBookingStatus.PENDING
+                        ? 'préréservation'
+                        : 'réservation'}
                     </ButtonLink>
                   </DropdownMenu.Item>
-                )}
-                {canPublishOffer && (
-                  <DropdownMenu.Item
-                    className={styles['menu-item']}
-                    onSelect={activateOffer}
+                  <DropdownMenu.Separator
+                    className={cn(styles['separator'], styles['tablet-only'])}
+                  />
+                </>
+              )}
+            {canDuplicateOffer && (
+              <DropdownMenu.Item
+                className={styles['menu-item']}
+                onSelect={handleCreateOfferClick}
+              >
+                <Button icon={fullCopyIcon} variant={ButtonVariant.TERNARY}>
+                  Dupliquer
+                </Button>
+              </DropdownMenu.Item>
+            )}
+            {canCreateBookableOffer && (
+              <DropdownMenu.Item
+                className={styles['menu-item']}
+                onSelect={handleCreateOfferClick}
+              >
+                <Button icon={fullPlusIcon} variant={ButtonVariant.TERNARY}>
+                  Créer une offre réservable
+                </Button>
+              </DropdownMenu.Item>
+            )}
+            {canEditOffer && (
+              <DropdownMenu.Item className={styles['menu-item']} asChild>
+                <ButtonLink
+                  to={editionOfferLink}
+                  icon={fullPenIcon}
+                  className={styles['button']}
+                  onClick={handleEditOfferClick}
+                >
+                  Modifier
+                </ButtonLink>
+              </DropdownMenu.Item>
+            )}
+            {canPublishOffer && (
+              <DropdownMenu.Item
+                className={styles['menu-item']}
+                onSelect={activateOffer}
+              >
+                <Button icon={strokeCheckIcon} variant={ButtonVariant.TERNARY}>
+                  Publier
+                </Button>
+              </DropdownMenu.Item>
+            )}
+            {canHideOffer && (
+              <DropdownMenu.Item
+                className={styles['menu-item']}
+                onSelect={activateOffer}
+              >
+                <Button icon={fullHideIcon} variant={ButtonVariant.TERNARY}>
+                  {areCollectiveNewStatusesEnabled
+                    ? 'Mettre en pause'
+                    : 'Masquer la publication'}
+                </Button>
+              </DropdownMenu.Item>
+            )}
+            {isBookingCancellable && (
+              <>
+                <DropdownMenu.Separator
+                  className={cn(styles['separator'], styles['tablet-only'])}
+                />
+                <DropdownMenu.Item
+                  className={cn(styles['menu-item'])}
+                  onSelect={() => setIsCancelledBookingModalOpen(true)}
+                  asChild
+                >
+                  <Button
+                    icon={fullClearIcon}
+                    variant={ButtonVariant.QUATERNARYPINK}
+                    className={styles['button-cancel-booking']}
                   >
+                    Annuler la réservation
+                  </Button>
+                </DropdownMenu.Item>
+              </>
+            )}
+            {canArchiveOffer && (
+              <>
+                <DropdownMenu.Separator
+                  className={cn(styles['separator'], styles['tablet-only'])}
+                />
+                <DropdownMenu.Item
+                  className={cn(styles['menu-item'])}
+                  onSelect={() => setIsArchivedModalOpen(true)}
+                  asChild
+                >
+                  <div className={styles['status-filter-label']}>
                     <Button
-                      icon={strokeCheckIcon}
+                      icon={strokeThingIcon}
                       variant={ButtonVariant.TERNARY}
                     >
-                      Publier
+                      Archiver
                     </Button>
-                  </DropdownMenu.Item>
-                )}
-                {canHideOffer && (
-                  <DropdownMenu.Item
-                    className={styles['menu-item']}
-                    onSelect={activateOffer}
-                  >
-                    <Button icon={fullHideIcon} variant={ButtonVariant.TERNARY}>
-                      {areCollectiveNewStatusesEnabled
-                        ? 'Mettre en pause'
-                        : 'Masquer la publication'}
-                    </Button>
-                  </DropdownMenu.Item>
-                )}
-                {isBookingCancellable && (
-                  <>
-                    <DropdownMenu.Separator
-                      className={cn(styles['separator'], styles['tablet-only'])}
-                    />
-                    <DropdownMenu.Item
-                      className={cn(styles['menu-item'])}
-                      onSelect={() => setIsCancelledBookingModalOpen(true)}
-                      asChild
-                    >
-                      <Button
-                        icon={fullClearIcon}
-                        variant={ButtonVariant.QUATERNARYPINK}
-                        className={styles['button-cancel-booking']}
-                      >
-                        Annuler la réservation
-                      </Button>
-                    </DropdownMenu.Item>
-                  </>
-                )}
-                {canArchiveOffer && (
-                  <>
-                    <DropdownMenu.Separator
-                      className={cn(styles['separator'], styles['tablet-only'])}
-                    />
-                    <DropdownMenu.Item
-                      className={cn(styles['menu-item'])}
-                      onSelect={() => setIsArchivedModalOpen(true)}
-                      asChild
-                    >
-                      <div className={styles['status-filter-label']}>
-                        <Button
-                          icon={strokeThingIcon}
-                          variant={ButtonVariant.TERNARY}
-                        >
-                          Archiver
-                        </Button>
-                      </div>
-                    </DropdownMenu.Item>
-                  </>
-                )}
-              </div>
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
+                  </div>
+                </DropdownMenu.Item>
+              </>
+            )}
+          </DropdownMenuWrapper>
+        )}
         <DuplicateOfferDialog
           onCancel={() => setIsModalOpen(false)}
           onConfirm={onDialogConfirm}

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/__specs__/CollectiveOfferRow.spec.tsx
@@ -62,7 +62,7 @@ describe('ollectiveOfferRow', () => {
     {
       startDatetime: String(new Date()),
       remainingQuantity: 0,
-      hasBookingLimitDatetimePassed: false
+      hasBookingLimitDatetimePassed: false,
     },
   ]
 
@@ -209,7 +209,9 @@ describe('ollectiveOfferRow', () => {
     props.offer.isEditable = false
     renderOfferItem(props)
 
-    expect(screen.getByRole('presentation')).toHaveClass('thumb-column-inactive')
+    expect(screen.getByRole('presentation')).toHaveClass(
+      'thumb-column-inactive'
+    )
   })
 
   it('should display disabled checkbox when offer is not editable', () => {
@@ -229,7 +231,9 @@ describe('ollectiveOfferRow', () => {
       props.offer.status = status
       renderOfferItem(props)
 
-      expect(screen.getByRole('presentation')).not.toHaveClass('thumb-column-inactive')
+      expect(screen.getByRole('presentation')).not.toHaveClass(
+        'thumb-column-inactive'
+      )
     }
   )
 
@@ -256,7 +260,7 @@ describe('ollectiveOfferRow', () => {
 
     renderOfferItem(props)
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     const duplicateButton = screen.getByRole('button', {
       name: 'Créer une offre réservable',
@@ -274,7 +278,7 @@ describe('ollectiveOfferRow', () => {
     Storage.prototype.getItem = vi.fn(() => 'true')
     renderOfferItem(props)
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     const duplicateButton = screen.getByRole('button', {
       name: 'Créer une offre réservable',
@@ -380,7 +384,7 @@ describe('ollectiveOfferRow', () => {
     })
     renderOfferItem(props)
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     const cancelBookingButton = screen.getByText('Annuler la réservation')
     await userEvent.click(cancelBookingButton)
@@ -418,7 +422,7 @@ describe('ollectiveOfferRow', () => {
 
     renderOfferItem(props)
 
-    await userEvent.click(screen.getByTitle('Action'))
+    await userEvent.click(screen.getByText('Voir les actions'))
 
     const cancelBookingButton = screen.getByText('Annuler la réservation')
     await userEvent.click(cancelBookingButton)

--- a/pro/src/styles/components/Cells.module.scss
+++ b/pro/src/styles/components/Cells.module.scss
@@ -57,10 +57,6 @@
     justify-content: center;
     gap: rem.torem(8px) rem.torem(24px);
   }
-
-  .offer-template-tag {
-    margin-bottom: rem.torem(4px);
-  }
 }
 
 .event-date-column {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34011

**Objectif**
Corriger les endroits où l'augmentation de la taille de la police a décalé le reste du contenu :

**Le bouton des actions de la table collective**
-> Utilisation le composant partagé du dropdown menu qui a lui une largeur auto
avant/après : 
![Capture d’écran 2025-01-15 à 11 53 17](https://github.com/user-attachments/assets/e81e6f04-1625-4ccd-8d2e-7c57d796eaa8)
<img width="424" alt="Capture d’écran 2025-01-15 à 13 58 15" src="https://github.com/user-attachments/assets/722d8ede-283e-406c-a482-973602f4626e" />


**Le badge "Offre vitrine"**
avant/après :
![Capture d’écran 2025-01-15 à 11 50 44](https://github.com/user-attachments/assets/2d0e7eea-610d-4946-87f9-0e6076f97878)
<img width="875" alt="Capture d’écran 2025-01-15 à 13 58 10" src="https://github.com/user-attachments/assets/5764aaa5-9c31-411a-973e-3063b4d52fff" />



## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
