### PR TITLE
(BSR)[API] fix: update address of some collective offers in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -34,6 +34,7 @@ class LocationOption(typing.TypedDict):
     locationType: educational_models.CollectiveLocationType
     locationComment: typing.NotRequired[str]
     isManualEdition: typing.NotRequired[bool]
+    street: typing.NotRequired[str]  # used in the Address model
 
 
 def get_location_options(venue: offerers_models.Venue) -> list[LocationOption]:
@@ -73,6 +74,7 @@ def get_location_options(venue: offerers_models.Venue) -> list[LocationOption]:
             "interventionArea": ["75", "92", "93", "94", "95"],
             "locationType": educational_models.CollectiveLocationType.ADDRESS,
             "isManualEdition": True,
+            "street": "35 Bd de Sébastopol",
         },
         {
             "name": "La culture à une adresse précise",
@@ -83,6 +85,7 @@ def get_location_options(venue: offerers_models.Venue) -> list[LocationOption]:
             },
             "interventionArea": ["75", "92", "93", "94", "95"],
             "locationType": educational_models.CollectiveLocationType.ADDRESS,
+            "street": "35 Bd de Sébastopol",
         },
         {
             "name": "La culture dans un lieu flou",
@@ -108,7 +111,7 @@ def get_location_options(venue: offerers_models.Venue) -> list[LocationOption]:
     ]
 
 
-def get_offer_address_id(
+def _get_offerer_address_id(
     location_option: LocationOption, managing_offerer: offerers_models.Offerer, oa_label: str
 ) -> int | None:
     if location_option["locationType"] != educational_models.CollectiveLocationType.ADDRESS:
@@ -124,7 +127,7 @@ def get_offer_address_id(
         if location_option.get("isManualEdition", False)
         else geography_factories.AddressFactory
     )
-    address = factory(street=offer_venue["otherAddress"])
+    address = factory(street=location_option["street"])
     offerer_address = offerers_factories.OffererAddressFactory(
         label=oa_label, address=address, offerer=managing_offerer
     )
@@ -799,7 +802,7 @@ def _set_offer_location_columns(
     if isinstance(offer, educational_models.CollectiveOfferTemplate):
         oa_label += " (template)"
 
-    offer.offererAddressId = get_offer_address_id(
+    offer.offererAddressId = _get_offerer_address_id(
         location_option=location_option, managing_offerer=offerer, oa_label=oa_label
     )
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : on a actuellement un champ `Address.street` avec la valeur `35 Bd de Sébastopol, 75001 Paris` ce qui n'est pas cohérent, on indique ici une valeur explicite

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
