### PR TITLE
(BSR)[ADAGE] feat: remove subcategoryLabel in adage bookings

### DIFF
--- a/api/src/pcapi/core/educational/schemas.py
+++ b/api/src/pcapi/core/educational/schemas.py
@@ -103,7 +103,6 @@ class EducationalBookingBaseResponse(AdageBaseResponseModel):
     participants: list[str] = Field(description="List of class levels which can participate")
     priceDetail: str | None = Field(description="Offer's stock price detail")
     venueTimezone: str
-    subcategoryLabel: str = Field(description="Subcategory label")
     totalAmount: decimal.Decimal = Field(description="Total price of the prebooking")
     url: str | None = Field(description="Url to access the offer")
     withdrawalDetails: str | None

--- a/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
+++ b/api/src/pcapi/routes/adage/v1/serialization/prebooking.py
@@ -155,7 +155,6 @@ def serialize_collective_booking(
         status=get_collective_booking_status(collective_booking),  # type: ignore[arg-type]
         cancellationReason=collective_booking.cancellationReason,
         venueTimezone=venue.timezone,
-        subcategoryLabel=offer.subcategory.app_label if offer.subcategory else "",
         totalAmount=stock.price,
         url=offer_app_link(offer),
         withdrawalDetails=None,
@@ -276,7 +275,6 @@ def serialize_reimbursement_notification(
         yearId=collective_booking.educationalYearId,  # type: ignore[arg-type]
         status=get_collective_booking_status(collective_booking),  # type: ignore[arg-type]
         venueTimezone=venue.timezone,
-        subcategoryLabel=offer.subcategory.app_label if offer.subcategory else "",
         totalAmount=stock.price,
         url=offer_app_link(offer),
         withdrawalDetails=None,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : ce champ n'est pas utilisé côté Adage

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
