### PR TITLE
Deactivate pcapi env preview deployment

### DIFF
--- a/.github/workflows/dev_on_pull_request_workflow.yml
+++ b/.github/workflows/dev_on_pull_request_workflow.yml
@@ -314,7 +314,8 @@ jobs:
       CHANNEL: ""
       REF: "${{ github.ref }}"
       CACHE_BUCKET_NAME: "passculture-infra-prod-github-runner-cache"
-      is_pull_request: true
+      # 2025/01/20 : Deactivate deploy backend env preview for PR
+      is_pull_request: false
 
   deploy-pro-on-firebase-testing:
     name: "[PRO] Deploy PR version for validation with testing backend"

--- a/.github/workflows/dev_on_workflow_deploy_pullrequests.yml
+++ b/.github/workflows/dev_on_workflow_deploy_pullrequests.yml
@@ -20,6 +20,10 @@ on:
         type: string
         required: false
         default: ehp
+      deploy:
+        type: boolean
+        required: false
+        default: false
     secrets:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
@@ -31,7 +35,7 @@ jobs:
     name: "Deploy pullrequest"
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }} || ${{ inputs.deploy == 'true' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## But de la pull request

Deactivate pcapi backend env preview deployment using flags to keep all code in place in case of future reactivation

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
