### PR TITLE
(PC-35309)[API] fix: ignore age18 fraud checks if the user was not yet 18

### DIFF
--- a/api/src/pcapi/core/users/eligibility_api.py
+++ b/api/src/pcapi/core/users/eligibility_api.py
@@ -137,13 +137,13 @@ def get_first_eligible_registration_date(
         for fraud_check in fraud_checks
         if (not eligibility or fraud_check.eligibilityType == eligibility)
     )
-    eligible_registration_dates = [
-        registration_date
-        for registration_date in registration_dates
-        if get_eligibility_at_date(birth_date, registration_date, user.departementCode) is not None
-    ]
-    if eligible_registration_dates:
-        return eligible_registration_dates[0]
+    for registration_date in registration_dates:
+        eligibility_at_date = get_eligibility_at_date(birth_date, registration_date, user.departementCode)
+        if eligibility is None and eligibility_at_date is not None:
+            return registration_date
+
+        if eligibility is not None and eligibility_at_date == eligibility:
+            return registration_date
 
     return None
 

--- a/api/tests/core/users/test_eligibility.py
+++ b/api/tests/core/users/test_eligibility.py
@@ -473,11 +473,11 @@ class GetFirstRegistrationDateTest:
             type=fraud_models.FraudCheckType.UBBLE,
             dateCreated=today_in_utc,
             resultContent=None,
-            eligibilityType=users_models.EligibilityType.UNDERAGE,
+            eligibilityType=users_models.EligibilityType.AGE17_18,
         )
 
         first_registration_date = eligibility_api.get_first_eligible_registration_date(
-            user, user.birth_date, users_models.EligibilityType.UNDERAGE
+            user, user.birth_date, users_models.EligibilityType.AGE17_18
         )
 
         assert first_registration_date == today_in_utc

--- a/api/tests/core/users/young_status_test.py
+++ b/api/tests/core/users/young_status_test.py
@@ -34,6 +34,7 @@ class YoungStatusTest:
                     registration_datetime=datetime.datetime.utcnow() - relativedelta(years=1)
                 ),
                 type=fraud_models.FraudCheckType.DMS,
+                eligibilityType=users_models.EligibilityType.AGE18,
                 user=user,
             )
             assert young_status.young_status(user).status_type == young_status.YoungStatusType.ELIGIBLE


### PR DESCRIPTION
Some users fill their birth date wrong, so their first fraud checks are considered age18. We should ignore these fraud checks eligibility type when the birth date is corrected by the identity provider.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35309
