### PR TITLE
(BSR) feat: update command to generate a script file

### DIFF
--- a/api/bin/generate_script_file.py
+++ b/api/bin/generate_script_file.py
@@ -1,9 +1,10 @@
+#!/usr/bin/env python
 """
 Generate a python (and sql) file in a folder of pcapi/scripts to be ran with a GitHub Action "console job"
 
 Usage:
 
-    $ python bin/generate_script_file.py --namespace my_script_namespace --with-sql
+    $ bin/generate_script_file.py <my_script_namespace> [--with-sql]
 
 Create the pcapi/scripts/<my_script_namespace> folder and add a main.py file with some base script code
 Add an empty main.sql file if --with-sql is passed
@@ -28,11 +29,12 @@ import logging
 from pcapi.app import app
 from pcapi.models import db
 
+
 logger = logging.getLogger(__name__)
 
-app.app_context().push()
-
 if __name__ == "__main__":
+    app.app_context().push()
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--not-dry", action="store_true")
     args = parser.parse_args()
@@ -62,7 +64,7 @@ def main(namespace: str, with_sql: bool) -> None:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--namespace", type=str)
+    parser.add_argument("namespace", type=str)
     parser.add_argument("--with-sql", action="store_true")
     args = parser.parse_args()
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) :

Modif sur `generate_script_file` pour le rendre plus simple à appeler

`bin/generate_script_file.py <my_script_namespace>`
au lieu de
`python bin/generate_script_file.py --namespace <my_script_namespace>`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
