### PR TITLE
(PC-34645)[API] feat: automatically close offerers with USED bookings when legally closed

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1357,16 +1357,17 @@ def field_to_venue_timezone(field: sa_orm.InstrumentedAttribute) -> sa.cast:
     return sa.cast(sa.func.timezone(Venue.timezone, sa.func.timezone("UTC", field)), sa.Date)
 
 
-def offerer_has_ongoing_collective_bookings(offerer_id: int) -> bool:
+def offerer_has_ongoing_collective_bookings(offerer_id: int, include_used: bool = False) -> bool:
+    statuses = [
+        educational_models.CollectiveBookingStatus.CONFIRMED,
+        educational_models.CollectiveBookingStatus.PENDING,
+    ]
+    if include_used:
+        statuses.append(educational_models.CollectiveBookingStatus.USED)
+
     return db.session.query(
         educational_models.CollectiveBooking.query.filter(
             educational_models.CollectiveBooking.offererId == offerer_id,
-            educational_models.CollectiveBooking.status.in_(
-                [
-                    educational_models.CollectiveBookingStatus.CONFIRMED,
-                    educational_models.CollectiveBookingStatus.PENDING,
-                    educational_models.CollectiveBookingStatus.USED,
-                ]
-            ),
+            educational_models.CollectiveBooking.status.in_(statuses),
         ).exists()
     ).scalar()

--- a/api/src/pcapi/core/mails/transactional/pro/offerer_closed.py
+++ b/api/src/pcapi/core/mails/transactional/pro/offerer_closed.py
@@ -2,9 +2,13 @@ import datetime
 from functools import partial
 
 from pcapi.core import mails
+from pcapi.core.bookings import models as bookings_models
+from pcapi.core.categories import subcategories
+from pcapi.core.educational import repository as educational_repository
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offers import models as offers_models
 from pcapi.core.users import repository as users_repository
 from pcapi.repository import on_commit
 from pcapi.utils.date import get_date_formatted_for_email
@@ -13,14 +17,45 @@ from pcapi.utils.date import get_date_formatted_for_email
 def get_offerer_closed_email_data(
     offerer: offerers_models.Offerer, closure_date: datetime.date | None
 ) -> models.TransactionalEmailData:
+    bookings_subcategory_ids = [
+        entities[0]
+        for entities in (
+            bookings_models.Booking.query.filter(
+                bookings_models.Booking.offererId == offerer.id,
+                bookings_models.Booking.status.in_(
+                    [bookings_models.BookingStatus.CONFIRMED, bookings_models.BookingStatus.USED]
+                ),
+            )
+            .join(bookings_models.Booking.stock)
+            .join(offers_models.Stock.offer)
+            .with_entities(offers_models.Offer.subcategoryId)
+            .distinct()
+        ).all()
+    ]
+
+    has_thing_bookings = False
+    has_event_bookings = False
+
+    for subcategory_id in bookings_subcategory_ids:
+        subcategory = subcategories.ALL_SUBCATEGORIES_DICT.get(subcategory_id)
+        if subcategory and subcategory.is_event:
+            has_event_bookings = True
+        else:
+            has_thing_bookings = True
+
+    if not has_event_bookings:
+        has_event_bookings = educational_repository.offerer_has_ongoing_collective_bookings(
+            offerer.id, include_used=True
+        )
+
     return models.TransactionalEmailData(
         template=TransactionalEmail.OFFERER_CLOSED.value,
         params={
             "OFFERER_NAME": offerer.name,
             "SIREN": offerer.siren,
             "END_DATE": get_date_formatted_for_email(closure_date) if closure_date else "",
-            "HAS_THING_BOOKINGS": False,
-            "HAS_EVENT_BOOKINGS": False,
+            "HAS_THING_BOOKINGS": has_thing_bookings,
+            "HAS_EVENT_BOOKINGS": has_event_bookings,
         },
     )
 

--- a/api/tests/core/educational/test_repository.py
+++ b/api/tests/core/educational/test_repository.py
@@ -770,7 +770,6 @@ class OffererHasOngoingCollectiveBookingsTest:
         [
             educational_factories.ConfirmedCollectiveBookingFactory,
             educational_factories.PendingCollectiveBookingFactory,
-            educational_factories.UsedCollectiveBookingFactory,
         ],
     )
     def test_has_bookings(self, app, factory):
@@ -782,10 +781,31 @@ class OffererHasOngoingCollectiveBookingsTest:
         with assert_num_queries(1):
             assert educational_repository.offerer_has_ongoing_collective_bookings(offerer_id=offerer_id) is True
 
+    @pytest.mark.parametrize(
+        "factory",
+        [
+            educational_factories.ConfirmedCollectiveBookingFactory,
+            educational_factories.PendingCollectiveBookingFactory,
+            educational_factories.UsedCollectiveBookingFactory,
+        ],
+    )
+    def test_has_bookings_include_used(self, app, factory):
+        offerer = offerers_factories.OffererFactory()
+        factory(offerer=offerer)
+        educational_factories.ReimbursedCollectiveBookingFactory(offerer=offerer)
+
+        offerer_id = offerer.id
+        with assert_num_queries(1):
+            assert (
+                educational_repository.offerer_has_ongoing_collective_bookings(offerer_id=offerer_id, include_used=True)
+                is True
+            )
+
     def test_has_no_booking(self, app):
         offerer = offerers_factories.OffererFactory()
         educational_factories.ReimbursedCollectiveBookingFactory(offerer=offerer)
         educational_factories.CancelledCollectiveBookingFactory(offerer=offerer)
+        educational_factories.UsedCollectiveBookingFactory(offerer=offerer)
 
         offerer_id = offerer.id
         with assert_num_queries(1):

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -3284,14 +3284,22 @@ def invoice_nc_test_data():
 
 class GenerateInvoicesTest:
     # Mock slow functions that we are not interested in.
+    @pytest.mark.parametrize(
+        "offerer_factory", [offerers_factories.OffererFactory, offerers_factories.ClosedOffererFactory]
+    )
     @mock.patch("pcapi.core.finance.api._generate_invoice_html")
     @mock.patch("pcapi.core.finance.api._store_invoice_pdf")
     @pytest.mark.usefixtures("clean_temp_files")
-    def test_basics(self, _mocked1, _mocked2):
-        stock1 = offers_factories.ThingStockFactory(offer__venue__pricing_point="self")
+    def test_basics(self, _mocked1, _mocked2, offerer_factory):
+        offerer = offerer_factory()
+        stock1 = offers_factories.ThingStockFactory(
+            offer__venue__managingOfferer=offerer, offer__venue__pricing_point="self"
+        )
         finance_event1 = factories.UsedBookingFinanceEventFactory(booking__stock=stock1)
         booking1 = finance_event1.booking
-        stock2 = offers_factories.ThingStockFactory(offer__venue__pricing_point="self")
+        stock2 = offers_factories.ThingStockFactory(
+            offer__venue__managingOfferer=offerer, offer__venue__pricing_point="self"
+        )
         finance_event2 = factories.UsedBookingFinanceEventFactory(booking__stock=stock2)
         booking2 = finance_event2.booking
         for finance_event in (finance_event1, finance_event2):

--- a/api/tests/core/mails/transactional/pro/offerer_closed_test.py
+++ b/api/tests/core/mails/transactional/pro/offerer_closed_test.py
@@ -3,10 +3,14 @@ from datetime import date
 
 import pytest
 
+from pcapi.core.bookings import factories as bookings_factories
+from pcapi.core.categories import subcategories
+from pcapi.core.educational import factories as educational_factories
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.pro import offerer_closed
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
 
 
 @pytest.mark.usefixtures("db_session")
@@ -17,6 +21,10 @@ class SendOffererClosedEmailTest:
         user_offerer_2 = offerers_factories.UserOffererFactory(offerer=offerer)
         offerers_factories.NotValidatedUserOffererFactory(offerer=offerer)
         offerers_factories.RejectedUserOffererFactory(offerer=offerer)
+
+        bookings_factories.CancelledBookingFactory(stock__offer__venue__managingOfferer=offerer)
+        bookings_factories.ReimbursedBookingFactory(stock__offer__venue__managingOfferer=offerer)
+        educational_factories.ReimbursedCollectiveBookingFactory(offerer=offerer)
 
         offerer_closed.send_offerer_closed_email_to_pro(offerer, date(2025, 3, 7))
 
@@ -31,3 +39,78 @@ class SendOffererClosedEmailTest:
                 "HAS_THING_BOOKINGS": False,
                 "HAS_EVENT_BOOKINGS": False,
             }
+
+    @pytest.mark.parametrize(
+        "booking_factory", [bookings_factories.BookingFactory, bookings_factories.UsedBookingFactory]
+    )
+    def test_send_mail_with_thing_booking(self, booking_factory):
+        offerer = offerers_factories.OffererFactory()
+        user_offerer = offerers_factories.UserOffererFactory(offerer=offerer)
+
+        booking_factory(
+            stock=offers_factories.ThingStockFactory(
+                offer__venue__managingOfferer=offerer, offer__subcategoryId=subcategories.LIVRE_PAPIER.id
+            )
+        )
+
+        offerer_closed.send_offerer_closed_email_to_pro(offerer, date(2025, 3, 17))
+
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0]["To"] == user_offerer.user.email
+        assert mails_testing.outbox[0]["template"] == asdict(TransactionalEmail.OFFERER_CLOSED.value)
+        assert mails_testing.outbox[0]["params"] == {
+            "OFFERER_NAME": offerer.name,
+            "SIREN": offerer.siren,
+            "END_DATE": "lundi 17 mars 2025",
+            "HAS_THING_BOOKINGS": True,
+            "HAS_EVENT_BOOKINGS": False,
+        }
+
+    @pytest.mark.parametrize(
+        "booking_factory", [bookings_factories.BookingFactory, bookings_factories.UsedBookingFactory]
+    )
+    def test_send_mail_with_event_booking(self, booking_factory):
+        offerer = offerers_factories.OffererFactory()
+        user_offerer = offerers_factories.UserOffererFactory(offerer=offerer)
+
+        booking_factory(
+            stock=offers_factories.EventStockFactory(
+                offer__venue__managingOfferer=offerer, offer__subcategoryId=subcategories.FESTIVAL_MUSIQUE.id
+            )
+        )
+
+        offerer_closed.send_offerer_closed_email_to_pro(offerer, date(2025, 3, 17))
+
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0]["To"] == user_offerer.user.email
+        assert mails_testing.outbox[0]["template"] == asdict(TransactionalEmail.OFFERER_CLOSED.value)
+        assert mails_testing.outbox[0]["params"] == {
+            "OFFERER_NAME": offerer.name,
+            "SIREN": offerer.siren,
+            "END_DATE": "lundi 17 mars 2025",
+            "HAS_THING_BOOKINGS": False,
+            "HAS_EVENT_BOOKINGS": True,
+        }
+
+    @pytest.mark.parametrize(
+        "booking_factory",
+        [educational_factories.PendingCollectiveBookingFactory, educational_factories.UsedCollectiveBookingFactory],
+    )
+    def test_send_mail_with_collective_booking(self, booking_factory):
+        offerer = offerers_factories.OffererFactory()
+        user_offerer = offerers_factories.UserOffererFactory(offerer=offerer)
+
+        booking_factory(offerer=offerer)
+
+        offerer_closed.send_offerer_closed_email_to_pro(offerer, date(2025, 3, 17))
+
+        assert len(mails_testing.outbox) == 1
+        assert mails_testing.outbox[0]["To"] == user_offerer.user.email
+        assert mails_testing.outbox[0]["template"] == asdict(TransactionalEmail.OFFERER_CLOSED.value)
+        assert mails_testing.outbox[0]["params"] == {
+            "OFFERER_NAME": offerer.name,
+            "SIREN": offerer.siren,
+            "END_DATE": "lundi 17 mars 2025",
+            "HAS_THING_BOOKINGS": False,
+            "HAS_EVENT_BOOKINGS": True,
+        }


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-34645

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
