### PR TITLE
(PC-34065)[API] fix: mark declined ubble checks as ko 

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -10,7 +10,6 @@ from urllib3 import exceptions as urllib3_exceptions
 from pcapi import settings
 from pcapi.connectors.serialization import ubble_serializers
 from pcapi.core.fraud import models as fraud_models
-from pcapi.core.subscription.ubble import exceptions as ubble_exceptions
 from pcapi.core.users import models as users_models
 from pcapi.utils import requests
 
@@ -118,9 +117,6 @@ def create_identity_verification(
             "webhook_url": webhook_url,
         },
     )
-    if response.status_code == 409:
-        # user tried to reattempt an identity verification while a previous one is being checked
-        raise ubble_exceptions.ExistingProcessingIdentityVerification()
     response.raise_for_status()
 
     ubble_identification = parse_obj_as(ubble_serializers.UbbleV2IdentificationResponse, response.json())

--- a/api/src/pcapi/core/fraud/ubble/api.py
+++ b/api/src/pcapi/core/fraud/ubble/api.py
@@ -40,11 +40,11 @@ def _ubble_result_fraud_item_using_status(
             if id_provider_detected_eligibility:
                 return fraud_models.FraudItem(status=fraud_models.FraudStatus.OK, detail=detail, reason_codes=[])
             return _ubble_not_eligible_fraud_item(user, content)
-        case (
-            ubble_serializers.UbbleIdentificationStatus.RETRY_REQUIRED
-            | ubble_serializers.UbbleIdentificationStatus.DECLINED
-        ):
+        case ubble_serializers.UbbleIdentificationStatus.RETRY_REQUIRED:
             status = fraud_models.FraudStatus.SUSPICIOUS
+        case ubble_serializers.UbbleIdentificationStatus.DECLINED:
+            status = fraud_models.FraudStatus.KO
+
         case _:
             raise ValueError(f"unhandled Ubble status {content.status} for identification {content.identification_id}")
 

--- a/api/src/pcapi/core/subscription/ubble/exceptions.py
+++ b/api/src/pcapi/core/subscription/ubble/exceptions.py
@@ -1,6 +1,2 @@
 class UbbleDownloadedFileEmpty(Exception):
     "raised when the downloaded file is empty"
-
-
-class ExistingProcessingIdentityVerification(Exception):
-    pass

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -12,7 +12,6 @@ from pcapi.core.subscription import exceptions
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription import profile_options
 from pcapi.core.subscription.ubble import api as ubble_subscription_api
-from pcapi.core.subscription.ubble import exceptions as ubble_exceptions
 from pcapi.core.users import models as users_models
 from pcapi.models import api_errors
 from pcapi.routes.native.security import authenticated_and_active_user_required
@@ -228,8 +227,7 @@ def start_identification_session(
             user, declared_names[0], declared_names[1], body.redirectUrl
         )
         return serializers.IdentificationSessionResponse(identificationUrl=identification_url)  # type: ignore[arg-type]
-    except ubble_exceptions.ExistingProcessingIdentityVerification:
-        raise api_errors.ApiErrors({"code": "IDCHECK_ALREADY_PROCESSED"})
+
     except requests_utils.ExternalAPIException as exception:
         if exception.is_retryable:
             code = "IDCHECK_SERVICE_UNAVAILABLE"

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -295,7 +295,7 @@ class UbbleWorkflowV2Test:
 
         ubble_content = fraud_check.resultContent
         assert ubble_content["status"] == ubble_serializers.UbbleIdentificationStatus.DECLINED.value
-        assert fraud_check.status == fraud_models.FraudCheckStatus.SUSPICIOUS
+        assert fraud_check.status == fraud_models.FraudCheckStatus.KO
         assert fraud_check.reasonCodes == [fraud_models.FraudReasonCode.ID_CHECK_DATA_MATCH]
         assert "Ubble DECLINED" in fraud_check.reason
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -35,7 +35,6 @@ import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 import pcapi.core.subscription.api as subscription_api
 import pcapi.core.subscription.models as subscription_models
-from pcapi.core.subscription.ubble import exceptions as ubble_exceptions
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
@@ -2591,20 +2590,6 @@ class IdentificationSessionTest:
         ][0]
         assert check
         assert response.json["identificationUrl"] == expected_url
-
-    def test_existing_processing_id_check(self, client):
-        user = build_user_at_id_check(18)
-
-        with patch(
-            "pcapi.core.subscription.ubble.api.start_ubble_workflow",
-            side_effect=ubble_exceptions.ExistingProcessingIdentityVerification,
-        ):
-            response = client.with_token(user.email).post(
-                "/native/v1/ubble_identification", json={"redirectUrl": "http://example.com/deeplink"}
-            )
-
-        assert response.status_code == 400
-        assert response.json["code"] == "IDCHECK_ALREADY_PROCESSED"
 
 
 class AccountSecurityTest:


### PR DESCRIPTION
Our Ubble v1 flow marked declined checks as suspicious instead of ko.
This used to work because we always create a new identity verification
at every Ubble v1 attempt.

However, we reuse existing Ubble v2 identity verifications if they are
marked as suspicious. If the id verification is declined, Ubble v2
returns a 409 error. Therefore, we should not reuse declined Ubble v2
checks by marking them as KO instead of suspicious.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34065
