### PR TITLE
(PC-34665)[PRO] feat: fix space between option and icon in select

### DIFF
--- a/pro/src/ui-kit/form/Select/Select.module.scss
+++ b/pro/src/ui-kit/form/Select/Select.module.scss
@@ -27,7 +27,7 @@
     @include fonts.body;
 
     color: var(--color-black);
-    padding: rem.torem(8px) rem.torem(12px);
+    padding: rem.torem(8px) rem.torem(28px) rem.torem(8px) rem.torem(12px);
     height: rem.torem(42px);
     border-radius: rem.torem(8px);
     cursor: pointer;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34665

Avant : 
<img width="428" alt="Capture d’écran 2025-03-12 à 15 32 38" src="https://github.com/user-attachments/assets/b2db39c3-4c0c-444f-817c-54fc8ae10764" />

Après : 
<img width="428" alt="Capture d’écran 2025-03-12 à 15 32 57" src="https://github.com/user-attachments/assets/a901a8c1-de05-495c-8e8e-5942b38db8a3" />
