### PR TITLE
(PC-34875)[PRO] feat: Street can be optional for venues and offers

### DIFF
--- a/api/src/pcapi/connectors/api_adresse.py
+++ b/api/src/pcapi/connectors/api_adresse.py
@@ -159,7 +159,7 @@ def get_municipality_centroid(city: str, postcode: str | None = None, citycode: 
 
 
 def get_address(
-    address: str,
+    address: str | None,
     *,
     postcode: str | None = None,
     city: str | None = None,
@@ -194,7 +194,7 @@ class BaseBackend:
 
     def get_single_address_result(
         self,
-        address: str,
+        address: str | None,
         *,
         postcode: str | None,
         city: str | None = None,
@@ -234,7 +234,7 @@ class TestingBackend(BaseBackend):
 
     def get_single_address_result(
         self,
-        address: str,
+        address: str | None,
         *,
         postcode: str | None,
         city: str | None = None,
@@ -358,7 +358,7 @@ class ApiAdresseBackend(BaseBackend):
 
     def get_single_address_result(
         self,
-        address: str,
+        address: str | None,
         *,
         postcode: str | None,
         city: str | None = None,

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -436,7 +436,7 @@ def create_venue(venue_data: venues_serialize.PostVenueBodyModel, author: users_
     venue = models.Venue()
     address = venue_data.address
 
-    if utils_regions.NON_DIFFUSIBLE_TAG in address.street:
+    if address.street is not None and utils_regions.NON_DIFFUSIBLE_TAG in address.street:
         address_info = api_adresse.get_municipality_centroid(address.city, address.postalCode)
         address_info.street = utils_regions.NON_DIFFUSIBLE_TAG
         address = get_or_create_address(
@@ -2073,8 +2073,6 @@ def create_from_onboarding_data(
     venue = offerers_repository.find_venue_by_siret(onboarding_data.siret)
     if not venue or onboarding_data.createVenueWithoutSiret:
         address = onboarding_data.address
-        if not address.street:
-            address = address.copy(update={"street": "n/d"})
         common_kwargs = dict(
             address=address,
             bookingEmail=user.email,

--- a/api/src/pcapi/core/offerers/schemas.py
+++ b/api/src/pcapi/core/offerers/schemas.py
@@ -81,7 +81,9 @@ class VenueBookingEmail(pydantic_v1.ConstrainedStr):
     max_length = 120
 
 
-class VenueAddress(RequiredStrippedString):
+class VenueAddress(pydantic_v1.ConstrainedStr):
+    strip_whitespace = True
+    # optional, hence no `min_length`
     max_length = 200
 
 
@@ -125,7 +127,7 @@ class AddressBodyModel(BaseModel):
     latitude: float | str
     longitude: float | str
     postalCode: VenuePostalCode
-    street: VenueAddress
+    street: VenueAddress | None
 
     @validator("city")
     def title_city_when_manually_edited(cls, city: str, values: dict) -> str:

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -2418,7 +2418,7 @@ class CreateFromOnboardingDataTest:
         user = users_factories.UserFactory(email="pro@example.com")
         user.add_non_attached_pro_role()
         onboarding_data = self.get_onboarding_data(create_venue_without_siret=False)
-        onboarding_data.address.street = ""
+        onboarding_data.address.street = None
 
         created_user_offerer = offerers_api.create_from_onboarding_data(user, onboarding_data)
 
@@ -2432,7 +2432,7 @@ class CreateFromOnboardingDataTest:
         # 1 Venue with siret have been created
         assert len(created_user_offerer.offerer.managedVenues) == 1
         created_venue = created_user_offerer.offerer.managedVenues[0]
-        assert created_venue.street == "n/d"
+        assert created_venue.street is None
         assert created_venue.city == "Paris"
         assert created_venue.latitude == decimal.Decimal("2.30829")
         assert created_venue.longitude == decimal.Decimal("48.87171")

--- a/pro/cypress/e2e/oaIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/oaIndividualOffer.cy.ts
@@ -273,7 +273,7 @@ describe('Create individual offers with OA', () => {
     cy.findByText('Vous ne trouvez pas votre adresse ?').click()
 
     cy.stepLog({ message: 'I want to put a custom address' })
-    cy.findAllByLabelText('Adresse postale *').last().type('Place de la gare')
+    cy.findAllByLabelText('Adresse postale').last().type('Place de la gare')
     cy.findAllByLabelText('Code postal *').type('123123')
     cy.findAllByLabelText('Ville *').type('Y')
     // eslint-disable-next-line cypress/unsafe-to-chain-command

--- a/pro/src/apiClient/v1/models/AddressBodyModel.ts
+++ b/pro/src/apiClient/v1/models/AddressBodyModel.ts
@@ -11,6 +11,6 @@ export type AddressBodyModel = {
   latitude: (number | string);
   longitude: (number | string);
   postalCode: string;
-  street: string;
+  street?: string | null;
 };
 

--- a/pro/src/components/Address/types.ts
+++ b/pro/src/components/Address/types.ts
@@ -3,7 +3,7 @@ export interface Address {
   latitude: number | null
   longitude: number | null
   postalCode: string
-  street: string
+  street: string | null
   banId: string | null
   manuallySetAddress?: boolean
 }

--- a/pro/src/components/Address/validationSchema.ts
+++ b/pro/src/components/Address/validationSchema.ts
@@ -10,10 +10,7 @@ export const validationSchema = {
         'Veuillez sélectionner une adresse parmi les suggestions'
       ),
   }),
-  street: yup
-    .string()
-    .trim()
-    .required('Veuillez renseigner une adresse postale'),
+  street: yup.string().trim(),
   postalCode: yup
     .string()
     .trim()

--- a/pro/src/components/Address/validationSchema.ts
+++ b/pro/src/components/Address/validationSchema.ts
@@ -10,7 +10,7 @@ export const validationSchema = {
         'Veuillez sélectionner une adresse parmi les suggestions'
       ),
   }),
-  street: yup.string().trim(),
+  street: yup.string().nullable().trim(),
   postalCode: yup
     .string()
     .trim()

--- a/pro/src/components/AddressManual/AddressManual.spec.tsx
+++ b/pro/src/components/AddressManual/AddressManual.spec.tsx
@@ -42,7 +42,7 @@ describe('AddressManual', () => {
     render(<TestForm />)
 
     // Fields must be present and required
-    expect(screen.getByLabelText(/Adresse postale/)).toBeRequired()
+    expect(screen.getByLabelText(/Adresse postale/)).not.toBeRequired()
     expect(screen.getByLabelText(/Code postal/)).toBeRequired()
     expect(screen.getByLabelText(/Ville/)).toBeRequired()
     expect(screen.getByLabelText(/Coordonnées GPS/)).toBeRequired()

--- a/pro/src/components/AddressManual/AddressManual.tsx
+++ b/pro/src/components/AddressManual/AddressManual.tsx
@@ -25,10 +25,12 @@ export interface AddressFormValues {
 
 interface AddressManualProps {
   readOnlyFields?: string[]
+  isStreetOptional?: boolean
 }
 
 export const AddressManual = ({
   readOnlyFields = [],
+  isStreetOptional = false,
 }: AddressManualProps): JSX.Element => {
   const [coords, coordsMeta] = useField<string>('coords')
 
@@ -64,6 +66,7 @@ export const AddressManual = ({
           name="street"
           disabled={readOnlyFields.includes('street')}
           maxLength={200}
+          isOptional={isStreetOptional}
         />
       </FormLayout.Row>
       <FormLayout.Row inline className={styles['inline-fields']}>

--- a/pro/src/components/AddressManual/AddressManual.tsx
+++ b/pro/src/components/AddressManual/AddressManual.tsx
@@ -25,12 +25,10 @@ export interface AddressFormValues {
 
 interface AddressManualProps {
   readOnlyFields?: string[]
-  isStreetOptional?: boolean
 }
 
 export const AddressManual = ({
   readOnlyFields = [],
-  isStreetOptional = false,
 }: AddressManualProps): JSX.Element => {
   const [coords, coordsMeta] = useField<string>('coords')
 
@@ -66,7 +64,7 @@ export const AddressManual = ({
           name="street"
           disabled={readOnlyFields.includes('street')}
           maxLength={200}
-          isOptional={isStreetOptional}
+          isOptional={true}
         />
       </FormLayout.Row>
       <FormLayout.Row inline className={styles['inline-fields']}>

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
@@ -42,7 +42,7 @@ export const OffererAuthentication = (): JSX.Element => {
     setOfferer({
       ...formValues,
       city: removeQuotes(formValues.city),
-      street: removeQuotes(formValues.street),
+      street: formValues.street ? removeQuotes(formValues.street) : null,
       hasVenueWithSiret: false,
       legalCategoryCode: offerer?.legalCategoryCode,
     })

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
@@ -24,11 +24,12 @@ export const OffererAuthentication = (): JSX.Element => {
 
   const { offerer, setOfferer } = useSignupJourneyContext()
 
+  const maybeStreet = offerer?.street && `${offerer.street} `
   const initialValues: OffererAuthenticationFormValues = {
     ...DEFAULT_OFFERER_FORM_VALUES,
     ...offerer,
-    addressAutocomplete: `${offerer?.street} ${offerer?.postalCode} ${offerer?.city}`,
-    'search-addressAutocomplete': `${offerer?.street} ${offerer?.postalCode} ${offerer?.city}`,
+    addressAutocomplete: `${maybeStreet}${offerer?.postalCode} ${offerer?.city}`,
+    'search-addressAutocomplete': `${maybeStreet}${offerer?.postalCode} ${offerer?.city}`,
   }
 
   const handlePreviousStep = () => {
@@ -42,7 +43,7 @@ export const OffererAuthentication = (): JSX.Element => {
     setOfferer({
       ...formValues,
       city: removeQuotes(formValues.city),
-      street: formValues.street ? removeQuotes(formValues.street) : null,
+      street: formValues.street ? removeQuotes(formValues.street) : '',
       hasVenueWithSiret: false,
       legalCategoryCode: offerer?.legalCategoryCode,
     })

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
@@ -43,7 +43,7 @@ export const OffererAuthentication = (): JSX.Element => {
     setOfferer({
       ...formValues,
       city: removeQuotes(formValues.city),
-      street: formValues.street ? removeQuotes(formValues.street) : '',
+      street: formValues.street ? removeQuotes(formValues.street) : null,
       hasVenueWithSiret: false,
       legalCategoryCode: offerer?.legalCategoryCode,
     })

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
@@ -73,7 +73,7 @@ export const OffererAuthenticationForm = (): JSX.Element => {
             <>Vous ne trouvez pas votre adresse ?</>
           )}
         </Button>
-        {manuallySetAddress.value && <AddressManual />}
+        {manuallySetAddress.value && <AddressManual isStreetOptional={true} />}
         {isOpenToPublicEnabled && <OpenToPublicToggle />}
       </FormLayout.Row>
     </FormLayout.Section>

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
@@ -73,7 +73,7 @@ export const OffererAuthenticationForm = (): JSX.Element => {
             <>Vous ne trouvez pas votre adresse ?</>
           )}
         </Button>
-        {manuallySetAddress.value && <AddressManual isStreetOptional={true} />}
+        {manuallySetAddress.value && <AddressManual />}
         {isOpenToPublicEnabled && <OpenToPublicToggle />}
       </FormLayout.Row>
     </FormLayout.Section>

--- a/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationForm.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationForm.spec.tsx
@@ -22,6 +22,7 @@ import {
   OffererAuthenticationFormValues,
 } from '../OffererAuthenticationForm'
 import { validationSchema } from '../validationSchema'
+import { expect } from 'vitest'
 
 const fetchMock = createFetchMock(vi)
 fetchMock.enableMocks()
@@ -79,11 +80,9 @@ fetchMock.mockResponse(
 const renderOffererAuthenticationForm = (
   {
     initialValues,
-    onSubmit = vi.fn(),
     contextValue,
   }: {
     initialValues: Partial<OffererAuthenticationFormValues>
-    onSubmit?: () => void
     contextValue: SignupJourneyContextValues
   },
   options: RenderWithProvidersOptions = {}
@@ -92,7 +91,7 @@ const renderOffererAuthenticationForm = (
     <SignupJourneyContext.Provider value={contextValue}>
       <Formik
         initialValues={initialValues}
-        onSubmit={onSubmit}
+        onSubmit={vi.fn()}
         validationSchema={validationSchema}
       >
         <Form>

--- a/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationForm.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationForm.spec.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
+import { expect } from 'vitest'
 import createFetchMock from 'vitest-fetch-mock'
 
 import { apiAdresse } from 'apiClient/adresse/apiAdresse'
@@ -22,7 +23,6 @@ import {
   OffererAuthenticationFormValues,
 } from '../OffererAuthenticationForm'
 import { validationSchema } from '../validationSchema'
-import { expect } from 'vitest'
 
 const fetchMock = createFetchMock(vi)
 fetchMock.enableMocks()

--- a/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
@@ -237,7 +237,7 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
         publicName: '',
         'search-addressAutocomplete': '',
         siret: '123 456 789 33333',
-        street: '',
+        street: null,
       })
     })
 

--- a/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { Route, Routes } from 'react-router-dom'
+import { beforeEach } from 'vitest'
 import createFetchMock from 'vitest-fetch-mock'
 
 import { apiAdresse } from 'apiClient/adresse/apiAdresse'
@@ -14,7 +15,6 @@ import { Notification } from 'components/Notification/Notification'
 import { DEFAULT_OFFERER_FORM_VALUES } from 'components/SignupJourneyForm/Offerer/constants'
 
 import { OffererAuthentication } from '../OffererAuthentication'
-import { beforeEach } from 'vitest'
 
 const fetchMock = createFetchMock(vi)
 fetchMock.enableMocks()
@@ -237,7 +237,7 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
         publicName: '',
         'search-addressAutocomplete': '',
         siret: '123 456 789 33333',
-        street: null,
+        street: '',
       })
     })
 

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
@@ -212,7 +212,8 @@ export const Validation = (): JSX.Element => {
           </div>
           <div className={styles['data-line']}>{offerer.siret}</div>
           <div className={styles['data-line']}>
-            {offerer.street}, {offerer.postalCode} {offerer.city}
+            {offerer.street && `${offerer.street}, `}
+            {offerer.postalCode} {offerer.city}
           </div>
         </div>
       </section>

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/OfferLocation/validationSchema.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/OfferLocation/validationSchema.ts
@@ -16,15 +16,7 @@ const locationSchema = {
           'Veuillez sélectionner une adresse parmi les suggestions'
         ),
     }),
-  street: yup
-    .string()
-    .trim()
-    .when(['offerLocation'], {
-      is: (offerLocation: string) =>
-        offerLocation === OFFER_LOCATION.OTHER_ADDRESS,
-      then: (schema) =>
-        schema.required('Veuillez renseigner une adresse postale'),
-    }),
+  street: yup.string().nullable().trim(),
   postalCode: yup
     .string()
     .trim()

--- a/pro/src/pages/IndividualOffer/commons/serializers.ts
+++ b/pro/src/pages/IndividualOffer/commons/serializers.ts
@@ -90,7 +90,9 @@ export const serializePatchOffer = ({
         latitude: sentValues.latitude ?? '',
         longitude: sentValues.longitude ?? '',
         postalCode: sentValues.postalCode ?? '',
-        street: removeQuotes(sentValues.street?.trim() ?? ''),
+        street: sentValues.street
+          ? removeQuotes(sentValues.street.trim())
+          : null,
         label: sentValues.locationLabel,
         isManualEdition: sentValues.manuallySetAddress,
         isVenueAddress:

--- a/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
@@ -141,9 +141,10 @@ export const VenueEditionHeader = ({
               ? `${offerer.name} (Offre numérique)`
               : venue.publicName || venue.name}
           </h2>
-          {!isOpenToPublicEnabled && venue.street && (
+          {!isOpenToPublicEnabled && venue.address && (
             <address className={styles['venue-address']}>
-              {venue.street}, {venue.postalCode} {venue.city}
+              {venue.address.street && `${venue.address.street}, `}
+              {venue.address.postalCode} {venue.address.city}
             </address>
           )}
         </div>
@@ -156,15 +157,17 @@ export const VenueEditionHeader = ({
           >
             Paramètres généraux
           </ButtonLink>
-          {isOpenToPublicEnabled && venue.isPermanent && <ButtonLink
-            variant={ButtonVariant.TERNARY}
-            icon={fullLinkIcon}
-            to={`${WEBAPP_URL}/lieu/${venue.id}`}
-            isExternal
-            opensInNewTab
-          >
-            Visualiser votre page
-          </ButtonLink>}
+          {isOpenToPublicEnabled && venue.isPermanent && (
+            <ButtonLink
+              variant={ButtonVariant.TERNARY}
+              icon={fullLinkIcon}
+              to={`${WEBAPP_URL}/lieu/${venue.id}`}
+              isExternal
+              opensInNewTab
+            >
+              Visualiser votre page
+            </ButtonLink>
+          )}
           {imageValues.originalImageUrl && (
             <ButtonImageEdit
               mode={UploaderModeEnum.VENUE}

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
@@ -95,15 +95,18 @@ describe('VenueEditionHeader', () => {
   })
 
   it('should display a preview link when venue is permanent and is open to public feature enabled', () => {
-    renderPartnerPages({
-      venue: {
-        ...defaultGetVenue,
-        venueTypeCode: VenueTypeCode.FESTIVAL,
-        isPermanent: true,
+    renderPartnerPages(
+      {
+        venue: {
+          ...defaultGetVenue,
+          venueTypeCode: VenueTypeCode.FESTIVAL,
+          isPermanent: true,
+        },
       },
-    }, {
-      features: ['WIP_IS_OPEN_TO_PUBLIC'],
-    })
+      {
+        features: ['WIP_IS_OPEN_TO_PUBLIC'],
+      }
+    )
 
     expect(screen.getByText('Visualiser votre page')).toBeInTheDocument()
   })
@@ -126,5 +129,65 @@ describe('VenueEditionHeader', () => {
     )
 
     expect(screen.queryByText('Créer une offre')).not.toBeInTheDocument()
+  })
+
+  it('should display the address', () => {
+    renderPartnerPages(
+      {
+        venue: {
+          ...defaultGetVenue,
+          address: {
+            city: 'paris',
+            id: 1,
+            id_oa: 1,
+            isManualEdition: false,
+            latitude: 1,
+            longitude: 2,
+            postalCode: '75001',
+            street: 'street',
+          },
+          venueTypeCode: VenueTypeCode.FESTIVAL,
+        },
+      },
+      {
+        user: sharedCurrentUserFactory(),
+        storeOverrides: {
+          user: { currentUser: sharedCurrentUserFactory() },
+          offerer: currentOffererFactory(),
+        },
+      }
+    )
+
+    expect(screen.getByText('street, 75001 paris')).toBeInTheDocument()
+  })
+
+  it('should display the address without street', () => {
+    renderPartnerPages(
+      {
+        venue: {
+          ...defaultGetVenue,
+          address: {
+            city: 'paris',
+            id: 1,
+            id_oa: 1,
+            isManualEdition: false,
+            latitude: 1,
+            longitude: 2,
+            postalCode: '75001',
+            street: null,
+          },
+          venueTypeCode: VenueTypeCode.FESTIVAL,
+        },
+      },
+      {
+        user: sharedCurrentUserFactory(),
+        storeOverrides: {
+          user: { currentUser: sharedCurrentUserFactory() },
+          offerer: currentOffererFactory(),
+        },
+      }
+    )
+
+    expect(screen.getByText('75001 paris')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/VenueSettings/VenueSettingsForm.tsx
+++ b/pro/src/pages/VenueSettings/VenueSettingsForm.tsx
@@ -122,9 +122,7 @@ export const VenueSettingsForm = ({
                     )}
                   </Button>
                 </FormLayout.Row>
-                {manuallySetAddress.value && (
-                  <AddressManual isStreetOptional={true} />
-                )}
+                {manuallySetAddress.value && <AddressManual />}
               </>
             </>
           )}

--- a/pro/src/pages/VenueSettings/VenueSettingsForm.tsx
+++ b/pro/src/pages/VenueSettings/VenueSettingsForm.tsx
@@ -122,7 +122,9 @@ export const VenueSettingsForm = ({
                     )}
                   </Button>
                 </FormLayout.Row>
-                {manuallySetAddress.value && <AddressManual />}
+                {manuallySetAddress.value && (
+                  <AddressManual isStreetOptional={true} />
+                )}
               </>
             </>
           )}

--- a/pro/src/pages/VenueSettings/__specs__/VenueSettingsScreen.spec.tsx
+++ b/pro/src/pages/VenueSettings/__specs__/VenueSettingsScreen.spec.tsx
@@ -189,6 +189,14 @@ describe('VenueSettingsScreen', () => {
     expect(
       await screen.findByText(/Vous ne trouvez pas votre adresse/)
     ).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText(/Vous ne trouvez pas votre adresse/))
+    expect(
+      screen.getByRole('textbox', { name: 'Adresse postale' })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole('textbox', { name: 'Adresse postale *' })
+    ).not.toBeInTheDocument()
   })
 
   it('should submit the form with valid payload', async () => {

--- a/pro/src/pages/VenueSettings/serializers.ts
+++ b/pro/src/pages/VenueSettings/serializers.ts
@@ -18,7 +18,7 @@ export const serializeEditVenueBodyModel = (
     name: formValues.name,
     postalCode: formValues.postalCode,
     publicName: formValues.publicName,
-    street: removeQuotes(formValues.street?.trim() ?? ''),
+    street: formValues.street ? removeQuotes(formValues.street.trim()) : null,
     siret: unhumanizeSiret(formValues.siret),
     withdrawalDetails: formValues.withdrawalDetails,
     venueLabelId: !formValues.venueLabel ? null : Number(formValues.venueLabel),

--- a/pro/src/pages/VenueSettings/validationSchema.ts
+++ b/pro/src/pages/VenueSettings/validationSchema.ts
@@ -15,7 +15,7 @@ export const getValidationSchema = (isVenueVirtual: boolean) =>
             'Veuillez sélectionner une adresse parmi les suggestions'
           ),
       }),
-    street: yup.string().trim(),
+    street: yup.string().nullable().trim(),
     postalCode: yup
       .string()
       .trim()

--- a/pro/src/pages/VenueSettings/validationSchema.ts
+++ b/pro/src/pages/VenueSettings/validationSchema.ts
@@ -15,10 +15,7 @@ export const getValidationSchema = (isVenueVirtual: boolean) =>
             'Veuillez sélectionner une adresse parmi les suggestions'
           ),
       }),
-    street: yup
-      .string()
-      .trim()
-      .required('Veuillez renseigner une adresse postale'),
+    street: yup.string().trim(),
     postalCode: yup
       .string()
       .trim()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34875

- Le champ street doit être optionnel pour les venues.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
