### PR TITLE
(PC-34785)[API] refactor: Remove ApiErrors/ClientErrors from core/educational

### DIFF
--- a/api/src/pcapi/core/educational/exceptions.py
+++ b/api/src/pcapi/core/educational/exceptions.py
@@ -1,7 +1,6 @@
 import typing
 
-from pcapi.domain.client_exceptions import ClientError
-from pcapi.models.api_errors import ApiErrors
+from pcapi.core.core_exception import CoreException
 
 
 if typing.TYPE_CHECKING:
@@ -10,21 +9,20 @@ if typing.TYPE_CHECKING:
     from pcapi.core.educational.models import CollectiveOfferTemplateAllowedAction
 
 
-class EducationalInstitutionUnknown(ClientError):
-    def __init__(self) -> None:
-        super().__init__("educationalInstitution", "Cette institution est inconnue")
+class EducationalException(CoreException):
+    pass
 
 
-class StockNotBookable(ClientError):
-    def __init__(self, stock_id: int) -> None:
-        super().__init__("stock", f"Le stock {stock_id} n'est pas réservable")
+class EducationalInstitutionUnknown(EducationalException):
+    pass
 
 
-class EducationalYearNotFound(ClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "educationalYear", "Aucune année scolaire correspondant à la réservation demandée n'a été trouvée"
-        )
+class CollectiveStockNotBookable(EducationalException):
+    pass
+
+
+class EducationalYearNotFound(EducationalException):
+    pass
 
 
 class InsufficientFund(Exception):
@@ -71,8 +69,8 @@ class CollectiveStockAlreadyExists(Exception):
     pass
 
 
-class StockDoesNotExist(ApiErrors):
-    status_code = 400
+class CollectiveStockDoesNotExist(EducationalException):
+    pass
 
 
 class PriceRequesteCantBedHigherThanActualPrice(Exception):

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -485,7 +485,7 @@ def get_and_lock_collective_stock(stock_id: int) -> educational_models.Collectiv
         .one_or_none()
     )
     if not stock:
-        raise educational_exceptions.StockDoesNotExist()
+        raise educational_exceptions.CollectiveStockDoesNotExist()
     return stock
 
 

--- a/api/src/pcapi/core/educational/validation.py
+++ b/api/src/pcapi/core/educational/validation.py
@@ -76,7 +76,7 @@ def check_ministry_fund(
 
 def check_collective_stock_is_bookable(stock: models.CollectiveStock) -> None:
     if not stock.isBookable:
-        raise exceptions.StockNotBookable(stock.id)
+        raise exceptions.CollectiveStockNotBookable()
 
 
 def check_collective_booking_status(collective_booking: models.CollectiveBooking) -> None:

--- a/api/src/pcapi/routes/adage_iframe/bookings.py
+++ b/api/src/pcapi/routes/adage_iframe/bookings.py
@@ -5,7 +5,6 @@ from pcapi.core.educational import utils as educational_utils
 from pcapi.core.educational.api import booking as educational_api_booking
 from pcapi.core.educational.models import AdageFrontRoles
 from pcapi.core.educational.repository import find_educational_institution_by_uai_code
-from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.models.api_errors import ApiErrors
 from pcapi.repository import atomic
 from pcapi.routes.adage_iframe import blueprint
@@ -71,7 +70,7 @@ def book_collective_offer(
             status_code=403,
         )
 
-    except offers_exceptions.StockDoesNotExist:
+    except exceptions.CollectiveStockDoesNotExist:
         logger.info("Could not book offer: stock does not exist", extra={"stock_id": body.stockId})
         raise ApiErrors({"stock": "Stock introuvable"}, status_code=400)
     except exceptions.CollectiveStockNotBookableByUser:
@@ -81,7 +80,7 @@ def book_collective_offer(
         )
         raise ApiErrors({"code": "WRONG_UAI_CODE"}, status_code=403)
 
-    except exceptions.StockNotBookable:
+    except exceptions.CollectiveStockNotBookable:
         logger.info("Could not book offer: stock is not bookable", extra={"stock_id": body.stockId})
         raise ApiErrors({"stock": "Cette offre n'est pas disponible à la réservation"})
     except exceptions.EducationalInstitutionUnknown:


### PR DESCRIPTION
## But de la pull request

- Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX
- https://www.notion.so/passcultureapp/D-coupler-les-erreurs-de-l-API-core-des-erreurs-renvoy-es-par-l-API-REST-que-l-API-Core-ne-renvoie--5bd63908cd984dc6b5b47eb907d8c6a3?pvs=4

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
