### PR TITLE
(BSR) docs: move warning at the top of changelogs

### DIFF
--- a/api/documentation/src/pages/change-logs.md
+++ b/api/documentation/src/pages/change-logs.md
@@ -5,15 +5,6 @@ title: Pass Culture API change logs
 # Change logs
 
 :::warning
-💡 Important notice some old resources are going to be removed in the coming months.
-
-- If you were using `/v2/venue/<venue_id>/stocks` to manage stocks, you will have to migrate to this endpoint : [/public/offers/v1/products/ean](/rest-api#tag/Product-Offer-Bulk-Operations/operation/PostProductOfferByEan). The endpoint `/v2/stock` will not be available anymore starting from September, the 31st 2024.
-- If you were using `/v2/bookings` to manage bookings, you will have to migrate to those endpoints [/public/bookings/v1/bookings](/rest-api#tag/Bookings).  The endpoint `/v2/bookings` will not be available anymore starting from June, the 30th 2025.
-
-**You can find a migration tutorial [here](/docs/tutorials/migrate-to-the-new-api).**
-:::
-
-:::warning
 💡 The `beginningDatetime` field is going to be removed in the following endpoints:
 
 Removed from the return value:
@@ -27,6 +18,15 @@ Removed from the input body and the return value:
 Please use the `startDatetime` and `endDatetime` fields instead.
 
 The `startDatetime` field will be required when creating a collective offer and its value will be copied to `endDatetime` if `endDatetime` is not provided.
+:::
+
+:::warning
+💡 Important notice some old resources are going to be removed in the coming months.
+
+- If you were using `/v2/venue/<venue_id>/stocks` to manage stocks, you will have to migrate to this endpoint : [/public/offers/v1/products/ean](/rest-api#tag/Product-Offer-Bulk-Operations/operation/PostProductOfferByEan). The endpoint `/v2/stock` will not be available anymore starting from September, the 31st 2024.
+- If you were using `/v2/bookings` to manage bookings, you will have to migrate to those endpoints [/public/bookings/v1/bookings](/rest-api#tag/Bookings).  The endpoint `/v2/bookings` will not be available anymore starting from June, the 30th 2025.
+
+**You can find a migration tutorial [here](/docs/tutorials/migrate-to-the-new-api).**
 :::
 
 ## December 2024


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) :

Le warning ajouté récemment dans le changelogs de l'api publique est mis en premier, pour être aligné avec le reste du fichier

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
