### PR TITLE
(PC-34250)[BO] feat: new CLOSED status in offerer lifecycle

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-1b5deb8e094c (pre) (head)
+8ee08df65b28 (pre) (head)
 7d06482102c6 (post) (head)

--- a/api/src/pcapi/alembic/versions/20250129T103506_8ee08df65b28_add_closed_validation_status_to_offerer.py
+++ b/api/src/pcapi/alembic/versions/20250129T103506_8ee08df65b28_add_closed_validation_status_to_offerer.py
@@ -1,0 +1,42 @@
+"""Add new ValidationStatus.CLOSED
+"""
+
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "8ee08df65b28"
+down_revision = "1b5deb8e094c"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE validationstatus ADD VALUE 'CLOSED'")
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.execute(
+        'ALTER TABLE offerer ALTER COLUMN "validationStatus" TYPE validationstatus USING '
+        '"validationStatus"::text::validationstatus'
+    )
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.execute(
+        'ALTER TABLE user_offerer ALTER COLUMN "validationStatus" TYPE validationstatus USING '
+        '"validationStatus"::text::validationstatus'
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TYPE validationstatus RENAME TO validationstatus_old")
+    op.execute("CREATE TYPE validationstatus AS ENUM ('NEW', 'PENDING', 'VALIDATED', 'REJECTED', 'DELETED')")
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.execute(
+        'ALTER TABLE offerer ALTER COLUMN "validationStatus" TYPE validationstatus USING '
+        '"validationStatus"::text::validationstatus'
+    )
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.execute(
+        'ALTER TABLE user_offerer ALTER COLUMN "validationStatus" TYPE validationstatus USING '
+        '"validationStatus"::text::validationstatus'
+    )
+    op.execute("DROP TYPE validationstatus_old")

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -29,6 +29,7 @@ class ActionType(enum.Enum):
     OFFERER_PENDING = "Entité juridique mise en attente"
     OFFERER_VALIDATED = "Entité juridique validée"
     OFFERER_REJECTED = "Entité juridique rejetée"
+    OFFERER_CLOSED = "Entité juridique fermée"
     OFFERER_SUSPENDED = "Entité juridique désactivée"
     OFFERER_UNSUSPENDED = "Entité juridique réactivée"
     OFFERER_ATTESTATION_CHECKED = "Attestation consultée"

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -54,6 +54,10 @@ class RejectedOffererFactory(OffererFactory):
     isActive = False
 
 
+class ClosedOffererFactory(OffererFactory):
+    validationStatus = ValidationStatus.CLOSED
+
+
 class CaledonianOffererFactory(OffererFactory):
     name = factory.Sequence("Structure calédonienne {}".format)
     street = "Avenue James Cook"

--- a/api/src/pcapi/models/validation_status_mixin.py
+++ b/api/src/pcapi/models/validation_status_mixin.py
@@ -12,6 +12,7 @@ class ValidationStatus(enum.Enum):
     VALIDATED = "VALIDATED"
     REJECTED = "REJECTED"
     DELETED = "DELETED"
+    CLOSED = "CLOSED"
 
 
 @declarative_mixin
@@ -69,3 +70,11 @@ class ValidationStatusMixin:
     def isDeleted(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
         # sqla.not_(isDeleted) works only if we check None separately.
         return cls.validationStatus == ValidationStatus.DELETED
+
+    @sqla_hybrid.hybrid_property
+    def isClosed(self) -> bool:
+        return self.validationStatus == ValidationStatus.CLOSED
+
+    @isClosed.expression  # type: ignore[no-redef]
+    def isClosed(cls) -> BinaryExpression:  # pylint: disable=no-self-argument
+        return cls.validationStatus == ValidationStatus.CLOSED

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -486,6 +486,8 @@ def format_validation_status(status: validation_status_mixin.ValidationStatus) -
             return "Rejeté"
         case validation_status_mixin.ValidationStatus.DELETED:
             return "Supprimé"
+        case validation_status_mixin.ValidationStatus.CLOSED:
+            return "Fermé"
         case _:
             return status.value
 

--- a/api/src/pcapi/routes/backoffice/offerers/forms.py
+++ b/api/src/pcapi/routes/backoffice/offerers/forms.py
@@ -187,7 +187,9 @@ class UserOffererValidationListForm(utils.PCForm):
     )
     status = fields.PCSelectMultipleField(
         "États de la demande de rattachement",
-        choices=utils.choices_from_enum(ValidationStatus, filters.format_validation_status),
+        choices=utils.choices_from_enum(
+            ValidationStatus, formatter=filters.format_validation_status, exclude_opts=(ValidationStatus.CLOSED,)
+        ),
     )
     instructors = fields.PCTomSelectField(
         "Dernier instructeur",
@@ -198,7 +200,9 @@ class UserOffererValidationListForm(utils.PCForm):
     )
     offerer_status = fields.PCSelectMultipleField(
         "États de l'entité juridique",
-        choices=utils.choices_from_enum(ValidationStatus, filters.format_validation_status),
+        choices=utils.choices_from_enum(
+            ValidationStatus, formatter=filters.format_validation_status, exclude_opts=(ValidationStatus.DELETED,)
+        ),
     )
     from_date = fields.PCDateField("Demande à partir du", validators=(wtforms.validators.Optional(),))
     to_date = fields.PCDateField("Demande jusqu'au", validators=(wtforms.validators.Optional(),))

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -11,6 +11,7 @@ from flask import url_for
 from flask_login import current_user
 from markupsafe import Markup
 import sqlalchemy as sa
+from werkzeug.exceptions import BadRequest
 from werkzeug.exceptions import NotFound
 
 from pcapi import repository
@@ -377,6 +378,8 @@ def get_revenue_details(offerer_id: int) -> utils.BackofficeResponse:
 @repository.atomic()
 def generate_api_key(offerer_id: int) -> utils.BackofficeResponse:
     offerer = offerers_models.Offerer.query.get_or_404(offerer_id)
+    if offerer.isRejected or offerer.isClosed:
+        raise BadRequest()  # No need for a user-friendly message since button is not available
     try:
         clear_key = offerers_api.generate_and_save_api_key(offerer.id)
         flash(

--- a/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
@@ -201,6 +201,7 @@ def list_offerers_to_be_validated(
                     history_models.ActionType.OFFERER_PENDING,
                     history_models.ActionType.OFFERER_VALIDATED,
                     history_models.ActionType.OFFERER_REJECTED,
+                    history_models.ActionType.OFFERER_CLOSED,
                     history_models.ActionType.COMMENT,
                 ]
             ),
@@ -313,6 +314,7 @@ def list_offerers_to_be_validated(
                         history_models.ActionType.OFFERER_PENDING,
                         history_models.ActionType.OFFERER_VALIDATED,
                         history_models.ActionType.OFFERER_REJECTED,
+                        history_models.ActionType.OFFERER_CLOSED,
                     )
                 ),
             )

--- a/api/src/pcapi/routes/backoffice/templates/components/badges.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/badges.html
@@ -1,4 +1,4 @@
-{% macro build_status_badge(object, new, pending, validated, rejected, deleted) %}
+{% macro build_status_badge(object, new, pending, validated, rejected, deleted, closed) %}
   {% if object.isNew %}
     <span class="me-1 pb-1 badge rounded-pill text-bg-info">{{ new }}</span>
   {% elif object.isPending %}
@@ -9,6 +9,8 @@
     <span class="me-1 pb-1 badge rounded-pill text-bg-danger">{{ rejected }}</span>
   {% elif object.isDeleted %}
     <span class="me-1 pb-1 badge rounded-pill text-bg-danger">{{ deleted }}</span>
+  {% elif object.isClosed %}
+    <span class="me-1 pb-1 badge rounded-pill text-bg-danger">{{ closed }}</span>
   {% endif %}
 {% endmacro %}
 {% macro build_venue_badges(venue) %}
@@ -27,6 +29,12 @@
       {% endif %}
     {% endif %}
   </span>
+  {% if venue.managingOfferer.isClosed %}
+    <span class="me-1 pb-1 badge rounded-pill text-bg-dark">
+      <i class="bi bi-x-circle"></i>
+      Fermé
+    </span>
+  {% endif %}
   {% if not venue.managingOfferer.isActive %}
     <span class="me-1 pb-1 badge rounded-pill text-bg-dark">
       <i class="bi bi-x-circle"></i>
@@ -35,7 +43,7 @@
   {% endif %}
 {% endmacro %}
 {% macro build_offerer_status_badge(offerer) %}
-  {{ build_status_badge(offerer, "Nouvelle", "En attente", "Validée", "Rejetée", "Supprimée") }}
+  {{ build_status_badge(offerer, "Nouvelle", "En attente", "Validée", "Rejetée", "Supprimée", "Fermée") }}
 {% endmacro %}
 {% macro build_offerer_badges(offerer) %}
   <span class="me-1 pb-1 badge rounded-pill text-bg-secondary">Entité juridique</span>
@@ -48,7 +56,7 @@
   {% endif %}
 {% endmacro %}
 {% macro build_user_offerer_status_badge(user_offerer) %}
-  {{ build_status_badge(user_offerer, "Nouveau", "En attente", "Validé", "Rejeté", "Supprimé") }}
+  {{ build_status_badge(user_offerer, "Nouveau", "En attente", "Validé", "Rejeté", "Supprimé", "Fermé") }}
 {% endmacro %}
 {% macro build_pro_user_status_badge(pro_user) %}
   {% if pro_user.proValidationStatus.value == "VALIDATED" %}

--- a/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
@@ -55,7 +55,7 @@
               {% endif %}
               {% set modified_info = action.extraData.get('modified_info', {}) %}
               {% if modified_info %}
-                {# INFO_MODIFIED but also tags modified in OFFERER_PENDING #}
+                {# INFO_MODIFIED but also tags modified in OFFERER_PENDING, OFFERER_CLOSED #}
                 <div>
                   <span class="fw-bold">Informations modifiées :</span>
                   {% if show_venue and action.venueId %}

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get.html
@@ -27,7 +27,7 @@
                 {{ build_modal_form("edit-offerer", url_for("backoffice_web.offerer.update_offerer", offerer_id=offerer.id) ,
                 edit_offerer_form, "Modifier les informations", "Modifier les informations de l'entité juridique", "Enregistrer") }}
               {% endif %}
-              {% if has_permission("ADVANCED_PRO_SUPPORT") %}
+              {% if has_permission("ADVANCED_PRO_SUPPORT") and not (offerer.isRejected or offerer.isClosed) %}
                 {{ build_modal_form("generate-api-key", url_for("backoffice_web.offerer.generate_api_key", offerer_id=offerer.id) ,
                 generate_api_key_form, "Générer une clé API", "Générer une clé API pour l'entité juridique " + offerer.name, "Confirmer la génération") }}
               {% endif %}

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
@@ -1,6 +1,7 @@
 from pcapi.sandboxes.scripts.creators.industrial.add_accessibility_compliance_to_venues import (
     add_accessibility_compliance_to_venues,
 )
+from pcapi.sandboxes.scripts.creators.industrial.create_closed_offerers import create_closed_offerers
 from pcapi.sandboxes.scripts.creators.industrial.create_gdpr_user_extracts import create_gdpr_user_extract_data
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_admin_users import *
 from pcapi.sandboxes.scripts.creators.industrial.create_industrial_app_users import *
@@ -171,6 +172,8 @@ def save_industrial_sandbox() -> None:
     create_industrial_bookings_for_statistics()
 
     create_user_account_update_requests()
+
+    create_closed_offerers()
 
     create_industrial_invoices()
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_closed_offerers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_closed_offerers.py
@@ -1,0 +1,102 @@
+import datetime
+import logging
+
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.categories import subcategories_v2 as subcategories
+from pcapi.core.history import factories as history_factories
+from pcapi.core.history import models as history_models
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.users import factories as users_factories
+
+
+logger = logging.getLogger(__name__)
+
+
+def create_closed_offerers() -> None:
+    logger.info("create_closed_offerers")
+
+    now = datetime.datetime.utcnow()
+    siren_caduc_tag = offerers_models.OffererTag.query.filter_by(name="siren-caduc").one()
+
+    offerer = offerers_factories.ClosedOffererFactory(
+        name="STRUCTURE FERMÉE", tags=[siren_caduc_tag], allowedOnAdage=True
+    )
+    history_factories.ActionHistoryFactory(
+        actionType=history_models.ActionType.OFFERER_CLOSED,
+        actionDate=now - datetime.timedelta(days=2),
+        authorUser=None,
+        offerer=offerer,
+        comment="L'entité juridique est détectée comme inactive via l'API Sirene (INSEE)",
+        extraData={"modified_info": {"tags": {"new_info": siren_caduc_tag.label}}},
+    )
+
+    venue = offerers_factories.VenueFactory(
+        managingOfferer=offerer,
+        name=offerer.name,
+        publicName="Structure fermée",
+        bookingEmail="structure.fermee@example.com",
+        adageId=offerer.siren,
+        contact=None,
+        pricing_point="self",
+    )
+
+    offerers_factories.UserOffererFactory(
+        user=users_factories.NonAttachedProFactory(
+            firstName="Acteur",
+            lastName="Structure-Fermée",
+            email="pro.structure.fermee@example.com",
+        ),
+        offerer=offerer,
+    )
+
+    beneficiary = users_factories.BeneficiaryGrant18Factory(
+        firstName="Jeune",
+        lastName="Réservant sur structure fermée",
+        email="jeune.structure.fermee@example.com",
+    )
+
+    thing_stock = offers_factories.ThingStockFactory(
+        offer__venue=venue,
+        offer__name="Offre physique d'une structure fermée",
+        offer__subcategoryId=subcategories.MATERIEL_ART_CREATIF.id,
+        price=30,
+        quantity=50,
+    )
+    bookings_factories.UsedBookingFactory(
+        user=beneficiary,
+        stock=thing_stock,
+        dateCreated=now - datetime.timedelta(days=8),  # booked before closure date
+        dateUsed=now - datetime.timedelta(days=1),  # validated after closure date
+    )
+    bookings_factories.BookingFactory(
+        user=beneficiary,
+        stock=thing_stock,
+        dateCreated=now - datetime.timedelta(days=3),  # booked before closure date, not used yet
+    )
+
+    event_offer = offers_factories.EventOfferFactory(
+        venue=venue,
+        name="Offre d'événement d'une structure fermée",
+        subcategoryId=subcategories.ATELIER_PRATIQUE_ART.id,
+    )
+    bookings_factories.UsedBookingFactory(
+        user=beneficiary,
+        stock__offer=event_offer,
+        stock__price=7.50,
+        stock__quantity=50,
+        stock__beginningDatetime=now - datetime.timedelta(days=4),  # event happened before closure date
+        dateCreated=now - datetime.timedelta(days=7),  # booked before closure date
+        dateUsed=now - datetime.timedelta(days=1),  # validated after closure date
+    )
+    bookings_factories.BookingFactory(
+        user=beneficiary,
+        stock__offer=event_offer,
+        stock__price=8,
+        stock__quantity=50,
+        stock__beginningDatetime=now + datetime.timedelta(days=7),  # future event, after closure date
+        dateCreated=now - datetime.timedelta(days=6),  # booked before closure date
+    )
+
+    logger.info("created closed offerer")

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -1955,7 +1955,7 @@ class CountOfferersByValidationStatusTest:
             stats = offerers_api.count_offerers_by_validation_status()
 
         # then
-        assert stats == {"DELETED": 0, "NEW": 1, "PENDING": 2, "VALIDATED": 3, "REJECTED": 4}
+        assert stats == {"DELETED": 0, "NEW": 1, "PENDING": 2, "VALIDATED": 3, "REJECTED": 4, "CLOSED": 0}
 
     def test_get_offerer_stats_zero(self, client):
         # when
@@ -1963,7 +1963,7 @@ class CountOfferersByValidationStatusTest:
             stats = offerers_api.count_offerers_by_validation_status()
 
         # then
-        assert stats == {"DELETED": 0, "NEW": 0, "PENDING": 0, "VALIDATED": 0, "REJECTED": 0}
+        assert stats == {"DELETED": 0, "NEW": 0, "PENDING": 0, "VALIDATED": 0, "REJECTED": 0, "CLOSED": 0}
 
 
 class UpdateOffererTagTest:

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -294,6 +294,18 @@ class GetOffererTest(GetEndpointHelper):
         assert ("Offres BO" in response_text) is has_offers_links
         assert ("Réservations BO" in response_text) is has_bookings_links
 
+    def test_get_closed_offerer(self, authenticated_client):
+        closed_offerer = offerers_factories.ClosedOffererFactory()
+        url = url_for(self.endpoint, offerer_id=closed_offerer.id)
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        response_text = html_parser.content_as_text(response.data)
+        assert "Entité juridique Fermée " in response_text
+        assert "Générer une clé API" not in response_text
+
     def test_get_offerer_which_does_not_exist(self, authenticated_client):
         response = authenticated_client.get(url_for(self.endpoint, offerer_id=12345))
         assert response.status_code == 404
@@ -573,6 +585,13 @@ class GenerateOffererAPIKeyTest(PostEndpointHelper):
         response = authenticated_client.get(response.location)
         alert = html_parser.extract_alert(response.data)
         assert alert == "Le nombre maximal de clés a été atteint"
+
+    def test_cant_generate_api_key_for_closed_offerer(self, legit_user, authenticated_client):
+        offerer = offerers_factories.ClosedOffererFactory()
+
+        response = self.post_to_endpoint(authenticated_client, offerer_id=offerer.id)
+
+        assert response.status_code == 400
 
 
 class UpdateOffererTest(PostEndpointHelper):
@@ -2438,6 +2457,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
                 (["NEW", "PENDING"], 200, {"A", "B", "C", "D", "E", "F"}),
                 ("VALIDATED", 200, {"G"}),
                 ("REJECTED", 200, {"H"}),
+                ("CLOSED", 200, {"Z"}),
                 (None, 200, {"C", "A", "E"}),  # status NEW as default
                 ("OTHER", 400, set()),  # unknown value
                 (["REJECTED", "OTHER"], 400, set()),
@@ -2446,6 +2466,8 @@ class ListOfferersToValidateTest(GetEndpointHelper):
         def test_list_filtering_by_status(
             self, authenticated_client, status_filter, expected_status, expected_offerer_names, offerers_to_be_validated
         ):
+            offerers_factories.ClosedOffererFactory(name="Z")
+
             expected_num_queries = (
                 self.expected_num_queries if expected_status == 200 else self.expected_num_queries - 1
             )

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -485,6 +485,17 @@ class GetVenueTest(GetEndpointHelper):
         assert "Cartographié sur ADAGE" not in response_text
         assert "ID ADAGE" not in response_text
 
+    def test_get_venue_managed_by_closed_offerer(self, authenticated_client):
+        closed_venue = offerers_factories.VenueFactory(managingOfferer=offerers_factories.ClosedOffererFactory())
+        url = url_for(self.endpoint, venue_id=closed_venue.id)
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(url)
+            assert response.status_code == 200
+
+        response_text = html_parser.content_as_text(response.data)
+        assert "Partenaire culturel Fermé " in response_text
+
     @pytest.mark.parametrize(
         "role,has_offers_links,has_bookings_links",
         [


### PR DESCRIPTION
This commit is a first step which defines the new status, creates an offerer in the sandbox and display it properly in the backoffice.

Next steps:
- Check and adapt the behevior for their offers in the application
- Check and adapt the behavior in PC Pro
- Implement transitions from VALIDATED to CLOSED

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-34250

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
