### PR TITLE
(PC-34366)[BO] fix: filter on Marseille en Grand in collective offers

### DIFF
--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -120,7 +120,9 @@ SEARCH_FIELD_TO_PYTHON = {
     "MEG": {
         "field": "boolean",
         "special": lambda x: x == "true",
-        "inner_join": "institution",
+        "custom_filters_inner_join": {  # "inner_join" would not be applied with custom filter
+            "NULLABLE": "institution"
+        },
         "custom_filters": {
             "NULLABLE": lambda value: (
                 sa.exists()
@@ -128,6 +130,8 @@ SEARCH_FIELD_TO_PYTHON = {
                     sa.and_(
                         educational_models.EducationalInstitutionProgramAssociation.institutionId
                         == educational_models.EducationalInstitution.id,
+                        educational_models.EducationalInstitutionProgram.id
+                        == educational_models.EducationalInstitutionProgramAssociation.programId,
                         educational_models.EducationalInstitutionProgram.name
                         == educational_models.PROGRAM_MARSEILLE_EN_GRAND,
                     )

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -148,7 +148,7 @@ SEARCH_FIELD_TO_PYTHON: dict[str, dict[str, typing.Any]] = {
     "TAG": {
         "field": "criteria",
         "column": criteria_models.Criterion.id,
-        "inner_join": "criterion",
+        "inner_join": "criterion",  # applied only when no custom filter (with operator IN)
         "outer_join": "offer_criterion",
         "outer_join_column": criteria_models.OfferCriterion.offerId,
         "custom_filters": {

--- a/api/src/pcapi/routes/backoffice/utils.py
+++ b/api/src/pcapi/routes/backoffice/utils.py
@@ -305,13 +305,15 @@ def generate_search_query(
 
         if custom_filter := meta_field.get("custom_filters", {}).get(operator):
             filters.append(custom_filter(field_value))
+            if custom_filter_inner_join := meta_field.get("custom_filters_inner_join", {}).get(operator):
+                inner_joins.add(custom_filter_inner_join)
             continue
 
         column = meta_field["column"]
         if OPERATOR_DICT[operator].get("outer_join", False):
             if not meta_field.get("outer_join") or not meta_field.get("outer_join_column"):
                 warnings.add(
-                    f"La règle de recherche '{search_field}' n'est pas correctement configuré pour "
+                    f"La règle de recherche '{search_field}' n'est pas correctement configurée pour "
                     f"l'opérateur '{operator}', merci de prévenir les devs"
                 )
                 continue


### PR DESCRIPTION
inner join on educational_institution was not applied when only Marseille en Grand was set, which caused too many SQL rows, then less results than Marseille en Grand + Ministry, which applied inner join properly.

The issue was about "inner_join" + "custom_filter" in advanced search filter.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-34366

## Vérifications

Testé en local avec 100 résultats max dans la recherche.
Pour vérifier en test auto il faudrait créer trop d'objets.