### PR TITLE
(PC-34203)[API] fix: enforce chronicle unicity even if typeform sends…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 1b5deb8e094c (pre) (head)
-704367eff1d5 (post) (head)
+65d6cbee26d7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20250124T094645_65d6cbee26d7_unicity_chronicle_formid.py
+++ b/api/src/pcapi/alembic/versions/20250124T094645_65d6cbee26d7_unicity_chronicle_formid.py
@@ -1,0 +1,58 @@
+"""enforce formId unicity for chronicles"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "65d6cbee26d7"
+down_revision = "704367eff1d5"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+DELETE FROM
+    chronicle as c
+WHERE
+    -- delete when more than one is present
+    c."formId" IN (
+        SELECT 
+            form_id
+        FROM (
+            SELECT 
+                "formId" AS form_id, 
+                count(id) AS count_id 
+            FROM 
+                chronicle 
+            GROUP BY 
+                "formId"
+        ) AS count_sub WHERE count_id>1 
+    )
+    -- keep one from delete
+    AND c.id != (
+        SELECT
+            id
+        FROM 
+            chronicle
+        WHERE
+            "formId"=c."formId"
+        ORDER BY id
+        LIMIT 1
+    )
+"""
+    )
+    # the lock is not a problem if we deactivate ENABLE_CHRONICLES_SYNC
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout = '300s'")
+        op.execute("select 1 -- squawk:ignore-next-statement")
+        op.create_unique_constraint("ix_chronicle_formId", "chronicle", ["formId"])
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    op.drop_constraint("ix_chronicle_formId", "chronicle", type_="unique")

--- a/api/src/pcapi/core/chronicles/factories.py
+++ b/api/src/pcapi/core/chronicles/factories.py
@@ -1,3 +1,5 @@
+from hashlib import sha1
+
 import factory
 
 from pcapi.core.factories import BaseFactory
@@ -11,4 +13,4 @@ class ChronicleFactory(BaseFactory):
 
     content = "A small chronicle content."
     email = factory.Sequence("chronicle-{}@example.com".format)
-    formId = "54c77f43519a"
+    formId = factory.Sequence(lambda x: sha1(bytes(x)).hexdigest()[0:12])

--- a/api/src/pcapi/core/chronicles/models.py
+++ b/api/src/pcapi/core/chronicles/models.py
@@ -34,7 +34,7 @@ class Chronicle(PcObject, Base, Model, DeactivableMixin):
     eanChoiceId = sa.Column(sa.Text(), nullable=True)
     email = sa.Column(sa.Text(), nullable=False)
     firstName = sa.Column(sa.Text(), nullable=True)
-    formId = sa.Column(sa.Text(), nullable=False)
+    formId = sa.Column(sa.Text(), nullable=False, unique=True)
     isIdentityDiffusible = sa.Column(
         sa.Boolean, nullable=False, server_default=sa.sql.expression.false(), default=False
     )

--- a/api/tests/core/chronicles/test_api.py
+++ b/api/tests/core/chronicles/test_api.py
@@ -414,6 +414,35 @@ class SaveBookClubChronicleTest:
 
         assert chronicle.products == [product]
 
+    def test_save_book_club_chronicle_already_saved(self):
+        old_chronicle = chronicles_factories.ChronicleFactory()
+        ean = "1234567890123"
+        ean_choice_id = random_string()
+        form = typeform.TypeformResponse(
+            response_id=old_chronicle.formId,
+            date_submitted=datetime.datetime(2024, 10, 24),
+            phone_number=None,
+            email="email@mail.test",
+            answers=[
+                typeform.TypeformAnswer(
+                    field_id=constants.BookClub.BOOK_EAN_ID.value,
+                    choice_id=ean_choice_id,
+                    text=ean,
+                ),
+                typeform.TypeformAnswer(
+                    field_id=constants.BookClub.CHRONICLE_ID.value,
+                    choice_id=None,
+                    text="some random chronicle description",
+                ),
+            ],
+        )
+
+        api.save_book_club_chronicle(form)
+
+        chronicles = models.Chronicle.query.all()
+        assert len(chronicles) == 1
+        assert chronicles[0].id == old_chronicle.id
+
 
 @pytest.mark.usefixtures("db_session")
 class ExtractBookClubEanTest:


### PR DESCRIPTION
… it twice

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34203

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
