### PR TITLE
(BSR)[PRO] fix: excess padding on selected tags

### DIFF
--- a/pro/src/ui-kit/SelectedValuesTags/SelectedValuesTags.module.scss
+++ b/pro/src/ui-kit/SelectedValuesTags/SelectedValuesTags.module.scss
@@ -6,7 +6,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: rem.torem(8px);
-  padding-top: rem.torem(8px);
 }
 
 .tag-extra-count {


### PR DESCRIPTION
## But de la pull request

BSR regression design sur le multiselect suite à l'intégration de celui-ci dans la page chiffre d'affaire 

AVANT 

<img width="555" alt="Capture d’écran 2025-03-10 à 09 22 35" src="https://github.com/user-attachments/assets/d9dc1669-fc30-4a47-b799-77b16986b703" />

APRÈS 

<img width="552" alt="Capture d’écran 2025-03-10 à 09 22 46" src="https://github.com/user-attachments/assets/c2210fac-9b4f-417d-8325-05cc036f50d6" />

