### PR TITLE
(BSR)[PRO] fix: do not send contactPhone on collective offer patch wh…

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
@@ -61,7 +61,7 @@ const serializer: PatchOfferSerializer<PatchCollectiveOfferBodyModel> = {
   }),
   phone: (payload, offer) => ({
     ...payload,
-    contactPhone: offer.phone,
+    contactPhone: offer.phone || null,
   }),
   email: (payload, offer) => ({
     ...payload,
@@ -114,8 +114,6 @@ export const createPatchOfferPayload = (
       changedValues = serializer[key]?.(changedValues, offer) ?? {}
     }
   })
-  // We use this to patch field when user want to make it empty
-  changedValues.contactPhone = offer.phone || null
 
   return changedValues
 }


### PR DESCRIPTION
…en it has not changed

## But de la pull request

Ticket Jira (ou description si BSR) : ne pas envoyer le champ `contactPhone` quand on PATCH une offre réservable alors que la valeur n'a pas changé

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
