### PR TITLE
(BSR)[API] feat: remove `WIP_URL_IN_OFFER_DRAFT` ff

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -206,8 +206,7 @@ def create_draft_offer(
 ) -> models.Offer:
     validation.check_offer_subcategory_is_valid(body.subcategory_id)
     subcategory = subcategories.ALL_SUBCATEGORIES_DICT[body.subcategory_id]
-    if feature.FeatureToggle.WIP_URL_IN_OFFER_DRAFT.is_active():
-        validation.check_url_is_coherent_with_subcategory(subcategory, body.url)
+    validation.check_url_is_coherent_with_subcategory(subcategory, body.url)
     validation.check_offer_name_does_not_contain_ean(body.name)
 
     body.extra_data = _format_extra_data(body.subcategory_id, body.extra_data) or {}

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -155,7 +155,6 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_BO_OFFER_TABLE_CUSTOMIZATION = (
         "Activer la personnalisation tu tableau des offres individuelles dans le BO"
     )
-    WIP_URL_IN_OFFER_DRAFT = "Activer la validation concernant l'url dans la création d'un brouillon d'offre"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -235,7 +234,6 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_HEADLINE_OFFER,
     FeatureToggle.WIP_IS_OPEN_TO_PUBLIC,
     FeatureToggle.WIP_UBBLE_V2,
-    FeatureToggle.WIP_URL_IN_OFFER_DRAFT,
     # Please keep alphabetic order
 )
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1149,7 +1149,6 @@ class CreateMediationV2Test:
         assert len(os.listdir(self.THUMBS_DIR)) == existing_number_of_files
 
 
-@pytest.mark.features(WIP_URL_IN_OFFER_DRAFT=True)
 @pytest.mark.usefixtures("db_session")
 class CreateDraftOfferTest:
     def test_create_draft_offer_from_scratch(self):

--- a/api/tests/routes/pro/post_draft_offer_test.py
+++ b/api/tests/routes/pro/post_draft_offer_test.py
@@ -281,7 +281,6 @@ class Returns201Test:
         assert offer.visualDisabilityCompliant == True
 
 
-@pytest.mark.features(WIP_URL_IN_OFFER_DRAFT=True)
 @pytest.mark.usefixtures("db_session")
 class Returns400Test:
 


### PR DESCRIPTION
## But de la pull request

**Description:** Suppression d'un FF temporaire `WIP_URL_IN_OFFER_DRAFT` 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
