### PR TITLE
(PC-35261)[API] fix: isolate has_partner_page SQL prop

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -759,16 +759,17 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin):
     def has_partner_page(cls):  # pylint: disable=no-self-argument
         from pcapi.core.offers.models import Offer
 
+        AliasedVenue = sa.orm.aliased(Venue)
         return (
             sa.select(1)
             .select_from(Offer)
-            .join(Venue, Offer.venueId == Venue.id)
-            .join(Offerer, Offerer.id == Venue.managingOffererId)
+            .join(AliasedVenue, Offer.venueId == AliasedVenue.id)
+            .join(Offerer, Offerer.id == AliasedVenue.managingOffererId)
             .where(
                 Offerer.isActive.is_(True),
-                Venue.isPermanent.is_(True),
-                Venue.isVirtual.is_(False),
-                Venue.id == cls.id,
+                AliasedVenue.isPermanent.is_(True),
+                AliasedVenue.isVirtual.is_(False),
+                AliasedVenue.id == cls.id,
             )
             .exists()
         )

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -602,12 +602,14 @@ class VenueHasPartnerPageTest:
             offers_factories.OfferFactory(venue=venue)
         assert venue.has_partner_page is has_partner_page
 
-    def test_chelou(self):
+    def test_has_partner_page_isolation(self):
         offerer_1 = factories.OffererFactory(isActive=True)
         offerer_2 = factories.OffererFactory(isActive=True)
-        partner_page = factories.VenueFactory(managingOfferer=offerer_2, isPermanent=True)
+        partner_page_venue = factories.VenueFactory(managingOfferer=offerer_2, isPermanent=True)
         venue = factories.VenueFactory(managingOfferer=offerer_1, isPermanent=False)
-        offers_factories.OfferFactory(venue=partner_page)
+        offers_factories.OfferFactory(venue=partner_page_venue)
 
         assert venue.has_partner_page is False
-        assert partner_page.has_partner_page is True
+        assert partner_page_venue.has_partner_page is True
+        assert models.Venue.query.filter(models.Venue.has_partner_page == False).all() == [venue]
+        assert models.Venue.query.filter(models.Venue.has_partner_page == True).all() == [partner_page_venue]


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-35261

The has_partner_page hybrid expression did not properly linked the venue's offers to the current venue.
Long story short, the SQL generated was similar to simplified:

    SELECT venue.* FROM venue
    WHERE venue.id = 978
    AND (EXISTS(
        SELECT 1
        FROM offer
        JOIN venue ON offer."venueId" = venue.id
        WHERE venue."isPermanent" IS true
        AND venue."isVirtual" IS false
        AND venue.id = venue.id
    )) = true

Note the useless venue.id = venue.id.
Using an aliased Venue table changes the SQL subquery to use an isolated venue table which can then be linked with the outer venue table through a `venue_1.id = venue.id`.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
