### PR TITLE
(PC-34142)[API] fix: edit stock: compare dates without tz

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -647,6 +647,12 @@ class EventStockEdition(BaseStockEdition):
     price_category_id: int | None = fields.PRICE_CATEGORY_ID
     id_at_provider: str | None = fields.ID_AT_PROVIDER_WITH_MAX_LENGTH
 
+    @pydantic_v1.validator("beginning_datetime")
+    def format_beginning_datetime(cls, value: datetime.datetime | None) -> datetime.datetime | None:
+        if not value:
+            return None
+        return serialization_utils.as_utc_without_timezone(value)
+
 
 class EventOfferEdition(OfferEditionBase):
     category_related_fields: event_category_edition_fields | None = pydantic_v1.Field(

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -2,6 +2,7 @@ import copy
 from datetime import date
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 import decimal
 from decimal import Decimal
 import logging


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34142

Fix rapide concernant la mise à jour des stocks.

Avant
Impossible de détecter que la nouvelle date et l'actuelle sont en fait les mêmes : celle qui vient de la base de données n'a pas d'information de fuseau horaire, le paramètre d'entrée de la fonction l'a. 

Après
On retire l'information du fuseau horaire le temps de comparer les deux dates avant de déterminer s'il y a eu un changement à ce niveau-là.
