### PR TITLE
(BSR)[BO] fix: avoid crash when displaying subscription tunnel for users with wrong birthdate

### DIFF
--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -617,9 +617,8 @@ def _get_tunnel_type(user: users_models.User) -> TunnelType:
             specified_datetime=user_creation_date,
             department_code=user.departementCode,
         )
-    assert age_now  # helps mypy
 
-    if not signup_age:
+    if not signup_age or not age_now:
         return TunnelType.NOT_ELIGIBLE
 
     ################################


### PR DESCRIPTION
## But de la pull request

Fix de la frise du parcours d'inscription: éviter l'erreur 500 si la date de naissance du jeune  est erronée 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
