### PR TITLE
(PC-34418)[ADAGE] feat: block booking creation in adage iframe route …

### DIFF
--- a/api/src/pcapi/routes/adage_iframe/bookings.py
+++ b/api/src/pcapi/routes/adage_iframe/bookings.py
@@ -29,6 +29,9 @@ logger = logging.getLogger(__name__)
 def book_collective_offer(
     body: BookCollectiveOfferRequest, authenticated_information: AuthenticatedInformation
 ) -> BookCollectiveOfferResponse:
+    if not authenticated_information.canPrebook:
+        raise ApiErrors({"global": "Could not book offer: not allowed"}, status_code=403)
+
     institution = find_educational_institution_by_uai_code(authenticated_information.uai)
     educational_utils.log_information_for_data_purpose(
         event_name="BookingConfirmationButtonClick",

--- a/api/tests/routes/adage_iframe/utils_create_test_token.py
+++ b/api/tests/routes/adage_iframe/utils_create_test_token.py
@@ -76,6 +76,7 @@ def create_adage_valid_token_with_email(
     uai: str = "EAU123",
     lat: float | None = None,
     lon: float | None = None,
+    can_prebook: bool | None = None,
 ) -> bytes:
     return create_adage_jwt_fake_valid_token(
         civility=civility,
@@ -86,6 +87,7 @@ def create_adage_valid_token_with_email(
         expiration_date=datetime.utcnow() + timedelta(days=1),
         lat=lat,
         lon=lon,
+        can_prebook=can_prebook,
     )
 
 


### PR DESCRIPTION
…when canPrebook is not True

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34418

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
