### PR TITLE
(PC-35284)[API] feat: Create new ActionHistory type for venue regularisation

### DIFF
--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -71,6 +71,7 @@ class ActionType(enum.Enum):
     LINK_VENUE_PROVIDER_UPDATED = "Lien avec le partenaire technique modifié"
     LINK_VENUE_PROVIDER_DELETED = "Suppression du lien avec le partenaire technique"
     SYNC_VENUE_TO_PROVIDER = "Synchronisation du lieu avec un partenaire technique"
+    MOVE_ALL_OFFER = "Migration de toutes les offres (individuelles et collectives)"
 
     # Permissions role changes:
     ROLE_PERMISSIONS_CHANGED = "Modification des permissions du rôle"


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35284

Ajout d'un type d'ActionHistory dans le cadre du chantier de régularisation. Ajout d'une méthode pour fixer le format attendu des entrées d'historique pour ces mouvements d'offres :
- Une entrée par venue, d'origine et de destination
- Une entrée par type d'offre, individuelles et collectives

Si le découpage des migrations d'offres est différent, il faudra peut-être ajouter plus d'information dans les extraData. Il se peut que le découpage se fasse par PriceCategoryLabel et/ou par offre collective vitrine si le nombre d'offre est trop important. Ce n'est pour l'instant pas la stratégie adoptée.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
