### PR TITLE
(BSR)[API] fix: check order of start and end dates when editing colle…

### DIFF
--- a/api/src/pcapi/core/educational/api/stock.py
+++ b/api/src/pcapi/core/educational/api/stock.py
@@ -107,6 +107,10 @@ def edit_collective_stock(
             after_update_start_datetime, after_update_end_datetime
         )
 
+        validation.check_start_is_before_end(
+            start_datetime=after_update_start_datetime, end_datetime=after_update_end_datetime
+        )
+
     booking_limit = stock_data.get("bookingLimitDatetime")
     booking_limit = serialization_utils.as_utc_without_timezone(booking_limit) if booking_limit else None
 

--- a/api/src/pcapi/routes/pro/collective_stocks.py
+++ b/api/src/pcapi/routes/pro/collective_stocks.py
@@ -85,6 +85,10 @@ def edit_collective_stock(
         raise ApiErrors({"global": ["Les stocks créés par l'api publique ne sont pas editables."]}, 403)
     except educational_exceptions.CollectiveOfferForbiddenAction:
         raise ApiErrors({"global": ["Cette action n'est pas autorisée sur l'offre collective liée à ce stock."]}, 403)
+    except educational_exceptions.EndDatetimeBeforeStartDatetime:
+        raise ApiErrors(
+            {"educationalStock": ["La date de fin de l'évènement ne peut précéder la date de début."]}, status_code=400
+        )
     except offers_exceptions.BookingLimitDatetimeTooLate:
         raise ApiErrors(
             {"educationalStock": ["La date limite de confirmation ne peut être fixée après la date de l évènement"]},

--- a/api/tests/core/educational/api/test_edit_collective_offer_stock.py
+++ b/api/tests/core/educational/api/test_edit_collective_offer_stock.py
@@ -770,3 +770,15 @@ class ReturnErrorTest:
                 educational_api_stock.edit_collective_stock(
                     stock=offer.collectiveStock, stock_data=new_stock_data.dict(exclude_unset=True)
                 )
+
+    @time_machine.travel("2020-11-17 15:00:00")
+    def test_cannot_set_end_before_stock_start(self):
+        start = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=10)
+        educational_factories.create_educational_year(date_time=start)
+        stock = educational_factories.CollectiveStockFactory(startDatetime=start)
+
+        new_end = start - datetime.timedelta(days=1)
+        new_stock_data = collective_stock_serialize.CollectiveStockEditionBodyModel(endDatetime=new_end)
+
+        with pytest.raises(exceptions.EndDatetimeBeforeStartDatetime):
+            educational_api_stock.edit_collective_stock(stock=stock, stock_data=new_stock_data.dict(exclude_unset=True))


### PR DESCRIPTION
…ctive stock

## But de la pull request

Ticket Jira (ou description si BSR) :

Ajout d'un check sur l'ordre start < end quand on édite un collective stock, comme cela a été ajouté récemment côté api publique

Actuellement la route peut recevoir `endDatetime` seul avec une date qui précède `stock.startDatetime`. En pratique on évite le problème actuellement car on reçoit toutes les dates du front (?)
Si on reçoit `startDatetime` seul, on a une logique endDatetime = (startDatetime reçu) donc on n'avait pas le soucis dans ce cas là

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
