### PR TITLE
(PC-35262)[API] fix: activate future offers: update filter

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -181,8 +181,13 @@ def get_capped_offers_for_filters(
 def get_offers_by_publication_date(publication_date: datetime.datetime | None = None) -> BaseQuery:
     if publication_date is None:
         publication_date = datetime.datetime.utcnow()
-    publication_date = publication_date.replace(minute=0, second=0, microsecond=0, tzinfo=None)
-    future_offers_subquery = db.session.query(models.FutureOffer.offerId).filter_by(publicationDate=publication_date)
+
+    upper_bound = publication_date
+    lower_bound = upper_bound - datetime.timedelta(minutes=15)
+
+    future_offers_subquery = db.session.query(models.FutureOffer.offerId).filter(
+        models.FutureOffer.publicationDate <= upper_bound, models.FutureOffer.publicationDate > lower_bound
+    )
     return models.Offer.query.filter(models.Offer.id.in_(future_offers_subquery))
 
 

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1035,10 +1035,12 @@ class GetOffersByPublicationDateTest:
         offer_to_publish_1 = factories.OfferFactory()
         factories.FutureOfferFactory(offer=offer_to_publish_1, publicationDate=publication_date)
         offer_to_publish_2 = factories.OfferFactory()
-        factories.FutureOfferFactory(offer=offer_to_publish_2, publicationDate=publication_date)
+        factories.FutureOfferFactory(
+            offer=offer_to_publish_2, publicationDate=publication_date - datetime.timedelta(minutes=13)
+        )
 
         offer_after = factories.OfferFactory()
-        publication_date_after = publication_date + datetime.timedelta(hours=1)
+        publication_date_after = publication_date + datetime.timedelta(minutes=17)
         factories.FutureOfferFactory(offer=offer_after, publicationDate=publication_date_after)
 
         query = repository.get_offers_by_publication_date(publication_date=publication_date)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35262

Fix : permettre aux offres dans le futur (?) d'être activées au-delà des heures piles par défaut puisque les dates de publication peuvent maintenant être tous les quarts d'heure.