### PR TITLE
(BSR)[API] chore: rename chronicle.formId to chronicle.externalId

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-8ee08df65b28 (pre) (head)
-7d06482102c6 (post) (head)
+a534059325fe (pre) (head)
+117b23c66633 (post) (head)

--- a/api/src/pcapi/alembic/versions/20250205T140815_a534059325fe_create_chronicle_external_id_column.py
+++ b/api/src/pcapi/alembic/versions/20250205T140815_a534059325fe_create_chronicle_external_id_column.py
@@ -1,0 +1,20 @@
+"""create column chronicle.externalId"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "a534059325fe"
+down_revision = "8ee08df65b28"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("chronicle", sa.Column("externalId", sa.Text()))
+
+
+def downgrade() -> None:
+    op.drop_column("chronicle", "externalId")

--- a/api/src/pcapi/alembic/versions/20250205T141711_8e97f8429b91_set_chronicle_external_id_not_null.py
+++ b/api/src/pcapi/alembic/versions/20250205T141711_8e97f8429b91_set_chronicle_external_id_not_null.py
@@ -1,0 +1,24 @@
+"""set chronicle.externalId to not null"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "8e97f8429b91"
+down_revision = "7d06482102c6"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute('UPDATE chronicle SET "externalId"="formId" WHERE "externalId" is NULL;')
+    op.alter_column("chronicle", "externalId", existing_type=sa.TEXT(), nullable=False)
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.create_unique_constraint("ix_chronicle_externalId", "chronicle", ["externalId"])
+
+
+def downgrade() -> None:
+    op.drop_constraint("ix_chronicle_externalId", "chronicle", type_="unique")
+    op.alter_column("chronicle", "externalId", existing_type=sa.TEXT(), nullable=True)

--- a/api/src/pcapi/alembic/versions/20250205T142335_117b23c66633_drop_column_chronicle_formId.py
+++ b/api/src/pcapi/alembic/versions/20250205T142335_117b23c66633_drop_column_chronicle_formId.py
@@ -1,0 +1,23 @@
+"""drom column chronicle.formId"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "117b23c66633"
+down_revision = "8e97f8429b91"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("ix_chronicle_formId", "chronicle", type_="unique")
+    op.drop_column("chronicle", "formId")
+
+
+def downgrade() -> None:
+    op.add_column("chronicle", sa.Column("formId", sa.TEXT(), autoincrement=False, nullable=False))
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.create_unique_constraint("ix_chronicle_formId", "chronicle", ["formId"])

--- a/api/src/pcapi/core/chronicles/api.py
+++ b/api/src/pcapi/core/chronicles/api.py
@@ -117,7 +117,7 @@ def save_book_club_chronicle(form: typeform.TypeformResponse) -> None:
                 eanChoiceId=ean_choice_id,
                 email=form.email,
                 firstName=answer_dict.get(constants.BookClub.NAME_ID.value, EMPTY_ANSWER).text,
-                formId=form.response_id,
+                externalId=form.response_id,
                 isIdentityDiffusible=is_identity_diffusible,
                 isSocialMediaDiffusible=is_social_media_diffusible,
                 products=products,

--- a/api/src/pcapi/core/chronicles/factories.py
+++ b/api/src/pcapi/core/chronicles/factories.py
@@ -13,4 +13,4 @@ class ChronicleFactory(BaseFactory):
 
     content = "A small chronicle content."
     email = factory.Sequence("chronicle-{}@example.com".format)
-    formId = factory.Sequence(lambda x: sha1(bytes(x)).hexdigest()[0:12])
+    externalId = factory.Sequence(lambda x: sha1(bytes(x)).hexdigest()[0:12])

--- a/api/src/pcapi/core/chronicles/models.py
+++ b/api/src/pcapi/core/chronicles/models.py
@@ -34,7 +34,7 @@ class Chronicle(PcObject, Base, Model, DeactivableMixin):
     eanChoiceId = sa.Column(sa.Text(), nullable=True)
     email = sa.Column(sa.Text(), nullable=False)
     firstName = sa.Column(sa.Text(), nullable=True)
-    formId = sa.Column(sa.Text(), nullable=False, unique=True)
+    externalId = sa.Column(sa.Text(), nullable=False, unique=True)
     isIdentityDiffusible = sa.Column(
         sa.Boolean, nullable=False, server_default=sa.sql.expression.false(), default=False
     )

--- a/api/tests/core/chronicles/test_api.py
+++ b/api/tests/core/chronicles/test_api.py
@@ -213,7 +213,7 @@ class SaveBookClubChronicleTest:
         assert chronicle.isIdentityDiffusible
         assert chronicle.isSocialMediaDiffusible
         assert not chronicle.isActive
-        assert chronicle.formId == form.response_id
+        assert chronicle.externalId == form.response_id
         assert chronicle.userId is None
 
     def test_save_book_club_chronicle_empty(self):
@@ -250,7 +250,7 @@ class SaveBookClubChronicleTest:
         assert not chronicle.isIdentityDiffusible
         assert not chronicle.isSocialMediaDiffusible
         assert not chronicle.isActive
-        assert chronicle.formId == form.response_id
+        assert chronicle.externalId == form.response_id
         assert chronicle.userId is None
 
     def test_do_not_save_book_club_chronicle_without_email(self):
@@ -419,7 +419,7 @@ class SaveBookClubChronicleTest:
         ean = "1234567890123"
         ean_choice_id = random_string()
         form = typeform.TypeformResponse(
-            response_id=old_chronicle.formId,
+            response_id=old_chronicle.externalId,
             date_submitted=datetime.datetime(2024, 10, 24),
             phone_number=None,
             email="email@mail.test",

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -3120,7 +3120,7 @@ def generate_minimal_beneficiary():
             dateCreated=now,
             content="",
             email="",
-            formId="",
+            externalId="",
         )
     )
     db.session.add(


### PR DESCRIPTION
## But de la pull request

Renommer chronicle.formId en chronicle.externalId par cohérence avec le reste de la bdd. On  profite du fait que la table soit encore petite pour pouvoir le faire facilement.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
