### PR TITLE
(PC-34314)[API] feat: add check_offer_name_does_not_contain_ean in offer.api methods

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -229,6 +229,14 @@ class EanFormatException(OfferCreationBaseException):
     pass
 
 
+class EanInOfferNameException(OfferCreationBaseException):
+    def __init__(self) -> None:
+        super().__init__(
+            "name",
+            "Le titre d'une offre ne peut contenir l'EAN",
+        )
+
+
 class ProductNotFoundForOfferCreation(OfferCreationBaseException):
     pass
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 from io import BytesIO
 import logging
+import re
 import typing
 import warnings
 
@@ -661,6 +662,11 @@ def check_ean_does_not_exist(ean: str | None, venue: offerers_models.Venue) -> N
     if repository.has_active_offer_with_ean(ean, venue):
         if ean:
             raise exceptions.OfferAlreadyExists("ean")
+
+
+def check_offer_name_does_not_contain_ean(offer_name: str) -> None:
+    if re.search(r"\d{13}", offer_name):
+        raise exceptions.EanInOfferNameException()
 
 
 def _check_offer_has_product(offer: models.Offer | None) -> None:

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -959,3 +959,17 @@ class CheckOffererIsEligibleForHeadlineOffersTest:
             validation.check_offer_is_eligible_to_be_headline(offer_without_image)
             msg = "Offers without images can not be set to the headline"
             assert exc.value.errors["headlineOffer"] == [msg]
+
+
+class CheckOfferNameDoesNotContainEanTest:
+    @pytest.mark.parametrize(
+        "offer_name",
+        [
+            "Mon offre de filou - 3759217254634",
+            "4759217254634",
+            "[3759217254634] J'essaye de mettre mon offre en avant",
+        ],
+    )
+    def test_check_offer_name_does_not_contain_ean_should_raise(self, offer_name):
+        with pytest.raises(exceptions.EanInOfferNameException):
+            validation.check_offer_name_does_not_contain_ean(offer_name)

--- a/api/tests/routes/pro/patch_draft_offer_test.py
+++ b/api/tests/routes/pro/patch_draft_offer_test.py
@@ -632,6 +632,26 @@ class Returns400Test:
         for key in forbidden_keys:
             assert key in response.json
 
+    def when_trying_to_set_offer_name_with_ean(self, client):
+        offer = offers_factories.OfferFactory(
+            subcategoryId=subcategories.CARTE_MUSEE.id,
+            name="New name",
+            url="http://example.com/offer",
+            description="description",
+        )
+        offerers_factories.UserOffererFactory(
+            user__email="user@example.com",
+            offerer=offer.venue.managingOfferer,
+        )
+
+        data = {
+            "name": "Le Visible et l'invisible - Suivi de notes de travail - 9782070286256",
+        }
+        response = client.with_session_auth("user@example.com").patch(f"offers/draft/{offer.id}", json=data)
+
+        assert response.status_code == 400
+        assert response.json["name"] == ["Le titre d'une offre ne peut contenir l'EAN"]
+
     @pytest.mark.features(WIP_EAN_CREATION=True)
     def when_trying_to_patch_offer_with_product_with_new_ean(self, client):
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")

--- a/api/tests/routes/pro/post_draft_offer_test.py
+++ b/api/tests/routes/pro/post_draft_offer_test.py
@@ -291,6 +291,21 @@ class Returns400Test:
         assert response.status_code == 400
         assert response.json["name"] == ["Le titre de l’offre doit faire au maximum 90 caractères."]
 
+    def test_fail_if_name_contains_ean(self, client):
+        venue = offerers_factories.VenueFactory()
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
+
+        data = {
+            "name": "Le Visible et l'invisible - Suivi de notes de travail - 9782070286256",
+            "subcategoryId": subcategories.LIVRE_PAPIER.id,
+            "venueId": venue.id,
+        }
+        response = client.with_session_auth("user@example.com").post("/offers/draft", json=data)
+
+        assert response.status_code == 400
+        assert response.json["name"] == ["Le titre d'une offre ne peut contenir l'EAN"]
+
     def test_fail_if_unknown_subcategory(self, client):
         venue = offerers_factories.VenueFactory()
         offerer = venue.managingOfferer

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -361,6 +361,29 @@ class Returns400Test:
         assert response.status_code == 400
         assert response.json["name"] == ["Le titre de l’offre doit faire au maximum 90 caractères."]
 
+    def test_fail_if_name_contains_ean(self, client):
+        # Given
+        venue = offerers_factories.VenueFactory()
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
+
+        # When
+        data = {
+            "venueId": venue.id,
+            "name": "Le Visible et l'invisible - Suivi de notes de travail - 9782070286256",
+            "subcategoryId": subcategories.LIVRE_PAPIER.id,
+            "withdrawalType": "no_ticket",
+            "mentalDisabilityCompliant": False,
+            "audioDisabilityCompliant": False,
+            "visualDisabilityCompliant": False,
+            "motorDisabilityCompliant": False,
+        }
+        response = client.with_session_auth("user@example.com").post("/offers", json=data)
+
+        # Then
+        assert response.status_code == 400
+        assert response.json["name"] == ["Le titre d'une offre ne peut contenir l'EAN"]
+
     def test_fail_if_unknown_subcategory(self, client):
         # Given
         venue = offerers_factories.VenueFactory()

--- a/api/tests/routes/public/individual_offers/v1/patch_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_product_test.py
@@ -330,6 +330,24 @@ class PatchProductTest(PublicAPIVenueEndpointHelper, ProductEndpointHelper):
             ]
         }
 
+    def test_update_with_ean_in_name_raises(self, client):
+        plain_api_key, venue_provider = self.setup_active_venue_provider()
+        product_offer = offers_factories.ThingOfferFactory(
+            venue=venue_provider.venue,
+            subcategoryId=subcategories.ABO_BIBLIOTHEQUE.id,
+            lastProvider=venue_provider.provider,
+        )
+
+        response = client.with_explicit_token(plain_api_key).patch(
+            self.endpoint_url,
+            json={
+                "offerId": product_offer.id,
+                "name": "Le Visible et l'invisible - Suivi de notes de travail - 9782070286256",
+            },
+        )
+        assert response.status_code == 400
+        assert response.json == {"name": ["Le titre d'une offre ne peut contenir l'EAN"]}
+
     def test_update_unallowed_subcategory_product_raises_error(self, client):
         venue, api_key = utils.create_offerer_provider_linked_to_venue()
         product_offer = offers_factories.ThingOfferFactory(

--- a/api/tests/routes/public/individual_offers/v1/post_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_test.py
@@ -404,6 +404,23 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         assert offers_models.Offer.query.first() is None
 
     @pytest.mark.usefixtures("db_session")
+    def test_offer_with_ean_in_name_is_not_accepted(self, client):
+        plain_api_key, venue_provider = self.setup_active_venue_provider()
+
+        response = client.with_explicit_token(plain_api_key).post(
+            self.endpoint_url,
+            json={
+                "location": {"type": "physical", "venueId": venue_provider.venue.id},
+                "categoryRelatedFields": {"category": "LIVRE_NUMERIQUE"},
+                "accessibility": utils.ACCESSIBILITY_FIELDS,
+                "name": "Le Visible et l'invisible - Suivi de notes de travail - 9782070286256",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json["name"] == ["Le titre d'une offre ne peut contenir l'EAN"]
+
+    @pytest.mark.usefixtures("db_session")
     def test_venue_allowed(self, client):
         utils.create_offerer_provider_linked_to_venue()
         not_allowed_venue = offerers_factories.VenueFactory()


### PR DESCRIPTION


Check added in `create_offer`, `update_offer`, `create_draft_offer`, `update_draft_offer`

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34314

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
