### PR TITLE
(BSR)[API] fix: book offers should only have one stock

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -376,7 +376,7 @@ def _create_library_with_writers() -> None:
                 artist_id=artist.id, product_id=product.id, artist_type=ArtistType.AUTHOR
             )
             offer = offers_factories.OfferFactory(product=product, venue=venue)
-            offers_factories.StockFactory.create_batch(5, offer=offer)
+            offers_factories.StockFactory(offer=offer)
 
 
 def create_offers_with_gtls() -> None:


### PR DESCRIPTION
## But de la pull request

Correction des offres de type livre pour qu'elles n'aient qu'un seul stock (avec 5 fois plus de quantité).
Avec plusieurs stocks sur une offre de livre, l'édition du stock sur PC Pro ne marche pas.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
