### PR TITLE
(BSR)[PRO] fix: Removes useless style and test in templates

### DIFF
--- a/pro/scripts/generator/_templates/component/<% name %>.module.scss.mustache
+++ b/pro/scripts/generator/_templates/component/<% name %>.module.scss.mustache
@@ -1,5 +1,4 @@
 @use "styles/mixins/_fonts.scss" as fonts;
-@use "styles/mixins/fonts-design-system.scss" as fonts-design-system;
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_a11y.scss" as a11y;
 @use "styles/mixins/_size.scss" as size;

--- a/pro/scripts/generator/_templates/component/<% name %>.spec.tsx.mustache
+++ b/pro/scripts/generator/_templates/component/<% name %>.spec.tsx.mustache
@@ -13,15 +13,7 @@ const render<% name %> = (options?: RenderWithProvidersOptions) => {
 }
 
 describe('<<% name %> />', () => {
-  it('should render correctly', async () => {
-    render<% name %>()
-
-    expect(
-      await screen.findByRole('heading', { name: /<% name %>/ })
-    ).toBeInTheDocument()
-  })
-
-  it('should not have accessibility violations', async () => {
+  it('should render without accessibility violations', async () => {
     const { container } = render<% name %>()
 
     expect(await axe(container)).toHaveNoViolations()


### PR DESCRIPTION
## But de la pull request

Met à jour le template de génération de composant (`yarn generate:component MyComponentName`) en prenant en compte : 
- la suppression du fichier `fonts-design-system.scss`
- un test unitaire finalement souvent inutile

