### PR TITLE
(PC-34943)[PRO] fix: total numbre offer in adage

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/Autocomplete.tsx
@@ -17,7 +17,7 @@ import {
   useRef,
   useState,
 } from 'react'
-import { useSearchBox } from 'react-instantsearch'
+import { useInstantSearch, useSearchBox } from 'react-instantsearch'
 import { useDispatch } from 'react-redux'
 
 import { SuggestionType } from 'apiClient/adage'
@@ -89,6 +89,7 @@ export const Autocomplete = ({ initialQuery }: AutocompleteProps) => {
   const dispatch = useDispatch()
 
   const { refine } = useSearchBox()
+  const { refresh } = useInstantSearch()
   const [instantSearchUiState, setInstantSearchUiState] = useState<
     AutocompleteState<SuggestionItem>
   >({
@@ -274,6 +275,7 @@ export const Autocomplete = ({ initialQuery }: AutocompleteProps) => {
           setInstantSearchUiState(state)
         },
         onSubmit: ({ state }) => {
+          refresh()
           refine(state.query)
           dispatch(setAdageQuery(state.query))
           dispatch(setAdagePageSaved(0))

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Autocomplete/__specs__/Autocomplete.spec.tsx
@@ -108,6 +108,7 @@ vi.mock('react-instantsearch', async () => {
   return {
     ...(await vi.importActual('react-instantsearch')),
     useSearchBox: () => ({ refine: refineMock }),
+    useInstantSearch: () => ({ refresh: vi.fn() }),
   }
 })
 

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/__spec__/OffersSearch.spec.tsx
@@ -137,6 +137,7 @@ vi.mock('react-instantsearch', async () => {
           },
         },
       ],
+      refresh: vi.fn(),
     }),
     Configure: vi.fn(() => <div />),
     Index: vi.fn(({ children }) => children),


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34943

On créer une offre vitrine, elle s'affiche dans la page de recherche sur ADAGE ensuite on l'archive depuis le portail pro, elle est censé disparaitre de la page recherche et le nombre total doit diminué de 1 (après une recherche) sans avoir à recharger la page 

<img width="221" alt="Capture d’écran 2025-04-03 à 14 53 18" src="https://github.com/user-attachments/assets/11e85bdc-2122-4c63-80ee-c3526ed3b445" />

