### PR TITLE
(PC-28095)[API] feat: public API: add warning log for deprecated enum

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -99,7 +99,7 @@ def post_event_offer(body: serialization.EventOfferCreation) -> serialization.Ev
                 description=body.description,
                 durationMinutes=body.event_duration,
                 externalTicketOfficeUrl=body.external_ticket_office_url,
-                extraData=serialization.deserialize_extra_data(body.category_related_fields),
+                extraData=serialization.deserialize_extra_data(body.category_related_fields, venue_id=venue.id),
                 idAtProvider=body.id_at_provider,
                 isDuo=body.enable_double_bookings,
                 url=body.location.url if isinstance(body.location, serialization.DigitalLocation) else None,
@@ -259,7 +259,9 @@ def edit_event(event_id: int, body: serialization.EventOfferEdition) -> serializ
                 description=get_field(offer, updates, "description"),
                 durationMinutes=get_field(offer, updates, "eventDuration", col="durationMinutes"),
                 extraData=(
-                    serialization.deserialize_extra_data(body.category_related_fields, extra_data)
+                    serialization.deserialize_extra_data(
+                        body.category_related_fields, extra_data, venue_id=offer.venueId
+                    )
                     if "categoryRelatedFields" in updates
                     else extra_data
                 ),

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -209,7 +209,7 @@ def _create_product(
             bookingEmail=body.booking_email,
             description=body.description,
             externalTicketOfficeUrl=body.external_ticket_office_url,
-            extraData=serialization.deserialize_extra_data(body.category_related_fields),
+            extraData=serialization.deserialize_extra_data(body.category_related_fields, venue_id=venue.id),
             idAtProvider=body.id_at_provider,
             isDuo=body.enable_double_bookings,
             url=body.location.url if isinstance(body.location, serialization.DigitalLocation) else None,
@@ -850,7 +850,9 @@ def edit_product(body: serialization.ProductOfferEdition) -> serialization.Produ
                 bookingEmail=get_field(offer, updates, "bookingEmail"),
                 description=get_field(offer, updates, "description"),
                 extraData=(
-                    serialization.deserialize_extra_data(body.category_related_fields, extra_data)
+                    serialization.deserialize_extra_data(
+                        body.category_related_fields, extra_data, venue_id=venue.id if venue else None
+                    )
                     if "categoryRelatedFields" in updates
                     else extra_data
                 ),

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -312,6 +312,7 @@ def serialize_extra_data(offer: offers_models.Offer) -> CategoryRelatedFields:
 def deserialize_extra_data(
     category_related_fields: CategoryRelatedFields | None,
     initial_extra_data: offers_models.OfferExtraData | None = None,
+    venue_id: int | None = None,
 ) -> dict[str, str]:
     extra_data: dict = initial_extra_data or {}  # type: ignore[assignment]
     if not category_related_fields:
@@ -327,6 +328,15 @@ def deserialize_extra_data(
                 extra_data["musicType"] = str(music_types.MUSIC_TYPES_BY_SLUG[music_slug].code)
                 extra_data["musicSubType"] = str(music_types.MUSIC_SUB_TYPES_BY_SLUG[music_slug].code)
             else:
+                extra = {
+                    "venue": venue_id if venue_id else "",
+                    "field_name": field_name,
+                    "field_value": field_value.value,
+                    "enum_used": type(field_value).__name__,
+                }
+
+                logger.info("offer: using old music type", extra=extra)
+
                 extra_data["musicSubType"] = str(music_types.MUSIC_SUB_TYPES_BY_SLUG[field_value].code)
                 extra_data["musicType"] = str(music_types.MUSIC_TYPES_BY_SLUG[field_value].code)
                 extra_data["gtl_id"] = constants.MUSIC_SLUG_TO_GTL_ID[field_value]


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-28095

Ajout d'un log qui nous permettra d'identifier si l'utilisation d'un enum de genre musical est encore (très) utilisé ou non et si oui, par qui.
L'idée étant de supprimer cet enum obsolète plus tard.
