### PR TITLE
(BSR)[PRO] fix: default value in input radio for non physical event t…

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/UsefulInformationForm/UsefulInformationForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/UsefulInformationForm/UsefulInformationForm.tsx
@@ -114,8 +114,7 @@ export const UsefulInformationForm = ({
           </FormLayout.Row>
         )}
 
-        {(conditionalFields.includes('withdrawalType') ||
-          Boolean(withdrawalType)) && (
+        {conditionalFields.includes('withdrawalType') && (
           <>
             <FormLayout.Row mdSpaceAfter>
               {/*


### PR DESCRIPTION


Résoudre un bug introduit lorsque l'on a voulu ajouter des valeurs par défaut pour tous les input radio, vérifier qu'un évènement physique datée a bien la section pour la billeterie mais ne plus l'afficher pour les autres type d'offre