### PR TITLE
(PC-34710)[API] feat: move offer with past stocks

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -1191,7 +1191,10 @@ def check_can_move_collective_offer_venue(
     if count_reimbursed_bookings > 0:
         raise offers_exceptions.OfferHasReimbursedBookings(count_reimbursed_bookings)
 
-    return offerers_repository.get_venues_with_same_pricing_point(collective_offer)
+    venues_choices = offerers_repository.get_offerers_venues_with_pricing_point(collective_offer.venue)
+    if not venues_choices:
+        raise offers_exceptions.NoDestinationVenue()
+    return venues_choices
 
 
 def move_collective_offer_venue(

--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -1191,7 +1191,7 @@ def check_can_move_collective_offer_venue(
     if count_reimbursed_bookings > 0:
         raise offers_exceptions.OfferHasReimbursedBookings(count_reimbursed_bookings)
 
-    return offers_api.get_venues_with_same_pricing_point(collective_offer)
+    return offerers_repository.get_venues_with_same_pricing_point(collective_offer)
 
 
 def move_collective_offer_venue(

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -16,7 +16,6 @@ from pcapi.core.educational.models import CollectiveOfferTemplate
 from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.finance import models as finance_models
 from pcapi.core.geography import models as geography_models
-import pcapi.core.offers.exceptions as offers_exceptions
 import pcapi.core.offers.models as offers_models
 from pcapi.core.offers.models import Offer
 import pcapi.core.users.models as users_models
@@ -728,13 +727,11 @@ def get_venues_with_non_free_offers_without_bank_accounts(offerer_id: int) -> li
     return [venue.id for venue in venue_with_non_free_offers]
 
 
-def get_venues_with_same_pricing_point(
-    offer: offers_models.Offer | educational_models.CollectiveOffer,
-) -> list[models.Venue]:
+def get_offerers_venues_with_pricing_point(venue: models.Venue) -> list[models.Venue]:
     venues_choices = (
         models.Venue.query.filter(
-            models.Venue.managingOffererId == offer.venue.managingOffererId,
-            models.Venue.id != offer.venueId,
+            models.Venue.managingOffererId == venue.managingOffererId,
+            models.Venue.id != venue.id,
         )
         .join(
             models.VenuePricingPointLink,
@@ -757,9 +754,6 @@ def get_venues_with_same_pricing_point(
         .order_by(models.Venue.common_name)
         .all()
     )
-    if not venues_choices:
-        raise offers_exceptions.NoDestinationVenue()
-
     return venues_choices
 
 

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1720,7 +1720,10 @@ def check_can_move_event_offer(offer: models.Offer) -> list[offerers_models.Venu
     if count_reimbursed_bookings > 0:
         raise exceptions.OfferHasReimbursedBookings(count_reimbursed_bookings)
 
-    return offerers_repository.get_venues_with_same_pricing_point(offer)
+    venues_choices = offerers_repository.get_offerers_venues_with_pricing_point(offer.venue)
+    if not venues_choices:
+        raise exceptions.NoDestinationVenue()
+    return venues_choices
 
 
 def check_can_move_offer(offer: models.Offer) -> list[offerers_models.Venue]:
@@ -1745,7 +1748,10 @@ def check_can_move_offer(offer: models.Offer) -> list[offerers_models.Venue]:
     if count_reimbursed_bookings > 0:
         raise exceptions.OfferHasReimbursedBookings(count_reimbursed_bookings)
 
-    return offerers_repository.get_venues_with_same_pricing_point(offer)
+    venues_choices = offerers_repository.get_offerers_venues_with_pricing_point(offer.venue)
+    if not venues_choices:
+        raise exceptions.NoDestinationVenue()
+    return venues_choices
 
 
 def _get_or_create_same_price_category_label(

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1727,18 +1727,6 @@ def check_can_move_event_offer(offer: models.Offer) -> list[offerers_models.Venu
 
 
 def check_can_move_offer(offer: models.Offer) -> list[offerers_models.Venue]:
-    count_past_stocks = (
-        models.Stock.query.with_entities(models.Stock.id)
-        .filter(
-            models.Stock.offerId == offer.id,
-            models.Stock.beginningDatetime < datetime.datetime.utcnow(),
-            models.Stock.isSoftDeleted.is_(False),
-        )
-        .count()
-    )
-    if count_past_stocks > 0:
-        raise exceptions.OfferEventInThePast(count_past_stocks)
-
     count_reimbursed_bookings = (
         bookings_models.Booking.query.with_entities(bookings_models.Booking.id)
         .join(bookings_models.Booking.stock)


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-34710

and fix missing condition on get_venues_with_same_pricing_point which returns any venue on the same offerer

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
