### PR TITLE
(PC-34390)[API] fix: log recaptcha errors and remove token length limit

### DIFF
--- a/api/src/pcapi/routes/auth/discord.py
+++ b/api/src/pcapi/routes/auth/discord.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import redirect
 from flask import render_template
 from flask import request
@@ -23,6 +25,8 @@ from pcapi.utils import requests
 from . import blueprint
 from . import utils
 
+
+logger = logging.getLogger(__name__)
 
 ERROR_STRING_PREFIX = "Erreur d'authentification Discord: "
 
@@ -162,7 +166,8 @@ def discord_signin_post() -> str | Response | None:
             original_action="discordSignin",
             minimal_score=settings.RECAPTCHA_MINIMAL_SCORE,
         )
-    except (ReCaptchaException, InvalidRecaptchaTokenException):
+    except (ReCaptchaException, InvalidRecaptchaTokenException) as exc:
+        logger.error("Recaptcha failed: %s", str(exc))
         raise ApiErrors({"recaptcha": "Erreur recaptcha"}, 401)
 
     try:

--- a/api/src/pcapi/routes/auth/forms/fields.py
+++ b/api/src/pcapi/routes/auth/forms/fields.py
@@ -66,13 +66,7 @@ class PCHiddenField(PCStringField):
 
 
 class PCLongHiddenField(PCHiddenField):
-    validators = [
-        validators.DataRequired("Information obligatoire"),
-        # This validator is used for the reCAPTCHA V3 tokens which can be very long.
-        # We decide to keep the validator with an arbitrarily high length value that,
-        # as far as we know, should be greater than 10_000.
-        validators.Length(max=2**16, message="doit contenir au maximum %(max)d caractères"),
-    ]
+    validators = [validators.DataRequired("Information obligatoire")]
 
 
 class PCEmailField(wtforms.EmailField):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34390

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
