### PR TITLE
(PC-34320)[PRO] fix: Do not reset applied filters when initialFilters…

### DIFF
--- a/pro/cypress/e2e/searchCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/searchCollectiveOffer.cy.ts
@@ -58,10 +58,7 @@ describe('Search collective offers', () => {
       message: 'I search with the name "' + offerPublished.name + '"',
     })
 
-    cy.findByRole('searchbox', { name: /Nom de l’offre/ }).type(
-      offerPublished.name
-    )
-
+    cy.findByLabelText(/Nom de l’offre/).type(offerPublished.name)
     cy.stepLog({ message: 'I validate my filters' })
     cy.findByText('Rechercher').click()
     cy.wait('@collectiveOffers').its('response.statusCode').should('eq', 200)
@@ -292,7 +289,7 @@ describe('Search collective offers', () => {
     cy.findByLabelText('Format').select('Représentation')
 
     cy.stepLog({ message: 'I search with the name "brouillon"' })
-    cy.findByRole('searchbox', { name: /Nom de l’offre/ }).type('brouillon')
+    cy.findByLabelText(/Nom de l’offre/).type('brouillon', { delay: 0 })
 
     cy.stepLog({ message: 'I search with status "Brouillon"' })
     cy.get('#search-status').click()

--- a/pro/src/commons/core/Offers/utils/__specs__/hasSearchFilters.spec.ts
+++ b/pro/src/commons/core/Offers/utils/__specs__/hasSearchFilters.spec.ts
@@ -1,0 +1,60 @@
+import { EacFormat } from 'apiClient/adage'
+import { CollectiveOfferDisplayedStatus } from 'apiClient/v1'
+
+import {
+  CollectiveOfferTypeEnum,
+  CollectiveSearchFiltersParams,
+} from '../../types'
+import { hasCollectiveSearchFilters } from '../hasSearchFilters'
+
+describe('hasSearchFilters', () => {
+  const defaultCollectiveFilters: CollectiveSearchFiltersParams = {
+    collectiveOfferType: CollectiveOfferTypeEnum.ALL,
+    format: 'all',
+    nameOrIsbn: '',
+    offererId: '333',
+    page: 1,
+    periodBeginningDate: '',
+    periodEndingDate: '',
+    status: [],
+    venueId: '',
+  }
+
+  it('should confirm whether collective filters are applied or not', () => {
+    expect(
+      hasCollectiveSearchFilters(defaultCollectiveFilters, {
+        ...defaultCollectiveFilters,
+      })
+    ).toBeFalsy()
+
+    expect(
+      hasCollectiveSearchFilters(defaultCollectiveFilters, {
+        ...defaultCollectiveFilters,
+        format: EacFormat.ATELIER_DE_PRATIQUE,
+      })
+    ).toBeTruthy()
+
+    expect(
+      hasCollectiveSearchFilters(defaultCollectiveFilters, {
+        ...defaultCollectiveFilters,
+        status: [CollectiveOfferDisplayedStatus.ACTIVE],
+      })
+    ).toBeTruthy()
+  })
+
+  it('should ignore the page number and offerer id', () => {
+    expect(
+      hasCollectiveSearchFilters(defaultCollectiveFilters, {
+        ...defaultCollectiveFilters,
+        page: 10,
+      })
+    ).toBeFalsy()
+
+    expect(
+      hasCollectiveSearchFilters(defaultCollectiveFilters, {
+        ...defaultCollectiveFilters,
+        offererId: '816',
+      })
+    ).toBeFalsy()
+  })
+})

--- a/pro/src/commons/core/Offers/utils/hasSearchFilters.ts
+++ b/pro/src/commons/core/Offers/utils/hasSearchFilters.ts
@@ -28,6 +28,14 @@ export const hasCollectiveSearchFilters = (
       searchFilters[filterName] &&
       filterName !== 'offererId' &&
       filterName !== 'page' &&
-      searchFilters[filterName] !== { ...defaultFilters }[filterName]
+      ((['string', 'number'].includes(typeof searchFilters[filterName]) &&
+        searchFilters[filterName] !== { ...defaultFilters }[filterName]) ||
+        (Array.isArray(searchFilters[filterName]) &&
+          Array.isArray(defaultFilters[filterName]) &&
+          !isSameArray(searchFilters[filterName], defaultFilters[filterName])))
   )
+}
+
+function isSameArray(arr1: unknown[], arr2: unknown[]) {
+  return arr1.length === arr2.length && arr1.every((el) => arr2.includes(el))
 }

--- a/pro/src/components/OffersTable/OffersTableSearch/OffersTableSearch.module.scss
+++ b/pro/src/components/OffersTable/OffersTableSearch/OffersTableSearch.module.scss
@@ -29,18 +29,8 @@
     }
   }
 
-  &-reset {
-    &-wrapper {
-      flex-direction: column;
-      margin-top: rem.torem(8px);
-    }
-
-    &-button {
-      min-height: size.$input-min-height;
-      margin-top: 0;
-      display: block;
-      text-align: left;
-    }
+  &-reset-wrapper {
+    margin-top: rem.torem(8px);
   }
 
   &-separator {

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -61,7 +61,11 @@ export const CollectiveOffers = (): JSX.Element => {
   )
   const offerer = offererQuery.data
 
-  const { data } = useSWR(
+  const {
+    data,
+    isLoading: isVenuesLoading,
+    isValidating: isVenuesValidating,
+  } = useSWR(
     [GET_VENUES_QUERY_KEY, offerer?.id],
     ([, offererIdParam]) => api.getVenues(null, null, offererIdParam),
     { fallbackData: { venues: [] } }
@@ -138,7 +142,10 @@ export const CollectiveOffers = (): JSX.Element => {
     <Layout mainHeading="Offres collectives">
       {/* When the venues are cached for a given offerer, we still need to reset the Screen component.
       SWR isLoading is only true when the data is not cached, while isValidating is always set to true when the key is updated */}
-      {offererQuery.isLoading || offererQuery.isValidating ? (
+      {offererQuery.isLoading ||
+      offererQuery.isValidating ||
+      isVenuesLoading ||
+      isVenuesValidating ? (
         <Spinner />
       ) : (
         <CollectiveOffersScreen

--- a/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/CollectiveOffersScreen.tsx
+++ b/pro/src/pages/CollectiveOffers/components/CollectiveOffersScreen/CollectiveOffersScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 
 import {
   CollectiveOfferResponseModel,
@@ -68,10 +68,6 @@ export const CollectiveOffersScreen = ({
   >([])
   const [selectedFilters, setSelectedFilters] = useState(initialSearchFilters)
 
-  useEffect(() => {
-    setSelectedFilters(initialSearchFilters)
-  }, [initialSearchFilters])
-
   const defaultCollectiveFilters = useDefaultCollectiveSearchFilters()
 
   const currentPageOffersSubset = offers.slice(
@@ -85,6 +81,7 @@ export const CollectiveOffersScreen = ({
     initialSearchFilters,
     defaultCollectiveFilters
   )
+
   const userHasNoOffers = !isLoading && !hasOffers && !hasFilters
 
   const areAllOffersSelected =
@@ -134,6 +131,7 @@ export const CollectiveOffersScreen = ({
   const resetFilters = () => {
     onResetFilters()
     applyUrlFiltersAndRedirect(defaultCollectiveFilters)
+    setSelectedFilters(defaultCollectiveFilters)
   }
 
   function onSetSelectedOffer(offer: CollectiveOfferResponseModel) {


### PR DESCRIPTION
… change, since they change each time the parent rerenders.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34320

**Objectif**
Corriger le test e2e flaky `searchCollectiveOffer.cy.ts` qui échoue par exemple [ici](https://github.com/pass-culture/pass-culture-main/actions/runs/13033852295/job/36359496084) ou [là](https://github.com/pass-culture/pass-culture-main/actions/runs/13047530102/job/36400692738).

**Ce qui se passe :**
Le test va sur la liste des offres collectives, remplit le champ de recherche avec un nom d'offre, clic sur "Rechercher" mais à ce moment là le champ de recherche ne contient que les quelques derniers caractères de la recherche initialement entrée. -> Donc pas de résultats si moins de 4 caractères entrés -> échec

Je reproduis presque systématiquement en local en faisant tourner ce test e2e là.

Pour reproduire en testing par exemple : Aller sur la recherche collective en mode réseau réduit 3G, immédiatement commencer à remplir le champ recherche, au bout d'un moment la recherche se supprime toute seule.

**Solution**
Ne pas réinitialiser les filtres à chaque fois que l'objet `initialSearchFilters` change. `initialSearchFilters` étant une props et sa ref changeant à chaque re-render du parent, on :
- Modifier un filtre (ex le statut) -> Modification de l'url + mise à jour du state `selectedFilters`-> le parent re-render -> la ref de `initialSearchFilters` change -> l'enfant re-render -> le useEffect basé sur `initialSearchFilters` est déclenché -> on réinitialise les filtres à la valeur initiale elle-même basée sur l'url mais qui est la même valeur qui a été mise à jour dans `selectedFilters`

Dans le test e2e ça arrive en particulier quand une des requetes sur l'offerer/la venue est recue après l'initialisation des filtres.

On a 3 sources de vérité dans les listes des offres : le state du composant, le sessionStorage et l'url. Garder les 3 sync a l'air d'être très complexe, peut-être qu'il y a des simplifications possibles ?

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
