### PR TITLE
(BSR)[API] chore: remove useless isEvent property on collective offers

### DIFF
--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -966,14 +966,6 @@ class CollectiveOffer(
             text_data.append(self.collectiveStock.priceDetail)
         return " ".join(text_data)
 
-    @hybrid_property
-    def isEvent(self) -> bool:
-        return self.subcategory.is_event
-
-    @isEvent.expression  # type: ignore[no-redef]
-    def isEvent(cls) -> sa_elements.BinaryExpression:  # pylint: disable=no-self-argument
-        return cls.subcategoryId.in_(subcategories.EVENT_SUBCATEGORIES)
-
     @property
     def is_cancellable_from_offerer(self) -> bool:
         if self.collectiveStock is None:
@@ -1369,14 +1361,6 @@ class CollectiveOfferTemplate(
     @property
     def visibleText(self) -> str:  # used in validation rule, do not remove
         return f"{self.name} {self.description} {self.priceDetail}"
-
-    @hybrid_property
-    def isEvent(self) -> bool:
-        return self.subcategory.is_event
-
-    @isEvent.expression  # type: ignore[no-redef]
-    def isEvent(cls) -> sa_elements.BinaryExpression:  # pylint: disable=no-self-argument
-        return cls.subcategoryId.in_(subcategories.EVENT_SUBCATEGORIES)
 
     @property
     def is_cancellable_from_offerer(self) -> bool:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : la property n'a plus de sens, et en plus elle ne sert pas

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
