### PR TITLE
(BSR) ci: use latest render-push-manifests action to pin dependency

### DIFF
--- a/.github/workflows/dev_on_workflow_deploy.yml
+++ b/.github/workflows/dev_on_workflow_deploy.yml
@@ -128,7 +128,7 @@ jobs:
 
       # Executes helmfile templating and push results to render-manifests repository
       - name: "Generate and push rendered manifests"
-        uses: pass-culture/common-workflows/actions/render-push-manifests@render-push-manifests/v2.0.0
+        uses: pass-culture/common-workflows/actions/render-push-manifests@render-push-manifests/v2.4.3
         with:
           environment: ${{ inputs.environment }}
           app_name: pcapi

--- a/.github/workflows/dev_on_workflow_deploy_pullrequests.yml
+++ b/.github/workflows/dev_on_workflow_deploy_pullrequests.yml
@@ -101,7 +101,7 @@ jobs:
 
       # Executes helmfile templating and push results to render-manifests repository
       - name: "Generate and push rendered manifests"
-        uses: pass-culture/common-workflows/actions/render-push-manifests@render-push-manifests/v2.4.2
+        uses: pass-culture/common-workflows/actions/render-push-manifests@render-push-manifests/v2.4.3
         with:
           environment: ${{ inputs.environment }}
           app_name: pcapi


### PR DESCRIPTION
## But de la pull request

Utiliser la dernière version de common-workflows pour traiter un souci de CI
