### PR TITLE
(BSR)[API] fix: check new collective offer location venue on public a…

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -380,8 +380,8 @@ def patch_collective_offer_public(
             )
 
     if new_values.get("offerVenue"):
-        if new_values["offerVenue"] == OfferAddressType.OFFERER_VENUE.value:
-            venue = offerers_repository.find_venue_by_id(new_values["offerVenue"]["venuId"])
+        if new_values["offerVenue"]["addressType"] == OfferAddressType.OFFERER_VENUE:
+            venue = offerers_repository.find_venue_by_id(new_values["offerVenue"]["venueId"])
             if (not venue) or (venue.managingOffererId != current_api_key.offerer.id):
                 raise ApiErrors(
                     errors={

--- a/api/tests/routes/public/helpers.py
+++ b/api/tests/routes/public/helpers.py
@@ -111,8 +111,8 @@ class PublicAPIEndpointBaseHelper:
 
         return plain_api_key, provider
 
-    def setup_venue(self) -> offerers_models.Venue:
-        return offerers_factories.VenueFactory()
+    def setup_venue(self, **kwargs: typing.Any) -> offerers_models.Venue:
+        return offerers_factories.VenueFactory(**kwargs)
 
 
 # pylint: disable=abstract-method
@@ -140,7 +140,7 @@ class PublicAPIVenueEndpointHelper(PublicAPIEndpointBaseHelper):
         self, provider_has_ticketing_urls=True
     ) -> tuple[str, providers_models.VenueProvider]:
         plain_api_key, provider = self.setup_provider(provider_has_ticketing_urls)
-        venue = self.setup_venue()
+        venue = self.setup_venue(managingOfferer=provider.offererProvider.offerer)
         venue_provider = providers_factories.VenueProviderFactory(venue=venue, provider=provider)
 
         return plain_api_key, venue_provider


### PR DESCRIPTION
…pi patch

## But de la pull request

Ticket Jira (ou description si BSR) : la logique actuelle pendant le PATCH public collective offers sur offerVenue.venueId ne vérifie pas correctement l'id en question

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
