### PR TITLE
(PC-34397)[PRO] feat: use localStorage to never display headline offer banner again once closed

### DIFF
--- a/pro/src/pages/IndividualOffers/IndividualOffers.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffers.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import useSWR from 'swr'
@@ -21,13 +20,13 @@ import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { selectCurrentOffererId } from 'commons/store/offerer/selectors'
 import { sortByLabel } from 'commons/utils/strings'
 import { getStoredFilterConfig } from 'components/OffersTable/OffersTableSearch/utils'
+import { IndividualOffersContextProvider } from 'pages/IndividualOffers/context/IndividualOffersContext'
 import {
   formatAndOrderAddresses,
   formatAndOrderVenues,
 } from 'repository/venuesService'
 import { Spinner } from 'ui-kit/Spinner/Spinner'
 
-import { IndividualOffersContextProvider } from './context/IndividualOffersContext'
 import { HeadlineOfferBanner } from './IndividualOffersContainer/components/HeadlineOfferBanner/HeadlineOfferBanner'
 import { IndividualOffersContainer } from './IndividualOffersContainer/IndividualOffersContainer'
 import { computeIndividualApiFilters } from './utils/computeIndividualApiFilters'
@@ -50,8 +49,6 @@ export const IndividualOffers = (): JSX.Element => {
   const selectedOffererId = useSelector(selectCurrentOffererId)
   const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
   const isHeadlineOfferEnabled = useActiveFeature('WIP_HEADLINE_OFFER')
-  const [isHeadlineOfferBannerOpen, setIsHeadlineOfferBannerOpen] =
-    useState(true)
 
   const categoriesQuery = useSWR(
     [GET_CATEGORIES_QUERY_KEY],
@@ -133,28 +130,21 @@ export const IndividualOffers = (): JSX.Element => {
   })
 
   const offers = offersQuery.error ? [] : offersQuery.data || []
+  const isHeadlineOfferBannerAvailable =
+    isHeadlineOfferEnabled &&
+    isHeadlineOfferAllowedForOfferer
 
   return (
-    <Layout
-      mainHeading="Offres individuelles"
-      mainBanner={
-        isHeadlineOfferEnabled &&
-        isHeadlineOfferAllowedForOfferer &&
-        isHeadlineOfferBannerOpen && (
-          <HeadlineOfferBanner
-            close={() => {
-              setIsHeadlineOfferBannerOpen(false)
-            }}
-          />
-        )
-      }
+    <IndividualOffersContextProvider
+      isHeadlineOfferAllowedForOfferer={isHeadlineOfferAllowedForOfferer}
     >
-      {isLoadingVenues || isValidatingVenues ? (
-        <Spinner />
-      ) : (
-        <IndividualOffersContextProvider
-          isHeadlineOfferAllowedForOfferer={isHeadlineOfferAllowedForOfferer}
-        >
+      <Layout
+        mainHeading="Offres individuelles"
+        mainBanner={isHeadlineOfferBannerAvailable && <HeadlineOfferBanner />}
+      >
+        {isLoadingVenues || isValidatingVenues ? (
+          <Spinner />
+        ) : (
           <IndividualOffersContainer
             categories={categoriesOptions}
             currentPageNumber={currentPageNumber}
@@ -165,9 +155,9 @@ export const IndividualOffers = (): JSX.Element => {
             venues={venues}
             offererAddresses={offererAddresses}
           />
-        </IndividualOffersContextProvider>
-      )}
-    </Layout>
+        )}
+      </Layout>
+    </IndividualOffersContextProvider>
   )
 }
 

--- a/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/HeadlineOfferBanner/HeadlineOfferBanner.spec.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/HeadlineOfferBanner/HeadlineOfferBanner.spec.tsx
@@ -11,7 +11,7 @@ const renderHeadlineOfferBaner = () => {
     <Routes>
       <Route
         path="/"
-        element={<HeadlineOfferBanner close={() => {}}/>}
+        element={<HeadlineOfferBanner />}
       />
     </Routes>
   )

--- a/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/HeadlineOfferBanner/HeadlineOfferBanner.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/HeadlineOfferBanner/HeadlineOfferBanner.tsx
@@ -1,4 +1,5 @@
 import strokeCloseIcon from 'icons/stroke-close.svg'
+import { useIndividualOffersContext } from 'pages/IndividualOffers/context/IndividualOffersContext'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 
@@ -6,11 +7,14 @@ import imgHeadlineOffer from './assets/headlineOffer.png'
 import { HeadlineOfferInformationDialog } from './components/HeadlineOfferInformationDialog'
 import styles from './HeadlineOfferBanner.module.scss'
 
-type HeadlineOfferBannerProps = {
-  close: () => void
-}
+export const HeadlineOfferBanner = () => {
+  const { isHeadlineOfferBannerOpen, closeHeadlineOfferBanner } = useIndividualOffersContext()
 
-export const HeadlineOfferBanner = ({ close }: HeadlineOfferBannerProps) => {
+  if (!isHeadlineOfferBannerOpen) {
+    return null
+  }
+
+
   return (
     <div className={styles['headline-offer-banner']}>
       <div className={styles['headline-offer-text-container']}>
@@ -36,7 +40,7 @@ export const HeadlineOfferBanner = ({ close }: HeadlineOfferBannerProps) => {
           variant={ButtonVariant.TERNARY}
           icon={strokeCloseIcon}
           iconAlt="Fermer la bannière"
-          onClick={close}
+          onClick={closeHeadlineOfferBanner}
         />
       </div>
     </div>

--- a/pro/src/pages/IndividualOffers/context/IndividualOffersContext.spec.tsx
+++ b/pro/src/pages/IndividualOffers/context/IndividualOffersContext.spec.tsx
@@ -1,0 +1,384 @@
+import { screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+
+
+import { api } from 'apiClient/api'
+import * as useAnalytics from 'app/App/analytics/firebase'
+import { GET_OFFERER_HEADLINE_OFFER_QUERY_KEY } from 'commons/config/swrQueryKeys'
+import { Events } from 'commons/core/FirebaseEvents/constants'
+import * as useNotification from 'commons/hooks/useNotification'
+import {
+  currentOffererFactory,
+} from 'commons/utils/factories/storeFactories'
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
+
+import {
+  LOCAL_STORAGE_HEADLINE_OFFER_BANNER_CLOSED_KEY,
+  IndividualOffersContextProvider,
+  IndividualOffersContextProviderProps,
+  useIndividualOffersContext
+} from "./IndividualOffersContext"
+
+const LABELS = {
+  display: {
+    headlineOffer: 'Headline Offer Id',
+    isHeadlineOfferAllowedForOfferer: 'Is Headline Offer Allowed For Offerer',
+    isHeadlineOfferBannerOpen: 'Is Headline Offer Banner Open',
+  },
+  controls: {
+    upsertHeadlineOffer: 'Upsert Headline Offer',
+    removeHeadlineOffer: 'Delete Headline Offer',
+    closeHeadlineOfferBanner: 'Close Headline Offer Banner',
+  },
+  notify: {
+    upsert: {
+      success: 'Votre offre a été mise à la une !',
+      error: 'Une erreur s’est produite lors de l’ajout de votre offre à la une',
+    },
+    delete: {
+      success: 'Votre offre n’est plus à la une',
+      error: 'Une erreur s’est produite lors du retrait de votre offre à la une',
+    }
+  }
+}
+
+const MOCK_DATA = {
+  offerer: currentOffererFactory(),
+  headlineOffer: {
+    id: 1,
+    name: 'Offre à la une',
+    venueId: 1,
+  },
+  newHeadlineOffer: {
+    id: 2,
+    name: 'Nouvelle offre à la une',
+    venueId: 1,
+  }
+}
+
+vi.mock('apiClient/api', () => ({
+  api: {
+    getOffererHeadlineOffer: vi.fn(),
+    upsertHeadlineOffer: vi.fn(),
+    deleteHeadlineOffer: vi.fn(),
+  }
+}))
+
+const mockMutate = vi.fn()
+vi.mock('swr', async () => ({
+  ...(await vi.importActual('swr')),
+  useSWRConfig: vi.fn(() => ({
+    mutate: mockMutate,
+  })),
+}))
+
+const TestComponent = () => {
+  const {
+    headlineOffer,
+    upsertHeadlineOffer,
+    removeHeadlineOffer,
+    isHeadlineOfferBannerOpen,
+    closeHeadlineOfferBanner,
+    isHeadlineOfferAllowedForOfferer,
+  } = useIndividualOffersContext()
+
+  return <>
+    <h1>Test Component</h1>
+    <div id="display">
+      <span>{LABELS.display.headlineOffer}: {headlineOffer ? headlineOffer.id : 'null'}</span>
+      <span>{LABELS.display.isHeadlineOfferAllowedForOfferer}: {isHeadlineOfferAllowedForOfferer ? 'true' : 'false'}</span>
+      <span>{LABELS.display.isHeadlineOfferBannerOpen}: {isHeadlineOfferBannerOpen ? 'true' : 'false'}</span>
+    </div>
+    <div id="controls">
+      <button onClick={() => upsertHeadlineOffer({
+        offerId: MOCK_DATA.newHeadlineOffer.id,
+        context: { actionType: 'add' }
+      })}>{LABELS.controls.upsertHeadlineOffer}</button>
+      <button onClick={removeHeadlineOffer}>{LABELS.controls.removeHeadlineOffer}</button>
+      <button onClick={closeHeadlineOfferBanner}>{LABELS.controls.closeHeadlineOfferBanner}</button>
+    </div>
+  </>
+}
+
+type IndividualOffersContextProviderTestProps = Partial<IndividualOffersContextProviderProps> & {
+  isFeatureEnabled?: boolean
+}
+
+const renderIndividualOffersContext = ({
+  isFeatureEnabled = true,
+  isHeadlineOfferAllowedForOfferer = true
+}: IndividualOffersContextProviderTestProps = {}) => {
+  return renderWithProviders(
+    <IndividualOffersContextProvider
+      isHeadlineOfferAllowedForOfferer={isHeadlineOfferAllowedForOfferer}
+    >
+      <TestComponent />
+    </IndividualOffersContextProvider>, 
+    {
+      features: [
+        ...(isFeatureEnabled ? ['WIP_HEADLINE_OFFER'] : [])
+      ],
+       storeOverrides: {
+        offerer: MOCK_DATA.offerer,
+      },
+    }
+  )
+}
+
+describe('IndividualOffersContext', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'getOffererHeadlineOffer').mockResolvedValue(MOCK_DATA.headlineOffer)
+    localStorage.clear()
+  })
+
+  describe('should tell if headline offer is available as a feature', () => {
+    // FIXME: isHeadlineOfferAvailable as a combination of
+    // isHeadlineOfferAllowedForOfferer and isFeatureEnabled should be 
+    // exported instead of isHeadlineOfferAllowedForOfferer alone.
+    // it('should be available if feature is enabled and offerer is allowed to use it', () => {})
+    // it('should not be available if feature is disabled', () => {})
+    // it('should not be available if offerer is not allowed to use it', () => {})
+  
+    // FIXME: we would like to manage isHeadlineOfferAllowedForOfferer in
+    // the context itself. This test should be rewritten.
+    it('should be available if offerer is allowed to use it', async () => {
+      renderIndividualOffersContext({ isHeadlineOfferAllowedForOfferer: true })
+
+      const display = await screen.findByText(new RegExp(LABELS.display.isHeadlineOfferAllowedForOfferer))
+      expect(display).toBeTruthy()
+    })
+  })
+
+  it('should fetch headline offer and make it available', async () => {
+    renderIndividualOffersContext()
+
+    const display = await screen.findByText(new RegExp(LABELS.display.headlineOffer))
+    expect(display.textContent).toContain(MOCK_DATA.headlineOffer.id)
+  })
+
+  describe('upsertHeadlineOffer', () => {
+    it('should upsert headline offer and update state', async () => {
+      renderIndividualOffersContext()
+
+      const upsertButton = await screen.findByRole('button', {
+        name: new RegExp(LABELS.controls.upsertHeadlineOffer)
+      })
+      await userEvent.click(upsertButton)
+
+      await waitFor(() => {
+        expect(api.upsertHeadlineOffer).toHaveBeenCalledWith({
+          offerId: MOCK_DATA.newHeadlineOffer.id
+        })
+      })
+
+      // We are not testing display update since this happens after a re-render,
+      // which is triggered by the SWR mutate function on GET_OFFERER_HEADLINE_OFFER_QUERY_KEY.
+      // This would be like testing the SWR library itself & its none of our concern.
+      // Yet, we expect the mutation to be called.
+      expect(mockMutate).toHaveBeenCalledWith([
+        GET_OFFERER_HEADLINE_OFFER_QUERY_KEY,
+        MOCK_DATA.offerer.selectedOffererId
+      ])
+    })
+
+    describe('about notifications', () => {
+      it('should notify success on successful upsert', async () => {
+        let notifySuccess = vi.fn()
+        vi.spyOn(useNotification, 'useNotification').mockImplementation(() => ({
+          success: notifySuccess,
+          error: vi.fn(),
+          information: vi.fn(),
+          pending: vi.fn(),
+          close: vi.fn(),
+        }))
+
+        renderIndividualOffersContext()
+  
+        const upsertButton = await screen.findByRole('button', {
+          name: new RegExp(LABELS.controls.upsertHeadlineOffer)
+        })
+        await userEvent.click(upsertButton)
+  
+        expect(notifySuccess).toHaveBeenCalledWith(LABELS.notify.upsert.success)
+      })
+
+      it('should notify error on failed upsert', async () => {
+        let notifyError = vi.fn()
+        vi.spyOn(useNotification, 'useNotification').mockImplementation(() => ({
+          success: vi.fn(),
+          error: notifyError,
+          information: vi.fn(),
+          pending: vi.fn(),
+          close: vi.fn(),
+        }))
+        vi.spyOn(api, 'upsertHeadlineOffer').mockRejectedValue('PLONK')
+
+        renderIndividualOffersContext()
+
+        const upsertButton = await screen.findByRole('button', {
+          name: new RegExp(LABELS.controls.upsertHeadlineOffer)
+        })
+        await userEvent.click(upsertButton)
+
+        expect(notifyError).toHaveBeenCalledWith(LABELS.notify.upsert.error)
+      })
+    })
+  
+    it('should log event on successful upsert', async () => {
+      let logEvent = vi.fn()
+      vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
+        logEvent
+      }))
+
+      renderIndividualOffersContext()
+
+      const upsertButton = await screen.findByRole('button', {
+        name: new RegExp(LABELS.controls.upsertHeadlineOffer)
+      })
+      await userEvent.click(upsertButton)
+
+      expect(logEvent).toHaveBeenCalledWith(Events.CLICKED_CONFIRMED_ADD_HEADLINE_OFFER, {
+        from: '/',
+        actionType: 'add',
+        requiredImageUpload: false,
+      })
+    })
+
+    it('should close headline offer banner on successful upsert', async () => {
+      renderIndividualOffersContext()
+
+      const display = await screen.findByText(new RegExp(LABELS.display.isHeadlineOfferBannerOpen))
+      expect(display.textContent).toContain('true')
+
+      const upsertButton = await screen.findByRole('button', {
+        name: new RegExp(LABELS.controls.upsertHeadlineOffer)
+      })
+      await userEvent.click(upsertButton)
+
+      await waitFor(async () => {
+        const updatedDisplay = await screen.findByText(new RegExp(LABELS.display.isHeadlineOfferBannerOpen))
+        expect(updatedDisplay.textContent).toContain('false')
+      })
+    })
+  })
+
+  describe('removeHeadlineOffer', () => {
+    it('should remove headline offer and update state', async () => {
+      renderIndividualOffersContext()
+
+      const removeButton = await screen.findByRole('button', {
+        name: new RegExp(LABELS.controls.removeHeadlineOffer)
+      })
+      await userEvent.click(removeButton)
+
+      await waitFor(() => {
+        expect(api.deleteHeadlineOffer).toHaveBeenCalled()
+      })
+
+      // We are not testing display update since this happens after a re-render,
+      // which is triggered by the SWR mutate function on GET_OFFERER_HEADLINE_OFFER_QUERY_KEY.
+      // This would be like testing the SWR library itself & its none of our concern.
+      // Yet, we expect the mutation to be called.
+      expect(mockMutate).toHaveBeenCalledWith([
+        GET_OFFERER_HEADLINE_OFFER_QUERY_KEY,
+        MOCK_DATA.offerer.selectedOffererId
+      ])
+    })
+
+    describe('about notifications', () => {
+      it('should notify success on successful removal', async () => {
+        let notifySuccess = vi.fn()
+        vi.spyOn(useNotification, 'useNotification').mockImplementation(() => ({
+          success: notifySuccess,
+          error: vi.fn(),
+          information: vi.fn(),
+          pending: vi.fn(),
+          close: vi.fn(),
+        }))
+
+        renderIndividualOffersContext()
+
+        const removeButton = await screen.findByRole('button', {
+          name: new RegExp(LABELS.controls.removeHeadlineOffer)
+        })
+        await userEvent.click(removeButton)
+
+        expect(notifySuccess).toHaveBeenCalledWith(LABELS.notify.delete.success)
+      })
+
+      it('should notify error on failed removal', async () => {
+        let notifyError = vi.fn()
+        vi.spyOn(useNotification, 'useNotification').mockImplementation(() => ({
+          success: vi.fn(),
+          error: notifyError,
+          information: vi.fn(),
+          pending: vi.fn(),
+          close: vi.fn(),
+        }))
+        vi.spyOn(api, 'deleteHeadlineOffer').mockRejectedValue('PLONK')
+
+        renderIndividualOffersContext()
+
+        const removeButton = await screen.findByRole('button', {
+          name: new RegExp(LABELS.controls.removeHeadlineOffer)
+        })
+        await userEvent.click(removeButton)
+
+        expect(notifyError).toHaveBeenCalledWith(LABELS.notify.delete.error)
+      })
+    })
+  
+    it('should log event on successful removal', async () => {
+      let logEvent = vi.fn()
+      vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
+        logEvent
+      }))
+
+      renderIndividualOffersContext()
+
+      const removeButton = await screen.findByRole('button', {
+        name: new RegExp(LABELS.controls.removeHeadlineOffer)
+      })
+      await userEvent.click(removeButton)
+
+      expect(logEvent).toHaveBeenCalledWith(Events.CLICKED_CONFIRMED_ADD_HEADLINE_OFFER, {
+        from: '/',
+        actionType: 'delete',
+      })
+    })
+  })
+
+  describe('closeHeadlineOfferBanner', () => {
+    it('should close headline offer banner and update state', async () => {
+      renderIndividualOffersContext()
+
+      await waitFor(async () => {
+        const display = await screen.findByText(new RegExp(LABELS.display.isHeadlineOfferBannerOpen))
+        expect(display.textContent).toContain('true')
+      })
+
+      const closeButton = await screen.findByRole('button', {
+        name: new RegExp(LABELS.controls.closeHeadlineOfferBanner)
+      })
+      await userEvent.click(closeButton)
+
+      await waitFor(async () => {
+        const updatedDisplay = await screen.findByText(new RegExp(LABELS.display.isHeadlineOfferBannerOpen))
+        expect(updatedDisplay.textContent).toContain('false')
+      })
+    })
+  
+    it('should remember the user choice', async () => {
+      renderIndividualOffersContext()
+
+      expect(localStorage.getItem(LOCAL_STORAGE_HEADLINE_OFFER_BANNER_CLOSED_KEY)).toBeNull()
+
+      const closeButton = await screen.findByRole('button', {
+        name: new RegExp(LABELS.controls.closeHeadlineOfferBanner)
+      })
+      await userEvent.click(closeButton)
+
+      expect(localStorage.getItem(LOCAL_STORAGE_HEADLINE_OFFER_BANNER_CLOSED_KEY)).toBe('true')
+    })
+  })
+})

--- a/pro/src/pages/IndividualOffers/context/IndividualOffersContext.tsx
+++ b/pro/src/pages/IndividualOffers/context/IndividualOffersContext.tsx
@@ -14,7 +14,7 @@ import { useNotification } from 'commons/hooks/useNotification'
 import { selectCurrentOffererId } from 'commons/store/offerer/selectors'
 import { storageAvailable } from 'commons/utils/storageAvailable'
 
-const LOCAL_STORAGE_HEADLINE_OFFER_BANNER_CLOSED_KEY = 'headlineOfferBannerClosed'
+export const LOCAL_STORAGE_HEADLINE_OFFER_BANNER_CLOSED_KEY = 'headlineOfferBannerClosed'
 
 type UpsertHeadlineOfferParams = {
   offerId: number
@@ -46,7 +46,7 @@ export const useIndividualOffersContext = () => {
   return useContext(IndividualOffersContext)
 }
 
-type IndividualOffersContextProviderProps = {
+export type IndividualOffersContextProviderProps = {
   children: React.ReactNode
   isHeadlineOfferAllowedForOfferer: boolean
 }
@@ -126,7 +126,7 @@ export function IndividualOffersContextProvider({
         await api.deleteHeadlineOffer({ offererId: selectedOffererId })
         notify.success('Votre offre n’est plus à la une')
         await mutate([GET_OFFERER_HEADLINE_OFFER_QUERY_KEY, selectedOffererId])
-        setHeadlineOffer(null)
+
         logEvent(Events.CLICKED_CONFIRMED_ADD_HEADLINE_OFFER, {
           from: location.pathname,
           actionType: 'delete',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34397

## Objectifs 
- Ajout du localStorage pour mémoriser la fermeture.
- Fermer la bannière lorsqu'une offre est mise en avant.

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~
- [X] J'ai fait la revue fonctionnelle de mon ticket
