### PR TITLE
(PC-34467)[PRO] fix: make sure days are always displayed in order in OpeningHoursReadOnly

### DIFF
--- a/pro/src/commons/utils/date.ts
+++ b/pro/src/commons/utils/date.ts
@@ -161,3 +161,5 @@ export function mapDayToFrench(
       return 'Dimanche'
   }
 }
+
+export const DAYS_IN_ORDER = ['MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY', 'SUNDAY']

--- a/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
@@ -1,5 +1,5 @@
 import { GetVenueResponseModel } from 'apiClient/v1'
-import { mapDayToFrench } from 'commons/utils/date'
+import { mapDayToFrench , DAYS_IN_ORDER } from 'commons/utils/date'
 import { SummaryDescriptionList } from 'components/SummaryLayout/SummaryDescriptionList'
 import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 
@@ -19,11 +19,17 @@ type HoursProps = {
 }
 
 export function OpeningHoursReadOnly({ openingHours }: OpeningHours) {
-  const filledDays = Object.entries(openingHours ?? {}).filter((dateAndHour) =>
-    Boolean(dateAndHour[1])
-  )
+  const filledDays = Object.entries(openingHours ?? {})
+    .filter((dateAndHour) =>
+      Boolean(dateAndHour[1])
+    )
 
-  if (!openingHours || filledDays.length === 0) {
+  const orderedFilledDays = DAYS_IN_ORDER.map(d => {
+    const index = filledDays.findIndex(([day]) => day === d)
+    return index === -1 ? null : filledDays[index]
+  }).filter(Boolean) as [string, any][]
+
+  if (!openingHours || orderedFilledDays.length === 0) {
     return (
       <SummarySubSection
         title={'Horaires d’ouverture'}
@@ -40,7 +46,7 @@ export function OpeningHoursReadOnly({ openingHours }: OpeningHours) {
   return (
     <SummarySubSection title={'Horaires d’ouverture'} shouldShowDivider={false}>
       <SummaryDescriptionList
-        descriptions={filledDays.map((dateAndHour) => {
+        descriptions={orderedFilledDays.map((dateAndHour) => {
           return {
             title: mapDayToFrench(dateAndHour[0]),
             text: <Hours hours={dateAndHour[1]} />,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34467

## Vérifications

- [ ] ~J'ai écrit les tests nécessaires~
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~
- [ ] J'ai fait la revue fonctionnelle de mon ticket
