### PR TITLE
(BSR)[PRO] fix: Flaky test depending on order

### DIFF
--- a/api/tests/routes/pro/get_venues_test.py
+++ b/api/tests/routes/pro/get_venues_test.py
@@ -129,16 +129,18 @@ def test_response_serialization(client):
 def test_response_created_offer_serialization(client):
     user_offerer = offerers_factories.UserOffererFactory()
 
-    venue_with_offer = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+    venue_with_offer = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer, name="venue 1")
     OfferFactory(venue=venue_with_offer)
 
-    venue_with_collective_offer = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+    venue_with_collective_offer = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer, name="venue 2")
     CollectiveOfferFactory(venue=venue_with_collective_offer)
 
-    venue_with_collective_offer_template = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+    venue_with_collective_offer_template = offerers_factories.VenueFactory(
+        managingOfferer=user_offerer.offerer, name="venue 3"
+    )
     CollectiveOfferTemplateFactory(venue=venue_with_collective_offer_template)
 
-    offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+    offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer, name="venue 4")
 
     client = client.with_session_auth(user_offerer.user.email)
     num_queries = testing.AUTHENTICATION_QUERIES


### PR DESCRIPTION
## But de la pull request

Dans certain cas de sequence nous avons un ordre alphabetique qui n'est pas respecter :
"Le Petit Rintintin 99" > "Le Petit Rintintin 98" > "Le Petit Rintintin 100"

Exemple de run en erreur https://github.com/pass-culture/pass-culture-main/actions/runs/13159480726

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
