### PR TITLE
(PC-35485)[API] fix: move_offer should not affect the offer's location

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1837,7 +1837,6 @@ def move_offer(
     }
     with transaction():
         offer.venue = destination_venue
-        offer.offererAddressId = destination_venue.offererAddressId
         db.session.add(offer)
 
         for price_category in offer.priceCategories:

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -4656,16 +4656,19 @@ class EditPriceCategoryTest:
 class MoveOfferTest:
     def test_move_physical_offer_without_pricing_point(self):
         """Moving an offer from a venue without pricing point to another venue
-        without pricing point should work"""
+        without pricing point should work and the offer's location should not change."""
         offer = factories.OfferFactory()
         new_venue = offerers_factories.VenueFactory(managingOfferer=offer.venue.managingOfferer)
         assert offer.venue.current_pricing_point is None
         assert new_venue.current_pricing_point is None
+        assert offer.offererAddressId != new_venue.offererAddressId
 
+        initial_offerer_address_id = offer.offererAddressId
         api.move_offer(offer, new_venue)
 
         db.session.refresh(offer)
         assert offer.venue == new_venue
+        assert offer.offererAddressId == initial_offerer_address_id
 
     def test_move_physical_offer_with_different_pricing_point(self):
         """Moving a physical offer from a venue to another venue without


### PR DESCRIPTION
It should only apply on the venue.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-35485

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
