### PR TITLE
(BSR)[PRO] fix: remove field layout from multiselect

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -96,7 +96,7 @@ export const FormOfferType = ({
               }}
               onBlur={() => setFieldTouched('domains', true)}
               disabled={disableForm}
-              showError={touched.domains && !!errors.domains}
+              required={true}
               error={
                 touched.domains && errors.domains
                   ? String(errors.domains)
@@ -105,6 +105,7 @@ export const FormOfferType = ({
             />
           </FormLayout.Row>
         )}
+
         <FormLayout.Row>
           <MultiSelect
             options={eacFormatOptions}
@@ -121,9 +122,9 @@ export const FormOfferType = ({
                 ...selectedOptions.map((elm) => elm.id),
               ])
             }
+            required={true}
             disabled={disableForm}
             onBlur={() => setFieldTouched('formats', true)}
-            showError={touched.formats && !!errors.formats}
             error={
               touched.formats && errors.formats
                 ? String(errors.formats)

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
@@ -85,7 +85,6 @@ export const FormPracticalInformation = ({
       hasSelectAllOptions
       onSelectedOptionsChanged={handleMultiSelectChange}
       onBlur={() => setFieldTouched('interventionArea', true)}
-      showError={touched.interventionArea && !!errors.interventionArea}
       error={
         touched.interventionArea && errors.interventionArea
           ? String(errors.interventionArea)

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormPracticalInformation/FormPracticalInformation.tsx
@@ -50,15 +50,22 @@ export const FormPracticalInformation = ({
 
   const isOfferAddressEnabled = useActiveFeature('WIP_ENABLE_OFFER_ADDRESS')
 
-  const handleMultiSelectChange = useCallback((selectedOption: Option[], addedOptions: Option[], removedOptions: Option[]) => {
-    const newSelectedOptions = interventionAreaMultiSelect({
-      selectedOption,
-      addedOptions,
-      removedOptions,
-    })
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    setFieldValue('interventionArea', Array.from(newSelectedOptions))
-  }, [setFieldValue])
+  const handleMultiSelectChange = useCallback(
+    (
+      selectedOption: Option[],
+      addedOptions: Option[],
+      removedOptions: Option[]
+    ) => {
+      const newSelectedOptions = interventionAreaMultiSelect({
+        selectedOption,
+        addedOptions,
+        removedOptions,
+      })
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      setFieldValue('interventionArea', Array.from(newSelectedOptions))
+    },
+    [setFieldValue]
+  )
 
   const MultiSelectComponent = (
     <MultiSelect
@@ -66,8 +73,12 @@ export const FormPracticalInformation = ({
       name="interventionArea"
       buttonLabel="Département(s)"
       options={offerInterventionOptions}
-      selectedOptions={offerInterventionOptions.filter((op) => values.interventionArea.includes(op.id))}
-      defaultOptions={offerInterventionOptions.filter((option) => values.interventionArea.includes(option.id))}
+      selectedOptions={offerInterventionOptions.filter((op) =>
+        values.interventionArea.includes(op.id)
+      )}
+      defaultOptions={offerInterventionOptions.filter((option) =>
+        values.interventionArea.includes(option.id)
+      )}
       disabled={disableForm}
       hasSearch
       searchLabel="Rechercher"
@@ -75,7 +86,11 @@ export const FormPracticalInformation = ({
       onSelectedOptionsChanged={handleMultiSelectChange}
       onBlur={() => setFieldTouched('interventionArea', true)}
       showError={touched.interventionArea && !!errors.interventionArea}
-      error={touched.interventionArea && errors.interventionArea ? String(errors.interventionArea) : undefined}
+      error={
+        touched.interventionArea && errors.interventionArea
+          ? String(errors.interventionArea)
+          : undefined
+      }
     />
   )
 
@@ -120,9 +135,10 @@ export const FormPracticalInformation = ({
             </InfoBox>
           }
         >
-        {MultiSelectComponent}
+          {MultiSelectComponent}
         </FormLayout.Row>
-    )},
+      ),
+    },
     {
       label: EVENT_ADDRESS_OTHER_LABEL,
       value: OfferAddressType.OTHER,

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
@@ -121,7 +121,6 @@ export const CollectiveDataForm = ({
                   <MultiSelect
                     name="collectiveStudents"
                     label="Public cible"
-                    required={true}
                     options={studentOptions}
                     defaultOptions={studentOptions.filter((option) =>
                       formik.values.collectiveStudents.includes(option.label)
@@ -169,7 +168,6 @@ export const CollectiveDataForm = ({
                   <MultiSelect
                     name="collectiveDomains"
                     label="Domaine artistique et culturel"
-                    required={true}
                     options={domains}
                     defaultOptions={domains.filter((option) =>
                       formik.values.collectiveDomains.includes(option.id)
@@ -197,7 +195,6 @@ export const CollectiveDataForm = ({
                   <MultiSelect
                     name="collectiveInterventionArea"
                     label="Zone de mobilité"
-                    required={true}
                     options={offerInterventionOptions}
                     selectedOptions={offerInterventionOptions.filter((op) =>
                       formik.values.collectiveInterventionArea.includes(op.id)

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataForm/CollectiveDataForm.tsx
@@ -121,12 +121,12 @@ export const CollectiveDataForm = ({
                   <MultiSelect
                     name="collectiveStudents"
                     label="Public cible"
+                    required={true}
                     options={studentOptions}
                     defaultOptions={studentOptions.filter((option) =>
                       formik.values.collectiveStudents.includes(option.label)
                     )}
                     hasSearch
-                    isOptional
                     searchLabel="Public cible"
                     onSelectedOptionsChanged={(selectedOption) =>
                       formik.setFieldValue('collectiveStudents', [
@@ -138,10 +138,6 @@ export const CollectiveDataForm = ({
                     buttonLabel="Public cible"
                     onBlur={() =>
                       formik.setFieldTouched('collectiveStudents', true)
-                    }
-                    showError={
-                      formik.touched.collectiveStudents &&
-                      !!formik.errors.collectiveStudents
                     }
                     error={
                       formik.touched.collectiveStudents &&
@@ -173,12 +169,12 @@ export const CollectiveDataForm = ({
                   <MultiSelect
                     name="collectiveDomains"
                     label="Domaine artistique et culturel"
+                    required={true}
                     options={domains}
                     defaultOptions={domains.filter((option) =>
                       formik.values.collectiveDomains.includes(option.id)
                     )}
                     hasSearch
-                    isOptional
                     searchLabel="Domaines artistiques et culturel"
                     onSelectedOptionsChanged={(selectedOption) =>
                       formik.setFieldValue('collectiveDomains', [
@@ -189,10 +185,6 @@ export const CollectiveDataForm = ({
                     onBlur={() =>
                       formik.setFieldTouched('collectiveDomains', true)
                     }
-                    showError={
-                      formik.touched.collectiveDomains &&
-                      !!formik.errors.collectiveDomains
-                    }
                     error={
                       formik.touched.collectiveDomains &&
                       formik.errors.collectiveDomains
@@ -201,11 +193,11 @@ export const CollectiveDataForm = ({
                     }
                   />
                 </FormLayout.Row>
-
                 <FormLayout.Row>
                   <MultiSelect
                     name="collectiveInterventionArea"
                     label="Zone de mobilité"
+                    required={true}
                     options={offerInterventionOptions}
                     selectedOptions={offerInterventionOptions.filter((op) =>
                       formik.values.collectiveInterventionArea.includes(op.id)
@@ -217,7 +209,6 @@ export const CollectiveDataForm = ({
                     )}
                     hasSelectAllOptions
                     hasSearch
-                    isOptional
                     searchLabel="Rechercher"
                     onSelectedOptionsChanged={(
                       selectedOption,
@@ -240,10 +231,6 @@ export const CollectiveDataForm = ({
                     onBlur={() =>
                       formik.setFieldTouched('collectiveDomains', true)
                     }
-                    showError={
-                      formik.touched.collectiveInterventionArea &&
-                      !!formik.errors.collectiveInterventionArea
-                    }
                     error={
                       formik.touched.collectiveInterventionArea &&
                       formik.errors.collectiveInterventionArea
@@ -252,7 +239,6 @@ export const CollectiveDataForm = ({
                     }
                   />
                 </FormLayout.Row>
-
                 <FormLayout.Row>
                   <Select
                     options={[

--- a/pro/src/ui-kit/MultiSelect/MultiSelect.module.scss
+++ b/pro/src/ui-kit/MultiSelect/MultiSelect.module.scss
@@ -5,12 +5,14 @@
 @use "styles/mixins/_outline.scss" as outline;
 
 .container {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  max-width: rem.torem(542px);
-  position: relative;
   margin-bottom: rem.torem(8px);
+
+  &-input {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    position: relative;
+  }
 
   &-label {
     display: block;
@@ -25,6 +27,7 @@
     }
   }
 }
+
 
 .legend {
   @include fonts.body;

--- a/pro/src/ui-kit/MultiSelect/MultiSelect.module.scss
+++ b/pro/src/ui-kit/MultiSelect/MultiSelect.module.scss
@@ -10,6 +10,20 @@
   width: 100%;
   max-width: rem.torem(542px);
   position: relative;
+  margin-bottom: rem.torem(8px);
+
+  &-label {
+    display: block;
+    margin-bottom: rem.torem(8px);
+  }
+
+  &-error {
+    margin-top: rem.torem(8px);
+
+    svg {
+      flex: 0 0 rem.torem(15px);
+    }
+  }
 }
 
 .legend {

--- a/pro/src/ui-kit/MultiSelect/MultiSelect.stories.tsx
+++ b/pro/src/ui-kit/MultiSelect/MultiSelect.stories.tsx
@@ -95,7 +95,6 @@ export const WithError: StoryObj<typeof MultiSelect> = {
     ...defaultProps,
     buttonLabel: 'Départements',
     label: 'Sélectionner des départements',
-    showError: true,
     error: 'Veuillez sélectionner un département',
     onBlur: () => {},
     name: 'départements',

--- a/pro/src/ui-kit/MultiSelect/MultiSelect.tsx
+++ b/pro/src/ui-kit/MultiSelect/MultiSelect.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames'
 import { useEffect, useId, useRef, useState } from 'react'
 
 import { useOnClickOrFocusOutside } from 'commons/hooks/useOnClickOrFocusOutside'
@@ -53,6 +54,8 @@ type MultiSelectProps = {
   required?: boolean
   /** display asterik  */
   asterisk?: boolean
+  /** this class offers the possibility of limiting the size of the multiselect  */
+  className?: string
 
   /** Trigger function to display error message when element is unfocus */
   onBlur?: () => void
@@ -105,6 +108,7 @@ type MultiSelectProps = {
  *
  */
 export const MultiSelect = ({
+  className,
   options,
   selectedOptions,
   defaultOptions = [],
@@ -191,13 +195,13 @@ export const MultiSelect = ({
   useOnClickOrFocusOutside(containerRef, () => setIsOpen(false))
 
   return (
-    <fieldset onBlur={onBlur}>
+    <fieldset className={styles.container} onBlur={onBlur}>
       {label && (
         <label className={styles['container-label']}>
           {label} {required && asterisk && '*'}
         </label>
       )}
-      <div className={styles.container}>
+      <div className={cn(className, styles['container-input'])}>
         <div ref={containerRef}>
           <MultiSelectTrigger
             id={id}
@@ -227,17 +231,6 @@ export const MultiSelect = ({
             />
           )}
         </div>
-
-        <SelectedValuesTags
-          disabled={disabled}
-          selectedOptions={selectedItems.map((item) => item.id)}
-          removeOption={handleRemoveTag}
-          fieldName="tags"
-          optionsLabelById={selectedItems.reduce(
-            (acc, item) => ({ ...acc, [item.id]: item.label }),
-            {}
-          )}
-        />
         <div
           role="alert"
           className={styles['container-error']}
@@ -246,6 +239,17 @@ export const MultiSelect = ({
           {error && <FieldError name={name}>{error}</FieldError>}
         </div>
       </div>
+
+      <SelectedValuesTags
+        disabled={disabled}
+        selectedOptions={selectedItems.map((item) => item.id)}
+        removeOption={handleRemoveTag}
+        fieldName="tags"
+        optionsLabelById={selectedItems.reduce(
+          (acc, item) => ({ ...acc, [item.id]: item.label }),
+          {}
+        )}
+      />
     </fieldset>
   )
 }

--- a/pro/src/ui-kit/MultiSelect/MultiSelect.tsx
+++ b/pro/src/ui-kit/MultiSelect/MultiSelect.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useId, useRef, useState } from 'react'
 
 import { useOnClickOrFocusOutside } from 'commons/hooks/useOnClickOrFocusOutside'
-import { FieldLayout } from 'ui-kit/form/shared/FieldLayout/FieldLayout'
+import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
 
 import { SelectedValuesTags } from '../SelectedValuesTags/SelectedValuesTags'
 
@@ -49,8 +49,11 @@ type MultiSelectProps = {
   name: string
   /** Label for the dropdown button */
   buttonLabel: string
-  isOptional?: boolean
-  showError?: boolean
+  /** field is required */
+  required?: boolean
+  /** display asterik  */
+  asterisk?: boolean
+
   /** Trigger function to display error message when element is unfocus */
   onBlur?: () => void
 } & (
@@ -114,8 +117,8 @@ export const MultiSelect = ({
   error,
   name,
   buttonLabel,
-  isOptional = false,
-  showError = false,
+  required = false,
+  asterisk = true,
   onBlur,
 }: MultiSelectProps): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false)
@@ -188,14 +191,13 @@ export const MultiSelect = ({
   useOnClickOrFocusOutside(containerRef, () => setIsOpen(false))
 
   return (
-    <FieldLayout
-      label={label}
-      name={name}
-      error={error}
-      showError={showError}
-      isOptional={isOptional}
-    >
-      <fieldset className={styles.container} onBlur={onBlur}>
+    <fieldset onBlur={onBlur}>
+      {label && (
+        <label className={styles['container-label']}>
+          {label} {required && asterisk && '*'}
+        </label>
+      )}
+      <div className={styles.container}>
         <div ref={containerRef}>
           <MultiSelectTrigger
             id={id}
@@ -236,7 +238,14 @@ export const MultiSelect = ({
             {}
           )}
         />
-      </fieldset>
-    </FieldLayout>
+        <div
+          role="alert"
+          className={styles['container-error']}
+          id={`error-details-${name}`}
+        >
+          {error && <FieldError name={name}>{error}</FieldError>}
+        </div>
+      </div>
+    </fieldset>
   )
 }


### PR DESCRIPTION
## But de la pull request

Cette PR enlève le fielLayout du multiselect pour éviter les effets de bord, la recommandation est de ne plus utilisé ce composant dans les composants. Il pose des problèmes pour le positionnement des inputs, les éléments de design ne doivent pas gérer leur positionnement au risque de devoir écraser les styles depuis le niveau du dessus.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
