### PR TITLE
(BSR)[PRO] feat: Migrates <UserPasswordForm/> to react-hook-form

### DIFF
--- a/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
@@ -25,7 +25,7 @@ type UserPasswordFormValues = {
   newConfirmationPassword: string
 }
 
-const isUserPasswordError = (
+export const isUserPasswordError = (
   error: unknown
 ): error is Record<keyof UserPasswordFormValues, string[]> => {
   if (typeof error !== 'object' || error === null) {

--- a/pro/src/components/UserPasswordForm/__specs__/UserPasswordForm.spec.tsx
+++ b/pro/src/components/UserPasswordForm/__specs__/UserPasswordForm.spec.tsx
@@ -5,7 +5,11 @@ import { api } from 'apiClient/api'
 import { sharedCurrentUserFactory } from 'commons/utils/factories/storeFactories'
 import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
-import { UserPasswordForm, UserPasswordFormProps } from '../UserPasswordForm'
+import {
+  isUserPasswordError,
+  UserPasswordForm,
+  UserPasswordFormProps,
+} from '../UserPasswordForm'
 
 const renderUserPasswordForm = (props: UserPasswordFormProps) => {
   return renderWithProviders(<UserPasswordForm {...props} />, {
@@ -53,6 +57,67 @@ describe('components:UserPasswordForm', () => {
       newConfirmationPassword: 'MyNewSuper1Password,',
       newPassword: 'MyNewSuper1Password,',
       oldPassword: 'MyCurrentSuper1Password,',
+    })
+  })
+
+  it('should displays API fields errors', async () => {
+    vi.spyOn(api, 'postChangePassword').mockRejectedValue({
+      message: 'Une erreur est survenue',
+      name: 'ApiError',
+      status: 400,
+      body: {
+        oldPassword: ['Le mot de passe actuel est incorrect.'],
+        newPassword: ['Le nouveau mot de passe est identique à l’ancien.'],
+      },
+    })
+
+    let props: UserPasswordFormProps = {
+      closeForm: vi.fn(),
+    }
+
+    renderUserPasswordForm(props)
+
+    await userEvent.type(
+      screen.getByLabelText(/Mot de passe actuel/),
+      'MyCurrentSuper1Password,'
+    )
+    await userEvent.type(
+      screen.getByLabelText(/Nouveau mot de passe/),
+      'MyNewSuper1Password,'
+    )
+    await userEvent.type(
+      screen.getByLabelText(/Confirmer votre nouveau mot de passe/),
+      'MyNewSuper1Password,'
+    )
+    await userEvent.tab()
+    await userEvent.click(screen.getByText('Enregistrer'))
+
+    expect(
+      await screen.findByText('Le mot de passe actuel est incorrect.')
+    ).toBeInTheDocument()
+    expect(
+      await screen.findByText(
+        'Le nouveau mot de passe est identique à l’ancien.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  describe('isUserPasswordError util', () => {
+    it('should detect if the error is a UserPasswordError', () => {
+      const error = {
+        oldPassword: ['Old password is incorrect'],
+      }
+      expect(isUserPasswordError(error)).toBe(true)
+    })
+
+    it('should detect if the error is not a UserPasswordError', () => {
+      const notEvenAnError = null
+      expect(isUserPasswordError(notEvenAnError)).toBe(false)
+
+      const error = {
+        message: 'Internal server error',
+      }
+      expect(isUserPasswordError(error)).toBe(false)
     })
   })
 })

--- a/pro/src/components/UserPasswordForm/validationSchema.ts
+++ b/pro/src/components/UserPasswordForm/validationSchema.ts
@@ -2,16 +2,18 @@ import * as yup from 'yup'
 
 import { isPasswordValid } from 'ui-kit/formV2/PasswordInput/validation'
 
-const passwordErrorMessage = 'Veuillez renseigner votre nouveau mot de passe'
-
 export const validationSchema = yup.object().shape({
   oldPassword: yup
     .string()
     .required('Veuillez renseigner votre mot de passe actuel'),
   newPassword: yup
     .string()
-    .test('isPasswordValid', passwordErrorMessage, isPasswordValid)
-    .required('Veuillez renseigner votre nouveau mot de passe'),
+    .required('Veuillez renseigner votre nouveau mot de passe')
+    .test(
+      'isPasswordValid',
+      'Veuillez respecter le format requis :',
+      isPasswordValid
+    ),
   newConfirmationPassword: yup
     .string()
     .oneOf(

--- a/pro/src/ui-kit/formV2/ValidationMessageList/ValidationMessageList.module.scss
+++ b/pro/src/ui-kit/formV2/ValidationMessageList/ValidationMessageList.module.scss
@@ -1,8 +1,13 @@
 @use "styles/mixins/_forms.scss" as forms;
+@use "styles/mixins/rem.scss" as rem;
 
 .password-footer {
   @include forms.field-layout-footer;
 
   margin-top: 0;
   flex-direction: column;
+
+  &:not(:empty):last-child {
+    margin-bottom: rem.torem(16px);
+  }
 }


### PR DESCRIPTION
## But de la pull request

- Migration du formulaire de modification du mot de passe vers `react-hook-form`
- Ajout de tests manquants sur l'affichage des erreurs.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
