### PR TITLE
(PC-35289)[PRO] fix: Use max-width for hook media queries.

### DIFF
--- a/pro/src/components/BackToNavLink/BackToNavLink.tsx
+++ b/pro/src/components/BackToNavLink/BackToNavLink.tsx
@@ -10,17 +10,16 @@ interface BackToNavLinkProps {
   className?: string
 }
 
-export const BackToNavLink = ({ className }: BackToNavLinkProps): JSX.Element => {
-  const isMobileScreen = useMediaQuery('(min-width: 64rem)')
+export const BackToNavLink = ({
+  className,
+}: BackToNavLinkProps): JSX.Element => {
+  const isMobileScreen = useMediaQuery('(max-width: 64rem)')
 
   return (
     <a
       id="back-to-nav-link"
       href={isMobileScreen ? '#header-nav-toggle' : '#lateral-panel'}
-      className={classnames(
-        className,
-        styles['back-to-nav-link']
-      )}
+      className={classnames(className, styles['back-to-nav-link'])}
     >
       <SvgIcon
         src={fullGoTop}

--- a/pro/src/components/IndividualOffer/StocksThing/StockThingFormActions/StockThingFormActions.tsx
+++ b/pro/src/components/IndividualOffer/StocksThing/StockThingFormActions/StockThingFormActions.tsx
@@ -12,7 +12,7 @@ export interface StockThingFormActionsProps {
 export const StockThingFormActions = ({
   actions,
 }: StockThingFormActionsProps): JSX.Element => {
-  const isMobileScreen = useMediaQuery('(min-width: 64rem)')
+  const isMobileScreen = useMediaQuery('(max-width: 64rem)')
 
   return (
     <div className={styles['button-actions']}>

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -68,7 +68,7 @@ export const Offers = ({
   const { nbHits } = useStats()
   const { scopedResults, results: nonScopedResult } = useInstantSearch()
 
-  const isMobileScreen = useMediaQuery('(min-width: 64rem)')
+  const isMobileScreen = useMediaQuery('(max-width: 64rem)')
 
   const location = useLocation()
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35289

**Objectif**
Corriger le test e2e sur `createCollectiveOffer` qui fail en testing ([comme ici](https://github.com/pass-culture/pass-culture-main/actions/runs/13974991129/job/39126548885)).

Pour corriger j'ai remplacé les "min-width" qui ont été modifiés par des "max-width". A priori "min-width" est mieux, et il faudrait faire `!useMediaQuery('(min-width: 64rem)')`, mais je crois que caster la variable isMobileScreen en booléen casse aussi le test e2e. Donc je propose de rester sur du max-width pour débloquer la ci rapidement.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
