### PR TITLE
(PC-34753)[BO] fix: don't alert Sentry when DS connection fails on user action

### DIFF
--- a/api/src/pcapi/connectors/dms/exceptions.py
+++ b/api/src/pcapi/connectors/dms/exceptions.py
@@ -22,3 +22,13 @@ class DmsGraphQLApiError(DmsGraphQLApiException):
     @property
     def is_not_found(self) -> bool:
         return self.code == "not_found"
+
+
+class DmsGraphQLAPIConnectError(DmsGraphQLApiError):
+    def __init__(self, message: str | None) -> None:
+        self._message = message
+        super().__init__(None)
+
+    @property
+    def message(self) -> str | None:
+        return f"La connexion à Démarches-Simplifiées a échoué : {self._message}"


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-34753

![image](https://github.com/user-attachments/assets/54a57089-2b25-40c1-8ab1-15ec3f895106)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
