### PR TITLE
(BSR)[API] chore: remove useless isEducational property

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -766,10 +766,6 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         else:
             self._durationMinutes = value
 
-    @property
-    def isEducational(self) -> bool:
-        return False
-
     @hybrid_property
     def isSoldOut(self) -> bool:
         for stock in self.stocks:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : la property n'est pas utilisée, car isEducational est hardcodée dans tous ses usages

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
