### PR TITLE
(PC-35156)[API] fix: external ticket booking: handle unexpected error

### DIFF
--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -75,7 +75,13 @@ def book_cinema_ticket(
     if not show_id:
         raise exceptions.ExternalBookingConfigurationException("Could not retrieve show_id")
 
-    return client.book_ticket(show_id, booking, beneficiary)
+    try:
+        return client.book_ticket(show_id, booking, beneficiary)
+    except (exceptions.ExternalBookingSoldOutError, exceptions.ExternalBookingTimeoutException):
+        raise
+    except Exception as exc:
+        logger.warning("Could not book external ticket: %s", exc)
+        raise exceptions.ExternalBookingException
 
 
 def disable_external_bookings() -> None:


### PR DESCRIPTION
Add a try/catch around client.book_ticket and raise a custom generic
error that will be handled by the controller.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35156

Ne pas laisser s'échapper une erreur lors de la réservation d'un ticket via une API externe.
En cas d'erreur : ajouter un log et en renvoyer une générique de chez nous qui devra être gérée par une fonction appelante (par exemple un contrôleur des routes de l'application native).
