### PR TITLE
(BSR)[ADAGE] fix: use OA for venue address in adage iframe route

### DIFF
--- a/api/src/pcapi/core/educational/api/adage.py
+++ b/api/src/pcapi/core/educational/api/adage.py
@@ -83,7 +83,7 @@ def get_venue_by_siret_for_adage_iframe(
             else:
                 relative.append(candidate.id)
     else:
-        venue = offerers_repository.find_venue_by_siret(siret)
+        venue = offerers_repository.find_venue_by_siret(siret, load_address=True)
     return venue, relative
 
 
@@ -100,7 +100,7 @@ def get_venue_by_id_for_adage_iframe(
             else:
                 relative.append(candidate.id)
     else:
-        venue = offerers_repository.find_venue_by_id(venue_id)
+        venue = offerers_repository.find_venue_by_id(venue_id, load_address=True)
     return venue, relative
 
 

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -216,8 +216,15 @@ def find_relative_venue_by_id(venue_id: int) -> list[models.Venue]:
     return query.all()
 
 
-def find_venue_by_siret(siret: str) -> models.Venue | None:
-    return models.Venue.query.filter_by(siret=siret).one_or_none()
+def find_venue_by_siret(siret: str, load_address: bool = False) -> models.Venue | None:
+    query = db.session.query(models.Venue).filter_by(siret=siret)
+
+    if load_address:
+        query = query.options(
+            sqla_orm.joinedload(models.Venue.offererAddress).joinedload(models.OffererAddress.address)
+        )
+
+    return query.one_or_none()
 
 
 def find_virtual_venue_by_offerer_id(offerer_id: int) -> models.Venue | None:

--- a/api/src/pcapi/routes/adage_iframe/serialization/venues.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/venues.py
@@ -1,5 +1,11 @@
+import logging
+
 from pcapi.core.offerers import models as offerers_models
 from pcapi.routes.serialization import BaseModel
+from pcapi.utils import regions
+
+
+logger = logging.getLogger(__name__)
 
 
 class GetRelativeVenuesQueryModel(BaseModel):
@@ -10,14 +16,32 @@ class VenueResponse(BaseModel):
     id: int
     publicName: str | None
     name: str
-    departementCode: str
+    departementCode: str | None
     relative: list[int]
     adageId: str | None
 
-    class Config:
-        orm_mode = True
-
     @classmethod
-    def from_orm(cls, venue: offerers_models.Venue, relative: list[int] | None = None) -> "VenueResponse":
-        venue.relative = relative or []
-        return super().from_orm(venue)
+    def build(
+        cls: "type[VenueResponse]", venue: offerers_models.Venue, relative: list[int] | None = None
+    ) -> "VenueResponse":
+        offerer_address = venue.offererAddress
+
+        departement_code: str | None
+        if offerer_address is None:
+            # we only use this model on venues related to a collective offer template, those should have an offererAddress
+            logger.error("Found venue with id %s without offererAddress", venue.id)
+            departement_code = None
+        else:
+            departement_code = offerer_address.address.departmentCode
+            if departement_code is None:
+                # Address.departmentCode is nullable, if None fallback to postalCode
+                departement_code = regions.get_department_code_from_city_code(offerer_address.address.postalCode)
+
+        return cls(
+            id=venue.id,
+            publicName=venue.publicName,
+            name=venue.name,
+            departementCode=departement_code,
+            relative=relative or [],
+            adageId=venue.adageId,
+        )

--- a/api/src/pcapi/routes/adage_iframe/venues.py
+++ b/api/src/pcapi/routes/adage_iframe/venues.py
@@ -28,7 +28,7 @@ def get_venue_by_siret(
         logger.info("Venue does not exists for given siret", extra={"siret": siret})
         raise ApiErrors({"siret": "Aucun lieu n'existe pour ce siret"}, status_code=404)
 
-    return VenueResponse.from_orm(venue, relative)
+    return VenueResponse.build(venue=venue, relative=relative)
 
 
 @blueprint.adage_iframe.route("/venues/<int:venue_id>", methods=["GET"])
@@ -46,4 +46,4 @@ def get_venue_by_id(
         logger.info("Venue does not exists for given venue_id", extra={"venue_id": venue_id})
         raise ApiErrors({"venue_id": "Aucun lieu n'existe pour ce venue_id"}, status_code=404)
 
-    return VenueResponse.from_orm(venue, relative)
+    return VenueResponse.build(venue=venue, relative=relative)

--- a/pro/src/apiClient/adage/models/VenueResponse.ts
+++ b/pro/src/apiClient/adage/models/VenueResponse.ts
@@ -4,7 +4,7 @@
 /* eslint-disable */
 export type VenueResponse = {
   adageId?: string | null;
-  departementCode: string;
+  departementCode?: string | null;
   id: number;
   name: string;
   publicName?: string | null;


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : on remplace l'usage du champ `venue.departementCode` par le champ `address.departementCode` dans les routes adage iframe des venues

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
