### PR TITLE
(BSR)[API] feat: add formats in collective offer factory

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -5,6 +5,7 @@ import typing
 from dateutil.relativedelta import relativedelta
 import factory
 
+from pcapi.core.categories import models as categories_models
 from pcapi.core.categories.subcategories import COLLECTIVE_SUBCATEGORIES
 from pcapi.core.educational import models
 from pcapi.core.educational import utils
@@ -71,6 +72,7 @@ class CollectiveOfferFactory(BaseFactory):
         "venueId": None,
     }
     interventionArea = ["93", "94", "95"]
+    formats = [categories_models.EacFormat.PROJECTION_AUDIOVISUELLE]
 
     @classmethod
     def _create(
@@ -132,6 +134,7 @@ class CollectiveOfferTemplateFactory(BaseFactory):
         start=datetime.datetime.utcnow() + datetime.timedelta(days=1),
         end=datetime.datetime.utcnow() + datetime.timedelta(days=7),
     )
+    formats = [categories_models.EacFormat.PROJECTION_AUDIOVISUELLE]
 
     @classmethod
     def _create(

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -629,7 +629,7 @@ def test_serialize_collective_offer_template():
             "lng": 2.40929,
         },
         "isTemplate": True,
-        "formats": [fmt.value for fmt in subcategories.CONCERT.formats],
+        "formats": [format.value for format in collective_offer_template.formats],
     }
 
 
@@ -698,5 +698,5 @@ def test_serialize_collective_offer_template_legacy():
             "lng": float(venue.longitude),
         },
         "isTemplate": True,
-        "formats": [fmt.value for fmt in subcategories.CONCERT.formats],
+        "formats": [format.value for format in collective_offer_template.formats],
     }

--- a/api/tests/routes/adage/v1/conftest.py
+++ b/api/tests/routes/adage/v1/conftest.py
@@ -61,5 +61,5 @@ def expected_serialized_prebooking(booking: models.CollectiveBooking) -> dict:
         "imageCredit": offer.imageCredit,
         "venueId": venue.id,
         "offererName": venue.managingOfferer.name,
-        "formats": sorted([offer.formats]) if offer.formats else None,
+        "formats": sorted([format.value for format in offer.formats]) if offer.formats else None,
     }

--- a/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
+++ b/api/tests/routes/adage/v1/get_all_bookings_per_year_test.py
@@ -11,7 +11,7 @@ from pcapi.utils.date import format_into_utc_date
 
 def expected_serialized_booking(booking) -> dict:
     formats = booking.collectiveStock.collectiveOffer.formats
-    formats = formats if formats else None
+    formats = [format.value for format in formats] if formats else None
     return {
         "id": booking.id,
         "UAICode": booking.educationalInstitution.institutionId,

--- a/api/tests/routes/pro/get_collective_offer_template_test.py
+++ b/api/tests/routes/pro/get_collective_offer_template_test.py
@@ -48,7 +48,7 @@ class Returns200Test:
             "start": format_into_utc_date(offer.start),
             "end": format_into_utc_date(offer.end),
         }
-        assert response.json["formats"] == offer.formats
+        assert response.json["formats"] == [format.value for format in offer.formats]
         assert response.json["displayedStatus"] == "ACTIVE"
         assert response.json["allowedActions"] == [
             "CAN_EDIT_DETAILS",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : les formats sont obligatoires quand on créé une offre collective. On ajoute une valeur dans la factory pour être cohérent (la colonne devra être rendue non-nullable ultérieurement)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
