### PR TITLE
(PC-34697)[API] fix: Ensure we don’t cache wrongly empty BAN response

### DIFF
--- a/api/src/pcapi/connectors/api_adresse.py
+++ b/api/src/pcapi/connectors/api_adresse.py
@@ -12,6 +12,7 @@ import json
 import logging
 import re
 
+from flask import current_app
 import pydantic.v1 as pydantic_v1
 
 from pcapi import settings
@@ -314,6 +315,10 @@ class ApiAdresseBackend(BaseBackend):
             key_args={"hash_params": hash_params},
             expire=60 * 60 * 24 * 7,  # time between 2 PC main releases
         )
+        if cached_data == json.dumps({"type": "FeatureCollection", "features": []}):
+            # This is a broken response from BAN API, real empty response should look like this
+            # {'type': 'FeatureCollection', 'version': 'draft', 'features': [], 'attribution': 'BAN', 'licence': 'ETALAB-2.0', 'query': 'Pouroi faire', 'filters': {'postcode': '97351'}, 'limit': 1}
+            current_app.redis_client.delete(key_template % {"hash_params": hash_params})
 
         return json.loads(str(cached_data))
 


### PR DESCRIPTION
... when searching for an address

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34697

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
