### PR TITLE
(BSR)[API] feat: remove get_or_create logic in OffererAddressFactory

### DIFF
--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -474,7 +474,6 @@ class AccessibilityProviderFactory(BaseFactory):
 class OffererAddressFactory(BaseFactory):
     class Meta:
         model = models.OffererAddress
-        sqlalchemy_get_or_create = ("offerer", "address", "label")
 
     label = factory.Sequence("Address label {}".format)
     address = factory.SubFactory(geography_factories.AddressFactory)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -120,8 +120,7 @@ def get_location_options(venue: offerers_models.Venue) -> list[LocationOption]:
 
 
 def get_offer_address_id(
-    location_option: LocationOption,
-    managing_offerer: offerers_models.Offerer,
+    location_option: LocationOption, managing_offerer: offerers_models.Offerer, oa_label: str
 ) -> int | None:
     if location_option["locationType"] != educational_models.CollectiveLocationType.ADDRESS:
         return None
@@ -138,7 +137,7 @@ def get_offer_address_id(
     )
     address = factory(street=offer_venue["otherAddress"])
     offerer_address = offerers_factories.OffererAddressFactory(
-        label=location_option["name"], address=address, offerer=managing_offerer
+        label=oa_label, address=address, offerer=managing_offerer
     )
     return offerer_address.id
 
@@ -806,7 +805,14 @@ def _set_offer_location_columns(
 ) -> None:
     offer.locationType = location_option.get("locationType")
     offer.locationComment = location_option.get("locationComment")
-    offer.offererAddressId = get_offer_address_id(location_option=location_option, managing_offerer=offerer)
+
+    oa_label = offer.name
+    if isinstance(offer, educational_models.CollectiveOfferTemplate):
+        oa_label += " (template)"
+
+    offer.offererAddressId = get_offer_address_id(
+        location_option=location_option, managing_offerer=offerer, oa_label=oa_label
+    )
 
 
 def create_offers_booking_with_different_offer_venues(

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
@@ -394,9 +394,9 @@ def create_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         adageInscriptionDate=datetime.utcnow() - timedelta(days=3),
         venueEducationalStatusId=next(educational_status_iterator),
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
-        departementCode="57",
-        postalCode="57000",
-        city="Lorient",
+        departementCode="33",
+        postalCode="33000",
+        city="Bordeaux",
         siret=siren_utils.complete_siren_or_siret(f"{offerer.siren}0002"),
         pricing_point="self",
     )

--- a/api/tests/routes/pro/patch_venue_test.py
+++ b/api/tests/routes/pro/patch_venue_test.py
@@ -536,6 +536,7 @@ class Returns200Test:
             managingOfferer=user_offerer.offerer,
         )
         venue_without_siret = offerers_factories.VenueWithoutSiretFactory(managingOfferer=user_offerer.offerer)
+        initial_offer_address_ids = [venue.offererAddressId, venue_without_siret.offererAddressId]
 
         mocked_get_address.return_value = AddressInfo(
             id="58062",
@@ -575,7 +576,8 @@ class Returns200Test:
         ).all()
         offerer_address = offerer_addresses[0]
 
-        assert len(offerer_addresses) == 2
+        assert len(offerer_addresses) == 3
+        assert {oa.id for oa in offerer_addresses} == {*initial_offer_address_ids, venue_without_siret.offererAddressId}
         assert venue.offererAddressId == offerer_address.id
         assert address.street == None  # Centroid found only, nothing to fill in street column
         assert address.city == venue.city == "Château-Chinon (Ville)"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) :

On a actuellement un get_or_create sur la factory OffererAddressFactory, on ne va donc pas recréer un objet si on appelle la factory avec les mêmes valeurs pour `("offerer", "address", "label")`.

Cela a du sens pour coller à la contrainte d'unicité, mais seulement dans le cas ou le label n'est pas None. En effet, plusieurs Venue d'un même Offerer peuvent être liés à la même Address, dans ce cas on aura plusieurs lignes avec les même valeurs `offererId, addressId, None` -> il ne faut donc pas aller chercher la même ligne dans ce cas

On supprime ici le get_or_create, il faudra potentiellement contourner la contrainte manuellement dans certains cas (en mettant un label explicite par exemple)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
