### PR TITLE
(PC-34940)[API] fix: expire deposit even sooner

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -92,7 +92,7 @@ from . import validation
 
 logger = logging.getLogger(__name__)
 
-RECREDIT_UNDERAGE_USERS_BATCH_SIZE = 1000
+RECREDIT_UNDERAGE_USERS_BATCH_SIZE = 500
 # When used through the cron, only price bookings that were used in 2022.
 # Prior bookings have been priced manually.
 MIN_DATE_TO_PRICE = datetime.datetime(2021, 12, 31, 23, 0)  # UTC
@@ -3320,7 +3320,7 @@ def expire_current_deposit_for_user(user: users_models.User) -> None:
         models.Deposit.expirationDate > datetime.datetime.utcnow(),
     ).update(
         {
-            models.Deposit.expirationDate: datetime.datetime.utcnow() - datetime.timedelta(seconds=5),
+            models.Deposit.expirationDate: datetime.datetime.utcnow() - datetime.timedelta(minutes=5),
             models.Deposit.dateUpdated: datetime.datetime.utcnow(),
         },
     )

--- a/api/src/pcapi/core/finance/exceptions.py
+++ b/api/src/pcapi/core/finance/exceptions.py
@@ -49,6 +49,10 @@ class UserCannotBeRecredited(Exception):
     pass
 
 
+class UserHasNotFinishedSubscription(Exception):
+    pass
+
+
 class UserHasAlreadyActiveDeposit(UserNotGrantable):
     pass
 

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -1019,8 +1019,6 @@ class DepositGrantFactory(BaseFactory):
 
         if not create:
             return []
-        if not FeatureToggle.WIP_ENABLE_CREDIT_V3.is_active() or self.dateCreated < settings.CREDIT_V3_DECREE_DATETIME:
-            return []
         if getattr(self, "recredits", None):
             # do not create new recredits if they already exist
             return getattr(self, "recredits", [])

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -5202,6 +5202,19 @@ class UserRecreditAfterDecreeTest:
         assert user_2.deposit.recredits[0].recreditType == models.RecreditType.RECREDIT_18
         assert user_2.deposit.amount == 30 + 150  #  30 (credit 17 before decree) + 150 (for 18 year old after decree)
 
+    @pytest.mark.skip(
+        reason="This test is very long and must be executed in a flask shell, outside of db_session fixture"
+    )
+    def test_recredit_users_does_not_crash_on_big_pages(self):
+        one_year_before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(years=1)
+        next_week = datetime.datetime.utcnow() + relativedelta(weeks=1)
+        with time_machine.travel(one_year_before_decree):
+            users_factories.BeneficiaryFactory.create_batch(
+                1000, age=16, phoneNumber="+33600000000", deposit__amount=12, deposit__expirationDate=next_week
+            )
+
+        assert api.recredit_users() is None
+
     def test_recredit_email_is_sent_to_18_years_old_users(self):
         last_year = datetime.datetime.utcnow() - relativedelta(years=1)
         with time_machine.travel(last_year):


### PR DESCRIPTION
When recrediting a big page of users, `get_wallet_balance` likes to
crash complaining that there is two active deposits. This messes up the
whole page transaction, so we work around it by setting the expiration
date to earlier.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34940

## Vérifications

Ce test à lancer dans le flask shell échoue sans le commit `fix: expire deposit even sooner` :  

```
import datetime

from dateutil.relativedelta import relativedelta
import time_machine

from pcapi import settings
from pcapi.core.finance import api
from pcapi.core.users import factories as users_factories


one_year_before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(years=1)
next_week = datetime.datetime.utcnow() + relativedelta(weeks=1)
with time_machine.travel(one_year_before_decree):
    users_factories.BeneficiaryFactory.create_batch(1000, age=16, deposit__expirationDate=next_week)

api.recredit_users()  # ne devrait pas parler d'erreur de transactions ou de rollback manquant
```
