### PR TITLE
(BSR)[PRO] hotfix: Didactic onboarding redirections

### DIFF
--- a/pro/src/app/App/App.tsx
+++ b/pro/src/app/App/App.tsx
@@ -97,7 +97,11 @@ export const App = (): JSX.Element | null => {
     ) {
       return <Navigate to="/onboarding" replace />
     }
-    if (location.pathname.includes('onboarding') && isOffererOnboarded) {
+    if (
+      location.pathname.includes('onboarding') &&
+      isOffererOnboarded &&
+      !searchParams.get('userHasJustOnBoarded')
+    ) {
       return <Navigate to="/accueil" replace />
     }
   }

--- a/pro/src/components/IndividualOffer/SummaryScreen/SummaryScreen.tsx
+++ b/pro/src/components/IndividualOffer/SummaryScreen/SummaryScreen.tsx
@@ -1,6 +1,6 @@
 import { Form, FormikProvider, useFormik } from 'formik'
 import { useState } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { useSWRConfig } from 'swr'
 
 import { api } from 'apiClient/api'
@@ -46,6 +46,7 @@ export const SummaryScreen = () => {
   const { offer, subCategories, publishedOfferWithSameEAN } =
     useIndividualOfferContext()
   const showEventPublicationForm = Boolean(offer?.isEvent)
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const onPublish = async (values: EventPublicationFormValues) => {
     // Edition mode offers are already published
@@ -79,6 +80,10 @@ export const SummaryScreen = () => {
           !offererResponse.hasPendingBankAccount)
 
       if (shouldDisplayRedirectDialog) {
+        setSearchParams(
+          { ...searchParams, userHasJustOnBoarded: '1' },
+          { replace: true }
+        )
         setDisplayRedirectDialog(true)
       } else {
         navigate(offerConfirmationStepUrl)


### PR DESCRIPTION
## But de la pull request

- Fix des redirections entre `/accueil` et `/onboarding` à la fin du parcours d'inscription (en fonction de si l'offerer est déjà activé ou non).
Mise à jour des différents états du store selon les cas.

- Fix du problème de redirection vers la page des remboursements bancaires à la fin de la création de la 1ère offre dans l'onBoarding.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
