### PR TITLE
(PC-35067)[API] script: Update venue isOpenToPublic null to false

### DIFF
--- a/api/src/pcapi/scripts/update_null_isopentopublic_to_false/main.sql
+++ b/api/src/pcapi/scripts/update_null_isopentopublic_to_false/main.sql
@@ -1,0 +1,1 @@
+UPDATE venue SET 'isOpenToPublic'=false WHERE 'isOpenToPublic' is NULL;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35067

Script de mise à jour du champ `isOpenToPublic` de `null` à `false`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
