### PR TITLE
(PC-35383)[PRO] feat: Add DayCHeckbox to FormV2 and rework it.

### DIFF
--- a/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.tsx
+++ b/pro/src/ui-kit/form/shared/BaseCheckbox/BaseCheckbox.tsx
@@ -75,7 +75,7 @@ export const BaseCheckbox = forwardRef(
       <div className={containerClasses}>
         <div className={styles['base-checkbox-row']}>
           <span className={styles['base-checkbox-label-row']}>
-            <label className={labelClasses}>
+            <label className={labelClasses} htmlFor={id}>
               <input
                 aria-invalid={hasError}
                 {...(ariaDescribedBy && {

--- a/pro/src/ui-kit/formV2/DayCheckbox/DayCheckbox.module.scss
+++ b/pro/src/ui-kit/formV2/DayCheckbox/DayCheckbox.module.scss
@@ -1,0 +1,80 @@
+@use "styles/variables/_forms.scss" as forms;
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_outline.scss" as outline;
+
+$checkbox-size: rem.torem(40px);
+
+.checkbox {
+  width: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 100%;
+  cursor: pointer;
+
+  &:hover:not(&.disabled) {
+    .checkbox-input {
+      border-color: var(--color-grey-dark);
+      box-shadow: forms.$input-hover-shadow;
+      background-color: var(--color-background-default);
+    }
+  }
+
+  &.error:not(&.disabled) {
+    .checkbox-input {
+      border-color: var(--color-border-error);
+    }
+
+    color: var(--color-text-error);
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+  }
+}
+
+.checkbox-label {
+  position: absolute;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.checkbox-input {
+  appearance: none;
+  position: relative;
+  width: $checkbox-size;
+  height: $checkbox-size;
+  background-color: var(--color-background-default);
+  border: rem.torem(1px) solid var(--color-grey-dark);
+  border-radius: 100%;
+  cursor: pointer;
+
+  &:focus-within {
+    @include outline.focus-outline;
+  }
+
+  &:focus {
+    border-color: var(--color-grey-dark);
+  }
+
+  &:checked {
+    @include fonts.button;
+
+    border: rem.torem(2px) solid var(--color-secondary-light);
+    background-color: var(--color-background-info);
+
+    &:focus {
+      border: rem.torem(2px) solid var(--color-secondary-light);
+      border-radius: 50%;
+      background-color: var(--color-background-info);
+    }
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    background-color: var(--color-background-disabled);
+    color: var(--color-text-disabled);
+    border: var(--color-border-disabled);
+  }
+}

--- a/pro/src/ui-kit/formV2/DayCheckbox/DayCheckbox.spec.tsx
+++ b/pro/src/ui-kit/formV2/DayCheckbox/DayCheckbox.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+
+import { DayCheckbox } from './DayCheckbox'
+
+describe('DayCheckbox', () => {
+  it('should display a checkbox input', () => {
+    render(<DayCheckbox name="field" label="L" tooltipContent="Lundi" />)
+
+    expect(screen.getByLabelText('Lundi')).toBeInTheDocument()
+  })
+
+  it('should display an error message', () => {
+    render(
+      <DayCheckbox
+        name="field"
+        label="L"
+        tooltipContent="Lundi"
+        error="error message"
+      />
+    )
+
+    expect(screen.getByText('error message')).toBeInTheDocument()
+  })
+})

--- a/pro/src/ui-kit/formV2/DayCheckbox/DayCheckbox.stories.tsx
+++ b/pro/src/ui-kit/formV2/DayCheckbox/DayCheckbox.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { PropsWithChildren } from 'react'
+import { FormProvider, useForm, useFormContext } from 'react-hook-form'
+
+import { DayCheckbox } from './DayCheckbox'
+
+const meta: Meta<typeof DayCheckbox> = {
+  title: 'ui-kit/formsV2/DayCheckbox',
+  component: DayCheckbox,
+}
+
+const Wrapper = ({ children }: PropsWithChildren) => {
+  const hookForm = useForm<{ myField: boolean }>({
+    defaultValues: { myField: true },
+  })
+
+  return (
+    <FormProvider {...hookForm}>
+      <form>{children}</form>
+    </FormProvider>
+  )
+}
+
+export default meta
+type Story = StoryObj<typeof DayCheckbox>
+
+export const Default: Story = {
+  args: {
+    label: 'L',
+    tooltipContent: 'Lundi',
+    name: 'myField',
+    checked: true,
+    onChange: () => {
+      //  Control the result here with e.target.checked
+    },
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    label: 'L',
+    tooltipContent: 'Lundi',
+    name: 'myField',
+    checked: false,
+    disabled: true,
+    onChange: () => {
+      //  Control the result here with e.target.checked
+    },
+  },
+}
+
+export const WithinAGroupInError: Story = {
+  args: {
+    label: 'L',
+    tooltipContent: 'Lundi',
+    name: 'myField',
+    checked: false,
+    error: 'error',
+    displayErrorMessage: false,
+    onChange: () => {
+      //  Control the result here with e.target.checked
+    },
+  },
+}
+
+export const WithinForm: Story = {
+  args: {
+    label: 'L',
+    tooltipContent: 'Lundi',
+  },
+  decorators: [
+    (Story) => (
+      <Wrapper>
+        <Story />
+      </Wrapper>
+    ),
+  ],
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { register } = useFormContext<{ myField: boolean }>()
+
+    return <DayCheckbox {...args} {...register('myField')} />
+  },
+}

--- a/pro/src/ui-kit/formV2/DayCheckbox/DayCheckbox.tsx
+++ b/pro/src/ui-kit/formV2/DayCheckbox/DayCheckbox.tsx
@@ -1,0 +1,81 @@
+import classNames from 'classnames'
+import { ForwardedRef, forwardRef, useId } from 'react'
+
+import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
+import { Tooltip, TooltipProps } from 'ui-kit/Tooltip/Tooltip'
+
+import styles from './DayCheckbox.module.scss'
+
+type DayCheckboxProps = {
+  /** Name of the input. Used for identifying it in an uncontrolled form, and for referencing the error */
+  name: string
+  className?: string
+  /** Error text for the checkbox */
+  error?: string
+  /** Whether or not to display the error message. If false, the field has the error styles but no message */
+  displayErrorMessage?: boolean
+  onChange?: React.InputHTMLAttributes<HTMLInputElement>['onChange']
+  onBlur?: React.InputHTMLAttributes<HTMLInputElement>['onBlur']
+  label: string | React.ReactNode
+  checked?: boolean
+  disabled?: boolean
+  tooltipContent: TooltipProps['content']
+}
+
+export const DayCheckbox = forwardRef(
+  (
+    {
+      name,
+      className,
+      error,
+      label,
+      displayErrorMessage = true,
+      onChange,
+      onBlur,
+      checked,
+      disabled,
+      tooltipContent,
+    }: DayCheckboxProps,
+    ref: ForwardedRef<HTMLInputElement>
+  ) => {
+    const errorId = useId()
+
+    return (
+      <div
+        className={classNames(
+          styles['checkbox'],
+          { [styles['disabled']]: disabled, [styles['error']]: Boolean(error) },
+          className
+        )}
+      >
+        {/* The tooltip already adds a aria-labelledby atribute to the input tag */}
+        <label className={styles['checkbox-label']} aria-hidden={true}>
+          {label}
+        </label>
+        <Tooltip content={tooltipContent}>
+          <input
+            type="checkbox"
+            className={styles['checkbox-input']}
+            name={name}
+            ref={ref}
+            aria-describedby={errorId}
+            onChange={onChange}
+            onBlur={onBlur}
+            checked={checked}
+            disabled={disabled}
+          />
+        </Tooltip>
+
+        <div role="alert" id={errorId}>
+          {error && displayErrorMessage && (
+            <FieldError name={name} className={styles['error']}>
+              {error}
+            </FieldError>
+          )}
+        </div>
+      </div>
+    )
+  }
+)
+
+DayCheckbox.displayName = 'DayCheckbox'


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35383

**Objectif**
Dans le cadre du nouveau drawer de récurrence qui est un form utilisant react-hook-form, on a besoin du DayCheckbox en mode FormV2. Au passage je l'ai modifié pour ajouter un Tooltip aux inputs.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
