### PR TITLE
(BSR) docs: Replace logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align=center>
-  <img src="https://pass.culture.fr/wp-content/uploads/2020/11/RVB_PASS_CULTURE_HD.png" style="width: 360px">
+  <img src="https://storage.googleapis.com/passculture-metier-prod-production-assets-fine-grained/assets/passculture.gif" style="width: 360px">
   <br />
   <a href="https://apps.apple.com/fr/app/pass-culture/id1557887412">
     <img src="https://upload.wikimedia.org/wikipedia/commons/4/40/Download_on_the_App_Store_Badge_FRCA_RGB_blk.svg" style="height: 50px">


### PR DESCRIPTION
# Avant
<img width="918" alt="Capture d’écran 2025-02-10 à 12 28 57" src="https://github.com/user-attachments/assets/60c36355-863c-40c3-9afc-265f83bc2c68" />

# Après
<img width="946" alt="Capture d’écran 2025-02-10 à 12 28 41" src="https://github.com/user-attachments/assets/4acad286-dc78-4beb-a087-5ee0f7057f95" />

