### PR TITLE
(PC-34345) setup decorator for celery tasks

### DIFF
--- a/api/src/pcapi/celery_tasks/sendinblue.py
+++ b/api/src/pcapi/celery_tasks/sendinblue.py
@@ -1,44 +1,34 @@
-import logging
-
 from brevo_python.rest import ApiException as SendinblueApiException
-from celery import shared_task
-from pydantic import ValidationError
 
+from pcapi.celery_tasks.tasks import celery_async_task
 from pcapi.core.external import sendinblue
 from pcapi.core.mails.transactional.send_transactional_email import send_transactional_email
 from pcapi.tasks.serialization.sendinblue_tasks import SendTransactionalEmailRequest
 from pcapi.tasks.serialization.sendinblue_tasks import UpdateSendinblueContactRequest
 
 
-logger = logging.getLogger(__name__)
-
-
-@shared_task(name="mails.tasks.update_contact_attributes", autoretry_for=(SendinblueApiException,), retry_backoff=True)
-def update_contact_attributes_task_celery(payload: dict) -> None:
-    try:
-        request = UpdateSendinblueContactRequest.parse_obj(payload)
-        sendinblue.make_update_request(request)
-    except ValidationError as exp:
-        logger.error("could not deserialize object", extra={"exception": exp})
-
-
-@shared_task(
-    name="mails.tasks.send_transactional_email_primary", autoretry_for=(SendinblueApiException,), retry_backoff=True
+@celery_async_task(
+    name="mails.tasks.update_contact_attributes",
+    autoretry_for=(SendinblueApiException,),
+    model=UpdateSendinblueContactRequest,
 )
-def send_transactional_email_primary_task_celery(payload: dict) -> None:
-    try:
-        request = SendTransactionalEmailRequest.parse_obj(payload)
-        send_transactional_email(request)
-    except ValidationError as exp:
-        logger.error("could not deserialize object", extra={"exception": exp})
+def update_contact_attributes_task_celery(payload: UpdateSendinblueContactRequest) -> None:
+    sendinblue.make_update_request(payload)
 
 
-@shared_task(
-    name="mails.tasks.send_transactional_email_secondary", autoretry_for=(SendinblueApiException,), retry_backoff=True
+@celery_async_task(
+    name="mails.tasks.send_transactional_email_primary",
+    autoretry_for=(SendinblueApiException,),
+    model=SendTransactionalEmailRequest,
 )
-def send_transactional_email_secondary_task_celery(payload: dict) -> None:
-    try:
-        request = SendTransactionalEmailRequest.parse_obj(payload)
-        send_transactional_email(request)
-    except ValidationError as exp:
-        logger.error("could not deserialize object", extra={"exception": exp})
+def send_transactional_email_primary_task_celery(payload: SendTransactionalEmailRequest) -> None:
+    send_transactional_email(payload)
+
+
+@celery_async_task(
+    name="mails.tasks.send_transactional_email_secondary",
+    autoretry_for=(SendinblueApiException,),
+    model=SendTransactionalEmailRequest,
+)
+def send_transactional_email_secondary_task_celery(payload: SendTransactionalEmailRequest) -> None:
+    send_transactional_email(payload)

--- a/api/src/pcapi/celery_tasks/tasks.py
+++ b/api/src/pcapi/celery_tasks/tasks.py
@@ -1,0 +1,49 @@
+from functools import wraps
+import json
+import logging
+import typing
+
+from celery import shared_task
+import pydantic.v1 as pydantic_v1
+
+
+logger = logging.getLogger(__name__)
+
+
+def celery_async_task(
+    name: str,
+    autoretry_for: typing.Tuple[Exception, ...],
+    model: type[pydantic_v1.BaseModel] | None,
+    retry_backoff: bool = True,
+) -> typing.Callable:
+    """
+    celery_async_task decorator is used to defer the function execution to a Celery worker.
+
+    Parameters :
+    name:  controls what route is used for the task and therefore which worker will run it.
+    model: if not None, will perform input validation against pydantic model and parse and load it to and from JSON to ensure
+    that the input is JSON serializable. Otherwise this step will be skipped.
+    """
+
+    def decorator(f: typing.Callable) -> typing.Callable:
+        @shared_task(name=name, autoretry_for=autoretry_for, retry_backoff=retry_backoff)
+        @wraps(f)
+        def task(payload: dict) -> None:
+            if model is not None:
+                try:
+                    # We want to ensure payload is JSON serializable, we do that by encoding and decoding
+                    # to and from json. This is needed because Celery uses the __repr__ of the task to pass
+                    # it so values like dates and Decimal will be preserved instead of being transformed to their
+                    # JSON representation.
+                    # This is the same behavior that we had on cloud_tasks
+                    parsed_payload = model.parse_obj(payload)
+                    parsed_payload = json.loads(parsed_payload.json())
+                    parsed_payload = model.parse_obj(parsed_payload)
+                except pydantic_v1.ValidationError as exp:
+                    logger.error("could not deserialize object", extra={"exception": exp})
+
+            f(parsed_payload)
+
+        return task
+
+    return decorator


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34345

Lorsque Celery passe une task avec le serializer JSON il utilise la __repr__() de l'objet et donc les champ de type Decimal par exemple sont conservés. Cela pose problème à la lib sendinblue qui s'attend à recevoir un objet JSON serializable, mais le champ Decimal ne l'est pas.

On a pas le problème sur les cloud_tasks car on a cette ligne qui est jouée : `payload = json.loads(payload.json())` et elle a pour effet de transformer les champs qui ne sont pas JSON serializable en champs qui le sont.

Cette PR reproduit ce comportement pour les cloud_task à l'aide d'un décorateur. J'ai également rajouté un petit test avec le cas concret que j'ai rencontré pour s'assurer qu'on ne retombe pas dessus.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai fait la revue fonctionnelle de mon ticket
