### PR TITLE
(BSR)[API] fix: correctly set the debit note's amount when pushing to cegid

### DIFF
--- a/api/src/pcapi/core/finance/backend/base.py
+++ b/api/src/pcapi/core/finance/backend/base.py
@@ -127,7 +127,7 @@ class BaseFinanceBackend:
             res.append(
                 {
                     "product_id": product_id,
-                    "amount": -entry.pricing_amount,
+                    "amount": entry.pricing_amount,
                     "title": TITLES[product_id],
                 }
             )
@@ -175,7 +175,7 @@ class BaseFinanceBackend:
             res.append(
                 {
                     "product_id": product_id,
-                    "amount": -entry.pricing_amount,
+                    "amount": entry.pricing_amount,
                     "title": TITLES[product_id],
                 }
             )

--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -239,10 +239,7 @@ def import_ds_bank_information_applications(ignore_previous: bool = False, since
 @cron_decorators.log_cron_with_transaction
 def push_bank_accounts(count: int) -> None:
     if not FeatureToggle.ENABLE_BANK_ACCOUNT_SYNC:
-        logger.info(
-            "Sync bank account cronjob will not run. "
-            "Both WIP_ENABLE_NEW_FINANCE_WORKFLOW and ENABLE_BANK_ACCOUNT_SYNC features must be activated"
-        )
+        logger.info("Sync bank account cronjob will not run. ENABLE_BANK_ACCOUNT_SYNC feature must be activated")
         return
 
     finance_external.push_bank_accounts(count)


### PR DESCRIPTION
## But de la pull request

Utilisation de la valeur absolue des montants des invoices lors du push vers cegid

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
