### PR TITLE
(PC-34983)[API] fix: reactivate underage deposits before 17-18 activation

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -3197,6 +3197,17 @@ def upsert_deposit(
         if has_active_underage_deposit:
             expire_current_deposit_for_user(user)
 
+    # If the user has an underage deposit, and is eligibile for a 17-18 deposit, they sometimes will have an expired underage deposit. (This should not usually be the case.)
+    # To compensate, we extend the expiration date of the underage deposit to the future.
+    # The deposit will be expired by the following code anyway (cf. _recredit_user).
+    if (
+        eligibility == users_models.EligibilityType.AGE17_18
+        and user.deposit
+        and user.deposit.type == DepositType.GRANT_15_17
+        and not user.has_active_deposit
+    ):
+        user.deposit.expirationDate = datetime.datetime.utcnow() + relativedelta(hours=1)
+
     if not user.has_active_deposit:
         deposit = create_deposit(user, deposit_source, eligibility, age_at_registration)
         user.recreditAmountToShow = deposit.amount

--- a/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
@@ -208,7 +208,7 @@ class RunIntegrationTest:
         deposits = finance_models.Deposit.query.filter_by(user=user).all()
         age_18_deposit = next(deposit for deposit in deposits if deposit.type == finance_models.DepositType.GRANT_17_18)
         assert len(deposits) == 2
-        assert age_18_deposit.amount == 150
+        assert age_18_deposit.amount == 150 + 20  # remaining amount
 
         fraud_check = fraud_models.BeneficiaryFraudCheck.query.filter(
             fraud_models.BeneficiaryFraudCheck.type == fraud_models.FraudCheckType.DMS


### PR DESCRIPTION
This commits handles non-regular data that to exist in production Further investigation may render this commit useless, however there is no garantee

## But de la pull request
Corriger le non-cumul de crédit au déblocage des 150€ pour certains users

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34983

## Vérifications

- [x] J'ai écrit les tests nécessaires