### PR TITLE
(PC-34687)[PRO] docs: Dependabot auto bump of frontend app.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
       - dependency-name: 'design-system' # Keep the design-system repo under control while it's early-stage
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+  - package-ecosystem: 'npm'
+    directory: '/api/documentation'
+    schedule:
+      interval: 'daily'
+      time: '09:00'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']
 
   - package-ecosystem: 'pip' # pip even if we use poetry
     directory: '/api'
@@ -24,15 +32,18 @@ updates:
       - dependency-name: boto3
       # Except for critical ones where we only allow patches update
       - dependency-name: 'flask'
-        update-types: ['version-update:semver-major', 'version-update:semver-minor']
+        update-types:
+          ['version-update:semver-major', 'version-update:semver-minor']
       - dependency-name: 'sqlalchemy'
-        update-types: ['version-update:semver-major', 'version-update:semver-minor']
+        update-types:
+          ['version-update:semver-major', 'version-update:semver-minor']
       - dependency-name: 'pydantic'
-        update-types: ['version-update:semver-major', 'version-update:semver-minor']
+        update-types:
+          ['version-update:semver-major', 'version-update:semver-minor']
       # We are not ready to handle upper version of spectree, even for patches
       - dependency-name: 'spectree'
     # Disable automatic rebasing for poetry pull requests
-    rebase-strategy: "disabled"
+    rebase-strategy: 'disabled'
 
   # Special configuration for Python packages that have very frequent updates.
   # We don't want to get a pull request every day for insignificant changes.
@@ -49,7 +60,7 @@ updates:
     open-pull-requests-limit: 15
     allow:
       - dependency-name: boto3
-    rebase-strategy: "disabled"
+    rebase-strategy: 'disabled'
 
   - package-ecosystem: 'github-actions'
     directory: '.github/workflows'


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34687

**Objectif**
Laisser dependabot bump automatiquement les dépendances du front de la doc.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
