### PR TITLE
(PC-34862)[API] fix: flush after expiring deposit

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -3325,6 +3325,7 @@ def expire_current_deposit_for_user(user: users_models.User) -> None:
             models.Deposit.dateUpdated: datetime.datetime.utcnow(),
         },
     )
+    db.session.flush()
 
 
 def _can_be_recredited(user: users_models.User, age: int | None = None) -> bool:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34862

Turns out not flushing makes `update_external_user` throw the biggest tantrum (`CardinalityViolation` and whatnot)