### PR TITLE
(BSR)[API] test: do not rely on ordered creation date in flaky test

### DIFF
--- a/api/tests/routes/pro/patch_offerer_bank_accounts_test.py
+++ b/api/tests/routes/pro/patch_offerer_bank_accounts_test.py
@@ -277,9 +277,7 @@ class OffererPatchBankAccountsTest:
             .count()
         )
 
-        actions_logged = history_models.ActionHistory.query.order_by(
-            history_models.ActionHistory.actionDate, history_models.ActionHistory.venueId
-        ).all()
+        actions_logged = history_models.ActionHistory.query.order_by(history_models.ActionHistory.venueId).all()
 
         assert len(actions_logged) == len(actions_occured)
 


### PR DESCRIPTION
ActionHistory.actionDate server default is set to the database now().
Multiple objects written almost at the same time may have different
insertions order in the db, making the column flaky for sorting.