### PR TITLE
(PC-34295)[PRO] fix: Compare offerer id and not whole object in fetch…

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -101,22 +101,22 @@ export const OfferEducationalForm = ({
           setIsEligible(userOfferer.allowedOnAdage)
         }
 
-        let venuesOptions = userOfferer.managedVenues.map((item) => ({
+        let newVenuesOptions = userOfferer.managedVenues.map((item) => ({
           value: item['id'].toString(),
           label: item['name'] as string,
         }))
-        if (venuesOptions.length > 1) {
-          venuesOptions = [
+        if (newVenuesOptions.length > 1) {
+          newVenuesOptions = [
             {
               value: '',
               label: `Sélectionner ${isOfferAddressEnabled ? 'une structure' : 'un lieu'}`,
             },
-            ...sortByLabel(venuesOptions),
+            ...sortByLabel(newVenuesOptions),
           ]
         }
-        setVenuesOptions(venuesOptions)
-        if (venuesOptions.length === 1) {
-          await setFieldValue('venueId', venuesOptions[0].value)
+        setVenuesOptions(newVenuesOptions)
+        if (newVenuesOptions.length === 1) {
+          await setFieldValue('venueId', newVenuesOptions[0].value)
         } else {
           await setFieldValue('venueId', initialValues.venueId)
         }
@@ -132,7 +132,7 @@ export const OfferEducationalForm = ({
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       handleOffererValues()
     })
-  }, [userOfferer])
+  }, [userOfferer?.id])
 
   return (
     <>


### PR DESCRIPTION
… related venues useEffect dependencies.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34295

**Objectif**
Corriger la flakyness du test `createCollectiveOffer.cy` à l'étape "I can create an offer with draft status" qui échoue [ici](https://github.com/pass-culture/pass-culture-main/actions/runs/13028676104) ou [là](https://github.com/pass-culture/pass-culture-main/actions/runs/13027580639).

Il semble que la ref l'objet de l'offerer change régulièrement (sans que l'id ne change), ce qui déclenche un re-chargement des venues qui reset l'affichage du form (le setTimeout est probablement à la source de la flakyness, mais je reproduis systématiquement en local).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
