### PR TITLE
(PC-34483)[API] fix: only pro user can have partner page

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -735,7 +735,9 @@ class User(PcObject, Base, Model, DeactivableMixin):
             sa.select(1)
             .select_from(UserOfferer)
             .join(Venue, UserOfferer.offererId == Venue.managingOffererId)
+            .join(User, UserOfferer.user)
             .where(
+                User.roles.contains([UserRole.PRO]),
                 UserOfferer.userId == self.id,
                 Offerer.isActive.is_(True),
                 Venue.isPermanent.is_(True),

--- a/api/tests/core/users/test_models.py
+++ b/api/tests/core/users/test_models.py
@@ -339,19 +339,23 @@ class UserTest:
         assert user.proValidationStatus == ValidationStatus.VALIDATED
 
     @pytest.mark.parametrize(
-        "active_offerer,permanent_venue,virtual_venue,at_least_one_offer,has_partner_page",
+        "active_offerer,permanent_venue,virtual_venue,at_least_one_offer,is_pro_user,has_partner_page",
         [
-            (False, True, False, True, False),
-            (True, False, False, True, False),
-            (True, True, True, True, False),
-            (True, True, False, False, False),
-            (True, True, False, True, True),
+            (False, True, False, True, True, False),
+            (True, False, False, True, True, False),
+            (True, True, True, True, True, False),
+            (True, True, False, False, True, False),
+            (True, True, False, True, False, False),
+            (True, True, False, True, True, True),
         ],
     )
     def test_has_partner_page(
-        self, active_offerer, permanent_venue, virtual_venue, at_least_one_offer, has_partner_page
+        self, active_offerer, permanent_venue, virtual_venue, at_least_one_offer, is_pro_user, has_partner_page
     ):
-        user = users_factories.UserFactory()
+        if is_pro_user:
+            user = users_factories.ProFactory()
+        else:
+            user = users_factories.UserFactory()
         offerer = offerers_factories.OffererFactory(isActive=active_offerer)
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34483

Fix d'un bug, les user NON_ATTACHED_PRO avaient accès à la page partenaire, ce n'est plus le cas (il faut âtre PRO)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
