### PR TITLE
(PC-34990)[PRO] feat: under isOpenToPublic FF, reorganize readonly venue settings headings (and fix edition ones)

### DIFF
--- a/pro/src/commons/utils/__specs__/getFormattedAddress.spec.ts
+++ b/pro/src/commons/utils/__specs__/getFormattedAddress.spec.ts
@@ -1,0 +1,17 @@
+import { getAddressResponseIsLinkedToVenueModelFactory } from 'commons/utils/factories/commonOffersApiFactories'
+
+import { getFormattedAddress } from '../getFormattedAddress';
+
+const MOCK_ADDRESS = getAddressResponseIsLinkedToVenueModelFactory()
+
+describe('getFormattedAddress', () => {
+  it('should return formatted address with complete info', () => {
+    const formattedAddress = getFormattedAddress(MOCK_ADDRESS)
+    expect(formattedAddress).toBe(`${MOCK_ADDRESS.street}, ${MOCK_ADDRESS.postalCode} ${MOCK_ADDRESS.city}`)
+  })
+
+  it('should return formatted address without street', () => {
+    const formattedAddress = getFormattedAddress({ ...MOCK_ADDRESS, street: undefined })
+    expect(formattedAddress).toBe(`${MOCK_ADDRESS.postalCode} ${MOCK_ADDRESS.city}`)
+  })
+})

--- a/pro/src/commons/utils/getFormattedAddress.ts
+++ b/pro/src/commons/utils/getFormattedAddress.ts
@@ -1,0 +1,9 @@
+import { GetVenueResponseModel } from 'apiClient/v1'
+
+export const getFormattedAddress = (address: GetVenueResponseModel['address']): string => {
+  const street = address?.street ? `${address.street}, ` : ''
+  const postalCode = address?.postalCode ? `${address.postalCode} ` : ''
+  const city = address?.city ? address.city : ''
+
+  return `${street}${postalCode}${city}`
+}

--- a/pro/src/components/AccessibilitySummarySection/AccessibilitySummarySection.tsx
+++ b/pro/src/components/AccessibilitySummarySection/AccessibilitySummarySection.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react'
 import { AccessibilityEnum } from 'commons/core/shared/types'
 import { SummaryDescriptionList } from 'components/SummaryLayout/SummaryDescriptionList'
 import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
+import { SummarySubSubSection } from 'components/SummaryLayout/SummarySubSubSection'
 import { AccessibilityLabel } from 'ui-kit/AccessibilityLabel/AccessibilityLabel'
 
 import styles from './AccessibilitySummarySection.module.scss'
@@ -20,6 +21,7 @@ interface AccessibilitySummarySectionProps {
   accessibleWording: string
   callout?: ReactNode
   shouldShowDivider?: boolean
+  isSubSubSection?: boolean
 }
 
 export const AccessibilitySummarySection = ({
@@ -27,6 +29,7 @@ export const AccessibilitySummarySection = ({
   accessibleWording,
   callout,
   shouldShowDivider = true,
+  isSubSubSection = false,
 }: AccessibilitySummarySectionProps) => {
   const {
     visualDisabilityCompliant,
@@ -39,8 +42,9 @@ export const AccessibilitySummarySection = ({
     motorDisabilityCompliant ||
     mentalDisabilityCompliant ||
     audioDisabilityCompliant
-  return (
-    <SummarySubSection title="Modalités d’accessibilité" shouldShowDivider={shouldShowDivider}>
+
+  const sectionContent = (
+    <>
       {callout && <div className={styles['callout']}>{callout}</div>}
       <SummaryDescriptionList
         descriptions={[
@@ -71,6 +75,18 @@ export const AccessibilitySummarySection = ({
           )}
         </ul>
       )}
+  </>)
+
+  return isSubSubSection ? (
+    <SummarySubSubSection title="Modalités d’accessibilité">
+      {sectionContent}
+    </SummarySubSubSection>
+  ) : (
+    <SummarySubSection
+      title="Modalités d’accessibilité"
+      shouldShowDivider={shouldShowDivider}
+    >
+      {sectionContent}
     </SummarySubSection>
   )
 }

--- a/pro/src/components/ExternalAccessibility/ExternalAccessibility.tsx
+++ b/pro/src/components/ExternalAccessibility/ExternalAccessibility.tsx
@@ -1,4 +1,5 @@
 import { GetVenueResponseModel } from 'apiClient/v1'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import strokeAccessibilityBrain from 'icons/stroke-accessibility-brain.svg'
 import strokeAccessibilityEar from 'icons/stroke-accessibility-ear.svg'
 import strokeAccessibilityEye from 'icons/stroke-accessibility-eye.svg'
@@ -18,11 +19,14 @@ export const ExternalAccessibility = ({
   externalAccessibilityId,
   externalAccessibilityData
 }: ExternalAccessibilityProps) => {
+  const isOpenToPublicEnabled = useActiveFeature('WIP_IS_OPEN_TO_PUBLIC')
+
   return (
     <>
       <div className={styles['sections-container']}>
         <ExternalAccessibilityCollapse
           title="Handicap moteur"
+          titleHeadingLevel={isOpenToPublicEnabled ? 'h5' : 'h4'}
           isAccessible={Boolean(
             externalAccessibilityData.isAccessibleMotorDisability
           )}
@@ -63,6 +67,7 @@ export const ExternalAccessibility = ({
         </ExternalAccessibilityCollapse>
         <ExternalAccessibilityCollapse
           title="Handicap cognitif"
+          titleHeadingLevel={isOpenToPublicEnabled ? 'h5' : 'h4'}
           isAccessible={Boolean(
             externalAccessibilityData.isAccessibleMentalDisability
           )}
@@ -80,6 +85,7 @@ export const ExternalAccessibility = ({
         </ExternalAccessibilityCollapse>
         <ExternalAccessibilityCollapse
           title="Handicap auditif"
+          titleHeadingLevel={isOpenToPublicEnabled ? 'h5' : 'h4'}
           isAccessible={Boolean(
             externalAccessibilityData.isAccessibleAudioDisability
           )}
@@ -109,6 +115,7 @@ export const ExternalAccessibility = ({
         </ExternalAccessibilityCollapse>
         <ExternalAccessibilityCollapse
           title="Handicap visuel"
+          titleHeadingLevel={isOpenToPublicEnabled ? 'h5' : 'h4'}
           isAccessible={Boolean(
             externalAccessibilityData.isAccessibleVisualDisability
           )}

--- a/pro/src/components/ExternalAccessibility/ExternalAccessibilityCollapse/ExternalAccessibilityCollapse.tsx
+++ b/pro/src/components/ExternalAccessibility/ExternalAccessibilityCollapse/ExternalAccessibilityCollapse.tsx
@@ -10,7 +10,7 @@ import styles from './ExternalAccessibilityCollapse.module.scss'
 
 export interface ExternalAccessibilityCollapseProps {
   title: string
-  titleHeadingLevel?: 'h3' | 'h4'
+  titleHeadingLevel?: 'h4' | 'h5'
   isAccessible: boolean
   icon: string
   children: ReactNode
@@ -51,10 +51,10 @@ export const ExternalAccessibilityCollapse = ({
           />
         </div>
         <div className={styles['title-container']}>
-          {titleHeadingLevel === 'h3' ? (
-            <h3 className={styles['title']}>{title}</h3>
-          ) : (
+          {titleHeadingLevel === 'h4' ? (
             <h4 className={styles['title']}>{title}</h4>
+          ) : (
+            <h5 className={styles['title']}>{title}</h5>
           )}
           <div className={styles['accessibility-label']}>
             {isAccessible ? 'Accessible' : 'Non accessible'}

--- a/pro/src/components/SummaryLayout/SummaryLayout.module.scss
+++ b/pro/src/components/SummaryLayout/SummaryLayout.module.scss
@@ -48,6 +48,16 @@
     margin-bottom: rem.torem(24px);
 
     &-title {
+      @include fonts.title3;
+
+      margin-bottom: rem.torem(24px);
+    }
+  }
+
+  &-sub-sub-section {
+    margin-bottom: rem.torem(24px);
+
+    &-title {
       @include fonts.title4;
 
       margin-bottom: rem.torem(24px);

--- a/pro/src/components/SummaryLayout/SummarySubSubSection.tsx
+++ b/pro/src/components/SummaryLayout/SummarySubSubSection.tsx
@@ -1,0 +1,20 @@
+import cn from 'classnames'
+
+import style from './SummaryLayout.module.scss'
+
+interface SummaryLayoutSubSubSectionProps {
+  title: string
+  children: React.ReactNode | React.ReactNode[]
+  className?: string
+}
+
+export const SummarySubSubSection = ({
+  title,
+  children,
+  className,
+}: SummaryLayoutSubSubSectionProps): JSX.Element => (
+  <div className={cn(style['summary-layout-sub-sub-section'], className)}>
+    <h4 className={style['summary-layout-sub-sub-section-title']}>{title}</h4>
+    {children}
+  </div>
+)

--- a/pro/src/pages/VenueEdition/AccessibilityReadOnly/AccessibilityReadOnly.tsx
+++ b/pro/src/pages/VenueEdition/AccessibilityReadOnly/AccessibilityReadOnly.tsx
@@ -1,0 +1,45 @@
+import { GetVenueResponseModel } from 'apiClient/v1'
+import { AccessibilitySummarySection as InternalAccessibilitySummarySection } from 'components/AccessibilitySummarySection/AccessibilitySummarySection'
+import { ExternalAccessibility } from 'components/ExternalAccessibility/ExternalAccessibility'
+import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
+import { SummarySubSubSection } from 'components/SummaryLayout/SummarySubSubSection'
+
+import { AccessibilityCallout } from '../AccessibilityCallout/AccessibilityCallout'
+
+interface AccessibilityReadOnlyProps {
+  isOpenToPublicEnabled: boolean
+  venue: GetVenueResponseModel
+}
+
+export const AccessibilityReadOnly = ({ isOpenToPublicEnabled, venue }: AccessibilityReadOnlyProps) => {
+  const isSubSubSection = isOpenToPublicEnabled
+
+  if (!venue.externalAccessibilityData) {
+    return <InternalAccessibilitySummarySection
+      callout={
+        venue.isPermanent ? (
+          <AccessibilityCallout />
+        ) : null
+      }
+      accessibleItem={venue}
+      accessibleWording="Votre établissement est accessible aux publics en situation de handicap :"
+      shouldShowDivider={false}
+      isSubSubSection={isSubSubSection}
+    />
+  }
+
+  const sectionContent = <ExternalAccessibility
+    externalAccessibilityId={venue.externalAccessibilityId}
+    externalAccessibilityData={venue.externalAccessibilityData}
+  />
+
+  return isSubSubSection ? (
+    <SummarySubSubSection title="Modalités d’accessibilité via acceslibre">
+      {sectionContent}
+    </SummarySubSubSection>
+  ) : (
+    <SummarySubSection title="Modalités d’accessibilité via acceslibre" shouldShowDivider={false}>
+      {sectionContent}
+    </SummarySubSection>
+  )
+}

--- a/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.module.scss
+++ b/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.module.scss
@@ -1,10 +1,11 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
 
-.important {
-  @include fonts.body-accent;
+.opening-hours-address {
+  display: block;
+  margin-bottom: rem.torem(16px);
 }
 
-.day {
-  color: var(--color-grey-dark);
+.important {
+  @include fonts.body-accent;
 }

--- a/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
+++ b/pro/src/pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly.tsx
@@ -1,14 +1,16 @@
 import { GetVenueResponseModel } from 'apiClient/v1'
 import { mapDayToFrench , DAYS_IN_ORDER } from 'commons/utils/date'
+import { getFormattedAddress } from 'commons/utils/getFormattedAddress'
 import { SummaryDescriptionList } from 'components/SummaryLayout/SummaryDescriptionList'
 import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
+import { SummarySubSubSection } from 'components/SummaryLayout/SummarySubSubSection'
 
 import styles from './OpeningHoursReadOnly.module.scss'
 
 type OpeningHours = {
   isOpenToPublicEnabled: boolean
-  isOpenToPublic: boolean
   openingHours: GetVenueResponseModel['openingHours']
+  address?: GetVenueResponseModel['address']
 }
 
 type OpenClose = {
@@ -23,7 +25,11 @@ type HoursProps = {
 type Entries<T> = T extends Record<infer W, infer U> ? [W, U][] : never;
 type OpeningHoursEntries = Entries<GetVenueResponseModel['openingHours']>;
 
-export function OpeningHoursReadOnly({ isOpenToPublicEnabled, isOpenToPublic, openingHours }: OpeningHours) {
+export function OpeningHoursReadOnly({
+  isOpenToPublicEnabled,
+  openingHours,
+  address,
+}: OpeningHours) {
   const filledDays = Object.entries(openingHours ?? {})
     .filter((dateAndHour) =>
       Boolean(dateAndHour[1])
@@ -34,33 +40,39 @@ export function OpeningHoursReadOnly({ isOpenToPublicEnabled, isOpenToPublic, op
     return index === -1 ? null : filledDays[index]
   }).filter(Boolean) as OpeningHoursEntries
 
-  return (
-    <SummarySubSection
-      title={isOpenToPublicEnabled ? "Accès et horaires" : "Horaires d'ouverture"}
-      shouldShowDivider={false}
-    >
-      {isOpenToPublicEnabled && !isOpenToPublic ? (
-        <p>
-          Accueil du public dans la structure : Non
-        </p>
-      ) : (!openingHours || orderedFilledDays.length === 0) ? (
+  const OpeningHours = () => <SummaryDescriptionList
+    descriptions={orderedFilledDays.map((dateAndHour) => {
+      return {
+        title: mapDayToFrench(dateAndHour[0]),
+        text: <Hours hours={dateAndHour[1]} />,
+      }
+    })}
+  />
+
+  if (isOpenToPublicEnabled) {
+    return <SummarySubSubSection title="Adresse et horaires">
+      <span className={styles['opening-hours-address']}>
+        {`Adresse : ${getFormattedAddress(address)}`}
+      </span>
+      {orderedFilledDays.length === 0 ? (
+        <span>
+          {openingHours === null
+            ? 'Horaires : Non renseigné'
+            : `Horaires : Vous n’avez pas renseigné d’horaire d’ouverture. Votre établissement est indiqué comme fermé sur l’application.`}
+        </span>
+      ) : <OpeningHours />}
+    </SummarySubSubSection>
+  } else {
+    return <SummarySubSection title="Horaires d'ouverture">
+      {orderedFilledDays.length === 0 ? (
         <p>
           {openingHours === null
             ? 'Non renseigné'
             : `Vous n’avez pas renseigné d’horaire d’ouverture. Votre établissement est indiqué comme fermé sur l’application.`}
         </p>
-      ) : (
-        <SummaryDescriptionList
-          descriptions={orderedFilledDays.map((dateAndHour) => {
-            return {
-              title: mapDayToFrench(dateAndHour[0]),
-              text: <Hours hours={dateAndHour[1]} />,
-            }
-          })}
-        />
-      )}
+      ) : <OpeningHours />}
     </SummarySubSection>
-  )
+  }
 }
 
 export function Hours({ hours }: HoursProps) {

--- a/pro/src/pages/VenueEdition/VenueEditionForm.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionForm.tsx
@@ -10,6 +10,7 @@ import { GET_VENUE_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { Events } from 'commons/core/FirebaseEvents/constants'
 import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useNotification } from 'commons/hooks/useNotification'
+import { getFormattedAddress } from 'commons/utils/getFormattedAddress'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { MandatoryInfo } from 'components/FormLayout/FormLayoutMandatoryInfo'
 import { OpenToPublicToggle } from 'components/OpenToPublicToggle/OpenToPublicToggle'
@@ -184,7 +185,7 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
                             className={styles['opening-hours-subsubsection-address-input']}
                             disabled
                             isOptional
-                            value={`${venue.street}, ${venue.postalCode} ${venue.city}`}
+                            value={getFormattedAddress(venue.address)}
                           />
                           <Callout
                             testId='address-callout'

--- a/pro/src/pages/VenueEdition/VenueEditionFormScreen.module.scss
+++ b/pro/src/pages/VenueEdition/VenueEditionFormScreen.module.scss
@@ -3,3 +3,7 @@
 .page-status {
   margin-bottom: rem.torem(32px)
 }
+
+.separator {
+  margin-bottom: rem.torem(24px);
+}

--- a/pro/src/pages/VenueEdition/VenueEditionReadOnly.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionReadOnly.tsx
@@ -1,13 +1,11 @@
 import { GetVenueResponseModel } from 'apiClient/v1'
 import { useActiveFeature } from 'commons/hooks/useActiveFeature'
-import { AccessibilitySummarySection as InternalAccessibilitySummarySubSection } from 'components/AccessibilitySummarySection/AccessibilitySummarySection'
-import { ExternalAccessibility } from 'components/ExternalAccessibility/ExternalAccessibility'
 import { SummaryDescriptionList } from 'components/SummaryLayout/SummaryDescriptionList'
 import { SummarySection } from 'components/SummaryLayout/SummarySection'
 import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import { OpeningHoursReadOnly } from 'pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly'
 
-import { AccessibilityCallout } from './AccessibilityCallout/AccessibilityCallout'
+import { AccessibilityReadOnly } from './AccessibilityReadOnly/AccessibilityReadOnly'
 
 interface VenueEditionReadOnlyProps {
   venue: GetVenueResponseModel
@@ -15,8 +13,16 @@ interface VenueEditionReadOnlyProps {
 
 export const VenueEditionReadOnly = ({ venue }: VenueEditionReadOnlyProps) => {
   const isOpenToPublicEnabled = useActiveFeature('WIP_IS_OPEN_TO_PUBLIC')
-  const isVenueOpenToPublic = !!venue.isOpenToPublic
-  const isAccessibilitySectionDisplayed = isOpenToPublicEnabled ? isVenueOpenToPublic : true
+
+  const PublicWelcomeSection = ({ children }: { children: React.ReactNode | React.ReactNode[] }): JSX.Element => {
+    return isOpenToPublicEnabled ?
+      <SummarySubSection
+        title="Accueil du public"
+        shouldShowDivider={false}
+      >
+        {children}
+      </SummarySubSection> : <>{children}</>
+  }
 
   return (
     <SummarySection
@@ -36,37 +42,22 @@ export const VenueEditionReadOnly = ({ venue }: VenueEditionReadOnlyProps) => {
           ]}
         />
       </SummarySubSection>
-      <OpeningHoursReadOnly
-        isOpenToPublicEnabled={isOpenToPublicEnabled}
-        isOpenToPublic={isVenueOpenToPublic}
-        openingHours={venue.openingHours}
-      />
-      {isAccessibilitySectionDisplayed && (
-        venue.externalAccessibilityData ? (
-          <>
-            <SummarySubSection
-              title="Modalités d’accessibilité via acceslibre"
-              shouldShowDivider={false}
-            >
-              <ExternalAccessibility
-                externalAccessibilityId={venue.externalAccessibilityId}
-                externalAccessibilityData={venue.externalAccessibilityData}
-              />
-            </SummarySubSection>
-          </>
-        ): (
-          <InternalAccessibilitySummarySubSection
-            callout={
-              venue.isPermanent ? (
-                <AccessibilityCallout />
-              ) : null
-            }
-            accessibleItem={venue}
-            accessibleWording="Votre établissement est accessible aux publics en situation de handicap :"
-            shouldShowDivider={false}
+      <PublicWelcomeSection>
+        {isOpenToPublicEnabled && !venue.isOpenToPublic && <span>
+          Accueil du public dans la structure : Non
+        </span>}
+        {(!isOpenToPublicEnabled || venue.isOpenToPublic) && <>
+          <OpeningHoursReadOnly
+            isOpenToPublicEnabled={isOpenToPublicEnabled}
+            openingHours={venue.openingHours}
+            address={venue.address}
           />
-        )
-      )}
+          <AccessibilityReadOnly
+            isOpenToPublicEnabled={isOpenToPublicEnabled}
+            venue={venue}
+          />
+        </>}
+      </PublicWelcomeSection>
       <SummarySubSection
         title="Informations de contact"
         shouldShowDivider={false}

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionFormScreen.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionFormScreen.spec.tsx
@@ -253,16 +253,25 @@ describe('VenueEditionFormScreen', () => {
     })
 
     describe('when open to public feature is enabled', () => {
-      it('should display a "Accès et horaires" section instead of a "Horaires d’ouverture" section',() => {
+      it('should always display an "Accueil du public"',() => {
         renderForm(baseVenue, {
           initialRouterEntries: ['/'],
           features: ['WIP_IS_OPEN_TO_PUBLIC'],
         })
-        expect(screen.getByText('Accès et horaires')).toBeInTheDocument()
+        expect(screen.getByText('Accueil du public')).toBeInTheDocument()
       })
 
       describe('when the venue is not open to public', () => {
-        it('should not display any accessibility section', () => {
+        it('should not display any address and hours subsection', () => {
+          renderForm({ ...baseVenue, isOpenToPublic: false }, {
+            initialRouterEntries: ['/'],
+            features: ['WIP_IS_OPEN_TO_PUBLIC'],
+          })
+
+          expect(screen.queryByText('Adresse et horaires')).not.toBeInTheDocument()
+        })
+
+        it('should not display any accessibility subsection', () => {
           renderForm({ ...baseVenue, isOpenToPublic: false }, {
             initialRouterEntries: ['/'],
             features: ['WIP_IS_OPEN_TO_PUBLIC'],
@@ -270,10 +279,28 @@ describe('VenueEditionFormScreen', () => {
 
           expect(screen.queryByText(/Modalités d’accessibilité/)).not.toBeInTheDocument()
         })
+
+        it('should display a message indicating the venue is not open to public', () => {
+          renderForm({ ...baseVenue, isOpenToPublic: false }, {
+            initialRouterEntries: ['/'],
+            features: ['WIP_IS_OPEN_TO_PUBLIC'],
+          })
+
+          expect(screen.getByText('Accueil du public dans la structure : Non')).toBeInTheDocument()
+        })
       })
 
       describe('when the venue is open to public', () => {
-        it('should display an accessibility section', () => {
+        it('should display an "Addresse et horaires" subsection', () => {
+          renderForm({ ...baseVenue, isOpenToPublic: true }, {
+            initialRouterEntries: ['/'],
+            features: ['WIP_IS_OPEN_TO_PUBLIC'],
+          })
+
+          expect(screen.getByText('Adresse et horaires')).toBeInTheDocument()
+        })
+
+        it('should display an accessibility subsection', () => {
           renderForm({ ...baseVenue, isOpenToPublic: true }, {
             initialRouterEntries: ['/'],
             features: ['WIP_IS_OPEN_TO_PUBLIC'],
@@ -281,7 +308,7 @@ describe('VenueEditionFormScreen', () => {
           expect(screen.queryByText(/Modalités d’accessibilité/)).toBeInTheDocument()
         })
 
-        it('should display the acceslibre section as an accessibility section when accessibility is externally defined', () => {
+        it('should display the acceslibre section as an accessibility sub section when accessibility is externally defined', () => {
           renderForm(
             {
               ...baseVenue,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34990

## Vérifications

- [X] ~J'ai écrit les tests nécessaires~
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~
- [X] J'ai fait la revue fonctionnelle de mon ticket
