### PR TITLE
Pc 34260 drawer

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventCreation/AddRecurrencesButton.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/AddRecurrencesButton.tsx
@@ -47,6 +47,7 @@ export const AddRecurrencesButton = ({
       <DialogBuilder
         onOpenChange={setIsRecurrenceModalOpen}
         open={isRecurrenceModalOpen}
+        variant="drawer"
         trigger={
           <Button
             variant={ButtonVariant.PRIMARY}

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.module.scss
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.module.scss
@@ -1,6 +1,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/variables/_z-index.scss" as zIndex;
 @use "styles/mixins/_size.scss" as size;
+@use "styles/mixins/_fonts.scss" as fonts;
 
 $drawer-width: rem.torem(684px);
 $animation-duration: 0.15s;
@@ -24,6 +25,22 @@ $animation-timing-function: ease-in-out;
   to {
     background-color: rgb(0 0 0 / 33%);
   }
+}
+
+.dialog-builder-title {
+  @include fonts.title3;
+}
+
+.dialog-builder-section {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.dialog-builder-footer {
+  border-top: rem.torem(1px) solid var(--color-grey-medium);
+  padding-top: rem.torem(24px);
 }
 
 .dialog-builder-overlay {
@@ -61,10 +78,10 @@ $animation-timing-function: ease-in-out;
 
 .dialog-builder-overlay-drawer > .dialog-builder-content {
   border-radius: 0;
-  height: 100vh;
   width: $drawer-width;
   max-width: 100vw;
   margin: 0;
+  height: 100%;
 
   @media not (prefers-reduced-motion) {
     &[data-state="open"] {

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.module.scss
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.module.scss
@@ -2,6 +2,30 @@
 @use "styles/variables/_z-index.scss" as zIndex;
 @use "styles/mixins/_size.scss" as size;
 
+$drawer-width: rem.torem(684px);
+$animation-duration: 0.15s;
+$animation-timing-function: ease-in-out;
+
+@keyframes slidein {
+  from {
+    transform: translate($drawer-width);
+  }
+
+  to {
+    transform: translate(0);
+  }
+}
+
+@keyframes fadein {
+  from {
+    background-color: transparent;
+  }
+
+  to {
+    background-color: rgb(0 0 0 / 33%);
+  }
+}
+
 .dialog-builder-overlay {
   background-color: rgb(0 0 0 / 33%);
   display: grid;
@@ -12,6 +36,14 @@
   width: 100vw;
   inset: 0;
   overflow: auto;
+
+  @media not (prefers-reduced-motion) {
+    &[data-state="open"] {
+      animation-duration: $animation-duration;
+      animation-name: fadein;
+      animation-timing-function: $animation-timing-function;
+    }
+  }
 }
 
 .dialog-builder-content {
@@ -21,6 +53,26 @@
   width: initial;
   margin: rem.torem(32px) auto;
   padding: rem.torem(16px);
+}
+
+.dialog-builder-overlay-drawer {
+  justify-content: flex-end;
+}
+
+.dialog-builder-overlay-drawer > .dialog-builder-content {
+  border-radius: 0;
+  height: 100vh;
+  width: $drawer-width;
+  max-width: 100vw;
+  margin: 0;
+
+  @media not (prefers-reduced-motion) {
+    &[data-state="open"] {
+      animation-duration: $animation-duration;
+      animation-name: slidein;
+      animation-timing-function: $animation-timing-function;
+    }
+  }
 }
 
 .dialog-builder-close-container {

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.spec.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.spec.tsx
@@ -1,0 +1,76 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant } from 'ui-kit/Button/types'
+
+import { DialogBuilder, DialogBuilderProps } from './DialogBuilder'
+
+const defaultProps: DialogBuilderProps = {
+  children: <p>Dialog content</p>,
+  title: 'Dialog title',
+  trigger: <Button>Open the dialog</Button>,
+  footer: (
+    <div>
+      <Dialog.Close asChild>
+        <Button variant={ButtonVariant.SECONDARY}>Annuler</Button>
+      </Dialog.Close>
+      <Dialog.Close asChild>
+        <Button>Continuer</Button>
+      </Dialog.Close>
+    </div>
+  ),
+}
+
+function renderDialogBuilder(props = defaultProps) {
+  return render(<DialogBuilder {...props}>{props.children}</DialogBuilder>)
+}
+
+describe('DialogBuilder', () => {
+  it('should open a dialog with a title and a footer', async () => {
+    renderDialogBuilder()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Open the dialog' })
+    )
+    expect(
+      screen.getByRole('heading', { name: 'Dialog title' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Continuer' })
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Annuler' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Fermer la modale' })
+    ).toBeInTheDocument()
+  })
+
+  it('should close the dialog when clicking the close button', async () => {
+    renderDialogBuilder()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Open the dialog' })
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Fermer la modale' })
+    )
+    expect(
+      screen.queryByRole('heading', { name: 'Dialog title' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should close the dialog when clicking outside the dialog', async () => {
+    renderDialogBuilder()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Open the dialog' })
+    )
+
+    await userEvent.click(screen.getByTestId('dialog-overlay'))
+    expect(
+      screen.queryByRole('heading', { name: 'Dialog title' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.spec.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.spec.tsx
@@ -42,7 +42,7 @@ describe('DialogBuilder', () => {
     ).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Annuler' })).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Fermer la modale' })
+      screen.getByRole('button', { name: 'Fermer la fenêtre modale' })
     ).toBeInTheDocument()
   })
 
@@ -54,7 +54,7 @@ describe('DialogBuilder', () => {
     )
 
     await userEvent.click(
-      screen.getByRole('button', { name: 'Fermer la modale' })
+      screen.getByRole('button', { name: 'Fermer la fenêtre modale' })
     )
     expect(
       screen.queryByRole('heading', { name: 'Dialog title' })

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.stories.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.stories.tsx
@@ -23,3 +23,18 @@ export const Default: StoryObj<typeof DialogBuilder> = {
     ),
   },
 }
+
+export const Drawer: StoryObj<typeof DialogBuilder> = {
+  args: {
+    variant: 'drawer',
+    trigger: <Button>Cliquez ici!</Button>,
+    children: (
+      <>
+        <Dialog.Title asChild>
+          <h1>Dialog title</h1>
+        </Dialog.Title>
+        <p>lorem ipsum dolor sit amet</p>
+      </>
+    ),
+  },
+}

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.stories.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.stories.tsx
@@ -2,6 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import type { StoryObj } from '@storybook/react'
 
 import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant } from 'ui-kit/Button/types'
 
 import { DialogBuilder } from './DialogBuilder'
 
@@ -28,13 +29,88 @@ export const Drawer: StoryObj<typeof DialogBuilder> = {
   args: {
     variant: 'drawer',
     trigger: <Button>Cliquez ici!</Button>,
+    title: 'Dialog title',
+    footer: (
+      <div style={{ display: 'flex', gap: '24px' }}>
+        <Dialog.Close asChild>
+          <Button variant={ButtonVariant.SECONDARY}>Annuler</Button>
+        </Dialog.Close>
+        <Dialog.Close asChild>
+          <Button>Continuer</Button>
+        </Dialog.Close>
+      </div>
+    ),
     children: (
       <>
-        <Dialog.Title asChild>
-          <h1>Dialog title</h1>
-        </Dialog.Title>
         <p>lorem ipsum dolor sit amet</p>
       </>
+    ),
+  },
+}
+
+export const DrawerWithLongContent: StoryObj<typeof DialogBuilder> = {
+  args: {
+    variant: 'drawer',
+    trigger: <Button>Cliquez ici!</Button>,
+    title: 'Dialog title',
+    footer: (
+      <div style={{ display: 'flex', gap: '1.5rem' }}>
+        <Dialog.Close asChild>
+          <Button variant={ButtonVariant.SECONDARY}>Annuler</Button>
+        </Dialog.Close>
+        <Dialog.Close asChild>
+          <Button>Continuer</Button>
+        </Dialog.Close>
+      </div>
+    ),
+    children: (
+      <div style={{ padding: '1rem 0' }}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam
+          blandit blandit purus, at suscipit arcu euismod lacinia. Suspendisse
+          sed porttitor arcu, nec consequat sem. Integer eget tincidunt lacus.
+          Nam luctus varius est a aliquam. Maecenas congue turpis a libero
+          pellentesque commodo a in nulla. Aliquam erat volutpat. Morbi non arcu
+          elit. Maecenas dictum at nunc nec dapibus. Donec sollicitudin nisi sed
+          cursus lobortis. Ut arcu odio, varius at elit a, pellentesque
+          scelerisque elit. Suspendisse potenti. Nullam malesuada dolor non
+          iaculis euismod. Praesent vel enim ac eros consectetur tempus. Donec
+          eget nibh nisl.
+        </p>
+        <p>
+          Praesent tempor elementum enim vitae dapibus. Nunc consectetur finibus
+          orci, vel venenatis nisi commodo lacinia. Donec suscipit nibh non
+          pharetra porttitor. In nec arcu ultrices, consequat ex vel,
+          scelerisque eros. Integer porttitor ipsum et urna suscipit, vel
+          hendrerit orci lacinia. In ut facilisis tortor. Suspendisse luctus
+          neque a odio vulputate malesuada ut sit amet nulla. Nam nec ipsum non
+          mauris mollis rutrum. Phasellus vel sem volutpat, pellentesque augue
+          ut, rhoncus eros. Quisque eu tellus ac lorem ornare iaculis.
+        </p>
+        <p>
+          Morbi accumsan maximus justo, eu varius nunc posuere a. Fusce sed
+          lacus a neque rutrum laoreet. Fusce varius bibendum interdum. Nunc
+          consequat ex ac nisi porta ultricies. Curabitur sodales cursus purus,
+          id efficitur orci condimentum eget. Etiam luctus massa id velit
+          volutpat tincidunt. Ut at risus arcu. Nunc semper lacus in sem rhoncus
+          elementum. Cras imperdiet vitae magna scelerisque ornare. Nam nec
+          cursus urna.
+        </p>
+        <p>
+          Aliquam dictum luctus lectus ac dignissim. Cras elementum interdum
+          scelerisque. Cras consectetur purus ex, vel rutrum ante tincidunt non.
+          Sed sapien purus, dignissim non odio sed, efficitur convallis libero.
+          Proin tristique tellus fermentum nisl posuere, sed accumsan dui
+          vulputate. Curabitur consequat rhoncus lacus sit amet consequat.
+          Aliquam maximus, massa quis auctor lacinia, ipsum magna finibus quam,
+          id hendrerit tortor tortor sit amet tortor. Mauris sit amet
+          scelerisque dolor. Nulla facilisi. Cras a sapien vitae dolor euismod
+          posuere in ut sem. Suspendisse vel nibh tortor. Quisque tempus a ex
+          vitae auctor. Donec in viverra leo. Nam eu gravida quam, et feugiat
+          metus. Proin egestas ipsum eget augue porttitor lobortis. Donec vitae
+          quam dui.
+        </p>
+      </div>
     ),
   },
 }

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
@@ -4,6 +4,8 @@ import cn from 'classnames'
 import styles from './DialogBuilder.module.scss'
 import { DialogBuilderCloseButton } from './DialogBuilderCloseButton'
 
+export type DialogVariant = 'default' | 'drawer'
+
 /**
  * Props for the DialogBuilder component.
  */
@@ -34,9 +36,10 @@ type DialogBuilderProps = {
    */
   closeButtonClassName?: string
   /**
-   * Custom CSS class for additional styling of the dialog.
+   * Custom CSS class for additional styling of the dialog content.
    */
   className?: string
+  variant?: DialogVariant
 }
 
 /**
@@ -56,8 +59,8 @@ type DialogBuilderProps = {
  * </DialogBuilder>
  *
  * @accessibility
- * - **Dialog Overlay**: The dialog includes an overlay to ensure the user's focus is directed to the dialog content.
- * - **Keyboard Navigation**: The dialog can be opened and closed using keyboard interactions, ensuring accessibility for all users.
+ * - **Keyboard Navigation**: When using the trigger prop along with the `<Dialog.Close>` tag
+ * around dialog validation buttons, the trigger button will automatically be re-focused on close.
  */
 export function DialogBuilder({
   trigger,
@@ -67,6 +70,7 @@ export function DialogBuilder({
   open,
   closeButtonClassName,
   className,
+  variant = 'default',
 }: DialogBuilderProps) {
   return (
     <Dialog.Root
@@ -76,7 +80,12 @@ export function DialogBuilder({
     >
       {trigger && <Dialog.Trigger asChild>{trigger}</Dialog.Trigger>}
       <Dialog.Portal>
-        <Dialog.Overlay className={styles['dialog-builder-overlay']}>
+        <Dialog.Overlay
+          className={cn(
+            styles['dialog-builder-overlay'],
+            styles[`dialog-builder-overlay-${variant}`]
+          )}
+        >
           <Dialog.Content
             className={cn(styles['dialog-builder-content'], className)}
             aria-describedby={undefined}

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
@@ -111,6 +111,7 @@ export function DialogBuilder({
               // Detect if click actually happened within the bounds of content.
               // This can happen if click was on an absolutely positioned element overlapping content,
               // such as a click on the scroll bar (https://github.com/radix-ui/primitives/issues/1280)
+              /* istanbul ignore next */
               const actuallyClickedInside =
                 e.detail.originalEvent.clientX > contentRect.left &&
                 e.detail.originalEvent.clientX <


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34260

**Objectif**
Créer une variation du dialog qui s'ouvre en mode "drawer"
- Ajout des props title et footer pour a terme centraliser les styles des titres de dialog & du separator + padding du footer
- Fix du click sur la scrollbar qui ferme le dialog dans le cas du drawer

**A noter**
Le formulaire de récurrence a temporairement été mis en "drawer" dans le dernier commit pour permettre à Marion de tester sur l'url de la PR.


<img width="1512" alt="Capture d’écran 2025-02-06 à 11 31 46" src="https://github.com/user-attachments/assets/ba8bc1f7-6413-4151-9fb7-e1113b0094e2" />
<img width="1512" alt="Capture d’écran 2025-02-06 à 11 31 53" src="https://github.com/user-attachments/assets/994ca088-93bb-450a-890c-327199b248ba" />

https://github.com/user-attachments/assets/3dc6cfd5-c0ad-4514-a695-16e23c16883c


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
