### PR TITLE
(PC-32138)[BO] feat: offer details: add product information

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/details.html
@@ -125,6 +125,11 @@
                   </p>
                 {% endif %}
                 {% if extra_data.genres %}<span class="fw-bold">Genres :</span> {{ extra_data.genres | format_string_list }}{% endif %}
+                {% if offer.product %}
+                    <p class="mb-1">
+                        <span class="fw-bold">Produit : </span> {{ offer.product.name }} ({{ offer.productId }})
+                    </p>
+                {% endif %}
                 <p class="mb-1 mt-4">
                   <span class="fw-bold">Voir dans l'app :</span>
                   {{ links.build_offer_webapp_link(offer) }}

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -2061,6 +2061,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert f"Offer ID : {offer.id}" in card_text
         assert "Catégorie : Cinéma" in card_text
         assert "Sous-catégorie : Séance de cinéma " in card_text
+        assert f"Produit : good movie ({product.id})" in card_text
         assert "Genres : ADVENTURE, ANIMATION, DRAMA " in card_text
         assert "Statut : Épuisée" in card_text
         assert "État : Validée" in card_text


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-32138

Ajouter une ligne sur la page de détails d'une offre (dans le BO) qui indique à quel produit elle est rattachée.
S'il l'offre n'est liée à aucun produit, ne rien afficher.

![Capture d'écran 2025-03-25 171152](https://github.com/user-attachments/assets/3729b918-5db5-41f5-89dc-5f1377425af0)

