### PR TITLE
(BSR)[API] ci: deploy testing every hour

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -258,75 +258,75 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' && needs.pcapi-init-job.outputs.pro-changed == 'true' }}
     uses: ./.github/workflows/dev_on_workflow_deploy_storybook.yml
 
-  push-pcapi:
-    name: "Push pcapi docker image to registry"
-    needs: [build-pcapi, pcapi-init-job, test-api]
-    uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
-    with:
-      image: pcapi
-      commit-hash: ${{ github.sha }}
-      checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
-      tag-latest: true
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  # push-pcapi:
+  #   name: "Push pcapi docker image to registry"
+  #   needs: [build-pcapi, pcapi-init-job, test-api]
+  #   uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
+  #   with:
+  #     image: pcapi
+  #     commit-hash: ${{ github.sha }}
+  #     checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+  #     tag-latest: true
+  #   secrets:
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  push-pcapi-console:
-    name: "Push pcapi-console docker image to registry"
-    needs: [build-pcapi-console, pcapi-init-job, test-api]
-    uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
-    with:
-      image: pcapi-console
-      commit-hash: ${{ github.sha }}
-      checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
-      tag-latest: true
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  # push-pcapi-console:
+  #   name: "Push pcapi-console docker image to registry"
+  #   needs: [build-pcapi-console, pcapi-init-job, test-api]
+  #   uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
+  #   with:
+  #     image: pcapi-console
+  #     commit-hash: ${{ github.sha }}
+  #     checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+  #     tag-latest: true
+  #   secrets:
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  deploy-to-testing:
-    name: "Deploy to testing"
-    needs: [pcapi-init-job, test-api, test-pro, push-pcapi-console, push-pcapi]
-    if: |
-      always() &&
-      github.ref == 'refs/heads/master' &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-api.result) &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-pro.result)
-    uses: ./.github/workflows/dev_on_workflow_deploy.yml
-    with:
-      environment: testing
-      app_version: ${{ github.sha }}
-      cluster_scope: metier
-      cluster_environment: ehp
-      workload_identity_provider_secret_name: gcp_metier_ehp_workload_identity_provider
-      apply_algolia_config: ${{ needs.pcapi-init-job.outputs.algolia-config-changed == 'true' }}
-      deploy_api: ${{ needs.test-api.result == 'success' }}
-      deploy_pro: ${{ needs.test-pro.result == 'success' }}
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  # deploy-to-testing:
+  #   name: "Deploy to testing"
+  #   needs: [pcapi-init-job, test-api, test-pro, push-pcapi-console, push-pcapi]
+  #   if: |
+  #     always() &&
+  #     github.ref == 'refs/heads/master' &&
+  #     contains(fromJSON('["success", "skipped"]'), needs.test-api.result) &&
+  #     contains(fromJSON('["success", "skipped"]'), needs.test-pro.result)
+  #   uses: ./.github/workflows/dev_on_workflow_deploy.yml
+  #   with:
+  #     environment: testing
+  #     app_version: ${{ github.sha }}
+  #     cluster_scope: metier
+  #     cluster_environment: ehp
+  #     workload_identity_provider_secret_name: gcp_metier_ehp_workload_identity_provider
+  #     apply_algolia_config: ${{ needs.pcapi-init-job.outputs.algolia-config-changed == 'true' }}
+  #     deploy_api: ${{ needs.test-api.result == 'success' }}
+  #     deploy_pro: ${{ needs.test-pro.result == 'success' }}
+  #   secrets:
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  deploy-to-ops:
-    name: "Deploy to ops"
-    needs: [test-api, test-pro, push-pcapi-console, push-pcapi]
-    if: |
-      always() &&
-      github.ref == 'refs/heads/master' &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-api.result) &&
-      contains(fromJSON('["success", "skipped"]'), needs.test-pro.result) &&
-      vars.DISABLE_PCAPI_OPS_DEPLOY == 'false'
-    uses: ./.github/workflows/dev_on_workflow_deploy.yml
-    with:
-      environment: ops
-      app_version: ${{ github.sha }}
-      cluster_scope: metier
-      cluster_environment: ops
-      workload_identity_provider_secret_name: gcp_metier_ops_workload_identity_provider
-      deploy_api: ${{ needs.test-api.result == 'success' }}
-      deploy_pro: false
-    secrets:
-      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+  # deploy-to-ops:
+  #   name: "Deploy to ops"
+  #   needs: [test-api, test-pro, push-pcapi-console, push-pcapi]
+  #   if: |
+  #     always() &&
+  #     github.ref == 'refs/heads/master' &&
+  #     contains(fromJSON('["success", "skipped"]'), needs.test-api.result) &&
+  #     contains(fromJSON('["success", "skipped"]'), needs.test-pro.result) &&
+  #     vars.DISABLE_PCAPI_OPS_DEPLOY == 'false'
+  #   uses: ./.github/workflows/dev_on_workflow_deploy.yml
+  #   with:
+  #     environment: ops
+  #     app_version: ${{ github.sha }}
+  #     cluster_scope: metier
+  #     cluster_environment: ops
+  #     workload_identity_provider_secret_name: gcp_metier_ops_workload_identity_provider
+  #     deploy_api: ${{ needs.test-api.result == 'success' }}
+  #     deploy_pro: false
+  #   secrets:
+  #     GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+  #     GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
   deploy-maintenance-site:
     name: "Deploy maintenance site"

--- a/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
+++ b/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
@@ -1,0 +1,175 @@
+name: "2 [on_schedule] deploy main and pro"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # This cron is defined in UTC timezone. It means that it will run :
+    # - during summer hours between 8:30am - 7:30pm
+    # - during winter hours between 7:30am - 6:30pm
+    # we cannot yet specify timezone : 
+    # https://github.com/orgs/community/discussions/13454
+    - cron: "30 6-17 * * 1-5"
+
+permissions: write-all
+
+env:
+  docker_registry: "europe-west1-docker.pkg.dev/passculture-infra-prod/pass-culture-artifact-registry"
+  GIT_CONFIG_EMAIL: github-actions-bot@passculture.app
+  GIT_CONFIG_NAME: scheduled-testing-deployment
+
+jobs:
+  pcapi-init-job:
+    runs-on: ubuntu-latest
+    outputs: 
+        checksum-tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+    steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+            fetch-tags: false
+            ref: 'master'
+        - name: "Define pcapi image tags."
+          id: pcapi-tags
+          run: |
+            DOCKER_IMAGE="${{ env.docker_registry }}/pcapi"
+            API_CHECKSUM=`tar --sort=name --owner=0 --group=0 --mtime='UTC 2019-01-01' -cf - api | sha1sum | awk '{ print $1 }'`
+            PUSH_TAGS="push-tags=$DOCKER_IMAGE:${{ github.sha }},$DOCKER_IMAGE:$API_CHECKSUM,$DOCKER_IMAGE:latest"
+            API_TAG="checksum-tag=$API_CHECKSUM"
+            echo "PUSH_TAGS=$PUSH_TAGS"
+            echo "API_TAG=$API_TAG"
+            echo $PUSH_TAGS >> "$GITHUB_OUTPUT"
+            echo $API_TAG >> "$GITHUB_OUTPUT"
+        - name: "pcapi"
+          id: check-checksum-tag
+          run: ./.github/workflows/scripts/check-image-tag-exists.sh
+          env:
+            image: pcapi
+            tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+            token: ${{ steps.openid-auth.outputs.access_token }}
+        - name: "Authentification to Google"
+          uses: "google-github-actions/auth@v2"
+          with:
+            workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+            service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+        - name: "Get Secret"
+          id: secrets
+          uses: "google-github-actions/get-secretmanager-secrets@v2"
+          with:
+            secrets: |-
+              SLACK_BOT_TOKEN:passculture-metier-ehp/passculture-ci-slack-bot-token
+              ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/infra-prod-gcp-workload-identity-provider
+              ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
+        - name: "OpenID Connect Authentication"
+          id: "openid-auth"
+          uses: "google-github-actions/auth@v2"
+          with:
+            create_credentials_file: false
+            token_format: "access_token"
+            workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
+            service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+        - name: "Docker login"
+          id: "docker-login"
+          uses: "docker/login-action@v3"
+          with:
+            registry: "europe-west1-docker.pkg.dev"
+            username: "oauth2accesstoken"
+            password: "${{ steps.openid-auth.outputs.access_token }}"
+        - name: "pcapi-console"
+          id: check-console-checksum-tag
+          run: ./.github/workflows/scripts/check-image-tag-exists.sh
+          env:
+            image: pcapi-console
+            tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+            token: ${{ steps.openid-auth.outputs.access_token }}
+        - name: "Summary"
+          run: |
+            echo "[pcapi] push-tags : ${{ steps.pcapi-tags.outputs.push-tags }}"
+            echo "[pcapi] checksum-tag : ${{ steps.pcapi-tags.outputs.checksum-tag }}"
+            echo "[pcapi] image tag ${{ steps.pcapi-tags.outputs.checksum-tag }} exists : ${{ steps.check-checksum-tag.outputs.tag-exists }}"
+            echo "[pcapi-console] image tag ${{ steps.pcapi-tags.outputs.checksum-tag }} exists : ${{ steps.check-console-checksum-tag.outputs.tag-exists }}"
+  
+  # Theses steps builds pcapi and pcapi-console image, tags them with the last commit sha then
+  # pushes them to the registry
+  build-pcapi:
+    name: "[pcapi] build docker image."
+    needs: [pcapi-init-job]
+    uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
+    with:
+      ref: ${{ github.sha }}
+      image: pcapi
+      tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+  build-pcapi-console:
+    name: "[pcapi-console] build docker image."
+    needs: [pcapi-init-job]
+    if: |
+    uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
+    with:
+      ref: ${{ github.sha }}
+      image: pcapi-console
+      tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+  push-pcapi:
+    name: "Push pcapi docker image to registry"
+    needs: [build-pcapi, pcapi-init-job]
+    uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
+    with:
+      image: pcapi
+      commit-hash: ${{ github.sha }}
+      checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+      tag-latest: true
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+  push-pcapi-console:
+    name: "Push pcapi-console docker image to registry"
+    needs: [build-pcapi-console, pcapi-init-job]
+    uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
+    with:
+      image: pcapi-console
+      commit-hash: ${{ github.sha }}
+      checksum-tag: ${{ needs.pcapi-init-job.outputs.checksum-tag }}
+      tag-latest: true
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+        
+  deploy-to-testing:
+    name: "Deploy to testing"
+    needs: [pcapi-init-job, push-pcapi-console, push-pcapi]
+    uses: ./.github/workflows/dev_on_workflow_deploy.yml
+    with:
+      environment: testing
+      app_version: ${{ github.sha }}
+      cluster_scope: metier
+      cluster_environment: ehp
+      workload_identity_provider_secret_name: gcp_metier_ehp_workload_identity_provider
+      apply_algolia_config: true
+      deploy_api: true
+      deploy_pro: true
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+  deploy-to-ops:
+    name: "Deploy to ops"
+    needs: [pcapi-init-job, push-pcapi-console, push-pcapi]
+    uses: ./.github/workflows/dev_on_workflow_deploy.yml
+    with:
+      environment: ops
+      app_version: ${{ github.sha }}
+      cluster_scope: metier
+      cluster_environment: ops
+      workload_identity_provider_secret_name: gcp_metier_ops_workload_identity_provider
+      deploy_api: true
+      deploy_pro: false
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
Deploy testing every hour between 7:30 to 19:30. We deploy everything, main, pro, api docs and algolia settings, like staging, production or integration deployment. 

Some things needs to be migrated to this new workflow too (maybe?) like storybook or maintenance site. 

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34934

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
