### PR TITLE
(PC-35434)[API] script: delete useless actions created when ADAGE ID did not change

### DIFF
--- a/api/src/pcapi/scripts/delete_useless_actions/main.sql
+++ b/api/src/pcapi/scripts/delete_useless_actions/main.sql
@@ -1,0 +1,8 @@
+delete
+from action_history
+where "actionType" = 'INFO_MODIFIED'
+and "venueId" is not null
+and comment = 'Synchronisation ADAGE'
+and "jsonData"->'modified_info'->'adageId'->>'new_info' = "jsonData"->'modified_info'->'adageId'->>'old_info';
+
+commit;


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-35434

Script de nettoyage.
Ça n'arrivera plus après https://github.com/pass-culture/pass-culture-main/pull/16951.

Ce script n'est pas destiné à être mergé sur master.