### PR TITLE
(PC-35321)[API] fix: prevent ean duplication when `extraData["ean"]` is an empty string

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -383,7 +383,9 @@ def update_offer(
             offer.subcategoryId, formatted_extra_data, offer.venue, is_from_private_api, offer=offer
         )
         # TODO: (pcharlet, 2025-02-04): Delete next line when body schemas contains specific EAN field outside extraData
-        updates.update({"ean": updates["extraData"].get("ean", None)})
+        ean = updates["extraData"].get("ean", None)
+        if ean != "":
+            updates.update({"ean": ean})
     if "isDuo" in updates:
         is_duo = get_field(offer, updates, "isDuo", aliases=aliases)
         validation.check_is_duo_compliance(is_duo, offer.subcategory)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1723,6 +1723,37 @@ class UpdateOfferTest:
         assert offer.name == "Offer linked to a provider"
         assert offer.idAtProvider == "some_id_at_provider"
 
+    def test_success_should_duplicate_ean(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        offerer = offerers_factories.OffererFactory()
+        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
+        offer = factories.OfferFactory(
+            lastProvider=provider,
+            name="Offer linked to a provider",
+            extraData={"ean": "1234567890124"},
+        )
+        body = offers_schemas.UpdateOffer(extraData={"ean": "1234567890125"})
+        api.update_offer(offer, body)
+
+        offer = models.Offer.query.one()
+        assert offer.ean == "1234567890125"
+        assert offer.extraData["ean"] == "1234567890125"
+
+    def test_success_should_not_duplicate_ean_when_it_is_an_empty_string(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        offerer = offerers_factories.OffererFactory()
+        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
+        offer = factories.EventOfferFactory(
+            lastProvider=provider,
+            name="Offer linked to a provider",
+            extraData={"ean": ""},
+        )
+        body = offers_schemas.UpdateOffer(extraData={"ean": ""})
+        api.update_offer(offer, body)
+
+        offer = models.Offer.query.one()
+        assert offer.ean == None
+
     def test_raise_error_on_updating_id_at_provider(self):
         offer = factories.OfferFactory(
             lastProvider=None,

--- a/api/tests/routes/public/individual_offers/v1/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_event_test.py
@@ -163,6 +163,50 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
             "stageDirector": "Robert",
         }
 
+    def test_should_update_extra_data_even_if_extra_data_has_an_empty_ean(self, client):
+        plain_api_key, venue_provider = self.setup_active_venue_provider()
+        event_offer = offers_factories.EventOfferFactory(
+            venue=venue_provider.venue,
+            subcategoryId="FESTIVAL_ART_VISUEL",
+            extraData={
+                "author": "Maurice",
+                "stageDirector": "Robert",
+                "performer": "Pink Pâtisserie",
+                "ean": "",  # faulty ean
+            },
+            lastProvider=venue_provider.provider,
+            withdrawalDelay=86400,
+            withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
+            bookingContact="contact@example.com",
+            bookingEmail="notify@example.com",
+        )
+
+        response = client.with_explicit_token(plain_api_key).patch(
+            self.endpoint_url.format(event_id=event_offer.id),
+            json={
+                "categoryRelatedFields": {
+                    "category": "FESTIVAL_ART_VISUEL",
+                    "author": "Maurice",
+                    "stageDirector": "Robert",
+                    "performer": "Pink Pâtisserie",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json["categoryRelatedFields"] == {
+            "author": "Maurice",
+            "category": "FESTIVAL_ART_VISUEL",
+            "performer": "Pink Pâtisserie",
+        }
+        assert event_offer.extraData == {
+            "author": "Maurice",
+            "ean": "",
+            "performer": "Pink Pâtisserie",
+            "stageDirector": "Robert",
+        }
+        assert not event_offer.ean
+
     def test_patch_all_fields(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=True)
         event_offer = offers_factories.EventOfferFactory(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35321

Fix du bug : https://pass-culture.sentry.io/issues/34393092/?alert_rule_id=155878&alert_type=issue&environment=production&notification_uuid=a7be98bb-01f4-4e90-86df-b50f84951950&project=4508776981069904&referrer=slack

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
