### PR TITLE
(BSR)[PRO] remove firld layout for text input v2

### DIFF
--- a/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
+++ b/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
@@ -76,6 +76,7 @@ export const UserIdentityForm = ({
               <TextInput
                 label="Prénom"
                 error={errors.firstName?.message}
+                required={true}
                 {...register('firstName')}
               />
             </FormLayout.Row>
@@ -83,6 +84,7 @@ export const UserIdentityForm = ({
               <TextInput
                 label="Nom"
                 error={errors.lastName?.message}
+                required={true}
                 {...register('lastName')}
               />
             </FormLayout.Row>

--- a/pro/src/ui-kit/formV2/TextInput/TextInput.module.scss
+++ b/pro/src/ui-kit/formV2/TextInput/TextInput.module.scss
@@ -1,4 +1,8 @@
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/variables/_forms.scss" as forms;
+@use "styles/mixins/_forms.scss" as formsM;
 @use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_a11y.scss" as a11y;
 
 .text-input {
   &-readonly {
@@ -16,4 +20,49 @@
       margin-left: rem.torem(16px);
     }
   }
+}
+
+.input-layout {
+  width: 100%;
+  margin-bottom: rem.torem(8px);
+
+  &-label {
+    @include fonts.body;
+
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+
+    &-container {
+      margin-bottom: rem.torem(forms.$label-space-before-input);
+    }
+
+    &-asterisk {
+      margin-left: rem.torem(8px);
+    }
+  }
+
+  &-footer {
+    @include formsM.field-layout-footer;
+  }
+
+  &-error {
+    flex: 1;
+
+    svg {
+      flex: 0 0 15px;
+    }
+  }
+
+  &-input-description {
+    @include fonts.body-xs;
+
+    display: block;
+    color: var(--color-grey-dark);
+    margin-top: rem.torem(4px);
+  }
+}
+
+.visually-hidden {
+  @include a11y.visually-hidden;
 }

--- a/pro/src/ui-kit/formV2/TextInput/TextInput.spec.tsx
+++ b/pro/src/ui-kit/formV2/TextInput/TextInput.spec.tsx
@@ -4,6 +4,14 @@ import userEvent from '@testing-library/user-event'
 import { TextInput } from './TextInput'
 
 describe('TextInput', () => {
+  const defaultProps = {
+    name: 'email',
+    label: 'Email Address',
+    required: true,
+    placeholder: 'Enter your email',
+    error: '',
+  }
+
   it.each([
     'text',
     'number',
@@ -17,8 +25,18 @@ describe('TextInput', () => {
     async (inputType) => {
       render(
         <>
-          <TextInput type={inputType} label="Input 1" name="test1" />
-          <TextInput type={inputType} label="Input 2" name="test2" />
+          <TextInput
+            type={inputType}
+            label="Input 1"
+            name="test1"
+            required={true}
+          />
+          <TextInput
+            type={inputType}
+            label="Input 2"
+            name="test2"
+            required={true}
+          />
         </>
       )
 
@@ -44,7 +62,6 @@ describe('TextInput', () => {
         label={inputLabel}
         description={descriptionContent}
         name={inputName}
-        isOptional={true}
       />
     )
 
@@ -80,12 +97,104 @@ describe('TextInput', () => {
   })
 
   it('should ignore onKeyDown event for type number', async () => {
-    render(<TextInput type="number" label="Input" name="test1" />)
+    render(
+      <TextInput type="number" label="Input" name="test1" required={true} />
+    )
 
     const input = screen.getByLabelText('Input *')
     await userEvent.type(input, '1000')
     await userEvent.keyboard('ArrowUp')
 
     expect(input).toHaveValue(1000)
+  })
+
+  it('renders the input field with the correct label', () => {
+    render(<TextInput {...defaultProps} />)
+
+    // Check if the input is rendered with the label and placeholder
+    const input = screen.getByLabelText(/email address/i) // Match case-insensitively
+    expect(input).toBeInTheDocument()
+    expect(input).toHaveAttribute('placeholder', 'Enter your email')
+  })
+
+  it('renders the input field with a mandatory asterisk when required', () => {
+    render(<TextInput {...defaultProps} />)
+
+    // Check if the label has the asterisk for required fields
+    const label = screen.getByText('Email Address *')
+    expect(label).toBeInTheDocument()
+  })
+
+  it('renders the error message when the error prop is provided', () => {
+    const errorMessage = 'This field is required'
+    render(<TextInput {...defaultProps} error={errorMessage} />)
+
+    // Check if the error message is displayed
+    const error = screen.getByRole('alert')
+    expect(error).toHaveTextContent(errorMessage)
+  })
+
+  it('does not display error when no error prop is passed', () => {
+    render(<TextInput {...defaultProps} />)
+
+    // Check if the error is not displayed
+    const error = screen.queryByRole('alert')
+    expect(error).toBeNull()
+  })
+
+  it('disables the input when the disabled prop is passed', () => {
+    render(<TextInput {...defaultProps} disabled />)
+
+    // Check if the input is disabled
+    const input = screen.getByLabelText(/email address/i)
+    expect(input).toBeDisabled()
+  })
+
+  it('handles readonly mode correctly', () => {
+    render(<TextInput {...defaultProps} readOnly value="readonly value" />)
+
+    // Check if the input field is readonly
+    const readOnly = screen.getByText(/email address/i)
+    expect(readOnly).toBeInTheDocument()
+  })
+
+  it('should handle decimal input correctly with hasDecimal=true', async () => {
+    render(<TextInput {...defaultProps} type="number" hasDecimal={true} />)
+
+    const input = screen.getByLabelText(/email address/i)
+
+    // Test if decimal input is allowed
+    await userEvent.type(input, '123.45')
+    expect(input).toHaveValue(123.45)
+
+    // Test if non-numeric input is rejected
+    await userEvent.keyboard('a')
+    expect(input).toHaveValue(123.45) // Input remains unchanged for non-numeric input
+  })
+
+  it('renders InputExtension correctly if passed', () => {
+    const InputExtension = <button>Reset</button>
+    render(<TextInput {...defaultProps} InputExtension={InputExtension} />)
+
+    // Check if the InputExtension is rendered next to the input
+    const extensionButton = screen.getByText('Reset')
+    expect(extensionButton).toBeInTheDocument()
+  })
+
+  it('renders description when the description prop is passed', () => {
+    const description = 'Please enter a valid email address'
+    render(<TextInput {...defaultProps} description={description} />)
+
+    // Check if the description is rendered correctly
+    const descriptionElement = screen.getByText(description)
+    expect(descriptionElement).toBeInTheDocument()
+  })
+
+  it('hides label when isLabelHidden is true', () => {
+    render(<TextInput {...defaultProps} isLabelHidden />)
+
+    // Check if the label is hidden
+    const label = screen.queryByText('Email Address')
+    expect(label).not.toBeInTheDocument()
   })
 })

--- a/pro/src/ui-kit/formV2/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/formV2/TextInput/TextInput.tsx
@@ -1,13 +1,12 @@
+import cn from 'classnames'
 import React, { ForwardedRef } from 'react'
 
 import {
   BaseInput,
   BaseInputProps,
 } from 'ui-kit/form/shared/BaseInput/BaseInput'
-import {
-  FieldLayout,
-  FieldLayoutBaseProps,
-} from 'ui-kit/form/shared/FieldLayout/FieldLayout'
+import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
+import { FieldLayoutBaseProps } from 'ui-kit/form/shared/FieldLayout/FieldLayout'
 
 import styles from './TextInput.module.scss'
 
@@ -29,9 +28,7 @@ type TextInputProps = FieldLayoutBaseProps &
     hasDecimal?: boolean
     /**
      * A custom error message to be displayed.
-     * If this prop is provided, the error message will be displayed
-     * and the field will be marked as errored regardless of the field's Formik state.
-     * Used for `error` & `showError` `FieldLayout` props.
+     * If this prop is provided, the error message will be displayed and the field will be marked as errored
      */
     error?: string
     /**
@@ -59,7 +56,7 @@ type TextInputProps = FieldLayoutBaseProps &
  *   name="email"
  *   label="Email Address"
  *   description="Please enter a valid email address."
- *   isOptional
+ *   required={true}
  * />
  *
  * @accessibility
@@ -75,29 +72,19 @@ export const TextInput = React.forwardRef(
     {
       name,
       type = 'text',
-      className,
-      classNameFooter,
-      classNameLabel,
-      classNameInput,
       disabled,
       readOnly,
-      hideFooter,
       label,
+      className,
       isLabelHidden = false,
       maxLength = 255,
-      smallLabel,
-      isOptional = false,
+      required = false,
       leftIcon,
       rightButton,
       rightIcon,
-      step,
       hasDecimal = true,
-      inline = false,
       description,
-      clearButtonProps,
-      hasLabelLineBreak = true,
       error,
-      showMandatoryAsterisk,
       InputExtension,
       ...props
     }: TextInputProps,
@@ -107,29 +94,20 @@ export const TextInput = React.forwardRef(
     const regexHasDecimal = /[0-9,.]/
     const regexHasNotDecimal = /[0-9]/
     const regexIsNavigationKey = /Tab|Backspace|Enter/
-    const showError = !!error
-
-    // Constructing aria-describedby attribute
-    const describedBy = []
-
-    if (description) {
-      describedBy.push(`description-${name}`)
-    }
 
     const input = (
       <BaseInput
         name={name}
         disabled={disabled}
-        hasError={showError}
+        hasError={!!error}
         maxLength={maxLength}
-        step={step}
         type={type}
         ref={ref}
         rightButton={rightButton}
         rightIcon={rightIcon}
         leftIcon={leftIcon}
-        aria-required={!isOptional}
-        aria-describedby={describedBy.join(' ') || undefined}
+        aria-required={required}
+        aria-describedby={description ? `description-${name}` : undefined}
         onKeyDown={(event) => {
           // Restrict input for number types
           if (type === 'number') {
@@ -159,39 +137,59 @@ export const TextInput = React.forwardRef(
     )
 
     return (
-      <FieldLayout
-        className={className}
-        classNameLabel={classNameLabel}
-        classNameFooter={classNameFooter}
-        classNameInput={classNameInput}
-        error={error}
-        isOptional={isOptional}
-        showMandatoryAsterisk={showMandatoryAsterisk}
-        label={label}
-        isLabelHidden={isLabelHidden}
-        maxLength={maxLength}
-        name={name}
-        showError={showError}
-        smallLabel={smallLabel}
-        inline={inline}
-        hideFooter={hideFooter}
-        description={description}
-        clearButtonProps={clearButtonProps}
-        hasLabelLineBreak={hasLabelLineBreak}
+      <div
+        className={cn(styles['input-layout'], className)}
+        data-testid={`wrapper-${name}`}
       >
-        {readOnly ? (
-          <span className={styles['text-input-readonly']}>{props.value}</span>
-        ) : InputExtension ? (
-          <div className={styles['text-input-group']} role="group">
-            {input}
-            <div className={styles['text-input-group-extension']}>
-              {InputExtension}
-            </div>
+        <div
+          className={cn(styles['input-layout-label-container'], {
+            [styles['visually-hidden']]: isLabelHidden,
+          })}
+        >
+          <label className={styles['input-layout-label']} htmlFor={name}>
+            {label} {required && '*'}
+          </label>
+          {description && (
+            <span
+              id={`description-${name}`}
+              data-testid={`description-${name}`}
+              className={styles['input-layout-input-description']}
+            >
+              {description}
+            </span>
+          )}
+        </div>
+
+        <div className={styles['input-layout-content']}>
+          <div className={cn(styles['input-wrapper'])}>
+            {readOnly ? (
+              <span className={styles['text-input-readonly']}>
+                {props.value}
+              </span>
+            ) : InputExtension ? (
+              <div className={styles['text-input-group']} role="group">
+                {input}
+                <div className={styles['text-input-group-extension']}>
+                  {InputExtension}
+                </div>
+              </div>
+            ) : (
+              input
+            )}
           </div>
-        ) : (
-          input
-        )}
-      </FieldLayout>
+          <div className={styles['input-layout-footer']}>
+            {error && (
+              <div
+                role="alert"
+                className={styles['input-layout-error']}
+                id={`error-details-${name}`}
+              >
+                <FieldError name={name}>{error}</FieldError>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
     )
   }
 )


### PR DESCRIPTION
## But de la pull request

BSR comme discuté en journée de pratique front, je retire le field layout des nouveaux formulaire

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
