### PR TITLE
(PC-33828)[PRO] feat: Add a new evolutions link in header menu.

### DIFF
--- a/pro/src/commons/core/FirebaseEvents/constants.ts
+++ b/pro/src/commons/core/FirebaseEvents/constants.ts
@@ -64,6 +64,8 @@ export enum Events {
   CLICKED_INVOICES_DOWNLOAD = 'hasClickedInvoicesDownload',
   CLICKED_PUBLISH_FUTURE_OFFER_EARLIER = 'hasClickedPublishFutureOfferEarlier',
   EXTRA_PRO_DATA = 'extra_pro_data',
+  CLICKED_NEW_EVOLUTIONS = 'hasClickedNewEvolutions',
+  CLICKED_CONSULT_HELP = 'hasClickedConsultHelp',
 }
 
 export enum VenueEvents {

--- a/pro/src/components/Header/components/HeaderHelpDropdown/HelpDropdownMenu.tsx
+++ b/pro/src/components/Header/components/HeaderHelpDropdown/HelpDropdownMenu.tsx
@@ -18,7 +18,7 @@ export const HelpDropdownMenu = () => {
           opensInNewTab
           icon={fullLinkIcon}
           onClick={() =>
-            logEvent(Events.CLICKED_HELP_CENTER, {
+            logEvent(Events.CLICKED_CONSULT_HELP, {
               from: location.pathname,
             })
           }
@@ -39,6 +39,21 @@ export const HelpDropdownMenu = () => {
           }
         >
           Contacter nos équipes
+        </ButtonLink>
+      </DropdownMenu.Item>
+      <DropdownMenu.Item className={dropdownStyles['menu-item']} asChild>
+        <ButtonLink
+          icon={fullLinkIcon}
+          to="https://passcultureapp.notion.site/db6b4a9f5fc84fb28626cfeb18d20340?v=19911882c20b4bb39524825164fcf3c2"
+          isExternal
+          opensInNewTab
+          onClick={() =>
+            logEvent(Events.CLICKED_NEW_EVOLUTIONS, {
+              from: location.pathname,
+            })
+          }
+        >
+          Découvrir les nouveautés
         </ButtonLink>
       </DropdownMenu.Item>
       <DropdownMenu.Item className={dropdownStyles['menu-item']} asChild>


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-33828

**Objectif**
Ajouter un lien des nouveautés du pass dans le header. + Ajout d'un tracker sur le click et update d'un autre tracker du header (doc notion trackers màj)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
