### PR TITLE
(PC-35408)[API] fix: avoid joinedload, prefer selectinload

### DIFF
--- a/api/tests/routes/public/individual_offers/v1/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_test.py
@@ -21,7 +21,14 @@ class GetEventTest(PublicAPIVenueEndpointHelper):
 
     num_queries_with_error = 1  # retrieve API key
     num_queries_with_error += 1  # retrieve offer
-    num_queries = num_queries_with_error + 1  # future_offer (a backref)
+
+    # fetch stocks (1 query)
+    # fetch mediations (1 query)
+    # fetch price categories (1 query)
+    num_queries = num_queries_with_error + 3
+
+    # fetch product (1 query)
+    num_queries_full = num_queries + 1
 
     def setup_base_resource(self, venue=None) -> offers_models.Offer:
         venue = venue or self.setup_venue()
@@ -65,7 +72,7 @@ class GetEventTest(PublicAPIVenueEndpointHelper):
         event_offer = self.setup_base_resource(venue=venue_provider.venue)
         event_offer_id = event_offer.id
 
-        with testing.assert_num_queries(self.num_queries):
+        with testing.assert_num_queries(self.num_queries_full):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(event_id=event_offer_id))
 
         assert response.status_code == 200
@@ -109,7 +116,7 @@ class GetEventTest(PublicAPIVenueEndpointHelper):
             publicationDate=publication_date,
         )
 
-        with testing.assert_num_queries(self.num_queries):
+        with testing.assert_num_queries(self.num_queries_full):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(event_id=event_offer_id))
 
         assert response.status_code == 200

--- a/api/tests/routes/public/individual_offers/v1/get_events_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_events_test.py
@@ -18,7 +18,12 @@ class GetEventsTest(PublicAPIVenueEndpointHelper):
 
     num_queries_with_error = 1  # select api_key, offerer and provider
     num_queries_with_error += 1  # check provider EXISTS
-    num_queries = num_queries_with_error + 1  # select offers
+
+    # fetch offers (1 query)
+    # fetch stocks (1 query)
+    # fetch mediations (1 query)
+    # fetch price categories (1 query)
+    num_queries = num_queries_with_error + 4
 
     def test_should_raise_404_because_has_no_access_to_venue(self, client):
         plain_api_key, _ = self.setup_provider()

--- a/api/tests/routes/public/individual_offers/v1/get_product_by_ean_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_product_by_ean_test.py
@@ -14,7 +14,14 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
 
     num_queries_400 = 1  # select api_key, offerer and provider
     num_queries_404 = num_queries_400 + 1  # check venue_provider exists
-    num_queries_success = num_queries_404 + 1  # select offers
+
+    # fetch offer (1 query)
+    num_queries_offer_not_found = num_queries_404 + 1
+
+    # fetch stocks (1 query)
+    # fetch mediations (1 query)
+    # fetch price categories (1 query)
+    num_queries_success = num_queries_offer_not_found + 3
 
     def test_should_raise_404_because_has_no_access_to_venue(self, client):
         plain_api_key, _ = self.setup_provider()
@@ -296,7 +303,7 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
             name="Vieux motard que jamais",
         )
 
-        with testing.assert_num_queries(self.num_queries_success):
+        with testing.assert_num_queries(self.num_queries_offer_not_found):
             response = client.with_explicit_token(plain_api_key).get(
                 f"/public/offers/v1/products/ean?eans=1234567890123&venueId={venue_id}"
             )

--- a/api/tests/routes/public/individual_offers/v1/get_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_product_test.py
@@ -18,8 +18,12 @@ class GetProductTest(PublicAPIVenueEndpointHelper):
     endpoint_method = "get"
     default_path_params = {"product_id": 1}
 
-    num_queries = 1  # select api_key, offerer and provider
-    num_queries += 1  # select offers
+    num_queries_404 = 1  # select api_key, offerer and provider
+    num_queries_404 += 1  # select offers
+
+    num_queries = num_queries_404 + 1  # select price categories
+    num_queries += 1  # select mediations
+    num_queries += 1  # select stocks
 
     def test_should_raise_404_because_has_no_access_to_venue(self, client):
         plain_api_key, _ = self.setup_provider()
@@ -31,7 +35,7 @@ class GetProductTest(PublicAPIVenueEndpointHelper):
             idAtProvider="provider_id_at_provider",
         ).id
 
-        with testing.assert_num_queries(self.num_queries):
+        with testing.assert_num_queries(self.num_queries_404):
             response = client.with_explicit_token(plain_api_key).get(
                 self.endpoint_url.format(product_id=product_offer_id)
             )
@@ -46,7 +50,7 @@ class GetProductTest(PublicAPIVenueEndpointHelper):
             idAtProvider="provider_id_at_provider",
         ).id
 
-        with testing.assert_num_queries(self.num_queries):
+        with testing.assert_num_queries(self.num_queries_404):
             response = client.with_explicit_token(plain_api_key).get(
                 self.endpoint_url.format(product_id=product_offer_id)
             )
@@ -164,7 +168,7 @@ class GetProductTest(PublicAPIVenueEndpointHelper):
         venue = venue_provider.venue
         event_offer_id = offers_factories.EventOfferFactory(venue=venue).id
 
-        with testing.assert_num_queries(self.num_queries):
+        with testing.assert_num_queries(self.num_queries_404):
             response = client.with_explicit_token(plain_api_key).get(f"/public/offers/v1/products/{event_offer_id}")
             assert response.status_code == 404
         assert response.json == {"product_id": ["The product offer could not be found"]}

--- a/api/tests/routes/public/individual_offers/v1/get_products_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_products_test.py
@@ -16,7 +16,13 @@ class GetProductsTest(PublicAPIVenueEndpointHelper):
 
     num_queries_400 = 1  # select api_key, offerer and provider
     num_queries_404 = num_queries_400 + 1  # check venue_provider exists
-    num_queries_success = num_queries_404 + 1  # select offer
+
+    num_queries_success_no_offers = num_queries_404 + 1  # fetch offers
+
+    # fetch stocks (1 query)
+    # fetch mediations (1 query)
+    # fetch price categories (1 query)
+    num_queries_success = num_queries_success_no_offers + 3
 
     def test_should_raise_404_because_has_no_access_to_venue(self, client):
         plain_api_key, _ = self.setup_provider()
@@ -133,11 +139,11 @@ class GetProductsTest(PublicAPIVenueEndpointHelper):
             assert response.status_code == 200
             assert response.json["products"][0]["name"] == name_more_than_90_signs_long
 
-    def test_404_when_the_page_is_too_high(self, client):
+    def test_200_when_the_page_is_too_high(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
 
         venue_id = venue_provider.venueId
-        with testing.assert_num_queries(self.num_queries_success):
+        with testing.assert_num_queries(self.num_queries_success_no_offers):
             response = client.with_explicit_token(plain_api_key).get(
                 self.endpoint_url, params={"venueId": venue_id, "limit": 5, "firstIndex": 1}
             )
@@ -148,7 +154,7 @@ class GetProductsTest(PublicAPIVenueEndpointHelper):
     def test_200_for_first_page_if_no_items(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         venue_id = venue_provider.venueId
-        with testing.assert_num_queries(self.num_queries_success):
+        with testing.assert_num_queries(self.num_queries_success_no_offers):
             response = client.with_explicit_token(plain_api_key).get(
                 self.endpoint_url, params={"venueId": venue_id, "limit": 5}
             )

--- a/api/tests/routes/public/individual_offers/v1/patch_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_product_test.py
@@ -386,11 +386,21 @@ class PatchProductTest(PublicAPIVenueEndpointHelper, ProductEndpointHelper):
         new_desc = product_offer.description + " updated"
 
         expected_num_queries = 1  # get api key
-        expected_num_queries += 1  # get offer and related data
+        expected_num_queries += 1  # get offer
+
+        expected_num_queries += 1  # get mediations
+        expected_num_queries += 1  # get stocks
+        expected_num_queries += 1  # get price categories
+
         expected_num_queries += 1  # select oa
         expected_num_queries += 1  # update offer
         expected_num_queries += 1  # reload provider
-        expected_num_queries += 1  # reload offer and related data (before serialization)
+        expected_num_queries += 1  # reload offer
+
+        expected_num_queries += 1  # reload stock
+        expected_num_queries += 1  # reload price categories
+        expected_num_queries += 1  # reload mediations
+
         expected_num_queries += 1  # check venue offerer address
         with assert_num_queries(expected_num_queries):
             response = client.with_explicit_token(offerers_factories.DEFAULT_CLEAR_API_KEY).patch(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35408

Remplacer des [joinedload ](https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#sqlalchemy.orm.joinedload) par des [selectinload](https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#sqlalchemy.orm.selectinload), utilisés indirectement par des routes de l'API publique.

Problème : certaines routes se retrouvent à charger toutes les données liées à chaque offre d'un coup, comme ses stocks, ses catégories de prix, etc. Ce qui entraînait quelques soucis en terme de consommation mémoire.

Au passage : ne charger que le strict nécessaire pour un lieu, dans ce contexte.
