### PR TITLE
(PC-34381)[API] feat: Update offer ean field when offer extraData contains ean info

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -219,6 +219,8 @@ def create_draft_offer(
     fields = {key: value for key, value in body.dict(by_alias=True).items() if key not in ("venueId", "callId")}
     fields.update(_get_accessibility_compliance_fields(venue))
     fields.update({"withdrawalDetails": venue.withdrawalDetails})
+    # TODO: (pcharlet, 2025-02-04): Delete next line when body schemas contains specific EAN field outside extraData
+    fields.update({"ean": body.extra_data.get("ean") if body.extra_data else None})
 
     fields.update({"isDuo": bool(subcategory and subcategory.is_event and subcategory.can_be_duo)})
 
@@ -264,6 +266,8 @@ def update_draft_offer(offer: models.Offer, body: offers_schemas.PatchDraftOffer
         validation.check_offer_extra_data(
             offer.subcategoryId, formatted_extra_data, offer.venue, is_from_private_api=True, offer=offer
         )
+        # TODO: (pcharlet, 2025-02-04): Delete next line when body schemas contains specific EAN field outside extraData
+        updates.update({"ean": updates["extraData"].get("ean", None)})
 
     for key, value in updates.items():
         setattr(offer, key, value)
@@ -301,6 +305,8 @@ def create_offer(
     validation.check_offer_name_does_not_contain_ean(body.name)
 
     fields = body.dict(by_alias=True)
+    # TODO: (pcharlet, 2025-02-04): Delete next line when body schemas contains specific EAN field outside extraData
+    fields.update({"ean": body.extra_data.get("ean") if body.extra_data else None})
 
     offerer_address = offerer_address or venue.offererAddress
 
@@ -379,6 +385,8 @@ def update_offer(
         validation.check_offer_extra_data(
             offer.subcategoryId, formatted_extra_data, offer.venue, is_from_private_api, offer=offer
         )
+        # TODO: (pcharlet, 2025-02-04): Delete next line when body schemas contains specific EAN field outside extraData
+        updates.update({"ean": updates["extraData"].get("ean", None)})
     if "isDuo" in updates:
         is_duo = get_field(offer, updates, "isDuo", aliases=aliases)
         validation.check_is_duo_compliance(is_duo, offer.subcategory)

--- a/api/tests/routes/pro/patch_draft_offer_test.py
+++ b/api/tests/routes/pro/patch_draft_offer_test.py
@@ -69,6 +69,7 @@ class Returns200Test:
 
         updated_offer = Offer.query.get(offer.id)
         assert updated_offer.extraData["ean"] == "2222222222222"
+        assert updated_offer.ean == "2222222222222"
 
     @pytest.mark.features(WIP_EAN_CREATION=True)
     def test_patch_draft_offer_without_product(self, client):
@@ -196,6 +197,8 @@ class Returns200Test:
 
         updated_offer = Offer.query.get(offer.id)
         assert updated_offer.extraData == {"gtl_id": "07000000", "ean": "1111111111111"}
+        # We do not update extraData if they are the same.
+        assert updated_offer.ean is None
 
     def test_patch_draft_offer_with_existing_extra_data_with_new_extra_data(self, client):
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")

--- a/api/tests/routes/pro/post_draft_offer_test.py
+++ b/api/tests/routes/pro/post_draft_offer_test.py
@@ -118,6 +118,7 @@ class Returns201Test:
         assert response_dict["id"] == offer.id
         assert response_dict["productId"] == product.id
         assert response_dict["extraData"] == {"ean": "9782123456803"}
+        assert offer.ean == "9782123456803"
         assert offer.product == product
         assert offer._description is None
         assert offer.description == product.description
@@ -198,6 +199,7 @@ class Returns201Test:
         assert response_dict["id"] == offer.id
         assert response_dict["productId"] == offer.productId
         assert response_dict["extraData"] == {"ean": "1234567891234"}
+        assert offer.ean == "1234567891234"
         assert offer.product == product
         assert offer.description == product.description
         assert offer._description is None

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -285,6 +285,7 @@ class Returns200Test:
         assert offer.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert offer.venue == venue
         assert offer.extraData["ean"] == "1234567890112"
+        assert offer.ean == "1234567890112"
 
     def test_withdrawable_event_offer_can_have_no_ticket_to_withdraw(self, client):
         # Given


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34381

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
