### PR TITLE
(BSR)[API] feat: extra data in GCP logs to help debug invalid email

### DIFF
--- a/api/src/pcapi/core/mails/transactional/send_transactional_email.py
+++ b/api/src/pcapi/core/mails/transactional/send_transactional_email.py
@@ -89,6 +89,11 @@ def send_transactional_email(payload: SendTransactionalEmailRequest) -> None:
                         ",".join(email_utils.anonymize_email(recipient) for recipient in payload.recipients),
                         code,
                         data.get("message"),
+                        extra={
+                            "template_id": payload.template_id,
+                            "recipients": payload.recipients,
+                            "bcc_recipients": payload.bcc_recipients,
+                        },
                     )
                     return
             except json.JSONDecodeError:

--- a/api/tests/core/mails/transactional/test_send_transactional_email.py
+++ b/api/tests/core/mails/transactional/test_send_transactional_email.py
@@ -82,7 +82,8 @@ class TransactionalEmailWithTemplateTest:
 
         payload = SendTransactionalEmailRequest(
             sender={"email": "support@example.com", "name": "pass Culture"},
-            recipients=["invalid@example"],
+            recipients=["invalid@example", "other@example.com"],
+            bcc_recipients=["bcc@example.com"],
             template_id=TransactionalEmail.EMAIL_CONFIRMATION.value.id,
             params={"name": "Avery"},
             reply_to={"email": "support@example.com", "name": "pass Culture"},
@@ -94,8 +95,13 @@ class TransactionalEmailWithTemplateTest:
         assert caplog.records[0].levelname == "ERROR"
         assert (
             caplog.records[0].message
-            == "Sendinblue can't send email to inv***@example: code=invalid_parameter, message=email is not valid in to"
+            == "Sendinblue can't send email to inv***@example,oth***@example.com: code=invalid_parameter, message=email is not valid in to"
         )
+        assert caplog.records[0].extra == {
+            "template_id": TransactionalEmail.EMAIL_CONFIRMATION.value.id,
+            "recipients": ["invalid@example", "other@example.com"],
+            "bcc_recipients": ["bcc@example.com"],
+        }
         assert len(caplog.records) == 1
 
     @patch(


### PR DESCRIPTION
## But de la pull request

Lors d'une erreur 400 sur Brevo, les emails sont anonymisés dans Sentry et le message de log, il est difficile de retrouver d'où vient l'erreur. Ajoutons les emails en clair dans les logs GCP pour visualiser l'erreur.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
