### PR TITLE
(PC-34016) upsert on inactive offer

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -788,9 +788,9 @@ def set_upper_timespan_of_inactive_headline_offers() -> None:
 
 def upsert_headline_offer(offer: models.Offer) -> models.HeadlineOffer:
     offerer_id = offer.venue.managingOffererId
-    headline_offer = offers_repository.get_offerers_active_headline_offer(offerer_id)
+    headline_offer = offers_repository.get_offerer_active_headline_offer_even_not_yet_disabled_by_cron(offerer_id)
     if headline_offer and headline_offer.offerId != offer.id:
-        remove_headline_offer(headline_offer)
+        remove_headline_offer(offerer_id)
         logger.info(
             "Headline Offer Deactivation",
             extra={
@@ -828,7 +828,9 @@ def make_offer_headline(offer: models.Offer) -> models.HeadlineOffer:
 
 
 def remove_headline_offer(offerer_id: int) -> None:
-    if active_headline_offer := offers_repository.get_offerers_active_headline_offer(offerer_id):
+    if active_headline_offer := offers_repository.get_offerer_active_headline_offer_even_not_yet_disabled_by_cron(
+        offerer_id
+    ):
         try:
             active_headline_offer.timespan = db_utils.make_timerange(
                 active_headline_offer.timespan.lower, datetime.datetime.utcnow()

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1196,9 +1196,7 @@ def get_active_headline_offer(offer_id: int) -> models.HeadlineOffer | None:
 
 def get_offerers_active_headline_offer(offerer_id: int) -> models.HeadlineOffer | None:
     managed_venue_ids_subquery = (
-        offerers_models.Venue.query.filter(offerers_models.Venue.managingOffererId == offerer_id)
-        .with_entities(offerers_models.Venue.id)
-        .subquery()
+        sa.select(offerers_models.Venue.id).filter(offerers_models.Venue.managingOffererId == offerer_id).subquery()
     )
     return (
         models.HeadlineOffer.query.join(models.Offer)

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1194,15 +1194,11 @@ def get_active_headline_offer(offer_id: int) -> models.HeadlineOffer | None:
     )
 
 
-def get_offerers_active_headline_offer(offerer_id: int) -> models.HeadlineOffer | None:
-    managed_venue_ids_subquery = (
-        sa.select(offerers_models.Venue.id).filter(offerers_models.Venue.managingOffererId == offerer_id).subquery()
-    )
+def get_offerer_active_headline_offer_even_not_yet_disabled_by_cron(offerer_id: int) -> models.HeadlineOffer | None:
     return (
-        models.HeadlineOffer.query.join(models.Offer)
+        models.HeadlineOffer.query.join(offerers_models.Venue)
         .filter(
-            models.HeadlineOffer.venueId.in_(managed_venue_ids_subquery),
-            models.HeadlineOffer.isActive == True,
+            models.HeadlineOffer.isActiveOrNotYetDisabled == True, offerers_models.Venue.managingOffererId == offerer_id
         )
         .one_or_none()
     )

--- a/api/src/pcapi/routes/pro/headline_offer.py
+++ b/api/src/pcapi/routes/pro/headline_offer.py
@@ -36,24 +36,11 @@ def upsert_headline_offer(body: headline_offer_serialize.HeadlineOfferCreationBo
 
     rest.check_user_has_access_to_offerer(current_user, offerer_id)
     try:
-        headline_offer = offers_repository.get_offerers_active_headline_offer(offer.venue.managingOffererId)
-        if headline_offer and headline_offer.offerId != offer.id:
-            offers_api.remove_headline_offer(headline_offer)
-            logger.info(
-                "Headline Offer Deactivation",
-                extra={
-                    "analyticsSource": "app-pro",
-                    "HeadlineOfferId": headline_offer.id,
-                    "Reason": "User chose to replace this headline offer by another offer",
-                },
-                technical_message_id="headline_offer_deactivation",
-            )
+        offers_api.upsert_headline_offer(offer)
     except exceptions.CannotRemoveHeadlineOffer:
         raise api_errors.ApiErrors(
             errors={"global": ["Une erreur est survenue au moment du retrait de l'offre à la une"]},
         )
-    try:
-        offers_api.make_offer_headline(offer)
     except exceptions.OffererCanNotHaveHeadlineOffer:
         raise api_errors.ApiErrors(
             errors={
@@ -93,14 +80,9 @@ def upsert_headline_offer(body: headline_offer_serialize.HeadlineOfferCreationBo
 @atomic()
 def delete_headline_offer(body: headline_offer_serialize.HeadlineOfferDeleteBodyModel) -> None:
     rest.check_user_has_access_to_offerer(current_user, body.offerer_id)
-    if active_headline_offer := offers_repository.get_offerers_active_headline_offer(body.offerer_id):
-        offers_api.remove_headline_offer(active_headline_offer)
-        logger.info(
-            "Headline Offer Deactivation",
-            extra={
-                "analyticsSource": "app-pro",
-                "HeadlineOfferId": active_headline_offer.id,
-                "Reason": "Headline offer has been deactivated by user",
-            },
-            technical_message_id="headline_offer_deactivation",
+    try:
+        offers_api.remove_headline_offer(body.offerer_id)
+    except exceptions.CannotRemoveHeadlineOffer:
+        raise api_errors.ApiErrors(
+            errors={"global": ["Une erreur est survenue au moment du retrait de l'offre à la une"]},
         )

--- a/api/src/pcapi/routes/pro/headline_offer.py
+++ b/api/src/pcapi/routes/pro/headline_offer.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 @atomic()
 def upsert_headline_offer(body: headline_offer_serialize.HeadlineOfferCreationBodyModel) -> None:
 
-    offer = offers_repository.get_offer_by_id(body.offer_id, load_options=["headline_offer"])
+    offer = offers_repository.get_offer_by_id(body.offer_id, load_options=["headline_offer", "venue"])
 
     if not offer:
         raise api_errors.ResourceNotFoundError

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -2149,7 +2149,7 @@ class HeadlineOfferTest:
         offer = factories.OfferFactory(isActive=True)
         headline_offer = factories.HeadlineOfferFactory(offer=offer, create_mediation=True)
 
-        api.remove_headline_offer(headline_offer)
+        api.remove_headline_offer(offer.venue.managingOffererId)
         db.session.commit()  # see comment in make_offer_headline()
 
         assert headline_offer.timespan.upper
@@ -2342,11 +2342,14 @@ class HeadlineOfferTest:
         assert headline_offer.timespan.upper is not None
 
     def test_upsert_headline_offer_on_another_offer(self):
-        offer = factories.OfferFactory()
+        offer = factories.OfferFactory(venue__venueTypeCode=VenueTypeCode.LIBRARY)
         another_offer = factories.OfferFactory(venue=offer.venue)
+        api.create_stock(offer=another_offer, price=10, quantity=7)
+        factories.MediationFactory(offer=another_offer)
         headline_offer = factories.HeadlineOfferFactory(offer=offer, create_mediation=True)
 
         new_headline_offer = api.upsert_headline_offer(another_offer)
+        db.session.commit()  # see comment in make_offer_headline()
 
         assert not offer.is_headline_offer
         assert another_offer.is_headline_offer
@@ -2356,12 +2359,12 @@ class HeadlineOfferTest:
         assert new_headline_offer.timespan.upper is None
 
     def test_upsert_headline_offer_on_same_offer(self):
-        offer = factories.OfferFactory()
+        offer = factories.OfferFactory(venue__venueTypeCode=VenueTypeCode.LIBRARY)
         creation_time = datetime.utcnow() - timedelta(days=20)
         finished_timespan = (creation_time, creation_time + timedelta(days=10))
         headline_offer = factories.HeadlineOfferFactory(offer=offer, timespan=finished_timespan, create_mediation=True)
-
         new_headline_offer = api.upsert_headline_offer(offer)
+        db.session.commit()  # see comment in make_offer_headline()
 
         assert not headline_offer.isActive
         assert headline_offer.timespan.upper is not None

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -2341,6 +2341,33 @@ class HeadlineOfferTest:
         assert not headline_offer.isActive
         assert headline_offer.timespan.upper is not None
 
+    def test_upsert_headline_offer_on_another_offer(self):
+        offer = factories.OfferFactory()
+        another_offer = factories.OfferFactory(venue=offer.venue)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, create_mediation=True)
+
+        new_headline_offer = api.upsert_headline_offer(another_offer)
+
+        assert not offer.is_headline_offer
+        assert another_offer.is_headline_offer
+        assert not headline_offer.isActive
+        assert headline_offer.timespan.upper is not None
+        assert new_headline_offer.isActive
+        assert new_headline_offer.timespan.upper is None
+
+    def test_upsert_headline_offer_on_same_offer(self):
+        offer = factories.OfferFactory()
+        creation_time = datetime.utcnow() - timedelta(days=20)
+        finished_timespan = (creation_time, creation_time + timedelta(days=10))
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, timespan=finished_timespan, create_mediation=True)
+
+        new_headline_offer = api.upsert_headline_offer(offer)
+
+        assert not headline_offer.isActive
+        assert headline_offer.timespan.upper is not None
+        assert new_headline_offer.isActive
+        assert new_headline_offer.timespan.upper is None
+
 
 @pytest.mark.usefixtures("db_session")
 class OfferExpenseDomainsTest:

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -2717,3 +2717,25 @@ class GetHeadlineOfferFiltersTest:
 
         headline_offer_query_result = repository.get_inactive_headline_offers()
         assert headline_offer_query_result == [headline_offer_without_mediation]
+
+    def test_get_offerer_active_headline_offer_even_not_yet_disabled_by_cron_for_active_offer(self):
+        offer = factories.OfferFactory(isActive=True)
+        factories.StockFactory(offer=offer)
+        user_offerer = offerers_factories.UserOffererFactory()
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, venue=venue)
+        headline_offer_query_result = repository.get_offerer_active_headline_offer_even_not_yet_disabled_by_cron(
+            user_offerer.offerer.id
+        )
+        assert headline_offer_query_result == headline_offer
+
+    def test_get_offerer_active_headline_offer_even_not_yet_disabled_by_cron_for_inactive_offer(self):
+        offer = factories.OfferFactory(isActive=True)
+        user_offerer = offerers_factories.UserOffererFactory()
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+        factories.StockFactory(offer=offer)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, venue=venue, create_mediation=False)
+        headline_offer_query_result = repository.get_offerer_active_headline_offer_even_not_yet_disabled_by_cron(
+            user_offerer.offerer.id
+        )
+        assert headline_offer_query_result == headline_offer


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34016

Context : Lors de l'ajout d'une offre en tant qu'offre à la une, il faut désactiver l'offre à la une déjà en place si elle existe. Pour cela, il faut ajouter une borne max au timespan. Un cron tourne toutes les 10min pour vérifier que les offres à la une sont toujours éligible (offre active, avec une image). Il existe donc un laps de temps de 10min pendant lequel on essaye de mettre une nouvelle offre à la une alors que la précédente n'est plus éligible mais dont l'objet `HeadlineOffer` ne possède toujours pas de borne max dans son timespan. Il faut donc récupérer ces offres à la une et non simplement les offres à la une avec une borne max dans leur timespan.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
