### PR TITLE
(BSR)[API] fix: celery worker in dev environment

### DIFF
--- a/api/start-celery-worker.sh
+++ b/api/start-celery-worker.sh
@@ -6,5 +6,4 @@ until psql $DATABASE_URL -c '\q'; do
   sleep 1
 done
 
-celery -A pcapi.celery_tasks.celery_worker worker -Q mails
-
+celery -A pcapi.celery_tasks.celery_worker worker -Q "celery.external_calls.priority,celery.external_calls.default" --loglevel=DEBUG


### PR DESCRIPTION
## But de la pull request

Corriger le lancement de celery en environnement de développemen et permettre de voir les logs des tâches celery.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
