### PR TITLE
(BSR)[API] feat: add sentry tags in `@provider_api_key_required`

### DIFF
--- a/api/src/pcapi/validation/routes/users_authentifications.py
+++ b/api/src/pcapi/validation/routes/users_authentifications.py
@@ -7,6 +7,7 @@ from flask import _request_ctx_stack
 from flask import g
 from flask import request
 from flask_login import current_user
+import sentry_sdk
 from werkzeug.local import LocalProxy
 
 from pcapi import settings
@@ -88,6 +89,8 @@ def provider_api_key_required(route_function: typing.Callable) -> typing.Callabl
             raise api_errors.UnauthorizedError(
                 errors={"auth": "Deprecated API key. Please contact provider support to get a new API key"}
             )
+        sentry_sdk.set_tag("provider-name", g.current_api_key.provider.name)
+        sentry_sdk.set_tag("provider-id", g.current_api_key.provider.id)
 
         _check_active_offerer(g.current_api_key)
         _check_active_provider(g.current_api_key)


### PR DESCRIPTION
To ease debugging of public API errors

## But de la pull request

Ticket Jira (ou description si BSR) : Ajout des tags sentry `provider-id` et `provider-name` au niveau du décorateur `@provider_api_key_required`.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
