### PR TITLE
(BSR)[API] fix: export csv invoices must also run with NEW_FINANCE_WORKLOW FF enabled

### DIFF
--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -72,8 +72,8 @@ def generate_cashflows_and_payment_files(
                 ],
                 icon_emoji=":large_green_circle:",
             )
-        if settings.GENERATE_CGR_KINEPOLIS_INVOICES:
-            export_csv_and_send_notification_emails_job.delay(batch.id, batch.label)
+    if settings.GENERATE_CGR_KINEPOLIS_INVOICES:
+        export_csv_and_send_notification_emails_job.delay(batch.id, batch.label)
 
 
 @blueprint.cli.command("generate_invoices")


### PR DESCRIPTION
Si le FF NEW_FINANCE_WORKLOW est activé, on veut créer les invoices