### PR TITLE
(PC-35142)[PRO] fix: Add a container to the adage favorite button too…

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.module.scss
@@ -67,12 +67,16 @@ $offer-image-width: rem.torem(216px);
   }
 }
 
+.offer-favorite-button-container {
+  position: absolute;
+  z-index: 1;
+  top: rem.torem(12px);
+  right: rem.torem(12px);
+}
+
 .offer-favorite-button {
   background-color: var(--color-background-default);
   padding: rem.torem(10px);
-  position: absolute;
-  top: rem.torem(12px);
-  right: rem.torem(12px);
 
   &:hover:not(:disabled),
   &:focus-visible {

--- a/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageDiscovery/OfferCard/OfferCard.tsx
@@ -116,11 +116,13 @@ export const OfferCardComponent = ({
             )}
         </div>
       </Link>
-      <OfferFavoriteButton
-        offer={{ ...offer, isTemplate: true }}
-        className={styles['offer-favorite-button']}
-        viewType={viewType}
-      />
+      <div className={styles['offer-favorite-button-container']}>
+        <OfferFavoriteButton
+          offer={{ ...offer, isTemplate: true }}
+          className={styles['offer-favorite-button']}
+          viewType={viewType}
+        />
+      </div>
     </div>
   )
 }

--- a/pro/src/ui-kit/Tooltip/Tooltip.module.scss
+++ b/pro/src/ui-kit/Tooltip/Tooltip.module.scss
@@ -2,7 +2,7 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
 
-$arrow-triangle-height: rem.torem(8px);
+$arrow-triangle-height: rem.torem(4px);
 
 .tooltip-container {
   display: inline-block;
@@ -20,14 +20,13 @@ $arrow-triangle-height: rem.torem(8px);
       &::after {
         content: "";
         position: absolute;
-        margin-bottom: 4px;
         width: 0;
         height: 0;
         border-width: $arrow-triangle-height;
         border-style: solid;
         border-color: var(--color-secondary-dark) transparent transparent
           transparent;
-        top: -($arrow-triangle-height * 1.6);
+        top: calc(-1.1 * ($arrow-triangle-height + rem.torem(2px)));
         left: 50%;
         transform: translate(-50%);
       }
@@ -38,14 +37,14 @@ $arrow-triangle-height: rem.torem(8px);
     @include fonts.body-accent-xs;
 
     position: absolute;
-    padding-bottom: rem.torem(12px);
+    padding-bottom: calc($arrow-triangle-height + rem.torem(2px));
     top: 0;
 
     &-panel {
       border-radius: rem.torem(3px);
       background-color: var(--color-secondary-dark);
       color: var(--color-white);
-      padding: rem.torem(4px);
+      padding: rem.torem(4px) rem.torem(8px);
       max-width: rem.torem(200px);
       width: max-content;
       text-align: center;


### PR DESCRIPTION
…ltip so that it is position above offer image.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35142

**Objectif**
Corriger l'affichage du bouton de favoris dans les cartes de la découverte ADAGE.

En changeant la structure des Tooltips, j'ai cassé l'affichage de ce bouton. Il est en `position: absolute`, et le wrapper `Tooltip` ajoute désormais une div autour du bouton (qui elle n'est pas en `position: absolute`). J'ai donc mis la position sur un parent du bouton.

**Avant/après**
<img width="240" alt="Capture d’écran 2025-03-13 à 15 36 07" src="https://github.com/user-attachments/assets/41497693-9ce0-4c31-9ade-81120ce2ab19" />
<img width="324" alt="Capture d’écran 2025-03-13 à 15 33 33" src="https://github.com/user-attachments/assets/2254a7b0-397c-45cc-b0d8-cd5eb6e48a2b" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
