### PR TITLE
(PC-34125)[API] fix: kinda: flush after product merge

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1535,6 +1535,8 @@ def merge_products(to_keep: models.Product, to_delete: models.Product) -> models
     )
     db.session.delete(to_delete)
 
+    db.session.flush()
+
     return to_keep
 
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -38,6 +38,7 @@ from pcapi.core.offers import repository as offers_repository
 from pcapi.core.offers import schemas as offers_schemas
 from pcapi.core.offers.exceptions import NotUpdateProductOrOffers
 from pcapi.core.offers.exceptions import ProductNotFound
+import pcapi.core.offers.factories as offers_factories
 from pcapi.core.providers.allocine import get_allocine_products_provider
 import pcapi.core.providers.factories as providers_factories
 import pcapi.core.providers.repository as providers_repository
@@ -4446,14 +4447,23 @@ class CreateMovieProductFromProviderTest:
 
     def test_updates_product_if_exists(self):
         # Given
-        product = factories.ProductFactory(extraData={"allocineId": 12345})
-        movie = self._get_movie(allocine_id="12345")
+        allocine_id = 12345
+        visa = "67890"
+
+        allocine_movie = factories.ProductFactory(extraData={"allocineId": allocine_id})
+        random_movie_with_visa = factories.ProductFactory(extraData={"visa": visa})
+
+        movie = self._get_movie(allocine_id=str(allocine_id), visa=visa)
+        offer = offers_factories.OfferFactory(product=random_movie_with_visa)
 
         # When
         api.upsert_movie_product_from_provider(movie, self.allocine_provider, "idAllocine")
 
         # Then
-        assert product.lastProvider.id == self.allocine_provider.id
+        assert allocine_movie.lastProvider.id == self.allocine_provider.id
+
+        db.session.refresh(offer)
+        offer.productId == allocine_movie.id
 
     def test_does_not_update_allocine_product_from_non_allocine_synchro(self):
         # Given


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34125

Tentative de fix d'un bug difficile à reproduire lors de la fusion de deux produits qui a lieu lors de la synchronisation d'offres de cinéma.
Il semblerait qu'avec les transactions, les flush, etc. on puisse se retrouver dans un état étrange où l'offre est censée être rattachée au nouveau produit... mais pas vraiment.

Je n'ai pas réussi à reproduire le bug en local mais vu la différence entre les tests et la production à ce niveau-là, je ne suis pas certain que ce soit possible.

Et vu le contexte de l'erreur, j'espère que ce simple flush() suffira. A voir... au moins, ça ne devrait rien casser.
