### PR TITLE
(PC-34217)[API] feat: drop constraint `venue.isVirtual=True` for digital offers

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -312,11 +312,15 @@ def create_offer(
 
     fields = body.dict(by_alias=True)
 
+    offerer_address = offerer_address or venue.offererAddress
+
+    if body.url:  # i.e. it is a digital offer
+        offerer_address = None
+
     offer = models.Offer(
         **fields,
         venue=venue,
-        # WARNING: quid des offres numériques ici ?
-        offererAddress=offerer_address or venue.offererAddress,
+        offererAddress=offerer_address,
         lastProvider=provider,
         isActive=False,
         validation=models.OfferValidationStatus.DRAFT,

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -418,11 +418,6 @@ def check_digital_offer_fields(offer: models.Offer) -> None:
     errors = api_errors.ApiErrors()
 
     if offer.isDigital:
-        if not venue.isVirtual:
-            errors.add_error(
-                "venue", 'Une offre numérique doit obligatoirement être associée au lieu "Offre numérique"'
-            )
-
         if offer.subcategory.is_offline_only:
             errors.add_error(
                 "url", f"Une offre de sous-catégorie {offer.subcategory.pro_label} ne peut pas être numérique"
@@ -432,9 +427,6 @@ def check_digital_offer_fields(offer: models.Offer) -> None:
             errors.add_error("offererAddress", "Une offre numérique ne peut pas avoir d'adresse")
             raise errors
     else:
-        if venue.isVirtual:
-            errors.add_error("venue", 'Une offre physique ne peut être associée au lieu "Offre numérique"')
-
         if offer.subcategory.is_online_only:
             errors.add_error("url", f'Une offre de catégorie {offer.subcategory.id} doit contenir un champ "url"')
         if offer.offererAddress is None and FeatureToggle.WIP_ENABLE_OFFER_ADDRESS.is_active():

--- a/api/src/pcapi/validation/models/offer.py
+++ b/api/src/pcapi/validation/models/offer.py
@@ -8,19 +8,11 @@ def validate(offer: Offer, api_errors: ApiErrors) -> ApiErrors:
     assert venue is not None  # helps mypy below
 
     if offer.isDigital:
-        if not venue.isVirtual:
-            api_errors.add_error(
-                "venue", 'Une offre numérique doit obligatoirement être associée au lieu "Offre numérique"'
-            )
-
         if offer.subcategory.is_offline_only:
             api_errors.add_error(
                 "url", f"Une offre de sous-catégorie {offer.subcategory.pro_label} ne peut pas être numérique"
             )
     else:
-        if venue.isVirtual:
-            api_errors.add_error("venue", 'Une offre physique ne peut être associée au lieu "Offre numérique"')
-
         if offer.subcategory.is_online_only:
             api_errors.add_error("url", f'Une offre de catégorie {offer.subcategory.id} doit contenir un champ "url"')
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1493,23 +1493,23 @@ class CreateOfferTest:
     def test_create_digital_offer_from_scratch_with_offerer_address(
         self,
     ):
-
         venue = offerers_factories.VenueFactory(isVirtual=True, offererAddress=None, siret=None)
         offerer_address = offerers_factories.OffererAddressFactory(offerer=venue.managingOfferer)
 
-        with pytest.raises(api_errors.ApiErrors) as error:
-            body = offers_schemas.CreateOffer(
-                name="A pretty good offer",
-                externalTicketOfficeUrl="http://example.net",
-                audioDisabilityCompliant=True,
-                mentalDisabilityCompliant=True,
-                motorDisabilityCompliant=True,
-                visualDisabilityCompliant=True,
-                url="http://example.com",
-                subcategoryId=subcategories.VOD.id,
-            )
-            api.create_offer(body=body, venue=venue, offerer_address=offerer_address)
-        assert error.value.errors["offererAddress"] == ["Une offre numérique ne peut pas avoir d'adresse"]
+        body = offers_schemas.CreateOffer(
+            name="A pretty good offer",
+            externalTicketOfficeUrl="http://example.net",
+            audioDisabilityCompliant=True,
+            mentalDisabilityCompliant=True,
+            motorDisabilityCompliant=True,
+            visualDisabilityCompliant=True,
+            url="http://example.com",
+            subcategoryId=subcategories.VOD.id,
+        )
+
+        offer = api.create_offer(body=body, venue=venue, offerer_address=offerer_address)
+
+        assert offer.offererAddressId == None
 
     def test_create_offer_from_scratch_with_offerer_address(self):
         venue = offerers_factories.VenueFactory()

--- a/api/tests/validation/models/entity_validator_test.py
+++ b/api/tests/validation/models/entity_validator_test.py
@@ -66,24 +66,10 @@ class VenueValidationTest:
 
 
 class OfferValidationTest:
-    def test_digital_offer_with_non_virtual_venue(self):
-        venue = offerers_factories.VenueFactory.build()
-        offer = offers_factories.DigitalOfferFactory.build(venue=venue)
-        api_errors = validate(offer)
-        assert api_errors.errors == {
-            "venue": ['Une offre numérique doit obligatoirement être associée au lieu "Offre numérique"']
-        }
-
     def test_digital_offer_with_virtual_venue(self):
         offer = offers_factories.DigitalOfferFactory.build()
         api_errors = validate(offer)
         assert not api_errors.errors
-
-    def test_physical_offer_with_virtual_venue(self):
-        venue = offerers_factories.VirtualVenueFactory.build()
-        offer = offers_factories.OfferFactory.build(venue=venue)
-        api_errors = validate(offer)
-        assert api_errors.errors == {"venue": ['Une offre physique ne peut être associée au lieu "Offre numérique"']}
 
     def test_physical_offer_with_non_virtual_venue(self):
         offer = offers_factories.OfferFactory.build()


### PR DESCRIPTION
To enable the creation of digital offers linked to physical venue

Première étape vers la suppression des venues virtuelles.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34217

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
