### PR TITLE
(PC-34523)[API] fix: beneficiary factory fraud check eligibility

### DIFF
--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -625,11 +625,7 @@ class BeneficiaryGrant18Factory(BaseFactory):
                 if obj.eligibility == models.EligibilityType.UNDERAGE
                 else fraud_factories.UbbleContentFactory(first_name=obj.firstName, last_name=obj.lastName)
             ),
-            eligibilityType=(
-                models.EligibilityType.UNDERAGE
-                if obj.eligibility == models.EligibilityType.UNDERAGE
-                else models.EligibilityType.AGE18
-            ),
+            eligibilityType=obj.eligibility,
         )
 
     @factory.post_generation


### PR DESCRIPTION
The new eligibility should have its own fraud check eligibility, instead of defaulting to EligibilityType.AGE18

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34523
