### PR TITLE
(BSR)[API] fix: Catch error when move offer

### DIFF
--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -280,6 +280,8 @@ def edit_collective_offer(
 
     try:
         educational_api_offer.update_collective_offer(offer_id=offer_id, body=body, user=current_user)
+    except offers_exceptions.ForbiddenDestinationVenue:
+        raise ApiErrors({"venueId": ["Ce partenaire culturel n'est pas éligible au transfert de l'offre"]}, 400)
     except offers_exceptions.SubcategoryNotEligibleForEducationalOffer:
         raise ApiErrors({"subcategoryId": "this subcategory is not educational"}, 400)
     except offers_exceptions.OfferEventInThePast:

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -770,6 +770,16 @@ class Returns400Test:
             assert response.status_code == 400
             assert response.json == {"venueId": ["No venue with a pricing point found for the destination venue."]}
 
+    def test_patch_collective_offer_replacing_by_venue_not_eligible(self, auth_client, venue, other_related_venue):
+        offer = educational_factories.ActiveCollectiveOfferFactory(venue=venue)
+
+        other_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
+
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
+            response = auth_client.patch(f"/collective/offers/{offer.id}", json={"venueId": other_venue.id})
+            assert response.status_code == 400
+            assert response.json == {"venueId": ["Ce partenaire culturel n'est pas éligible au transfert de l'offre"]}
+
     def test_patch_collective_offer_description_invalid(self, auth_client, venue):
         offer = educational_factories.ActiveCollectiveOfferFactory(venue=venue)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : BSR

Catch erreur lors du transfert d'une offre sur une venue non éligible.

Résoudre [cette erreur sentry](https://pass-culture.sentry.io/issues/35599614/?alert_rule_id=139263&alert_type=issue&environment=testing&notification_uuid=19f8bdf2-f585-4add-8e3f-fc834c56cec4&project=4508776981069904&referrer=slack) 

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
