### PR TITLE
(BSR)[PRO] feat: Migrates <Checkbox>, <EmailSpellCheckInput> and <PhoneNumberInput> for react-hook-form

### DIFF
--- a/pro/src/ui-kit/formV2/Checkbox/Checkbox.module.scss
+++ b/pro/src/ui-kit/formV2/Checkbox/Checkbox.module.scss
@@ -1,0 +1,9 @@
+@use "styles/variables/_forms.scss" as forms;
+@use "styles/mixins/_rem.scss" as rem;
+
+.checkbox {
+  &-error {
+    margin-top: rem.torem(forms.$input-space-before-error);
+    min-height: rem.torem(forms.$input-error-reserved-space);
+  }
+}

--- a/pro/src/ui-kit/formV2/Checkbox/Checkbox.spec.tsx
+++ b/pro/src/ui-kit/formV2/Checkbox/Checkbox.spec.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+
+import { Checkbox, CheckboxProps } from './Checkbox'
+
+const renderCheckbox = ({
+  label = 'Accessible',
+  name = 'accessible',
+  ...props
+}: Partial<CheckboxProps>) => {
+  render(<Checkbox label={label} name={name} {...props} />)
+}
+
+describe('EmailSpellCheckInput', () => {
+  it('should display an error if prop is set', () => {
+    renderCheckbox({ error: 'This is an error' })
+    expect(screen.getByText('This is an error')).toBeInTheDocument()
+  })
+
+  it('should hide footer if hideFooter is set, no matter if error prop is set', () => {
+    renderCheckbox({ error: 'This is an error', hideFooter: true })
+    expect(screen.queryByText('This is an error')).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/ui-kit/formV2/Checkbox/Checkbox.stories.tsx
+++ b/pro/src/ui-kit/formV2/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Checkbox } from './Checkbox'
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'ui-kit/formsV2/Checkbox',
+  component: Checkbox,
+}
+
+export default meta
+type Story = StoryObj<typeof Checkbox>
+
+export const Default: Story = {
+  args: {
+    label: 'Accessible',
+    name: 'accessibility',
+    value: 'accessible',
+  },
+}

--- a/pro/src/ui-kit/formV2/Checkbox/Checkbox.tsx
+++ b/pro/src/ui-kit/formV2/Checkbox/Checkbox.tsx
@@ -1,0 +1,35 @@
+import cn from 'classnames'
+
+import {
+  BaseCheckbox,
+  BaseCheckboxProps,
+} from 'ui-kit/form/shared/BaseCheckbox/BaseCheckbox'
+import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
+
+import styles from './Checkbox.module.scss'
+
+export interface CheckboxProps extends BaseCheckboxProps {
+  name: string
+  className?: string
+  hideFooter?: boolean
+  error?: string
+}
+
+export const Checkbox = ({
+  name,
+  className,
+  hideFooter,
+  error,
+  ...props
+}: CheckboxProps): JSX.Element => {
+  return (
+    <div className={cn(styles['checkbox'], className)}>
+      <BaseCheckbox hasError={!!error} {...props} />
+      {!hideFooter && (
+        <div className={styles['checkbox-error']}>
+          {error && <FieldError name={name}>{error}</FieldError>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/pro/src/ui-kit/formV2/EmailSpellCheckInput/EmailSpellCheckInput.module.scss
+++ b/pro/src/ui-kit/formV2/EmailSpellCheckInput/EmailSpellCheckInput.module.scss
@@ -1,0 +1,16 @@
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_rem.scss" as rem;
+
+.email-validation-error {
+  margin-top: rem.torem(8px);
+  margin-bottom: rem.torem(16px);
+  background-color: var(--color-background-secondary);
+  padding: rem.torem(16px);
+  border-radius: 6px;
+}
+
+.email-validation-tip {
+  margin-bottom: rem.torem(8px);
+
+  @include fonts.body;
+}

--- a/pro/src/ui-kit/formV2/EmailSpellCheckInput/EmailSpellCheckInput.spec.tsx
+++ b/pro/src/ui-kit/formV2/EmailSpellCheckInput/EmailSpellCheckInput.spec.tsx
@@ -1,0 +1,104 @@
+import { yupResolver } from '@hookform/resolvers/yup'
+import { render, screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { FormProvider, useForm } from 'react-hook-form'
+import * as yup from 'yup'
+
+import { emailSchema } from 'commons/utils/isValidEmail'
+
+import { EmailSpellCheckInput } from './EmailSpellCheckInput'
+
+// <FormWrapper> provides a react-hook-form context, which is necessary for the storybook demo to work
+type WrapperFormValues = { email: string }
+const FormWrapper = () => {
+  const hookForm = useForm<WrapperFormValues>({
+    resolver: yupResolver(
+      yup.object().shape({ email: yup.string().required().test(emailSchema) })
+    ),
+  })
+
+  const { register, setValue } = hookForm
+
+  return (
+    <FormProvider {...hookForm}>
+      <EmailSpellCheckInput
+        {...register('email')}
+        label="Email"
+        required={true}
+        asterisk={true}
+        description="Format : mail@exemple.com"
+        onApplyTip={(tip) => {
+          setValue('email', tip)
+        }}
+      />
+    </FormProvider>
+  )
+}
+
+const renderEmailSpellCheckInput = () => {
+  render(<FormWrapper />)
+}
+
+describe('EmailSpellCheckInput', () => {
+  it('The email suggestion should not be displayed when the field is empty', async () => {
+    renderEmailSpellCheckInput()
+    const emailField = screen.getByLabelText('Email *')
+    await userEvent.click(emailField)
+    await userEvent.tab()
+    expect(
+      screen.queryByText(/Voulez-vous plutôt dire/)
+    ).not.toBeInTheDocument()
+  })
+
+  it('The email suggestion should not be displayed when the field is invalid', async () => {
+    renderEmailSpellCheckInput()
+    const emailField = screen.getByLabelText('Email *')
+    await userEvent.click(emailField)
+    await userEvent.type(emailField, 'this is not an email')
+    await userEvent.tab()
+    expect(
+      screen.queryByText(/Voulez-vous plutôt dire/)
+    ).not.toBeInTheDocument()
+  })
+
+  it('The email suggestion should not be displayed when the email is already valid', async () => {
+    renderEmailSpellCheckInput()
+    const emailField = screen.getByLabelText('Email *')
+    await userEvent.click(emailField)
+    await userEvent.type(emailField, 'email@exemple.com')
+    await userEvent.tab()
+    expect(
+      screen.queryByText(/Voulez-vous plutôt dire/)
+    ).not.toBeInTheDocument()
+  })
+
+  it('The email suggestion should be displayed when the email is invalid', async () => {
+    renderEmailSpellCheckInput()
+    const emailField = screen.getByLabelText('Email *')
+    await userEvent.click(emailField)
+    await userEvent.type(emailField, 'email@gmil.com')
+    await userEvent.tab()
+    await waitFor(() => {
+      expect(screen.getByText(/Voulez-vous plutôt dire/)).toBeInTheDocument()
+    })
+  })
+
+  it('The apply button should change the email value', async () => {
+    renderEmailSpellCheckInput()
+    const emailField = screen.getByLabelText('Email *')
+    await userEvent.click(emailField)
+    await userEvent.type(emailField, 'email@gmil.com')
+    await userEvent.tab()
+    const applyButton = screen.getByText(/Appliquer la modification/)
+    expect(applyButton).toHaveFocus()
+
+    await userEvent.keyboard('{enter}')
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Voulez-vous plutôt dire/)
+      ).not.toBeInTheDocument()
+    })
+    expect(emailField).toHaveValue('email@gmail.com')
+  })
+})

--- a/pro/src/ui-kit/formV2/EmailSpellCheckInput/EmailSpellCheckInput.stories.tsx
+++ b/pro/src/ui-kit/formV2/EmailSpellCheckInput/EmailSpellCheckInput.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { FormProvider, useForm, useFormContext } from 'react-hook-form'
+
+import { EmailSpellCheckInput } from './EmailSpellCheckInput'
+
+// <FormWrapper> provides a react-hook-form context, which is necessary for the storybook demo to work
+type WrapperFormValues = { email: string }
+const FormWrapper = ({ children }: { children: React.ReactNode }) => {
+  const hookForm = useForm<WrapperFormValues>({
+    defaultValues: { email: 'jmclery@htomil.com' },
+  })
+
+  return <FormProvider {...hookForm}>{children}</FormProvider>
+}
+
+const meta: Meta<typeof EmailSpellCheckInput> = {
+  title: 'ui-kit/formsV2/EmailSpellCheckInput',
+  component: EmailSpellCheckInput,
+
+  decorators: [
+    (Story: any) => (
+      <FormWrapper>
+        <Story />
+      </FormWrapper>
+    ),
+  ],
+}
+
+export default meta
+
+type Story = StoryObj<typeof EmailSpellCheckInput>
+
+export const Default: Story = {
+  args: {
+    name: 'email',
+    label: 'Adresse email',
+    description: 'Format: email@exemple.com',
+    error: '',
+    required: true,
+    asterisk: true,
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { setValue, register } = useFormContext<WrapperFormValues>()
+
+    return (
+      <EmailSpellCheckInput
+        {...args}
+        {...register('email')}
+        onApplyTip={(tip) => {
+          setValue('email', tip)
+        }}
+      />
+    )
+  },
+}

--- a/pro/src/ui-kit/formV2/EmailSpellCheckInput/EmailSpellCheckInput.tsx
+++ b/pro/src/ui-kit/formV2/EmailSpellCheckInput/EmailSpellCheckInput.tsx
@@ -1,0 +1,99 @@
+import { ForwardedRef, forwardRef, useState } from 'react'
+
+import fullNextIcon from 'icons/full-next.svg'
+import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
+import { suggestEmail } from 'ui-kit/formV2/EmailSpellCheckInput/suggestEmail'
+import { TextInput } from 'ui-kit/formV2/TextInput/TextInput'
+
+import styles from './EmailSpellCheckInput.module.scss'
+
+type EmailSpellCheckInputProps = {
+  name: string
+  description: string
+  label: string
+  onApplyTip(tip: string): void
+  overrideInitialTip?: string | null
+  maxLength?: number
+  required?: boolean
+  asterisk?: boolean
+  error?: string
+  className?: string
+}
+
+export const EmailSpellCheckInput = forwardRef(
+  (
+    {
+      name,
+      description,
+      label,
+      className,
+      onApplyTip,
+      maxLength = 255,
+      required,
+      asterisk = true,
+      error,
+    }: EmailSpellCheckInputProps,
+    ref: ForwardedRef<HTMLInputElement>
+  ): JSX.Element => {
+    const [emailValidationTip, setEmailValidationTip] = useState<
+      string | null
+    >()
+
+    const handleEmailValidation = (
+      event: React.ChangeEvent<HTMLInputElement>
+    ) => {
+      const fieldValue = event.target.value
+      if (fieldValue.length > 0) {
+        const suggestion = suggestEmail(fieldValue.toString(), !!error)
+        if (suggestion) {
+          setEmailValidationTip(suggestion)
+        }
+      }
+    }
+    const resetEmailValidation = () => {
+      setEmailValidationTip(null)
+    }
+
+    return (
+      <>
+        <TextInput
+          ref={ref}
+          label={label}
+          name={name}
+          description={description}
+          onBlur={handleEmailValidation}
+          onFocus={resetEmailValidation}
+          autoComplete="email"
+          autoFocus={true}
+          className={className}
+          maxLength={maxLength}
+          required={required}
+          asterisk={asterisk}
+          error={error}
+        />
+        {emailValidationTip && (
+          <div className={styles['email-validation-error']}>
+            <div className={styles['email-validation-tip']}>
+              Voulez-vous plutôt dire {emailValidationTip} ?
+            </div>
+            <Button
+              variant={ButtonVariant.TERNARY}
+              icon={fullNextIcon}
+              iconPosition={IconPositionEnum.LEFT}
+              onClick={() => {
+                onApplyTip(emailValidationTip)
+                resetEmailValidation()
+              }}
+              autoFocus
+            >
+              Appliquer la modification
+            </Button>
+          </div>
+        )}
+      </>
+    )
+  }
+)
+
+EmailSpellCheckInput.displayName = 'EmailSpellCheckInput'

--- a/pro/src/ui-kit/formV2/EmailSpellCheckInput/suggestEmail.ts
+++ b/pro/src/ui-kit/formV2/EmailSpellCheckInput/suggestEmail.ts
@@ -1,0 +1,32 @@
+import emailSpellChecker from '@zootools/email-spell-checker'
+
+const TOP_MOST_USED_DOMAINS = [
+  'gmail.com',
+  'orange.fr',
+  'wanadoo.fr',
+  'yahoo.fr',
+  'hotmail.fr',
+  'free.fr',
+  'fnac.com',
+  'hotmail.com',
+  'outlook.fr',
+  'cultura.fr',
+]
+
+const config = {
+  domainThreshold: 4,
+  domains: TOP_MOST_USED_DOMAINS,
+  secondLevelDomains: [],
+  topLevelDomains: [],
+}
+
+export const suggestEmail = (
+  email: string,
+  fieldHasError: boolean
+): string | undefined => {
+  if (fieldHasError) {
+    return
+  }
+
+  return emailSpellChecker.run({ ...config, email })?.full
+}

--- a/pro/src/ui-kit/formV2/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
+++ b/pro/src/ui-kit/formV2/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
@@ -1,0 +1,97 @@
+@use "styles/mixins/_forms.scss" as formsM;
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/variables/_forms.scss" as forms;
+@use "styles/mixins/_size.scss" as size;
+
+$icon-width: rem.torem(16px);
+$icon-padding-left: rem.torem(16px);
+$space-icon-text: rem.torem(8px);
+$focus-border-width: rem.torem(2px);
+$base-border-width: rem.torem(1px);
+$input-height: calc(
+  #{size.$input-min-height} - (2 * #{size.$input-border-width})
+);
+$input-width: rem.torem(88px);
+$text-padding-left: calc(
+  #{$icon-width} + #{$icon-padding-left} + #{$space-icon-text}
+);
+
+.select-input-wrapper {
+  position: relative;
+  border-radius: rem.torem(forms.$input-border-radius) 0 0
+    rem.torem(forms.$input-border-radius);
+  margin: 0 $base-border-width;
+
+  &:focus,
+  &:focus-within {
+    border: solid var(--color-input-border-color-focus) $base-border-width;
+    border-radius: rem.torem(forms.$input-border-radius) 0 0
+      rem.torem(forms.$input-border-radius);
+    background-color: transparent;
+    box-shadow: inset 0 0 0 rem.torem(1px) var(--color-input-border-color-focus);
+
+    .select-input {
+      height: calc(#{$input-height} - #{$focus-border-width});
+      min-height: calc(#{$input-height} - #{$focus-border-width});
+      padding-left: calc(#{$text-padding-left} - (#{$focus-border-width} / 2));
+    }
+
+    .select-input-icon {
+      left: calc(#{$icon-padding-left} - (#{$focus-border-width} / 2));
+    }
+  }
+
+  &:hover {
+    border-radius: rem.torem(forms.$input-border-radius) 0 0
+      rem.torem(forms.$input-border-radius);
+  }
+}
+
+.select-input {
+  @include formsM.input-theme;
+  @include fonts.body-accent;
+
+  padding-left: $text-padding-left;
+  padding-right: rem.torem(8px);
+  width: $input-width;
+  height: $input-height;
+  min-height: $input-height;
+  margin: 1px;
+  background-color: transparent;
+
+  // -- override default select style --
+  border: unset;
+  box-shadow: unset;
+
+  @include formsM.input-theme-nested;
+
+  &:hover,
+  &:hover:not(:focus),
+  &:focus {
+    box-shadow: none;
+    outline: none;
+    border: none;
+  }
+
+  &-icon {
+    position: absolute;
+    top: 0;
+    left: $icon-padding-left;
+    height: 100%;
+    width: $icon-width;
+    fill: var(--color-black);
+    transform: rotate(90deg);
+    pointer-events: none;
+
+    &-disabled {
+      fill: var(--color-input-text-color-disabled);
+    }
+  }
+
+  &-placeholder {
+    @include fonts.body-italic;
+
+    color: var(--color-grey-dark);
+  }
+}

--- a/pro/src/ui-kit/formV2/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.tsx
+++ b/pro/src/ui-kit/formV2/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.tsx
@@ -1,0 +1,55 @@
+import cn from 'classnames'
+import { ChangeEvent, FocusEvent } from 'react'
+
+import fullRightIcon from 'icons/full-right.svg'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+
+import { PhoneCodeSelectOption } from '../constants'
+
+import styles from './CountryCodeSelect.module.scss'
+
+interface CountryCodeSelectProps {
+  disabled: boolean
+  options: PhoneCodeSelectOption[]
+  className?: string
+  value: string
+  onChange: (event: ChangeEvent<HTMLSelectElement>) => void
+  onBlur: (event: FocusEvent<HTMLSelectElement>) => void
+}
+
+export const CountryCodeSelect = ({
+  disabled,
+  options,
+  className,
+  value,
+  onChange,
+  onBlur,
+}: CountryCodeSelectProps) => {
+  return (
+    <div className={cn(styles['select-input-wrapper'], className)}>
+      <SvgIcon
+        src={fullRightIcon}
+        alt=""
+        className={cn(styles['select-input-icon'], {
+          [styles['select-input-icon-disabled']]: disabled,
+        })}
+        width="16"
+      />
+      <select
+        className={styles['select-input']}
+        id="countryCode"
+        disabled={disabled}
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        autoComplete="tel-country-code"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value} label={option.value}>
+            {option.value}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.module.scss
+++ b/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.module.scss
@@ -1,0 +1,68 @@
+@use "./CodeCountrySelect/CountryCodeSelect.module.scss" as countryCodeSelect;
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/variables/_forms.scss" as forms;
+@use "styles/mixins/_forms.scss" as formsM;
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_a11y.scss" as a11y;
+
+$input-phone-number-padding-left: calc(
+  countryCodeSelect.$input-width + rem.torem(8px) +
+    countryCodeSelect.$focus-border-width
+);
+
+.phone-number {
+  width: 100%;
+  margin-bottom: rem.torem(8px);
+
+  &-input {
+    padding-left: calc($input-phone-number-padding-left + rem.torem(1px));
+
+    &:focus {
+      padding-left: $input-phone-number-padding-left;
+    }
+
+    &-wrapper {
+      position: relative;
+      margin-bottom: rem.torem(8px);
+    }
+
+    &-legend {
+      display: flex;
+      width: 100%;
+      justify-content: space-between;
+    }
+
+    &-footer {
+      @include formsM.field-layout-footer;
+    }
+
+    &-error {
+      flex: 1;
+
+      svg {
+        flex: 0 0 15px;
+      }
+    }
+  }
+}
+
+.country-code-select {
+  position: absolute;
+  top: 0;
+  left: -1px;
+}
+
+.visually-hidden {
+  @include a11y.visually-hidden;
+}
+
+.phone-format {
+  @include fonts.body-xs;
+
+  color: var(--color-grey-dark);
+  margin-bottom: rem.torem(forms.$label-space-before-input);
+}
+
+.phone-number-inpus {
+  position: relative;
+}

--- a/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.spec.tsx
+++ b/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.spec.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+
+import { PHONE_CODE_COUNTRY_CODE_OPTIONS, PHONE_EXAMPLE_MAP } from './constants'
+import { PhoneNumberInput, PhoneNumberInputProps } from './PhoneNumberInput'
+
+const renderPhoneNumberInput = ({
+  label = 'Mon label',
+  ...props
+}: Partial<PhoneNumberInputProps>) => {
+  render(
+    <>
+      <PhoneNumberInput name="phone" label={label} {...props} />
+      <a href="#">Dummy element only here to receive the focus</a>
+    </>
+  )
+}
+
+describe('PhoneNumberInput', () => {
+  it('should have by default the first prefix of the list PHONE_CODE_COUNTRY_CODE_OPTIONS and its corresponding placeholder', () => {
+    renderPhoneNumberInput({})
+
+    const defaultCountryCodeOption = PHONE_CODE_COUNTRY_CODE_OPTIONS[0]
+    const defaultExample = PHONE_EXAMPLE_MAP[defaultCountryCodeOption.value]
+
+    expect(defaultExample).toBeDefined()
+    expect(screen.getByRole('combobox')).toHaveValue(
+      defaultCountryCodeOption.value
+    )
+    expect(
+      screen.getByText(`Par exemple : ${defaultExample}`)
+    ).toBeInTheDocument()
+  })
+
+  it('should change the placeholder when user change country code', async () => {
+    renderPhoneNumberInput({})
+    const countryCodeSelect = screen.getByRole('combobox')
+
+    await userEvent.selectOptions(countryCodeSelect, '+590')
+
+    const guadeloupeExample = PHONE_EXAMPLE_MAP['+590']
+    expect(guadeloupeExample).toBeDefined()
+    expect(
+      screen.getByText(`Par exemple : ${guadeloupeExample}`)
+    ).toBeInTheDocument()
+  })
+
+  it('should show an error if prop "error" is set', () => {
+    renderPhoneNumberInput({
+      error:
+        'Veuillez renseigner un numéro de téléphone valide, exemple : 612345678',
+    })
+    expect(
+      screen.queryByText(
+        'Veuillez renseigner un numéro de téléphone valide, exemple : 612345678'
+      )
+    ).toBeInTheDocument()
+  })
+
+  describe('should separate correctly phone values', () => {
+    it.each([
+      {
+        value: '+33612345678',
+        prefix: '+33',
+        phoneNumber: '612345678',
+      },
+      {
+        value: '+262692123456',
+        prefix: '+262',
+        phoneNumber: '692123456',
+      },
+      {
+        value: '+508551234',
+        prefix: '+508',
+        phoneNumber: '551234',
+      },
+      {
+        value: '+590690000102',
+        prefix: '+590',
+        phoneNumber: '690000102',
+      },
+      {
+        value: '+594694000102',
+        prefix: '+594',
+        phoneNumber: '694000102',
+      },
+      {
+        value: '+596696000102',
+        prefix: '+596',
+        phoneNumber: '696000102',
+      },
+      {
+        value: '+687751234',
+        prefix: '+687',
+        phoneNumber: '751234',
+      },
+    ])(
+      'should split value $value into $prefix and $phoneNumber',
+      ({ value, prefix, phoneNumber }) => {
+        renderPhoneNumberInput({ value })
+        const countryCodeSelect = screen.getByRole('combobox')
+        const phoneNumberInput = screen.getByRole('textbox')
+
+        expect(countryCodeSelect).toHaveValue(prefix)
+        expect(phoneNumberInput).toHaveValue(phoneNumber)
+      }
+    )
+  })
+
+  it('should give the correct value to the "onChange" functions', async () => {
+    const onChangeFn = vi.fn()
+    const onBlurFn = vi.fn()
+    let changeEvent, blurEvent
+    renderPhoneNumberInput({
+      value: '+33612345678',
+      onChange: onChangeFn,
+      onBlur: onBlurFn,
+    })
+
+    // Changes phone number value
+    const phoneNumberInput = screen.getByRole('textbox')
+    await userEvent.clear(phoneNumberInput)
+    await userEvent.type(phoneNumberInput, '8845678') // triggers "onChange"
+    await userEvent.tab() // triggers "onBlur"
+
+    // Expect change and blur events to have been called with the correct value
+    changeEvent = onChangeFn.mock.lastCall?.[0]
+    blurEvent = onBlurFn.mock.lastCall?.[0]
+    ;[changeEvent, blurEvent].forEach((event) => {
+      expect(event).toBeDefined()
+      expect(event.target.name).toBe('phone')
+      expect(event.target.value).toBe('+338845678')
+    })
+
+    // Then changes country code (prefix)
+    const countryCodeSelect = screen.getByRole('combobox')
+    await userEvent.selectOptions(countryCodeSelect, '+590') // triggers "onChange"
+    await userEvent.tab() // triggers "onBlur"
+
+    // Expect change and blur events to have been called with the correct value
+    changeEvent = onChangeFn.mock.lastCall?.[0]
+    blurEvent = onBlurFn.mock.lastCall?.[0]
+    ;[changeEvent, blurEvent].forEach((event) => {
+      expect(event).toBeDefined()
+      expect(event.target.name).toBe('phone')
+      expect(event.target.value).toBe('+5908845678')
+    })
+  })
+
+  it('should expose a ref with the good value to the phone number input', () => {
+    const refMock = vi.fn()
+    renderPhoneNumberInput({ value: '+33687451542', ref: refMock })
+
+    const inputRef = refMock.mock.lastCall?.[0] as HTMLInputElement
+
+    expect(inputRef).toBeDefined()
+    expect(inputRef.value).toBe('+33687451542')
+  })
+})

--- a/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.stories.tsx
+++ b/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.stories.tsx
@@ -1,0 +1,104 @@
+import { yupResolver } from '@hookform/resolvers/yup'
+import type { Meta, StoryObj } from '@storybook/react'
+import { FormProvider, useForm, useFormContext } from 'react-hook-form'
+import * as yup from 'yup'
+
+import { isPhoneValid } from 'commons/core/shared/utils/parseAndValidateFrenchPhoneNumber'
+
+import { PhoneNumberInput } from './PhoneNumberInput'
+
+// <FormWrapper> provides a react-hook-form context, which is necessary for the storybook demo with error to work
+type WrapperFormValues = { phone: string }
+const FormWrapper = ({ children }: { children: React.ReactNode }) => {
+  const hookForm = useForm<WrapperFormValues>({
+    defaultValues: { phone: '+33612345678' },
+    resolver: yupResolver(
+      yup.object().shape({
+        phone: yup.string().required().test({
+          name: 'is-phone-valid',
+          message: 'Veuillez entrer un numéro de téléphone valide',
+          test: isPhoneValid,
+        }),
+      })
+    ),
+    mode: 'onTouched',
+  })
+
+  return <FormProvider {...hookForm}>{children}</FormProvider>
+}
+
+const meta: Meta<typeof PhoneNumberInput> = {
+  title: 'ui-kit/formsV2/PhoneNumberInput',
+  component: PhoneNumberInput,
+
+  decorators: [
+    (Story: any) => (
+      <FormWrapper>
+        <Story />
+      </FormWrapper>
+    ),
+  ],
+}
+
+export default meta
+
+type Story = StoryObj<typeof PhoneNumberInput>
+
+const demoStyles = {
+  wrapper: {
+    color: '#666',
+    fontSize: '0.8rem',
+    padding: '0 1rem',
+    backgroundColor: '#f5f5f5',
+    borderRadius: '0.2rem',
+    border: 'thin solid #e1e1e1',
+  },
+  pre: { display: 'inline-block', padding: '0.5rem' },
+}
+
+export const Default: Story = {
+  args: {
+    name: 'phone',
+    label: 'Custom label for my required field (with validation)',
+  },
+  render: (args) => {
+    const {
+      register,
+      watch,
+      formState: { errors },
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+    } = useFormContext<WrapperFormValues>()
+
+    const phoneNumber = watch('phone')
+
+    return (
+      <>
+        <PhoneNumberInput
+          {...args}
+          {...register('phone')}
+          required={true}
+          error={errors.phone?.message}
+        />
+        <div style={demoStyles['wrapper']}>
+          RAW value: <pre style={demoStyles['pre']}>{phoneNumber}</pre>
+        </div>
+      </>
+    )
+  },
+}
+
+export const WithOptional: Story = {
+  args: {
+    name: 'phone',
+    label: 'Phone number input optional',
+    required: false,
+  },
+}
+
+export const InErrorState: Story = {
+  args: {
+    name: 'phone',
+    label: 'Custom label in forced error state',
+    error: 'Ce champs comporte une erreur',
+  },
+}

--- a/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.tsx
@@ -1,0 +1,215 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useState,
+} from 'react'
+
+import { BaseInput } from 'ui-kit/form/shared/BaseInput/BaseInput'
+import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
+
+import { CountryCodeSelect } from './CodeCountrySelect/CountryCodeSelect'
+import {
+  PHONE_CODE_COUNTRY_CODE_OPTIONS,
+  PHONE_EXAMPLE_MAP,
+  PlusString,
+} from './constants'
+import styles from './PhoneNumberInput.module.scss'
+
+export type PhoneNumberInputProps = {
+  // native props that are used by react-hook-form’s register() function
+  value?: string
+  onChange?: (e: { target: { value: string; name?: string } }) => void
+  onBlur?: (e: React.FocusEvent<HTMLSelectElement | HTMLInputElement>) => void
+  name: string
+  ref?: React.Ref<HTMLInputElement>
+  // other business-oriented props
+  disabled?: boolean
+  maxLength?: number
+  error?: string
+  label: string | JSX.Element
+  required?: boolean
+  asterisk?: boolean
+}
+
+export const PhoneNumberInput = forwardRef<
+  HTMLInputElement,
+  PhoneNumberInputProps
+>(
+  (
+    {
+      value = '',
+      onChange,
+      onBlur,
+      name,
+      disabled,
+      maxLength = 25,
+      error,
+      label,
+      required = false,
+      asterisk = true,
+      ...props
+    },
+    ref
+  ) => {
+    const formatId = useId()
+
+    const defaultPrefix = PHONE_CODE_COUNTRY_CODE_OPTIONS[0].value
+
+    // Initialize states with given value (splits prefix "+33" and phone number "612345678")
+    const { prefix: initialPrefix, phoneNumber: initialPhoneNumber } =
+      extractPhoneParts(value)
+
+    const [prefix, setPrefix] = useState(initialPrefix || defaultPrefix)
+    const [phoneNumber, setPhoneNumber] = useState(initialPhoneNumber)
+
+    // Function that will updates internal states
+    const setPrefixAndPhoneNumberFrom = useCallback(
+      (value: string) => {
+        const { prefix: newPrefix, phoneNumber: newPhoneNumber } =
+          extractPhoneParts(value)
+        setPrefix(newPrefix || defaultPrefix)
+        setPhoneNumber(newPhoneNumber)
+      },
+      [defaultPrefix]
+    )
+
+    // Updates internal states when the "value" prop changes from the outside
+    useEffect(() => {
+      setPrefixAndPhoneNumberFrom(value)
+    }, [value, setPrefixAndPhoneNumberFrom])
+
+    // When <CountryCodeSelect> changes, combine prefix and phone number and notify the change up
+    const handlePrefixChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const newPrefix = e.target.value
+      setPrefix(newPrefix)
+      if (onChange) {
+        // fire an event object based on the original event, but with the combined value
+        onChange({
+          ...e,
+          target: { ...e.target, value: newPrefix + phoneNumber, name },
+        })
+      }
+    }
+
+    // When <BaseInput> changes, combine prefix and phone number and notify the change up
+    const handleNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newPhoneNumber = e.target.value
+      setPhoneNumber(newPhoneNumber)
+      if (onChange) {
+        // fire an event object based on the original event, but with the combined value
+        onChange({
+          ...e,
+          target: { ...e.target, value: prefix + newPhoneNumber, name },
+        })
+      }
+    }
+
+    // Handles onBlur events
+    const handleBlur = (
+      e: React.FocusEvent<HTMLSelectElement | HTMLInputElement>
+    ) => {
+      if (onBlur) {
+        // fire an event object based on the original event, but with the combined value
+        onBlur({
+          ...e,
+          target: { ...e.target, value: prefix + phoneNumber, name },
+        })
+      }
+    }
+
+    // This does the trick to combine prefix and phone number into a single value :
+    // It will expose a reference to an dummy input element that can be used by react-hook-form or any other external usage that implies a ref
+    useImperativeHandle(ref, () => {
+      const element = document.createElement('input')
+
+      Object.defineProperty(element, 'value', {
+        get: () => prefix + phoneNumber,
+        set: (newValue) => {
+          setPrefixAndPhoneNumberFrom(newValue)
+        },
+      })
+
+      element.name = name || ''
+
+      return element
+    })
+
+    return (
+      <fieldset className={styles['phone-number-input-wrapper']}>
+        <legend className={styles['phone-number-input-legend']}>
+          {label} {required && asterisk && '*'}
+        </legend>
+        <p className={styles['phone-format']} id={formatId}>
+          Par exemple : {PHONE_EXAMPLE_MAP[prefix as PlusString]}
+        </p>
+        <div className={styles['phone-number-inpus']}>
+          <label htmlFor="countryCode" className={styles['visually-hidden']}>
+            Indicatif téléphonique
+          </label>
+          <CountryCodeSelect
+            disabled={Boolean(disabled)}
+            options={PHONE_CODE_COUNTRY_CODE_OPTIONS}
+            className={styles['country-code-select']}
+            value={prefix}
+            onChange={handlePrefixChange}
+            onBlur={handleBlur}
+          />
+
+          <label htmlFor={name} className={styles['visually-hidden']}>
+            Numéro de téléphone
+          </label>
+          <BaseInput
+            disabled={disabled}
+            hasError={!!error}
+            type="text"
+            name={`${name}-phoneNumber`}
+            value={phoneNumber}
+            onChange={handleNumberChange}
+            onBlur={handleBlur}
+            className={styles['phone-number-input']}
+            autoComplete="tel-national"
+            maxLength={maxLength}
+            aria-describedby={formatId}
+            {...props}
+          />
+          <div className={styles['phone-number-input-footer']}>
+            {error && (
+              <div className={styles['phone-number-input-error']}>
+                <FieldError name={name}>{error}</FieldError>
+              </div>
+            )}
+          </div>
+        </div>
+      </fieldset>
+    )
+  }
+)
+
+PhoneNumberInput.displayName = 'PhoneNumberInput'
+
+/**
+ * Splits a phone number into a valid prefix and phone number.
+ *
+ * @param {string} fullNumber - The full phone number including the country code prefix.
+ * @returns {{ prefix: string, phoneNumber: string }} An object containing the extracted prefix and phone number.
+ *
+ * @example
+ * // returns { prefix: "+33", phoneNumber: "612345678" }
+ * extractPhoneParts("+33612345678")
+ */
+const extractPhoneParts = (fullNumber: string) => {
+  const prefixes = PHONE_CODE_COUNTRY_CODE_OPTIONS.map((o) => o.value)
+  const foundPrefix = prefixes.find((p) => fullNumber.startsWith(p))
+
+  if (foundPrefix) {
+    return {
+      prefix: foundPrefix,
+      phoneNumber: fullNumber.substring(foundPrefix.length),
+    }
+  }
+
+  return { prefix: '', phoneNumber: fullNumber }
+}

--- a/pro/src/ui-kit/formV2/PhoneNumberInput/constants.ts
+++ b/pro/src/ui-kit/formV2/PhoneNumberInput/constants.ts
@@ -1,0 +1,25 @@
+export type PlusString = `+${string}`
+
+export type PhoneCodeSelectOption = {
+  value: PlusString
+}
+
+export const PHONE_CODE_COUNTRY_CODE_OPTIONS: PhoneCodeSelectOption[] = [
+  { value: '+33' },
+  { value: '+262' },
+  { value: '+508' },
+  { value: '+590' },
+  { value: '+594' },
+  { value: '+596' },
+  { value: '+687' },
+]
+
+export const PHONE_EXAMPLE_MAP: Record<PlusString, string> = {
+  '+33': '6 12 34 56 78',
+  '+262': '692 12 34 56',
+  '+508': '55 12 34',
+  '+590': '690 00 01 02',
+  '+594': '694 00 01 02',
+  '+596': '696 00 01 02',
+  '+687': '75 12 34',
+}


### PR DESCRIPTION
## But de la pull request

- 1er commit : Met à jour les composants `<Checkbox>` et `<EmailSpellCheckInput>` vers /formV2/ pour react-hook-form 
- 2ème commit : Réécriture complète du coeur du composant `<PhoneNumberInput>` vers /formV2/ pour react-hook-form
  - Le composant utilise toujours deux states internes pour gérer la partie préfixe du numéro (ex: +33) et le reste du numéro, mais effectue une remontée de la valeur combinée vers le parent en exposant une ref customisée

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
