### PR TITLE
(BSR)[API] fix: set collective offers location columns in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -811,6 +811,16 @@ def create_offers_templates_with_different_displayed_status(
         )
 
 
+def _set_offer_location_columns(
+    offer: educational_models.CollectiveOffer | educational_models.CollectiveOfferTemplate,
+    location_option: LocationOption,
+    offerer: offerers_models.Offerer,
+) -> None:
+    offer.locationType = location_option.get("locationType")
+    offer.locationComment = location_option.get("locationComment")
+    offer.offererAddressId = get_offer_address_id(location_option=location_option, managing_offerer=offerer)
+
+
 def create_offers_booking_with_different_offer_venues(
     *,
     institutions: list[educational_models.EducationalInstitution],
@@ -841,12 +851,8 @@ def create_offers_booking_with_different_offer_venues(
         )
 
         if with_new_format:
-            collective_offer = collective_stock.collectiveOffer
-            collective_offer.location_type = location_option.get("locationType")
-            collective_offer.location_comment = location_option.get("locationComment")
-            collective_offer.offererAddressId = get_offer_address_id(
-                location_option=location_option,
-                managing_offerer=venue.managingOfferer,
+            _set_offer_location_columns(
+                offer=collective_stock.collectiveOffer, location_option=location_option, offerer=venue.managingOfferer
             )
 
 
@@ -874,11 +880,8 @@ def create_offers_templates_with_different_offer_venues(
         )
 
         if with_new_format:
-            collective_offer_template.location_type = location_option.get("locationType")
-            collective_offer_template.location_comment = location_option.get("locationComment")
-            collective_offer_template.offererAddressId = get_offer_address_id(
-                location_option=location_option,
-                managing_offerer=venue.managingOfferer,
+            _set_offer_location_columns(
+                offer=collective_offer_template, location_option=location_option, offerer=venue.managingOfferer
             )
 
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : On set les attributs location_type et location_comment au lieu de locationType et locationComment dans la sandbox

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
