### PR TITLE
(PC-34233)[API] feat: add `ean` column in `product` table

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 1b5deb8e094c (pre) (head)
-5450a88dc12b (post) (head)
+5eb5a5f7189c (post) (head)

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-066c0b3fadd6 (pre) (head)
+1b5deb8e094c (pre) (head)
 5450a88dc12b (post) (head)

--- a/api/src/pcapi/alembic/versions/20250127T104717_1b5deb8e094c_add_ean_column_in_product_table.py
+++ b/api/src/pcapi/alembic/versions/20250127T104717_1b5deb8e094c_add_ean_column_in_product_table.py
@@ -1,0 +1,21 @@
+"""Add EAN column in product table
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "1b5deb8e094c"
+down_revision = "066c0b3fadd6"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("product", sa.Column("ean", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("product", "ean")

--- a/api/src/pcapi/alembic/versions/20250127T105755_5eb5a5f7189c_add_not_valid_constraint_on_product_ean_column.py
+++ b/api/src/pcapi/alembic/versions/20250127T105755_5eb5a5f7189c_add_not_valid_constraint_on_product_ean_column.py
@@ -1,0 +1,25 @@
+"""Add not valid check constraint on product ean column
+"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "5eb5a5f7189c"
+down_revision = "5450a88dc12b"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_check_constraint(
+        "check_ean_validity",
+        "product",
+        "ean ~ '^\\d{13}$'",
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("check_ean_validity", "product", "check")

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -177,7 +177,7 @@ class Product(PcObject, Base, Model, HasThumbMixin, ProvidableMixin):
         passive_deletes=True,
     )
     likesCount: sa_orm.Mapped["int"] = sa_orm.query_expression()
-    ean = sa.Column(sa.Text, nullable=True)
+    ean = sa.Column(sa.Text, sa.CheckConstraint("ean ~ '^\\d{13}$'", name="check_ean_validity"), nullable=True)
 
     sa.Index("product_ean_idx", extraData["ean"].astext)
     sa.Index("product_allocineId_idx", extraData["allocineId"].cast(sa.Integer))

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -177,6 +177,7 @@ class Product(PcObject, Base, Model, HasThumbMixin, ProvidableMixin):
         passive_deletes=True,
     )
     likesCount: sa_orm.Mapped["int"] = sa_orm.query_expression()
+    ean = sa.Column(sa.Text, nullable=True)
 
     sa.Index("product_ean_idx", extraData["ean"].astext)
     sa.Index("product_allocineId_idx", extraData["allocineId"].cast(sa.Integer))


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34233

Une fois cette PR mergée et déployée dans les différents environnements, il faudra lancer dans chaque environnement : 
- Le script pour valider la contrainte sur `product.ean` (#16042)
- Le script pour créer l'index unique sur `product.ean` (#16043)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
