### PR TITLE
(BSR)[BO] fix: internal link to offer details

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/details/bookings.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/details/bookings.html
@@ -18,7 +18,7 @@
         <tr>
           <th scope="row">{{ build_booking_toggle_extra_row_button(booking) }}</th>
           <td>{{ booking.offerer.name | escape }}</td>
-          <td>{{ links.build_offer_name_to_pc_pro_link(booking.stock.offer) }}</td>
+          <td>{{ links.build_offer_name_to_details_link(booking.stock.offer) }}</td>
           <td>
             {{ booking.amount | format_amount(target=booking.user) }}
             {% if booking.stock.offer.isDuo and booking.quantity == 2 %}(Duo){% endif %}


### PR DESCRIPTION
## But de la pull request

Lien interne vers l'offre dans le BO plutôt que vers PC Pro depuis l'onglet de suivi de réservations d'un jeune.

## Vérifications

- [x] Nom testé avec les tests existants, on n'auto-teste pas les URL dans le html.
