### PR TITLE
(BSR)[ADAGE] fix: send beginningDatetime to adage until the switch to…

### DIFF
--- a/api/src/pcapi/core/educational/adage_backends/serialize.py
+++ b/api/src/pcapi/core/educational/adage_backends/serialize.py
@@ -25,6 +25,8 @@ class AdageRedactor(educational_schemas.AdageBaseResponseModel):
 class AdageCollectiveOffer(educational_schemas.AdageBaseResponseModel):
     UAICode: str
     address: str
+    # TODO: once Adage has made the switch to startDatetime, we can remove beginningDatetime here
+    beginningDatetime: datetime
     startDatetime: datetime
     endDatetime: datetime
     city: str
@@ -60,6 +62,7 @@ def serialize_collective_offer(collective_offer: models.CollectiveOffer) -> Adag
     return AdageCollectiveOffer(
         UAICode=institution.institutionId,
         address=_get_collective_offer_address(collective_offer),
+        beginningDatetime=stock.startDatetime,
         startDatetime=stock.startDatetime,
         endDatetime=stock.endDatetime,
         city=venue.city,  # type: ignore[arg-type]  # TODO: check that it cannot be None


### PR DESCRIPTION
… startDatetime is done on their side

## But de la pull request

Ticket Jira (ou description si BSR) :

Les usages du champ `beginningDatetime` ont été retirés de l'app, mais il faut pour l'instant le garder dans le body que l'on envoie à Adage le temps que le passage sur `startDatetime` soit fait de leur côté

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
