### PR TITLE
(PC-34897)[API] fix: pro: update offers when venue provider is recreated

### DIFF
--- a/api/src/pcapi/routes/pro/venue_providers.py
+++ b/api/src/pcapi/routes/pro/venue_providers.py
@@ -11,6 +11,7 @@ from pcapi.core.providers import api
 from pcapi.core.providers import exceptions
 from pcapi.core.providers import models as providers_models
 from pcapi.core.providers import repository as providers_repository
+from pcapi.core.providers.api import update_venue_synchronized_offers_active_status_job
 from pcapi.core.providers.models import VenueProviderCreationPayload
 from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.apis import private_api
@@ -86,6 +87,15 @@ def create_venue_provider(
                 quantity=body.quantity,
                 venueIdAtOfferProvider=body.venueIdAtOfferProvider,
             ),
+        )
+
+        repository.on_commit(
+            functools.partial(
+                update_venue_synchronized_offers_active_status_job.delay,
+                venue.id,
+                provider.id,
+                new_venue_provider.isActive,
+            )
         )
     except exceptions.NoMatchingAllocineTheater:
         raise ApiErrors(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34897

Sur le portail pro lorsqu'une synchronisation est supprimée puis recréée avec le même partenaire technique, toutes les offres qui étaient synchronisées avec doivent être remises à jour. Ce scénario revient en fait à une mise en pause.
