### PR TITLE
(BSR)[PRO] fix: do not use firebase to choose user's A/B variant

### DIFF
--- a/pro/src/commons/hooks/__specs__/useHasAccessToDidacticOnboarding.spec.tsx
+++ b/pro/src/commons/hooks/__specs__/useHasAccessToDidacticOnboarding.spec.tsx
@@ -1,15 +1,18 @@
 import { screen } from '@testing-library/react'
 
-import * as useAnalytics from 'app/App/analytics/firebase'
 import { useHasAccessToDidacticOnboarding } from 'commons/hooks/useHasAccessToDidacticOnboarding'
+import { sharedCurrentUserFactory } from 'commons/utils/factories/storeFactories'
 import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
 const TestComponent = () => {
   return <div>{useHasAccessToDidacticOnboarding() ? 'OUI' : 'NON'}</div>
 }
 
-const renderuseHasAccessToDidacticOnboarding = (features: string[] = []) => {
-  return renderWithProviders(<TestComponent />, { features })
+const renderuseHasAccessToDidacticOnboarding = (features: string[] = [], userId: number = 2) => {
+  return renderWithProviders(<TestComponent />, {
+    features,
+    user: sharedCurrentUserFactory({ id: userId })
+  })
 }
 
 describe('useHasAccessToDidacticOnboarding', () => {
@@ -38,23 +41,21 @@ describe('useHasAccessToDidacticOnboarding', () => {
     })
 
     describe('... and with WIP_ENABLE_PRO_DIDACTIC_ONBOARDING enabled', () => {
-      it('should return true if firebase config is true for user', () => {
-        vi.spyOn(useAnalytics, 'useRemoteConfigParams').mockReturnValue({
-          PRO_DIDACTIC_ONBOARDING_AB_TEST: 'true',
-        })
+
+      it('should return true if user id is an even number', () => {
         renderuseHasAccessToDidacticOnboarding([
           'WIP_ENABLE_PRO_DIDACTIC_ONBOARDING',
           'WIP_ENABLE_PRO_DIDACTIC_ONBOARDING_AB_TEST',
-        ])
+        ], 2)
 
         expect(screen.getByText('OUI')).toBeInTheDocument()
       })
 
-      it('should return false if firebase config is false for user', () => {
+      it('should return false if user id is an odd number', () => {
         renderuseHasAccessToDidacticOnboarding([
           'WIP_ENABLE_PRO_DIDACTIC_ONBOARDING',
           'WIP_ENABLE_PRO_DIDACTIC_ONBOARDING_AB_TEST',
-        ])
+        ], 1)
         expect(screen.getByText('NON')).toBeInTheDocument()
       })
     })

--- a/pro/src/commons/hooks/useHasAccessToDidacticOnboarding.ts
+++ b/pro/src/commons/hooks/useHasAccessToDidacticOnboarding.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
+import { useSelector } from 'react-redux'
 
-import { useRemoteConfigParams } from 'app/App/analytics/firebase'
 import { useActiveFeature } from 'commons/hooks/useActiveFeature'
+import { selectCurrentUser } from 'commons/store/user/selectors'
 
 export const useHasAccessToDidacticOnboarding = () => {
   const [hasAccess, setHasAccess] = useState<boolean | undefined>()
@@ -11,16 +12,17 @@ export const useHasAccessToDidacticOnboarding = () => {
   const isDidacticAbTestEnabled = useActiveFeature(
     'WIP_ENABLE_PRO_DIDACTIC_ONBOARDING_AB_TEST'
   )
-  const { PRO_DIDACTIC_ONBOARDING_AB_TEST: firebaseUserCanSeeOnboarding } =
-    useRemoteConfigParams()
+
+  const currentUser = useSelector(selectCurrentUser)
+  const isUserIncludedinDidacticOnboarding = Boolean(currentUser && (currentUser.id % 2 === 0))
 
   useEffect(() => {
     setHasAccess(
       isDidacticOnboardingEnabled &&
-        (!isDidacticAbTestEnabled || Boolean(firebaseUserCanSeeOnboarding))
+        (!isDidacticAbTestEnabled || isUserIncludedinDidacticOnboarding)
     )
   }, [
-    firebaseUserCanSeeOnboarding,
+    isUserIncludedinDidacticOnboarding,
     isDidacticOnboardingEnabled,
     isDidacticAbTestEnabled,
   ])


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : Les paramètres de Remote Config de Firebase ne permettant pas d'obtenir des données robustes et fiables pour l'AB Test Onboarding Didactique, leur utilisation est supprimée. A la place, le choix de la version proposée à l'acteur culturel est calculé en fonction de l'identifiant technique de l'utilisateur (sous réserve de FF activé ou non, et de statut onboardé ou non) : 
- id pair : l'acteur culturel voit l'Onboarding Didactique
- id impair : l'acteur culturel ne voit pas l'Onboarding Didactique

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
