### PR TITLE
(PC-34727)[PRO] fix: A user has a partner page only if managing a permanent, non virtual venue with at least one individual offer

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -486,6 +486,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
             can_be_searched
             and self.managingOfferer.isActive
             and self.managingOfferer.isValidated
+            and self.hasOffers
             and not_administrative
         )
 

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -727,6 +727,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
 
     @property
     def has_partner_page(self) -> bool:
+        from pcapi.core.offerers.models import Offerer
         from pcapi.core.offerers.models import UserOfferer
         from pcapi.core.offerers.models import Venue
 
@@ -736,8 +737,10 @@ class User(PcObject, Base, Model, DeactivableMixin):
             .join(Venue, UserOfferer.offererId == Venue.managingOffererId)
             .where(
                 UserOfferer.userId == self.id,
+                Offerer.isActive.is_(True),
                 Venue.isPermanent.is_(True),
                 Venue.isVirtual.is_(False),
+                Venue.hasOffers == True,
             )
             .exists()
         ).scalar()

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -184,25 +184,27 @@ class VenueIsEligibleForSearchTest:
             isPermanent=permanent,
             venueTypeCode=type,
         )
+        offers_factories.OfferFactory(venue=venue)
         assert venue.is_eligible_for_search == is_eligible_for_search
 
     @pytest.mark.features(WIP_IS_OPEN_TO_PUBLIC=True)
     @pytest.mark.parametrize(
-        "open_to_public,permanent,validation_status,active,type,is_eligible_for_search",
+        "open_to_public,permanent,validation_status,active,type,has_indiv_offer,is_eligible_for_search",
         [
-            (True, True, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, True),
-            (True, False, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, True),
-            (False, True, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, False),
-            (False, True, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.ADMINISTRATIVE, False),
-            (False, True, ValidationStatus.VALIDATED, False, offerers_schemas.VenueTypeCode.BOOKSTORE, False),
-            (False, False, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, False),
-            (False, False, ValidationStatus.VALIDATED, False, offerers_schemas.VenueTypeCode.BOOKSTORE, False),
-            (True, True, ValidationStatus.NEW, True, offerers_schemas.VenueTypeCode.BOOKSTORE, False),
-            (True, True, ValidationStatus.CLOSED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, False),
+            (True, True, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, True, True),
+            (True, True, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, False, False),
+            (True, False, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, True, True),
+            (False, True, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, True, False),
+            (False, True, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.ADMINISTRATIVE, True, False),
+            (False, True, ValidationStatus.VALIDATED, False, offerers_schemas.VenueTypeCode.BOOKSTORE, True, False),
+            (False, False, ValidationStatus.VALIDATED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, True, False),
+            (False, False, ValidationStatus.VALIDATED, False, offerers_schemas.VenueTypeCode.BOOKSTORE, True, False),
+            (True, True, ValidationStatus.NEW, True, offerers_schemas.VenueTypeCode.BOOKSTORE, True, False),
+            (True, True, ValidationStatus.CLOSED, True, offerers_schemas.VenueTypeCode.BOOKSTORE, True, False),
         ],
     )
     def test_is_eligible_for_search(
-        self, open_to_public, permanent, validation_status, active, type, is_eligible_for_search
+        self, open_to_public, permanent, validation_status, active, type, has_indiv_offer, is_eligible_for_search
     ):
         venue = factories.VenueFactory(
             isVirtual=False,
@@ -212,6 +214,8 @@ class VenueIsEligibleForSearchTest:
             isPermanent=permanent,
             venueTypeCode=type,
         )
+        if has_indiv_offer:
+            offers_factories.OfferFactory(venue=venue)
         assert venue.is_eligible_for_search == is_eligible_for_search
 
 

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -267,6 +267,7 @@ class ReindexOfferIdsTest:
 class ReindexVenueIdsTest:
     def test_index_new_venue(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
+        offers_factories.OfferFactory(venue=venue)
         assert search_testing.search_store["venues"] == {}
         search.reindex_venue_ids([venue.id])
         assert venue.id in search_testing.search_store["venues"]
@@ -296,6 +297,7 @@ class ReindexVenueIdsTest:
         indexable_venue = offerers_factories.VenueFactory(
             isPermanent=True, managingOfferer__isActive=True, venueTypeCode=offerers_models.VenueTypeCode.BOOKSTORE
         )
+        offers_factories.OfferFactory(venue=indexable_venue)
 
         venue1 = offerers_factories.VenueFactory(isPermanent=False)
         venue2 = offerers_factories.VenueFactory(isPermanent=True, managingOfferer__isActive=False)

--- a/api/tests/core/search/test_commands_indexation.py
+++ b/api/tests/core/search/test_commands_indexation.py
@@ -127,8 +127,11 @@ def test_partially_index_collective_offer_templates(app):
 def test_partially_index_venues(app):
     _not_indexable_venue = offerers_factories.VenueFactory(isPermanent=False)
     indexable_venue1 = offerers_factories.VenueFactory(isPermanent=True)
+    offers_factories.OfferFactory(venue=indexable_venue1)
     _indexable_venue2 = offerers_factories.VenueFactory(isPermanent=True)
+    offers_factories.OfferFactory(venue=_indexable_venue2)
     _indexable_venue3 = offerers_factories.VenueFactory(isPermanent=True)
+    offers_factories.OfferFactory(venue=_indexable_venue3)
 
     expected_to_be_reindexed = {
         indexable_venue1.id,
@@ -152,7 +155,9 @@ def test_partially_index_venues(app):
 @pytest.mark.usefixtures("clean_database")
 def test_partially_index_venues_removes_non_eligible_venues(app):
     future_not_indexable_venue = offerers_factories.VenueFactory(isPermanent=True)
+    offers_factories.OfferFactory(venue=future_not_indexable_venue)
     indexable_venue1 = offerers_factories.VenueFactory(isPermanent=True)
+    offers_factories.OfferFactory(venue=indexable_venue1)
 
     expected_to_be_reindexed = {
         future_not_indexable_venue.id,

--- a/api/tests/core/search/test_integration.py
+++ b/api/tests/core/search/test_integration.py
@@ -47,6 +47,7 @@ def test_offer_indexation_on_venue_cycle(app):
 
 def test_venue_indexation_cycle(app):
     venue = offerers_factories.VenueFactory(isPermanent=True)
+    offers_factories.OfferFactory(venue=venue)
     assert search_testing.search_store["venues"] == {}
 
     search.async_index_venue_ids([venue.id], search.IndexationReason.VENUE_CREATION)

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -175,10 +175,11 @@ class GetOffererTest:
         with testing.assert_num_queries(self.num_queries):
             response = client.get(f"/offerers/{offerer_id}")
             assert response.status_code == 200
-        assert response.json["managedVenues"][0]["hasCreatedOffer"] is True
-        assert response.json["managedVenues"][1]["hasCreatedOffer"] is True
-        assert response.json["managedVenues"][2]["hasCreatedOffer"] is True
-        assert response.json["managedVenues"][3]["hasCreatedOffer"] is False
+        managed_venues_list = sorted(response.json["managedVenues"], key=lambda d: d["id"])
+        assert managed_venues_list[0]["hasCreatedOffer"] is True
+        assert managed_venues_list[1]["hasCreatedOffer"] is True
+        assert managed_venues_list[2]["hasCreatedOffer"] is True
+        assert managed_venues_list[3]["hasCreatedOffer"] is False
         assert response.json["hasValidBankAccount"] is False
         assert response.json["hasPendingBankAccount"] is False
         assert response.json["venuesWithNonFreeOffersWithoutBankAccounts"] == []


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34727

Les contraintes sur la présence d'une offre individuelle et l'offerer actif n'existaient pas, c'est désormais le cas.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
