### PR TITLE
(PC-35010)[PRO] fix: Do not consider that another offer exist with sa…

### DIFF
--- a/pro/src/commons/context/IndividualOfferContext/IndividualOfferContext.tsx
+++ b/pro/src/commons/context/IndividualOfferContext/IndividualOfferContext.tsx
@@ -92,6 +92,12 @@ export const IndividualOfferContextProvider = ({
     return <Spinner />
   }
 
+  //  Only consider a puslished offer that is different from the one we are editing or creating now
+  const publishedOfferWithSameEAN =
+    offer && publishedOfferWithSameEANQuery.data?.id !== offer.id
+      ? publishedOfferWithSameEANQuery.data
+      : undefined
+
   return (
     <IndividualOfferContext.Provider
       value={{
@@ -100,7 +106,7 @@ export const IndividualOfferContextProvider = ({
         categories: categoriesQuery.data.categories,
         subCategories: categoriesQuery.data.subcategories,
         setIsEvent,
-        publishedOfferWithSameEAN: publishedOfferWithSameEANQuery.data,
+        publishedOfferWithSameEAN,
       }}
     >
       {children}


### PR DESCRIPTION
…me EAN if id is the same as current offer.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35010

**Objectif**
Ne pas considérer qu'il existe une autre offre avec le même EAN, si cette autre offre est la même que celle sur laquelle on est 😢 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
