### PR TITLE
(PC-34757)[BO] fix: catch external booking exceptions instead of crashing

### DIFF
--- a/api/src/pcapi/routes/backoffice/pivots/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pivots/blueprint.py
@@ -5,7 +5,6 @@ from flask import request
 from flask import url_for
 from flask_login import current_user
 from markupsafe import Markup
-import sqlalchemy as sa
 
 from pcapi.core.history import api as history_api
 from pcapi.core.history import models as history_models
@@ -108,7 +107,8 @@ def create_pivot(name: str) -> utils.BackofficeResponse:
             db.session.flush()
         else:
             mark_transaction_as_invalid()
-    except sa.exc.IntegrityError as exc:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        # IntegrityError or external error (which inherit from any ExternalBooking*)
         mark_transaction_as_invalid()
         flash(Markup("Une erreur s'est produite : {message}").format(message=str(exc)), "warning")
     else:
@@ -155,7 +155,8 @@ def update_pivot(name: str, pivot_id: int) -> utils.BackofficeResponse:
             db.session.flush()
         else:
             mark_transaction_as_invalid()
-    except sa.exc.IntegrityError as exc:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        # IntegrityError or external error (which inherit from any ExternalBooking*)
         mark_transaction_as_invalid()
         flash(Markup("Une erreur s'est produite : {message}").format(message=str(exc)), "warning")
     else:
@@ -190,7 +191,7 @@ def delete_pivot(name: str, pivot_id: int) -> utils.BackofficeResponse:
         can_delete_pivot = pivot_context.delete_pivot(pivot_id)
         if can_delete_pivot:
             db.session.flush()
-    except sa.exc.IntegrityError as exc:
+    except Exception as exc:  # pylint: disable=broad-exception-caught
         mark_transaction_as_invalid()
         flash(Markup("Une erreur s'est produite : {message}").format(message=str(exc)), "warning")
     else:


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-34757

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
