### PR TITLE
(BSR)[BO] chore: remove inefficient connect as button

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/venue/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get.html
@@ -262,14 +262,6 @@
                   {{ venue_provider.lastSyncDate | format_date_time }}
                 </p>
               {% endfor %}
-              {% if has_permission("CONNECT_AS_PRO") %}
-                <p class="mb-1">
-                  {{ links.build_connect_as_pseudo_link(venue.id, "venue", "/reservations?offerVenueId="~venue.id~"", "Réservations " , "fw-bold link-primary") }}
-                </p>
-                <p class="mb-1">
-                  {{ links.build_connect_as_pseudo_link(venue.id, "venue", "/offres?lieu="~venue.id~"", "Offres associées " , "fw-bold link-primary") }}
-                </p>
-              {% endif %}
               {% set search_params = {
                               "search-0-search_field": "VENUE",
                               "search-0-operator": "IN",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : On ne peut plus filtrer les offres par venueId sur PC Pro, ce bouton ne sert donc plus

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
