### PR TITLE
(BSR)[API] fix: Type extraData for patch and post offers forms

### DIFF
--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -73,6 +73,20 @@ class CategoryResponseModel(BaseModel):
         orm_mode = True
 
 
+class OfferExtraDataModel(BaseModel):
+    author: str | None
+    gtl_id: str | None
+    musicType: str | None
+    musicSubType: str | None
+    performer: str | None
+    ean: str | None
+    showType: str | None
+    showSubType: str | None
+    speaker: str | None
+    stageDirector: str | None
+    visa: str | None
+
+
 class PostOfferBodyModel(BaseModel):
     address: offerers_schemas.AddressBodyModel | None
     audio_disability_compliant: bool
@@ -81,7 +95,7 @@ class PostOfferBodyModel(BaseModel):
     description: str | None
     duration_minutes: int | None
     external_ticket_office_url: HttpUrl | None
-    extra_data: dict[str, typing.Any] | None
+    extra_data: OfferExtraDataModel | None
     is_duo: bool | None
     is_national: bool | None
     mental_disability_compliant: bool
@@ -118,7 +132,7 @@ class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
     description: str | None
     isNational: bool | None
     name: str | None
-    extraData: Any
+    extraData: OfferExtraDataModel | None
     externalTicketOfficeUrl: HttpUrl | None
     url: HttpUrl | None
     withdrawalDetails: str | None
@@ -421,7 +435,7 @@ class GetIndividualOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     publicationDate: datetime.datetime | None
     description: str | None
     durationMinutes: int | None
-    extraData: Any
+    extraData: OfferExtraDataModel | None
     hasBookingLimitDatetimesPassed: bool
     hasStocks: bool
     isActive: bool

--- a/pro/package.json
+++ b/pro/package.json
@@ -12,7 +12,7 @@
     "build:integration": "VITE_APP_VERSION=$(node -pe 'require(\"./package.json\").version') vite build --mode integration",
     "build:production": "VITE_APP_VERSION=$(node -pe 'require(\"./package.json\").version') vite build --mode production",
     "generate:api:client:local": "./scripts/generate_api_client_local.sh",
-    "generate:api:client:local:no:docker": "PCAPI_HOST=0.0.0.0:5001 ./scripts/generate_api_client_local.sh",
+    "generate:api:client:local:no:docker": "PCAPI_HOST=localhost:5001 ./scripts/generate_api_client_local.sh",
     "generate:component": "node ./scripts/generator/index.js --component",
     "generate:util": "node ./scripts/generator/index.js --util",
     "lint:js": "eslint 'src/**/*.{ts,tsx}'",

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -184,6 +184,7 @@ export { OffererMemberStatus } from './models/OffererMemberStatus';
 export type { OffererStatsDataModel } from './models/OffererStatsDataModel';
 export type { OffererStatsResponseModel } from './models/OffererStatsResponseModel';
 export type { OffererViewsModel } from './models/OffererViewsModel';
+export type { OfferExtraDataModel } from './models/OfferExtraDataModel';
 export type { OfferImage } from './models/OfferImage';
 export { OfferStatus } from './models/OfferStatus';
 export type { OpeningHoursModel } from './models/OpeningHoursModel';

--- a/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferResponseModel.ts
@@ -5,6 +5,7 @@
 import type { GetOfferLastProviderResponseModel } from './GetOfferLastProviderResponseModel';
 import type { GetOfferMediationResponseModel } from './GetOfferMediationResponseModel';
 import type { GetOfferVenueResponseModel } from './GetOfferVenueResponseModel';
+import type { OfferExtraDataModel } from './OfferExtraDataModel';
 import type { OfferStatus } from './OfferStatus';
 import type { PriceCategoryResponseModel } from './PriceCategoryResponseModel';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
@@ -19,7 +20,7 @@ export type GetIndividualOfferResponseModel = {
   description?: string | null;
   durationMinutes?: number | null;
   externalTicketOfficeUrl?: string | null;
-  extraData?: any;
+  extraData?: OfferExtraDataModel | null;
   hasBookingLimitDatetimesPassed: boolean;
   hasStocks: boolean;
   id: number;

--- a/pro/src/apiClient/v1/models/GetIndividualOfferWithAddressResponseModel.ts
+++ b/pro/src/apiClient/v1/models/GetIndividualOfferWithAddressResponseModel.ts
@@ -6,6 +6,7 @@ import type { AddressResponseIsLinkedToVenueModel } from './AddressResponseIsLin
 import type { GetOfferLastProviderResponseModel } from './GetOfferLastProviderResponseModel';
 import type { GetOfferMediationResponseModel } from './GetOfferMediationResponseModel';
 import type { GetOfferVenueResponseModel } from './GetOfferVenueResponseModel';
+import type { OfferExtraDataModel } from './OfferExtraDataModel';
 import type { OfferStatus } from './OfferStatus';
 import type { PriceCategoryResponseModel } from './PriceCategoryResponseModel';
 import type { SubcategoryIdEnum } from './SubcategoryIdEnum';
@@ -21,7 +22,7 @@ export type GetIndividualOfferWithAddressResponseModel = {
   description?: string | null;
   durationMinutes?: number | null;
   externalTicketOfficeUrl?: string | null;
-  extraData?: any;
+  extraData?: OfferExtraDataModel | null;
   hasBookingLimitDatetimesPassed: boolean;
   hasPendingBookings: boolean;
   hasStocks: boolean;

--- a/pro/src/apiClient/v1/models/OfferExtraDataModel.ts
+++ b/pro/src/apiClient/v1/models/OfferExtraDataModel.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type OfferExtraDataModel = {
+  author?: string | null;
+  ean?: string | null;
+  gtl_id?: string | null;
+  musicSubType?: string | null;
+  musicType?: string | null;
+  performer?: string | null;
+  showSubType?: string | null;
+  showType?: string | null;
+  speaker?: string | null;
+  stageDirector?: string | null;
+  visa?: string | null;
+};
+

--- a/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { AddressBodyModel } from './AddressBodyModel';
+import type { OfferExtraDataModel } from './OfferExtraDataModel';
 import type { WithdrawalTypeEnum } from './WithdrawalTypeEnum';
 export type PatchOfferBodyModel = {
   address?: AddressBodyModel | null;
@@ -12,7 +13,7 @@ export type PatchOfferBodyModel = {
   description?: string | null;
   durationMinutes?: number | null;
   externalTicketOfficeUrl?: string | null;
-  extraData?: any;
+  extraData?: OfferExtraDataModel | null;
   isActive?: boolean | null;
   isDuo?: boolean | null;
   isNational?: boolean | null;

--- a/pro/src/apiClient/v1/models/PostOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostOfferBodyModel.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { AddressBodyModel } from './AddressBodyModel';
+import type { OfferExtraDataModel } from './OfferExtraDataModel';
 import type { WithdrawalTypeEnum } from './WithdrawalTypeEnum';
 export type PostOfferBodyModel = {
   address?: AddressBodyModel | null;
@@ -12,7 +13,7 @@ export type PostOfferBodyModel = {
   description?: string | null;
   durationMinutes?: number | null;
   externalTicketOfficeUrl?: string | null;
-  extraData?: Record<string, any> | null;
+  extraData?: OfferExtraDataModel | null;
   isDuo?: boolean | null;
   isNational?: boolean | null;
   mentalDisabilityCompliant: boolean;

--- a/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/__specs__/serializer.spec.ts
+++ b/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/__specs__/serializer.spec.ts
@@ -102,6 +102,7 @@ describe('routes::Summary::serializers', () => {
       visa: '',
       performer: 'Offer performer',
       ean: '',
+      gtl_id: '',
       isProductBased: false,
       durationMinutes: '140',
       status: OfferStatus.ACTIVE,

--- a/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/serializer.ts
+++ b/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/serializer.ts
@@ -9,8 +9,8 @@ import { showOptionsTree } from 'commons/core/Offers/categoriesSubTypes'
 
 const getMusicData = (
   offer: GetIndividualOfferResponseModel,
-  musicTypes?: GetMusicTypesResponse,
-  gtl_id?: string
+  musicTypes?: GetMusicTypesResponse | null,
+  gtl_id?: string | null
 ): {
   musicTypeName?: string
   musicSubTypeName?: string
@@ -23,7 +23,7 @@ const getMusicData = (
         : musicTypes?.find(
             (item) => item.gtl_id.substring(0, 2) === gtl_id?.substring(0, 2) // Gtl_id is a string of 8 characters, only first 2 are relevant to music genre
           )?.label,
-    gtl_id: offer.extraData?.gtl_id,
+    gtl_id: offer.extraData?.gtl_id || '',
   }
 }
 
@@ -62,10 +62,10 @@ const serializerOfferSubCategoryFields = (
     }
   }
   const showType = showOptionsTree.find(
-    (item) => item.code === parseInt(offer.extraData?.showType, 10)
+    (item) => item.code === parseInt(offer.extraData?.showType || '', 10)
   )
   const showSubType = showType?.children.find(
-    (item) => item.code === parseInt(offer.extraData?.showSubType, 10)
+    (item) => item.code === parseInt(offer.extraData?.showSubType || '', 10)
   )
 
   const { musicTypeName, musicSubTypeName, gtl_id } = getMusicData(

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.tsx
@@ -21,7 +21,7 @@ export type DetailsEanSearchProps = {
   isDirtyDraftOffer: boolean
   productId: string
   subcategoryId: string
-  initialEan?: string
+  initialEan?: string | null
   eanSubmitError?: string
   onEanSearch: (ean: string, product: Product) => Promise<void>
   onEanReset: () => void

--- a/pro/src/pages/IndividualOffer/commons/serializers.ts
+++ b/pro/src/pages/IndividualOffer/commons/serializers.ts
@@ -43,6 +43,8 @@ export const serializeExtraDataForPatch = (
   extraData.stageDirector = formValues.stageDirector
   extraData.visa = formValues.visa
 
+  // Why does this appear ?
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const isEmpty = Object.values(extraData).every((value) => value === undefined)
 
   return isEmpty ? undefined : extraData

--- a/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.spec.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.spec.tsx
@@ -6,12 +6,12 @@ import {
 
 import { api } from 'apiClient/api'
 import { OfferStatus } from 'apiClient/v1'
+import * as useHasAccessToDidacticOnboarding from 'commons/hooks/useHasAccessToDidacticOnboarding'
 import {
   defaultGetOffererResponseModel,
   defaultGetOffererVenueResponseModel,
   listOffersOfferFactory,
 } from 'commons/utils/factories/individualApiFactories'
-import * as useHasAccessToDidacticOnboarding from 'commons/hooks/useHasAccessToDidacticOnboarding'
 import {
   renderWithProviders,
   RenderWithProvidersOptions,


### PR DESCRIPTION
## But de la pull request

Type extraData for patch and post offers forms

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
