### PR TITLE
(PC-34447)[API] test: enable ApplyMoveSiretTest.test_move_siret_ok

### DIFF
--- a/api/src/pcapi/core/finance/siret_api.py
+++ b/api/src/pcapi/core/finance/siret_api.py
@@ -261,7 +261,6 @@ def remove_siret(
     override_revenue_check: bool = False,
     new_pricing_point_id: int | None = None,
     author_user_id: int | None = None,
-    new_db_session: bool = True,
 ) -> None:
     check_can_remove_siret(venue, comment, override_revenue_check=override_revenue_check)
     old_siret = venue.siret
@@ -286,10 +285,6 @@ def remove_siret(
         new_siret = new_pricing_point_venue.siret
 
     with db.session.no_autoflush:  # do not flush anything before commit
-        if new_db_session:
-            db.session.rollback()  # discard any previous transaction to start a fresh new one.
-            db.session.begin()
-
         try:
             _force_close_custom_reimbursement_rules_for_venue(venue)
             modified_info_by_venue: dict[int, dict[str, dict]] = defaultdict(dict)

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -1227,7 +1227,6 @@ def remove_siret(venue_id: int) -> utils.BackofficeResponse:
             override_revenue_check=bool(form.override_revenue_check.data),
             new_pricing_point_id=form.new_pricing_point.data,
             author_user_id=current_user.id,
-            new_db_session=False,
         )
     except siret_api.CheckError as exc:
         return _render_remove_siret_content(venue, form=form, error=str(exc))

--- a/api/tests/routes/backoffice/move_siret_test.py
+++ b/api/tests/routes/backoffice/move_siret_test.py
@@ -237,7 +237,3 @@ class ApplyMoveSiretTest(MoveSiretTestHelper):
 
         assert response.status_code == 303
         assert finance_models.CustomReimbursementRule.query.count() == 0
-
-    @pytest.mark.skip("TODO: fix issue with test 'A transaction is already begun on this Session.'")
-    def test_move_siret_ok(self, authenticated_client, override_revenue_check):
-        pass


### PR DESCRIPTION
Test was skipped because of session restarted in the code, to ensure that flask command did not commit anything tried before. Command has already been removed.

Skipped test was already implemented in superclass and _assert_move_siret_ok_response.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-34447

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
