### PR TITLE
(PC-35301)[API] fix: DS webhook concurrent calls

### DIFF
--- a/api/src/pcapi/utils/lock.py
+++ b/api/src/pcapi/utils/lock.py
@@ -1,0 +1,36 @@
+from contextlib import contextmanager
+import datetime
+import time
+import typing
+
+from flask import current_app
+import redis
+
+
+class LockError(Exception):
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __str__(self) -> str:
+        return f"Failed to acquire lock: {self._name}"
+
+
+@contextmanager
+def lock(name: str, ttl: int | datetime.timedelta = 60, timeout: int | float = 30) -> typing.Iterator[None]:
+    redis_client = current_app.redis_client
+    start = time.time()
+    while True:
+        if not redis_client.exists(name):
+            break
+        if time.time() - start > timeout:
+            raise LockError(name)
+        time.sleep(0.1)
+
+    redis_client.set(name, "1", ex=ttl, nx=True)
+    try:
+        yield
+    finally:
+        try:
+            redis_client.delete(name)
+        except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+            pass

--- a/api/tests/utils/lock_test.py
+++ b/api/tests/utils/lock_test.py
@@ -1,0 +1,27 @@
+import datetime
+
+import pytest
+
+from pcapi.utils import lock as lock_utils
+
+
+class LockTest:
+    def test_lock(self):
+        step = 0
+        with lock_utils.lock("test_lock", ttl=5, timeout=0):
+            step += 1
+        with lock_utils.lock("test_lock", ttl=5, timeout=0):
+            step += 1
+        assert step == 2
+
+    def test_lock_already_acquired(self):
+        with lock_utils.lock("test_lock_already_acquired", ttl=5, timeout=0):
+            with pytest.raises(lock_utils.LockError) as error:
+                with lock_utils.lock("test_lock_already_acquired", ttl=5, timeout=0):
+                    pass
+        assert str(error.value) == "Failed to acquire lock: test_lock_already_acquired"
+
+    def test_lock_timeout(self):
+        with lock_utils.lock("test_lock_timeout", ttl=1, timeout=2):
+            with lock_utils.lock("test_lock_timeout", ttl=5, timeout=3):
+                pass


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-35301

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
