### PR TITLE
(PC-34321)[PRO] fix: Fix unintended redirection to /onboarding when creation first offer

### DIFF
--- a/pro/src/commons/store/StoreProvider/StoreProvider.tsx
+++ b/pro/src/commons/store/StoreProvider/StoreProvider.tsx
@@ -6,9 +6,9 @@ import { HTTP_STATUS, isErrorAPIError } from 'apiClient/helpers'
 import { SAVED_OFFERER_ID_KEY } from 'commons/core/shared/constants'
 import { updateFeatures } from 'commons/store/features/reducer'
 import {
+  updateOffererIsOnboarded,
   updateOffererNames,
   updateSelectedOffererId,
-  updateOffererIsOnboarded,
 } from 'commons/store/offerer/reducer'
 import { updateUser } from 'commons/store/user/reducer'
 import { storageAvailable } from 'commons/utils/storageAvailable'

--- a/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.spec.tsx
+++ b/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.spec.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { expect } from 'vitest'
 
+import { api } from 'apiClient/api'
 import {
   GetOffererNameResponseModel,
   GetOffererResponseModel,
@@ -111,6 +112,33 @@ describe('App', () => {
       await waitFor(() => {
         expect(screen.getByText('Ajouter'))
       })
+    })
+  })
+
+  describe('Switch Offerer', () => {
+    it('should call "handleChangeOfferer" on value change', async () => {
+      renderHeaderDropdown()
+
+      vi.mock('apiClient/api', () => ({
+        api: {
+          getOfferer: vi.fn(),
+        },
+      }))
+
+      // Opens main menu
+      await userEvent.click(screen.getByTestId('offerer-select'))
+
+      // Opens sub-menu
+      await userEvent.click(screen.getByText(/Changer de structure/))
+
+      // Get structures list
+      const offererList = screen.getByTestId('offerers-selection-menu')
+      const offerers = within(offererList).getAllByRole('menuitemradio')
+
+      // Clic on one structure
+      await userEvent.click(offerers[0])
+
+      expect(api.getOfferer).toHaveBeenCalledOnce()
     })
   })
 })

--- a/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.tsx
+++ b/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.tsx
@@ -107,7 +107,7 @@ export const HeaderDropdown = () => {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       handleChangeOfferer(offererOptions[0]?.value)
     }
-  }, [])
+  })
 
   useEffect(() => {
     const handleResize = () => {

--- a/pro/src/components/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.tsx
+++ b/pro/src/components/IndividualOffer/IndivualOfferLayout/IndivualOfferLayout.tsx
@@ -57,7 +57,7 @@ export const IndivualOfferLayout = ({
       )) ||
     mode !== OFFER_WIZARD_MODE.CREATION
 
-  if (isOnboarding && !isDidacticOnboardingEnabled) {
+  if (isOnboarding && isDidacticOnboardingEnabled === false) {
     return <Navigate to="/accueil" />
   }
 

--- a/pro/src/components/IndividualOffer/SummaryScreen/SummaryScreen.tsx
+++ b/pro/src/components/IndividualOffer/SummaryScreen/SummaryScreen.tsx
@@ -1,6 +1,6 @@
 import { Form, FormikProvider, useFormik } from 'formik'
 import { useState } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useSWRConfig } from 'swr'
 
 import { api } from 'apiClient/api'

--- a/pro/src/components/RedirectToBankAccountDialog/RedirectToBankAccountDialog.tsx
+++ b/pro/src/components/RedirectToBankAccountDialog/RedirectToBankAccountDialog.tsx
@@ -1,7 +1,9 @@
-import { useNavigate } from 'react-router-dom'
+import { useDispatch } from 'react-redux'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { Events, VenueEvents } from 'commons/core/FirebaseEvents/constants'
+import { updateOffererIsOnboarded } from 'commons/store/offerer/reducer'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { RedirectDialog } from 'components/RedirectDialog/RedirectDialog'
 import fullWaitIcon from 'icons/full-wait.svg'
@@ -22,6 +24,9 @@ export const RedirectToBankAccountDialog = ({
 }: RedirectToBankAccountDialogProps): JSX.Element => {
   const navigate = useNavigate()
   const { logEvent } = useAnalytics()
+  const { pathname } = useLocation()
+  const isOnboarding = pathname.indexOf('onboarding') !== -1
+  const dispatch = useDispatch()
 
   return (
     <RedirectDialog
@@ -30,6 +35,9 @@ export const RedirectToBankAccountDialog = ({
         logEvent(Events.CLICKED_SEE_LATER_FROM_SUCCESS_OFFER_CREATION_MODAL, {
           from: OFFER_WIZARD_STEP_IDS.SUMMARY,
         })
+        if (isOnboarding) {
+          dispatch(updateOffererIsOnboarded(true))
+        }
         navigate(cancelRedirectUrl)
       }}
       title="Félicitations, vous avez créé votre offre !"
@@ -38,12 +46,15 @@ export const RedirectToBankAccountDialog = ({
         to: `/remboursements/informations-bancaires?structure=${offerId}`,
         isExternal: false,
       }}
-      onRedirect={() =>
+      onRedirect={() => {
         logEvent(VenueEvents.CLICKED_VENUE_ADD_RIB_BUTTON, {
           venue_id: venueId,
           from: OFFER_WIZARD_STEP_IDS.SUMMARY,
         })
-      }
+        if (isOnboarding) {
+          dispatch(updateOffererIsOnboarded(true))
+        }
+      }}
       cancelText="Plus tard"
       cancelIcon={fullWaitIcon}
       withRedirectLinkIcon={false}

--- a/pro/src/components/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
@@ -27,6 +27,11 @@ vi.mock('apiClient/api', () => ({
   },
 }))
 
+const useHasAccessToDidacticOnboarding = vi.hoisted(() => vi.fn())
+vi.mock('commons/hooks/useHasAccessToDidacticOnboarding', () => ({
+  useHasAccessToDidacticOnboarding,
+}))
+
 const addressInformations: Address = {
   street: '3 Rue de Valois',
   city: 'Paris',
@@ -54,6 +59,7 @@ const renderValidationScreen = (contextValue: SignupJourneyContextValues) => {
             element={<Validation />}
           />
           <Route path="/accueil" element={<div>accueil</div>} />
+          <Route path="/onboarding" element={<div>onboarding</div>} />
         </Routes>
       </SignupJourneyContext.Provider>
       <Notification />
@@ -173,6 +179,7 @@ describe('ValidationScreen', () => {
     })
 
     it('should redirect to home after submit', async () => {
+      useHasAccessToDidacticOnboarding.mockReturnValue(false)
       vi.spyOn(api, 'saveNewOnboardingData').mockResolvedValue(
         {} as PostOffererResponseModel
       )
@@ -184,6 +191,21 @@ describe('ValidationScreen', () => {
       await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
       await userEvent.click(screen.getByText('Valider et créer ma structure'))
       expect(await screen.findByText('accueil')).toBeInTheDocument()
+    })
+
+    it('should redirect to onboarding after submit if isDidacticOnboardingEnabled is true', async () => {
+      useHasAccessToDidacticOnboarding.mockReturnValue(true)
+      vi.spyOn(api, 'saveNewOnboardingData').mockResolvedValue(
+        {} as PostOffererResponseModel
+      )
+      vi.spyOn(utils, 'initReCaptchaScript').mockReturnValue({
+        remove: vi.fn(),
+      } as unknown as HTMLScriptElement)
+      vi.spyOn(utils, 'getReCaptchaToken').mockResolvedValue('token')
+      renderValidationScreen(contextValue)
+      await waitForElementToBeRemoved(() => screen.queryAllByTestId('spinner'))
+      await userEvent.click(screen.getByText('Valider et créer ma structure'))
+      expect(await screen.findByText('onboarding')).toBeInTheDocument()
     })
   })
 

--- a/pro/src/components/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/__specs__/ValidationScreen.spec.tsx
@@ -10,8 +10,8 @@ import { api } from 'apiClient/api'
 import { PostOffererResponseModel, Target } from 'apiClient/v1'
 import { DEFAULT_ACTIVITY_VALUES } from 'commons/context/SignupJourneyContext/constants'
 import {
-  SignupJourneyContextValues,
   SignupJourneyContext,
+  SignupJourneyContextValues,
 } from 'commons/context/SignupJourneyContext/SignupJourneyContext'
 import { sharedCurrentUserFactory } from 'commons/utils/factories/storeFactories'
 import * as utils from 'commons/utils/recaptcha'

--- a/pro/src/pages/IndividualOfferWizard/IndividualOfferWizard.tsx
+++ b/pro/src/pages/IndividualOfferWizard/IndividualOfferWizard.tsx
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import { Outlet, useLocation, Navigate } from 'react-router-dom'
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
 
 import { Layout } from 'app/App/layout/Layout'
 import { IndividualOfferContextProvider } from 'commons/context/IndividualOfferContext/IndividualOfferContext'
@@ -13,7 +13,7 @@ export const IndividualOfferWizard = () => {
   const isConfirmationPage = pathname.endsWith('confirmation')
   const isDidacticOnboardingEnabled = useHasAccessToDidacticOnboarding()
 
-  if (isOnboarding && !isDidacticOnboardingEnabled) {
+  if (isOnboarding && isDidacticOnboardingEnabled === false) {
     return <Navigate to="/accueil" />
   }
 

--- a/pro/src/pages/OfferType/OfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType.tsx
@@ -1,5 +1,4 @@
-import { Navigate } from 'react-router'
-import { useLocation } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 
 import { Layout } from 'app/App/layout/Layout'
 import { useHasAccessToDidacticOnboarding } from 'commons/hooks/useHasAccessToDidacticOnboarding'
@@ -11,7 +10,7 @@ export const OfferType = (): JSX.Element => {
   const isOnboarding = pathname.indexOf('onboarding') !== -1
   const isDidacticOnboardingEnabled = useHasAccessToDidacticOnboarding()
 
-  if (isOnboarding && !isDidacticOnboardingEnabled) {
+  if (isOnboarding && isDidacticOnboardingEnabled === false) {
     return <Navigate to="/accueil" />
   }
 

--- a/pro/src/pages/OfferType/OfferType/OfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType/OfferType.tsx
@@ -68,6 +68,8 @@ export const OfferTypeScreen = (): JSX.Element => {
 
   const areSuggestedSubcategoriesUsed = useSuggestedSubcategoriesAbTest()
 
+  const isOnboarding = location.pathname.indexOf('onboarding') !== -1
+
   const onSubmit = async (values: OfferTypeFormValues) => {
     if (values.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO) {
       const params = new URLSearchParams(location.search)
@@ -79,7 +81,7 @@ export const OfferTypeScreen = (): JSX.Element => {
         pathname: getIndividualOfferUrl({
           step: OFFER_WIZARD_STEP_IDS.DETAILS,
           mode: OFFER_WIZARD_MODE.CREATION,
-          isOnboarding: location.pathname.indexOf('onboarding') !== -1,
+          isOnboarding,
         }),
         search: params.toString(),
       })
@@ -166,38 +168,41 @@ export const OfferTypeScreen = (): JSX.Element => {
 
   return (
     <>
-      <h1 className={styles['offer-type-title']}>Créer une offre</h1>
-      {offerer?.allowedOnAdage && (
+      {!isOnboarding && offerer?.allowedOnAdage && (
         <CollectiveBudgetCallout pageName="offer-creation-hub" />
       )}
       <div className={styles['offer-type-container']}>
+        <h1 className={styles['offer-type-title']}>Créer une offre</h1>
         <FormikProvider value={formik}>
           <form onSubmit={formik.handleSubmit}>
             <FormLayout>
-              <FormLayout.Section title="À qui destinez-vous cette offre ?">
-                <FormLayout.Row inline>
-                  <RadioButtonWithImage
-                    name="offerType"
-                    icon={phoneStrokeIcon}
-                    isChecked={
-                      values.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO
-                    }
-                    label="Au grand public"
-                    onChange={handleChange}
-                    value={OFFER_TYPES.INDIVIDUAL_OR_DUO}
-                    className={styles['offer-type-button']}
-                  />
-                  <RadioButtonWithImage
-                    name="offerType"
-                    icon={strokeProfIcon}
-                    isChecked={values.offerType === OFFER_TYPES.EDUCATIONAL}
-                    label="À un groupe scolaire"
-                    onChange={handleChange}
-                    value={OFFER_TYPES.EDUCATIONAL}
-                    className={styles['offer-type-button']}
-                  />
-                </FormLayout.Row>
-              </FormLayout.Section>
+              {/* If we're on boarding process, we don't need to ask for offer type (we already chose individual at previous step) */}
+              {!isOnboarding && (
+                <FormLayout.Section title="À qui destinez-vous cette offre ?">
+                  <FormLayout.Row inline>
+                    <RadioButtonWithImage
+                      name="offerType"
+                      icon={phoneStrokeIcon}
+                      isChecked={
+                        values.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO
+                      }
+                      label="Au grand public"
+                      onChange={handleChange}
+                      value={OFFER_TYPES.INDIVIDUAL_OR_DUO}
+                      className={styles['offer-type-button']}
+                    />
+                    <RadioButtonWithImage
+                      name="offerType"
+                      icon={strokeProfIcon}
+                      isChecked={values.offerType === OFFER_TYPES.EDUCATIONAL}
+                      label="À un groupe scolaire"
+                      onChange={handleChange}
+                      value={OFFER_TYPES.EDUCATIONAL}
+                      className={styles['offer-type-button']}
+                    />
+                  </FormLayout.Row>
+                </FormLayout.Section>
+              )}
 
               {!areSuggestedSubcategoriesUsed &&
                 values.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO && (

--- a/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.spec.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.spec.tsx
@@ -6,12 +6,12 @@ import {
 
 import { api } from 'apiClient/api'
 import { OfferStatus } from 'apiClient/v1'
+import * as useHasAccessToDidacticOnboarding from 'commons/hooks/useHasAccessToDidacticOnboarding'
 import {
   defaultGetOffererResponseModel,
   defaultGetOffererVenueResponseModel,
   listOffersOfferFactory,
 } from 'commons/utils/factories/individualApiFactories'
-import * as useHasAccessToDidacticOnboarding from 'commons/hooks/useHasAccessToDidacticOnboarding'
 import {
   renderWithProviders,
   RenderWithProvidersOptions,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34321

- **[Commit 1](https://github.com/pass-culture/pass-culture-main/pull/16103/commits/b03351b0dbe10626b717f019864608f83ad6a79b)** : Fix d'un problème (régression) ➡️  au clic sur "manuellement" sur la page `/onboarding/individuel` on est redirigé vers `/onboarding` au lieu de poursuivre vers la créa d'offre.
> [!NOTE]
> Le bug venait du fait que le récent hook `useHasAccessToDidacticOnboarding()` s'initialise avec la valeur "undefined" et se met à jour avec "useEffect" à la suite d'un retour de firebase.
>
> Or les composant de page qui lisaient le retour de `useHasAccessToDidacticOnboarding()` obtenaient un "undefined" et testaient la condition : `if ( … && !isDidacticOnboardingEnabled)` qui équivaut littéralement à un `if (… && !undefined)` et redirigeaient immédiatement vers `/accueil` -> `/onboarding` au lieu d'attendre que potentiellement le hook ne soit mit à jour avec un vrai boolean.
>
> Le changement `!isDidacticOnboardingEnabled` -> `isDidacticOnboardingEnabled === false` s'assure qu'on a bien un booléen "false" avant de rediriger.


- **[Commit 2](https://github.com/pass-culture/pass-culture-main/pull/16103/commits/cb517adeec98379c19d27ee8c4c53f08a660c73d)** : Corrige un autre problème sur la mise à jour de l'état `isOnboarded` dans le store de l'offerer qui n'était pas fait de façon dynamique après la création de la structure et la publication de la première offre (nécessitait de faire un hard-refresh).
Ce commit dispatche l'état de l'offerer directement à ces étapes du parcours.
Il corrige également les redirections vers /accueil ou /onboarding suivant l'état de l'offerer et de l'A/B test


- **[Commit 3](https://github.com/pass-culture/pass-culture-main/pull/16103/commits/3e2b3f658401213afa85f9b09b3cf850eedbeb17)** : Ajoute des tests pour la coverage (l'un manquait sur le switch de l'offerer dans le menu, et un autre pour tester la redirection vers l'accueil ou l'onboarding suivant l'A/B test)


- **[Commit 4](https://github.com/pass-culture/pass-culture-main/pull/16103/commits/041ed71001904fd0186f573b7d7e0a03ce240225)** : Retire la callout d'avertissement pour le collectif ainsi que le choix du type d'offre lors de l'onboarding

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
