### PR TITLE
(BSR)[ADAGE] feat: send formats in reimbursement notification

### DIFF
--- a/api/src/pcapi/core/educational/schemas.py
+++ b/api/src/pcapi/core/educational/schemas.py
@@ -69,7 +69,7 @@ class Redactor(AdageBaseResponseModel):
         alias_generator = to_camel
 
 
-class EducationalBookingBaseResponse(AdageBaseResponseModel):
+class EducationalBookingResponse(AdageBaseResponseModel):
     accessibility: str = Field(description="Accessibility of the offer")
     address: str = Field(description="Adresse of event")
     startDatetime: datetime = Field(description="Start date of event")
@@ -114,6 +114,7 @@ class EducationalBookingBaseResponse(AdageBaseResponseModel):
     imageUrl: str | None = Field(description="Url for offer image")
     venueId: int
     offererName: str
+    formats: list[subcategories.EacFormat] | None
 
     class Config:
         title = "Prebooking detailed response"
@@ -121,15 +122,11 @@ class EducationalBookingBaseResponse(AdageBaseResponseModel):
         allow_population_by_field_name = True
 
 
-class EducationalBookingResponse(EducationalBookingBaseResponse):
-    formats: list[subcategories.EacFormat] | None
-
-
 class EducationalBookingEdition(EducationalBookingResponse):
     updatedFields: list[str] = Field(description="List of fields updated")
 
 
-class AdageReimbursementNotification(EducationalBookingBaseResponse):
+class AdageReimbursementNotification(EducationalBookingResponse):
     reimbursementReason: str
     reimbursedValue: decimal.Decimal
     reimbursementDetails: str

--- a/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
+++ b/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
@@ -290,4 +290,5 @@ def serialize_reimbursement_notification(
         reimbursementDetails=details,
         venueId=venue.id,
         offererName=venue.managingOfferer.name,
+        formats=collective_booking.collectiveStock.collectiveOffer.formats,
     )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : ajout des formats de l'offre dans `notify_reimburse_collective_booking` (notif à Adage lors d'un remboursement d'une offre)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
