### PR TITLE
(PC-35114)[PRO] feat: Force hard refresh when changing offerer

### DIFF
--- a/pro/cypress/e2e/financialManagement.cy.ts
+++ b/pro/cypress/e2e/financialManagement.cy.ts
@@ -30,7 +30,7 @@ describe('Financial Management - messages, links to external help page, reimburs
       )
     })
 
-    it('I should be able to see messages, reimbursement details and offerer selection change', () => {
+    it('I should be redirected to the homepage when offerer selection change', () => {
       logInAndGoToPage(login1, '/remboursements')
 
       cy.stepLog({
@@ -96,50 +96,12 @@ describe('Financial Management - messages, links to external help page, reimburs
       cy.findByTestId('header-dropdown-menu-div').should('not.exist')
       cy.findAllByTestId('spinner').should('not.exist')
 
-      cy.stepLog({ message: 'These receipt results should be displayed' })
-      const data = [
-        [
-          'Date du justificatif',
-          'Type de document',
-          'Compte bancaire',
-          'N° de virement',
-          'Montant remboursé',
-          'Actions',
-        ],
-        [
-          '',
-          '',
-          'Trop perçu',
-          'Libellé des coordonnées bancaires n°0',
-          'N/A',
-          '-10,00',
-        ],
-      ]
-      const numRows = data.length - 1
-      const numColumns = data[0].length
-
-      cy.findAllByTestId('spinner').should('not.exist')
-      cy.findAllByTestId('invoice-item-row').should('have.length', numRows)
-
-      // Vérification des titres des colonnes
-      const titleArray = data[0]
-      cy.findAllByTestId('invoice-title-row').within(() => {
-        cy.get('th').then(($elt) => {
-          for (let column = 0; column < numColumns; column++) {
-            if (titleArray[column] !== '') {
-              cy.wrap($elt).eq(column).should('contain', titleArray[column])
-            }
-          }
-        })
+      cy.stepLog({
+        message:
+          'We must be redirected on the homepage of the new offerer, who’s not onboarded',
       })
-
-      cy.stepLog({ message: 'I download reimbursement details' })
-      cy.findByTestId('dropdown-menu-trigger').click()
-      cy.findByText(/Télécharger le détail des réservations/).click()
-
-      cy.stepLog({ message: 'I can see the reimbursement details' })
-      const filename = `${Cypress.config('downloadsFolder')}/remboursements_pass_culture.csv`
-      cy.readFile(filename, { timeout: 15000 }).should('not.be.empty')
+      cy.findByText('Bienvenue sur le pass Culture Pro !')
+      cy.findByText('À qui souhaitez-vous proposer votre première offre ?')
     })
   })
 

--- a/pro/src/app/App/hook/__specs__/useLogExtraProData.spec.tsx
+++ b/pro/src/app/App/hook/__specs__/useLogExtraProData.spec.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor } from '@testing-library/react'
-import { userEvent } from '@testing-library/user-event'
 import { beforeEach } from 'vitest'
 
 import * as useAnalytics from 'app/App/analytics/firebase'
@@ -55,20 +54,6 @@ describe('useLogExtraProData', () => {
     expect(mockLogEvent).toHaveBeenCalledTimes(1)
     expect(mockLogEvent).toHaveBeenNthCalledWith(1, 'extra_pro_data', {
       offerer_id: 1,
-      from: '/accueil',
-    })
-  })
-
-  it('should log another event on offerer change', async () => {
-    await renderLogExtraProData()
-
-    await userEvent.click(screen.getByTestId('offerer-select'))
-    await userEvent.click(screen.getByText(/Changer/))
-    await userEvent.click(screen.getByText('super structure'))
-
-    expect(mockLogEvent).toHaveBeenCalledTimes(2)
-    expect(mockLogEvent).toHaveBeenNthCalledWith(2, 'extra_pro_data', {
-      offerer_id: 2,
       from: '/accueil',
     })
   })

--- a/pro/src/commons/hooks/swr/useOffererNamesQuery.spec.tsx
+++ b/pro/src/commons/hooks/swr/useOffererNamesQuery.spec.tsx
@@ -1,0 +1,105 @@
+import { screen, waitFor } from '@testing-library/react'
+
+import { api } from 'apiClient/api'
+import { sharedCurrentUserFactory } from 'commons/utils/factories/storeFactories'
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
+
+import { useOffererNamesQuery } from './useOffererNamesQuery'
+
+vi.mock('apiClient/api', () => ({
+  api: {
+    listOfferersNames: vi.fn(),
+  },
+}))
+
+const mockDispatch = vi.fn()
+vi.mock('react-redux', async () => {
+  const actual = await vi.importActual('react-redux')
+  return {
+    ...actual,
+    useDispatch: () => mockDispatch,
+  }
+})
+
+const user = sharedCurrentUserFactory()
+
+const TestComponent = () => {
+  const offererNamesQuery = useOffererNamesQuery()
+
+  const offererNames = offererNamesQuery.data?.offerersNames
+
+  return (
+    <div data-testid="offerernamesquery-hook">
+      <ul>
+        {offererNames?.map((offererName) => (
+          <li key={offererName.id}>{offererName.name}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+const renderComponent = (
+  overrides: any = {
+    offerer: {
+      offererNames: null,
+    },
+  }
+) => {
+  return renderWithProviders(<TestComponent />, {
+    user,
+    storeOverrides: overrides,
+  })
+}
+
+describe('useOffererNamesQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should invoke API and dispatch if no data is present in the store', async () => {
+    const mockOffererNames = [
+      { id: 1, name: 'Offerer 1', allowedOnAdage: false },
+      { id: 2, name: 'Offerer 2', allowedOnAdage: true },
+    ]
+
+    vi.mocked(api.listOfferersNames).mockResolvedValueOnce({
+      offerersNames: mockOffererNames,
+    })
+
+    renderComponent()
+
+    await waitFor(() => {
+      expect(api.listOfferersNames).toHaveBeenCalledTimes(1)
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: mockOffererNames,
+        })
+      )
+    })
+
+    expect(screen.getByText('Offerer 1')).toBeInTheDocument()
+    expect(screen.getByText('Offerer 2')).toBeInTheDocument()
+  })
+
+  it('should not invoke API and dispatch if data is present in the store', async () => {
+    const mockOffererNames = [
+      { id: 3, name: 'Offerer 3', allowedOnAdage: true },
+      { id: 4, name: 'Offerer 4', allowedOnAdage: false },
+    ]
+
+    renderComponent({
+      offerer: {
+        offererNames: mockOffererNames,
+      },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Offerer 3')).toBeInTheDocument()
+      expect(screen.getByText('Offerer 4')).toBeInTheDocument()
+    })
+
+    expect(api.listOfferersNames).not.toHaveBeenCalled()
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+})

--- a/pro/src/commons/hooks/swr/useOffererNamesQuery.ts
+++ b/pro/src/commons/hooks/swr/useOffererNamesQuery.ts
@@ -1,0 +1,48 @@
+import { useDispatch, useSelector } from 'react-redux'
+import useSWR, { SWRResponse } from 'swr'
+
+import { api } from 'apiClient/api'
+import { GetOfferersNamesResponseModel } from 'apiClient/v1'
+import { GET_OFFERER_NAMES_QUERY_KEY } from 'commons/config/swrQueryKeys'
+import { updateOffererNames } from 'commons/store/offerer/reducer'
+import { selectOffererNames } from 'commons/store/offerer/selectors'
+
+/**
+ * Custom hook to fetch the list of offerer names
+ *
+ * This hook combines Redux store data with a SWR request to get
+ * the list of offerer names. If the data is already present in the store,
+ * it is returned immediately without making a new request.
+ * Else, we perform the query and dispatch it to the store.
+ *
+ * @returns {SWRResponse<GetOfferersNamesResponseModel>} An object containing:
+ * - data: The offerer names data
+ * - isLoading: Loading state
+ * - isValidating: Validation state
+ * - error: Potential error
+ */
+export const useOffererNamesQuery =
+  (): SWRResponse<GetOfferersNamesResponseModel> => {
+    const storeOffererNames = useSelector(selectOffererNames)
+    const dispatch = useDispatch()
+
+    const offererNamesQuery = useSWR(
+      [GET_OFFERER_NAMES_QUERY_KEY],
+      async () => {
+        if (!storeOffererNames) {
+          const response = await api.listOfferersNames()
+          dispatch(updateOffererNames(response.offerersNames))
+          return response
+        } else {
+          return {
+            offerersNames: storeOffererNames,
+          }
+        }
+      },
+      {
+        shouldRetryOnError: false,
+      }
+    )
+
+    return offererNamesQuery
+  }

--- a/pro/src/commons/utils/__specs__/hardRefresh.spec.ts
+++ b/pro/src/commons/utils/__specs__/hardRefresh.spec.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { hardRefresh } from 'commons/utils/hardRefresh'
+
+describe('hardRefresh', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    // Mock window.location
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { href: '' },
+    })
+  })
+
+  afterEach(() => {
+    // Restore window.location
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('should set window.location.href with the provided URL', () => {
+    const url = '/nouvelle-page'
+
+    hardRefresh(url)
+
+    expect(window.location.href).toBe(url)
+  })
+
+  it('should work with an absolute URL', () => {
+    const url = 'https://example.com/page'
+
+    hardRefresh(url)
+
+    expect(window.location.href).toBe(url)
+  })
+})

--- a/pro/src/commons/utils/hardRefresh.ts
+++ b/pro/src/commons/utils/hardRefresh.ts
@@ -1,0 +1,10 @@
+/**
+ * Performs a complete page refresh by redirecting to the specified URL.
+ * Having this as a helper makes it easier to mock in unit tests
+ *
+ * @param {string} to - The destination URL to redirect to
+ * @returns {void}
+ */
+export const hardRefresh = (to: string): void => {
+  window.location.href = to
+}

--- a/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.spec.tsx
+++ b/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.spec.tsx
@@ -1,4 +1,4 @@
-import { screen, within, waitFor } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { expect } from 'vitest'
 
@@ -12,6 +12,7 @@ import {
   defaultGetOffererVenueResponseModel,
 } from 'commons/utils/factories/individualApiFactories'
 import { currentOffererFactory } from 'commons/utils/factories/storeFactories'
+import { hardRefresh } from 'commons/utils/hardRefresh'
 import {
   renderWithProviders,
   RenderWithProvidersOptions,
@@ -89,27 +90,13 @@ describe('App', () => {
         },
       }))
 
+      vi.mock('commons/utils/hardRefresh', () => ({
+        hardRefresh: vi.fn(),
+      }))
+
       vi.spyOn(api, 'getOfferer').mockResolvedValue(
         defaultGetOffererResponseModel
       )
-    })
-
-    it('should call "handleChangeOfferer" on value change', async () => {
-      renderHeaderDropdown()
-
-      // Opens main menu
-      await userEvent.click(screen.getByTestId('offerer-select'))
-
-      // Opens sub-menu
-      await userEvent.click(screen.getByText(/Changer/))
-
-      // Get structures list
-      const offererList = screen.getByTestId('offerers-selection-menu')
-      const offerers = within(offererList).getAllByRole('menuitemradio')
-
-      await userEvent.click(offerers[0])
-
-      expect(api.getOfferer).toHaveBeenCalledOnce()
     })
 
     it('should reset url query parameters & stored search filters', async () => {
@@ -145,9 +132,8 @@ describe('App', () => {
       // Clic on one structure
       await userEvent.click(offerers[0])
 
-      await waitFor(() => {
-        expect(api.getOfferer).toHaveBeenCalledOnce()
-      })
+      // Verify that hardRefresh has been called once
+      expect(hardRefresh).toHaveBeenCalledOnce()
 
       // Stored search filters should be reset, while filters
       // visibility must be remembered.

--- a/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.tsx
+++ b/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.tsx
@@ -14,6 +14,7 @@ import {
 } from 'commons/store/offerer/selectors'
 import { selectCurrentUser } from 'commons/store/user/selectors'
 import { getSavedOffererId } from 'commons/utils/getSavedOffererId'
+import { hardRefresh } from 'commons/utils/hardRefresh'
 import { storageAvailable } from 'commons/utils/storageAvailable'
 import { sortByLabel } from 'commons/utils/strings'
 import { resetAllStoredFilterConfig } from 'components/OffersTable/OffersTableSearch/utils'
@@ -82,7 +83,7 @@ export const HeaderDropdown = () => {
     }
 
     // Hard refresh to homepage after offerer change
-    window.location.href = '/accueil'
+    hardRefresh('/accueil')
   }
 
   useEffect(() => {

--- a/pro/src/pages/Homepage/Homepage.tsx
+++ b/pro/src/pages/Homepage/Homepage.tsx
@@ -5,11 +5,9 @@ import useSWR from 'swr'
 import { api } from 'apiClient/api'
 import { useRemoteConfigParams } from 'app/App/analytics/firebase'
 import { Layout } from 'app/App/layout/Layout'
-import {
-  GET_OFFERER_NAMES_QUERY_KEY,
-  GET_VENUE_TYPES_QUERY_KEY,
-} from 'commons/config/swrQueryKeys'
+import { GET_VENUE_TYPES_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { useOfferer } from 'commons/hooks/swr/useOfferer'
+import { useOffererNamesQuery } from 'commons/hooks/swr/useOffererNamesQuery'
 import { selectCurrentOffererId } from 'commons/store/offerer/selectors'
 import { storageAvailable } from 'commons/utils/storageAvailable'
 import { sortByLabel } from 'commons/utils/strings'
@@ -47,9 +45,8 @@ export const Homepage = (): JSX.Element => {
     }
   }, [remoteConfigData])
 
-  const offererNamesQuery = useSWR([GET_OFFERER_NAMES_QUERY_KEY], () =>
-    api.listOfferersNames()
-  )
+  const offererNamesQuery = useOffererNamesQuery()
+
   const offererNames = offererNamesQuery.data?.offerersNames
 
   const venueTypesQuery = useSWR([GET_VENUE_TYPES_QUERY_KEY], () =>

--- a/pro/src/pages/Homepage/__specs__/Homepage.spec.tsx
+++ b/pro/src/pages/Homepage/__specs__/Homepage.spec.tsx
@@ -16,8 +16,8 @@ import {
   defaultGetOffererVenueResponseModel,
 } from 'commons/utils/factories/individualApiFactories'
 import {
-  sharedCurrentUserFactory,
   currentOffererFactory,
+  sharedCurrentUserFactory,
 } from 'commons/utils/factories/storeFactories'
 import {
   renderWithProviders,
@@ -140,8 +140,6 @@ describe('Homepage', () => {
 
     renderHomePage()
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
-
-    expect(api.listOfferersNames).toHaveBeenCalled()
 
     expect(
       screen.getByText(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35114

> [!NOTE]
> Nouveau hook `useOffererNamesQuery` dont le but est de récupérer les "offererNames"
>
> Ce hook combine les données du Redux store avec une requête SWR pour obtenir la liste des "offererNames".
> Si les données sont déjà présentes dans le store, elles sont renvoyées immédiatement sans faire de requête (plus éco)

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
