### PR TITLE
(BSR)[API] script: delete problematic Ubble fraud check

### DIFF
--- a/api/src/pcapi/scripts/ubble/main.py
+++ b/api/src/pcapi/scripts/ubble/main.py
@@ -1,0 +1,15 @@
+from pcapi.core.fraud.models import BeneficiaryFraudCheck
+from pcapi.repository import transaction
+
+
+def delete_problematic_fraud_check() -> None:
+    with transaction():
+        BeneficiaryFraudCheck.query.filter(BeneficiaryFraudCheck.id == 24685364).delete()
+
+
+if __name__ == "__main__":
+    from pcapi.flask_app import app
+
+    app.app_context().push()
+
+    delete_problematic_fraud_check()


### PR DESCRIPTION
There is a single bugged id verification in Ubble that is stuck in an infinite loop: the verification is not accessible through the dashboard and does not have a birth date, which crashes the Ubble recovery cron.

While that verification is pending, the young user cannot retry an Ubble verification and is stuck. To free that user's verification flow, an easy fix is to delete the problematic fraud check.

## Bug Sentry

https://sentry.passculture.team/organizations/sentry/issues/1627227/events/latest/?project=5&referrer=latest-event

## Vérifications

- C'est le bon fraud check à supprimer :

<img width="751" alt="image" src="https://github.com/user-attachments/assets/db0d644a-6811-4d45-be42-92fe7cafea09" />

