### PR TITLE
(BSR)[API] feat: do not catch all exceptions when calling adage in bo…

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -31,7 +31,6 @@ class FeatureToggle(enum.Enum):
     API_SIRENE_AVAILABLE = "Active les fonctionnalitées liées à l'API Sirene"
     APP_ENABLE_AUTOCOMPLETE = "Active l'autocomplete sur la barre de recherche relative au rework de la homepage"
     BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS = "Active la validation d'un bénéficiaire via les contrôles de sécurité"
-    DISABLE_ADAGE_INSTITUTION_NOTIFICATION = "Désactiver la notification de l'établissement à la validation des offres collectives (à utiliser lorsqu'ADAGE est KO)"
     DISABLE_ENTERPRISE_API = "Désactiver les appels à l'API entreprise"
     DISABLE_BOOST_EXTERNAL_BOOKINGS = "Désactiver les réservations externes Boost"
     DISABLE_CDS_EXTERNAL_BOOKINGS = "Désactiver les réservations externes CDS"
@@ -172,7 +171,6 @@ class Feature(PcObject, Base, Model, DeactivableMixin):
 
 
 FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
-    FeatureToggle.DISABLE_ADAGE_INSTITUTION_NOTIFICATION,
     FeatureToggle.DISABLE_BOOST_EXTERNAL_BOOKINGS,
     FeatureToggle.DISABLE_CDS_EXTERNAL_BOOKINGS,
     FeatureToggle.DISABLE_CGR_EXTERNAL_BOOKINGS,

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -30,7 +30,6 @@ from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models import offer_mixin
-from pcapi.models.feature import FeatureToggle
 from pcapi.repository import atomic
 from pcapi.repository import mark_transaction_as_invalid
 from pcapi.repository import on_commit
@@ -479,11 +478,7 @@ def _batch_validate_or_reject_collective_offers(
                 )
             )
 
-            if (
-                validation is offer_mixin.OfferValidationStatus.APPROVED
-                and collective_offer.institutionId is not None
-                and not FeatureToggle.DISABLE_ADAGE_INSTITUTION_NOTIFICATION.is_active()
-            ):
+            if validation is offer_mixin.OfferValidationStatus.APPROVED and collective_offer.institutionId is not None:
                 try:
                     adage_client.notify_institution_association(serialize_collective_offer(collective_offer))
                 except educational_exceptions.AdageInvalidEmailException:
@@ -508,19 +503,6 @@ def _batch_validate_or_reject_collective_offers(
                         collective_offer_update_succeed_ids.remove(collective_offer.id)
 
                     collective_offer_update_failed_ids.append(collective_offer.id)
-                except Exception as exc:  # pylint: disable=broad-exception-caught
-                    # ConnectionError, ReadTimeout...
-                    # When ADAGE is unavailable, we still need to validate collective offers, so the notification
-                    # will not be sent to educational institution.
-                    flash(
-                        Markup(
-                            "Erreur lors de la notification à ADAGE pour l'offre <b>{offer_id}</b> : {message}"
-                        ).format(
-                            offer_id=collective_offer.id,
-                            message=getattr(exc, "message", None) or str(exc) or type(exc).__name__,
-                        ),
-                        "warning",
-                    )
 
     if len(collective_offer_update_succeed_ids) == 1:
         flash(


### PR DESCRIPTION
… and remove FF for adage skip

## But de la pull request

Ticket Jira (ou description si BSR) : 

Les erreurs de type `ReadTimeout` lors des appels à adage sont maintenant correctement catch, on peut donc retirer le `except Exception` dans la logique de validate / reject du BO

On retire également le FF qui désactive l'appel à adage, qui n'est plus nécessaire aux équipes

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
