### PR TITLE
(PC-35083)[API] fix: delete numeric filters in Algolia conf

### DIFF
--- a/api/src/pcapi/algolia_settings_offers.json
+++ b/api/src/pcapi/algolia_settings_offers.json
@@ -127,9 +127,5 @@
             "offer.searchGroupNamev2:CONCERTS_FESTIVALS",
             "offer.searchGroupNamev2:MUSEES_VISITES_CULTURELLES"
         ]
-    ],
-    "numericAttributesForFiltering": [
-            "offer.prices",
-            "offer.releaseDate"
     ]
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35083

```
The creation of array `numericAttributesForFiltering` implies
that all facets not mentioned in this array won't be able to
be used as numeric filters. Whereas if the array is not specified,
all facets can be used as numeric filters. This is what we want
for now.
cf: https://www.algolia.com/doc/api-reference/api-parameters/numericAttributesForFiltering/#how-to-use
```

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
