### PR TITLE
(BSR)[PRO] fix: always deploy on testing env

### DIFF
--- a/.github/workflows/dev_on_pull_request_workflow.yml
+++ b/.github/workflows/dev_on_pull_request_workflow.yml
@@ -320,7 +320,6 @@ jobs:
     needs: [pcapi-init-job, test-pro]
     if: |
       always() && 
-      (needs.test-pro.result == 'success' || needs.test-pro.result == 'skipped') &&
       needs.pcapi-init-job.outputs.api-changed == 'false'
     uses: ./.github/workflows/dev_on_workflow_deploy_pro_pr_version_generic.yml
     secrets:

--- a/.github/workflows/dev_on_workflow_deploy.yml
+++ b/.github/workflows/dev_on_workflow_deploy.yml
@@ -212,7 +212,7 @@ jobs:
           entryPoint: "${{ inputs.doc-api-entrypoint }}"
           channelId: "live"
 
-  deploy-pro-on-testing-on-firebase:
+  deploy-pro-on-firebase-testing:
     name: "Deploy pro on testing live channel"
     concurrency:
       group: deploy-pro-${{ inputs.environment }}
@@ -220,7 +220,6 @@ jobs:
     needs: deploy-api
     if: |
       always() &&
-      (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') &&
       inputs.environment == 'testing' &&
       inputs.deploy_pro == true
     uses: ./.github/workflows/dev_on_workflow_deploy_pro_pr_version_generic.yml


### PR DESCRIPTION
## But de la pull request

BSR : cette PR à pour but de toujours déployer un env de test, même si les tests failed pour le front

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
