### PR TITLE
(BSR)[ADAGE] fix: catch requests ConnectionError when calling Adage +…

### DIFF
--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -866,12 +866,13 @@ class ValidateCollectiveOfferTest(PostEndpointHelper):
 
         assert (
             html_parser.extract_alert(response.data)
-            == f"Erreur lors de la notification à ADAGE pour l'offre {collective_offer.id} : ReadTimeout"
+            == f"Erreur lors de la notification à ADAGE pour l'offre {collective_offer.id} : Cannot establish connection to omogen api"
         )
 
         assert endpoint.called
 
         db.session.refresh(collective_offer)
+        # isActive should be False as session is marked as invalid, does not work with test session
         assert collective_offer.isActive is True
         assert collective_offer.validation == OfferValidationStatus.APPROVED
         assert collective_offer.lastValidationType == OfferValidationType.MANUAL


### PR DESCRIPTION
… refactor

## But de la pull request

Ticket Jira (ou description si BSR) :

- Lors d'un appel à Adage on a actuellement un `except ConnectionError` au lieu de `except requests.exception.ConnectionError`
- Dans chaque méthode d'appel à adage on a le même try / except -> on factorise ça dans une méthode

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
