### PR TITLE
(PC-34330)[BO] feat: change non event offers' venue

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -111,6 +111,7 @@ class FeatureToggle(enum.Enum):
     LOG_EMS_CINEMAS_AVAILABLE_FOR_SYNC = "Stocker dans Google Drive les cinémas EMS activables"
     ENABLE_PRO_FEEDBACK = "Activer l'envoi des commentaires du portail pro vers Harvestr"
     ENABLE_MOVIE_FESTIVAL_RATE = "Activer les tarifs spéciaux pour un festival cinéma"
+    MOVE_OFFER_TEST = "Test le déplacement de n'importe quelle offre vers une autre venue"
     # For features under construction, a temporary feature flag must be named with the `WIP_` prefix
     WIP_ASYNCHRONOUS_CELERY_TASKS = "Activer le backend de tâches asynchrone Celery pour les tâches qui le supporte"
     WIP_ENABLE_REMINDER_MARKETING_MAIL_METADATA_DISPLAY = "Changer le template d'email de confirmation de réservation"
@@ -211,6 +212,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.ENABLE_ZENDESK_SELL_CREATION,
     FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
     FeatureToggle.LOG_EMS_CINEMAS_AVAILABLE_FOR_SYNC,
+    FeatureToggle.MOVE_OFFER_TEST,
     FeatureToggle.SEND_ALL_EMAILS_TO_EHP,
     FeatureToggle.SYNCHRONIZE_TITELIVE_API_MUSIC_PRODUCTS,
     FeatureToggle.WIP_2025_SIGN_UP,

--- a/api/src/pcapi/routes/backoffice/templates/offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/details.html
@@ -85,6 +85,10 @@
                 {% set edit_offer_venue_aria_described_by_id = random_hash() %}
                 {{ build_modal_form("edit-offer-venue", url_for("backoffice_web.offer.edit_offer_venue", offer_id=offer.id) , edit_offer_venue_form, "Modifier le partenaire culturel", "Modifier le partenaire culturel", "Enregistrer") }}
               {% endif %}
+              {% if move_offer_form %}
+                {% set edit_offer_venue_aria_described_by_id = random_hash() %}
+                {{ build_modal_form("move-offer", url_for("backoffice_web.offer.move_offer", offer_id=offer.id) , move_offer_form, "Déplacer l'offre", "Déplacer l'offre", "Enregistrer") }}
+              {% endif %}
             </div>
             <div class="col-2"></div>
           </div>

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -1887,7 +1887,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
             compliance_reasons=["stock_price", "offer_subcategory_id", "offer_description"],
         )
         url = url_for(self.endpoint, offer_id=offer.id, _external=True)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1924,7 +1924,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         product = offers_factories.ProductFactory(subcategoryId=subcategories.LIVRE_PAPIER.id, name="good book")
         offer = offers_factories.OfferFactory(product=product)
         url = url_for(self.endpoint, offer_id=offer.id, _external=True)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2044,7 +2044,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         )
 
         url = url_for(self.endpoint, offer_id=offer.id, _external=True)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2061,7 +2061,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         )
 
         url = url_for(self.endpoint, offer_id=offer.id, _external=True)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2075,7 +2075,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
 
         authenticated_client = client.with_bo_session_auth(user)
         url = url_for(self.endpoint, offer_id=offer.id, _external=True)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2099,7 +2099,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
 
         authenticated_client = client.with_bo_session_auth(user)
         url = url_for(self.endpoint, offer_id=offer.id, _external=True)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2120,7 +2120,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         )
 
         url = url_for(self.endpoint, offer_id=offer.id, _external=True)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2137,7 +2137,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
             offer=offer, beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(hours=1), price=6.66
         )
 
-        query_count = self.expected_num_queries
+        query_count = self.expected_num_queries_with_ff
         query_count += 1  # _get_editable_stock
         query_count += 1  # check_can_move_event_offer
 
@@ -2170,7 +2170,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
             beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(hours=1),
         )
 
-        query_count = self.expected_num_queries
+        query_count = self.expected_num_queries_with_ff
         query_count += 1  # _get_editable_stock
         query_count += 1  # check_can_move_event_offer
 
@@ -2347,7 +2347,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         # - count stocks with beginningDatetime in the past
         # - count reimbursed bookings
         # - fetch destination venue candidates
-        with assert_num_queries(self.expected_num_queries + 4):
+        with assert_num_queries(self.expected_num_queries_with_ff + 4):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2371,7 +2371,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         )
 
         url = url_for(self.endpoint, offer_id=offer.id)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2383,7 +2383,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         offer = offers_factories.OfferFactory(venue__managingOfferer=rule.offerer)
 
         url = url_for(self.endpoint, offer_id=offer.id)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2395,7 +2395,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         offer = offers_factories.OfferFactory(venue=rule.venue)
 
         url = url_for(self.endpoint, offer_id=offer.id)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -2409,7 +2409,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         )
 
         url = url_for(self.endpoint, offer_id=offer.id)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 


### PR DESCRIPTION
This is under feature flag to let users to change the offer's venue on various types in order to pre-test the venue migration.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34330

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
