### PR TITLE
(PC-34345)[API] fix: use the same serialization logic as cloud tasks in celery tasks

### DIFF
--- a/api/src/pcapi/celery_tasks/sendinblue.py
+++ b/api/src/pcapi/celery_tasks/sendinblue.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from brevo_python.rest import ApiException as SendinblueApiException
@@ -16,8 +17,12 @@ logger = logging.getLogger(__name__)
 @shared_task(name="mails.tasks.update_contact_attributes", autoretry_for=(SendinblueApiException,), retry_backoff=True)
 def update_contact_attributes_task_celery(payload: dict) -> None:
     try:
-        request = UpdateSendinblueContactRequest.parse_obj(payload)
-        sendinblue.make_update_request(request)
+        # We must reload the payload because Celery will use __repr__ of the payload
+        # to pass it to the worker. This means that objects such as Decimal will be passed as is
+        # We do the same process on the cloud tasks side so we keep it here for consistency
+        parsed_payload = UpdateSendinblueContactRequest.parse_obj(payload)
+        request = json.loads(parsed_payload.json())
+        sendinblue.make_update_request(UpdateSendinblueContactRequest.parse_obj(request))
     except ValidationError as exp:
         logger.error("could not deserialize object", extra={"exception": exp})
 
@@ -27,8 +32,12 @@ def update_contact_attributes_task_celery(payload: dict) -> None:
 )
 def send_transactional_email_primary_task_celery(payload: dict) -> None:
     try:
-        request = SendTransactionalEmailRequest.parse_obj(payload)
-        send_transactional_email(request)
+        # We must reload the payload because Celery will use __repr__ of the payload
+        # to pass it to the worker. This means that objects such as Decimal will be passed as is
+        # We do the same process on the cloud tasks side so we keep it here for consistency
+        parsed_payload = SendTransactionalEmailRequest.parse_obj(payload)
+        request = json.loads(parsed_payload.json())
+        send_transactional_email(SendTransactionalEmailRequest.parse_obj(request))
     except ValidationError as exp:
         logger.error("could not deserialize object", extra={"exception": exp})
 
@@ -38,7 +47,11 @@ def send_transactional_email_primary_task_celery(payload: dict) -> None:
 )
 def send_transactional_email_secondary_task_celery(payload: dict) -> None:
     try:
-        request = SendTransactionalEmailRequest.parse_obj(payload)
-        send_transactional_email(request)
+        # We must reload the payload because Celery will use __repr__ of the payload
+        # to pass it to the worker. This means that objects such as Decimal will be passed as is
+        # We do the same process on the cloud tasks side so we keep it here for consistency
+        parsed_payload = SendTransactionalEmailRequest.parse_obj(payload)
+        request = json.loads(parsed_payload.json())
+        send_transactional_email(SendTransactionalEmailRequest.parse_obj(request))
     except ValidationError as exp:
         logger.error("could not deserialize object", extra={"exception": exp})


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34345

Lors qu'une task celery contient un objet tel que `Decimal`, celui-ci ne va pas être serialisé en float mais va rester un Decimal. Ce comportement n'est pas le même que lorsqu'on utilise une cloud task et cela pose problème pour l'envoi de certains mails.

Cette PR corrige ce problème spécifiquement pour les tâches Celery de mails. Une autre PR viendra pour mettre en place un décorateur qui contient cette logique afin d'être cohérent avec ce que l'on a côté cloud tasks. Mais je fais cette PR en attendant afin de pouvoir rapidement réactiver le feature flag

