### PR TITLE
(PC-35421)[PRO] style: Use dark purple for primary & secondary button…

### DIFF
--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -58,8 +58,8 @@
     min-height: rem.torem(40px);
     align-items: center;
     color: var(--color-white);
-    background-color: var(--color-background-brand-primary);
-    border-color: var(--color-border-brand-primary);
+    background-color: var(--color-primary);
+    border-color: var(--color-primary);
 
     &:hover {
       background-color: var(--color-primary-dark);
@@ -85,14 +85,14 @@
   &-secondary {
     min-height: rem.torem(40px);
     align-items: center;
-    color: var(--color-text-brand-primary);
+    color: var(--color-primary);
     background-color: var(--color-background-default);
-    border-color: var(--color-border-brand-primary);
+    border-color: var(--color-primary);
 
     &:hover {
-      color: var(--color-text-inverted);
-      background-color: var(--color-background-brand-primary-hover);
-      border-color: var(--color-border-brand-primary-hover);
+      color: var(--color-white);
+      background-color: var(--color-primary-dark);
+      border-color: var(--color-primary-dark);
 
       .button-icon {
         color: var(--color-white);


### PR DESCRIPTION
… borders.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35421

**Objectif**
Corriger la couleur de la bordure des boutons primary/secondary (j'ai remis comme c'était avant l'introduction des couleurs DS) avant/après :
<img width="232" alt="Capture d’écran 2025-03-31 à 09 17 58" src="https://github.com/user-attachments/assets/3a4f9137-6df3-4b39-ac5c-a6bc7569e7d7" />
<img width="266" alt="Capture d’écran 2025-03-31 à 09 18 03" src="https://github.com/user-attachments/assets/1e6a1938-642b-4e28-a629-896e1352058a" />

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
