### PR TITLE
Pc 35172 form calendar 1 day

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.spec.tsx
@@ -1,13 +1,35 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
 import { StocksCalendar } from './StocksCalendar'
 
+function renderStocksCalendar() {
+  renderWithProviders(<StocksCalendar offer={getIndividualOfferFactory()} />)
+}
+
 describe('StocksCalendar', () => {
   it('should display a button to add calendar infos', () => {
-    render(<StocksCalendar />)
+    renderStocksCalendar()
 
     expect(
       screen.getByRole('button', { name: 'Définir le calendrier' })
+    ).toBeInTheDocument()
+  })
+
+  it('should open the recurrence form when clicking on the button', async () => {
+    renderStocksCalendar()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Définir le calendrier' })
+    )
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Définir le calendrier de votre offre',
+      })
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.tsx
@@ -1,11 +1,22 @@
+import { useState } from 'react'
+
+import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
 import fullMoreIcon from 'icons/full-more.svg'
 import strokeAddCalendarIcon from 'icons/stroke-add-calendar.svg'
 import { Button } from 'ui-kit/Button/Button'
+import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './StocksCalendar.module.scss'
+import { StocksCalendarForm } from './StocksCalendarForm/StocksCalendarForm'
 
-export function StocksCalendar() {
+export function StocksCalendar({
+  offer,
+}: {
+  offer: GetIndividualOfferWithAddressResponseModel
+}) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
   return (
     <div className={styles['container']}>
       <h2 className={styles['title']}>Calendrier</h2>
@@ -17,9 +28,24 @@ export function StocksCalendar() {
             src={strokeAddCalendarIcon}
           />
         </div>
-        <Button className={styles['button']} icon={fullMoreIcon}>
-          Définir le calendrier
-        </Button>
+        <DialogBuilder
+          trigger={
+            <Button className={styles['button']} icon={fullMoreIcon}>
+              Définir le calendrier
+            </Button>
+          }
+          open={isDialogOpen}
+          onOpenChange={setIsDialogOpen}
+          variant="drawer"
+          title="Définir le calendrier de votre offre"
+        >
+          <StocksCalendarForm
+            offer={offer}
+            onAfterValidate={() => {
+              setIsDialogOpen(false)
+            }}
+          />
+        </DialogBuilder>
       </div>
     </div>
   )

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarForm.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarForm.module.scss
@@ -1,0 +1,23 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.form {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+
+  &-content {
+    flex-grow: 1;
+    margin-top: rem.torem(16px);
+  }
+}
+
+.duration-type-group {
+  margin-bottom: rem.torem(24px);
+}
+
+.title {
+  @include fonts.title4;
+
+  margin-bottom: rem.torem(8px);
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarForm.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarForm.spec.tsx
@@ -1,0 +1,132 @@
+import * as Dialog from '@radix-ui/react-dialog'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { addDays } from 'date-fns'
+
+import { api } from 'apiClient/api'
+import * as useNotification from 'commons/hooks/useNotification'
+import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
+
+import {
+  StocksCalendarForm,
+  StocksCalendarFormProps,
+} from './StocksCalendarForm'
+
+vi.mock('apiClient/api', () => ({
+  api: {
+    upsertStocks: vi.fn(),
+  },
+}))
+
+function renderStocksCalendarForm(props: StocksCalendarFormProps) {
+  return renderWithProviders(
+    <Dialog.Root defaultOpen>
+      <StocksCalendarForm {...props} />
+    </Dialog.Root>
+  )
+}
+
+describe('StocksCalendarForm', () => {
+  const notifyError = vi.fn()
+  const notifySuccess = vi.fn()
+
+  beforeEach(async () => {
+    const notifsImport = (await vi.importActual(
+      'commons/hooks/useNotification'
+    )) as ReturnType<typeof useNotification.useNotification>
+    vi.spyOn(useNotification, 'useNotification').mockImplementation(() => ({
+      ...notifsImport,
+      error: notifyError,
+      success: notifySuccess,
+    }))
+  })
+
+  it('should sumbit the form when clicking on "Valider" and close the dialog', async () => {
+    const afterValidate = vi.fn()
+    const upsertStocksSpy = vi
+      .spyOn(api, 'upsertStocks')
+      .mockResolvedValueOnce({ stocks_count: 0 })
+
+    renderStocksCalendarForm({
+      offer: getIndividualOfferFactory({
+        priceCategories: [{ id: 1, price: 10, label: 'Price category' }],
+      }),
+      onAfterValidate: afterValidate,
+    })
+
+    await userEvent.type(
+      screen.getByLabelText('Date *'),
+      addDays(new Date(), 1).toISOString().split('T')[0]
+    )
+
+    await userEvent.type(screen.getByLabelText('Horaire 1 *'), '11:11')
+
+    await userEvent.selectOptions(screen.getByLabelText('Tarif *'), '1')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Valider' }))
+
+    expect(upsertStocksSpy).toHaveBeenCalled()
+    expect(notifySuccess).toHaveBeenCalled()
+    expect(afterValidate).toHaveBeenCalled()
+  })
+
+  it('should show an error messages if the stocks cound not be created', async () => {
+    const afterValidate = vi.fn()
+    const upsertStocksSpy = vi
+      .spyOn(api, 'upsertStocks')
+      .mockRejectedValueOnce(null)
+
+    renderStocksCalendarForm({
+      offer: getIndividualOfferFactory({
+        priceCategories: [{ id: 1, price: 10, label: 'Price category' }],
+      }),
+      onAfterValidate: afterValidate,
+    })
+
+    await userEvent.type(
+      screen.getByLabelText('Date *'),
+      addDays(new Date(), 1).toISOString().split('T')[0]
+    )
+
+    await userEvent.type(screen.getByLabelText('Horaire 1 *'), '11:11')
+
+    await userEvent.selectOptions(screen.getByLabelText('Tarif *'), '1')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Valider' }))
+
+    expect(upsertStocksSpy).toHaveBeenCalled()
+    expect(notifySuccess).not.toHaveBeenCalled()
+    expect(notifyError).toHaveBeenCalled()
+    expect(afterValidate).toHaveBeenCalled()
+  })
+
+  it('should not display the the one day form until a specific day has been chosen', async () => {
+    renderStocksCalendarForm({
+      offer: getIndividualOfferFactory(),
+      onAfterValidate: () => {},
+    })
+
+    expect(screen.queryByLabelText('Horaire 1 *')).not.toBeInTheDocument()
+
+    await userEvent.type(
+      screen.getByLabelText('Date *'),
+      addDays(new Date(), 1).toISOString().split('T')[0]
+    )
+
+    expect(screen.getByLabelText('Horaire 1 *')).toBeInTheDocument()
+  })
+
+  it('should not display the the one day form if multiple the option days/weeks is chosen', async () => {
+    renderStocksCalendarForm({
+      offer: getIndividualOfferFactory(),
+      onAfterValidate: () => {},
+    })
+
+    expect(screen.getByLabelText('Date *')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByLabelText(/Plusieurs jours, semaines/))
+
+    expect(screen.queryByLabelText('Date *')).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarForm.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarForm.tsx
@@ -1,0 +1,123 @@
+import { yupResolver } from '@hookform/resolvers/yup'
+import { FormProvider, useForm } from 'react-hook-form'
+
+import { api } from 'apiClient/api'
+import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import { useNotification } from 'commons/hooks/useNotification'
+import { MandatoryInfo } from 'components/FormLayout/FormLayoutMandatoryInfo'
+import { getDepartmentCode } from 'components/IndividualOffer/utils/getDepartmentCode'
+import { ScrollToFirstHookFormErrorAfterSubmit } from 'components/ScrollToFirstErrorAfterSubmit/ScrollToFirstErrorAfterSubmit'
+import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
+import { RadioVariant } from 'ui-kit/form/shared/BaseRadio/BaseRadio'
+import { RadioGroup } from 'ui-kit/formV2/RadioGroup/RadioGroup'
+
+import {
+  DurationTypeOption,
+  StocksCalendarFormValues,
+  TimeSlotTypeOption,
+} from '../../form/types'
+import { validationSchema } from '../../form/validationSchema'
+import { getStocksForOneDay } from '../utils'
+
+import styles from './StocksCalendarForm.module.scss'
+import { StocksCalendarFormFooter } from './StocksCalendarFormFooter/StocksCalendarFormFooter'
+import { StocksCalendarFormOneDay } from './StocksCalendarFormOneDay/StocksCalendarFormOneDay'
+
+export type StocksCalendarFormProps = {
+  offer: GetIndividualOfferWithAddressResponseModel
+  onAfterValidate: () => void
+}
+
+export function StocksCalendarForm({
+  offer,
+  onAfterValidate,
+}: StocksCalendarFormProps) {
+  const notify = useNotification()
+  const form = useForm<StocksCalendarFormValues>({
+    defaultValues: {
+      durationType: DurationTypeOption.ONE_DAY,
+      timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
+      specificTimeSlots: [{ slot: '' }],
+      pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+      oneDayDate: '',
+    },
+    mode: 'onSubmit',
+    resolver: yupResolver(validationSchema),
+  })
+
+  const onSubmit = async () => {
+    const departmentCode = getDepartmentCode(offer)
+
+    const stocks = getStocksForOneDay(form.getValues(), departmentCode)
+
+    try {
+      const { stocks_count } = await api.upsertStocks({
+        offerId: offer.id,
+        stocks: stocks,
+      })
+      notify.success(
+        stocks_count > 1
+          ? `${new Intl.NumberFormat('fr-FR').format(
+              stocks_count
+            )} nouvelles dates ont été ajoutées`
+          : `${stocks_count} nouvelle date a été ajoutée`
+      )
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (e) {
+      notify.error(
+        'Une erreur est survenue lors de l’enregistrement de vos stocks.'
+      )
+    }
+
+    onAfterValidate()
+  }
+
+  return (
+    <FormProvider {...form}>
+      <form className={styles['form']} onSubmit={form.handleSubmit(onSubmit)}>
+        <ScrollToFirstHookFormErrorAfterSubmit />
+        <div className={styles['form-content']}>
+          <MandatoryInfo />
+          <RadioGroup
+            name="durationType"
+            variant={RadioVariant.BOX}
+            displayMode="inline-grow"
+            checkedOption={form.watch('durationType')}
+            className={styles['duration-type-group']}
+            onChange={(e) =>
+              form.setValue(
+                'durationType',
+                e.target.value as DurationTypeOption
+              )
+            }
+            group={[
+              {
+                label: '1 jour',
+                value: DurationTypeOption.ONE_DAY,
+                description:
+                  'Planifiez un événement sur une journée entière ou une partie.',
+              },
+              {
+                label: 'Plusieurs jours, semaines',
+                value: DurationTypeOption.MULTIPLE_DAYS_WEEKS,
+                description:
+                  'Planifier un événement sur plusieurs jours, semaines ou mois.',
+              },
+            ]}
+            legend={
+              <h2 className={styles['title']}>
+                Votre évènement se déroule sur :
+              </h2>
+            }
+          />
+          {form.watch('durationType') === DurationTypeOption.ONE_DAY && (
+            <StocksCalendarFormOneDay form={form} offer={offer} />
+          )}
+        </div>
+        <DialogBuilder.Footer>
+          <StocksCalendarFormFooter />
+        </DialogBuilder.Footer>
+      </form>
+    </FormProvider>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormFooter/StocksCalendarFormFooter.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormFooter/StocksCalendarFormFooter.module.scss
@@ -1,0 +1,7 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.footer-container {
+  display: flex;
+  align-items: center;
+  gap: rem.torem(24px);
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormFooter/StocksCalendarFormFooter.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormFooter/StocksCalendarFormFooter.tsx
@@ -1,0 +1,17 @@
+import * as Dialog from '@radix-ui/react-dialog'
+
+import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant } from 'ui-kit/Button/types'
+
+import styles from './StocksCalendarFormFooter.module.scss'
+
+export function StocksCalendarFormFooter() {
+  return (
+    <div className={styles['footer-container']}>
+      <Dialog.Close asChild>
+        <Button variant={ButtonVariant.SECONDARY}>Annuler</Button>
+      </Dialog.Close>
+      <Button type="submit">Valider</Button>
+    </div>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormOneDay/StocksCalendarFormOneDay.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormOneDay/StocksCalendarFormOneDay.module.scss
@@ -1,0 +1,25 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.date-field-layout {
+  max-width: rem.torem(180px);
+}
+
+.time-slot-type-group {
+  margin-top: rem.torem(32px);
+}
+
+.time-slots {
+  margin-top: rem.torem(24px);
+}
+
+.pricing-categories,
+.limit-dates {
+  margin: rem.torem(32px) 0;
+}
+
+.title {
+  @include fonts.title4;
+
+  margin-bottom: rem.torem(8px);
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormOneDay/StocksCalendarFormOneDay.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormOneDay/StocksCalendarFormOneDay.spec.tsx
@@ -1,0 +1,77 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { addDays } from 'date-fns'
+import { FormProvider, useForm } from 'react-hook-form'
+
+import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
+import {
+  DurationTypeOption,
+  StocksCalendarFormValues,
+  TimeSlotTypeOption,
+} from 'components/IndividualOffer/StocksEventCreation/form/types'
+
+import { StocksCalendarFormOneDay } from './StocksCalendarFormOneDay'
+
+function renderStocksCalendarFormOneDay(
+  defaultOptions?: Partial<StocksCalendarFormValues>
+) {
+  function StocksCalendarFormOneDayWrapper() {
+    const form = useForm<StocksCalendarFormValues>({
+      defaultValues: {
+        durationType: DurationTypeOption.ONE_DAY,
+        timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
+        specificTimeSlots: [{ slot: '' }],
+        pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+        oneDayDate: '',
+        ...defaultOptions,
+      },
+    })
+
+    return (
+      <FormProvider {...form}>
+        <StocksCalendarFormOneDay
+          form={form}
+          offer={getIndividualOfferFactory()}
+        />
+      </FormProvider>
+    )
+  }
+
+  return renderWithProviders(<StocksCalendarFormOneDayWrapper />)
+}
+
+describe('StocksCalendarFormOneDay', () => {
+  it('should show the time slots form when the specific time option is chosen', async () => {
+    renderStocksCalendarFormOneDay({
+      oneDayDate: addDays(new Date(), 1).toISOString().split('T')[0],
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'Ajouter un horaire' })
+    ).toBeInTheDocument()
+
+    await userEvent.click(screen.getByLabelText(/Aux horaires d’ouverture/))
+
+    expect(
+      screen.queryByRole('button', { name: 'Ajouter un horaire' })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not display the form if the date is invalid', async () => {
+    renderStocksCalendarFormOneDay()
+
+    expect(
+      screen.queryByRole('heading', { name: 'Le public doit se présenter :' })
+    ).not.toBeInTheDocument()
+
+    await userEvent.type(
+      screen.getByLabelText('Date *'),
+      addDays(new Date(), 1).toISOString().split('T')[0]
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Le public doit se présenter :' })
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormOneDay/StocksCalendarFormOneDay.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormOneDay/StocksCalendarFormOneDay.tsx
@@ -1,0 +1,94 @@
+import { isValid } from 'date-fns'
+import { UseFormReturn } from 'react-hook-form'
+
+import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import {
+  StocksCalendarFormValues,
+  TimeSlotTypeOption,
+} from 'components/IndividualOffer/StocksEventCreation/form/types'
+import { RadioVariant } from 'ui-kit/form/shared/BaseRadio/BaseRadio'
+import { DatePicker } from 'ui-kit/formV2/DatePicker/DatePicker'
+import { RadioGroup } from 'ui-kit/formV2/RadioGroup/RadioGroup'
+
+import { StocksCalendarFormSpecificTimeSlots } from '../StocksCalendarFormSpecificTimeSlots/StocksCalendarFormSpecificTimeSlots'
+import { StocksCalendarLimitDates } from '../StocksCalendarLimitDates/StocksCalendarLimitDates'
+import { StocksCalendarPriceCategories } from '../StocksCalendarPriceCategories/StocksCalendarPriceCategories'
+
+import styles from './StocksCalendarFormOneDay.module.scss'
+
+export function StocksCalendarFormOneDay({
+  form,
+  offer,
+}: {
+  form: UseFormReturn<StocksCalendarFormValues>
+  offer: GetIndividualOfferWithAddressResponseModel
+}) {
+  const date = form.watch('oneDayDate') || ''
+
+  const isValidDate = isValid(new Date(date))
+
+  return (
+    <div className={styles['container']}>
+      <DatePicker
+        className={styles['date-field-layout']}
+        label="Date"
+        required
+        minDate={new Date()}
+        error={form.formState.errors.oneDayDate?.message}
+        {...form.register('oneDayDate')}
+      />
+
+      {isValidDate && (
+        <>
+          <RadioGroup
+            name="timeSlotType"
+            legend={
+              <h2 className={styles['title']}>Le public doit se présenter :</h2>
+            }
+            variant={RadioVariant.BOX}
+            className={styles['time-slot-type-group']}
+            displayMode="inline-grow"
+            checkedOption={form.watch('timeSlotType')}
+            onChange={(e) =>
+              form.setValue(
+                'timeSlotType',
+                e.target.value as TimeSlotTypeOption
+              )
+            }
+            group={[
+              {
+                label: 'À un horaire précis',
+                value: TimeSlotTypeOption.SPECIFIC_TIME,
+                description:
+                  'Le jeune doit réserver et se présenter sur un des horaires précis que vous avez défini.',
+              },
+              {
+                label: 'Aux horaires d’ouverture',
+                value: TimeSlotTypeOption.OPENING_HOURS,
+                description:
+                  'Le jeune se présente à n’importe quel moment sur les horaires d’ouverture que vous avez défini.',
+              },
+            ]}
+          />
+          <div className={styles['time-slots']}>
+            {form.watch('timeSlotType') ===
+              TimeSlotTypeOption.SPECIFIC_TIME && (
+              <StocksCalendarFormSpecificTimeSlots form={form} />
+            )}
+          </div>
+
+          <div className={styles['pricing-categories']}>
+            <StocksCalendarPriceCategories
+              form={form}
+              priceCategories={offer.priceCategories}
+            />
+          </div>
+
+          <div className={styles['limit-dates']}>
+            <StocksCalendarLimitDates form={form} />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormSpecificTimeSlots/StocksCalendarFormSpecificTimeSlots.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormSpecificTimeSlots/StocksCalendarFormSpecificTimeSlots.module.scss
@@ -1,0 +1,52 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_outline.scss" as outline;
+
+.time-slots {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: rem.torem(16px);
+}
+
+.time-slot {
+  position: relative;
+  width: rem.torem(100px);
+
+  &-picker {
+    min-width: rem.torem(110px);
+  }
+
+  &-clear {
+    position: absolute;
+    z-index: 1;
+    top: calc(var(--typography-body-line-height) / 2 + rem.torem(8px));
+    right: calc(-1 * rem.torem(10px));
+
+    &-button {
+      background-color: var(--color-background-default);
+      border-radius: 100%;
+      padding: rem.torem(1px);
+      color: var(--color-grey-semi-dark);
+      border: none;
+      cursor: pointer;
+      display: flex;
+
+      &:focus-visible {
+        @include outline.focus-outline;
+      }
+
+      &-icon {
+        width: rem.torem(20px);
+        height: rem.torem(20px);
+      }
+    }
+  }
+}
+
+.info {
+  margin: rem.torem(24px) 0;
+}
+
+.add-time-slot {
+  margin-top: rem.torem(24px);
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormSpecificTimeSlots/StocksCalendarFormSpecificTimeSlots.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormSpecificTimeSlots/StocksCalendarFormSpecificTimeSlots.spec.tsx
@@ -1,0 +1,82 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormProvider, useForm } from 'react-hook-form'
+
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
+import {
+  DurationTypeOption,
+  StocksCalendarFormValues,
+  TimeSlotTypeOption,
+} from 'components/IndividualOffer/StocksEventCreation/form/types'
+
+import { StocksCalendarFormSpecificTimeSlots } from './StocksCalendarFormSpecificTimeSlots'
+
+function renderStocksCalendarFormSpecificTimeSlots(
+  defaultOptions?: Partial<StocksCalendarFormValues>
+) {
+  function StocksCalendarFormSpecificTimeSlotsWrapper() {
+    const form = useForm<StocksCalendarFormValues>({
+      defaultValues: {
+        durationType: DurationTypeOption.ONE_DAY,
+        timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
+        specificTimeSlots: [{ slot: '' }],
+        pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+        oneDayDate: '',
+        ...defaultOptions,
+      },
+    })
+
+    return (
+      <FormProvider {...form}>
+        <StocksCalendarFormSpecificTimeSlots form={form} />
+      </FormProvider>
+    )
+  }
+
+  return renderWithProviders(<StocksCalendarFormSpecificTimeSlotsWrapper />)
+}
+
+describe('StocksCalendarFormSpecificTimeSlots', () => {
+  it('should display a time input for each time slot in the form', () => {
+    renderStocksCalendarFormSpecificTimeSlots({
+      specificTimeSlots: [
+        { slot: '00:00' },
+        { slot: '01:00' },
+        { slot: '02:00' },
+      ],
+    })
+    expect(screen.getAllByLabelText(/Horaire/)).toHaveLength(3)
+  })
+
+  it('should let the user remove a time slot only when there are multiple time slots', async () => {
+    renderStocksCalendarFormSpecificTimeSlots({
+      specificTimeSlots: [{ slot: '00:00' }],
+    })
+
+    expect(
+      screen.queryByRole('button', { name: /Supprimer l'horaire/ })
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Ajouter un horaire' })
+    )
+
+    expect(
+      screen.getAllByRole('button', { name: /Supprimer l'horaire/ })
+    ).toHaveLength(2)
+  })
+
+  it('should be able to remove a time slot if there are more than one', async () => {
+    renderStocksCalendarFormSpecificTimeSlots({
+      specificTimeSlots: [{ slot: '00:00' }, { slot: '01:00' }],
+    })
+
+    expect(screen.getAllByLabelText(/Horaire/)).toHaveLength(2)
+
+    await userEvent.click(
+      screen.getAllByRole('button', { name: /Supprimer l'horaire/ })[0]
+    )
+
+    expect(screen.getAllByLabelText(/Horaire/)).toHaveLength(1)
+  })
+})

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormSpecificTimeSlots/StocksCalendarFormSpecificTimeSlots.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormSpecificTimeSlots/StocksCalendarFormSpecificTimeSlots.tsx
@@ -1,0 +1,93 @@
+import { useFieldArray, UseFormReturn } from 'react-hook-form'
+
+import { StocksCalendarFormValues } from 'components/IndividualOffer/StocksEventCreation/form/types'
+import fullClearIcon from 'icons/full-clear.svg'
+import fullMoreIcon from 'icons/full-more.svg'
+import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant } from 'ui-kit/Button/types'
+import { TimePicker } from 'ui-kit/formV2/TimePicker/TimePicker'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+import { Tooltip } from 'ui-kit/Tooltip/Tooltip'
+
+import styles from './StocksCalendarFormSpecificTimeSlots.module.scss'
+
+export function StocksCalendarFormSpecificTimeSlots({
+  form,
+}: {
+  form: UseFormReturn<StocksCalendarFormValues>
+}) {
+  const { fields, remove, append } = useFieldArray({
+    name: 'specificTimeSlots',
+  })
+
+  return (
+    <>
+      <div className={styles['time-slots']}>
+        {fields.map((timeSlot, index) => (
+          <div className={styles['time-slot']} key={timeSlot.id}>
+            <TimePicker
+              required
+              label={`Horaire ${index + 1}`}
+              className={styles['time-slot-picker']}
+              error={
+                form.formState.errors.specificTimeSlots?.[index]?.slot?.message
+              }
+              {...form.register(`specificTimeSlots.${index}.slot`)}
+            />
+            {fields.length > 1 && (
+              <div className={styles['time-slot-clear']}>
+                <Tooltip content={`Supprimer l'horaire ${index + 1}`}>
+                  <button
+                    type="button"
+                    className={styles['time-slot-clear-button']}
+                    onClick={() => {
+                      remove(index)
+
+                      const nextInput = `specificTimeSlots.${index}.slot`
+                      const previousInput = `specificTimeSlots.${index - 1}.slot`
+
+                      //    Focus on the next input if it exists, otherwise focus on the previous input
+                      setTimeout(() => {
+                        ;(
+                          document.querySelector<HTMLInputElement>(
+                            `[name="${nextInput}"]`
+                          ) ||
+                          document.querySelector<HTMLInputElement>(
+                            `[name="${previousInput}"]`
+                          )
+                        )?.focus()
+                      })
+                    }}
+                  >
+                    <SvgIcon
+                      alt={`Supprimer l'horaire ${index + 1}`}
+                      src={fullClearIcon}
+                      className={styles['time-slot-clear-button-icon']}
+                    ></SvgIcon>
+                  </button>
+                </Tooltip>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <div className={styles['add-time-slot']}>
+        <Button
+          variant={ButtonVariant.TERNARY}
+          icon={fullMoreIcon}
+          onClick={() => {
+            append({ slot: '' })
+            const inputToFocus = `specificTimeSlots.${fields.length}.slot`
+
+            // The input we want to focus has not been rendered first
+            setTimeout(() => {
+              document.getElementById(inputToFocus)?.focus()
+            }, 0)
+          }}
+        >
+          Ajouter un horaire
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarLimitDates/StocksCalendarLimitDates.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarLimitDates/StocksCalendarLimitDates.module.scss
@@ -1,0 +1,24 @@
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_rem.scss" as rem;
+
+.legend {
+  @include fonts.title4;
+
+  margin-bottom: rem.torem(16px);
+}
+
+.booking-date-limit {
+  &-input {
+    width: rem.torem(72px);
+    margin-right: rem.torem(8px);
+  }
+}
+
+.booking-date-limit-row {
+  display: flex;
+  align-items: center;
+
+  &-error {
+    margin-top: rem.torem(16px);
+  }
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarLimitDates/StocksCalendarLimitDates.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarLimitDates/StocksCalendarLimitDates.tsx
@@ -1,0 +1,78 @@
+import { useId } from 'react'
+import { UseFormReturn } from 'react-hook-form'
+
+import { useAnalytics } from 'app/App/analytics/firebase'
+import { Events } from 'commons/core/FirebaseEvents/constants'
+import { StocksCalendarFormValues } from 'components/IndividualOffer/StocksEventCreation/form/types'
+import { BaseInput } from 'ui-kit/form/shared/BaseInput/BaseInput'
+import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
+
+import styles from './StocksCalendarLimitDates.module.scss'
+
+export function StocksCalendarLimitDates({
+  form,
+}: {
+  form: UseFormReturn<StocksCalendarFormValues>
+}) {
+  const { logEvent } = useAnalytics()
+
+  const limitDateLabelId = useId()
+  const limitDateErrorId = useId()
+  const errorMessage = form.formState.errors.bookingLimitDateInterval?.message
+
+  const bookingLimitDateIntervalRegister = form.register(
+    'bookingLimitDateInterval'
+  )
+
+  return (
+    <fieldset className={styles['container']}>
+      <legend>
+        <h2 className={styles['legend']}>Date limite de réservation</h2>
+      </legend>
+
+      <div className={styles['booking-date-limit']}>
+        <div className={styles['booking-date-limit-row']}>
+          <BaseInput
+            type="number"
+            step="1"
+            hasError={Boolean(errorMessage)}
+            className={styles['booking-date-limit-input']}
+            id={limitDateLabelId}
+            {...bookingLimitDateIntervalRegister}
+            onBlur={async (e) => {
+              await bookingLimitDateIntervalRegister.onBlur(e)
+
+              if (form.getFieldState('bookingLimitDateInterval').isDirty) {
+                logEvent(Events.UPDATED_BOOKING_LIMIT_DATE, {
+                  from: location.pathname,
+                  bookingLimitDateInterval: form.watch(
+                    'bookingLimitDateInterval'
+                  ),
+                })
+              }
+            }}
+          />
+
+          <label
+            className={styles['booking-date-limit-text']}
+            htmlFor={limitDateLabelId}
+          >
+            jours avant le début de l’évènement
+          </label>
+        </div>
+
+        <div
+          role="alert"
+          id={limitDateErrorId}
+          className={styles['booking-date-limit-row-error']}
+        >
+          {errorMessage && (
+            <FieldError name="bookingLimitDateInterval">
+              {errorMessage}
+            </FieldError>
+          )}
+        </div>
+      </div>
+    </fieldset>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarPriceCategories/StocksCalendarPriceCategories.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarPriceCategories/StocksCalendarPriceCategories.module.scss
@@ -1,0 +1,52 @@
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_a11y.scss" as a11y;
+
+.title {
+  @include fonts.title4;
+
+  margin-bottom: rem.torem(16px);
+}
+
+.add-price-catgory {
+  margin-top: rem.torem(16px);
+}
+
+.price-categories {
+  display: flex;
+  flex-direction: column;
+  gap: rem.torem(16px);
+}
+
+.price-category-row {
+  display: flex;
+  align-items: center;
+  gap: rem.torem(16px);
+  flex-wrap: wrap;
+
+  &-legend {
+    @include a11y.visually-hidden;
+  }
+
+  &-quantity {
+    width: rem.torem(150px);
+
+    &-label {
+      margin-bottom: rem.torem(8px);
+      display: inline-block;
+    }
+
+    &-error {
+      margin-top: rem.torem(8px);
+    }
+  }
+
+  &-category {
+    flex-grow: 1;
+  }
+
+  &-unlimited,
+  &-trash {
+    margin-top: calc(var(--typography-body-line-height) + rem.torem(8px));
+  }
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarPriceCategories/StocksCalendarPriceCategories.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarPriceCategories/StocksCalendarPriceCategories.spec.tsx
@@ -1,0 +1,112 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormProvider, useForm } from 'react-hook-form'
+
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
+import {
+  DurationTypeOption,
+  StocksCalendarFormValues,
+  TimeSlotTypeOption,
+} from 'components/IndividualOffer/StocksEventCreation/form/types'
+
+import { StocksCalendarPriceCategories } from './StocksCalendarPriceCategories'
+
+function renderStocksCalendarPriceCategories(
+  defaultOptions?: Partial<StocksCalendarFormValues>
+) {
+  function StocksCalendarPriceCategoriesWrapper() {
+    const form = useForm<StocksCalendarFormValues>({
+      defaultValues: {
+        durationType: DurationTypeOption.ONE_DAY,
+        timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
+        specificTimeSlots: [{ slot: '' }],
+        pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+        oneDayDate: '',
+        ...defaultOptions,
+      },
+    })
+
+    return (
+      <FormProvider {...form}>
+        <StocksCalendarPriceCategories
+          form={form}
+          priceCategories={[
+            { id: 1, label: 'Tarif 1', price: 10 },
+            { id: 2, label: 'Tarif 2', price: 20 },
+          ]}
+        />
+      </FormProvider>
+    )
+  }
+
+  return renderWithProviders(<StocksCalendarPriceCategoriesWrapper />)
+}
+
+describe('StocksCalendarPriceCategories', () => {
+  it('should display price and category inputs', () => {
+    renderStocksCalendarPriceCategories()
+
+    expect(screen.getByLabelText('Nombre de places')).toBeInTheDocument()
+    expect(screen.getByLabelText('Illimité')).toBeChecked()
+  })
+
+  it('should uncheck the unlimited checkbox when a valid price is typed', async () => {
+    renderStocksCalendarPriceCategories()
+
+    expect(screen.getByLabelText('Illimité')).toBeChecked()
+
+    await userEvent.type(screen.getByLabelText('Nombre de places'), '10')
+
+    expect(screen.getByLabelText('Illimité')).not.toBeChecked()
+  })
+
+  it('should check the unlimited checkbox when the price is cleared', async () => {
+    renderStocksCalendarPriceCategories({
+      pricingCategoriesQuantities: [{ quantity: 10, priceCategory: '1' }],
+    })
+
+    expect(screen.getByLabelText('Illimité')).not.toBeChecked()
+
+    await userEvent.clear(screen.getByLabelText('Nombre de places'))
+
+    expect(screen.getByLabelText('Illimité')).toBeChecked()
+  })
+
+  it('should clear the quantity when the unlimited checkbox is checked', async () => {
+    renderStocksCalendarPriceCategories({
+      pricingCategoriesQuantities: [{ quantity: 10, priceCategory: '1' }],
+    })
+
+    expect(screen.getByLabelText('Nombre de places')).toHaveValue(10)
+
+    await userEvent.click(screen.getByLabelText('Illimité'))
+
+    expect(screen.getByLabelText('Nombre de places')).toHaveValue(null)
+  })
+
+  it('should be able to remove a price and category when there are more than two', async () => {
+    renderStocksCalendarPriceCategories({
+      pricingCategoriesQuantities: [{ quantity: 10, priceCategory: '1' }],
+    })
+
+    expect(
+      screen.queryByRole('button', { name: 'Supprimer les places' })
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Ajouter d’autres places et tarifs' })
+    )
+
+    expect(
+      screen.getAllByRole('button', { name: 'Supprimer les places' })
+    ).toHaveLength(2)
+
+    await userEvent.click(
+      screen.getAllByRole('button', { name: 'Supprimer les places' })[0]
+    )
+
+    expect(
+      screen.queryByRole('button', { name: 'Supprimer les places' })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarPriceCategories/StocksCalendarPriceCategories.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarPriceCategories/StocksCalendarPriceCategories.tsx
@@ -1,0 +1,179 @@
+import { useId } from 'react'
+import { useFieldArray, UseFormReturn } from 'react-hook-form'
+
+import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import { StocksCalendarFormValues } from 'components/IndividualOffer/StocksEventCreation/form/types'
+import { getPriceCategoryOptions } from 'components/IndividualOffer/StocksEventEdition/getPriceCategoryOptions'
+import fullMoreIcon from 'icons/full-more.svg'
+import fullTrashIcon from 'icons/full-trash.svg'
+import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
+import { BaseInput } from 'ui-kit/form/shared/BaseInput/BaseInput'
+import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
+import { Checkbox } from 'ui-kit/formV2/Checkbox/Checkbox'
+import { Select } from 'ui-kit/formV2/Select/Select'
+
+import styles from './StocksCalendarPriceCategories.module.scss'
+
+export function StocksCalendarPriceCategories({
+  form,
+  priceCategories,
+}: {
+  form: UseFormReturn<StocksCalendarFormValues>
+  priceCategories: GetIndividualOfferWithAddressResponseModel['priceCategories']
+}) {
+  const { fields, remove, append } = useFieldArray({
+    name: 'pricingCategoriesQuantities',
+  })
+
+  const priceCategoriesOptions = getPriceCategoryOptions(priceCategories)
+
+  const quantityErrorsId = useId()
+
+  return (
+    <>
+      <h2 className={styles['title']}>Places et tarifs</h2>
+      <div className={styles['price-categories']}>
+        {fields.map((pricingPointQuantity, index) => {
+          const registeredUnlimitedCheckbox = form.register(
+            `pricingCategoriesQuantities.${index}.isUnlimited`
+          )
+
+          const registeredQuantity = form.register(
+            `pricingCategoriesQuantities.${index}.quantity`
+          )
+
+          const quantityErrorId = `${quantityErrorsId}-${pricingPointQuantity.id}`
+          const quantityErrorMessage =
+            form.formState.errors.pricingCategoriesQuantities?.[index]?.quantity
+              ?.message
+
+          return (
+            <fieldset
+              key={pricingPointQuantity.id}
+              className={styles['price-category-row']}
+            >
+              <legend className={styles['price-category-row-legend']}>
+                Places et tarifs {index + 1} sur {fields.length}
+              </legend>
+              <div className={styles['price-category-row-quantity']}>
+                <label
+                  className={styles['price-category-row-quantity-label']}
+                  htmlFor={`pricingCategoriesQuantities.${index}.quantity`}
+                >
+                  Nombre de places
+                </label>
+                <BaseInput
+                  type="number"
+                  min={0}
+                  {...registeredQuantity}
+                  aria-describedby={quantityErrorId}
+                  onChange={async (e) => {
+                    if (e.target.value) {
+                      form.setValue(
+                        `pricingCategoriesQuantities.${index}.isUnlimited`,
+                        false
+                      )
+                    }
+
+                    if (e.target.value === '') {
+                      form.setValue(
+                        `pricingCategoriesQuantities.${index}.isUnlimited`,
+                        true
+                      )
+                    }
+                    await registeredQuantity.onChange(e)
+                  }}
+                />
+                <div role="alert" id={quantityErrorId}>
+                  {quantityErrorMessage && (
+                    <FieldError
+                      className={styles['price-category-row-quantity-error']}
+                      name={`pricingCategoriesQuantities.${index}.quantity`}
+                    >
+                      {quantityErrorMessage}
+                    </FieldError>
+                  )}
+                </div>
+              </div>
+              <Checkbox
+                label="Illimité"
+                className={styles['price-category-row-unlimited']}
+                {...registeredUnlimitedCheckbox}
+                onChange={async (e) => {
+                  await registeredUnlimitedCheckbox.onChange(e)
+
+                  if (e.target.checked) {
+                    form.setValue(
+                      `pricingCategoriesQuantities.${index}.quantity`,
+                      undefined
+                    )
+                  }
+                }}
+              />
+              <Select
+                className={styles['price-category-row-category']}
+                options={priceCategoriesOptions}
+                required
+                label="Tarif"
+                defaultOption={{
+                  label: 'Sélectionner un tarif',
+                  value: '',
+                }}
+                {...form.register(
+                  `pricingCategoriesQuantities.${index}.priceCategory`
+                )}
+                error={
+                  form.formState.errors.pricingCategoriesQuantities?.[index]
+                    ?.priceCategory?.message
+                }
+              />
+              {fields.length > 1 && (
+                <div className={styles['price-category-row-trash']}>
+                  <Button
+                    variant={ButtonVariant.TERNARY}
+                    icon={fullTrashIcon}
+                    iconPosition={IconPositionEnum.CENTER}
+                    onClick={() => {
+                      remove(index)
+
+                      const nextInput = `pricingCategoriesQuantities.${index}.quantity`
+                      const previousInput = `pricingCategoriesQuantities.${index - 1}.quantity`
+
+                      //    Focus on the next input if it exists, otherwise focus on the previous input
+                      setTimeout(() => {
+                        ;(
+                          document.getElementById(nextInput) ||
+                          document.getElementById(previousInput)
+                        )?.focus()
+                      })
+                    }}
+                    tooltipContent="Supprimer les places"
+                  />
+                </div>
+              )}
+            </fieldset>
+          )
+        })}
+      </div>
+      {fields.length < priceCategoriesOptions.length && (
+        <Button
+          className={styles['add-price-catgory']}
+          variant={ButtonVariant.TERNARY}
+          icon={fullMoreIcon}
+          onClick={() => {
+            append({ isUnlimited: true, priceCategory: '' })
+            const inputToFocus = `pricingCategoriesQuantities.${fields.length}.quantity`
+
+            // The input we want to focus has not been rendered first
+            setTimeout(() => {
+              document.getElementById(inputToFocus)?.focus()
+            }, 0)
+          }}
+        >
+          Ajouter d’autres places et tarifs
+        </Button>
+      )}
+    </>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/utils.ts
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/utils.ts
@@ -1,0 +1,49 @@
+import { format, sub } from 'date-fns'
+
+import {
+  FORMAT_ISO_DATE_ONLY,
+  toISOStringWithoutMilliseconds,
+} from 'commons/utils/date'
+import { serializeDateTimeToUTCFromLocalDepartment } from 'components/IndividualOffer/StocksEventEdition/serializers'
+import { StocksEvent } from 'components/StocksEventList/StocksEventList'
+
+import { StocksCalendarFormValues } from '../form/types'
+
+export function getStocksForOneDay(
+  formValues: StocksCalendarFormValues,
+  departmentCode: string
+): Partial<StocksEvent>[] {
+  const date = formValues.oneDayDate
+  const times = formValues.specificTimeSlots.map((s) => s.slot)
+
+  if (!date || times.length === 0) {
+    throw new Error('Selected date is invalid')
+  }
+
+  const formattedDate = format(date, FORMAT_ISO_DATE_ONLY)
+
+  return times.flatMap((t) => {
+    const dateTime = serializeDateTimeToUTCFromLocalDepartment(
+      formattedDate,
+      t,
+      departmentCode
+    )
+
+    return formValues.pricingCategoriesQuantities.map(
+      (quantityPerPriceCategory) => {
+        const quantity = quantityPerPriceCategory.quantity || null
+
+        return {
+          priceCategoryId: parseInt(quantityPerPriceCategory.priceCategory),
+          quantity: quantity !== null ? Number(quantity) : quantity,
+          beginningDatetime: dateTime,
+          bookingLimitDatetime: toISOStringWithoutMilliseconds(
+            sub(new Date(dateTime), {
+              days: Number(formValues.bookingLimitDateInterval || 0),
+            })
+          ),
+        }
+      }
+    )
+  })
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
@@ -25,6 +25,7 @@ export interface StocksEventCreationProps {
 export const StocksEventCreation = ({
   offer,
 }: StocksEventCreationProps): JSX.Element => {
+  //  TODO in OHO epic : rework the fetching of data so that stocks are retrieved from here
   const isEventWithOpeningHoursEnabled = useActiveFeature(
     'WIP_ENABLE_EVENT_WITH_OPENING_HOUR'
   )
@@ -73,7 +74,7 @@ export const StocksEventCreation = ({
     <>
       <div className={styles['container']}>
         {isEventWithOpeningHoursEnabled ? (
-          <StocksCalendar />
+          <StocksCalendar offer={offer} />
         ) : (
           <>
             {hasStocks === false && (

--- a/pro/src/components/IndividualOffer/StocksEventCreation/form/types.ts
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/form/types.ts
@@ -36,3 +36,27 @@ export type RecurrenceFormValues = {
   bookingLimitDateInterval: number | ''
   monthlyOption: MonthlyOption | null
 }
+
+//  Under WIP_ENABLE_EVENT_WITH_OPENING_HOUR FF
+export enum DurationTypeOption {
+  ONE_DAY = 'ONE_DAY',
+  MULTIPLE_DAYS_WEEKS = 'MULTIPLE_DAYS_WEEKS',
+}
+
+export enum TimeSlotTypeOption {
+  SPECIFIC_TIME = 'SPECIFIC_TIME',
+  OPENING_HOURS = 'OPENING_HOURS',
+}
+
+export type StocksCalendarFormValues = {
+  durationType: DurationTypeOption
+  oneDayDate: string
+  timeSlotType: TimeSlotTypeOption
+  specificTimeSlots: { slot: string }[]
+  pricingCategoriesQuantities: {
+    quantity?: number
+    isUnlimited?: boolean
+    priceCategory: string
+  }[]
+  bookingLimitDateInterval?: number
+}

--- a/pro/src/components/StocksEventList/StocksEventList.tsx
+++ b/pro/src/components/StocksEventList/StocksEventList.tsx
@@ -83,7 +83,7 @@ export const StocksEventList = ({
   readonly = false,
   onStocksLoad,
   canAddStocks = false,
-}: StocksEventListProps): JSX.Element => {
+}: StocksEventListProps) => {
   // utilities
   const { logEvent } = useAnalytics()
   const notify = useNotification()

--- a/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
+++ b/pro/src/components/UserIdentityForm/UserIdentityForm.tsx
@@ -72,7 +72,7 @@ export const UserIdentityForm = ({
       <BoxFormLayout.Fields>
         <form onSubmit={handleSubmit(onSubmit)}>
           <FormLayout>
-            <FormLayout.Row>
+            <div className={styles['text-input']}>
               <TextInput
                 label="Prénom"
                 error={errors.firstName?.message}
@@ -80,8 +80,8 @@ export const UserIdentityForm = ({
                 asterisk={false}
                 {...register('firstName')}
               />
-            </FormLayout.Row>
-            <FormLayout.Row>
+            </div>
+            <div className={styles['text-input']}>
               <TextInput
                 label="Nom"
                 error={errors.lastName?.message}
@@ -89,7 +89,7 @@ export const UserIdentityForm = ({
                 asterisk={false}
                 {...register('lastName')}
               />
-            </FormLayout.Row>
+            </div>
           </FormLayout>
           <div className={styles['buttons-field']}>
             <Button onClick={onCancel} variant={ButtonVariant.SECONDARY}>

--- a/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
@@ -104,14 +104,14 @@ export const UserPasswordForm = ({
       <BoxFormLayout.Fields>
         <form onSubmit={handleSubmit(onSubmit)}>
           <FormLayout>
-            <FormLayout.Row>
+            <div className={styles['text-input']}>
               <PasswordInput
                 {...register('oldPassword')}
                 error={errors.oldPassword?.message}
                 label="Mot de passe actuel"
               />
-            </FormLayout.Row>
-            <FormLayout.Row className={styles['form-row-password']}>
+            </div>
+            <div className={styles['text-input']}>
               <PasswordInput
                 {...register('newPassword', {
                   onChange: () => trigger('newPassword'),
@@ -129,14 +129,14 @@ export const UserPasswordForm = ({
                 passwordValue={newPassword}
                 hasError={!!errors.newPassword}
               />
-            </FormLayout.Row>
-            <FormLayout.Row>
+            </div>
+            <div className={styles['text-input']}>
               <PasswordInput
                 {...register('newConfirmationPassword')}
                 error={errors.newConfirmationPassword?.message}
                 label="Confirmer votre nouveau mot de passe"
               />
-            </FormLayout.Row>
+            </div>
           </FormLayout>
 
           <div className={styles['buttons-field']}>

--- a/pro/src/components/UserPhoneForm/UserForm.module.scss
+++ b/pro/src/components/UserPhoneForm/UserForm.module.scss
@@ -14,10 +14,6 @@
   }
 }
 
-.form-row-password {
-  // Only way to target inner form layout’s error message
-  // Needed to space with password indications that are below
-  [id="error-details-newPassword"] {
-    margin-bottom: 0.75rem;
-  }
+.text-input {
+  margin-bottom: rem.torem(24px);
 }

--- a/pro/src/pages/Desk/Desk.module.scss
+++ b/pro/src/pages/Desk/Desk.module.scss
@@ -16,7 +16,7 @@
 }
 
 .desk-form-input {
-  margin: rem.torem(10px) auto 0;
+  margin-bottom: rem.torem(24px);
   max-width: rem.torem(328px);
   text-align: left;
 }

--- a/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.module.scss
+++ b/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.module.scss
@@ -45,3 +45,7 @@
     }
   }
 }
+
+.text-input {
+  margin-bottom: rem.torem(24px);
+}

--- a/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
@@ -42,7 +42,7 @@ export const ChangePasswordForm = ({
       <ScrollToFirstHookFormErrorAfterSubmit />
 
       <FormLayout>
-        <FormLayout.Row>
+        <div className={styles['text-input']}>
           <PasswordInput
             label="Nouveau mot de passe"
             {...register('newPassword')}
@@ -51,16 +51,16 @@ export const ChangePasswordForm = ({
             passwordValue={newPassword}
             hasError={!!errors.newPassword}
           />
-        </FormLayout.Row>
+        </div>
         {is2025SignUpEnabled ? (
           <>
-            <FormLayout.Row>
+            <div className={styles['text-input']}>
               <PasswordInput
                 label="Confirmation mot de passe"
                 error={errors.newConfirmationPassword?.message}
                 {...register('newConfirmationPassword')}
               />
-            </FormLayout.Row>
+            </div>
 
             <div className={styles['buttons-field']}>
               <Button

--- a/pro/src/pages/SignIn/Signin.module.scss
+++ b/pro/src/pages/SignIn/Signin.module.scss
@@ -1,4 +1,4 @@
- @use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/variables/_forms.scss" as forms;
 @use "styles/mixins/_size.scss" as size;
@@ -39,4 +39,8 @@
       @include fonts.body;
     }
   }
+}
+
+.text-input {
+  margin-bottom: rem.torem(24px);
 }

--- a/pro/src/pages/SignIn/SigninForm.tsx
+++ b/pro/src/pages/SignIn/SigninForm.tsx
@@ -43,7 +43,7 @@ export const SigninForm = ({ onSubmit }: SigninFormProps): JSX.Element => {
       <ScrollToFirstHookFormErrorAfterSubmit />
 
       <FormLayout>
-        <FormLayout.Row>
+        <div className={styles['text-input']}>
           <TextInput
             label="Adresse email"
             required={true}
@@ -51,9 +51,10 @@ export const SigninForm = ({ onSubmit }: SigninFormProps): JSX.Element => {
             description="Format : email@exemple.com"
             {...register('email')}
             asterisk={false}
+            className={styles['text-input']}
           />
-        </FormLayout.Row>
-        <FormLayout.Row>
+        </div>
+        <div className={styles['text-input']}>
           <PasswordInput
             label="Mot de passe"
             required={true}
@@ -61,7 +62,7 @@ export const SigninForm = ({ onSubmit }: SigninFormProps): JSX.Element => {
             {...register('password')}
             asterisk={false}
           />
-        </FormLayout.Row>
+        </div>
         <ButtonLink
           icon={fullKeyIcon}
           variant={ButtonVariant.TERNARY}

--- a/pro/src/pages/Signup/SignupContainer/SignupContainer.module.scss
+++ b/pro/src/pages/Signup/SignupContainer/SignupContainer.module.scss
@@ -52,15 +52,16 @@
 .signup-form-row {
   display: flex;
   flex-direction: column;
+  margin-bottom: rem.torem(24px);
 
   @media (min-width: size.$tablet) {
     flex-direction: row;
     gap: rem.torem(16px);
   }
+}
 
-  &-password {
-    margin-bottom: rem.torem(32px);
-  }
+.text-input {
+  margin-bottom: rem.torem(24px);
 }
 
 .signup-form-group {

--- a/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
+++ b/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
@@ -83,7 +83,7 @@ export const SignupForm = (): JSX.Element => {
           ].sort(() => (isNewSignupEnabled ? -1 : 1))}
           {/* This is to display fields "PRÉNOM" <> "NOM" in the correct DOM order depending on the FF */}
         </div>
-        <FormLayout.Row>
+        <div className={styles['text-input']}>
           <EmailSpellCheckInput
             {...register('email')}
             error={errors.email?.message}
@@ -95,8 +95,8 @@ export const SignupForm = (): JSX.Element => {
             required
             asterisk={!isNewSignupEnabled}
           />
-        </FormLayout.Row>
-        <FormLayout.Row className={styles['signup-form-row-password']}>
+        </div>
+        <div className={styles['text-input']}>
           <PasswordInput
             {...register('password')}
             label="Mot de passe"
@@ -108,7 +108,8 @@ export const SignupForm = (): JSX.Element => {
             passwordValue={newPassword}
             hasError={!!errors.password}
           />
-        </FormLayout.Row>
+        </div>
+
         {!isNewSignupEnabled && (
           <FormLayout.Row>
             <PhoneNumberInput

--- a/pro/src/pages/User/UserProfile/UserEmail/UserEmailForm/UserEmailForm.module.scss
+++ b/pro/src/pages/User/UserProfile/UserEmail/UserEmailForm/UserEmailForm.module.scss
@@ -7,3 +7,7 @@
     margin-left: rem.torem(8px);
   }
 }
+
+.text-input {
+  margin-bottom: rem.torem(24px);
+}

--- a/pro/src/pages/User/UserProfile/UserEmail/UserEmailForm/UserEmailForm.tsx
+++ b/pro/src/pages/User/UserProfile/UserEmail/UserEmailForm/UserEmailForm.tsx
@@ -82,7 +82,7 @@ export const UserEmailForm = ({
       <BoxFormLayout.Fields>
         <form onSubmit={handleSubmit(onSubmit)}>
           <FormLayout>
-            <FormLayout.Row>
+            <div className={styles['text-input']}>
               <TextInput
                 label="Nouvelle adresse email"
                 description="Format : email@exemple.com"
@@ -91,8 +91,8 @@ export const UserEmailForm = ({
                 {...register('email')}
                 asterisk={false}
               />
-            </FormLayout.Row>
-            <FormLayout.Row>
+            </div>
+            <div className={styles['text-input']}>
               <PasswordInput
                 label="Mot de passe (requis pour modifier votre email)"
                 error={errors.password?.message}
@@ -100,7 +100,7 @@ export const UserEmailForm = ({
                 {...register('password')}
                 asterisk={false}
               />
-            </FormLayout.Row>
+            </div>
           </FormLayout>
 
           <div className={styles['buttons-field']}>

--- a/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
+++ b/pro/src/ui-kit/form/shared/BaseRadio/BaseRadio.module.scss
@@ -8,7 +8,6 @@
   align-items: center;
 
   &-label {
-    line-height: rem.torem(16px);
     flex-grow: 1;
     cursor: pointer;
     display: flex;

--- a/pro/src/ui-kit/form/shared/FieldError/FieldError.module.scss
+++ b/pro/src/ui-kit/form/shared/FieldError/FieldError.module.scss
@@ -12,6 +12,7 @@
     height: rem.torem(16px);
     margin-right: rem.torem(4px);
     width: rem.torem(16px);
+    min-width: 1rem;
   }
 
   &-text {

--- a/pro/src/ui-kit/formV2/TextInput/TextInput.module.scss
+++ b/pro/src/ui-kit/formV2/TextInput/TextInput.module.scss
@@ -16,34 +16,33 @@
 
 .input-layout {
   width: 100%;
-  margin-bottom: rem.torem(8px);
 
   &-label {
     @include fonts.body;
 
+    margin-bottom: rem.torem(8px);
     display: flex;
     align-items: center;
     white-space: nowrap;
-
-    &-container {
-      margin-bottom: rem.torem(forms.$label-space-before-input);
-    }
 
     &-asterisk {
       margin-left: rem.torem(8px);
     }
   }
 
+  &.has-description {
+    .input-layout-label {
+      margin-bottom: 0;
+    }
+  }
+
   &-footer {
-    @include formsM.field-layout-footer;
+    display: flex;
+    justify-content: space-between;
   }
 
   &-error {
-    flex: 1;
-
-    svg {
-      flex: 0 0 15px;
-    }
+    margin-top: rem.torem(8px);
   }
 
   &-input-description {
@@ -51,7 +50,7 @@
 
     display: block;
     color: var(--color-grey-dark);
-    margin-top: rem.torem(4px);
+    margin-bottom: rem.torem(4px);
   }
 }
 

--- a/pro/src/ui-kit/formV2/TextInput/TextInput.spec.tsx
+++ b/pro/src/ui-kit/formV2/TextInput/TextInput.spec.tsx
@@ -54,7 +54,6 @@ describe('TextInput', () => {
     const inputName = 'test'
     const inputLabel = 'Ceci est un champ texte'
     const descriptionContent = 'Instructions pour le remplissage du champ.'
-    const descriptionId = `description-${inputName}`
 
     render(
       <TextInput
@@ -65,12 +64,7 @@ describe('TextInput', () => {
       />
     )
 
-    const description = screen.queryByTestId(descriptionId)
-    expect(description).toBeInTheDocument()
-    expect(description).toHaveTextContent(descriptionContent)
-
-    const input = screen.getByRole('textbox', { name: inputLabel })
-    expect(input.getAttribute('aria-describedby')).toBe(descriptionId)
+    expect(screen.getByText(descriptionContent))
   })
 
   it('should display the element with an error', () => {

--- a/pro/src/ui-kit/formV2/TextInput/TextInput.stories.tsx
+++ b/pro/src/ui-kit/formV2/TextInput/TextInput.stories.tsx
@@ -29,6 +29,7 @@ export const ReadOnly: Story = {
 export const WithExternalError: Story = {
   args: {
     ...Default.args,
+    count: 100,
     error: 'This field is required',
   },
 }

--- a/pro/src/ui-kit/formV2/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/formV2/TextInput/TextInput.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames'
-import React, { ForwardedRef } from 'react'
+import React, { ForwardedRef, useId } from 'react'
 
 import {
   BaseInput,
@@ -96,6 +96,11 @@ export const TextInput = React.forwardRef(
     }: TextInputProps,
     ref: ForwardedRef<HTMLInputElement>
   ) => {
+    const errorId = useId()
+    const descriptionId = useId()
+
+    const describedBy = `${error ? errorId : ''}${description ? ` ${descriptionId}` : ''}`
+
     const input = (
       <BaseInput
         name={name}
@@ -108,7 +113,7 @@ export const TextInput = React.forwardRef(
         rightIcon={rightIcon}
         leftIcon={leftIcon}
         aria-required={required}
-        aria-describedby={description ? `description-${name}` : undefined}
+        aria-describedby={describedBy}
         onKeyDown={(event) => {
           // If the number input should have no decimal, prevent the user from typing "," or "."
           if (type === 'number' && !hasDecimal && /[,.]/.test(event.key)) {
@@ -121,7 +126,11 @@ export const TextInput = React.forwardRef(
 
     return (
       <div
-        className={cn(styles['input-layout'], className)}
+        className={cn(
+          styles['input-layout'],
+          { [styles['has-description']]: Boolean(description) },
+          className
+        )}
         data-testid={`wrapper-${name}`}
       >
         <div
@@ -149,7 +158,7 @@ export const TextInput = React.forwardRef(
             <div className={styles['text-input']}>
               {input}
               <div className={styles['input-layout-footer']}>
-                <div role="alert" id={`error-details-${name}`}>
+                <div role="alert" id={errorId}>
                   {error && (
                     <FieldError
                       name={name}

--- a/pro/src/ui-kit/formV2/TextInput/TextInput.tsx
+++ b/pro/src/ui-kit/formV2/TextInput/TextInput.tsx
@@ -149,12 +149,15 @@ export const TextInput = React.forwardRef(
             <div className={styles['text-input']}>
               {input}
               <div className={styles['input-layout-footer']}>
-                <div
-                  role="alert"
-                  className={styles['input-layout-error']}
-                  id={`error-details-${name}`}
-                >
-                  {error && <FieldError name={name}>{error}</FieldError>}
+                <div role="alert" id={`error-details-${name}`}>
+                  {error && (
+                    <FieldError
+                      name={name}
+                      className={styles['input-layout-error']}
+                    >
+                      {error}
+                    </FieldError>
+                  )}
                 </div>
 
                 {count !== undefined && (

--- a/pro/src/ui-kit/formV2/ValidationMessageList/ValidationMessageList.module.scss
+++ b/pro/src/ui-kit/formV2/ValidationMessageList/ValidationMessageList.module.scss
@@ -6,7 +6,6 @@
   @include forms.field-layout-footer;
 
   min-height: initial;
-  margin-top: rem.torem(-20px);
   flex-flow: row wrap;
   justify-content: flex-start;
   gap: rem.torem(8px) rem.torem(12px);


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35172

**Objectif**
Intégrer le nouveau formulaire de récurrence dans le drawer, à l'étape "calendrier" de la créa d'offre événement individuelle.

FF à activer : `WIP_ENABLE_EVENT_WITH_OPENING_HOUR`

Ce qui doit fonctionner : tout le parcours du drawer pour 1 seul jour (1ère option du 1er radio group), et des horaires précis (1ère option du 2e radio group). La validation du formulaire doit fonctionner. Au moment de la validation, le tableau des stocks ne se met pas à jour à la fermeture du drawer, ce sera fait dans un 2e temps au moment du rework/redesign de ce tableau.

Lien figma : https://www.figma.com/design/VshPOA1D5k9PxYSSQSER7u/PRO---Offres-sur-plage-horaire?node-id=5211-51472&t=FTiPxAjsP6kAPe5I-4

Quelques screens : 
<img width="908" alt="Capture d’écran 2025-03-21 à 17 50 01" src="https://github.com/user-attachments/assets/d1ae8eb2-51ff-4bd7-819e-0e8140888202" />
<img width="907" alt="Capture d’écran 2025-03-21 à 17 50 14" src="https://github.com/user-attachments/assets/7347e3f0-0fb5-4255-af62-28bdbf2cebca" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
