### PR TITLE
(PC-34671)[API] feat: Move collective offer from one venue to another

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1741,7 +1741,7 @@ def check_can_move_offer(offer: models.Offer) -> list[offerers_models.Venue]:
     venues_choices = offerers_repository.get_offerers_venues_with_pricing_point(
         offer.venue,
         include_without_pricing_points=True,
-        check_pricing_points=True,
+        only_similar_pricing_points=True,
     )
     if not venues_choices:
         raise exceptions.NoDestinationVenue()

--- a/api/src/pcapi/routes/backoffice/collective_offers/forms.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/forms.py
@@ -11,6 +11,7 @@ import wtforms
 
 from pcapi.core.categories import subcategories
 from pcapi.core.educational import models as educational_models
+from pcapi.core.offerers import models as offerers_models
 from pcapi.models.offer_mixin import CollectiveOfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.routes.backoffice import autocomplete
@@ -389,3 +390,12 @@ class RejectCollectiveOfferForm(FlaskForm):
 
 class BatchRejectCollectiveOfferForm(empty_forms.BatchForm, RejectCollectiveOfferForm):
     pass
+
+
+class MoveCollectiveOfferForm(FlaskForm):
+    venue = fields.PCSelectWithPlaceholderValueField("Nouveau partenaire culturel", choices=[], validate_choice=False)
+
+    def set_venue_choices(self, venues: list[offerers_models.Venue]) -> None:
+        self.venue.choices = [
+            (venue.id, f"{venue.common_name} ({venue.siret if venue.siret else 'Pas de SIRET'})") for venue in venues
+        ]

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -34,6 +34,14 @@
                     <button class="btn btn-outline-primary lead fw-bold mt-2">Rejeter l'offre</button>
                   </a>
                   {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_reject_collective_offer_form', collective_offer_id=collective_offer.id) , "reject-collective-offer-modal-" + collective_offer.id|string) }}
+                  {% if move_offer_form %}
+                    <a class=" px-3"
+                       data-bs-toggle="modal"
+                       data-bs-target="#move-collective-offer-modal-{{ collective_offer.id }}">
+                      <button class="btn btn-outline-primary lead fw-bold mt-2">Changer le partenaire culturel</button>
+                    </a>
+                    {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_move_collective_offer_form', collective_offer_id=collective_offer.id) , "move-collective-offer-modal-" + collective_offer.id|string) }}
+                  {% endif %}
                 </div>
               {% endif %}
             </div>

--- a/api/tests/core/educational/api/test_move_collective_offer.py
+++ b/api/tests/core/educational/api/test_move_collective_offer.py
@@ -1,0 +1,376 @@
+import datetime
+
+import pytest
+
+from pcapi.core.educational import factories as educational_factories
+from pcapi.core.educational import models as educational_models
+from pcapi.core.educational.api import offer as collective_offer_api
+from pcapi.core.educational.models import CollectiveBookingStatus
+from pcapi.core.finance import api as finance_api
+from pcapi.core.finance import factories as finance_factories
+from pcapi.core.finance import models as finance_models
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import api as api
+from pcapi.models import db
+from pcapi.models.offer_mixin import CollectiveOfferStatus
+from pcapi.models.offer_mixin import OfferValidationStatus
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+@pytest.fixture(name="venues_with_same_pricing_point")
+def venues_with_same_pricing_point_fixture():
+    venue = offerers_factories.VenueFactory()
+    destination_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
+    pricing_point_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer, name="current")
+
+    offerers_factories.VenuePricingPointLinkFactory(
+        venue=destination_venue,
+        pricingPoint=pricing_point_venue,
+        timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+    )
+    offerers_factories.VenuePricingPointLinkFactory(
+        venue=venue,
+        pricingPoint=pricing_point_venue,
+        timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+    )
+    return venue, destination_venue
+
+
+def create_offer_by_offer_state(venue, state):
+    collective_offer = None
+    if state == OfferValidationStatus.DRAFT:
+        collective_offer = educational_factories.CollectiveOfferFactory(
+            venue=venue, validation=OfferValidationStatus.DRAFT
+        )
+    if state == OfferValidationStatus.PENDING:
+        collective_offer = educational_factories.CollectiveOfferFactory(
+            venue=venue, validation=OfferValidationStatus.PENDING
+        )
+    if state == OfferValidationStatus.REJECTED:
+        collective_offer = educational_factories.CollectiveOfferFactory(
+            venue=venue, validation=OfferValidationStatus.REJECTED
+        )
+
+    if state == CollectiveOfferStatus.ACTIVE:
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+    if state == CollectiveOfferStatus.EXPIRED:
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stock = educational_factories.CollectiveStockFactory(
+            collectiveOffer=collective_offer, startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=30)
+        )
+    if state == CollectiveOfferStatus.SOLD_OUT:
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stock = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        educational_factories.UsedCollectiveBookingFactory(collectiveStock=collective_stock)
+    if state == CollectiveOfferStatus.INACTIVE:
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue, isActive=False)
+    if state == CollectiveOfferStatus.ARCHIVED:
+        collective_offer = educational_factories.CollectiveOfferFactory(
+            venue=venue, dateArchived=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        )
+    return collective_offer
+
+
+def create_offer_by_booking_state(venue, state):
+    collective_offer = None
+    if state == educational_models.CollectiveBookingStatus.PENDING:
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stock = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        educational_factories.CollectiveBookingFactory(collectiveStock=collective_stock)
+    if state == educational_models.CollectiveBookingStatus.CONFIRMED:
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stock = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        educational_factories.CollectiveBookingFactory(collectiveStock=collective_stock)
+    if state == educational_models.CollectiveBookingStatus.USED:
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stock = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        educational_factories.UsedCollectiveBookingFactory(collectiveStock=collective_stock)
+    if state == educational_models.CollectiveBookingStatus.REIMBURSED:
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stock = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        educational_factories.ReimbursedCollectiveBookingFactory(collectiveStock=collective_stock)
+    if state == educational_models.CollectiveBookingStatus.CANCELLED:
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stock = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        educational_factories.CancelledCollectiveBookingFactory(collectiveStock=collective_stock)
+    return collective_offer
+
+
+class MoveCollectiveOfferSuccessTest:
+    def test_move_collective_offer_without_pricing_points(self):
+        """
+        A collective offer on a venue without pricing point can be moved to another venue without pricing point
+        """
+        collective_offer = educational_factories.CollectiveOfferFactory()
+        destination_venue = offerers_factories.VenueFactory(managingOfferer=collective_offer.venue.managingOfferer)
+        assert collective_offer.venue.current_pricing_point_link is None
+        assert destination_venue.current_pricing_point_link is None
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        db.session.refresh(collective_offer)
+        assert collective_offer.venue == destination_venue
+
+    def test_move_collective_offer_without_pricing_point_to_venue_with_pricing_point(self):
+        """
+        A collective offer on a venue without pricing point can be moved to another venue with a pricing point
+        """
+        venue = offerers_factories.VenueFactory()
+        destination_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
+        pricing_point_venue_1 = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer, name="current")
+
+        offerers_factories.VenuePricingPointLinkFactory(
+            venue=destination_venue,
+            pricingPoint=pricing_point_venue_1,
+            timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+        )
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        db.session.refresh(collective_offer)
+        assert collective_offer.venue == destination_venue
+
+    def test_move_collective_offer_with_same_pricing_points_without_bookings(self, venues_with_same_pricing_point):
+        """
+        A collective offer on a venue with a pricing point can be moved to another venue with the same pricing point
+        """
+        venue, destination_venue = venues_with_same_pricing_point
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        db.session.refresh(collective_offer)
+        assert collective_offer.venue == destination_venue
+
+    def test_move_collective_offer_with_past_stocks(self, venues_with_same_pricing_point):
+        venue, destination_venue = venues_with_same_pricing_point
+        yesterday = datetime.date.today() - datetime.timedelta(days=1)
+
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer, startDatetime=yesterday)
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        db.session.refresh(collective_offer)
+        assert collective_offer.venue == destination_venue
+
+    def test_move_collective_offer_with_unused_bookings_without_reimbursment(self, venues_with_same_pricing_point):
+        venue, destination_venue = venues_with_same_pricing_point
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stocks = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        collective_booking = educational_factories.CollectiveBookingFactory(
+            collectiveStock=collective_stocks, status=CollectiveBookingStatus.CONFIRMED
+        )
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        db.session.refresh(collective_offer)
+        db.session.refresh(collective_booking)
+        assert collective_offer.venue == destination_venue
+        assert collective_booking.venue == destination_venue
+
+    def test_move_collective_offer_with_used_bookings(self, venues_with_same_pricing_point):
+        """
+        A finance event is created when a collectiveBooking is used.
+        Reimbursement does not create new finance event, only create CashFlow and Invoices.
+        Link to venues is through BankAccount.
+        Because an offer can only be moved to a venue with the same bank account, it should not be a problem
+        """
+        venue, destination_venue = venues_with_same_pricing_point
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stocks = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        collective_booking = educational_factories.UsedCollectiveBookingFactory(collectiveStock=collective_stocks)
+        finance_event = finance_api.add_event(
+            finance_models.FinanceEventMotive.BOOKING_USED, booking=collective_booking
+        )
+        assert finance_event.venue == venue
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        db.session.refresh(collective_offer)
+        db.session.refresh(collective_booking)
+        db.session.refresh(finance_event)
+        assert collective_offer.venue == destination_venue
+        assert collective_booking.venue == destination_venue
+        assert finance_event.venue == destination_venue
+
+    def test_move_collective_offer_without_bank_account(self, venues_with_same_pricing_point):
+        """
+        A collective offer on a venue without bank account can be moved to another venue without bank account
+        """
+        venue, destination_venue = venues_with_same_pricing_point
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stocks = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        collective_booking = educational_factories.CollectiveBookingFactory(collectiveStock=collective_stocks)
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        assert collective_offer.venue == destination_venue
+        assert collective_booking.venue == destination_venue
+
+    def test_move_collective_offer_without_bank_account_to_venue_with_bank_account(
+        self, venues_with_same_pricing_point
+    ):
+        """
+        A collective offer on a venue without bank account can be moved to another venue with the bank account
+        """
+        now = datetime.datetime.utcnow()
+        venue, destination_venue = venues_with_same_pricing_point
+        bank_account = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=destination_venue,
+            bankAccount=bank_account,
+            timespan=[now - datetime.timedelta(days=30), now - datetime.timedelta(days=3)],
+        )
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stocks = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        collective_booking = educational_factories.CollectiveBookingFactory(collectiveStock=collective_stocks)
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        assert collective_offer.venue == destination_venue
+        assert collective_booking.venue == destination_venue
+
+    def test_move_collective_offer_with_bank_account(self, venues_with_same_pricing_point):
+        """
+        A collective offer on a venue with a bank account can be moved to another venue with the same bank account
+        """
+        now = datetime.datetime.utcnow()
+        venue, destination_venue = venues_with_same_pricing_point
+        bank_account = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue,
+            bankAccount=bank_account,
+            timespan=[now - datetime.timedelta(days=30), now - datetime.timedelta(days=3)],
+        )
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=destination_venue,
+            bankAccount=bank_account,
+            timespan=[now - datetime.timedelta(days=30), now - datetime.timedelta(days=3)],
+        )
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        collective_stocks = educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer)
+        collective_booking = educational_factories.CollectiveBookingFactory(collectiveStock=collective_stocks)
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        assert collective_offer.venue == destination_venue
+        assert collective_booking.venue == destination_venue
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            OfferValidationStatus.DRAFT,
+            OfferValidationStatus.PENDING,
+            OfferValidationStatus.REJECTED,
+            CollectiveOfferStatus.ACTIVE,
+            CollectiveOfferStatus.EXPIRED,
+            CollectiveOfferStatus.SOLD_OUT,
+            CollectiveOfferStatus.INACTIVE,
+            CollectiveOfferStatus.ARCHIVED,
+        ],
+    )
+    def test_move_collective_offer_with_different_statuses(self, state):
+        venue = offerers_factories.VenueFactory()
+        destination_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
+        collective_offer = create_offer_by_offer_state(venue, state)
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        db.session.refresh(collective_offer)
+        assert collective_offer.venue == destination_venue
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            educational_models.CollectiveBookingStatus.PENDING,
+            educational_models.CollectiveBookingStatus.CONFIRMED,
+            educational_models.CollectiveBookingStatus.USED,
+            educational_models.CollectiveBookingStatus.REIMBURSED,
+            educational_models.CollectiveBookingStatus.CANCELLED,
+        ],
+    )
+    def test_move_collective_offer_with_different_booking_statuses(self, state):
+        venue = offerers_factories.VenueFactory()
+        destination_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
+        collective_offer = create_offer_by_booking_state(venue, state)
+
+        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+
+        db.session.refresh(collective_offer)
+        assert collective_offer.venue == destination_venue
+        assert educational_models.CollectiveBooking.query.count() == 1
+        assert educational_models.CollectiveBooking.query.all()[0].venue == destination_venue
+
+
+class MoveCollectiveOfferFailTest:
+    def test_move_collective_offer_with_different_pricing_point(self):
+        venue = offerers_factories.VenueFactory()
+        invalid_destination_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
+        pricing_point_venue_1 = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer, name="current")
+        pricing_point_venue_2 = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer, name="current")
+
+        offerers_factories.VenuePricingPointLinkFactory(
+            venue=invalid_destination_venue,
+            pricingPoint=pricing_point_venue_1,
+            timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+        )
+        offerers_factories.VenuePricingPointLinkFactory(
+            venue=venue,
+            pricingPoint=pricing_point_venue_2,
+            timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+        )
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        with pytest.raises(api.exceptions.NoDestinationVenue):
+            collective_offer_api.move_collective_offer_venue(
+                collective_offer, invalid_destination_venue, with_restrictions=False
+            )
+
+        db.session.refresh(collective_offer)
+        assert collective_offer.venue != invalid_destination_venue
+
+    def test_move_collective_offer_with_pricing_point_to_venue_without_pricing_point(self):
+        venue = offerers_factories.VenueFactory()
+        invalid_destination_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
+        pricing_point_venue_1 = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer, name="current")
+
+        offerers_factories.VenuePricingPointLinkFactory(
+            venue=venue,
+            pricingPoint=pricing_point_venue_1,
+            timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+        )
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        with pytest.raises(api.exceptions.NoDestinationVenue):
+            collective_offer_api.move_collective_offer_venue(
+                collective_offer, invalid_destination_venue, with_restrictions=False
+            )
+
+        db.session.refresh(collective_offer)
+        assert collective_offer.venue != invalid_destination_venue
+
+    def test_move_collective_offer_with_different_banking_account(self, venues_with_same_pricing_point):
+        now = datetime.datetime.utcnow()
+        venue, invalid_destination_venue = venues_with_same_pricing_point
+        bank_account_1 = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
+        bank_account_2 = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=venue,
+            bankAccount=bank_account_1,
+            timespan=[now - datetime.timedelta(days=30), now + datetime.timedelta(days=3)],
+        )
+        offerers_factories.VenueBankAccountLinkFactory(
+            venue=invalid_destination_venue,
+            bankAccount=bank_account_2,
+            timespan=[now - datetime.timedelta(days=30), now + datetime.timedelta(days=3)],
+        )
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+        with pytest.raises(api.exceptions.NoDestinationVenue):
+            collective_offer_api.move_collective_offer_venue(
+                collective_offer, invalid_destination_venue, with_restrictions=False
+            )
+
+        db.session.refresh(collective_offer)
+        assert collective_offer.venue != invalid_destination_venue

--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -1326,6 +1326,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
     # - fetch CollectiveOffer
     # - _is_collective_offer_price_editable
     expected_num_queries = 4
+    expected_num_queries_with_ff = expected_num_queries + 1  # FF MOVE_OFFER_TEST
 
     def test_nominal(self, legit_user, authenticated_client):
         start_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
@@ -1344,7 +1345,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
             ),
         )
         url = url_for(self.endpoint, collective_offer_id=collective_booking.collectiveStock.collectiveOffer.id)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1370,7 +1371,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         )
         url = url_for(self.endpoint, collective_offer_id=pricing.collectiveBooking.collectiveStock.collectiveOffer.id)
 
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1383,7 +1384,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         )
         url = url_for(self.endpoint, collective_offer_id=pricing.collectiveBooking.collectiveStock.collectiveOffer.id)
 
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1396,7 +1397,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         url = url_for(self.endpoint, collective_offer_id=pricing.collectiveBooking.collectiveStock.collectiveOffer.id)
         app.redis_client.set(finance_conf.REDIS_GENERATE_CASHFLOW_LOCK, "1", 600)
         try:
-            with assert_num_queries(3):
+            with assert_num_queries(4):
                 response = authenticated_client.get(url)
                 assert response.status_code == 200
         finally:
@@ -1414,7 +1415,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
             collectiveStock__collectiveOffer__lastValidationAuthor=legit_user,
         )
         url = url_for(self.endpoint, collective_offer_id=collective_booking.collectiveStock.collectiveOffer.id)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
 
         content_as_text = html_parser.content_as_text(response.data)
@@ -1433,7 +1434,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
             collectiveStock__collectiveOffer__rejectionReason=educational_models.CollectiveOfferRejectionReason.MISSING_DESCRIPTION,
         )
         url = url_for(self.endpoint, collective_offer_id=collective_booking.collectiveStock.collectiveOffer.id)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries_with_ff):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1447,7 +1448,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         collective_offer = educational_factories.CollectiveOfferFactory(venue__managingOfferer=rule.offerer)
 
         url = url_for(self.endpoint, collective_offer_id=collective_offer.id)
-        with assert_num_queries(self.expected_num_queries - 1):  # no _is_collective_offer_price_editable
+        with assert_num_queries(self.expected_num_queries_with_ff - 1):  # no _is_collective_offer_price_editable
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1459,7 +1460,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         collective_offer = educational_factories.CollectiveOfferFactory(venue=rule.venue)
 
         url = url_for(self.endpoint, collective_offer_id=collective_offer.id)
-        with assert_num_queries(self.expected_num_queries - 1):  # no _is_collective_offer_price_editable
+        with assert_num_queries(self.expected_num_queries_with_ff - 1):  # no _is_collective_offer_price_editable
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1476,7 +1477,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         )
 
         url = url_for(self.endpoint, collective_offer_id=collective_offer.id)
-        with assert_num_queries(self.expected_num_queries - 1):  # no _is_collective_offer_price_editable
+        with assert_num_queries(self.expected_num_queries_with_ff - 1):  # no _is_collective_offer_price_editable
             response = authenticated_client.get(url)
             assert response.status_code == 200
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34671

Principalement un ajout de tests
Fonctionnalité de mouvement d'une offre collective vers une nouvelle venue disponible dans le BO (sur la page de détail d'une offre collective) si au moins une venue de destination est disponible.

Il s'agit de tester le changement de venue d'une offre collective sans restrictions pour, à terme, implémenter un script de modification de venue par lot : toutes les offres collective de cette venue A vers venue B.

L'ajout de cette option dans le BO sera supprimé.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
