### PR TITLE
(BSR) feat: add vitest config in vscode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,6 +85,21 @@
             "console": "integratedTerminal",
             "cwd": "${workspaceFolder}/api",
             "justMyCode": false
+        },
+        // Pro test debug
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Debug current spec test file",
+            "cwd": "${workspaceFolder}/pro",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": [
+                "test:unit",
+                "run",
+                "${file}"
+            ],
+            "smartStep": true,
+            "console": "integratedTerminal"
         }
     ],
     "inputs": [


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : ajout d'une config dans launch.json pour debug vitest

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
