### PR TITLE
(BSR) docs: add a section in README to run tests in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "python.formatting.provider": "black"
+  "python.formatting.provider": "black",
+  "python.testing.cwd": "${workspaceFolder}/api",
+  "python.testing.pytestEnabled": true
 }

--- a/README.md
+++ b/README.md
@@ -110,6 +110,25 @@ Ces utilisateurs existent également pour le 97, en remplaçant `93` par `97`.
 
 D'autres informations sont disponibles sur le [README de Pro](./pro/README.md)
 
+### Lancer les tests sur VSCode
+
+#### Tests back
+
+Il est possible de lancer / débugger les tests python directement depuis VSCode. Pour cela il faut avoir installé les extensions `ms-python.python` et `ms-python.debugpy`.
+
+On peut voir la liste des tests dans l'onglet Testing, où l'on peut lancer les tests par fonction / classe / fichier / dossier. Lorsqu'on est dans un fichier de test, on peut également utiliser les icones placées directement à côté de chaque fonction.
+
+Quelques commandes VSCode utiles lorsqu'on est dans un fichier de test, avec leur équivalent `Debug Test` :
+- `Test: Run Test in Current File`
+- `Test: Run Test at Cursor`
+- `Test: Rerun Last Run`
+- `Test: Rerun Failed Tests`
+
+Voir https://code.visualstudio.com/docs/python/testing pour plus d'informations.
+
+#### Tests front
+
+Pour lancer / débugger un test front, on peut utiliser la commande de launch `Debug current spec test file`. Lorsqu'on est dans un fichier `*.spec.tsx`, on peut lancer la commande depuis l'onglet `Run and Debug` et les tests du fichier seront exécutés.
 
 ### Commandes utiles
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : ajout d'une section dans le README pour tester via VSCode

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
