### PR TITLE
(BSR)[PRO] ci: do not issue delete preview env command if not exists

### DIFF
--- a/.github/workflows/dev_on_pull_request_closed.yml
+++ b/.github/workflows/dev_on_pull_request_closed.yml
@@ -104,6 +104,13 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: "Setup firebase tools"
+          npm install -g firebase-tools
+
       - name: "Get secrets"
         id: "secrets"
         uses: "google-github-actions/get-secretmanager-secrets@v2"
@@ -111,14 +118,33 @@ jobs:
           secrets: |-
             FIREBASE_SERVICE_ACCOUNT_TESTING:passculture-metier-ehp/pc_pro_testing_firebase_json
 
+      - name: "Authentification to Google"
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: ${{ steps.secrets.outputs.FIREBASE_SERVICE_ACCOUNT_TESTING }}
+
       - name: "Get pro channel name"
         id: pro-channel-name
         run: |
           shortname=$(echo "${{ github.head_ref }}" | cut -c1-20)
           echo "channel-name=pr${{ github.event.pull_request.number }}-$shortname" >> $GITHUB_OUTPUT
 
+      - name: "Test if channel exists"
+        id: test-channel-existence 
+        working-directory: pro
+        run: |
+          channel="${{ steps.pro-channel-name.outputs.channel-name }}"
+          firebase projects:list 
+          firebase use testing
+          if firebase hosting:channel:list | grep "$channel"; then
+            echo "should_delete=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_delete=false" >> $GITHUB_OUTPUT
+          fi
+
       # Delete pro firebase deployment
       - uses: w9jds/firebase-action@v13.32.0
+        if: steps.test-channel-existence.outputs.should_delete == 'true'
         with:
           args: hosting:channel:delete ${{ steps.pro-channel-name.outputs.channel-name }} --force
         env:


### PR DESCRIPTION
## But de la pull request

Rajout d'une commande pour vérifier si l'environnement de preview associé à la PR existe avant de tenter de le delete

Exemple ou il existe et ou il delete : https://github.com/pass-culture/pass-culture-main/actions/runs/14058276433/job/39362643873

Exemple ou il n'existe pas et donc il skip le delete : https://github.com/pass-culture/pass-culture-main/actions/runs/14057465924/job/39360043240

