### PR TITLE
(PC-35118)[API] fix: if EAN is shared, return the most recent offer

### DIFF
--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -6,7 +6,6 @@ from flask_login import login_required
 import sqlalchemy as sqla
 from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import load_only
-import sqlalchemy.orm.exc as sa_exceptions
 
 from pcapi.core.categories import pro_categories
 from pcapi.core.categories import subcategories
@@ -648,7 +647,7 @@ def get_active_venue_offer_by_ean(venue_id: int, ean: str) -> offers_serialize.G
         venue = offerers_repository.get_venue_by_id(venue_id)
         rest.check_user_has_access_to_offerer(current_user, venue.managingOffererId)
         offer = offers_repository.get_active_offer_by_venue_id_and_ean(venue_id, ean)
-    except sa_exceptions.NoResultFound:
+    except exceptions.OfferNotFound:
         raise api_errors.ApiErrors(
             errors={
                 "global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"],


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35118

**Bug**
La route `GET /offers/<int:venue_id>/ean/<string:ean>` du portail pro renvoie une erreur lorsqu'on cherche à savoir si une offre active avec un EAN existe déjà ou non : la fonction chargée de la recherche part du principe que pour un lieu donné, chaque EAN (au niveau des offres) est unique, ce qui n'est pas le cas dans la pratique.

**Fix**
Si plusieurs offres actives sont trouvées, alors on enregistre un log avec l'EAN et l'identifiant du lieu et la plus récente est renvoyée. Ceci est tout à fait acceptable puisque l'intérêt principal de cette route est de savoir si un lieu a déjà une offre avec cet EAN, on ne cherche pas à identifier une offre spécifiquement.
