### PR TITLE
(PC-34083)[API] fix: pro: draft offer: always check if EAN is used

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -27,6 +27,7 @@ import pcapi.core.bookings.models as bookings_models
 from pcapi.core.bookings.models import BookingCancellationReasons
 import pcapi.core.bookings.repository as bookings_repository
 from pcapi.core.categories import subcategories_v2 as subcategories
+from pcapi.core.categories.subcategories_v2 import ExtraDataFieldEnum
 import pcapi.core.criteria.models as criteria_models
 from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import models as educational_models
@@ -1087,6 +1088,10 @@ def publish_offer(
 ) -> models.Offer:
     publication_date = _format_publication_date(publication_date, offer.venue.timezone)
     validation.check_publication_date(offer, publication_date)
+
+    if offer.extraData:
+        if ean := offer.extraData.get(ExtraDataFieldEnum.EAN.value):
+            validation.check_other_offer_with_ean_does_not_exist(ean, offer.venue, offer.id)
 
     update_offer_fraud_information(offer, user)
 

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -219,6 +219,11 @@ class OfferFactory(BaseFactory):
         return super()._create(model_class, *args, **kwargs)
 
 
+class DraftOfferFactory(OfferFactory):
+    isActive = False
+    validation = models.OfferValidationStatus.DRAFT
+
+
 class ArtistProductLinkFactory(BaseFactory):
     class Meta:
         model = artist_models.ArtistProductLink

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -621,9 +621,11 @@ def check_offer_extra_data(
 
     try:
         ean = extra_data.get(ExtraDataFieldEnum.EAN.value)
-        if ean and (not offer or (offer.extraData and ean != offer.extraData.get(ExtraDataFieldEnum.EAN.value))):
+        if ean:
             _check_ean_field(extra_data, ExtraDataFieldEnum.EAN.value)
-            check_ean_does_not_exist(ean, venue)
+
+            offer_id = offer.id if offer else None
+            check_other_offer_with_ean_does_not_exist(ean, venue, offer_id)
     except (exceptions.EanFormatException, exceptions.OfferAlreadyExists) as e:
         errors.add_client_error(e)
 
@@ -658,8 +660,10 @@ def check_product_for_venue_and_subcategory(
     )
 
 
-def check_ean_does_not_exist(ean: str | None, venue: offerers_models.Venue) -> None:
-    if repository.has_active_offer_with_ean(ean, venue):
+def check_other_offer_with_ean_does_not_exist(
+    ean: str | None, venue: offerers_models.Venue, offer_id: int | None = None
+) -> None:
+    if repository.has_active_offer_with_ean(ean, venue, offer_id):
         if ean:
             raise exceptions.OfferAlreadyExists("ean")
 
@@ -696,7 +700,7 @@ def check_product_cgu_and_offerer(
     # We can only check the existence of an offer with this EAN if the offerer has one venue.
     if len(not_virtual_venues) == 1:
         try:
-            check_ean_does_not_exist(ean, not_virtual_venues[0])
+            check_other_offer_with_ean_does_not_exist(ean, not_virtual_venues[0])
         except exceptions.OfferAlreadyExists:
             raise api_errors.ApiErrors(
                 errors={"ean": ["Une offre avec cet EAN existe déjà. Vous pouvez la retrouver dans l'onglet Offres."]},

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -374,6 +374,8 @@ def patch_publish_offer(
                 offers_api.publish_offer(offer, current_user, publication_date=body.publicationDate)
             except exceptions.FutureOfferException as exc:
                 raise api_errors.ApiErrors(exc.errors, status_code=400)
+            except (exceptions.OfferCreationBaseException, exceptions.OfferEditionBaseException) as exc:
+                raise api_errors.ApiErrors(exc.errors, status_code=400)
 
             return offers_serialize.GetIndividualOfferResponseModel.from_orm(offer)
 

--- a/api/tests/routes/pro/patch_draft_offer_test.py
+++ b/api/tests/routes/pro/patch_draft_offer_test.py
@@ -14,6 +14,7 @@ from pcapi.core.offers.models import OfferStatus
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.providers.repository import get_provider_by_local_class
 import pcapi.core.users.factories as users_factories
+from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -52,7 +53,7 @@ class Returns200Test:
     def test_patch_draft_offer_without_product_with_new_ean_should_succeed(self, client):
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
         venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
-        offer = offers_factories.OfferFactory(
+        offer = offers_factories.DraftOfferFactory(
             name="Name",
             subcategoryId=subcategories.LIVRE_PAPIER.id,
             venue=venue,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34083

**Avant**

Sur le portail pro, il était possible d'éditer en de publier une offre en brouillon même si l'EAN était déjà utilisé par une offre publiée.
Pour l'offre en brouillon, il faut la créer, en publier une avec le même EAN et revenir dessus : il n'y a plus de vérification sur l'EAN.

**Après**

La vérification au niveau de l'EAN se fait au moment de la publication et de l'édition d'un brouillon d'offre, et plus seulement à sa création.
