### PR TITLE
(PC-34938)[API] docs: Improve doc landing page accessibility.

### DIFF
--- a/api/documentation/package-lock.json
+++ b/api/documentation/package-lock.json
@@ -11,7 +11,6 @@
         "@docusaurus/core": "^3.6.3",
         "@docusaurus/preset-classic": "^3.7.0",
         "@mdx-js/react": "^3.1.0",
-        "clsx": "^2.0.0",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",

--- a/api/documentation/package.json
+++ b/api/documentation/package.json
@@ -18,7 +18,6 @@
     "@docusaurus/core": "^3.6.3",
     "@docusaurus/preset-classic": "^3.7.0",
     "@mdx-js/react": "^3.1.0",
-    "clsx": "^2.0.0",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/api/documentation/src/components/HomepageFeatures/index.tsx
+++ b/api/documentation/src/components/HomepageFeatures/index.tsx
@@ -1,12 +1,11 @@
-import clsx from 'clsx';
-import Heading from '@theme/Heading';
-import styles from './styles.module.css';
+import Heading from '@theme/Heading'
+import styles from './styles.module.css'
 
 type FeatureItem = {
-  title: string;
-  description: JSX.Element;
-  imageUrl: string;
-};
+  title: string
+  description: JSX.Element
+  imageUrl: string
+}
 
 const FeatureList: FeatureItem[] = [
   {
@@ -14,7 +13,9 @@ const FeatureList: FeatureItem[] = [
     imageUrl: '/img/manage_stock.jpg',
     description: (
       <>
-        With pass Culture API you will be able to create and manage easy all your stocks, whether you are a bookshop, a music shop or a digital platform. 
+        With pass Culture API you will be able to create and manage easy all
+        your stocks, whether you are a bookshop, a music shop or a digital
+        platform.
       </>
     ),
   },
@@ -23,7 +24,9 @@ const FeatureList: FeatureItem[] = [
     imageUrl: '/img/theater.jpg',
     description: (
       <>
-        If you are a concert hall, a theater, a museum, a movie theater, or other cultural partner organizing events, pass Culture API will help you manage your gauge and directly send tickets to beneficiary. 
+        If you are a concert hall, a theater, a museum, a movie theater, or
+        other cultural partner organizing events, pass Culture API will help you
+        manage your gauge and directly send tickets to beneficiary.
       </>
     ),
   },
@@ -32,7 +35,8 @@ const FeatureList: FeatureItem[] = [
     imageUrl: '/img/scholar_group.jpg',
     description: (
       <>
-        The pass Culture API enables you to create bookable offers for scholar groups. 
+        The pass Culture API enables you to create bookable offers for scholar
+        groups.
       </>
     ),
   },
@@ -41,7 +45,12 @@ const FeatureList: FeatureItem[] = [
     imageUrl: '/img/integration_access.jpg',
     description: (
       <>
-        <a href='https://passculture.typeform.com/to/JHmbK9Hg'>Fill this form</a> to obtain your access. You will receive your dedicated API key and an access to your integration environment so you can see the situation for pass Culture users : beneficiary user and cultural actor user.. 
+        <a href="https://passculture.typeform.com/to/JHmbK9Hg">
+          Fill this form
+        </a>{' '}
+        to obtain your access. You will receive your dedicated API key and an
+        access to your integration environment so you can see the situation for
+        pass Culture users : beneficiary user and cultural actor user..
       </>
     ),
   },
@@ -50,7 +59,9 @@ const FeatureList: FeatureItem[] = [
     imageUrl: '/img/your_integration.jpg',
     description: (
       <>
-        In this documentation, you will find tutorials to help you design your integration and all the different resources. Do not hesitate to download our openAPI specifications and reuse it in Postman for instance.
+        In this documentation, you will find tutorials to help you design your
+        integration and all the different resources. Do not hesitate to download
+        our openAPI specifications and reuse it in Postman for instance.
       </>
     ),
   },
@@ -59,36 +70,41 @@ const FeatureList: FeatureItem[] = [
     imageUrl: '/img/production_access.jpg',
     description: (
       <>
-        Once your integration is completed, we will ask you a short documentation of it that we will published on our help center and a quick demo. If your integration is public, we can organize a share communication.
+        Once your integration is completed, we will ask you a short
+        documentation of it that we will published on our help center and a
+        quick demo. If your integration is public, we can organize a share
+        communication.
       </>
     ),
   },
-];
+]
 
-function Feature({title, description, imageUrl}: FeatureItem) {
+function Feature({ title, description, imageUrl }: FeatureItem) {
   return (
-    <div className={clsx('col col--4')}>
+    <li className="col col--4">
       <div className="text--center">
-        <img src={imageUrl} className={styles.featureSvg} />
+        <img src={imageUrl} className={styles['feature-svg']} alt="" />
       </div>
       <div className="text--center padding-horiz--md">
-        <Heading as="h3">{title}</Heading>
+        <Heading as="h2" className={styles['feature-title']}>
+          {title}
+        </Heading>
         <p>{description}</p>
       </div>
-    </div>
-  );
+    </li>
+  )
 }
 
 export default function HomepageFeatures(): JSX.Element {
   return (
     <section className={styles.features}>
       <div className="container">
-        <div className="row">
+        <ul className={`row  ${styles['features-list']}`}>
           {FeatureList.map((props, idx) => (
             <Feature key={idx} {...props} />
           ))}
-        </div>
+        </ul>
       </div>
     </section>
-  );
+  )
 }

--- a/api/documentation/src/components/HomepageFeatures/styles.module.css
+++ b/api/documentation/src/components/HomepageFeatures/styles.module.css
@@ -5,7 +5,15 @@
   width: 100%;
 }
 
-.featureSvg {
+.feature-title {
+  font-size: 1.25rem;
+}
+
+.feature-svg {
   height: 200px;
   width: 200px;
+}
+
+.features-list {
+  list-style: none;
 }

--- a/api/documentation/src/pages/index.tsx
+++ b/api/documentation/src/pages/index.tsx
@@ -1,38 +1,44 @@
-import clsx from 'clsx';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Layout from '@theme/Layout';
-import HomepageFeatures from '@site/src/components/HomepageFeatures';
-import Heading from '@theme/Heading';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import Layout from '@theme/Layout'
+import HomepageFeatures from '@site/src/components/HomepageFeatures'
+import Heading from '@theme/Heading'
 
-import styles from './index.module.css';
+import styles from './index.module.css'
 
 function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext()
   return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
+    <header className={`hero hero--primary ${styles.heroBanner}`}>
       <div className="container">
-        <img src="/img/pass_culture_white_logo.png"/>
+        <img src="/img/pass_culture_white_logo.png" alt="pass Culture" />
         <Heading as="h1" className="hero__title">
           {siteConfig.title}
         </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <p>The pass Culture API is meant for plugging your tools with the pass Culture and for fostering new uses on the pass Culture. Whether you're an association, a developer, a ticketing system editor, a stock management tool, an online diary, etc., you'll find in this documentation all the information you need to integrate the pass Culture API.</p>
+        <p>
+          The pass Culture API is meant for plugging your tools with the pass
+          Culture and for fostering new uses on the pass Culture. Whether you're
+          an association, a developer, a ticketing system editor, a stock
+          management tool, an online diary, etc., you'll find in this
+          documentation all the information you need to integrate the pass
+          Culture API.
+        </p>
       </div>
     </header>
-  );
+  )
 }
 
 export default function Home(): JSX.Element {
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext()
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      description="Description will go into a meta tag in <head />"
+    >
       <HomepageHeader />
       <main>
         <HomepageFeatures />
       </main>
     </Layout>
-  );
+  )
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34938

**Objectif**
Améliorer l'accessibilité de la page d'accueil de la doc api.
- Ajout de texte alternatif sur les images
- Structure des features en liste html
- Correction de la hiérarchie des titres

Et au passage suppression de la dépendance pour concaténer les classes qui est pas très utile

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
