### PR TITLE
(PC-34895)[API] fix: expire underage credit before checking for active credit

### DIFF
--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -4498,11 +4498,11 @@ class CreateDepositV3Test:
         assert deposit.type == models.DepositType.GRANT_18
         assert deposit.amount == 300
 
-    def test_create_deposit_age_18_expires_underage_deposit(self):
+    def test_upsert_deposit_age_18_expires_underage_deposit(self):
         before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(days=1)
         user = users_factories.BeneficiaryFactory(age=17, dateCreated=before_decree)
 
-        deposit = api.create_deposit(user, "created by test", users_models.EligibilityType.AGE18)
+        deposit = api.upsert_deposit(user, "created by test", users_models.EligibilityType.AGE18)
 
         assert deposit.type == models.DepositType.GRANT_18
         underage_deposit = min(*user.deposits, key=lambda d: d.id)

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -1807,8 +1807,12 @@ class ActivateBeneficiaryIfNoMissingStepTest:
     def test_pre_decree_underage_transition_to_18(self):
         before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(days=1)
         eighteen_years_ago = before_decree - relativedelta(years=18)
+        next_week = datetime.today() + relativedelta(weeks=1)
         user = users_factories.Transition1718Factory(
-            validatedBirthDate=eighteen_years_ago, _phoneNumber="0123456789", dateCreated=before_decree
+            validatedBirthDate=eighteen_years_ago,
+            _phoneNumber="0123456789",
+            dateCreated=before_decree,
+            deposit__expirationDate=next_week,
         )
         fraud_factories.ProfileCompletionFraudCheckFactory(user=user, dateCreated=before_decree)
         fraud_factories.HonorStatementFraudCheckFactory(user=user, dateCreated=before_decree)


### PR DESCRIPTION
Deposit upsertion should expire the underage credit, not the creation.

Ref: c62ee19f

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34895
