### PR TITLE
(PC-34344)[API] feat: add a dummy webhook for ubble

### DIFF
--- a/api/src/pcapi/routes/external/users_subscription.py
+++ b/api/src/pcapi/routes/external/users_subscription.py
@@ -28,6 +28,15 @@ def dms_webhook_update_application_status(form: dms_validation.DMSWebhookRequest
     dms_subscription_api.handle_dms_application(dms_application)
 
 
+@public_api.route("/webhooks/ubble/dummy", methods=["POST"])
+@spectree_serialize(
+    on_success_status=200,
+    response_model=ubble_serializers.WebhookDummyReponse,  # type: ignore[arg-type]
+)
+def dummy_webook_ubble_v2(body: ubble_serializers.WebhookBodyV2) -> ubble_serializers.WebhookDummyReponse:
+    return ubble_serializers.WebhookDummyReponse()
+
+
 @public_api.route("/webhooks/ubble/v2/application_status", methods=["POST"])
 @ubble_validation.require_ubble_v2_signature
 @spectree_serialize(

--- a/api/tests/core/subscription/ubble/end_to_end/test_subscription_via_ubble.py
+++ b/api/tests/core/subscription/ubble/end_to_end/test_subscription_via_ubble.py
@@ -199,6 +199,12 @@ class UbbleV2EndToEndTest:
         assert response.status_code == 204, response.json
 
 
+class UbbleDummyWebhookTest:
+    def test_dummy_webhook_with_data(self, ubble_client):
+        response = ubble_client.post("/webhooks/ubble/dummy", json=fixtures.ID_VERIFICATION_APPROVED_WEBHOOK_BODY)
+        assert response.status_code == 200
+
+
 @pytest.mark.usefixtures("db_session")
 class UbbleEndToEndTest:
     def _get_ubble_webhook_signature(self, payload):


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34344

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
