### PR TITLE
(PC-34189)[PRO] fix: Dont show/hide beamer if it has not loaded yet.

### DIFF
--- a/pro/src/commons/custom_types/window.d.ts
+++ b/pro/src/commons/custom_types/window.d.ts
@@ -15,6 +15,7 @@ declare global {
       destroy: () => void
       hide: () => void
       show: () => void
+      config?: Record<string, unknown>
     }
 
     grecaptcha?: {

--- a/pro/src/pages/SignupJourneyRoutes/SignupJourneyRoutes.tsx
+++ b/pro/src/pages/SignupJourneyRoutes/SignupJourneyRoutes.tsx
@@ -12,12 +12,12 @@ export const SignupJourneyRoutes = () => {
   const currentUser = useSelector(selectCurrentUser)
 
   useEffect(() => {
-    if (window.Beamer !== undefined) {
+    if (window.Beamer?.config) {
       window.Beamer.hide()
     }
 
     return () => {
-      if (window.Beamer !== undefined) {
+      if (window.Beamer?.config) {
         window.Beamer.show()
       }
     }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34189

**Objectif**
Quand on ouvre la signup journey depuis la page d'accueil, il faut que Beamer ait chargé avant de pouvoir le cacher.
La reproduction du bug est dispo dans le ticket.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
