### PR TITLE
(PC-35369)[PRO] fix: Do not use venue address details.

### DIFF
--- a/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
@@ -217,7 +217,7 @@ jobs:
           config-file: cypress/cypress.config.ts
           env: TAGS="@P0"
           spec: ${{ matrix.chunk }}
-          record: ${{ github.ref == 'refs/heads/master' }} # for Cypress
+          record: true #${{ github.ref == 'refs/heads/master' }} # for Cypress
         env:
           CYPRESS_RECORD_KEY: ${{ steps.secrets.outputs.CYPRESS_CLOUD_RECORD_KEY }}
           CYPRESS_PROJECT_ID: ${{ steps.secrets.outputs.CYPRESS_CLOUD_PROJECT_ID }}

--- a/pro/cypress/e2e/navigation.cy.ts
+++ b/pro/cypress/e2e/navigation.cy.ts
@@ -12,6 +12,10 @@ describe('Navigation', () => {
         login = response.body.user.email
       }
     )
+    cy.intercept({
+      method: 'GET',
+      url: `/venues/**`,
+    }).as('getVenue')
   })
 
   it('I should see the top of the page when changing page', () => {
@@ -19,6 +23,8 @@ describe('Navigation', () => {
 
     cy.stepLog({ message: 'I close the collective budget information modal' })
     cy.findAllByText('Fermer').click()
+
+    cy.wait('@getVenue')
 
     cy.stepLog({ message: 'I scroll to my venue' })
     cy.contains(
@@ -36,7 +42,7 @@ describe('Navigation', () => {
     cy.get('a[aria-label^="Gérer la page pour les enseignants"]').click()
 
     cy.stepLog({ message: 'I should be at the top of the page' })
-    cy.get('[id=unaccessible-top-page]').should('have.focus', { timeout: 1000 })
+    cy.get('[id=back-to-nav-link]').should('have.focus', { timeout: 1000 })
     cy.get('[id=content-wrapper]').then((el) => {
       expect(el.get(0).scrollTop).to.eq(0)
     })

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -36,7 +36,7 @@ export interface LayoutProps {
    */
   mainTopElement?: React.ReactNode
   /**
-   * In case both <h1> & back to nav link
+   * In case both `<h1>` & back to nav link
    * had to be declared within the children
    */
   areMainHeadingAndBackToNavLinkInChild?: boolean

--- a/pro/src/pages/Homepage/components/Offerers/components/PartnerPages/components/PartnerPage.tsx
+++ b/pro/src/pages/Homepage/components/Offerers/components/PartnerPages/components/PartnerPage.tsx
@@ -4,8 +4,8 @@ import { useSWRConfig } from 'swr'
 
 import {
   GetOffererResponseModel,
-  GetOffererVenueResponseModel,
   VenueTypeResponseModel,
+  type GetVenueResponseModel,
 } from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { GET_OFFERER_QUERY_KEY } from 'commons/config/swrQueryKeys'
@@ -27,14 +27,16 @@ import { PartnerPageIndividualSection } from './PartnerPageIndividualSection'
 
 export interface PartnerPageProps {
   offerer: GetOffererResponseModel
-  venue: GetOffererVenueResponseModel
+  venue: GetVenueResponseModel
   venueTypes: VenueTypeResponseModel[]
+  venueHasPartnerPage: boolean
 }
 
 export const PartnerPage = ({
   offerer,
   venue,
   venueTypes,
+  venueHasPartnerPage,
 }: PartnerPageProps) => {
   const { logEvent } = useAnalytics()
   const { mutate } = useSWRConfig()
@@ -105,9 +107,13 @@ export const PartnerPage = ({
             {venue.publicName || venue.name}
           </h3>
 
-          {venue.street && (
-            <address className={styles['venue-address']}>
-              {venue.street}, {venue.postalCode} {venue.city}
+          {venue.address && (
+            <address
+              data-testid="venue-address"
+              className={styles['venue-address']}
+            >
+              {venue.address.street ? `${venue.address.street}, ` : ''}
+              {venue.address.postalCode} {venue.address.city}
             </address>
           )}
         </div>
@@ -116,17 +122,22 @@ export const PartnerPage = ({
       <VenueOfferSteps
         className={styles['venue-offer-steps']}
         offerer={offerer}
-        venue={venue}
+        venue={{
+          ...venue,
+          hasCreatedOffer: venue.hasOffers,
+        }}
         hasVenue
         isInsidePartnerBlock
       />
-      {venue.hasPartnerPage && <PartnerPageIndividualSection
-        venueId={venue.id}
-        venueName={venue.name}
-        offererId={offerer.id}
-        isVisibleInApp={Boolean(venue.isVisibleInApp)}
-        isDisplayedInHomepage
-      />}
+      {venueHasPartnerPage && (
+        <PartnerPageIndividualSection
+          venueId={venue.id}
+          venueName={venue.name}
+          offererId={offerer.id}
+          isVisibleInApp={Boolean(venue.isVisibleInApp)}
+          isDisplayedInHomepage
+        />
+      )}
       <PartnerPageCollectiveSection
         collectiveDmsApplications={venue.collectiveDmsApplications}
         venueId={venue.id}

--- a/pro/src/pages/Homepage/components/Offerers/components/PartnerPages/components/__specs__/PartnerPage.spec.tsx
+++ b/pro/src/pages/Homepage/components/Offerers/components/PartnerPages/components/__specs__/PartnerPage.spec.tsx
@@ -5,6 +5,7 @@ import { VenueTypeCode } from 'apiClient/v1'
 import * as useAnalytics from 'app/App/analytics/firebase'
 import { Events } from 'commons/core/FirebaseEvents/constants'
 import { defaultGetVenue } from 'commons/utils/factories/collectiveApiFactories'
+import { getAddressResponseIsLinkedToVenueModelFactory } from 'commons/utils/factories/commonOffersApiFactories'
 import { defaultGetOffererResponseModel } from 'commons/utils/factories/individualApiFactories'
 import {
   sharedCurrentUserFactory,
@@ -14,7 +15,6 @@ import { renderWithProviders } from 'commons/utils/renderWithProviders'
 import { UploaderModeEnum } from 'components/ImageUploader/types'
 
 import { PartnerPage, PartnerPageProps } from '../PartnerPage'
-import { getAddressResponseIsLinkedToVenueModelFactory } from 'commons/utils/factories/commonOffersApiFactories'
 
 const mockLogEvent = vi.fn()
 

--- a/pro/src/pages/Homepage/components/Offerers/components/VenueList/venueUtils.ts
+++ b/pro/src/pages/Homepage/components/Offerers/components/VenueList/venueUtils.ts
@@ -4,6 +4,7 @@ import {
   GetOffererVenueResponseModel,
 } from 'apiClient/v1'
 import { getLastCollectiveDmsApplication } from 'commons/utils/getLastCollectiveDmsApplication'
+import { VenueThing } from 'pages/Homepage/components/VenueOfferSteps/VenueOfferSteps'
 
 export const getVirtualVenueFromOfferer = (
   offerer?: GetOffererResponseModel | null
@@ -26,7 +27,7 @@ export const hasOffererAtLeastOnePhysicalVenue = (
   offerer?.managedVenues?.some((venue) => !venue.isVirtual && venue.id) ?? false
 
 export const shouldDisplayEACInformationSectionForVenue = (
-  venue?: GetOffererVenueResponseModel
+  venue?: VenueThing
 ): boolean => {
   const dmsInformations = getLastCollectiveDmsApplication(
     venue?.collectiveDmsApplications ?? []
@@ -39,7 +40,5 @@ export const shouldDisplayEACInformationSectionForVenue = (
   )
 }
 
-export const shouldShowVenueOfferStepsForVenue = (
-  venue?: GetOffererVenueResponseModel
-) =>
+export const shouldShowVenueOfferStepsForVenue = (venue?: VenueThing) =>
   shouldDisplayEACInformationSectionForVenue(venue) || !venue?.hasCreatedOffer

--- a/pro/src/pages/Homepage/components/VenueOfferSteps/VenueOfferSteps.tsx
+++ b/pro/src/pages/Homepage/components/VenueOfferSteps/VenueOfferSteps.tsx
@@ -2,7 +2,7 @@ import cn from 'classnames'
 
 import {
   GetOffererResponseModel,
-  GetOffererVenueResponseModel,
+  type DMSApplicationForEAC,
 } from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
 import {
@@ -25,9 +25,16 @@ import {
 
 import styles from './VenueOfferSteps.module.scss'
 
+export type VenueThing = {
+  hasCreatedOffer: boolean
+  id: number
+  collectiveDmsApplications: Array<DMSApplicationForEAC>
+  hasAdageId: boolean
+}
+
 export interface VenueOfferStepsProps {
   offerer: GetOffererResponseModel
-  venue?: GetOffererVenueResponseModel
+  venue?: VenueThing
   hasVenue: boolean
   isFirstVenue?: boolean
   isInsidePartnerBlock?: boolean

--- a/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
@@ -141,9 +141,13 @@ export const VenueEditionHeader = ({
               ? `${offerer.name} (Offre numérique)`
               : venue.publicName || venue.name}
           </h2>
-          {!isOpenToPublicEnabled && venue.street && (
-            <address className={styles['venue-address']}>
-              {venue.street}, {venue.postalCode} {venue.city}
+          {!isOpenToPublicEnabled && venue.address && (
+            <address
+              data-testid="venue-address"
+              className={styles['venue-address']}
+            >
+              {venue.address.street ? `${venue.address.street}, ` : ''}
+              {venue.address.postalCode} {venue.address.city}
             </address>
           )}
         </div>
@@ -156,15 +160,17 @@ export const VenueEditionHeader = ({
           >
             Paramètres généraux
           </ButtonLink>
-          {isOpenToPublicEnabled && venue.isPermanent && <ButtonLink
-            variant={ButtonVariant.TERNARY}
-            icon={fullLinkIcon}
-            to={`${WEBAPP_URL}/lieu/${venue.id}`}
-            isExternal
-            opensInNewTab
-          >
-            Visualiser votre page
-          </ButtonLink>}
+          {isOpenToPublicEnabled && venue.isPermanent && (
+            <ButtonLink
+              variant={ButtonVariant.TERNARY}
+              icon={fullLinkIcon}
+              to={`${WEBAPP_URL}/lieu/${venue.id}`}
+              isExternal
+              opensInNewTab
+            >
+              Visualiser votre page
+            </ButtonLink>
+          )}
           {imageValues.originalImageUrl && (
             <ButtonImageEdit
               mode={UploaderModeEnum.VENUE}

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
@@ -5,6 +5,7 @@ import { VenueTypeCode } from 'apiClient/v1'
 import * as useAnalytics from 'app/App/analytics/firebase'
 import { Events } from 'commons/core/FirebaseEvents/constants'
 import { defaultGetVenue } from 'commons/utils/factories/collectiveApiFactories'
+import { getAddressResponseIsLinkedToVenueModelFactory } from 'commons/utils/factories/commonOffersApiFactories'
 import { defaultGetOffererResponseModel } from 'commons/utils/factories/individualApiFactories'
 import {
   sharedCurrentUserFactory,
@@ -20,7 +21,6 @@ import {
   VenueEditionHeader,
   VenueEditionHeaderProps,
 } from '../VenueEditionHeader'
-import { getAddressResponseIsLinkedToVenueModelFactory } from 'commons/utils/factories/commonOffersApiFactories'
 
 const mockLogEvent = vi.fn()
 

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
@@ -20,6 +20,7 @@ import {
   VenueEditionHeader,
   VenueEditionHeaderProps,
 } from '../VenueEditionHeader'
+import { getAddressResponseIsLinkedToVenueModelFactory } from 'commons/utils/factories/commonOffersApiFactories'
 
 const mockLogEvent = vi.fn()
 
@@ -95,17 +96,44 @@ describe('VenueEditionHeader', () => {
   })
 
   it('should display a preview link when venue is permanent and is open to public feature enabled', () => {
+    renderPartnerPages(
+      {
+        venue: {
+          ...defaultGetVenue,
+          venueTypeCode: VenueTypeCode.FESTIVAL,
+          isPermanent: true,
+        },
+      },
+      {
+        features: ['WIP_IS_OPEN_TO_PUBLIC'],
+      }
+    )
+
+    expect(screen.getByText('Visualiser votre page')).toBeInTheDocument()
+  })
+
+  it('should display the address if present', () => {
     renderPartnerPages({
       venue: {
         ...defaultGetVenue,
         venueTypeCode: VenueTypeCode.FESTIVAL,
         isPermanent: true,
+        address: getAddressResponseIsLinkedToVenueModelFactory(),
       },
-    }, {
-      features: ['WIP_IS_OPEN_TO_PUBLIC'],
     })
 
-    expect(screen.getByText('Visualiser votre page')).toBeInTheDocument()
+    expect(screen.getByTestId('venue-address')).toBeInTheDocument()
+    expect(screen.getByText(/ma super rue, 75008/)).toBeInTheDocument()
+  })
+
+  it('should not display the address if not present', () => {
+    renderPartnerPages({
+      venue: {
+        ...defaultGetVenue,
+      },
+    })
+
+    expect(screen.queryByTestId('venue-address')).not.toBeInTheDocument()
   })
 
   it('should not display new offer button in new nav', () => {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35369

- Ne plus utiliser les données dans `venue` pour afficher l'addresse.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
