### PR TITLE
(PC-34357)[API] fix: use postal code sent by provider if address not found on BAN API

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/addresses.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/addresses.py
@@ -99,7 +99,10 @@ def search_addresses(query: AddressModel) -> SearchAddressResponse:
         addresses = geography_repository.search_addresses(
             street=query.street,
             city=municipality_address.city,  # we use normalized data for `city`
-            postal_code=municipality_address.postcode,  # we use normalized data for `postal_code`
+            # we use the postal sent by the client because in the case of a big city like Paris or Lyon
+            # `api_adresse.get_municipality_centroid` returns a default postal code (the postal code of the
+            # 1st neighborhood) which might lead to incoherent addresses
+            postal_code=query.postalCode,
             latitude=query.latitude,
             longitude=query.longitude,
         )
@@ -163,11 +166,14 @@ def create_address(body: AddressModel) -> AddressResponse:
         location_data = offerers_api.LocationData(
             # Data coming from the BAN API
             city=municipality_address.city,
-            postal_code=municipality_address.postcode,
             insee_code=municipality_address.citycode,
             ban_id=None,
             # Data coming from the request body
             street=body.street,
+            # we use the postal sent by the client because in the case of a big city like Paris or Lyon
+            # `api_adresse.get_municipality_centroid` returns a default postal code (the postal code of the
+            # 1st neighborhood) which might lead to incoherent addresses
+            postal_code=body.postalCode,
             latitude=body.latitude,
             longitude=body.longitude,
         )


### PR DESCRIPTION
To prevent incoherent addresses in case of big cities

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34357

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
