### PR TITLE
(BSR)[Sandbox] feat: add more relevant future offers in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_future_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_future_offers.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import random
 
 from pcapi.core.categories import subcategories
 from pcapi.core.categories.models import Subcategory
@@ -18,12 +17,10 @@ def _create_future_offer_factory(
     description: str | None = None,
 ) -> None:
     offer = offer_factories.OfferFactory(
-        isActive=is_active, subcategoryId=subcategory.id, name=name, description=description
+        isActive=is_active, isDuo=True, subcategoryId=subcategory.id, name=name, description=description
     )
     offer_factories.EventStockFactory(
-        offer=offer,
-        beginningDatetime=publication_date + datetime.timedelta(days=random.randint(0, 10)),
-        price=random.randint(10, 40) + random.randint(0, 100) / 100,
+        offer=offer, beginningDatetime=publication_date - datetime.timedelta(days=1), price=12.25
     )
 
     offer_factories.FutureOfferFactory(offer=offer, publicationDate=publication_date)
@@ -32,7 +29,7 @@ def _create_future_offer_factory(
 def create_future_offers() -> None:
     # Create future Offers not active, i.e. proper coming soon offers
     for i in range(5):
-        publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=i * 5)
+        publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=(i + 1) * 5)
         _create_future_offer_factory(
             is_active=False,
             publication_date=publication_date,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : corrections de la creation de Future Offers dans la Sandbox, les date de disponibilité des stocks ne sont pas valables, suppression de l'utilisation de random.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [x] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [x] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [x] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
