### PR TITLE
(PC-34064)[PRO] feat: Add a default time to the time of publication s…

### DIFF
--- a/pro/src/components/IndividualOffer/SummaryScreen/EventPublicationForm/EventPublicationForm.tsx
+++ b/pro/src/components/IndividualOffer/SummaryScreen/EventPublicationForm/EventPublicationForm.tsx
@@ -102,6 +102,7 @@ export const EventPublicationForm = () => {
                 label="Heure de publication"
                 name="publicationTime"
                 options={getPublicationHoursOptions()}
+                defaultOption={{ label: 'HH:MM', value: '' }}
               />
             </FormLayout.Row>
           )}


### PR DESCRIPTION
…elect input.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34064

**Objectif**
Ajouter une option par défaut au select des heures de la publication des offres événements dans le futur pour voir "HH:MM" à la place de "00:00"

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
