### PR TITLE
(PC-35169)[PRO] fix: display stepper for collective offer in edition

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/CollectiveOfferCreation/CollectiveOfferCreation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/CollectiveOfferCreation/CollectiveOfferCreation.tsx
@@ -39,10 +39,8 @@ export const CollectiveOfferCreation = ({
       subTitle={offer?.name}
       isCreation
       isTemplate={isTemplate}
-      isFromTemplate={location.pathname.includes('vitrine')}
       requestId={requestId}
       offer={offer}
-      userOfferer={offerEducationalFormData.offerer}
     >
       <OfferEducational
         userOfferer={offerEducationalFormData.offerer}

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/CollectiveOfferCreation/CollectiveOfferCreation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/CollectiveOfferCreation/CollectiveOfferCreation.tsx
@@ -42,6 +42,7 @@ export const CollectiveOfferCreation = ({
       isFromTemplate={location.pathname.includes('vitrine')}
       requestId={requestId}
       offer={offer}
+      userOfferer={offerEducationalFormData.offerer}
     >
       <OfferEducational
         userOfferer={offerEducationalFormData.offerer}

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferLayout.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferLayout.tsx
@@ -26,7 +26,6 @@ export interface CollectiveOfferLayoutProps {
   subTitle?: string
   isCreation?: boolean
   isTemplate?: boolean
-  isFromTemplate?: boolean
   requestId?: string | null
   offer?:
     | GetCollectiveOfferResponseModel
@@ -36,7 +35,6 @@ export interface CollectiveOfferLayoutProps {
 export const CollectiveOfferLayout = ({
   children,
   subTitle,
-  isFromTemplate = false,
   isCreation = false,
   isTemplate = false,
   requestId = null,
@@ -57,7 +55,7 @@ export const CollectiveOfferLayout = ({
     offerId: string
   }>()
   let title = isCreation
-    ? isFromTemplate
+    ? isTemplate
       ? 'Créer une offre vitrine'
       : 'Créer une offre réservable'
     : isSummaryPage

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferLayout.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferLayout.tsx
@@ -5,7 +5,6 @@ import { useLocation, useParams } from 'react-router-dom'
 import {
   GetCollectiveOfferResponseModel,
   GetCollectiveOfferTemplateResponseModel,
-  GetEducationalOffererResponseModel,
 } from 'apiClient/v1'
 import { Layout } from 'app/App/layout/Layout'
 import { useOfferer } from 'commons/hooks/swr/useOfferer'
@@ -14,6 +13,8 @@ import { HelpLink } from 'components/HelpLink/HelpLink'
 import { CollectiveCreationOfferNavigation } from 'pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferNavigation/CollectiveCreationOfferNavigation'
 import { getActiveStep } from 'pages/CollectiveOfferRoutes/utils/getActiveStep'
 import { Tag, TagVariant } from 'ui-kit/Tag/Tag'
+
+import { useOfferEducationalFormData } from '../CollectiveOffer/components/OfferEducational/useOfferEducationalFormData'
 
 import { CollectiveEditionOfferNavigation } from './CollectiveEditionOfferNavigation/CollectiveEditionOfferNavigation'
 import styles from './CollectiveOfferLayout.module.scss'
@@ -28,7 +29,6 @@ export interface CollectiveOfferLayoutProps {
   offer?:
     | GetCollectiveOfferResponseModel
     | GetCollectiveOfferTemplateResponseModel
-  userOfferer?: GetEducationalOffererResponseModel | null
 }
 
 export const CollectiveOfferLayout = ({
@@ -39,12 +39,16 @@ export const CollectiveOfferLayout = ({
   isTemplate = false,
   requestId = null,
   offer,
-  userOfferer,
 }: CollectiveOfferLayoutProps): JSX.Element => {
   const location = useLocation()
   const isSummaryPage = location.pathname.includes('recapitulatif')
 
-  const { data: selectedOfferer } = useOfferer(userOfferer?.id)
+  const { ...offerEducationalFormData } = useOfferEducationalFormData(
+    null,
+    offer
+  )
+
+  const { data: selectedOfferer } = useOfferer(offerEducationalFormData.offerer?.id)
   const { offerId: offerIdFromParams } = useParams<{
     offerId: string
   }>()

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferLayout.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferLayout.tsx
@@ -1,5 +1,6 @@
 import cn from 'classnames'
 import React from 'react'
+import { useSelector } from 'react-redux'
 import { useLocation, useParams } from 'react-router-dom'
 
 import {
@@ -8,6 +9,7 @@ import {
 } from 'apiClient/v1'
 import { Layout } from 'app/App/layout/Layout'
 import { useOfferer } from 'commons/hooks/swr/useOfferer'
+import { selectCurrentOffererId } from 'commons/store/offerer/selectors'
 import { CollectiveBudgetCallout } from 'components/CollectiveBudgetInformation/CollectiveBudgetCallout'
 import { HelpLink } from 'components/HelpLink/HelpLink'
 import { CollectiveCreationOfferNavigation } from 'pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferNavigation/CollectiveCreationOfferNavigation'
@@ -42,9 +44,11 @@ export const CollectiveOfferLayout = ({
 }: CollectiveOfferLayoutProps): JSX.Element => {
   const location = useLocation()
   const isSummaryPage = location.pathname.includes('recapitulatif')
+  const selectedOffererId = useSelector(selectCurrentOffererId)
+  const offererId = selectedOffererId?.toString()
 
   const { ...offerEducationalFormData } = useOfferEducationalFormData(
-    null,
+    Number(offererId),
     offer
   )
 

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/__specs__/CollectiveOfferLayout.spec.tsx
@@ -67,12 +67,11 @@ describe('CollectiveOfferLayout', () => {
 
   it('should display creation from template title', () => {
     renderCollectiveOfferLayout('/offre/A1/collectif/', {
-      isFromTemplate: true,
       isCreation: true,
     })
 
     const title = screen.getByRole('heading', {
-      name: /Créer une offre vitrine/,
+      name: /Créer une offre réservable/,
     })
 
     expect(title).toBeInTheDocument()

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferPreview/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferPreview/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreation.tsx
@@ -1,4 +1,3 @@
-import { isCollectiveOffer } from 'commons/core/OfferEducational/types'
 import { RouteLeavingGuardCollectiveOfferCreation } from 'components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation'
 import {
   MandatoryCollectiveOfferFromParamsProps,
@@ -15,7 +14,6 @@ export const CollectiveOfferPreviewCreation = ({
   return (
     <CollectiveOfferLayout
       subTitle={offer.name}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
       isTemplate={isTemplate}
       isCreation
       offer={offer}

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferPreview/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferPreview/CollectiveOfferPreviewCreation/__specs__/CollectiveOfferPreviewCreation.spec.tsx
@@ -11,6 +11,7 @@ import {
   getCollectiveOfferTemplateFactory,
 } from 'commons/utils/factories/collectiveApiFactories'
 import { defaultGetOffererResponseModel } from 'commons/utils/factories/individualApiFactories'
+import { managedVenueFactory, userOffererFactory } from 'commons/utils/factories/userOfferersFactories'
 import {
   RenderWithProvidersOptions,
   renderWithProviders,
@@ -28,6 +29,14 @@ vi.mock('react-router-dom', async () => ({
   }),
   useNavigate: () => vi.fn(),
   default: vi.fn(),
+}))
+
+vi.mock('apiClient/api', () => ({
+  api: {
+    listEducationalOfferers: vi.fn(),
+    getVenue: vi.fn(),
+    patchCollectiveOfferPublication: vi.fn()
+  },
 }))
 
 const renderCollectiveOfferPreviewCreation = (
@@ -55,8 +64,19 @@ const defaultProps = {
 const mockLogEvent = vi.fn()
 
 describe('CollectiveOfferPreviewCreation', () => {
+    const venue = managedVenueFactory({ id: 1 })
+    const offerer = userOffererFactory({
+      id: 1,
+      name: 'Ma super structure',
+      managedVenues: [venue],
+    })
+    
   beforeEach(() => {
     vi.spyOn(api, 'getVenue').mockResolvedValue(defaultGetVenue)
+
+    vi.spyOn(api, 'listEducationalOfferers').mockResolvedValue({
+      educationalOfferers: [offerer],
+    })
 
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
       logEvent: mockLogEvent,

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferStock/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferStock/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
@@ -170,7 +170,6 @@ export const CollectiveOfferStockCreation = ({
   return (
     <CollectiveOfferLayout
       subTitle={offer.name}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
       isTemplate={isTemplate}
       isCreation={isCreation}
       requestId={requestId}

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferStock/CollectiveOfferStockEdition/CollectiveOfferStockEdition.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferStock/CollectiveOfferStockEdition/CollectiveOfferStockEdition.tsx
@@ -76,7 +76,7 @@ const CollectiveOfferStockEdition = ({
   }
 
   return (
-    <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
+    <CollectiveOfferLayout offer={offer} subTitle={offer.name} isTemplate={isTemplate}>
       <OfferEducationalStock
         initialValues={initialValues}
         mode={

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom'
 
-import { isCollectiveOffer, Mode } from 'commons/core/OfferEducational/types'
+import { Mode } from 'commons/core/OfferEducational/types'
 import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
 import { RouteLeavingGuardCollectiveOfferCreation } from 'components/RouteLeavingGuardCollectiveOfferCreation/RouteLeavingGuardCollectiveOfferCreation'
 import {
@@ -34,7 +34,6 @@ export const CollectiveOfferSummaryCreation = ({
   return (
     <CollectiveOfferLayout
       subTitle={offer.name}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
       isTemplate={isTemplate}
       isCreation={true}
       offer={offer}

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
@@ -7,7 +7,6 @@ import {
   GET_EDUCATIONAL_INSTITUTIONS_QUERY_KEY,
 } from 'commons/config/swrQueryKeys'
 import {
-  isCollectiveOffer,
   isCollectiveOfferTemplate,
   Mode,
 } from 'commons/core/OfferEducational/types'
@@ -63,7 +62,6 @@ export const CollectiveOfferVisibility = ({
   return (
     <CollectiveOfferLayout
       subTitle={offer.name}
-      isFromTemplate={isCollectiveOffer(offer) && Boolean(offer.templateId)}
       isTemplate={isTemplate}
       isCreation={isCreation}
       requestId={requestId}

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferEditionVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferEditionVisibility.tsx
@@ -65,7 +65,7 @@ const CollectiveOfferVisibility = ({
   }
 
   return (
-    <CollectiveOfferLayout subTitle={offer.name} isTemplate={isTemplate}>
+    <CollectiveOfferLayout offer={offer} subTitle={offer.name} isTemplate={isTemplate}>
       <CollectiveOfferVisibilityScreen
         mode={offer.isVisibilityEditable ? Mode.EDITION : Mode.READ_ONLY}
         initialValues={extractInitialVisibilityValues(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35169

Ré-afficher le stepper pour les étapes de création d'une offre collective
Ré-afficher le menu qui s'affiche dans le récapitulatif d'une offre 

## Vérifications

- [x] J'ai écrit les tests nécessaires
