### PR TITLE
(PC-34105)[PRO] fix: Lostpassword 2025 wording.

### DIFF
--- a/pro/src/pages/LostPassword/LostPassword.tsx
+++ b/pro/src/pages/LostPassword/LostPassword.tsx
@@ -78,13 +78,12 @@ export const LostPassword = (): JSX.Element => {
         Vous allez recevoir un email !
       </h1>
       <p className={styles['change-password-request-success-body']}>
-        Cliquez sur le lien que nous vous avons envoyé par email à{' '}
-        <b>{email}</b>
+        Cliquez sur le lien envoyé par email à <b>{email}</b>
       </p>
       <Callout variant={CalloutVariant.DEFAULT}>
         <p className={styles['change-password-request-success-info']}>
-          Vous n’avez pas reçu notre email ? <br /> Vérifiez vos spams ou
-          cliquez ici pour le recevoir à nouveau.
+          Vous n’avez pas reçu d’email ? <br /> Vérifiez vos spams ou cliquez
+          ici pour le recevoir à nouveau.
         </p>
       </Callout>
     </section>

--- a/pro/src/pages/LostPassword/__specs__/LostPassword.spec.tsx
+++ b/pro/src/pages/LostPassword/__specs__/LostPassword.spec.tsx
@@ -1,11 +1,11 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
+import { beforeEach, expect } from 'vitest'
 
 import * as utils from 'commons/utils/recaptcha'
 import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
 import { LostPassword } from '../LostPassword'
-import { beforeEach, expect } from 'vitest'
 
 vi.mock('apiClient/api', () => ({
   api: {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34105

- Corrections de wording.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
