### PR TITLE
(BSR)[API] fix: do not use 'message' in logger info

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2579,7 +2579,7 @@ def synchronize_accessibility_provider(venue: models.Venue, force_sync: bool = F
                     "analyticsSource": "app-pro",
                     "venue_id": venue.id,
                     "acceslibre_slug": slug,
-                    "message": "Slug not found at acceslibre, AccessibilityProvider removed for this venue",
+                    "slug_loss_message": "Slug not found at acceslibre, AccessibilityProvider removed for this venue",
                 },
                 technical_message_id="acceslibre.synchronisation",
             )


### PR DESCRIPTION
utiliser "message" dans un log est interdit : 

```shell
 for key in extra:
          if (key in ["message", "asctime"]) or (key in rv.__dict__):
             raise KeyError("Attempt to overwrite %r in LogRecord" % key)
          rv.__dict__[key] = extra[key]
 return rv

```