### PR TITLE
(BSR)[API] feat: remove unused notify_pro_users_one_day command

### DIFF
--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -112,15 +112,6 @@ def synchronize_offerers_from_adage_cultural_partners(with_timestamp: bool = Fal
         adage_api.synchronize_adage_ids_on_offerers(adage_cultural_partners.partners)
 
 
-# TODO(EAC): remove this command once the eac_notify_pro_one_day_before
-# is deployed and used in production
-@blueprint.cli.command("eac_notify_pro_one_day")
-@log_cron_with_transaction
-def notify_pro_users_one_day() -> None:
-    """Notify pro users 1 day before EAC event."""
-    educational_api_booking.notify_pro_users_one_day_before()
-
-
 @blueprint.cli.command("eac_notify_pro_one_day_before")
 @log_cron_with_transaction
 def notify_pro_users_one_day_before() -> None:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : suppression de la commande `notify_pro_users_one_day` qui n'est pas utilisée (on a à la place `eac_notify_pro_one_day_before` et `eac_notify_pro_one_day_after`)

On peut vérifier sur le repo deployment : https://github.com/search?q=repo%3Apass-culture%2Fpass-culture-deployment%20eac_notify_pro_one_day&type=code

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
