### PR TITLE
(PC-34921)[API] Ajouter des validations sur les routes patch et post pour les champs oa

### DIFF
--- a/api/src/pcapi/core/educational/constants.py
+++ b/api/src/pcapi/core/educational/constants.py
@@ -1,3 +1,6 @@
+from itertools import chain
+
+
 INSTITUTION_TYPES = {
     "EC AGRIC PR": "ECOLE AGRICOLE PRIVEE",
     "LGTA PR": "LYCEE GENERAL TECHNOLOGIQUE AGRICOLE PRIVE",
@@ -177,3 +180,16 @@ INSTITUTION_TYPES = {
     "LEA": "LYCEE D’ENSEIGNEMENT ADAPTE",
     "IAP": "INSTITUT AGRICOLE PRIVE",
 }
+
+
+MAINLAND_INTERVENTION_AREA = [str(i).zfill(2) for i in chain(range(1, 95), ["2A", "2B", "mainland"]) if i != 20]
+ALL_INTERVENTION_AREA = [
+    *MAINLAND_INTERVENTION_AREA,
+    "971",
+    "972",
+    "973",
+    "974",
+    "975",
+    "976",
+    "all",
+]

--- a/api/src/pcapi/core/educational/testing.py
+++ b/api/src/pcapi/core/educational/testing.py
@@ -67,3 +67,14 @@ STATUSES_NOT_ALLOWING_ARCHIVE_OFFER = (
     models.CollectiveOfferDisplayedStatus.PENDING,
     models.CollectiveOfferDisplayedStatus.ARCHIVED,
 )
+
+ADDRESS_DICT = {
+    "isVenueAddress": False,
+    "isManualEdition": False,
+    "city": "Paris",
+    "label": "My address",
+    "latitude": "48.87171",
+    "longitude": "2.308289",
+    "postalCode": "75001",
+    "street": "3 Rue de Valois",
+}

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
@@ -1,27 +1,14 @@
 from datetime import datetime
 from datetime import timedelta
-from itertools import chain
 from itertools import count
 from itertools import cycle
 import typing
 
 from pcapi.core.educational import factories as educational_factories
+from pcapi.core.educational.constants import ALL_INTERVENTION_AREA
 from pcapi.core.finance import factories as finance_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
-
-
-MAINLAND_INTERVENTION_AREA = [str(i).zfill(2) for i in chain(range(1, 95), ["2A", "2B", "mainland"]) if i != 20]
-ALL_INTERVENTION_AREA = [
-    *MAINLAND_INTERVENTION_AREA,
-    "971",
-    "972",
-    "973",
-    "974",
-    "975",
-    "976",
-    "all",
-]
 
 
 VENUE_EDUCATIONAL_STATUS = {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34921 
## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
