### PR TITLE
(PC-35126)[API] feat: New option to clean mediation before building sandbox

### DIFF
--- a/api/src/pcapi/core/object_storage/__init__.py
+++ b/api/src/pcapi/core/object_storage/__init__.py
@@ -66,6 +66,12 @@ def delete_public_object(folder: str, object_id: str, *, bucket: str = "") -> No
         backend(bucket_name=bucket).delete_public_object(folder, object_id)
 
 
+def delete_public_object_recursively(storage_path: str, bucket: str = "") -> None:
+    for backend_path in _get_backends():
+        backend = import_string(backend_path)
+        backend(bucket_name=bucket).delete_public_object_recursively(storage_path)
+
+
 def list_files(folder: str, *, bucket: str = "", max_results: int = 1000) -> list[str]:
     files = []
     for backend_path in _get_backends():

--- a/api/src/pcapi/core/object_storage/backends/base.py
+++ b/api/src/pcapi/core/object_storage/backends/base.py
@@ -15,5 +15,8 @@ class BaseBackend:
     def delete_public_object(self, folder: str, object_id: str) -> None:
         raise NotImplementedError()
 
+    def delete_public_object_recursively(self, storage_path: str) -> None:
+        raise NotImplementedError()
+
     def list_files(self, folder: str, *, max_results: int = 1000) -> list[str]:
         raise NotImplementedError()

--- a/api/src/pcapi/core/object_storage/backends/gcp.py
+++ b/api/src/pcapi/core/object_storage/backends/gcp.py
@@ -70,6 +70,26 @@ class GCPBackend(BaseBackend):
             )
             raise exc
 
+    def delete_public_object_recursively(self, storage_path: str) -> None:
+        try:
+            bucket = self.get_gcp_storage_client_bucket()
+            gcp_cloud_blobs = bucket.list_blobs(prefix=storage_path)
+            for blob in gcp_cloud_blobs:
+                blob.delete(timeout=TIMEOUT, retry=RETRY_STRATEGY)
+        except NotFound:
+            logger.info("Folder not found on deletion on GCP bucket: %s", storage_path)
+        except Exception as exc:
+            logger.exception(
+                "An error has occurred while trying to delete file on GCP bucket",
+                extra={
+                    "exc": exc,
+                    "project_id": self.project_id,
+                    "bucket_name": self.bucket_name,
+                    "storage_path": storage_path,
+                },
+            )
+            raise exc
+
     def delete_public_object(self, folder: str, object_id: str) -> None:
         storage_path = folder + "/" + object_id
         try:

--- a/api/src/pcapi/core/object_storage/backends/local.py
+++ b/api/src/pcapi/core/object_storage/backends/local.py
@@ -68,6 +68,9 @@ class LocalBackend(BaseBackend):
             logger.exception("An error has occurred while trying to delete file on local file storage: %s", exc)
             raise exc
 
+    def delete_public_object_recursively(self, storage_path: str) -> None:
+        pass
+
     def list_files(self, folder: str, *, max_results: int = 1000) -> list[str]:
         results = []
         local_dir_len = len(str(self.local_dir("", ""))) + 1

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_mediations.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_mediations.py
@@ -2,7 +2,9 @@ import logging
 from pathlib import Path
 from shutil import copyfile
 
+from pcapi import settings
 from pcapi.core.categories import subcategories
+from pcapi.core.object_storage import delete_public_object_recursively
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import Offer
 from pcapi.repository import repository
@@ -61,3 +63,9 @@ def create_industrial_mediations(offers_by_name: dict[str, Offer]) -> None:
     repository.save(*mediations_with_asset.values())
 
     logger.info("created %d mediations", len(mediations_by_name))
+
+
+def clean_industrial_mediations_bucket() -> None:
+    logger.info("Cleaning mediation bucket")
+    delete_public_object_recursively(storage_path="thumbs/mediations", bucket=settings.GCP_BUCKET_NAME)
+    logger.info("Mediation bucket cleaned")

--- a/api/src/pcapi/sandboxes/scripts/save_sandbox.py
+++ b/api/src/pcapi/sandboxes/scripts/save_sandbox.py
@@ -6,16 +6,19 @@ from pcapi.core.offers import models as offers_models
 from pcapi.models import db
 from pcapi.repository.clean_database import clean_all_database
 from pcapi.sandboxes import scripts
+from pcapi.sandboxes.scripts.creators.industrial.create_industrial_mediations import clean_industrial_mediations_bucket
 
 
 logger = logging.getLogger(__name__)
 
 
-def save_sandbox(name: str, with_clean: bool = True) -> None:
+def save_sandbox(name: str, with_clean: bool = True, with_clean_bucket: bool = False) -> None:
     if with_clean:
         logger.info("Cleaning database")
         clean_all_database(reset_ids=True)
         logger.info("All databases cleaned")
+    if with_clean_bucket:
+        clean_industrial_mediations_bucket()
 
     script_name = "sandbox_" + name
     sandbox_module = getattr(scripts, script_name)

--- a/api/src/pcapi/sandboxes/scripts/utils/storage_utils.py
+++ b/api/src/pcapi/sandboxes/scripts/utils/storage_utils.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
 from pcapi.connectors.thumb_storage import create_thumb
+from pcapi.core.object_storage import FileNotFound
+from pcapi.core.object_storage import get_public_object
 from pcapi.core.object_storage import store_public_object
 from pcapi.models import Model
 import pcapi.sandboxes
@@ -10,6 +12,11 @@ from pcapi.utils.human_ids import humanize
 def store_public_object_from_sandbox_assets(folder: str, model: Model, subcategory_id: str) -> Model:
     mimes_by_folder = {"spreadsheets": "application/CSV", "thumbs": "image/jpeg", "zips": "application/zip"}
     thumb_id = humanize(model.id)
+    try:
+        get_public_object(folder, model.thumb_path_component + "/" + thumb_id)
+        return model
+    except FileNotFound:
+        pass
     thumbs_folder_path = Path(pcapi.sandboxes.__path__[0]) / "thumbs"
     picture_path = str(thumbs_folder_path / "mediations" / subcategory_id) + ".jpg"
     with open(picture_path, mode="rb") as thumb_file:

--- a/api/src/pcapi/scripts/sandbox.py
+++ b/api/src/pcapi/scripts/sandbox.py
@@ -11,9 +11,11 @@ blueprint = Blueprint(__name__, __name__)
 @blueprint.cli.command("sandbox")
 @click.option("-n", "--name", help="Sandbox name", default="classic")
 @click.option("-c", "--clean", help="Clean database first", default="true")
-def sandbox(name: str, clean: str) -> None:
+@click.option("-c", "--clean-bucket", help="Clean mediation bucket", default="false")
+def sandbox(name: str, clean: str, clean_bucket: str) -> None:
     if settings.CAN_RUN_SANDBOX:
         with_clean = clean == "true"
-        save_sandbox(name, with_clean)
+        with_clean_bucket = clean_bucket == "true"
+        save_sandbox(name, with_clean, with_clean_bucket)
     else:
         print("Sandbox is disabled on this environment")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35126

[Commit 1](https://github.com/pass-culture/pass-culture-main/pull/16833/commits/bffb59bd3bb8dfa5738a933fd7802f8692388793) : Option de nettoyage des mediations de la sandboxe
[Commit 2](https://github.com/pass-culture/pass-culture-main/pull/16833/commits/03bb57ea1d43c3a3e494ba3d6b7bbefcad99bce2) : Récupération des images déjà présentent sur le bucket plutôt que d'en créer de nouvelles à chaque fois

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
