### PR TITLE
(PC-34046)[API] fix: use PostgresQL's now instead of Python's

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -552,11 +552,10 @@ class HeadlineOffer(PcObject, Base, Model):
 
     @isActive.expression  # type: ignore[no-redef]
     def isActive(cls) -> bool:  # pylint: disable=no-self-argument
-        now = datetime.datetime.utcnow()
         offer_alias = sa_orm.aliased(Offer)  # avoids cartesian product
         return sa.and_(
-            sa.or_(sa.func.upper(cls.timespan) == None, (sa.func.upper(cls.timespan) > now)),
-            sa.func.lower(cls.timespan) <= now,
+            sa.or_(sa.func.upper(cls.timespan) == None, (sa.func.upper(cls.timespan) > sa.func.now())),
+            sa.func.lower(cls.timespan) <= sa.func.now(),
             offer_alias.id == cls.offerId,
             offer_alias.status == OfferStatus.ACTIVE,
         )


### PR DESCRIPTION
Somehow the hybrid properties' expression are not evaluated on usage but rather at the start time when a server is started. Print statements within those functions will only appear when the server is started.
Surprisingly they are reevaluated between the tests. Anyway, one should not rely on anything dynamic in the hybrid properties' expression part and should only include defered calls.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34046

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
