### PR TITLE
(PC-35177)[BO] fix: exception when refreshing after exception during flush()

### DIFF
--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -773,7 +773,9 @@ def update_venue(venue_id: int) -> utils.BackofficeResponse:
         )
         flash(Markup("Une erreur s'est produite : {message}").format(message=str(err)), "warning")
         mark_transaction_as_invalid()
-        return render_venue_details(venue, form), 400
+        # Redirect because we can't fetch data in the current request:
+        # This Session's transaction has been rolled back due to a previous exception during flush
+        return redirect(url_for(".get", venue_id=venue_id))
     except ApiErrors as api_errors:
         for error_key, error_details in api_errors.errors.items():
             for error_detail in error_details:
@@ -782,7 +784,7 @@ def update_venue(venue_id: int) -> utils.BackofficeResponse:
                     "warning",
                 )
         mark_transaction_as_invalid()
-        return render_venue_details(venue, form), 400
+        return redirect(url_for(".get", venue_id=venue_id))
 
     if not venue_was_permanent and new_permanent and venue.thumbCount == 0:
         transactional_mails.send_permanent_venue_needs_picture(venue)

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -2239,9 +2239,9 @@ class UpdateVenueTest(PostEndpointHelper):
         data = self._get_current_data(venue)
 
         with patch("pcapi.core.offerers.api.update_venue", side_effect=sa.exc.IntegrityError("test", "test", "test")):
-            response = self.post_to_endpoint(authenticated_client, venue_id=venue.id, form=data)
+            response = self.post_to_endpoint(authenticated_client, venue_id=venue.id, form=data, follow_redirects=True)
 
-        assert response.status_code == 400
+        assert response.status_code == 200  # after redirect
         assert (
             "Une erreur s'est produite : (builtins.str) test [SQL: test] [parameters: 'test']"
             in html_parser.extract_alert(response.data)


### PR DESCRIPTION
```
PendingRollbackError: This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback(). Original exception was: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "ix_unique_offerer_address_per_label"
```

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-35177

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
