### PR TITLE
(PC-33116)[API] feat: use isOpenToPublic to index venues

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -481,7 +481,10 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     @property
     def is_eligible_for_search(self) -> bool:
         not_administrative = self.venueTypeCode != VenueTypeCode.ADMINISTRATIVE
-        return bool(self.isPermanent) and self.managingOfferer.isActive and not_administrative
+        can_be_searched = bool(self.isPermanent)
+        if FeatureToggle.WIP_IS_OPEN_TO_PUBLIC.is_active():
+            can_be_searched = bool(self.isOpenToPublic)
+        return can_be_searched and self.managingOfferer.isActive and not_administrative
 
     def store_departement_code(self) -> None:
         if not self.postalCode:


### PR DESCRIPTION
## But de la pull request

isOpenToPublic will replace isPermanent to know whether or not a venue should be indexed in Algolia.
Ticket Jira: https://passculture.atlassian.net/browse/PC-33116

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
