### PR TITLE
(PC-34512) ci: Pytest output tweaks

### DIFF
--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -509,7 +509,7 @@ jobs:
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -e SQLALCHEMY_WARN_20 -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests
           run: |
-            pytest ${{ matrix.pytest_args }} --durations=10 --junitxml='/tests/junit.xml' -vv
+            pytest ${{ matrix.pytest_args }} --durations=10 --junitxml='/tests/junit.xml' -vv --color=yes
       - name: "Publish Test Report"
         uses: mikepenz/action-junit-report@v5
         if: always() # always run even if the previous step fails

--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -517,6 +517,7 @@ jobs:
           report_paths: "${{ runner.workspace }}/pass-culture-main/api/tests/junit.xml"
           check_name: "Pytest Report"
           fail_on_failure: true
+          skip_success_summary: true
       - name: "Slack Notification"
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}
         uses: slackapi/slack-github-action@v1.27.0

--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -516,7 +516,7 @@ jobs:
         with:
           report_paths: "${{ runner.workspace }}/pass-culture-main/api/tests/junit.xml"
           check_name: "Pytest Report"
-          fail_on_failure: true
+          fail_on_failure: false
           skip_success_summary: true
       - name: "Slack Notification"
         if: ${{ failure() && github.ref == 'refs/heads/master'  }}

--- a/.github/workflows/dev_on_workflow_tests_api.yml
+++ b/.github/workflows/dev_on_workflow_tests_api.yml
@@ -509,7 +509,7 @@ jobs:
           shell: bash
           options: -e RUN_ENV -e DATABASE_URL_TEST -e REDIS_URL -e SQLALCHEMY_WARN_20 -v ${{ runner.workspace }}/pass-culture-main/api/tests/:/tests
           run: |
-            pytest ${{ matrix.pytest_args }} --durations=10 --junitxml='/tests/junit.xml' -vv --color=yes
+            pytest ${{ matrix.pytest_args }} --durations=10 --junitxml='/tests/junit.xml' -q --color=yes
       - name: "Publish Test Report"
         uses: mikepenz/action-junit-report@v5
         if: always() # always run even if the previous step fails


### PR DESCRIPTION
# But de la PR

https://passculture.atlassian.net/browse/PC-34512

- output en couleurs
- 1 ligne par fichier plutôt qu’une ligne par fonction de test
- Le job Pytest report ne doit pas échouer en plus du job de test
- Ne pas publier de job summary pour les jobs pytest réussis

exemple:
https://github.com/pass-culture/pass-culture-main/actions/runs/13245381814/job/36970834632?pr=16259