### PR TITLE
(PC-34439)[PRO] feat: change algoliasearch client import

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersInstantSearch.tsx
@@ -1,4 +1,4 @@
-import algoliasearch from 'algoliasearch/lite'
+import liteClient from 'algoliasearch/lite'
 import { useEffect, useState } from 'react'
 import { Configure, Index, InstantSearch } from 'react-instantsearch'
 import { useSelector } from 'react-redux'
@@ -26,7 +26,7 @@ import {
   adageFiltersToFacetFilters,
 } from './utils'
 
-const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
+const searchClient = liteClient(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
 
 export const MAIN_INDEX_ID = 'main_offers_index'
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -5,7 +5,7 @@ import {
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions'
 import { AutocompleteQuerySuggestionsHit } from '@algolia/autocomplete-plugin-query-suggestions/dist/esm/types'
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches'
-import algoliasearch from 'algoliasearch/lite'
+import liteClient from 'algoliasearch/lite'
 import { FormikContext } from 'formik'
 import {
   BaseSyntheticEvent,
@@ -139,7 +139,7 @@ export const Autocomplete = ({ initialQuery }: AutocompleteProps) => {
     },
   })
 
-  const searchClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
+  const searchClient = liteClient(ALGOLIA_APP_ID, ALGOLIA_API_KEY)
 
   // provides search suggestions based on existing partners
   /* istanbul ignore next: We dont want to test algolia implementation */


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34439

Utiliser liteClient dans l'import au lieu de algoliasearch
