### PR TITLE
(PC-35036)[API] fix: Add WIP_ENABLE_EVENT_WITH_OPENING_HOUR  FF.

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -154,6 +154,7 @@ class FeatureToggle(enum.Enum):
     WIP_ENABLE_BO_OFFER_TABLE_CUSTOMIZATION = (
         "Activer la personnalisation tu tableau des offres individuelles dans le BO"
     )
+    WIP_ENABLE_EVENT_WITH_OPENING_HOUR = "Activer la nouvelle création d'un événement sur horaires d'ouverture"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -223,6 +224,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_EAN_CREATION,
     FeatureToggle.WIP_ENABLE_BO_OFFER_TABLE_CUSTOMIZATION,
     FeatureToggle.WIP_ENABLE_CLICKHOUSE_IN_BO,
+    FeatureToggle.WIP_ENABLE_EVENT_WITH_OPENING_HOUR,
     FeatureToggle.WIP_ENABLE_OFFER_ADDRESS_COLLECTIVE,
     FeatureToggle.WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE,
     FeatureToggle.WIP_ENABLE_NEW_FINANCE_WORKFLOW,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35036

**Objectif**
Ajout du FF `WIP_ENABLE_EVENT_WITH_OPENING_HOUR`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
