### PR TITLE
(PC-35137)[PRO] feat: Replace text color with DS color-text-default.

### DIFF
--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/BookingsTable.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/BookingsTable.module.scss
@@ -20,14 +20,12 @@
   @include a11y.visually-hidden;
 
   text-align: left;
-  color: var(--color-black);
 }
 
 // <th>
 .table-header-cell {
   @include fonts.body-accent-xs;
 
-  color: var(--color-black);
   padding: rem.torem(8px);
   white-space: nowrap;
 }

--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/BookingsTable.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/BookingsTable.module.scss
@@ -108,7 +108,7 @@
   word-break: break-word;
 
   .institution-cell-subtitle {
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
   }
 }
 

--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/Cells/BeneficiaryCell.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/Cells/BeneficiaryCell.module.scss
@@ -1,3 +1,3 @@
 .beneficiary-subtitle {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }

--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingDateCell.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingDateCell.module.scss
@@ -1,5 +1,5 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .booking-date-subtitle {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }

--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingOfferCell.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingOfferCell.module.scss
@@ -16,7 +16,7 @@
 .booking-offer-additional-info {
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   display: flex;
   align-items: center;
 }
@@ -25,7 +25,7 @@
   @include fonts.body-accent-xs;
 
   margin-top: rem.torem(4px);
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }
 
 .stocks {

--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingStatusCell.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/Cells/BookingStatusCell.module.scss
@@ -33,7 +33,7 @@
   background-color: var(--color-background-default);
   border-radius: rem.torem(4px);
   box-shadow: 0 rem.torem(2px) rem.torem(10px) 0 var(--color-large-shadow);
-  color: var(--color-black);
+  color: var(--color-text-default);
   display: block;
   padding: rem.torem(16px) rem.torem(24px) rem.torem(16px) rem.torem(24px);
   position: absolute;

--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.module.scss
@@ -9,13 +9,13 @@
   &-step-title-passed {
     @include fonts.body-accent;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
   }
 
   &-step-title-disabled {
     @include fonts.body-accent;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-disabled);
   }
 
   &-step-decription-with-link {

--- a/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/BookingsTable/CollectiveTimeLine.module.scss
@@ -47,11 +47,10 @@
 .contact-link {
   @include fonts.button;
 
-  color: var(--color-black);
+  color: var(--color-text-default);
 
   &:hover,
   &:focus {
-    color: var(--color-black);
     cursor: pointer;
     text-decoration: underline;
   }

--- a/pro/src/components/Bookings/BookingsRecapTable/Filters/Filters.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/Filters/Filters.module.scss
@@ -12,7 +12,7 @@
   .bs-filter-legend {
     @include fonts.body-accent-xs;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     padding-bottom: rem.torem(8px);
     white-space: nowrap;
   }

--- a/pro/src/components/Bookings/BookingsRecapTable/Filters/Filters.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/Filters/Filters.module.scss
@@ -47,7 +47,7 @@
 .table-head-label {
   @include fonts.body-accent-xs;
 
-  color: var(--color-black);
+  color: var(--color-text-default);
   min-height: rem.torem(60px);
   padding: rem.torem(14px);
   vertical-align: middle;

--- a/pro/src/components/Bookings/BookingsRecapTable/NoFilteredBookings/NoFilteredBookings.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/NoFilteredBookings/NoFilteredBookings.module.scss
@@ -16,7 +16,7 @@
   }
 
   &-text {
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     margin-bottom: rem.torem(8px);
   }
 }

--- a/pro/src/components/Bookings/BookingsRecapTable/utils/BookingStatus.module.scss
+++ b/pro/src/components/Bookings/BookingsRecapTable/utils/BookingStatus.module.scss
@@ -5,7 +5,7 @@
 
 .booking-status-pending {
   background-color: var(--color-alert-dark);
-  color: var(--color-black);
+  color: var(--color-text-default);
 
   svg {
     color: var(--color-black);

--- a/pro/src/components/CollectiveStatusLabel/CollectiveStatusLabel.module.scss
+++ b/pro/src/components/CollectiveStatusLabel/CollectiveStatusLabel.module.scss
@@ -38,7 +38,7 @@
 
   &-pre-booked {
     background-color: var(--color-alert-dark);
-    color: var(--color-black);
+    color: var(--color-text-default);
 
     .status-label-icon {
       color: var(--color-black);
@@ -58,7 +58,7 @@
 
   &-archived {
     background-color: var(--color-background-subtle);
-    color: var(--color-black);
+    color: var(--color-text-default);
 
     .status-label-icon {
       color: var(--color-black);

--- a/pro/src/components/ConstraintCheck/ConstraintCheck.module.scss
+++ b/pro/src/components/ConstraintCheck/ConstraintCheck.module.scss
@@ -9,7 +9,7 @@
 
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 
   &-failing-constraint {
     display: flex;

--- a/pro/src/components/ExternalAccessibility/ExternalAccessibilityCollapse/ExternalAccessibilityCollapse.module.scss
+++ b/pro/src/components/ExternalAccessibility/ExternalAccessibilityCollapse/ExternalAccessibilityCollapse.module.scss
@@ -22,11 +22,11 @@
   border-radius: 50%;
 
   &.accessible {
-    color: var(--color-valid);
+    color: var(--color-text-success);
   }
 
   &.non-accessible {
-    color: var(--color-error);
+    color: var(--color-text-error);
   }
 }
 

--- a/pro/src/components/FormLayout/FormLayout.module.scss
+++ b/pro/src/components/FormLayout/FormLayout.module.scss
@@ -129,7 +129,7 @@ $info-box-margin-left: rem.torem(24px);
   @include fonts.body-xs;
 
   margin-bottom: rem.torem(32px);
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }
 
 @media (min-width: size.$laptop) {

--- a/pro/src/components/Header/Header.module.scss
+++ b/pro/src/components/Header/Header.module.scss
@@ -58,7 +58,7 @@
   .logo {
     display: inline-flex;
     height: 100%;
-    color: var(--color-input-text-color);
+    color: var(--color-text-default);
 
     svg {
       width: rem.torem(80px);

--- a/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.module.scss
+++ b/pro/src/components/Header/components/HeaderDropdown/HeaderDropdown.module.scss
@@ -121,7 +121,7 @@ $sub-popin-full-width-breakpoint: rem.torem(673px);
   &-title {
     @include fonts.body-accent-xs;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
 
     &.tablet-only {
       margin-top: rem.torem(8px);
@@ -155,7 +155,7 @@ $sub-popin-full-width-breakpoint: rem.torem(673px);
 
     @include fonts.body-accent-xs;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
 
     &.tablet-only {
       margin-top: rem.torem(8px);

--- a/pro/src/components/ImageUploader/components/ButtonAppPreview/components/ModalAppPreview/ModalAppPreview.module.scss
+++ b/pro/src/components/ImageUploader/components/ButtonAppPreview/components/ModalAppPreview/ModalAppPreview.module.scss
@@ -14,7 +14,7 @@
 }
 
 .subtitle {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   margin-bottom: rem.torem(24px);
 }
 

--- a/pro/src/components/ImageUploader/components/ButtonImageEdit/ButtonImageEdit.module.scss
+++ b/pro/src/components/ImageUploader/components/ButtonImageEdit/ButtonImageEdit.module.scss
@@ -9,7 +9,7 @@
   gap: rem.torem(16px);
   border: none;
   background-color: var(--color-background-subtle);
-  color: var(--color-black);
+  color: var(--color-text-default);
   box-shadow: 0 rem.torem(1px) rem.torem(8px)
     rgb(from var(--color-large-shadow) r g b / 15%);
   border-radius: rem.torem(8px);

--- a/pro/src/components/ImageUploader/components/ButtonImageEdit/ModalImageEdit/components/ModalImageCrop/ImageEditor/ImageEditor.module.scss
+++ b/pro/src/components/ImageUploader/components/ButtonImageEdit/ModalImageEdit/components/ModalImageCrop/ImageEditor/ImageEditor.module.scss
@@ -27,7 +27,7 @@
       margin-left: rem.torem(28px);
       margin-right: rem.torem(28px);
       padding-bottom: rem.torem(4px);
-      color: var(--color-grey-dark);
+      color: var(--color-text-subtle);
     }
 
     &-input {

--- a/pro/src/components/ImageUploader/components/ButtonImageEdit/ModalImageEdit/components/ModalImageUploadConfirm/ModalImageUploadConfirm.module.scss
+++ b/pro/src/components/ImageUploader/components/ButtonImageEdit/ModalImageEdit/components/ModalImageUploadConfirm/ModalImageUploadConfirm.module.scss
@@ -15,7 +15,7 @@
 }
 
 .subtitle {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   margin-bottom: rem.torem(24px);
 }
 

--- a/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.module.scss
@@ -107,7 +107,7 @@
 .mandatory {
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   margin-bottom: rem.torem(16px);
 }
 

--- a/pro/src/components/IndividualOffer/StocksThing/ActivationCodeFormDialog/ActivationCodeFormDialog.module.scss
+++ b/pro/src/components/IndividualOffer/StocksThing/ActivationCodeFormDialog/ActivationCodeFormDialog.module.scss
@@ -27,7 +27,7 @@
     @include fonts.body-accent-xs;
 
     margin-top: rem.torem(16px);
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
   }
 
   .activation-codes-upload-separator {

--- a/pro/src/components/IndividualOffer/StocksThing/StockThing.module.scss
+++ b/pro/src/components/IndividualOffer/StocksThing/StockThing.module.scss
@@ -19,7 +19,7 @@
 .mandatory {
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }
 
 @media (min-width: size.$tablet) {

--- a/pro/src/components/IndividualOffer/SummaryScreen/StockSection/StockSection.module.scss
+++ b/pro/src/components/IndividualOffer/SummaryScreen/StockSection/StockSection.module.scss
@@ -1,3 +1,3 @@
 .stock-section-warning {
-  color: var(--color-error);
+  color: var(--color-text-error);
 }

--- a/pro/src/components/LegalInfos/LegalInfos.module.scss
+++ b/pro/src/components/LegalInfos/LegalInfos.module.scss
@@ -4,7 +4,7 @@
 .legal-infos {
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 
   .quaternary-link {
     color: var(--color-primary);
@@ -28,7 +28,7 @@
     @include fonts.body-accent-s;
 
     margin-bottom: rem.torem(8px);
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
   }
 
   &-link {
@@ -46,7 +46,7 @@
     @include fonts.body-accent-s;
 
     display: inline;
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     text-decoration: underline;
 
     &:hover {

--- a/pro/src/components/NoResults/NoResults.module.scss
+++ b/pro/src/components/NoResults/NoResults.module.scss
@@ -16,7 +16,7 @@
   }
 
   &-text {
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     margin-bottom: rem.torem(8px);
   }
 }

--- a/pro/src/components/OnboardingOffersChoice/components/OnboardingCollectiveModal/OnboardingCollectiveModal.module.scss
+++ b/pro/src/components/OnboardingOffersChoice/components/OnboardingCollectiveModal/OnboardingCollectiveModal.module.scss
@@ -66,5 +66,5 @@
 }
 
 .error-message {
-  color: var(--color-error);
+  color: var(--color-text-error);
 }

--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.module.scss
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.module.scss
@@ -68,7 +68,7 @@
   .issue-text {
     @include fonts.body-accent-xs;
 
-    color: var(--color-error);
+    color: var(--color-text-error);
     margin-bottom: rem.torem(16px);
   }
 

--- a/pro/src/components/ReimbursementsTabs/ReimbursementsTabs.module.scss
+++ b/pro/src/components/ReimbursementsTabs/ReimbursementsTabs.module.scss
@@ -2,5 +2,5 @@
 
 .error-icon {
   margin-left: rem.torem(8px);
-  color: var(--color-error);
+  color: var(--color-text-error);
 }

--- a/pro/src/components/SideNavLinks/SideNavLinks.module.scss
+++ b/pro/src/components/SideNavLinks/SideNavLinks.module.scss
@@ -7,6 +7,7 @@
   &-button {
     @include fonts.button;
 
+    color: var(--color-text-default);
     padding: rem.torem(12px) rem.torem(16px);
     display: flex;
     gap: rem.torem(8px);

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.module.scss
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.module.scss
@@ -15,13 +15,12 @@
   margin-top: rem.torem(8px);
   padding: rem.torem(16px);
   background: var(--color-background-subtle);
-  color: var(--color-grey-dark);
+  color: var(--color-text-default);
   border-radius: rem.torem(8px);
 
   .data-line {
     @include fonts.body;
 
-    color: var(--color-black);
     margin-bottom: rem.torem(8px);
     overflow-wrap: break-word;
 

--- a/pro/src/components/SignupJourneyForm/Welcome/Welcome.module.scss
+++ b/pro/src/components/SignupJourneyForm/Welcome/Welcome.module.scss
@@ -23,5 +23,5 @@ $welcome-gap: rem.torem(32px);
 .caption-informations {
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }

--- a/pro/src/components/SoftDeletedOffererWarning/SoftDeletedOffererWarning.module.scss
+++ b/pro/src/components/SoftDeletedOffererWarning/SoftDeletedOffererWarning.module.scss
@@ -21,7 +21,6 @@
     width: 100%;
 
     p {
-      color: var(--color-black);
       text-align: center;
     }
 

--- a/pro/src/components/Stepper/Stepper.module.scss
+++ b/pro/src/components/Stepper/Stepper.module.scss
@@ -52,7 +52,7 @@ $number-size: rem.torem(30px);
 
     &.selectionnable {
       .step {
-        color: var(--color-black);
+        color: var(--color-text-default);
 
         .number {
           .inner {

--- a/pro/src/components/Stepper/Stepper.module.scss
+++ b/pro/src/components/Stepper/Stepper.module.scss
@@ -29,7 +29,7 @@ $number-size: rem.torem(30px);
     .step {
       display: flex;
       position: relative;
-      color: var(--color-grey-dark);
+      color: var(--color-text-subtle);
       align-items: center;
     }
 

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
@@ -123,7 +123,7 @@ $offer-image-width: rem.torem(216px);
   &-distance {
     @include fonts.body-accent-xs;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     text-transform: uppercase;
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/VenueCard/VenueCard.module.scss
@@ -77,7 +77,7 @@ $venue-image-width: rem.torem(276px);
   &-distance {
     @include fonts.body-accent-xs;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     text-transform: uppercase;
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/HighlightBanner/HighlightBanner.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/HighlightBanner/HighlightBanner.module.scss
@@ -29,7 +29,6 @@
   &-description {
     @include fonts.body;
 
-    color: var(--color-black);
     margin: rem.torem(8px) 0 rem.torem(16px) 0;
     height: max-content;
   }

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOffer.module.scss
@@ -70,7 +70,7 @@
       &-subtitle {
         @include fonts.body-accent-xs;
 
-        color: var(--color-grey-dark);
+        color: var(--color-text-subtle);
         margin-bottom: rem.torem(8px);
       }
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.module.scss
@@ -78,7 +78,7 @@
       &-text {
         @include fonts.body-accent-xs;
 
-        color: var(--color-grey-dark);
+        color: var(--color-text-subtle);
         display: flex;
         align-items: center;
         margin-top: rem.torem(16px);

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/FiltersTags/FiltersTags.module.scss
@@ -15,6 +15,7 @@
   @include fonts.body-accent-xs;
 
   background-color: var(--color-background-info);
+  color: var(--color-text-default);
   border: none;
   padding: rem.torem(8px) rem.torem(12px);
   border-radius: rem.torem(20px);

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/AdageButtonFilter/AdageButtonFilter.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/AdageButtonFilter/AdageButtonFilter.module.scss
@@ -40,7 +40,7 @@
   &:disabled {
     cursor: not-allowed;
     border: none;
-    color: var(--color-grey-dark);
+    color: var(--color-text-disabled);
     background-color: var(--color-background-disabled);
   }
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/AdageButtonFilter/AdageButtonFilter.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/AdageButtonFilter/AdageButtonFilter.module.scss
@@ -17,6 +17,7 @@
   height: rem.torem(40px);
   white-space: nowrap;
   cursor: pointer;
+  color: var(--color-text-default);
 
   &-is-active {
     @include fonts.button;

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/ModalFilterLayout/ModalFilterLayout.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/ModalFilterLayout/ModalFilterLayout.module.scss
@@ -3,6 +3,7 @@
 .modal-content {
   padding: rem.torem(24px);
   min-width: rem.torem(416px);
+  color: var(--color-text-default);
 
   &-title {
     color: var(--color-grey-dark);

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/ModalFilterLayout/ModalFilterLayout.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/ModalFilterLayout/ModalFilterLayout.module.scss
@@ -6,7 +6,7 @@
   color: var(--color-text-default);
 
   &-title {
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     margin-bottom: rem.torem(24px);
   }
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OfferFilters/OfferFilters.module.scss
@@ -50,7 +50,7 @@
     margin-bottom: rem.torem(24px);
 
     legend {
-      color: var(--color-grey-dark);
+      color: var(--color-text-subtle);
     }
   }
 }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.module.scss
@@ -84,7 +84,7 @@
   }
 
   &:active {
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     text-decoration: none;
     box-shadow: 0 3px 4px 0 var(--color-medium-shadow);
   }

--- a/pro/src/pages/AdageIframe/app/components/ToggleButtonGroup/ToggleButtonGroupButton/ToggleButtonGroupButton.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/ToggleButtonGroup/ToggleButtonGroupButton/ToggleButtonGroupButton.module.scss
@@ -44,7 +44,7 @@
 
   &:disabled {
     cursor: not-allowed;
-    color: var(--color-grey-dark);
+    color: var(--color-text-disabled);
     background-color: var(--color-background-disabled);
   }
 }

--- a/pro/src/pages/Bookings/ChoosePreFiltersMessage/ChoosePreFiltersMessage.module.scss
+++ b/pro/src/pages/Bookings/ChoosePreFiltersMessage/ChoosePreFiltersMessage.module.scss
@@ -15,7 +15,7 @@
 
   &-text {
     white-space: pre-line;
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     max-width: rem.torem(445px);
   }
 }

--- a/pro/src/pages/Bookings/NoBookingsForPreFiltersMessage/NoBookingsForPreFiltersMessage.module.scss
+++ b/pro/src/pages/Bookings/NoBookingsForPreFiltersMessage/NoBookingsForPreFiltersMessage.module.scss
@@ -16,7 +16,7 @@
   }
 
   &-text {
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     margin-bottom: rem.torem(8px);
   }
 }

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/OfferEducationalForm.module.scss
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/OfferEducationalForm.module.scss
@@ -14,7 +14,7 @@
 .educational-form-adress-banner {
   padding: rem.torem(16px);
   background: var(--color-background-subtle);
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   border-radius: rem.torem(8px);
   word-break: break-word;
 }

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/OfferEducationalStock/OfferEducationalStock.module.scss
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/OfferEducationalStock/OfferEducationalStock.module.scss
@@ -7,7 +7,7 @@
   &-example {
     @include fonts.body-xs;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
   }
 }
 

--- a/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.module.scss
+++ b/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.module.scss
@@ -50,7 +50,7 @@
 }
 
 .search-no-results {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   text-align: center;
 
   &-icon {

--- a/pro/src/pages/Desk/BookingDetails.module.scss
+++ b/pro/src/pages/Desk/BookingDetails.module.scss
@@ -13,7 +13,7 @@
 }
 
 .desk-label {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   text-align: right;
 }
 

--- a/pro/src/pages/Desk/BookingDetails.module.scss
+++ b/pro/src/pages/Desk/BookingDetails.module.scss
@@ -18,7 +18,6 @@
 }
 
 .desk-value {
-  color: var(--color-black);
   padding-left: rem.torem(5px);
   text-align: left;
 }

--- a/pro/src/pages/Desk/DeskInputMessage/DeskInputMessage.module.scss
+++ b/pro/src/pages/Desk/DeskInputMessage/DeskInputMessage.module.scss
@@ -6,7 +6,7 @@
   white-space: pre-line;
 
   &-default {
-    color: var(--color-valid);
+    color: var(--color-text-success);
   }
 
   &-error {
@@ -14,6 +14,6 @@
   }
 
   &-success {
-    color: var(--color-valid);
+    color: var(--color-text-success);
   }
 }

--- a/pro/src/pages/Homepage/components/Offerers/components/PartnerPages/components/PartnerPage.module.scss
+++ b/pro/src/pages/Homepage/components/Offerers/components/PartnerPages/components/PartnerPage.module.scss
@@ -26,7 +26,7 @@
   flex-direction: column;
 
   &-type {
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     text-transform: uppercase;
   }
 
@@ -55,7 +55,7 @@
 
 .details-normal {
   margin-right: rem.torem(8px);
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }
 
 .details-description {

--- a/pro/src/pages/Homepage/components/Offerers/components/VenueList/Venue.module.scss
+++ b/pro/src/pages/Homepage/components/Offerers/components/VenueList/Venue.module.scss
@@ -32,6 +32,7 @@
   background: none;
   border: none;
   word-break: break-all;
+  color: var(--color-text-default);
 
   &-button {
     @include fonts.title3;

--- a/pro/src/pages/Homepage/components/StatisticsDashboard/StatisticsDashboard.module.scss
+++ b/pro/src/pages/Homepage/components/StatisticsDashboard/StatisticsDashboard.module.scss
@@ -22,7 +22,7 @@
 }
 
 .no-data {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/pro/src/pages/LostPassword/LostPassword.module.scss
+++ b/pro/src/pages/LostPassword/LostPassword.module.scss
@@ -35,7 +35,7 @@
   .subtitle {
     @include fonts.body-xs;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     margin-bottom: rem.torem(32px);
   }
 

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDmsTimeline/CollectiveDmsTimeline.module.scss
@@ -9,13 +9,13 @@
   &-step-title-passed {
     @include fonts.body-accent;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
   }
 
   &-step-title-disabled {
     @include fonts.body-accent;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-disabled);
   }
 
   &-infobox {

--- a/pro/src/pages/Onboarding/OnboardingOfferIndividual/CardLink/CardLink.module.scss
+++ b/pro/src/pages/Onboarding/OnboardingOfferIndividual/CardLink/CardLink.module.scss
@@ -53,7 +53,7 @@ $cardlink-max-width: rem.torem(565px);
   &-description {
     @include fonts.body-xs;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     margin-top: rem.torem(4px);
   }
 

--- a/pro/src/pages/Reimbursements/Income/Income.module.scss
+++ b/pro/src/pages/Reimbursements/Income/Income.module.scss
@@ -30,7 +30,7 @@
         background: none;
         cursor: pointer;
         padding: rem.torem(10px);
-        color: var(--color-black);
+        color: var(--color-text-default);
         border: solid rem.torem(1px) var(--color-grey-dark);
         border-radius: rem.torem(10px);
 

--- a/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.module.scss
+++ b/pro/src/pages/Reimbursements/ReimbursementsInvoices/InvoiceTable/InvoiceTable.module.scss
@@ -51,7 +51,7 @@
 }
 
 .negative-amount {
-  color: var(--color-error);
+  color: var(--color-text-error);
 }
 
 .download-actions {

--- a/pro/src/pages/VenueEdition/VenueEditionHeader.module.scss
+++ b/pro/src/pages/VenueEdition/VenueEditionHeader.module.scss
@@ -45,7 +45,7 @@
 }
 
 .venue-type {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   text-transform: uppercase;
 }
 

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/StocksProviderForm/StocksProviderForm.module.scss
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/StocksProviderForm/StocksProviderForm.module.scss
@@ -6,7 +6,7 @@
 
 .aide-stock-button {
   margin-top: rem.torem(32px);
-  color: var(--color-black);
+  color: var(--color-text-default);
 }
 
 .account-section {

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/VenueProviderCard.module.scss
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/VenueProviderCard.module.scss
@@ -87,7 +87,7 @@
 .venue-id-at-offer-provider-container {
   display: flex;
   flex-direction: column;
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   margin-top: rem.torem(8px);
   gap: rem.torem(8px);
 }

--- a/pro/src/styles/components/Cells.module.scss
+++ b/pro/src/styles/components/Cells.module.scss
@@ -255,7 +255,7 @@
 }
 
 .button-cancel-booking {
-  color: var(--color-error);
+  color: var(--color-text-error);
 }
 
 .status-filter-label {

--- a/pro/src/styles/components/Cells.module.scss
+++ b/pro/src/styles/components/Cells.module.scss
@@ -120,13 +120,13 @@
 .isbn {
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }
 
 .stocks {
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   display: flex;
   align-items: center;
   position: relative;

--- a/pro/src/styles/components/Cells.module.scss
+++ b/pro/src/styles/components/Cells.module.scss
@@ -208,7 +208,7 @@
   outline: none;
   border: none;
   background-color: var(--color-background-default);
-  color: var(--color-black);
+  color: var(--color-text-default);
   height: rem.torem(32px);
 
   &[data-state="open"] {

--- a/pro/src/styles/components/_CookieModals.scss
+++ b/pro/src/styles/components/_CookieModals.scss
@@ -18,7 +18,7 @@ $action-gap: rem.torem(10px);
 .orejime-Modal {
   background: var(--color-background-default);
   box-shadow: 0 2px 16px var(--color-medium-shadow);
-  color: var(--color-input-text-color);
+  color: var(--color-text-default);
 }
 
 .orejime-Notice-actionItem button,
@@ -55,7 +55,6 @@ $action-gap: rem.torem(10px);
   &-title {
     @include fonts.body-accent;
 
-    color: var(--color-input-text-color);
     line-height: var(--typography-body-line-height);
     margin-bottom: rem.torem(8px);
   }
@@ -67,7 +66,6 @@ $action-gap: rem.torem(10px);
 
   &-description {
     margin-bottom: rem.torem(16px);
-    color: var(--color-black);
 
     @include fonts.body;
   }
@@ -209,10 +207,6 @@ $action-gap: rem.torem(10px);
     &-label {
       margin-bottom: rem.torem(8px);
       display: inline-block;
-
-      & > span {
-        color: var(--color-input-text-color);
-      }
     }
 
     &-purposes {

--- a/pro/src/styles/components/_CookieModals.scss
+++ b/pro/src/styles/components/_CookieModals.scss
@@ -144,7 +144,7 @@ $action-gap: rem.torem(10px);
     &[disabled] {
       background: var(--color-background-disabled);
       border-color: var(--color-grey-light);
-      color: var(--color-grey-dark);
+      color: var(--color-text-disabled);
       border-radius: 30px;
       opacity: 1;
       cursor: default;

--- a/pro/src/styles/global/_layout.scss
+++ b/pro/src/styles/global/_layout.scss
@@ -3,7 +3,7 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 
 body {
-  color: var(--color-black);
+  color: var(--color-text-default);
   background-color: var(--color-background-default);
 }
 

--- a/pro/src/styles/global/_themes.scss
+++ b/pro/src/styles/global/_themes.scss
@@ -24,7 +24,7 @@
   --color-accent: #06f;
   --color-valid: #15884f;
   --color-error-light: #e60039;
-  --color-error: #b60025;
+  --color-error: #a20121;
   --color-accent-light: #b3e7ff;
   --color-alert-dark: #f9c030;
 

--- a/pro/src/styles/mixins/_forms.scss
+++ b/pro/src/styles/mixins/_forms.scss
@@ -36,7 +36,7 @@
   &:disabled {
     cursor: unset;
     background-color: var(--color-background-disabled);
-    color: var(--color-input-text-color-disabled);
+    color: var(--color-text-disabled);
     opacity: 1;
     border-color: var(--color-input-border-color-disabled);
 
@@ -48,7 +48,7 @@
   &::placeholder {
     @include fonts.body-italic;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     opacity: 1;
   }
 
@@ -85,7 +85,7 @@
   }
 
   :disabled + & {
-    color: var(--color-input-text-color-disabled);
+    color: var(--color-text-disabled);
   }
 }
 

--- a/pro/src/styles/mixins/_forms.scss
+++ b/pro/src/styles/mixins/_forms.scss
@@ -15,7 +15,7 @@
   border-radius: rem.torem(forms.$input-border-radius);
   background-color: var(--color-background-default);
   padding: 0 rem.torem(16px);
-  color: var(--color-input-text-color);
+  color: var(--color-text-default);
   box-shadow: 0 0 0 0 var(--color-black);
   transition:
     background 150ms ease,
@@ -55,7 +55,7 @@
   &:-webkit-autofill,
   &:-internal-autofill-selected {
     background-color: var(--color-background-default) !important;
-    color: var(--color-input-text-color) !important;
+    color: var(--color-text-default) !important;
   }
 }
 

--- a/pro/src/ui-kit/BoxFormLayout/BoxFormLayout.module.scss
+++ b/pro/src/ui-kit/BoxFormLayout/BoxFormLayout.module.scss
@@ -6,7 +6,7 @@
 
 .box-form-layout-header-title {
   margin-bottom: rem.torem(8px);
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }
 
 .box-form-layout-fields {
@@ -19,7 +19,7 @@
 }
 
 .box-form-layout-form-header-secondary {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
 }
 
 .box-form-layout-required-message {

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -69,7 +69,7 @@
     &:disabled,
     &.button-disabled {
       background-color: var(--color-background-disabled);
-      color: var(--color-grey-dark);
+      color: var(--color-text-disabled);
       border-color: var(--color-grey-light);
 
       .button-icon {
@@ -102,7 +102,7 @@
     &:disabled,
     &.button-disabled {
       background-color: var(--color-background-disabled);
-      color: var(--color-grey-dark);
+      color: var(--color-text-disabled);
       border-color: var(--color-grey-light);
     }
 
@@ -141,7 +141,7 @@
     &:disabled,
     &.button-disabled {
       text-decoration: none;
-      color: var(--color-grey-dark);
+      color: var(--color-text-disabled);
     }
 
     &:disabled .button-icon,
@@ -200,6 +200,7 @@
     border: rem.torem(1px) solid var(--color-grey-dark);
     border-radius: rem.torem(6px);
     max-width: rem.torem(400px);
+    color: var(--color-text-subtle);
 
     &:hover:not(:disabled, .button-disabled) {
       box-shadow: rem.torem(0) rem.torem(3px) rem.torem(4px)
@@ -210,7 +211,7 @@
     &.button-disabled {
       background: var(--color-background-disabled);
       border-color: var(--color-grey-light);
-      color: var(--color-grey-dark);
+      color: var(--color-text-disabled);
 
       .button-icon {
         color: var(--color-grey-dark);

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -120,7 +120,7 @@
   &-quaternary,
   &-ternary-pink,
   &-quaternary-pink {
-    color: var(--color-black);
+    color: var(--color-text-default);
     align-items: flex-start;
     justify-content: flex-start;
     background-color: transparent;
@@ -167,7 +167,7 @@
 
     margin-top: rem.torem(6px);
     margin-bottom: rem.torem(6px);
-    color: var(--color-black);
+    color: var(--color-text-default);
 
     .button-icon:not(.has-tooltip) {
       height: var(--typography-body-xs-line-height);

--- a/pro/src/ui-kit/ButtonFilter/ButtonFilter.module.scss
+++ b/pro/src/ui-kit/ButtonFilter/ButtonFilter.module.scss
@@ -15,6 +15,7 @@
   border: rem.torem(1px) solid var(--color-grey-dark);
   border-radius: rem.torem(8px);
   max-width: rem.torem(400px);
+  color: var(--color-text-default);
 
   &-icon {
     height: size.$button-icon-size;

--- a/pro/src/ui-kit/Callout/Callout.module.scss
+++ b/pro/src/ui-kit/Callout/Callout.module.scss
@@ -5,7 +5,6 @@
   position: relative;
   display: flex;
   justify-content: left;
-  color: var(--color-black);
   border-radius: rem.torem(8px);
   padding: rem.torem(16px);
 

--- a/pro/src/ui-kit/DropdownMenuWrapper/DropdownMenuWrapper.module.scss
+++ b/pro/src/ui-kit/DropdownMenuWrapper/DropdownMenuWrapper.module.scss
@@ -35,14 +35,14 @@
   @include fonts.button;
 
   display: flex;
-  color: var(--color-black);
+  color: var(--color-text-default);
   padding: 0.5rem;
 
   &[data-highlighted] {
     outline: none;
     border-radius: rem.torem(2px);
     background: var(--color-background-subtle);
-    color: var(--color-black);
+    color: var(--color-text-default);
     cursor: pointer;
   }
 

--- a/pro/src/ui-kit/LinkNodes/LinkNodes.module.scss
+++ b/pro/src/ui-kit/LinkNodes/LinkNodes.module.scss
@@ -2,7 +2,7 @@
 
 .bi-link {
   justify-content: left;
-  color: var(--color-black);
+  color: var(--color-text-default);
 
   &-item {
     display: flex;

--- a/pro/src/ui-kit/MultiSelect/MultiSelect.module.scss
+++ b/pro/src/ui-kit/MultiSelect/MultiSelect.module.scss
@@ -55,7 +55,7 @@
   &:disabled {
     background-color: var(--color-background-disabled);
     border: rem.torem(1px) solid var(--color-input-border-color-disabled);
-    color: var(--color-grey-dark);
+    color: var(--color-text-disabled);
     cursor: auto;
   }
 

--- a/pro/src/ui-kit/MultiSelect/MultiSelect.module.scss
+++ b/pro/src/ui-kit/MultiSelect/MultiSelect.module.scss
@@ -33,13 +33,14 @@
 .legend {
   @include fonts.body;
 
-  color: var(--color-black);
+  color: var(--color-text-default);
   margin-bottom: rem.torem(8px);
 }
 
 .trigger {
   @include fonts.body;
 
+  color: var(--color-text-default);
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/pro/src/ui-kit/SelectedValuesTags/SelectedValuesTags.module.scss
+++ b/pro/src/ui-kit/SelectedValuesTags/SelectedValuesTags.module.scss
@@ -14,13 +14,14 @@
 
   border-radius: rem.torem(4px);
   background-color: var(--color-background-info);
-  color: var(--color-black);
+  color: var(--color-text-default);
   padding: rem.torem(4px) rem.torem(8px);
 }
 
 .tag-button {
   @include fonts.body-accent-xs;
 
+  color: var(--color-text-default);
   display: flex;
   align-items: center;
   cursor: pointer;

--- a/pro/src/ui-kit/Spinner/Spinner.module.scss
+++ b/pro/src/ui-kit/Spinner/Spinner.module.scss
@@ -1,7 +1,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .loading-spinner {
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   text-align: center;
 
   &-icon {

--- a/pro/src/ui-kit/Tag/Tag.module.scss
+++ b/pro/src/ui-kit/Tag/Tag.module.scss
@@ -26,7 +26,7 @@
 
   &.light-grey {
     background-color: var(--color-background-subtle);
-    color: var(--color-black);
+    color: var(--color-text-default);
   }
 
   &.dark-grey {

--- a/pro/src/ui-kit/Toggle/Toggle.module.scss
+++ b/pro/src/ui-kit/Toggle/Toggle.module.scss
@@ -15,6 +15,7 @@
   border: 0;
   padding: 0;
   background-color: transparent;
+  color: var(--color-text-default);
 }
 
 .toggle:active:not([disabled]) {
@@ -75,7 +76,7 @@
 }
 
 .toggle[disabled] {
-  color: var(--color-black);
+  color: var(--color-text-disabled);
   cursor: not-allowed;
 }
 

--- a/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
+++ b/pro/src/ui-kit/form/AdageMultiselect/AdageMultiselect.module.scss
@@ -17,6 +17,7 @@
   overflow-y: scroll;
   padding: rem.torem(8px) 0 0 rem.torem(8px);
   margin-top: rem.torem(18px);
+  color: var(--color-text-default);
 
   li:last-child {
     margin-bottom: rem.torem(20px);

--- a/pro/src/ui-kit/form/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
+++ b/pro/src/ui-kit/form/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
@@ -88,10 +88,4 @@ $text-padding-left: calc(
       fill: var(--color-input-text-color-disabled);
     }
   }
-
-  &-placeholder {
-    @include fonts.body-italic;
-
-    color: var(--color-grey-dark);
-  }
 }

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.module.scss
@@ -59,7 +59,7 @@ $input-phone-number-padding-left: calc(
 .phone-format {
   @include fonts.body-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   margin-bottom: rem.torem(forms.$label-space-before-input);
 }
 

--- a/pro/src/ui-kit/form/Select/Select.module.scss
+++ b/pro/src/ui-kit/form/Select/Select.module.scss
@@ -26,7 +26,7 @@
   &.form-variant {
     @include fonts.body;
 
-    color: var(--color-black);
+    color: var(--color-text-default);
     padding: rem.torem(8px) rem.torem(28px) rem.torem(8px) rem.torem(12px);
     height: rem.torem(42px);
     border-radius: rem.torem(8px);

--- a/pro/src/ui-kit/form/Select/Select.module.scss
+++ b/pro/src/ui-kit/form/Select/Select.module.scss
@@ -43,7 +43,7 @@
 
     &:disabled {
       border: rem.torem(1px) solid var(--color-input-border-color-disabled);
-      color: var(--color-grey-dark);
+      color: var(--color-text-disabled);
       cursor: auto;
     }
   }
@@ -78,6 +78,6 @@
   &-placeholder {
     @include fonts.body-italic;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
   }
 }

--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.module.scss
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.module.scss
@@ -11,7 +11,7 @@
 
 .multi-select-autocomplete-placeholder-input::placeholder {
   &:not(:disabled) {
-    color: var(--color-black);
+    color: var(--color-text-default);
   }
 }
 
@@ -25,7 +25,7 @@
     align-items: center;
     background-color: var(--color-background-subtle);
     border-radius: rem.torem(100px);
-    color: var(--color-black);
+    color: var(--color-text-default);
     cursor: pointer;
     display: flex;
     height: rem.torem(18px);

--- a/pro/src/ui-kit/form/Slider/Slider.module.scss
+++ b/pro/src/ui-kit/form/Slider/Slider.module.scss
@@ -22,7 +22,7 @@
 .min-max-container {
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   display: flex;
   justify-content: space-between;
 }

--- a/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.module.scss
@@ -22,7 +22,7 @@
   &-description {
     @include fonts.body-accent-xs;
 
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     margin-top: rem.torem(4px);
   }
 
@@ -98,7 +98,7 @@
   }
 
   &.is-disabled {
-    color: var(--color-input-text-color-disabled);
+    color: var(--color-text-disabled);
 
     .base-checkbox-label {
       cursor: not-allowed;

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
@@ -15,7 +15,7 @@
     gap: rem.torem(12px);
 
     :disabled + & {
-      color: var(--color-input-text-color-disabled);
+      color: var(--color-text-disabled);
       cursor: default;
     }
 
@@ -33,7 +33,7 @@
     &-description {
       @include fonts.body-xs;
 
-      color: var(--color-grey-dark);
+      color: var(--color-text-subtle);
       margin-top: rem.torem(4px);
     }
   }
@@ -134,7 +134,7 @@
   &.is-disabled {
     border-color: var(--color-input-border-color-disabled);
     background-color: var(--color-background-disabled);
-    color: var(--color-grey-dark);
+    color: var(--color-text-disabled);
 
     &:hover {
       box-shadow: none;

--- a/pro/src/ui-kit/form/shared/FieldError/FieldError.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldError/FieldError.module.scss
@@ -4,7 +4,7 @@
 .field-error {
   @include fonts.body-accent-xs;
 
-  color: var(--color-error);
+  color: var(--color-text-error);
   display: flex;
   text-align: left;
 

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayout.module.scss
@@ -85,7 +85,7 @@
     @include fonts.body-xs;
 
     display: block;
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     margin-top: rem.torem(4px);
   }
 }

--- a/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldLayout/FieldLayoutCharacterCount/FieldLayoutCharacterCount.module.scss
@@ -5,7 +5,7 @@
 .field-layout-character-count {
   @include fonts.body-accent-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   margin-top: rem.torem(8px);
 }
 

--- a/pro/src/ui-kit/form/shared/FieldSuccess/FieldSuccess.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldSuccess/FieldSuccess.module.scss
@@ -5,7 +5,7 @@
 .field-success {
   @include fonts.body-accent-xs;
 
-  color: var(--color-valid);
+  color: var(--color-text-success);
   display: flex;
   text-align: left;
 

--- a/pro/src/ui-kit/formV2/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
+++ b/pro/src/ui-kit/formV2/PhoneNumberInput/CodeCountrySelect/CountryCodeSelect.module.scss
@@ -88,10 +88,4 @@ $text-padding-left: calc(
       fill: var(--color-input-text-color-disabled);
     }
   }
-
-  &-placeholder {
-    @include fonts.body-italic;
-
-    color: var(--color-grey-dark);
-  }
 }

--- a/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.module.scss
+++ b/pro/src/ui-kit/formV2/PhoneNumberInput/PhoneNumberInput.module.scss
@@ -59,7 +59,7 @@ $input-phone-number-padding-left: calc(
 .phone-format {
   @include fonts.body-xs;
 
-  color: var(--color-grey-dark);
+  color: var(--color-text-subtle);
   margin-bottom: rem.torem(forms.$label-space-before-input);
 }
 

--- a/pro/src/ui-kit/formV2/TextInput/TextInput.module.scss
+++ b/pro/src/ui-kit/formV2/TextInput/TextInput.module.scss
@@ -49,7 +49,7 @@
     @include fonts.body-xs;
 
     display: block;
-    color: var(--color-grey-dark);
+    color: var(--color-text-subtle);
     margin-bottom: rem.torem(4px);
   }
 }

--- a/pro/src/ui-kit/formV2/ValidationMessageList/ValidationMessageList.module.scss
+++ b/pro/src/ui-kit/formV2/ValidationMessageList/ValidationMessageList.module.scss
@@ -16,5 +16,5 @@
 }
 
 .field-error-pristine {
-  color: var(--color-grey-semi-dark);
+  color: var(--color-text-subtle);
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35137

**Objectif**
Utiliser les couleurs du DS `color-text-default/subtle/disabled/error/success` là ou c'est applicable.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
