### PR TITLE
(PC-35019)[API] fix: avoid cartesian product on partner page check

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -748,6 +748,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
             sa.select(1)
             .select_from(UserOfferer)
             .join(Venue, UserOfferer.offererId == Venue.managingOffererId)
+            .join(Offerer, UserOfferer.offererId == Offerer.id)
             .where(
                 UserOfferer.userId == self.id,
                 Offerer.isActive.is_(True),


### PR DESCRIPTION
The join between UserOfferer and Offer was missing, leading to unhealthy cartesian product between the two tables, possible perfomance issues and non fonctional check on offerer being active.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35019

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
