### PR TITLE
(PC-35091)[BO] fix: avoid repetition of a response when a beneficiary…

### DIFF
--- a/api/src/pcapi/routes/backoffice/operations/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/operations/blueprint.py
@@ -164,6 +164,14 @@ def get_event_details(special_event_id: int) -> utils.BackofficeResponse:
             full_answers_subquery.label("full_answers"),
         )
         .filter(*response_rows_filters)
+        .outerjoin(operations_models.SpecialEventResponse.user)
+        .outerjoin(
+            finance_models.Deposit,
+            sa.and_(
+                users_models.User.id == finance_models.Deposit.userId,
+                finance_models.Deposit.expirationDate > sa.func.now(),
+            ),
+        )
         .options(
             sa.orm.joinedload(operations_models.SpecialEventResponse.user)
             .load_only(
@@ -174,7 +182,7 @@ def get_event_details(special_event_id: int) -> utils.BackofficeResponse:
                 users_models.User.email,
                 users_models.User.roles,
             )
-            .joinedload(users_models.User.deposits)
+            .contains_eager(users_models.User.deposits)
             .load_only(
                 finance_models.Deposit.expirationDate,
                 finance_models.Deposit.type,


### PR DESCRIPTION
… has multiple deposits

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35091

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
