### PR TITLE
(BSR)[API] refactor: remove unneeded imports in educational api

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -320,7 +320,7 @@ def create_offer(
     return offer
 
 
-def _get_offerer_address_from_address_body(
+def get_offerer_address_from_address_body(
     address_body: offerers_schemas.AddressBodyModel | None, venue: offerers_models.Venue
 ) -> offerers_models.OffererAddress | None:
     if not address_body:
@@ -344,7 +344,7 @@ def update_offer(
 
     # updated using the pro interface
     if body.address:
-        offerer_address_from_body = _get_offerer_address_from_address_body(address_body=body.address, venue=offer.venue)
+        offerer_address_from_body = get_offerer_address_from_address_body(address_body=body.address, venue=offer.venue)
 
         if offerer_address_from_body is not None:
             fields["offererAddress"] = offerer_address_from_body


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) :

Suite au déplacement de la logique EAC dans educational/api, on peut nettoyer quelques imports non nécessaires

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
