### PR TITLE
(BSR)[API] refactor: move mock path for collective routes testing in …

### DIFF
--- a/api/src/pcapi/core/educational/testing.py
+++ b/api/src/pcapi/core/educational/testing.py
@@ -16,6 +16,8 @@ def reset_requests() -> None:
     adage_requests = []
 
 
+PATCH_CAN_CREATE_OFFER_PATH = "pcapi.core.offerers.api.can_offerer_create_educational_offer"
+
 STATUSES_ALLOWING_EDIT_DETAILS = (
     models.CollectiveOfferDisplayedStatus.DRAFT,
     models.CollectiveOfferDisplayedStatus.ACTIVE,

--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -20,9 +20,6 @@ from pcapi.utils.date import format_into_utc_date
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-PATCH_CAN_CREATE_OFFER_PATH = "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer"
-
-
 @dataclass
 class OfferContext:
     user_offerer: offerers_models.UserOfferer
@@ -99,7 +96,7 @@ class Returns200Test:
         pro_client = build_pro_client(client, offer_ctx.user)
         offer_id = offer_ctx.offer.id
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload_ctx.payload)
 
         assert response.status_code == 200
@@ -142,7 +139,7 @@ class Returns200Test:
             },
         }
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         assert response.status_code == 200
@@ -156,7 +153,7 @@ class Returns200Test:
         assert offer.dateRange.lower
         assert offer.dateRange.upper
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer.id)
             response = pro_client.patch(endpoint, json={})
             assert response.status_code == 200
@@ -177,7 +174,7 @@ class Returns200Test:
         assert offer.dateRange.lower
         assert offer.dateRange.upper
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer.id)
             response = pro_client.patch(endpoint, json={"dates": None})
             assert response.status_code == 200
@@ -196,7 +193,7 @@ class Returns200Test:
         assert offer.dateRange.lower
         assert offer.dateRange.upper
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer.id)
             response = pro_client.patch(endpoint, json={"contactPhone": None, "dates": None})
             assert response.status_code == 200
@@ -211,7 +208,7 @@ class Returns200Test:
         pro_client = build_pro_client(client, offer_ctx.user)
         endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer_ctx.offer.id)
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(endpoint, json={"contactPhone": None})
             assert response.status_code == 200
 
@@ -221,7 +218,7 @@ class Returns200Test:
         offer = offer_ctx.offer
         endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer.id)
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(
                 endpoint,
                 json={
@@ -248,7 +245,7 @@ class Returns200Test:
         endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer.id)
         now = datetime.utcnow()
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(endpoint, json={"dates": {"start": now.isoformat(), "end": now.isoformat()}})
             assert response.status_code == 200
 
@@ -269,7 +266,7 @@ class Returns200Test:
         payload["contactUrl"] = None
         payload["contactForm"] = None
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         db.session.flush()  # otherwise "Failed to add object to the flush context!" in teardown
@@ -285,7 +282,7 @@ class Returns200Test:
 
         data = {"name": "New name", "description": "Ma super description"}
         auth_client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(f"/collective/offers-template/{offer.id}", json=data)
             assert response.status_code == 200
 
@@ -301,7 +298,7 @@ class Returns200Test:
         venue = offerers_factories.VenueFactory(managingOfferer=offer_ctx.venue.managingOfferer)
 
         payload = {"offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": venue.id}}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         assert response.status_code == 200
@@ -317,7 +314,7 @@ class Returns200Test:
         offer_id = offer_ctx.offer.id
 
         payload = {"offerVenue": {"addressType": "school", "otherAddress": "", "venueId": None}}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         assert response.status_code == 200
@@ -333,7 +330,7 @@ class Returns200Test:
         offer_id = offer_ctx.offer.id
 
         payload = {"offerVenue": {"addressType": "other", "otherAddress": "In Paris", "venueId": None}}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         assert response.status_code == 200
@@ -353,7 +350,7 @@ class Returns400Test:
 
         data = {"name": " "}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 400
@@ -367,7 +364,7 @@ class Returns400Test:
 
         data = {"name": None}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 400
@@ -381,7 +378,7 @@ class Returns400Test:
 
         data = {"subcategoryId": "LIVRE_PAPIER"}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 400
@@ -395,7 +392,7 @@ class Returns400Test:
 
         data = {"domains": []}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 400
@@ -409,7 +406,7 @@ class Returns400Test:
 
         data = {"nationalProgramId": -1}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 400
@@ -428,7 +425,7 @@ class Returns400Test:
         payload["contactUrl"] = None
         payload["contactForm"] = None
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         db.session.flush()  # otherwise "Failed to add object to the flush context!" in teardown
@@ -447,7 +444,7 @@ class Returns400Test:
         payload["contactUrl"] = "https://example.com/contact"
         payload["contactForm"] = educational_models.OfferContactFormEnum.FORM.value
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         db.session.flush()  # otherwise "Failed to add object to the flush context!" in teardown
@@ -464,7 +461,7 @@ class Returns400Test:
         payload = payload_ctx.payload
 
         payload["bookingEmails"] = ["test@testmail.com", "test@test", "test"]
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         assert response.status_code == 400
@@ -482,7 +479,7 @@ class Returns400Test:
         payload = payload_ctx.payload
 
         payload["description"] = "too_long" * 200
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         assert response.status_code == 400
@@ -498,7 +495,7 @@ class Returns400Test:
         offerers_factories.UserOffererFactory(user=offer_ctx.user, offerer=offer.venue.managingOfferer)
 
         data = {"visualDisabilityCompliant": True}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
 
             assert response.status_code == 400
@@ -585,7 +582,7 @@ class InvalidDatesTest:
         assert "dates.end" in response.json
 
     def send_request(self, pro_client, offer_id, dates):
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             endpoint = url_for("Private API.edit_collective_offer_template", offer_id=offer_id)
             return pro_client.patch(endpoint, json={"dates": dates})
 
@@ -601,7 +598,7 @@ class Returns403Test:
         previous_description = offer.description
         data = {"name": "New name", "description": "Ma super description"}
         auth_client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(f"/collective/offers-template/{offer.id}", json=data)
             assert response.status_code == 403
             assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
@@ -634,7 +631,7 @@ class Returns403Test:
         unrelated_venue = offerers_factories.VenueFactory()
         data = {"venueId": unrelated_venue.id}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 403
@@ -648,7 +645,7 @@ class Returns403Test:
 
         data = {"name": "Update some random field"}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH, return_value=False):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH, return_value=False):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 403
@@ -662,7 +659,7 @@ class Returns403Test:
         venue = offerers_factories.VenueFactory()
 
         payload = {"offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": venue.id}}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=payload)
 
         assert response.status_code == 403
@@ -687,7 +684,7 @@ class Returns404Test:
 
         data = {"domains": [0]}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 404
@@ -701,7 +698,7 @@ class Returns404Test:
 
         data = {"venueId": 0}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 404

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -25,8 +25,6 @@ from pcapi.routes.adage.v1.serialization.prebooking import serialize_collective_
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
-PATCH_CAN_CREATE_OFFER_PATH = "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer"
-
 
 @pytest.fixture(name="venue")
 def venue_fixture():
@@ -92,7 +90,7 @@ class Returns200Test:
         }
 
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 200
@@ -153,7 +151,7 @@ class Returns200Test:
         data = {"name": "New name"}
 
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 200
@@ -177,7 +175,7 @@ class Returns200Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -195,7 +193,7 @@ class Returns200Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -220,8 +218,7 @@ class Returns200Test:
             venue=other_related_venue, collectiveStock=stock
         )
 
-        patch_path = PATCH_CAN_CREATE_OFFER_PATH
-        with patch(patch_path):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(url_for(self.endpoint, offer_id=offer.id), json={"venueId": venue.id})
             assert response.status_code == 200
 
@@ -242,8 +239,7 @@ class Returns200Test:
             venue=other_related_venue, collectiveStock=stock
         )
 
-        patch_path = PATCH_CAN_CREATE_OFFER_PATH
-        with patch(patch_path):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(url_for(self.endpoint, offer_id=offer.id), json={"venueId": venue.id})
             assert response.status_code == 200
 
@@ -270,9 +266,9 @@ class Returns200Test:
             "interventionArea": ["01", "2A"],
             "formats": [subcategories.EacFormat.CONCERT.value],
         }
-        patch_path = PATCH_CAN_CREATE_OFFER_PATH
+
         auth_client = client.with_session_auth("user@example.com")
-        with patch(patch_path):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(url_for(self.endpoint, offer_id=offer.id), json=data)
             assert response.status_code == 200
 
@@ -293,7 +289,7 @@ class Returns200Test:
         data = {"offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": offer.venue.id}}
 
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 200
@@ -307,7 +303,7 @@ class Returns200Test:
         data = {"offerVenue": {"addressType": "school", "otherAddress": "", "venueId": None}}
 
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 200
@@ -321,7 +317,7 @@ class Returns200Test:
         data = {"offerVenue": {"addressType": "other", "otherAddress": "In Paris", "venueId": None}}
 
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 200
@@ -338,7 +334,7 @@ class Returns400Test:
 
         data = {"visualDisabilityCompliant": True}
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 400
@@ -355,7 +351,7 @@ class Returns400Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -387,7 +383,7 @@ class Returns400Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -408,7 +404,7 @@ class Returns400Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
         # Then
         assert response.status_code == 400
@@ -428,7 +424,7 @@ class Returns400Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -449,7 +445,7 @@ class Returns400Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -470,7 +466,7 @@ class Returns400Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -491,7 +487,7 @@ class Returns400Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -531,7 +527,7 @@ class Returns400Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -544,7 +540,7 @@ class Returns400Test:
 
         data = {"bookingEmails": ["test@testmail.com", "test@test", "test"]}
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 400
@@ -559,8 +555,7 @@ class Returns400Test:
         other_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
 
         endpoint = "Private API.edit_collective_offer"
-        patch_path = PATCH_CAN_CREATE_OFFER_PATH
-        with patch(patch_path):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(url_for(endpoint, offer_id=offer.id), json={"venueId": other_venue.id})
             assert response.status_code == 400
             assert response.json == {"venueId": ["No venue with a pricing point found for the destination venue."]}
@@ -569,7 +564,7 @@ class Returns400Test:
         offer = educational_factories.ActiveCollectiveOfferFactory(venue=venue)
 
         endpoint = "Private API.edit_collective_offer"
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(url_for(endpoint, offer_id=offer.id), json={"description": "too_long" * 200})
 
         assert response.status_code == 400
@@ -586,7 +581,7 @@ class Returns403Test:
         data = {"name": "New name"}
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -606,7 +601,7 @@ class Returns403Test:
         data = {"name": "New name"}
 
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 403
@@ -620,7 +615,7 @@ class Returns403Test:
         data = {"name": "New name"}
 
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 403
@@ -640,7 +635,7 @@ class Returns403Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -654,7 +649,7 @@ class Returns403Test:
 
         data = {"venueId": other_related_venue.id}
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 403
@@ -688,8 +683,7 @@ class Returns403Test:
         )
 
         endpoint = "Private API.edit_collective_offer"
-        patch_path = PATCH_CAN_CREATE_OFFER_PATH
-        with patch(patch_path):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(url_for(endpoint, offer_id=offer.id), json={"venueId": venue.id})
             assert response.status_code == 403
 
@@ -710,9 +704,9 @@ class Returns403Test:
         previous_name = offer.name
         previous_description = offer.description
         data = {"name": "New name", "description": "Ma super description"}
-        patch_path = PATCH_CAN_CREATE_OFFER_PATH
+
         auth_client = client.with_session_auth("user@example.com")
-        with patch(patch_path):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(f"/collective/offers/{offer.id}", json=data)
             assert response.status_code == 403
             assert response.json == {"offer": "This collective offer status does not allow editing details"}
@@ -729,9 +723,9 @@ class Returns403Test:
         previous_name = offer.name
         previous_description = offer.description
         data = {"name": "New name", "description": "Ma super description"}
-        patch_path = PATCH_CAN_CREATE_OFFER_PATH
+
         auth_client = client.with_session_auth("user@example.com")
-        with patch(patch_path):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(f"/collective/offers/{offer.id}", json=data)
             assert response.status_code == 403
             assert response.json == {"offer": "This collective offer status does not allow editing details"}
@@ -747,7 +741,7 @@ class Returns403Test:
         data = {"offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": venue.id}}
 
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 403
@@ -760,7 +754,7 @@ class Returns403Test:
         offer = educational_factories.CollectiveOfferFactory(venue=other_related_venue)
         educational_factories.CollectiveStockFactory(collectiveOffer=offer, startDatetime=datetime(2024, 1, 1))
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(
                 url_for("Private API.edit_collective_offer", offer_id=offer.id), json={"venueId": venue.id}
             )
@@ -774,7 +768,7 @@ class Returns403Test:
         offer = educational_factories.CollectiveOfferFactory(venue=other_related_venue)
         educational_factories.CollectiveStockFactory(collectiveOffer=offer, startDatetime=datetime(2024, 1, 1))
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = auth_client.patch(
                 url_for("Private API.edit_collective_offer", offer_id=offer.id), json={"venueId": venue.id}
             )
@@ -808,7 +802,7 @@ class Returns404Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then
@@ -829,7 +823,7 @@ class Returns404Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH, return_value=False):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH, return_value=False):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # THEN
@@ -848,7 +842,7 @@ class Returns404Test:
 
         # WHEN
         client = client.with_session_auth("user@example.com")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         # Then

--- a/api/tests/routes/pro/patch_collective_offers_active_status_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_active_status_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from pcapi.core import testing
+from pcapi.core.educational import testing as educational_testing
 from pcapi.core.educational.factories import CollectiveOfferFactory
 from pcapi.core.educational.models import CollectiveOffer
 from pcapi.core.offerers import factories as offerers_factories
@@ -22,7 +23,7 @@ class Returns204Test:
 
         data = {"ids": [offer1.id, offer2.id], "isActive": True}
 
-        with patch("pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("pro@example.com").patch("/collective/offers/active-status", json=data)
 
         assert response.status_code == 204
@@ -60,7 +61,7 @@ class Returns204Test:
             "isActive": True,
         }
 
-        with patch("pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             client = client.with_session_auth("pro@example.com")
             response = client.patch("/collective/offers/active-status", json=data)
 
@@ -85,10 +86,7 @@ class Returns403Test:
         client = client.with_session_auth("pro@example.com")
         data = {"ids": [offer1.id, offer2.id], "isActive": True}
 
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-            return_value=False,
-        ):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH, return_value=False):
             response = client.patch("/collective/offers/active-status", json=data)
 
         # Then
@@ -103,7 +101,7 @@ class Returns403Test:
 
         client = client.with_session_auth("pro@example.com")
         data = {"ids": [offer.id], "isActive": False}
-        with patch("pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch("/collective/offers/active-status", json=data)
 
         assert response.status_code == 403
@@ -112,7 +110,7 @@ class Returns403Test:
 
         offer.isActive = False
         data = {"ids": [offer.id], "isActive": True}
-        with patch("pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch("/collective/offers/active-status", json=data)
 
         assert response.status_code == 403

--- a/api/tests/routes/pro/patch_collective_offers_template_active_status_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_template_active_status_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from pcapi.core import testing
+from pcapi.core.educational import testing as educational_testing
 from pcapi.core.educational.factories import CollectiveOfferFactory
 from pcapi.core.educational.factories import CollectiveOfferTemplateFactory
 from pcapi.core.educational.models import CollectiveOfferTemplate
@@ -23,9 +24,7 @@ class Returns204Test:
         # When
         data = {"ids": [offer1.id, offer2.id], "isActive": True}
 
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             client = client.with_session_auth("pro@example.com")
             response = client.patch("/collective/offers-template/active-status", json=data)
 
@@ -67,9 +66,7 @@ class Returns204Test:
             "isActive": True,
         }
 
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             client = client.with_session_auth("pro@example.com")
             response = client.patch("/collective/offers-template/active-status", json=data)
 
@@ -92,10 +89,7 @@ class Returns403Test:
         client = client.with_session_auth("pro@example.com")
         data = {"ids": [offer1.id, offer2.id], "isActive": True}
 
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-            return_value=False,
-        ):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH, return_value=False):
             response = client.patch("/collective/offers-template/active-status", json=data)
 
         # Then
@@ -116,9 +110,7 @@ class Returns403Test:
             "isActive": False,
         }
 
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             client = client.with_session_auth("pro@example.com")
             response = client.patch("/collective/offers-template/active-status", json=data)
 

--- a/api/tests/routes/pro/patch_collective_offers_template_archive_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_template_archive_test.py
@@ -25,9 +25,7 @@ class Returns204Test:
         # When
         data = {"ids": [offer1.id, offer2.id]}
 
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             # 1. authentication
             # 2. load current_user
             # 3. feature flag
@@ -88,9 +86,7 @@ class Returns204Test:
         # When
         data = {"ids": [draft_template_offer.id, other_template_offer.id]}
 
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             # 1. authentication
             # 2. load current_user
             # 3. feature flag
@@ -119,9 +115,7 @@ class Returns204Test:
 
         data = {"ids": [rejected_template_offer.id, other_template_offer.id]}
 
-        with patch(
-            "pcapi.routes.pro.collective_offers.offerers_api.can_offerer_create_educational_offer",
-        ):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             # 1. authentication
             # 2. load current_user
             # 3. feature flag

--- a/api/tests/routes/pro/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/post_collective_offers_template_test.py
@@ -8,14 +8,12 @@ from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models
+from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.utils.date import format_into_utc_date
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
-
-
-PATCH_CAN_CREATE_OFFER_PATH = "pcapi.core.offerers.api.can_offerer_create_educational_offer"
 
 
 @pytest.fixture(name="venue")
@@ -111,7 +109,7 @@ class Returns200Test:
         # When
         data = {**payload, "nationalProgramId": national_program.id}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         # Then
@@ -152,7 +150,7 @@ class Returns200Test:
             "contactEmail": None,
         }
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 201
@@ -170,7 +168,7 @@ class Returns200Test:
             "interventionArea": [],
         }
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 201
@@ -184,7 +182,7 @@ class Returns200Test:
             },
         }
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 201
@@ -193,7 +191,7 @@ class Returns200Test:
         now = datetime.utcnow()
         data = {**payload, "dates": {"start": format_into_utc_date(now), "end": format_into_utc_date(now)}}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 201
@@ -204,7 +202,7 @@ class Returns200Test:
     def test_offerer_address_venue(self, pro_client, payload, venue):
         data = {**payload, "offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": venue.id}}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 201
@@ -215,7 +213,7 @@ class Returns200Test:
     def test_offerer_address_school(self, pro_client, payload):
         data = {**payload, "offerVenue": {"addressType": "school", "otherAddress": "", "venueId": None}}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 201
@@ -226,7 +224,7 @@ class Returns200Test:
     def test_offerer_address_other(self, pro_client, payload):
         data = {**payload, "offerVenue": {"addressType": "other", "otherAddress": "In Paris", "venueId": None}}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 201
@@ -239,7 +237,7 @@ class Returns403Test:
     def test_random_user(self, client, payload):
         user = offerers_factories.UserOffererFactory().user
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth(user.email).post("/collective/offers-template", json=payload)
 
         assert response.status_code == 403
@@ -249,7 +247,7 @@ class Returns403Test:
         def raise_ac(*args, **kwargs):
             raise educational_exceptions.CulturalPartnerNotFoundException("pouet")
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH, side_effect=raise_ac):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH, side_effect=raise_ac):
             response = pro_client.post("/collective/offers-template", json=payload)
 
         assert response.status_code == 403
@@ -259,7 +257,7 @@ class Returns403Test:
         venue = offerers_factories.VenueFactory()
         data = {**payload, "offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": venue.id}}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 403
@@ -272,7 +270,7 @@ class Returns400Test:
     def test_unselectable_category(self, pro_client, payload):
         data = {**payload, "subcategoryId": subcategories.OEUVRE_ART.id}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
@@ -285,7 +283,7 @@ class Returns400Test:
     def test_no_collective_category(self, pro_client, payload):
         data = {**payload, "subcategoryId": subcategories.SUPPORT_PHYSIQUE_FILM.id}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
@@ -296,7 +294,7 @@ class Returns400Test:
     def test_empty_domains(self, pro_client, payload):
         data = {**payload, "domains": []}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
@@ -307,7 +305,7 @@ class Returns400Test:
     def test_too_long_price_details(self, pro_client, payload):
         data = {**payload, "priceDetail": "a" * 1001}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
@@ -324,7 +322,7 @@ class Returns400Test:
             "contactForm": None,
         }
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
@@ -339,7 +337,7 @@ class Returns400Test:
             "contactForm": "form",
         }
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
@@ -347,7 +345,7 @@ class Returns400Test:
 
     def test_booking_emails_invalid(self, pro_client, payload):
         data = {**payload, "bookingEmails": ["test@testmail.com", "test@test", "test"]}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
@@ -358,7 +356,7 @@ class Returns400Test:
 
     def test_description_invalid(self, pro_client, payload):
         data = {**payload, "description": "too_long" * 200}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
@@ -402,7 +400,7 @@ class InvalidDatesTest:
 
     def send_request(self, pro_client, payload, dates_extra):
         data = {**payload, "dates": {**dates_extra}}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             return pro_client.post("/collective/offers-template", json=data)
 
 
@@ -410,7 +408,7 @@ class Returns404Test:
     def test_unknown_domain(self, pro_client, payload):
         data = {**payload, "domains": [0]}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 404
@@ -419,7 +417,7 @@ class Returns404Test:
     def test_unknown_national_program(self, pro_client, payload):
         data = {**payload, "nationalProgramId": -1}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400

--- a/api/tests/routes/pro/post_collective_offers_test.py
+++ b/api/tests/routes/pro/post_collective_offers_test.py
@@ -12,9 +12,6 @@ from pcapi.core.users import testing as sendinblue_testing
 import pcapi.core.users.factories as users_factories
 
 
-PATCH_CAN_CREATE_OFFER_PATH = "pcapi.core.offerers.api.can_offerer_create_educational_offer"
-
-
 def base_offer_payload(
     venue, domains=None, subcategory_id=None, template_id=None, national_program_id=None, formats=None
 ) -> dict:
@@ -99,7 +96,7 @@ class Returns200Test:
         data = base_offer_payload(venue=venue)
 
         # When
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         # Then
@@ -121,7 +118,7 @@ class Returns200Test:
 
         # When
         data = {**base_offer_payload(venue=venue), "students": ["Collège - 6e"]}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         # Then
@@ -146,7 +143,7 @@ class Returns200Test:
         data["interventionArea"] = []
         data["offerVenue"] = {"addressType": "offererVenue", "otherAddress": "", "venueId": venue.id}
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         # Then
@@ -159,7 +156,7 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
 
         data = {**base_offer_payload(venue=venue), "students": ["Écoles Marseille - Maternelle"]}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 201
@@ -174,7 +171,7 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
 
         data = {**base_offer_payload(venue=venue), "students": ["Écoles Marseille - Maternelle"]}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 400
@@ -192,7 +189,7 @@ class Returns200Test:
 
         data = base_offer_payload(venue=venue, template_id=collective_offer_template.id)
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 201
@@ -206,7 +203,7 @@ class Returns200Test:
             "offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": venue.id},
         }
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 201
@@ -223,7 +220,7 @@ class Returns200Test:
             "offerVenue": {"addressType": "school", "otherAddress": "", "venueId": None},
         }
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 201
@@ -240,7 +237,7 @@ class Returns200Test:
             "offerVenue": {"addressType": "other", "otherAddress": "In Paris", "venueId": None},
         }
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 201
@@ -260,7 +257,7 @@ class Returns403Test:
 
         # When
         data = base_offer_payload(venue=venue)
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth(user.email).post("/collective/offers", json=data)
 
         # Then
@@ -278,7 +275,7 @@ class Returns403Test:
 
         # When
         data = base_offer_payload(venue=venue)
-        with patch(PATCH_CAN_CREATE_OFFER_PATH, side_effect=raise_ac):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH, side_effect=raise_ac):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         # Then
@@ -294,7 +291,7 @@ class Returns403Test:
             **base_offer_payload(venue=venue),
             "offerVenue": {"addressType": "offererVenue", "otherAddress": "", "venueId": other_venue.id},
         }
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 403
@@ -314,7 +311,7 @@ class Returns400Test:
 
         # When
         data = base_offer_payload(venue=venue, subcategory_id="pouet")
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth(user.email).post("/collective/offers", json=data)
 
         # Then
@@ -330,7 +327,7 @@ class Returns400Test:
 
         # When
         data = base_offer_payload(venue=venue, subcategory_id=subcategories.OEUVRE_ART.id)
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth(user.email).post("/collective/offers", json=data)
 
         # Then
@@ -346,7 +343,7 @@ class Returns400Test:
 
         # When
         data = base_offer_payload(venue=venue, subcategory_id=subcategories.SUPPORT_PHYSIQUE_FILM.id)
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth(user.email).post("/collective/offers", json=data)
 
         # Then
@@ -362,7 +359,7 @@ class Returns400Test:
 
         # When
         data = base_offer_payload(venue=venue, domains=[])
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth(user.email).post("/collective/offers", json=data)
 
         # Then
@@ -376,7 +373,7 @@ class Returns400Test:
 
         data = base_offer_payload(venue=venue)
         data["bookingEmails"] = ["test@testmail.com", "test@test", "test"]
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth(user.email).post("/collective/offers", json=data)
 
         assert response.status_code == 400
@@ -391,7 +388,7 @@ class Returns400Test:
         offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com")
 
         data = {**base_offer_payload(venue=venue), "bookingEmails": []}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 400
@@ -403,7 +400,7 @@ class Returns400Test:
         offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com")
 
         data = {**base_offer_payload(venue=venue), "interventionArea": []}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 400
@@ -415,7 +412,7 @@ class Returns400Test:
         offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com")
 
         data = {**base_offer_payload(venue=venue), "domains": []}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 400
@@ -427,7 +424,7 @@ class Returns400Test:
         offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com")
 
         data = {**base_offer_payload(venue=venue), "description": "too_long" * 200}
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 400
@@ -447,7 +444,7 @@ class Returns404Test:
         # When
         data = base_offer_payload(venue=venue, domains=[0, domain.id])
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         # Then
@@ -463,7 +460,7 @@ class Returns404Test:
         # When
         data = base_offer_payload(venue=venue, national_program_id=-1)
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         # Then
@@ -479,7 +476,7 @@ class Returns404Test:
         # When
         data = base_offer_payload(venue=venue, template_id=1234567890)
 
-        with patch(PATCH_CAN_CREATE_OFFER_PATH):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         # Then
@@ -498,7 +495,7 @@ class Returns404Test:
 
         data = base_offer_payload(venue=venue, template_id=collective_offer_template.id)
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 403

--- a/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
@@ -11,6 +11,7 @@ from pcapi import settings
 import pcapi.core.categories.subcategories_v2 as subcategories
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
+from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.providers import factories as provider_factories
 from pcapi.models import db
@@ -108,7 +109,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             "educationalInstitutionId": educational_institution.id,
         }
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -174,7 +175,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -208,7 +209,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -239,7 +240,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -270,7 +271,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -308,7 +309,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             "endDatetime": stringified_next_month,
         }
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -342,7 +343,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -369,7 +370,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             "bookingLimitDatetime": date_utils.utc_datetime_to_department_timezone(new_limit, None).isoformat(),
         }
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -402,7 +403,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -453,7 +454,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             "educationalInstitutionId": educational_institution.id,
         }
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -500,7 +501,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -544,7 +545,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             "educationalInstitutionId": educational_institution.id,
         }
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -571,7 +572,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -625,7 +626,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             "educationalInstitutionId": educational_institution.id,
         }
         # when
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -648,7 +649,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         payload = {"imageCredit": "a great artist", "imageFile": image_data.GOOD_IMAGE}
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -675,7 +676,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         payload = {"name": "pouet", "imageCredit": "a great artist", "imageFile": image_data.WRONG_IMAGE_SIZE}
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -702,7 +703,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         payload = {"name": "pouet", "imageCredit": "a great artist", "imageFile": image_data.WRONG_IMAGE_TYPE}
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -728,7 +729,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
 
         payload = {"imageCredit": "a great artist", "imageFile": image_data.GOOD_IMAGE}
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -741,7 +742,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         # actual test
         payload = {"imageFile": None}
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -772,7 +773,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -805,7 +806,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         }
 
         # When
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -828,7 +829,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         ).collectiveOffer
 
         payload = {institution_field: None}
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{offer.id}", json=payload
             )
@@ -890,7 +891,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             "nationalProgramId": 0,
         }
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(
                 f"/v2/collective/offers/{stock.collectiveOffer.id}", json=payload
             )
@@ -910,7 +911,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         assert offer.nationalProgramId is not None
 
         payload = {"nationalProgramId": None}
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(f"/v2/collective/offers/{offer.id}", json=payload)
 
         assert response.status_code == 200
@@ -938,7 +939,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         )
 
         new_limit = now + timedelta(days=1)
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(
                 self.endpoint_url.format(offer_id=offer.id), json={"bookingLimitDatetime": new_limit.isoformat()}
             )
@@ -974,7 +975,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         )
 
         new_limit = now + timedelta(days=1)
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(
                 self.endpoint_url.format(offer_id=offer.id), json={"bookingLimitDatetime": new_limit.isoformat()}
             )
@@ -995,7 +996,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             venue=venue_provider.venue, provider=venue_provider.provider
         )
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(
                 self.endpoint_url.format(offer_id=offer.id), json={"description": "too_long" * 200}
             )
@@ -1032,7 +1033,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         payload = {
             "endDatetime": date_utils.utc_datetime_to_department_timezone(datetime(2023, 10, 5), None).isoformat()
         }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json=payload)
 
         assert response.status_code == 400
@@ -1045,7 +1046,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         payload = {
             "startDatetime": date_utils.utc_datetime_to_department_timezone(datetime(2021, 10, 5), None).isoformat()
         }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json=payload)
 
         assert response.status_code == 400
@@ -1059,7 +1060,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             "startDatetime": date_utils.utc_datetime_to_department_timezone(datetime(2021, 10, 5), None).isoformat(),
             "endDatetime": date_utils.utc_datetime_to_department_timezone(datetime(2022, 10, 5), None).isoformat(),
         }
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json=payload)
 
         assert response.status_code == 400
@@ -1080,7 +1081,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer)
 
         payload = {"startDatetime": stock.startDatetime.replace(stock.startDatetime.year + 1).isoformat()}
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json=payload)
 
         assert response.status_code == 400
@@ -1098,7 +1099,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer)
 
         payload = {"endDatetime": stock.endDatetime.replace(stock.endDatetime.year + 1).isoformat()}
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json=payload)
 
         assert response.status_code == 400
@@ -1122,7 +1123,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             input_end = date_utils.utc_datetime_to_department_timezone(input_end, None)
 
         payload = {"endDatetime": input_end.isoformat()}
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json=payload)
 
         assert response.status_code == 400
@@ -1148,7 +1149,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             input_start = date_utils.utc_datetime_to_department_timezone(input_start, None)
 
         payload = {"startDatetime": input_start.isoformat()}
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json=payload)
 
         assert response.status_code == 400
@@ -1174,7 +1175,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             input_start = date_utils.utc_datetime_to_department_timezone(input_start, None)
 
         payload = {"startDatetime": input_start.isoformat()}
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json=payload)
 
         assert response.status_code == 400
@@ -1200,7 +1201,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
             input_limit = date_utils.utc_datetime_to_department_timezone(input_limit, None)
 
         payload = {"bookingLimitDatetime": input_limit.isoformat()}
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json=payload)
 
         assert response.status_code == 400
@@ -1332,7 +1333,7 @@ class UpdateOfferVenueTest(PublicAPIVenueEndpointHelper):
     def test_should_raise_404_because_has_no_access_to_venue(self, client):
         plain_api_key, _ = self.setup_active_venue_provider()
         offer = educational_factories.CollectiveStockFactory().collectiveOffer
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(plain_api_key).patch(
                 f"/v2/collective/offers/{offer.id}", json={"offerVenue": self.offer_venue_school()}
             )
@@ -1353,7 +1354,7 @@ class UpdateOfferVenueTest(PublicAPIVenueEndpointHelper):
             collectiveOffer__provider=venue_provider.provider,
         ).collectiveOffer
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.with_explicit_token(api_key).patch(
                 f"/v2/collective/offers/{offer.id}", json={"offerVenue": payload}
             )
@@ -1441,7 +1442,7 @@ class UpdatePriceTest(PublicAPIVenueEndpointHelper):
         )
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer, price=200)
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(self.endpoint_url.format(offer_id=offer.id), json={"totalPrice": 250})
 
         assert response.status_code == 200
@@ -1456,7 +1457,7 @@ class UpdatePriceTest(PublicAPIVenueEndpointHelper):
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer, price=200)
         educational_factories.PendingCollectiveBookingFactory(collectiveStock=stock)
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(f"/v2/collective/offers/{offer.id}", json={"totalPrice": 250})
 
         assert response.status_code == 200
@@ -1471,7 +1472,7 @@ class UpdatePriceTest(PublicAPIVenueEndpointHelper):
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer, price=200)
         educational_factories.CancelledCollectiveBookingFactory(collectiveStock=stock)
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(f"/v2/collective/offers/{offer.id}", json={"totalPrice": 250})
 
         assert response.status_code == 200
@@ -1486,7 +1487,7 @@ class UpdatePriceTest(PublicAPIVenueEndpointHelper):
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer, price=200)
         educational_factories.UsedCollectiveBookingFactory(collectiveStock=stock)
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(f"/v2/collective/offers/{offer.id}", json={"totalPrice": 150})
 
         assert response.status_code == 422
@@ -1502,7 +1503,7 @@ class UpdatePriceTest(PublicAPIVenueEndpointHelper):
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer, price=200)
         educational_factories.ReimbursedCollectiveBookingFactory(collectiveStock=stock)
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(f"/v2/collective/offers/{offer.id}", json={"totalPrice": 150})
 
         assert response.status_code == 422
@@ -1519,7 +1520,7 @@ class UpdatePriceTest(PublicAPIVenueEndpointHelper):
         educational_factories.ConfirmedCollectiveBookingFactory(collectiveStock=stock)
 
         new_tickets = stock.numberOfTickets + 10
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(
                 f"/v2/collective/offers/{offer.id}",
                 json={"totalPrice": 150, "educationalPriceDetail": "hello", "numberOfTickets": new_tickets},
@@ -1539,7 +1540,7 @@ class UpdatePriceTest(PublicAPIVenueEndpointHelper):
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer, price=200)
         educational_factories.ConfirmedCollectiveBookingFactory(collectiveStock=stock)
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(f"/v2/collective/offers/{offer.id}", json={"totalPrice": 250})
 
         assert response.status_code == 400
@@ -1556,7 +1557,7 @@ class UpdatePriceTest(PublicAPIVenueEndpointHelper):
         educational_factories.ConfirmedCollectiveBookingFactory(collectiveStock=stock)
 
         limit = stock.bookingLimitDatetime
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client_with_token.patch(
                 f"/v2/collective/offers/{offer.id}",
                 json={"bookingLimitDatetime": (limit + timedelta(days=1)).isoformat()},

--- a/api/tests/routes/public/collective/endpoints/post_collective_offer_test.py
+++ b/api/tests/routes/public/collective/endpoints/post_collective_offer_test.py
@@ -13,6 +13,7 @@ from pcapi.core.categories import subcategories_v2 as subcategories
 from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
+from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.providers import factories as provider_factories
 from pcapi.core.testing import assert_num_queries
@@ -194,7 +195,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     def test_post_offers_without_end_datetime(self, public_client, payload):
         del payload["endDatetime"]
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 200
@@ -211,7 +212,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
         payload["educationalInstitution"] = institution.institutionId
         del payload["educationalInstitutionId"]
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 200
@@ -238,7 +239,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
         payload["educationalInstitution"] = institution.institutionId
         payload["educationalInstitutionId"] = institution.id
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 400
@@ -253,7 +254,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     @time_machine.travel(time_travel_str)
     def test_user_cannot_create_collective_offer(self, public_client, payload):
         with patch(
-            "pcapi.core.offerers.api.can_offerer_create_educational_offer",
+            educational_testing.PATCH_CAN_CREATE_OFFER_PATH,
             side_effect=educational_exceptions.CulturalPartnerNotFoundException,
         ):
             response = public_client.post("/v2/collective/offers/", json=payload)
@@ -264,7 +265,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     def test_bad_educational_institution(self, public_client, payload):
         payload["educationalInstitutionId"] = -1
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 404
@@ -273,7 +274,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     def test_unlinked_venue(self, public_client, payload):
         payload["venueId"] = offerers_factories.VenueFactory().id
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 404
@@ -289,7 +290,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     def test_invalid_image_size(self, public_client, payload):
         payload["imageFile"] = image_data.WRONG_IMAGE_SIZE
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 400
@@ -299,7 +300,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     def test_invalid_image_type(self, public_client, payload):
         payload["imageFile"] = image_data.WRONG_IMAGE_TYPE
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 400
@@ -312,7 +313,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
         payload["startDatetime"] = start_datetime.isoformat(timespec="seconds")
         payload["endDatetime"] = end_datetime.isoformat(timespec="seconds")
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 400
@@ -323,7 +324,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
         institution = educational_factories.EducationalInstitutionFactory(isActive=False)
         payload["educationalInstitutionId"] = institution.id
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 403
@@ -333,7 +334,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
         payload["nationalProgramId"] = None
         payload["domains"] = [-1]
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 404
@@ -343,7 +344,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     def test_national_program_not_linked_to_domains(self, public_client, payload):
         payload["nationalProgramId"] = educational_factories.NationalProgramFactory().id
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 400
@@ -357,7 +358,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
             "otherAddress": "",
         }
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 404
@@ -367,7 +368,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     def test_missing_formats(self, public_client, payload):
         del payload["formats"]
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 400
@@ -377,7 +378,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     def test_description_invalid(self, public_client, payload):
         payload["description"] = "too_long" * 200
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 400
@@ -387,7 +388,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
     def test_missing_start_datetime(self, public_client, payload):
         del payload["startDatetime"]
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 400
@@ -399,7 +400,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
             datetime.fromisoformat(payload["startDatetime"]) + timedelta(days=1)
         ).isoformat(timespec="seconds")
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=payload)
 
         assert response.status_code == 400
@@ -417,7 +418,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
 
         minimal_payload["endDatetime"] = end.isoformat()
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=minimal_payload)
 
         assert response.status_code == 400
@@ -428,7 +429,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
         start = datetime.fromisoformat(minimal_payload["startDatetime"])
         minimal_payload["startDatetime"] = start.replace(year=start.year + 1).isoformat()
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=minimal_payload)
 
         assert response.status_code == 400
@@ -439,7 +440,7 @@ class CollectiveOffersPublicPostOfferTest(PublicAPIEndpointBaseHelper):
         start = datetime.fromisoformat(minimal_payload["startDatetime"])
         minimal_payload["endDatetime"] = start.replace(year=start.year + 1).isoformat()
 
-        with patch("pcapi.core.offerers.api.can_offerer_create_educational_offer"):
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = public_client.post("/v2/collective/offers/", json=minimal_payload)
 
         assert response.status_code == 400


### PR DESCRIPTION
…common file

## But de la pull request

Ticket Jira (ou description si BSR) : déplacement de PATCH_CAN_CREATE_OFFER_PATH dans educational/testing.py

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
