### PR TITLE
(BSR)[PRO] style: Changes to password page style.

### DIFF
--- a/pro/src/pages/LostPassword/LostPassword.module.scss
+++ b/pro/src/pages/LostPassword/LostPassword.module.scss
@@ -21,27 +21,25 @@
   }
 }
 
-.change-password-request-form:not(.change-password-request-form-old), .change-password-request-success {
-  max-width: rem.torem(486px);
-}
 
 .change-password-request-form {
   .title {
     @include fonts.title1;
 
-    margin-bottom: rem.torem(12px);
+    margin-bottom: rem.torem(16px);
   }
 
   .subtitle {
-    @include fonts.body-xs;
+    @include fonts.body-accent-xs;
 
-    margin-bottom: rem.torem(24px);
+    color: var(--color-grey-dark);
+    margin-bottom: rem.torem(16px);
   }
 
   .validation-button {
     min-width: rem.torem(208px);
     width: 100%;
-    margin-bottom: rem.torem(32px);
+    margin: rem.torem(32px) 0;
   }
 
   .back-button {
@@ -49,6 +47,10 @@
     justify-content: center;
     width: 100%;
     text-align: center;
+  }
+
+  &-input {
+    margin-bottom: 0;
   }
 
   // remove when removing WIP_2025_SIGN_UP
@@ -65,7 +67,6 @@
 
     .validation-button {
       width: auto;
-      margin-bottom: none;
     }
   }
 }

--- a/pro/src/pages/LostPassword/LostPassword.tsx
+++ b/pro/src/pages/LostPassword/LostPassword.tsx
@@ -11,6 +11,7 @@ import {
 } from 'commons/core/shared/constants'
 import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useInitReCaptcha } from 'commons/hooks/useInitReCaptcha'
+import { useMediaQuery } from 'commons/hooks/useMediaQuery'
 import { useNotification } from 'commons/hooks/useNotification'
 import { useRedirectLoggedUser } from 'commons/hooks/useRedirectLoggedUser'
 import { getReCaptchaToken } from 'commons/utils/recaptcha'
@@ -39,6 +40,7 @@ export const LostPassword = (): JSX.Element => {
   useRedirectLoggedUser()
   useInitReCaptcha()
   const is2025SignUpEnabled = useActiveFeature('WIP_2025_SIGN_UP')
+  const isLaptopScreenAtLeast = useMediaQuery('(min-width: 64rem)')
 
   const notification = useNotification()
 
@@ -123,6 +125,7 @@ export const LostPassword = (): JSX.Element => {
                   error={errors.email?.message}
                   required={true}
                   asterisk={false}
+                  className={styles['change-password-request-form-input']}
                   {...register('email')}
                 />
               </FormLayout.Row>
@@ -141,7 +144,11 @@ export const LostPassword = (): JSX.Element => {
                   <ButtonLink
                     to="/connexion"
                     className={styles['back-button']}
-                    variant={ButtonVariant.TERNARY}
+                    variant={
+                      isLaptopScreenAtLeast
+                        ? ButtonVariant.TERNARY
+                        : ButtonVariant.QUATERNARY
+                    }
                     icon={fullNextIcon}
                   >
                     Retour à la connexion


### PR DESCRIPTION
## But de la pull request

- Corrections d'alignements pour le nouveau design de la page mot de passe perdu.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
