### PR TITLE
(PC-34889)[API] feat: Add new AppsFlyer events

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -64,6 +64,7 @@ import pcapi.serialization.utils as serialization_utils
 from pcapi.tasks.serialization.external_api_booking_notification_tasks import BookingAction
 from pcapi.utils import queue
 from pcapi.utils.requests import exceptions as requests_exceptions
+from pcapi.workers import apps_flyer_job
 from pcapi.workers import push_notification_job
 from pcapi.workers import user_emails_job
 
@@ -372,6 +373,9 @@ def book_offer(
             extra={"offer_id": stock.offer.id, "provider_id": stock.offer.lastProviderId},
         )
         raise
+
+    if "apps_flyer" in beneficiary.externalIds:
+        apps_flyer_job.log_user_booked_offer_event_job.delay(beneficiary.id, stock.offerId, booking.id)
 
     logger.info(
         "Beneficiary booked an offer",

--- a/api/src/pcapi/workers/apps_flyer_job.py
+++ b/api/src/pcapi/workers/apps_flyer_job.py
@@ -1,4 +1,7 @@
+from pcapi.connectors.apps_flyer import log_offer_event
 from pcapi.connectors.apps_flyer import log_user_event
+from pcapi.core.bookings.models import Booking
+from pcapi.core.offers.models import Stock
 from pcapi.core.users.models import User
 from pcapi.workers import worker
 from pcapi.workers.decorators import job
@@ -14,3 +17,18 @@ def log_user_becomes_beneficiary_event_job(user_id: int) -> None:
         log_user_event(user, f"af_complete_beneficiary_{user.age}")
     elif user.age >= 18:
         log_user_event(user, "af_complete_beneficiary_18")
+
+
+@job(worker.default_queue)
+def log_user_registration_event_job(user_id: int) -> None:
+    user = User.query.get(user_id)
+    if 15 <= user.age <= 18:
+        log_user_event(user, f"af_complete_registration_{user.age}")
+    elif user.age >= 19:
+        log_user_event(user, "af_complete_registration_19+")
+
+
+@job(worker.default_queue)
+def log_user_booked_offer_event_job(booking_id: int) -> None:
+    booking = Booking.query.get(booking_id).joinedload(Booking.user).joinedload(Booking.stock).joinedload(Stock.offer)
+    log_offer_event(booking, "af_complete_book_offer")

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -3803,3 +3803,47 @@ class BypassEmailConfirmationTest:
 
         assert len(mails_testing.outbox) == 0
         assert not user.isEmailValidated
+
+    @pytest.mark.parametrize(
+        "age,expected_event_name",
+        [
+            (15, "af_complete_registration_15"),
+            (16, "af_complete_registration_16"),
+            (17, "af_complete_registration_17"),
+            (18, "af_complete_registration_18"),
+            (19, "af_complete_registration_19+"),
+            (25, "af_complete_registration_19+"),
+        ],
+    )
+    def test_apps_flyer_called_when_validating_email(self, requests_mock, client, age, expected_event_name):
+        apps_flyer_data = {
+            "apps_flyer": {"user": "some-user-id", "platform": "ANDROID"},
+            "firebase_pseudo_id": "firebase_pseudo_id",
+        }
+        user = users_factories.UserFactory(
+            email="user@example.com",
+            isEmailValidated=False,
+            externalIds=apps_flyer_data,
+            dateOfBirth=datetime.date.today() - relativedelta(years=age),
+        )
+        token = token_utils.Token.create(
+            type_=token_utils.TokenType.SIGNUP_EMAIL_CONFIRMATION,
+            ttl=users_constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME,
+            user_id=user.id,
+        )
+        posted = requests_mock.post("https://api2.appsflyer.com/inappevent/app.passculture.webapp")
+
+        response = client.post("/native/v1/validate_email", json={"email_validation_token": token.encoded_token})
+
+        assert response.status_code == 200
+        assert posted.call_count == 1
+        assert posted.request_history[0].json() == {
+            "appsflyer_id": "some-user-id",
+            "eventName": expected_event_name,
+            "eventValue": {
+                "af_user_id": str(user.id),
+                "af_firebase_pseudo_id": "firebase_pseudo_id",
+                "type": None,
+            },
+        }
+        assert user.isEmailValidated


### PR DESCRIPTION
# Intégration des événements AppsFlyer pour le tracking des conversions

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/(PC-34889

Cette PR ajoute le tracking des événements AppsFlyer pour suivre les conversions clés dans l'application :

- Validation d'email lors de l'inscription
- Réservation d'une offre

## 🔍 Détails techniques

### Nouveaux événements trackés
- af_complete_registration_XX : Déclenché lors de la validation d'email
   - Différencié par âge : 15, 16, 17, 18, 19+
   - Inclut l'ID utilisateur et firebase_pseudo_id
- af_complete_book_offer : Déclenché lors d'une réservation
   - Inclut les détails de la réservation (offre, prix, catégorie)
   
### Modifications principales
- Ajout de log_offer_event dans le connecteur AppsFlyer
- Intégration dans le flow de réservation via bookings/api.py
- Intégration dans le processus de validation d'email
- Utilisation de jobs asynchrones pour éviter l'impact sur les performances

## ✅ Tests

- Tests unitaires pour chaque nouvel événement
- Tests paramétrés pour les différents cas d'âge
- Mock des appels externes
- Vérification des cas d'erreur et absence d'ID AppsFlyer
