### PR TITLE
(PC-35415)[PRO] feat: Rework the stocks table for event creation.

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.module.scss
@@ -6,17 +6,24 @@
   padding: rem.torem(32px) 0;
 }
 
-.title {
-  @include fonts.title2;
-
-  margin-bottom: rem.torem(64px);
+.header {
+  display: flex;
+  align-items: center;
+  gap: rem.torem(32px);
+  flex-wrap: wrap;
+  margin-bottom: rem.torem(24px);
 }
 
-.content {
+.title {
+  @include fonts.title2;
+}
+
+.no-stocks-content {
   display: flex;
   flex-direction: column;
   gap: rem.torem(40px);
   align-items: center;
+  margin-top: rem.torem(64px);
 }
 
 .icon {
@@ -30,4 +37,12 @@
 .button {
   display: inline-block;
   width: fit-content;
+}
+
+.spinner {
+  margin-top: rem.torem(16px);
+}
+
+.pagination {
+  margin: rem.torem(24px) 0;
 }

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.spec.tsx
@@ -1,26 +1,70 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { addDays } from 'date-fns'
 
-import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
+import { api } from 'apiClient/api'
+import {
+  getIndividualOfferFactory,
+  getOfferStockFactory,
+} from 'commons/utils/factories/individualApiFactories'
 import { renderWithProviders } from 'commons/utils/renderWithProviders'
+import { Notification } from 'components/Notification/Notification'
 
 import { StocksCalendar } from './StocksCalendar'
 
-function renderStocksCalendar() {
-  renderWithProviders(<StocksCalendar offer={getIndividualOfferFactory()} />)
+vi.mock('apiClient/api', () => ({
+  api: {
+    getStocks: vi.fn(),
+    deleteStocks: vi.fn(),
+    upsertStocks: vi.fn(),
+  },
+}))
+
+const defaultStocks = Array(19)
+  .fill(null)
+  .map((_, index) => getOfferStockFactory({ id: index }))
+
+function renderStocksCalendar(stocks = defaultStocks) {
+  vi.spyOn(api, 'getStocks').mockResolvedValueOnce({
+    stocks: stocks,
+    stockCount: stocks.length,
+    hasStocks: stocks.length > 0,
+  })
+
+  vi.spyOn(api, 'upsertStocks').mockResolvedValue({ stocks_count: 20 })
+
+  renderWithProviders(
+    <>
+      <StocksCalendar
+        offer={getIndividualOfferFactory()}
+        handleNextStep={() => {}}
+        handlePreviousStep={() => {}}
+        departmentCode="56"
+      />
+      <Notification />
+    </>
+  )
 }
 
 describe('StocksCalendar', () => {
-  it('should display a button to add calendar infos', () => {
-    renderStocksCalendar()
+  it('should display a button to add calendar infos when there are no stocks yet', async () => {
+    renderStocksCalendar([])
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
 
     expect(
       screen.getByRole('button', { name: 'Définir le calendrier' })
     ).toBeInTheDocument()
   })
 
-  it('should open the recurrence form when clicking on the button', async () => {
-    renderStocksCalendar()
+  it('should open the recurrence form when clicking on the button when there are no stocks yet', async () => {
+    renderStocksCalendar([])
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Définir le calendrier' })
@@ -31,5 +75,118 @@ describe('StocksCalendar', () => {
         name: 'Définir le calendrier de votre offre',
       })
     ).toBeInTheDocument()
+  })
+
+  it('should show a button to add more stocks if there are already stocks in the table', async () => {
+    renderStocksCalendar()
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Ajouter une ou plusieurs dates' })
+    )
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Définir le calendrier de votre offre',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('should delete a stock from the stock line trash button', async () => {
+    renderStocksCalendar()
+
+    const deleteSpy = vi.spyOn(api, 'deleteStocks').mockResolvedValueOnce()
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
+    await userEvent.click(
+      screen.getAllByRole('button', { name: 'Supprimer le stock' })[0]
+    )
+
+    expect(deleteSpy).toHaveBeenCalledOnce()
+
+    expect(screen.getByText(/Une date a été supprimée/)).toBeInTheDocument()
+  })
+
+  it('should delete all the checked stocks', async () => {
+    renderStocksCalendar()
+
+    const deleteSpy = vi.spyOn(api, 'deleteStocks').mockResolvedValueOnce()
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: 'Sélectionner tous les stocks' })
+    )
+    await userEvent.click(screen.getAllByRole('checkbox')[2])
+    await userEvent.click(screen.getAllByRole('checkbox')[2])
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Supprimer ces dates' })
+    )
+
+    expect(deleteSpy).toHaveBeenCalledOnce()
+
+    expect(screen.getByText(/19 dates ont été supprimées/)).toBeInTheDocument()
+  })
+
+  it('should close the dialog when the form is validated', async () => {
+    renderStocksCalendar([])
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Définir le calendrier' })
+    )
+
+    await userEvent.type(
+      screen.getByLabelText('Date *'),
+      addDays(new Date(), 1).toISOString().split('T')[0]
+    )
+
+    await userEvent.type(screen.getByLabelText('Horaire 1 *'), '22:22')
+
+    await userEvent.selectOptions(screen.getByLabelText('Tarif *'), '6')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Valider' }))
+
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Définir le calendrier de votre offre',
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it('should navigate through the pages', async () => {
+    renderStocksCalendar(
+      Array(50)
+        .fill(null)
+        .map((_, index) => getOfferStockFactory({ id: index }))
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Page 1/3'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Page suivante' }))
+
+    expect(screen.getByText('Page 2/3'))
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Page précédente' })
+    )
+
+    expect(screen.getByText('Page 1/3'))
   })
 })

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.tsx
@@ -1,52 +1,167 @@
 import { useState } from 'react'
+import useSWR, { mutate } from 'swr'
 
+import { api } from 'apiClient/api'
 import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import { GET_STOCKS_QUERY_KEY } from 'commons/config/swrQueryKeys'
+import { useNotification } from 'commons/hooks/useNotification'
 import fullMoreIcon from 'icons/full-more.svg'
 import strokeAddCalendarIcon from 'icons/stroke-add-calendar.svg'
 import { Button } from 'ui-kit/Button/Button'
 import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
+import { Pagination } from 'ui-kit/Pagination/Pagination'
+import { Spinner } from 'ui-kit/Spinner/Spinner'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './StocksCalendar.module.scss'
+import { StocksCalendarActionsBar } from './StocksCalendarActionsBar/StocksCalendarActionsBar'
 import { StocksCalendarForm } from './StocksCalendarForm/StocksCalendarForm'
+import { StocksCalendarTable } from './StocksCalendarTable/StocksCalendarTable'
+
+const STOCKS_PER_PAGE = 20
 
 export function StocksCalendar({
   offer,
+  handlePreviousStep,
+  handleNextStep,
+  departmentCode,
 }: {
   offer: GetIndividualOfferWithAddressResponseModel
+  handlePreviousStep: () => void
+  handleNextStep: () => void
+  departmentCode: string
 }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [page, setPage] = useState(1)
+  const [checkedStocks, setCheckedStocks] = useState(new Set<number>())
+  const notify = useNotification()
+
+  const { data, isLoading } = useSWR(
+    [GET_STOCKS_QUERY_KEY, offer.id, page],
+    ([, offerId, pageNum]) =>
+      api.getStocks(
+        offerId,
+        null,
+        null,
+        null,
+        undefined,
+        undefined,
+        pageNum || 1,
+        STOCKS_PER_PAGE
+      ),
+    {
+      //  Display previous data in the table until the new data has loaded so that
+      //  the scroll position in the table remains the same in-between pagination loads
+      keepPreviousData: true,
+      onSuccess: () => {
+        setCheckedStocks(new Set())
+      },
+    }
+  )
+
+  async function deleteStocks(ids: number[]) {
+    await api.deleteStocks(offer.id, { ids_to_delete: ids })
+
+    if (
+      page > 1 &&
+      data?.stockCount &&
+      data.stockCount - ids.length <= (page - 1) * STOCKS_PER_PAGE
+    ) {
+      //  Descrease the page number if deleting the ids would leave the user on an empty stocks page
+      setPage((p) => p - 1)
+    }
+
+    notify.success(
+      ids.length === 1
+        ? 'Une date a été supprimée'
+        : `${ids.length} dates ont été supprimées`
+    )
+    await mutate([GET_STOCKS_QUERY_KEY, offer.id, page])
+  }
+
+  const stocks = data?.stocks || []
+
+  const getDialogBuilderButton = (buttonLabel: string) => (
+    <DialogBuilder
+      trigger={
+        <Button className={styles['button']} icon={fullMoreIcon}>
+          {buttonLabel}
+        </Button>
+      }
+      open={isDialogOpen}
+      onOpenChange={setIsDialogOpen}
+      variant="drawer"
+      title="Définir le calendrier de votre offre"
+    >
+      <StocksCalendarForm
+        offer={offer}
+        onAfterValidate={async () => {
+          await mutate([GET_STOCKS_QUERY_KEY, offer.id, page], data, {
+            revalidate: true,
+          })
+
+          setIsDialogOpen(false)
+        }}
+      />
+    </DialogBuilder>
+  )
 
   return (
     <div className={styles['container']}>
-      <h2 className={styles['title']}>Calendrier</h2>
-      <div className={styles['content']}>
-        <div className={styles['icon-container']}>
-          <SvgIcon
-            alt=""
-            className={styles['icon']}
-            src={strokeAddCalendarIcon}
-          />
-        </div>
-        <DialogBuilder
-          trigger={
-            <Button className={styles['button']} icon={fullMoreIcon}>
-              Définir le calendrier
-            </Button>
-          }
-          open={isDialogOpen}
-          onOpenChange={setIsDialogOpen}
-          variant="drawer"
-          title="Définir le calendrier de votre offre"
-        >
-          <StocksCalendarForm
-            offer={offer}
-            onAfterValidate={() => {
-              setIsDialogOpen(false)
-            }}
-          />
-        </DialogBuilder>
+      <div className={styles['header']}>
+        <h2 className={styles['title']}>Calendrier</h2>
+        {data?.hasStocks &&
+          getDialogBuilderButton('Ajouter une ou plusieurs dates')}
       </div>
+
+      {isLoading && <Spinner className={styles['spinner']} />}
+
+      {data?.hasStocks && (
+        <>
+          <StocksCalendarTable
+            stocks={stocks}
+            offer={offer}
+            onDeleteStocks={deleteStocks}
+            checkedStocks={checkedStocks}
+            updateCheckedStocks={setCheckedStocks}
+            departmentCode={departmentCode}
+          />
+          <div className={styles['pagination']}>
+            <Pagination
+              currentPage={page}
+              onNextPageClick={() => setPage((p) => p + 1)}
+              onPreviousPageClick={() => setPage((p) => p - 1)}
+              pageCount={
+                data.stockCount % STOCKS_PER_PAGE === 0
+                  ? data.stockCount / STOCKS_PER_PAGE
+                  : Math.trunc(data.stockCount / STOCKS_PER_PAGE) + 1
+              }
+            />
+          </div>
+        </>
+      )}
+
+      {!data?.hasStocks && !isLoading && (
+        <div className={styles['no-stocks-content']}>
+          <div className={styles['icon-container']}>
+            <SvgIcon
+              alt=""
+              className={styles['icon']}
+              src={strokeAddCalendarIcon}
+            />
+          </div>
+          {getDialogBuilderButton('Définir le calendrier')}
+        </div>
+      )}
+
+      <StocksCalendarActionsBar
+        handlePreviousStep={handlePreviousStep}
+        handleNextStep={handleNextStep}
+        checkedStocks={checkedStocks}
+        hasStocks={Boolean(data?.hasStocks)}
+        deleteStocks={deleteStocks}
+        updateCheckedStocks={setCheckedStocks}
+      />
     </div>
   )
 }

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarActionsBar/StocksCalendarActionsBar.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarActionsBar/StocksCalendarActionsBar.module.scss
@@ -1,0 +1,21 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.sticky {
+  z-index: 10;
+
+  &-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: rem.torem(16px);
+    flex-wrap: wrap;
+    width: 100%;
+
+    &-buttons {
+      display: flex;
+      align-items: center;
+      gap: rem.torem(16px);
+      flex-wrap: wrap;
+    }
+  }
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarActionsBar/StocksCalendarActionsBar.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarActionsBar/StocksCalendarActionsBar.spec.tsx
@@ -1,0 +1,110 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
+import { Notification } from 'components/Notification/Notification'
+
+import {
+  StocksCalendarActionsBar,
+  StocksCalendarActionsBarProps,
+} from './StocksCalendarActionsBar'
+
+function renderStocksCalendarActionsBar(
+  props?: Partial<StocksCalendarActionsBarProps>
+) {
+  return renderWithProviders(
+    <>
+      <StocksCalendarActionsBar
+        checkedStocks={new Set([])}
+        deleteStocks={() => {}}
+        handleNextStep={() => {}}
+        handlePreviousStep={() => {}}
+        hasStocks={false}
+        updateCheckedStocks={() => {}}
+        {...props}
+      />
+      <Notification />
+    </>
+  )
+}
+
+describe('StocksCalendarActionsBar', () => {
+  it('should show the navigation links in the action bar when no stock is checked yet', () => {
+    renderStocksCalendarActionsBar()
+
+    expect(
+      screen.getByRole('button', { name: 'Annuler et quitter' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Enregistrer les modifications' })
+    ).toBeInTheDocument()
+  })
+
+  it('should trigger the navigation to the form previous and next steps', async () => {
+    const nextStepMock = vi.fn()
+    const previousStepMock = vi.fn()
+
+    renderStocksCalendarActionsBar({
+      handleNextStep: nextStepMock,
+      handlePreviousStep: previousStepMock,
+      hasStocks: true,
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Annuler et quitter' })
+    )
+    expect(previousStepMock).toHaveBeenCalled()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enregistrer les modifications' })
+    )
+    expect(nextStepMock).toHaveBeenCalled()
+  })
+
+  it('should show an error message when going to the next step without having added any stock', async () => {
+    renderStocksCalendarActionsBar()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Enregistrer les modifications' })
+    )
+
+    expect(
+      screen.getByText('Veuillez renseigner au moins une date')
+    ).toBeInTheDocument()
+  })
+
+  it('should show the checked stocks action bar when some stocks are checked', () => {
+    renderStocksCalendarActionsBar({
+      hasStocks: true,
+      checkedStocks: new Set([1]),
+    })
+
+    expect(
+      screen.queryByRole('button', { name: 'Enregistrer les modifications' })
+    ).not.toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: 'Désélectionner' })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.getByRole('button', { name: 'Supprimer cette date' })
+    ).toBeInTheDocument()
+  })
+
+  it('should uncheck all checked stocks', async () => {
+    const updateCheckedStocks = vi.fn()
+
+    renderStocksCalendarActionsBar({
+      hasStocks: true,
+      checkedStocks: new Set([1, 2]),
+      updateCheckedStocks: updateCheckedStocks,
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Désélectionner' })
+    )
+
+    expect(updateCheckedStocks).toHaveBeenCalled()
+  })
+})

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarActionsBar/StocksCalendarActionsBar.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarActionsBar/StocksCalendarActionsBar.tsx
@@ -1,0 +1,71 @@
+import { useNotification } from 'commons/hooks/useNotification'
+import { pluralize } from 'commons/utils/pluralize'
+import { ActionsBarSticky } from 'components/ActionsBarSticky/ActionsBarSticky'
+import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
+import { ActionBar } from 'pages/IndividualOffer/components/ActionBar/ActionBar'
+import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant } from 'ui-kit/Button/types'
+
+import styles from './StocksCalendarActionsBar.module.scss'
+
+export type StocksCalendarActionsBarProps = {
+  checkedStocks: Set<number>
+  hasStocks: boolean
+  updateCheckedStocks: (newStocks: Set<number>) => void
+  deleteStocks: (ids: number[]) => void
+  handlePreviousStep: () => void
+  handleNextStep: () => void
+}
+
+export function StocksCalendarActionsBar({
+  checkedStocks,
+  hasStocks,
+  updateCheckedStocks,
+  deleteStocks,
+  handlePreviousStep,
+  handleNextStep,
+}: StocksCalendarActionsBarProps) {
+  const notify = useNotification()
+
+  return (
+    <>
+      {checkedStocks.size > 0 ? (
+        <ActionsBarSticky className={styles['sticky']}>
+          <div className={styles['sticky-content']}>
+            <div>{pluralize(checkedStocks.size, 'date sélectionnée')}</div>
+            <div className={styles['sticky-content-buttons']}>
+              <Button
+                variant={ButtonVariant.SECONDARY}
+                onClick={() => {
+                  updateCheckedStocks(new Set())
+                }}
+              >
+                Désélectionner
+              </Button>
+              <Button
+                onClick={() => {
+                  deleteStocks(Array.from(checkedStocks))
+                }}
+              >
+                Supprimer {checkedStocks.size > 1 ? 'ces dates' : 'cette date'}
+              </Button>
+            </div>
+          </div>
+        </ActionsBarSticky>
+      ) : (
+        <ActionBar
+          onClickPrevious={handlePreviousStep}
+          onClickNext={() => {
+            if (!hasStocks) {
+              notify.error('Veuillez renseigner au moins une date')
+              return
+            }
+            handleNextStep()
+          }}
+          step={OFFER_WIZARD_STEP_IDS.STOCKS}
+          dirtyForm={false}
+        />
+      )}
+    </>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.module.scss
@@ -1,0 +1,66 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_a11y.scss" as a11y;
+
+.table {
+  width: 100%;
+  border-bottom: rem.torem(1px) solid var(--color-border-subtle);
+}
+
+.thead {
+  border-top-left-radius: rem.torem(8px);
+  border-top-right-radius: rem.torem(8px);
+  width: 100%;
+  background-color: var(--color-background-subtle);
+
+  &-th {
+    @include fonts.body-accent-xs;
+
+    padding: rem.torem(8px);
+    text-align: left;
+
+    &:first-child {
+      border-top-left-radius: rem.torem(8px);
+      padding-left: rem.torem(16px);
+    }
+
+    &:last-child {
+      border-top-right-radius: rem.torem(8px);
+      padding-right: rem.torem(16px);
+      text-align: right;
+    }
+
+    &-date {
+      display: flex;
+      align-items: center;
+      gap: rem.torem(8px);
+    }
+  }
+}
+
+.tbody {
+  &-td {
+    padding: rem.torem(8px);
+
+    &-date {
+      margin-left: rem.torem(8px);
+    }
+
+    &:first-of-type {
+      padding-left: rem.torem(16px);
+    }
+
+    &:last-of-type {
+      text-align: right;
+      padding-right: rem.torem(16px);
+    }
+  }
+}
+
+.tr {
+  border-bottom: rem.torem(1px) solid var(--color-border-subtle);
+}
+
+.visually-hidden {
+  @include a11y.visually-hidden;
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.tsx
@@ -1,0 +1,134 @@
+import {
+  GetIndividualOfferResponseModel,
+  GetOfferStockResponseModel,
+} from 'apiClient/v1'
+import { getPriceCategoryName } from 'components/IndividualOffer/StocksEventEdition/getPriceCategoryOptions'
+import fullTrashIcon from 'icons/full-trash.svg'
+import { Checkbox } from 'ui-kit/formV2/Checkbox/Checkbox'
+import { ListIconButton } from 'ui-kit/ListIconButton/ListIconButton'
+
+import styles from './StocksCalendarTable.module.scss'
+import { formatLocalTimeDateString } from 'commons/utils/timezone'
+
+export function StocksCalendarTable({
+  stocks,
+  offer,
+  onDeleteStocks,
+  checkedStocks,
+  updateCheckedStocks,
+  departmentCode,
+}: {
+  stocks: GetOfferStockResponseModel[]
+  offer: GetIndividualOfferResponseModel
+  onDeleteStocks: (id: number[]) => void
+  checkedStocks: Set<number>
+  updateCheckedStocks: (newStocks: Set<number>) => void
+  departmentCode: string
+}) {
+  function handleStockCheckboxClicked(stockId: number) {
+    const newChecked = new Set(Array.from(checkedStocks))
+    if (checkedStocks.has(stockId)) {
+      newChecked.delete(stockId)
+    } else {
+      newChecked.add(stockId)
+    }
+    updateCheckedStocks(newChecked)
+  }
+
+  return (
+    <div className={styles['container']}>
+      <table className={styles['table']}>
+        <thead className={styles['thead']}>
+          <tr>
+            <th className={styles['thead-th']}>
+              <div className={styles['thead-th-date']}>
+                <Checkbox
+                  label={
+                    <span className={styles['visually-hidden']}>
+                      Sélectionner tous les stocks
+                    </span>
+                  }
+                  partialCheck={
+                    checkedStocks.size < stocks.length && checkedStocks.size > 0
+                  }
+                  checked={checkedStocks.size === stocks.length}
+                  onChange={() => {
+                    if (checkedStocks.size < stocks.length) {
+                      updateCheckedStocks(new Set(stocks.map((s) => s.id)))
+                    } else {
+                      updateCheckedStocks(new Set())
+                    }
+                  }}
+                  name="select-all"
+                />
+                Date
+              </div>
+            </th>
+            <th className={styles['thead-th']}>Horaire</th>
+            <th className={styles['thead-th']}>Tarif</th>
+            <th className={styles['thead-th']}>Place</th>
+            <th className={styles['thead-th']}>Date limite de réservation</th>
+            <th className={styles['thead-th']}>Actions</th>
+          </tr>
+        </thead>
+        <tbody className={styles['tbody']}>
+          {stocks.map((stock) => {
+            const priceCaregory = offer.priceCategories?.find(
+              (p) => p.id === stock.priceCategoryId
+            )
+
+            const checkboxDateLabel = stock.beginningDatetime ? (
+              <span className={styles['tbody-td-date']}>
+                {new Date(stock.beginningDatetime).toLocaleDateString()}
+              </span>
+            ) : (
+              'Date invalide'
+            )
+
+            return (
+              <tr key={stock.id} className={styles['tr']}>
+                <td className={styles['tbody-td']}>
+                  <Checkbox
+                    label={checkboxDateLabel}
+                    checked={checkedStocks.has(stock.id)}
+                    onChange={() => handleStockCheckboxClicked(stock.id)}
+                    name="select-stock"
+                  />
+                </td>
+                <td className={styles['tbody-td']}>
+                  {stock.beginningDatetime
+                    ? formatLocalTimeDateString(
+                        stock.beginningDatetime,
+                        departmentCode,
+                        'HH:mm'
+                      )
+                    : 'Horaire invalide'}
+                </td>
+                <td className={styles['tbody-td']}>
+                  {priceCaregory
+                    ? getPriceCategoryName(priceCaregory)
+                    : 'Tarif invalide'}
+                </td>
+                <td className={styles['tbody-td']}>
+                  {stock.quantity === null ? 'Illimité' : stock.quantity}
+                </td>
+                <td className={styles['tbody-td']}>
+                  {stock.bookingLimitDatetime
+                    ? new Date(stock.bookingLimitDatetime).toLocaleDateString()
+                    : 'Date invalide'}
+                </td>
+                <td className={styles['tbody-td']}>
+                  <ListIconButton
+                    icon={fullTrashIcon}
+                    tooltipContent="Supprimer le stock"
+                    onClick={() => onDeleteStocks([stock.id])}
+                  />
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
@@ -52,7 +52,7 @@ export const StocksEventCreation = ({
 
   const handleNextStep = async () => {
     // Check that there is at least one stock left
-    if (!hasStocks) {
+    if (!hasStocks && !isEventWithOpeningHoursEnabled) {
       notify.error('Veuillez renseigner au moins une date')
       return
     }
@@ -74,7 +74,12 @@ export const StocksEventCreation = ({
     <>
       <div className={styles['container']}>
         {isEventWithOpeningHoursEnabled ? (
-          <StocksCalendar offer={offer} />
+          <StocksCalendar
+            offer={offer}
+            handlePreviousStep={handlePreviousStep}
+            handleNextStep={handleNextStep}
+            departmentCode={departmentCode}
+          />
         ) : (
           <>
             {hasStocks === false && (
@@ -91,14 +96,16 @@ export const StocksEventCreation = ({
           </>
         )}
       </div>
-      <ActionBar
-        isDisabled={false}
-        onClickPrevious={handlePreviousStep}
-        onClickNext={handleNextStep}
-        step={OFFER_WIZARD_STEP_IDS.STOCKS}
-        // now we submit in RecurrenceForm, StocksEventCreation could not be dirty
-        dirtyForm={false}
-      />
+      {!isEventWithOpeningHoursEnabled && (
+        <ActionBar
+          isDisabled={false}
+          onClickPrevious={handlePreviousStep}
+          onClickNext={handleNextStep}
+          step={OFFER_WIZARD_STEP_IDS.STOCKS}
+          // now we submit in RecurrenceForm, StocksEventCreation could not be dirty
+          dirtyForm={false}
+        />
+      )}
     </>
   )
 }

--- a/pro/src/components/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
@@ -90,11 +90,9 @@ const renderStockEventCreation = async (
     }
   )
 
-  if (!features?.includes('WIP_ENABLE_EVENT_WITH_OPENING_HOUR')) {
-    await waitFor(() => {
-      expect(api.getStocks).toHaveBeenCalledTimes(1)
-    })
-  }
+  await waitFor(() => {
+    expect(api.getStocks).toHaveBeenCalledTimes(1)
+  })
 }
 
 const tomorrow = format(addDays(new Date(), 1), FORMAT_ISO_DATE_ONLY)
@@ -201,5 +199,15 @@ describe('StocksEventCreation', () => {
     expect(
       screen.getByRole('heading', { name: 'Calendrier' })
     ).toBeInTheDocument()
+  })
+
+  it('should not show the action bar here when the FF WIP_ENABLE_EVENT_WITH_OPENING_HOUR is enabled', async () => {
+    await renderStockEventCreation([], { offer: getIndividualOfferFactory() }, [
+      'WIP_ENABLE_EVENT_WITH_OPENING_HOUR',
+    ])
+
+    expect(
+      screen.queryByRole('link', { name: 'Enregistrer et continuer' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/pro/src/components/IndividualOffer/StocksEventEdition/getPriceCategoryOptions.ts
+++ b/pro/src/components/IndividualOffer/StocksEventEdition/getPriceCategoryOptions.ts
@@ -16,8 +16,14 @@ export const getPriceCategoryOptions = (
 
   return newPriceCategories.map(
     (priceCategory): SelectOption => ({
-      label: `${formatPrice(priceCategory.price)} - ${priceCategory.label}`,
+      label: getPriceCategoryName(priceCategory),
       value: priceCategory.id,
     })
   )
+}
+
+export function getPriceCategoryName(
+  priceCategory: PriceCategoryResponseModel
+) {
+  return `${formatPrice(priceCategory.price)} - ${priceCategory.label}`
 }

--- a/pro/src/pages/IndividualOffer/components/ActionBar/ActionBar.tsx
+++ b/pro/src/pages/IndividualOffer/components/ActionBar/ActionBar.tsx
@@ -19,7 +19,7 @@ import styles from './ActionBar.module.scss'
 export interface ActionBarProps {
   onClickNext?: () => void
   onClickPrevious?: () => void
-  isDisabled: boolean
+  isDisabled?: boolean
   step: OFFER_WIZARD_STEP_IDS
   dirtyForm?: boolean
 }
@@ -27,7 +27,7 @@ export interface ActionBarProps {
 export const ActionBar = ({
   onClickNext,
   onClickPrevious,
-  isDisabled,
+  isDisabled = false,
   step,
   dirtyForm,
 }: ActionBarProps) => {

--- a/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
+++ b/pro/src/ui-kit/ListIconButton/ListIconButton.module.scss
@@ -13,15 +13,6 @@
   transition: background-color 100ms ease-in-out;
   cursor: pointer;
 
-  &:active:not(:disabled),
-  &:hover:not(:disabled),
-  &:focus-visible {
-    .button-icon {
-      height: rem.torem(20px);
-      width: rem.torem(20px);
-    }
-  }
-
   &:focus-visible {
     outline: rem.torem(1px) solid var(--color-black);
   }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35415

**Objectif**
- Retravail de la structure de `StocksEventCreation` pour afficher la table des stocks quand le FF est activé
- Création du nouveau composant de la table
- Passage des "sticky actions" au même niveau quand le FF est actif pour ne pas afficher les barres l'une par dessus l'autre

**FF à activer**
WIP_ENABLE_EVENT_WITH_OPENING_HOUR

**A noter**
Les options de tri et de filtre sur la table seront ajoutées par la suite, mais la pagination doit déjà être fonctionnelle.

<img width="965" alt="Capture d’écran 2025-04-03 à 09 12 45" src="https://github.com/user-attachments/assets/fc048d0e-9f10-441a-b7b6-87d360242d90" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
