### PR TITLE
(PC-34728)[PRO] fix: refresh indiv. list offer after headline offer deletion

### DIFF
--- a/pro/src/commons/context/HeadlineOfferContext/HeadlineOfferContext.spec.tsx
+++ b/pro/src/commons/context/HeadlineOfferContext/HeadlineOfferContext.spec.tsx
@@ -4,7 +4,6 @@ import { userEvent } from '@testing-library/user-event'
 
 import { api } from 'apiClient/api'
 import * as useAnalytics from 'app/App/analytics/firebase'
-import { GET_OFFERER_HEADLINE_OFFER_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { Events } from 'commons/core/FirebaseEvents/constants'
 import * as useNotification from 'commons/hooks/useNotification'
 import { venueListItemFactory } from 'commons/utils/factories/individualApiFactories'
@@ -207,10 +206,7 @@ describe('HeadlineOfferContext', () => {
       // which is triggered by the SWR mutate function on GET_OFFERER_HEADLINE_OFFER_QUERY_KEY.
       // This would be like testing the SWR library itself & its none of our concern.
       // Yet, we expect the mutation to be called.
-      expect(mockMutate).toHaveBeenCalledWith([
-        GET_OFFERER_HEADLINE_OFFER_QUERY_KEY,
-        MOCK_DATA.offerer.selectedOffererId
-      ])
+      expect(mockMutate).toHaveBeenCalled()
     })
 
     describe('about notifications', () => {
@@ -243,7 +239,9 @@ describe('HeadlineOfferContext', () => {
           pending: vi.fn(),
           close: vi.fn(),
         }))
-        vi.spyOn(api, 'upsertHeadlineOffer').mockRejectedValue('PLONK')
+
+        // Api call rejects with an error and so does the mutation.
+        mockMutate.mockImplementation(() => Promise.reject())
 
         renderIndividualOffersContext()
 
@@ -305,18 +303,11 @@ describe('HeadlineOfferContext', () => {
       })
       await userEvent.click(removeButton)
 
-      await waitFor(() => {
-        expect(api.deleteHeadlineOffer).toHaveBeenCalled()
-      })
-
       // We are not testing display update since this happens after a re-render,
       // which is triggered by the SWR mutate function on GET_OFFERER_HEADLINE_OFFER_QUERY_KEY.
       // This would be like testing the SWR library itself & its none of our concern.
       // Yet, we expect the mutation to be called.
-      expect(mockMutate).toHaveBeenCalledWith([
-        GET_OFFERER_HEADLINE_OFFER_QUERY_KEY,
-        MOCK_DATA.offerer.selectedOffererId
-      ])
+      expect(mockMutate).toHaveBeenCalled()
     })
 
     describe('about notifications', () => {
@@ -349,7 +340,9 @@ describe('HeadlineOfferContext', () => {
           pending: vi.fn(),
           close: vi.fn(),
         }))
-        vi.spyOn(api, 'deleteHeadlineOffer').mockRejectedValue('PLONK')
+
+        // Api call rejects with an error and so does the mutation.
+        mockMutate.mockImplementation(() => Promise.reject())
 
         renderIndividualOffersContext()
 

--- a/pro/src/commons/context/HeadlineOfferContext/HeadlineOfferContext.tsx
+++ b/pro/src/commons/context/HeadlineOfferContext/HeadlineOfferContext.tsx
@@ -104,10 +104,12 @@ export function HeadlineOfferContextProvider({ children }: HeadlineOfferContextP
     context,
   }: UpsertHeadlineOfferParams) => {
     try {
-      await api.upsertHeadlineOffer({ offerId })
-      notify.success('Votre offre a été mise à la une !')
-      await mutate([GET_OFFERER_HEADLINE_OFFER_QUERY_KEY, selectedOffererId])
+      await mutate([GET_OFFERER_HEADLINE_OFFER_QUERY_KEY, selectedOffererId],
+        api.upsertHeadlineOffer({ offerId }),
+        { revalidate: true, throwOnError: true }
+      )
 
+      notify.success('Votre offre a été mise à la une !')
       logEvent(Events.CLICKED_CONFIRMED_ADD_HEADLINE_OFFER, {
         from: location.pathname,
         actionType: context.actionType,
@@ -127,10 +129,16 @@ export function HeadlineOfferContextProvider({ children }: HeadlineOfferContextP
   const removeHeadlineOffer = async () => {
     if (selectedOffererId) {
       try {
-        await api.deleteHeadlineOffer({ offererId: selectedOffererId })
-        notify.success('Votre offre n’est plus à la une')
-        await mutate([GET_OFFERER_HEADLINE_OFFER_QUERY_KEY, selectedOffererId])
+        await mutate([GET_OFFERER_HEADLINE_OFFER_QUERY_KEY, selectedOffererId],
+          api.deleteHeadlineOffer({ offererId: selectedOffererId }),
+          {
+            populateCache: () => null,
+            revalidate: false,
+            throwOnError: true,
+          }
+        )
 
+        notify.success('Votre offre n’est plus à la une')
         logEvent(Events.CLICKED_CONFIRMED_ADD_HEADLINE_OFFER, {
           from: location.pathname,
           actionType: 'delete',


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34728

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~
- [ ] J'ai fait la revue fonctionnelle de mon ticket
