### PR TITLE
(PC-34066)[API] fix: allow missing id photo in ubble response

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -245,7 +245,6 @@ def start_identification(
     user_id: int, first_name: str, last_name: str, redirect_url: str, webhook_url: str
 ) -> fraud_models.UbbleContent:
     session = configure_session()
-    logger.info("Ubble v1 request session state", extra={"cert": session.cert})
 
     data = {
         "data": {
@@ -328,7 +327,6 @@ def start_identification(
 
 def get_content(identification_id: str) -> fraud_models.UbbleContent:
     session = configure_session()
-    logger.info("Ubble v1 request session state", extra={"cert": session.cert})
     base_extra_log = {"request_type": "get-content", "identification_id": identification_id}
 
     try:

--- a/api/src/pcapi/connectors/serialization/ubble_serializers.py
+++ b/api/src/pcapi/connectors/serialization/ubble_serializers.py
@@ -54,7 +54,7 @@ class UbbleDocument(pydantic_v1.BaseModel):
     document_type: str | None
     document_number: str | None
     gender: users_models.GenderEnum | None
-    front_image_signed_url: str
+    front_image_signed_url: str | None
     back_image_signed_url: str | None
 
     @pydantic_v1.validator("gender", pre=True)

--- a/api/tests/connectors/beneficiaries/ubble_test.py
+++ b/api/tests/connectors/beneficiaries/ubble_test.py
@@ -133,7 +133,7 @@ class StartIdentificationV1Test:
         assert attributes["redirect_url"] == "http://redirect/url"
 
         assert len(caplog.records) >= 1
-        record = caplog.records[2]
+        record = caplog.records[1]
         assert record.extra["status_code"] == 201
         assert record.extra["identification_id"] == str(response.identification_id)
         assert record.extra["request_type"] == "start-identification"
@@ -239,9 +239,9 @@ class GetContentTest:
             with caplog.at_level(logging.INFO):
                 ubble.get_content(ubble_response.data.attributes.identification_id)
 
-            assert caplog.records[1].message == "External service called"
+            assert caplog.records[0].message == "External service called"
 
-            supervision_record = caplog.records[2]
+            supervision_record = caplog.records[1]
             assert supervision_record.message == "Valid response from Ubble"
             assert supervision_record.extra["status_code"] == 200
             assert supervision_record.extra["identification_id"] == ubble_response.data.attributes.identification_id

--- a/api/tests/core/subscription/ubble/end_to_end/fixtures.py
+++ b/api/tests/core/subscription/ubble/end_to_end/fixtures.py
@@ -139,13 +139,7 @@ ID_CHECKS_IN_PROGRESS_RESPONSE = {
     "applicant_id": "aplt_01je97fqhmtk2jmn6gcgyram3s",
     "created_on": "2024-12-04T16:19:09.766392Z",
     "declared_data": {"name": "Catherine Destivelle"},
-    "documents": [
-        {
-            "back_image_signed_url": "https://minio.ubble.example.com/production.ubble.ai/OIOXQTAYFYMF/idv_01je97fqt08dn6a687jcqnxd1b/a9febddd-6a89-4aa5-bd6a-912f4ca9f5da/dd1e68f6-1a8d-4267-916f-8b381b6d7f87/back_id.jpeg?response-content-type=image%2Fpng&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=6nzrc5UNPR864KRwHLkZ%2F20241204%2Feu-west-2%2Fs3%2Faws4_request&X-Amz-Date=20241204T162302Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=38ef832caeb76326b96676b2ad0a0d5041888b35764a99373bf9dab7c8de7933",
-            "front_image_signed_url": "https://minio.ubble.example.com/production.ubble.ai/OIOXQTAYFYMF/idv_01je97fqt08dn6a687jcqnxd1b/a9febddd-6a89-4aa5-bd6a-912f4ca9f5da/dd1e68f6-1a8d-4267-916f-8b381b6d7f87/front_id.jpeg?response-content-type=image%2Fpng&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=6nzrc5UNPR864KRwHLkZ%2F20241204%2Feu-west-2%2Fs3%2Faws4_request&X-Amz-Date=20241204T162302Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=97f6d7bb582ae373c1ec653e4274bd77cc95a5398b015289b03a69e3f3141e3b",
-            "full_name": "",
-        }
-    ],
+    "documents": [{"full_name": ""}],
     "face": {
         "image_signed_url": "https://minio.ubble.example.com/production.ubble.ai/OIOXQTAYFYMF/idv_01je97fqt08dn6a687jcqnxd1b/a9febddd-6a89-4aa5-bd6a-912f4ca9f5da/dd1e68f6-1a8d-4267-916f-8b381b6d7f87/face.jpeg?response-content-type=image%2Fpng&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=6nzrc5UNPR864KRwHLkZ%2F20241204%2Feu-west-2%2Fs3%2Faws4_request&X-Amz-Date=20241204T162302Z&X-Amz-Expires=600&X-Amz-SignedHeaders=host&X-Amz-Signature=efa1440aeb03afb107562924d22de89643cc3a248ace772907147921cba5f921"
     },


### PR DESCRIPTION
There is a window when Ubble notifies us of a check in progress, but the photo of the ID document is not ready yet.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34066
