### PR TITLE
(PC-34037)[API] fix: isolate the two Ubble requests sessions

### DIFF
--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -133,7 +133,7 @@ class StartIdentificationV1Test:
         assert attributes["redirect_url"] == "http://redirect/url"
 
         assert len(caplog.records) >= 1
-        record = caplog.records[1]
+        record = caplog.records[2]
         assert record.extra["status_code"] == 201
         assert record.extra["identification_id"] == str(response.identification_id)
         assert record.extra["request_type"] == "start-identification"


### PR DESCRIPTION
In staging and production, going through an Ubble v2 flow has a nasty side-effect. The certificates used for mutual TLS are also sent during the Ubble v1 flow, making Ubble crash and return 500 errors.

This commit attempts to isolate the requests session to prevent this side-effect.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34037