### PR TITLE
(PC-34126)[PRO] fix: Let the user delete the first price category lin…

### DIFF
--- a/pro/src/components/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.tsx
+++ b/pro/src/components/IndividualOffer/PriceCategoriesScreen/PriceCategoriesForm.tsx
@@ -53,9 +53,10 @@ export const PriceCategoriesForm = ({
   const onDeletePriceCategory = async (
     index: number,
     arrayHelpers: FieldArrayRenderProps,
-    priceCategories: PriceCategoryForm[],
-    priceCategoryId?: number
+    priceCategories: PriceCategoryForm[]
   ) => {
+    const priceCategoryId = priceCategories[index].id
+
     if (priceCategoryId) {
       if (currentDeletionIndex === null && offer.hasStocks) {
         setCurrentDeletionIndex(index)
@@ -113,15 +114,12 @@ export const PriceCategoriesForm = ({
               <ConfirmDialog
                 onCancel={() => setCurrentDeletionIndex(null)}
                 onConfirm={() => {
-                  if (!currentDeletionIndex) {
-                    return
-                  }
-
                   return onDeletePriceCategory(
-                    currentDeletionIndex,
+                    //  TODO : restructure this composant so that this hack is not necessary
+                    //  By creating a component for each of the price category lines
+                    currentDeletionIndex!,
                     arrayHelpers,
-                    values.priceCategories,
-                    values.priceCategories[currentDeletionIndex].id
+                    values.priceCategories
                   )
                 }}
                 title="En supprimant ce tarif vous allez aussi supprimer l’ensemble des dates qui lui sont associées."
@@ -176,8 +174,7 @@ export const PriceCategoriesForm = ({
                           onDeletePriceCategory(
                             index,
                             arrayHelpers,
-                            values.priceCategories,
-                            values.priceCategories[index].id
+                            values.priceCategories
                           )
                         }
                         hasTooltip={

--- a/pro/src/components/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategoriesForm.spec.tsx
+++ b/pro/src/components/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategoriesForm.spec.tsx
@@ -208,6 +208,34 @@ describe('PriceCategories', () => {
     expect(api.deletePriceCategory).toHaveBeenNthCalledWith(1, 42, 144)
   })
 
+  it('should be able to delete the first price category when it has stocks', async () => {
+    vi.spyOn(api, 'deletePriceCategory').mockResolvedValue()
+    const values: PriceCategoriesFormValues = {
+      priceCategories: [
+        priceCategoryFormFactory({ id: 2 }),
+        priceCategoryFormFactory({ id: 144 }),
+      ],
+      isDuo: false,
+    }
+
+    renderPriceCategoriesForm(values, {
+      offer: getIndividualOfferFactory({ id: 42, hasStocks: true }),
+    })
+
+    // I can cancel
+    await userEvent.click(
+      screen.getAllByRole('button', { name: 'Supprimer le tarif' })[0]
+    )
+    expect(
+      screen.getByText(
+        'En supprimant ce tarif vous allez aussi supprimer l’ensemble des dates qui lui sont associées.'
+      )
+    ).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Confirmer la supression'))
+    expect(api.deletePriceCategory).toHaveBeenCalledWith(42, 2)
+  })
+
   it('should handle unique line label cases', async () => {
     renderPriceCategoriesForm({
       priceCategories: [FIRST_INITIAL_PRICE_CATEGORY],


### PR DESCRIPTION
…ked to stocks when creating an event offer.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34126

**Objectif**
Pouvoir supprimer le premier tarif lié à des dates d'une offre indiv d'événement (auj on vérifie que l'index est "truthy" donc on ne peut pas supprimer l'index "0").

J'ai mis un TODO pour corriger le bug rapidement, et prendre le temps de revoir la structure à l'avenir.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
