### PR TITLE
(PC-35051)[PRO] fix: Useless margin added by display inline.

### DIFF
--- a/pro/src/pages/Reimbursements/Income/IncomeResultsBox/IncomeResultsBox.module.scss
+++ b/pro/src/pages/Reimbursements/Income/IncomeResultsBox/IncomeResultsBox.module.scss
@@ -1,6 +1,7 @@
 @use "styles/mixins/_size.scss" as size;
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_outline.scss" as outline;
 
 .income-results-block {
   min-width: rem.torem(150px);
@@ -21,6 +22,28 @@
     @include fonts.title2;
 
     text-align: left;
+  }
+
+  &-tooltip {
+    margin-left: rem.torem(10px);
+    display: inline-flex;
+
+    &-button {
+      border: none;
+      background: none;
+      display: flex;
+      align-items: center;
+
+      &:focus-visible {
+        @include outline.focus-outline;
+      }
+
+      &-icon {
+        color: var(--color-primary);
+        width: rem.torem(22px);
+        height: rem.torem(22px);
+      }
+    }
   }
 }
 

--- a/pro/src/pages/Reimbursements/Income/IncomeResultsBox/IncomeResultsBox.tsx
+++ b/pro/src/pages/Reimbursements/Income/IncomeResultsBox/IncomeResultsBox.tsx
@@ -6,8 +6,8 @@ import type {
 } from 'apiClient/v1'
 import fullHelpIcon from 'icons/full-help.svg'
 import { BoxRounded } from 'ui-kit/BoxRounded/BoxRounded'
-import { Button } from 'ui-kit/Button/Button'
-import { ButtonVariant } from 'ui-kit/Button/types'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+import { Tooltip } from 'ui-kit/Tooltip/Tooltip'
 
 import { isCollectiveAndIndividualRevenue, isCollectiveRevenue } from '../utils'
 
@@ -30,14 +30,20 @@ const IncomeResultsSubBox = ({ title, number, help }: IncomeSubBoxProps) => {
       <div className={styles['income-results-block-title']}>
         {title}
         {help && (
-          <Button
-            className={styles['income-results-block-tooltip']}
-            icon={fullHelpIcon}
-            iconAlt="À propos"
-            type="button"
-            tooltipContent={help}
-            variant={ButtonVariant.SECONDARY}
-          />
+          <div className={styles['income-results-block-tooltip']}>
+            <Tooltip content={help}>
+              <button
+                type="button"
+                className={styles['income-results-block-tooltip-button']}
+              >
+                <SvgIcon
+                  src={fullHelpIcon}
+                  alt="À propos"
+                  className={styles['income-results-block-tooltip-button-icon']}
+                />
+              </button>
+            </Tooltip>
+          </div>
         )}
       </div>
       <div className={styles['income-results-block-number']}>{numberStr}</div>

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -10,6 +10,7 @@
   border: rem.torem(2px) solid;
   border-radius: rem.torem(24px);
   display: inline-flex;
+  vertical-align: top;
   justify-content: center;
   padding: 0 rem.torem(16px);
 

--- a/pro/src/ui-kit/Tooltip/Tooltip.module.scss
+++ b/pro/src/ui-kit/Tooltip/Tooltip.module.scss
@@ -58,6 +58,5 @@ $arrow-triangle-height: rem.torem(8px);
   position: absolute;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
   border: 0;
 }

--- a/pro/src/ui-kit/Tooltip/Tooltip.spec.tsx
+++ b/pro/src/ui-kit/Tooltip/Tooltip.spec.tsx
@@ -34,19 +34,4 @@ describe('Tooltip', () => {
       'visually-hidden'
     )
   })
-
-  it.skip('should prevent creation a tooltip on a non-interactive trigger', () => {
-    try {
-      render(
-        <Tooltip content="Tooltip content">
-          <span>Tooltip content</span>
-        </Tooltip>
-      )
-      expect(true).toBe(false)
-    } catch (e: unknown) {
-      expect(e).toContain(
-        'The tooltip immediate child must be an interactive element of one of the following types'
-      )
-    }
-  })
 })

--- a/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.module.scss
@@ -118,6 +118,7 @@
 
 .base-checkbox-row {
   display: inline-flex;
+  vertical-align: top;
   width: 100%;
 
   &:hover {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35051

**Objectif**
Faire disparaitre l'espace qui apparait en dessous des liens ternary, et des checkbox. Et corriger l'affichage du tooltip income (voir screen).

**Avant/après**
<img width="677" alt="Capture d’écran 2025-03-10 à 14 19 27" src="https://github.com/user-attachments/assets/3433c1ed-be2b-41b1-81a5-891d51aaa08a" />
<img width="649" alt="Capture d’écran 2025-03-10 à 14 19 34" src="https://github.com/user-attachments/assets/185881a4-befb-40aa-bae8-99cf47e79b11" />
<img width="681" alt="Capture d’écran 2025-03-10 à 14 25 17" src="https://github.com/user-attachments/assets/a63f90ba-9c1e-4f4d-b7cf-7f4ee8802028" />
<img width="770" alt="Capture d’écran 2025-03-10 à 14 25 29" src="https://github.com/user-attachments/assets/38823742-36c5-480a-8b7e-922051e21be6" />

**Tooltip avant/après** 
<img width="439" alt="Capture d’écran 2025-03-10 à 15 29 53" src="https://github.com/user-attachments/assets/2af2b48c-bb35-40ad-84e2-3c674527b73d" />
<img width="397" alt="Capture d’écran 2025-03-10 à 15 29 37" src="https://github.com/user-attachments/assets/9812e270-9fdd-4f0b-9f99-7b4665a2222c" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
