### PR TITLE
(BSR)[API] feat: use dateCreated kwarg in completed profile user factory

### DIFF
--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -205,6 +205,7 @@ class ProfileCompletedUserFactory(PhoneValidatedUserFactory):
                 resultContent__firstName=obj.firstName,
                 resultContent__lastName=obj.lastName,
                 resultContent__postalCode=obj.postalCode,
+                dateCreated=kwargs.get("dateCreated", datetime.utcnow()),
             )
         )
         return fraud_checks

--- a/api/tests/core/users/test_generator.py
+++ b/api/tests/core/users/test_generator.py
@@ -232,11 +232,17 @@ class UserGeneratorTest:
 
         user = users_generator.generate_user(user_data)
 
+        profile_completion_check = next(
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == fraud_models.FraudCheckType.PROFILE_COMPLETION
+        )
+        assert profile_completion_check.dateCreated == date_in_the_past
+
         identity_fraud_check = next(
             fraud_check
             for fraud_check in user.beneficiaryFraudChecks
             if fraud_check.type == fraud_models.FraudCheckType.UBBLE
         )
-
         assert identity_fraud_check.dateCreated == date_in_the_past
         assert identity_fraud_check.source_data().get_registration_datetime().date() == date_in_the_past.date()


### PR DESCRIPTION
## Vérifications

```python
development❯ from pcapi.core.users.factories import ProfileCompletedUserFactory
        ...: from datetime import datetime
        ...: 
        ...: user = ProfileCompletedUserFactory(age=16, beneficiaryFraudChecks__dateCreated=datetime(2024, 12, 1))
        ...: user.eligibility
<EligibilityType.UNDERAGE: 'underage'>
```
