### PR TITLE
(PC-34642)[API] feat: read ean from product.ean instead of product.jsonData->>'ean'

### DIFF
--- a/api/src/pcapi/alembic/versions/20250214T125754_7f05525f7b5e_wip_do_not_merge.py
+++ b/api/src/pcapi/alembic/versions/20250214T125754_7f05525f7b5e_wip_do_not_merge.py
@@ -1,0 +1,20 @@
+"""This is only to be sure that we don't write EAN in product.jsonData ever"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "7f05525f7b5e"
+down_revision = "6d08cf9b25c2"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("select 1 -- squawk:ignore-next-statement")
+    op.execute("""ALTER TABLE product ADD CONSTRAINT check_no_ean_key CHECK (NOT ("jsonData" ? 'ean')); """)
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34642

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
