### PR TITLE
(PC-35015)[API] fix: missing DS annotation date and time

### DIFF
--- a/api/src/pcapi/connectors/dms/graphql/beneficiaries/get_applications_with_details.graphql
+++ b/api/src/pcapi/connectors/dms/graphql/beneficiaries/get_applications_with_details.graphql
@@ -121,6 +121,7 @@ fragment ChampFragment on Champ {
   id
   label
   stringValue
+  updatedAt
   ... on LinkedDropDownListChamp {
     primaryValue
     secondaryValue


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-35015

`updatedAt` était bien dans `get_single_application_details.graphql` mais manquant dans `get_applications_with_details.graphql`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
