### PR TITLE
(PC-34746)[PRO] feat: refacto partner page display (moving / deleting / renaming sections) in context of isOpenToPublic feature

### DIFF
--- a/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
@@ -6,6 +6,8 @@ import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import styles from './OpeningHoursReadOnly.module.scss'
 
 type OpeningHours = {
+  isOpenToPublicEnabled: boolean
+  isOpenToPublic: boolean
   openingHours: GetVenueResponseModel['openingHours']
 }
 
@@ -21,7 +23,7 @@ type HoursProps = {
 type Entries<T> = T extends Record<infer W, infer U> ? [W, U][] : never;
 type OpeningHoursEntries = Entries<GetVenueResponseModel['openingHours']>;
 
-export function OpeningHoursReadOnly({ openingHours }: OpeningHours) {
+export function OpeningHoursReadOnly({ isOpenToPublicEnabled, isOpenToPublic, openingHours }: OpeningHours) {
   const filledDays = Object.entries(openingHours ?? {})
     .filter((dateAndHour) =>
       Boolean(dateAndHour[1])
@@ -32,30 +34,31 @@ export function OpeningHoursReadOnly({ openingHours }: OpeningHours) {
     return index === -1 ? null : filledDays[index]
   }).filter(Boolean) as OpeningHoursEntries
 
-  if (!openingHours || orderedFilledDays.length === 0) {
-    return (
-      <SummarySubSection
-        title={'Horaires d’ouverture'}
-        shouldShowDivider={false}
-      >
+  return (
+    <SummarySubSection
+      title={isOpenToPublicEnabled ? "Accès et horaires" : "Horaires d'ouverture"}
+      shouldShowDivider={false}
+    >
+      {isOpenToPublicEnabled && !isOpenToPublic ? (
+        <p>
+          Accueil du public dans la structure : Non
+        </p>
+      ) : (!openingHours || orderedFilledDays.length === 0) ? (
         <p>
           {openingHours === null
             ? 'Non renseigné'
             : `Vous n’avez pas renseigné d’horaire d’ouverture. Votre établissement est indiqué comme fermé sur l’application.`}
         </p>
-      </SummarySubSection>
-    )
-  }
-  return (
-    <SummarySubSection title={'Horaires d’ouverture'} shouldShowDivider={false}>
-      <SummaryDescriptionList
-        descriptions={orderedFilledDays.map((dateAndHour) => {
-          return {
-            title: mapDayToFrench(dateAndHour[0]),
-            text: <Hours hours={dateAndHour[1]} />,
-          }
-        })}
-      />
+      ) : (
+        <SummaryDescriptionList
+          descriptions={orderedFilledDays.map((dateAndHour) => {
+            return {
+              title: mapDayToFrench(dateAndHour[0]),
+              text: <Hours hours={dateAndHour[1]} />,
+            }
+          })}
+        />
+      )}
     </SummarySubSection>
   )
 }

--- a/pro/src/pages/VenueEdition/OpeningHoursReadOnly/__specs__/OpeningHoursReadOnly.spec.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursReadOnly/__specs__/OpeningHoursReadOnly.spec.tsx
@@ -29,7 +29,13 @@ describe('OpeningHoursReadOnly', () => {
       SUNDAY: null,
     }
 
-    render(<OpeningHoursReadOnly openingHours={openingHours} />)
+    render(
+      <OpeningHoursReadOnly
+        isOpenToPublicEnabled={false}
+        isOpenToPublic={false}
+        openingHours={openingHours}
+      />
+    )
 
     expect(screen.getByText(/Lundi/)).toBeInTheDocument()
     expect(screen.getByText(/Mardi/)).toBeInTheDocument()
@@ -42,13 +48,34 @@ describe('OpeningHoursReadOnly', () => {
 
   it('should display no opening hours !', () => {
     const openingHours = undefined
-    render(<OpeningHoursReadOnly openingHours={openingHours} />)
+    render(
+      <OpeningHoursReadOnly
+        isOpenToPublicEnabled={false}
+        isOpenToPublic={false}
+        openingHours={openingHours}
+      />
+    )
 
     expect(
       screen.getByText(
         /Vous n’avez pas renseigné d’horaire d’ouverture. Votre établissement est indiqué comme fermé sur l’application./
       )
     ).toBeInTheDocument()
+  })
+
+  describe('when open to public feature is enabled', () => {
+    it('should display a specific message when the venue is not open to public', () => {
+      const openingHours = undefined
+      render(
+        <OpeningHoursReadOnly
+          isOpenToPublicEnabled
+          isOpenToPublic={false}
+          openingHours={openingHours}
+        />
+      )
+
+      expect(screen.getByText(/Accueil du public dans la structure : Non/)).toBeInTheDocument()
+    })
   })
 })
 

--- a/pro/src/pages/VenueEdition/VenueEdition.module.scss
+++ b/pro/src/pages/VenueEdition/VenueEdition.module.scss
@@ -1,11 +1,4 @@
 @use "styles/mixins/_rem.scss" as rem;
-@use "styles/mixins/_fonts.scss" as fonts;
-
-.header {
-  @include fonts.title1;
-
-  margin-bottom: rem.torem(32px);
-}
 
 .select-partner-page {
   margin-top: rem.torem(32px);

--- a/pro/src/pages/VenueEdition/VenueEdition.tsx
+++ b/pro/src/pages/VenueEdition/VenueEdition.tsx
@@ -110,10 +110,9 @@ export const VenueEdition = (): JSX.Element | null => {
         : 'Page sur l’application'
 
   return (
-    <Layout>
+    <Layout mainHeading={titleText}>
       <div>
         <FormLayout>
-          <h1 className={styles['header']}>{titleText}</h1>
           {venuesOptions.length > 1 && venue.isPermanent && (
             <>
               <FormLayout.Row>

--- a/pro/src/pages/VenueEdition/VenueEditionForm.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionForm.tsx
@@ -8,6 +8,7 @@ import { GetVenueResponseModel } from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { GET_VENUE_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { Events } from 'commons/core/FirebaseEvents/constants'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useNotification } from 'commons/hooks/useNotification'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { MandatoryInfo } from 'components/FormLayout/FormLayoutMandatoryInfo'
@@ -35,6 +36,7 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
   const notify = useNotification()
   const { logEvent } = useAnalytics()
   const { mutate } = useSWRConfig()
+  const isOpenToPublicEnabled = useActiveFeature('WIP_IS_OPEN_TO_PUBLIC')
 
   const onSubmit: FormikConfig<VenueEditionFormValues>['onSubmit'] = async (
     values,
@@ -126,7 +128,7 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
               </FormLayout.Row>
             </FormLayout.SubSection>
             {venue.isPermanent && (
-              <FormLayout.SubSection title="Horaires d'ouverture">
+              <FormLayout.SubSection title={isOpenToPublicEnabled ? "Accès et horaires" : "Horaires d'ouverture"}>
                 <OpeningHoursForm />
               </FormLayout.SubSection>
             )}

--- a/pro/src/pages/VenueEdition/VenueEditionFormScreen.module.scss
+++ b/pro/src/pages/VenueEdition/VenueEditionFormScreen.module.scss
@@ -1,14 +1,5 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .page-status {
-  margin-bottom: rem.torem(32px);
-}
-
-.separator {
-  width: 100%;
-  height: 2px;
-  background: var(--color-grey-medium);
-  border: none;
-  margin-top: rem.torem(32px);
-  margin-bottom: rem.torem(32px);
+  margin-bottom: rem.torem(32px)
 }

--- a/pro/src/pages/VenueEdition/VenueEditionFormScreen.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionFormScreen.tsx
@@ -1,6 +1,7 @@
 import { useLocation } from 'react-router-dom'
 
 import { GetVenueResponseModel } from 'apiClient/v1'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { PartnerPageIndividualSection } from 'pages/Homepage/components/Offerers/components/PartnerPages/components/PartnerPageIndividualSection'
 import { Callout } from 'ui-kit/Callout/Callout'
 
@@ -15,6 +16,9 @@ interface VenueEditionProps {
 export const VenueEditionFormScreen = ({
   venue,
 }: VenueEditionProps): JSX.Element => {
+  const isOpenToPublicEnabled = useActiveFeature('WIP_IS_OPEN_TO_PUBLIC')
+  const shouldDisplayPartnerPageSection = !isOpenToPublicEnabled
+
   const location = useLocation()
 
   if (venue.isVirtual) {
@@ -36,15 +40,14 @@ export const VenueEditionFormScreen = ({
               Les informations que vous renseignez ci-dessous sont affichées
               dans votre page partenaire, visible sur l’application pass Culture
             </Callout>
-            <PartnerPageIndividualSection
+            {shouldDisplayPartnerPageSection && <PartnerPageIndividualSection
               venueId={venue.id}
               venueName={venue.name}
               offererId={venue.managingOfferer.id}
               isVisibleInApp={Boolean(venue.isVisibleInApp)}
-            />
+            />}
           </div>
-
-          <hr className={styles['separator']} />
+          {shouldDisplayPartnerPageSection && <hr className={styles['separator']} />}
         </>
       )}
 

--- a/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
@@ -12,13 +12,16 @@ import {
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { GET_VENUE_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { Events } from 'commons/core/FirebaseEvents/constants'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useNotification } from 'commons/hooks/useNotification'
 import { selectCurrentOffererId } from 'commons/store/offerer/selectors'
+import { WEBAPP_URL } from 'commons/utils/config'
 import { ButtonImageEdit } from 'components/ImageUploader/components/ButtonImageEdit/ButtonImageEdit'
 import { OnImageUploadArgs } from 'components/ImageUploader/components/ButtonImageEdit/ModalImageEdit/ModalImageEdit'
 import { UploadImageValues } from 'components/ImageUploader/components/ButtonImageEdit/types'
 import { ImageUploader } from 'components/ImageUploader/ImageUploader'
 import { UploaderModeEnum } from 'components/ImageUploader/types'
+import fullLinkIcon from 'icons/full-link.svg'
 import fullParametersIcon from 'icons/full-parameters.svg'
 import { postImageToVenue } from 'repository/pcapi/pcapi'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
@@ -63,6 +66,7 @@ export const VenueEditionHeader = ({
   const { mutate } = useSWRConfig()
   const notify = useNotification()
   const selectedOffererId = useSelector(selectCurrentOffererId)
+  const isOpenToPublicEnabled = useActiveFeature('WIP_IS_OPEN_TO_PUBLIC')
 
   const venueType = venueTypes.find(
     (venueType) => venueType.id === venue.venueTypeCode
@@ -137,8 +141,7 @@ export const VenueEditionHeader = ({
               ? `${offerer.name} (Offre numérique)`
               : venue.publicName || venue.name}
           </h2>
-
-          {venue.street && (
+          {!isOpenToPublicEnabled && venue.street && (
             <address className={styles['venue-address']}>
               {venue.street}, {venue.postalCode} {venue.city}
             </address>
@@ -153,7 +156,15 @@ export const VenueEditionHeader = ({
           >
             Paramètres généraux
           </ButtonLink>
-
+          {isOpenToPublicEnabled && venue.isPermanent && <ButtonLink
+            variant={ButtonVariant.TERNARY}
+            icon={fullLinkIcon}
+            to={`${WEBAPP_URL}/lieu/${venue.id}`}
+            isExternal
+            opensInNewTab
+          >
+            Visualiser votre page
+          </ButtonLink>}
           {imageValues.originalImageUrl && (
             <ButtonImageEdit
               mode={UploaderModeEnum.VENUE}

--- a/pro/src/pages/VenueEdition/VenueEditionReadOnly.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionReadOnly.tsx
@@ -1,4 +1,5 @@
 import { GetVenueResponseModel } from 'apiClient/v1'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { AccessibilitySummarySection as InternalAccessibilitySummarySubSection } from 'components/AccessibilitySummarySection/AccessibilitySummarySection'
 import { ExternalAccessibility } from 'components/ExternalAccessibility/ExternalAccessibility'
 import { SummaryDescriptionList } from 'components/SummaryLayout/SummaryDescriptionList'
@@ -13,6 +14,10 @@ interface VenueEditionReadOnlyProps {
 }
 
 export const VenueEditionReadOnly = ({ venue }: VenueEditionReadOnlyProps) => {
+  const isOpenToPublicEnabled = useActiveFeature('WIP_IS_OPEN_TO_PUBLIC')
+  const isVenueOpenToPublic = !!venue.isOpenToPublic
+  const isAccessibilitySectionDisplayed = isOpenToPublicEnabled ? isVenueOpenToPublic : true
+
   return (
     <SummarySection
       title="Vos informations pour le grand public"
@@ -31,36 +36,37 @@ export const VenueEditionReadOnly = ({ venue }: VenueEditionReadOnlyProps) => {
           ]}
         />
       </SummarySubSection>
-
-      {venue.isPermanent && (
-        <OpeningHoursReadOnly openingHours={venue.openingHours} />
-      )}
-
-      {venue.externalAccessibilityData ? (
-        <>
-          <SummarySubSection
-            title="Modalités d’accessibilité via acceslibre"
+      <OpeningHoursReadOnly
+        isOpenToPublicEnabled={isOpenToPublicEnabled}
+        isOpenToPublic={isVenueOpenToPublic}
+        openingHours={venue.openingHours}
+      />
+      {isAccessibilitySectionDisplayed && (
+        venue.externalAccessibilityData ? (
+          <>
+            <SummarySubSection
+              title="Modalités d’accessibilité via acceslibre"
+              shouldShowDivider={false}
+            >
+              <ExternalAccessibility
+                externalAccessibilityId={venue.externalAccessibilityId}
+                externalAccessibilityData={venue.externalAccessibilityData}
+              />
+            </SummarySubSection>
+          </>
+        ): (
+          <InternalAccessibilitySummarySubSection
+            callout={
+              venue.isPermanent ? (
+                <AccessibilityCallout />
+              ) : null
+            }
+            accessibleItem={venue}
+            accessibleWording="Votre établissement est accessible aux publics en situation de handicap :"
             shouldShowDivider={false}
-          >
-            <ExternalAccessibility
-              externalAccessibilityId={venue.externalAccessibilityId}
-              externalAccessibilityData={venue.externalAccessibilityData}
-            />
-          </SummarySubSection>
-        </>
-      ): (
-        <InternalAccessibilitySummarySubSection
-          callout={
-            venue.isPermanent ? (
-              <AccessibilityCallout />
-            ) : null
-          }
-          accessibleItem={venue}
-          accessibleWording="Votre établissement est accessible aux publics en situation de handicap :"
-          shouldShowDivider={false}
-        />
+          />
+        )
       )}
-
       <SummarySubSection
         title="Informations de contact"
         shouldShowDivider={false}

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionFormScreen.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionFormScreen.spec.tsx
@@ -58,6 +58,7 @@ vi.mock('apiClient/api', () => ({
     canOffererCreateEducationalOffer: vi.fn(),
   },
 }))
+
 vi.spyOn(api, 'getSiretInfo').mockResolvedValue({
   active: true,
   address: {
@@ -139,36 +140,6 @@ const baseVenue: GetVenueResponseModel = {
 }
 
 describe('VenueFormScreen', () => {
-  it('should display readonly info', async () => {
-    renderForm(
-      {
-        ...baseVenue,
-        description: 'TOTOTO',
-        contact: {
-          phoneNumber: '123',
-          email: 'e@mail.fr',
-          website: 'site.web',
-        },
-      },
-      { initialRouterEntries: ['/'] }
-    )
-
-    expect(
-      await screen.findByText('Vos informations pour le grand public')
-    ).toBeInTheDocument()
-    expect(screen.getByText('À propos de votre activité')).toBeInTheDocument()
-    expect(screen.getByText(/Description/)).toBeInTheDocument()
-    expect(screen.getByText(/TOTOTO/)).toBeInTheDocument()
-    expect(screen.getByText('Modalités d’accessibilité')).toBeInTheDocument()
-    expect(screen.getByText('Informations de contact')).toBeInTheDocument()
-    expect(screen.getByText(/Adresse e-mail/)).toBeInTheDocument()
-    expect(screen.getByText('e@mail.fr')).toBeInTheDocument()
-    expect(screen.getByText(/Téléphone/)).toBeInTheDocument()
-    expect(screen.getByText('123')).toBeInTheDocument()
-    expect(screen.getByText(/URL de votre site web/)).toBeInTheDocument()
-    expect(screen.getByText('site.web')).toBeInTheDocument()
-  })
-
   it('should display the partner info', async () => {
     renderForm(baseVenue)
 
@@ -181,165 +152,245 @@ describe('VenueFormScreen', () => {
     expect(screen.getByText('Non visible')).toBeInTheDocument()
   })
 
-  it('should display an error when the venue could not be updated', async () => {
-    renderForm(baseVenue)
-
-    vi.spyOn(api, 'editVenue').mockRejectedValue(
-      new ApiError(
-        {} as ApiRequestOptions,
-        {
-          body: {
-            email: ['ensure this is an email'],
-          },
-        } as ApiResult,
-        ''
-      )
-    )
-    // This is necessary to trigger formik dirty state, and allow submitting the form
-    await userEvent.type(screen.getByLabelText('Description'), '…')
-
-    await userEvent.click(screen.getByText(/Enregistrer/))
-
-    await waitFor(() => {
-      expect(screen.getByText('ensure this is an email')).toBeInTheDocument()
+  it('should mention "structure" instead of "lieu"', () => {
+    renderForm({ ...baseVenue, isVirtual: true }, {
+      features: ['WIP_ENABLE_OFFER_ADDRESS'],
     })
-  })
-
-  it('should display the route leaving guard when leaving without saving', async () => {
-    renderForm(baseVenue)
-
-    await userEvent.type(screen.getByLabelText('Description'), 'test')
-    await userEvent.click(screen.getByText('Annuler'))
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Les informations non enregistrées seront perdues')
-      ).toBeInTheDocument()
-    })
-  })
-
-  it('should display specific message when venue is virtual', () => {
-    renderForm({ ...baseVenue, isVirtual: true })
 
     expect(
       screen.getByText(
-        /Cette structure vous permet uniquement de créer des offres numériques/
+        /Cette structure vous permet uniquement de créer des offres numériques, elle/
       )
     ).toBeInTheDocument()
-
-    expect(screen.queryAllByRole('input')).toHaveLength(0)
   })
 
-  it('should diplay only some fields when the venue is virtual', async () => {
-    renderForm({ ...baseVenue, isVirtual: true })
-
-    await waitFor(() => {
-      expect(screen.queryByTestId('wrapper-publicName')).not.toBeInTheDocument()
-    })
-
-    expect(screen.queryByTestId('wrapper-description')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('wrapper-venueLabel')).not.toBeInTheDocument()
-    expect(screen.queryByText('Accessibilité du lieu')).not.toBeInTheDocument()
-    expect(
-      screen.queryByText('Informations de retrait de vos offres')
-    ).not.toBeInTheDocument()
-    expect(screen.queryByText('Contact')).not.toBeInTheDocument()
-    expect(
-      screen.queryByText(
-        'Cette adresse s’appliquera par défaut à toutes vos offres, vous pourrez la modifier à l’échelle de chaque offre.'
-      )
-    ).not.toBeInTheDocument()
-  })
-
-  it('should display the acceslibre section in readonly if the feature is enabled and data is present', () => {
-    renderForm(
-      {
-        ...baseVenue,
-        externalAccessibilityData: {
-          isAccessibleAudioDisability: true,
-          isAccessibleMentalDisability: false,
-          isAccessibleMotorDisability: true,
-          isAccessibleVisualDisability: true,
-        },
-      },
-      {
-        initialRouterEntries: ['/'],
-      }
-    )
-
-    expect(
-      screen.queryByText(
-        /Votre établissement est accessible aux publics en situation de handicap/
-      )
-    ).not.toBeInTheDocument()
-    expect(
-      screen.getByText('Modalités d’accessibilité via acceslibre')
-    ).toBeInTheDocument()
-  })
-
-  it('should display the acceslibre section under the form if the feature is enabled and data is present', () => {
-    renderForm({
-      ...baseVenue,
-      externalAccessibilityData: {
-        isAccessibleAudioDisability: true,
-        isAccessibleMentalDisability: false,
-        isAccessibleMotorDisability: true,
-        isAccessibleVisualDisability: true,
-      },
-    })
-
-    expect(
-      screen.getByText('Modalités d’accessibilité via acceslibre')
-    ).toBeInTheDocument()
-  })
-
-  it('should not send opening hours if the field was not filled, and if there were no opening hours already added previously', async () => {
-    const editVenueSpy = vi.spyOn(api, 'editVenue')
-
-    renderForm({ ...baseVenue, openingHours: null })
-
-    // This is necessary to trigger formik dirty state, and allow submitting the form
-    await userEvent.type(screen.getByLabelText('Description'), '…')
-
-    await userEvent.click(screen.getByText(/Enregistrer/))
-
-    expect(editVenueSpy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ openingHours: null })
-    )
-  })
-
-  it('should send opening hours if the field was not filled, but the openingHours already existed', async () => {
-    const editVenueSpy = vi.spyOn(api, 'editVenue')
-
-    renderForm({
-      ...baseVenue,
-      openingHours: {
-        MONDAY: [
-          { open: '09:00', close: '12:00' },
-          { open: '13:00', close: '18:00' },
-        ],
-      },
-    })
-
-    // This is necessary to trigger formik dirty state, and allow submitting the form
-    await userEvent.type(screen.getByLabelText('Description'), '…')
-
-    await userEvent.click(screen.getByText(/Enregistrer/))
-
-    expect(editVenueSpy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        openingHours: expect.arrayContaining([
-          {
-            weekday: 'monday',
-            timespan: [
-              ['09:00', '12:00'],
-              ['13:00', '18:00'],
-            ],
-          },
-        ]),
+  describe('when open to public feature is enabled', () => {
+    it('should no longer display the partner info', async () => {
+      renderForm(baseVenue, {
+        features: ['WIP_IS_OPEN_TO_PUBLIC'],
       })
-    )
+
+      expect(
+        await screen.findByText('À propos de votre activité')
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText('État de votre page partenaire sur l’application :')
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe('on readonly', () => {
+    it('should display readonly info', async () => {
+      renderForm(
+        {
+          ...baseVenue,
+          description: 'TOTOTO',
+          contact: {
+            phoneNumber: '123',
+            email: 'e@mail.fr',
+            website: 'site.web',
+          },
+        },
+        { initialRouterEntries: ['/'] }
+      )
+
+      expect(
+        await screen.findByText('Vos informations pour le grand public')
+      ).toBeInTheDocument()
+      expect(screen.getByText('À propos de votre activité')).toBeInTheDocument()
+      expect(screen.getByText(/Description/)).toBeInTheDocument()
+      expect(screen.getByText(/TOTOTO/)).toBeInTheDocument()
+      expect(screen.getByText('Modalités d’accessibilité')).toBeInTheDocument()
+      expect(screen.getByText('Informations de contact')).toBeInTheDocument()
+      expect(screen.getByText(/Adresse e-mail/)).toBeInTheDocument()
+      expect(screen.getByText('e@mail.fr')).toBeInTheDocument()
+      expect(screen.getByText(/Téléphone/)).toBeInTheDocument()
+      expect(screen.getByText('123')).toBeInTheDocument()
+      expect(screen.getByText(/URL de votre site web/)).toBeInTheDocument()
+      expect(screen.getByText('site.web')).toBeInTheDocument()
+    })
+
+    it('should display the acceslibre section when accessibility is externally defined (via acceslibre)', () => {
+      renderForm(
+        {
+          ...baseVenue,
+          externalAccessibilityData: {
+            isAccessibleAudioDisability: true,
+            isAccessibleMentalDisability: false,
+            isAccessibleMotorDisability: true,
+            isAccessibleVisualDisability: true,
+          },
+        },
+        {
+          initialRouterEntries: ['/'],
+        }
+      )
+
+      expect(
+        screen.queryByText(
+          /Votre établissement est accessible aux publics en situation de handicap/
+        )
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByText('Modalités d’accessibilité via acceslibre')
+      ).toBeInTheDocument()
+    })
+
+    describe('when open to public feature is enabled', () => {
+      it('should display a "Accès et horaires" section',() => {
+        renderForm(baseVenue, {
+          initialRouterEntries: ['/'],
+          features: ['WIP_IS_OPEN_TO_PUBLIC'],
+        })
+
+        expect(screen.getByText('Accès et horaires')).toBeInTheDocument()
+      })
+
+      describe('when the venue is not open to public', () => {
+        it('should not display any accessibility section', () => {
+          renderForm({ ...baseVenue, isOpenToPublic: false }, {
+            initialRouterEntries: ['/'],
+            features: ['WIP_IS_OPEN_TO_PUBLIC'],
+          })
+
+          expect(screen.queryByText(/Modalités d’accessibilité/)).not.toBeInTheDocument()
+        })
+      })
+
+      describe('when the venue is open to public', () => {
+        it('should display the accessibility section', () => {
+          renderForm({ ...baseVenue, isOpenToPublic: true }, {
+            initialRouterEntries: ['/'],
+            features: ['WIP_IS_OPEN_TO_PUBLIC'],
+          })
+
+          expect(screen.queryByText(/Modalités d’accessibilité/)).toBeInTheDocument()
+        })
+      })
+    })
+  })
+
+  describe('on edition', () => {
+    it('should display an error when the venue could not be updated', async () => {
+      renderForm(baseVenue)
+
+      vi.spyOn(api, 'editVenue').mockRejectedValue(
+        new ApiError(
+          {} as ApiRequestOptions,
+          {
+            body: {
+              email: ['ensure this is an email'],
+            },
+          } as ApiResult,
+          ''
+        )
+      )
+      // This is necessary to trigger formik dirty state, and allow submitting the form
+      await userEvent.type(screen.getByLabelText('Description'), '…')
+
+      await userEvent.click(screen.getByText(/Enregistrer/))
+
+      await waitFor(() => {
+        expect(screen.getByText('ensure this is an email')).toBeInTheDocument()
+      })
+    })
+
+    it('should display the route leaving guard when leaving without saving', async () => {
+      renderForm(baseVenue)
+
+      await userEvent.type(screen.getByLabelText('Description'), 'test')
+      await userEvent.click(screen.getByText('Annuler'))
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Les informations non enregistrées seront perdues')
+        ).toBeInTheDocument()
+      })
+    })
+
+    it('should not send opening hours if the field was not filled, and if there were no opening hours already added previously', async () => {
+      const editVenueSpy = vi.spyOn(api, 'editVenue')
+
+      renderForm({ ...baseVenue, openingHours: null })
+
+      // This is necessary to trigger formik dirty state, and allow submitting the form
+      await userEvent.type(screen.getByLabelText('Description'), '…')
+
+      await userEvent.click(screen.getByText(/Enregistrer/))
+
+      expect(editVenueSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ openingHours: null })
+      )
+    })
+
+    it('should send opening hours if the field was not filled, but the openingHours already existed', async () => {
+      const editVenueSpy = vi.spyOn(api, 'editVenue')
+
+      renderForm({
+        ...baseVenue,
+        openingHours: {
+          MONDAY: [
+            { open: '09:00', close: '12:00' },
+            { open: '13:00', close: '18:00' },
+          ],
+        },
+      })
+
+      // This is necessary to trigger formik dirty state, and allow submitting the form
+      await userEvent.type(screen.getByLabelText('Description'), '…')
+
+      await userEvent.click(screen.getByText(/Enregistrer/))
+
+      expect(editVenueSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          openingHours: expect.arrayContaining([
+            {
+              weekday: 'monday',
+              timespan: [
+                ['09:00', '12:00'],
+                ['13:00', '18:00'],
+              ],
+            },
+          ]),
+        })
+      )
+    })
+
+    describe('when the venue is virtual', () => {
+      it('should display a specific message', () => {
+        renderForm({ ...baseVenue, isVirtual: true })
+
+        expect(
+          screen.getByText(
+            /Cette structure vous permet uniquement de créer des offres numériques/
+          )
+        ).toBeInTheDocument()
+
+        expect(screen.queryAllByRole('input')).toHaveLength(0)
+      })
+
+      it('should diplay only some fields', async () => {
+        renderForm({ ...baseVenue, isVirtual: true })
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('wrapper-publicName')).not.toBeInTheDocument()
+        })
+
+        expect(screen.queryByTestId('wrapper-description')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('wrapper-venueLabel')).not.toBeInTheDocument()
+        expect(screen.queryByText('Accessibilité du lieu')).not.toBeInTheDocument()
+        expect(
+          screen.queryByText('Informations de retrait de vos offres')
+        ).not.toBeInTheDocument()
+        expect(screen.queryByText('Contact')).not.toBeInTheDocument()
+        expect(
+          screen.queryByText(
+            'Cette adresse s’appliquera par défaut à toutes vos offres, vous pourrez la modifier à l’échelle de chaque offre.'
+          )
+        ).not.toBeInTheDocument()
+      })
+    })
   })
 })

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
@@ -44,7 +44,7 @@ const renderPartnerPages = (
   )
 }
 
-describe('PartnerPages', () => {
+describe('VenueEditionHeader', () => {
   it('should display image upload if no image', async () => {
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
       logEvent: mockLogEvent,
@@ -92,6 +92,20 @@ describe('PartnerPages', () => {
       'src',
       'https://www.example.com/image.png'
     )
+  })
+
+  it('should display a preview link when venue is permanent and is open to public feature enabled', () => {
+    renderPartnerPages({
+      venue: {
+        ...defaultGetVenue,
+        venueTypeCode: VenueTypeCode.FESTIVAL,
+        isPermanent: true,
+      },
+    }, {
+      features: ['WIP_IS_OPEN_TO_PUBLIC'],
+    })
+
+    expect(screen.getByText('Visualiser votre page')).toBeInTheDocument()
   })
 
   it('should not display new offer button in new nav', () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34746

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket

## Screenshots
![Capture d’écran 2025-02-27 à 16 16 13](https://github.com/user-attachments/assets/8b627ce1-3b1e-42a8-a11f-26c698e5b294)
![Capture d’écran 2025-02-27 à 16 16 49](https://github.com/user-attachments/assets/d456a1db-ab46-4ba4-8399-382774f2676a)

