### PR TITLE
(BSR)[PRO] ci: Retrying sandbox calls.

### DIFF
--- a/pro/cypress/support/index.d.ts
+++ b/pro/cypress/support/index.d.ts
@@ -43,7 +43,8 @@ declare namespace Cypress {
     sandboxCall(
       method: 'GET' | 'POST',
       url: string,
-      onRequest: (response: any) => void
+      onRequest: (response: any) => void,
+      retry?: boolean
     ): Chainable
   }
 }


### PR DESCRIPTION
## But de la pull request

Ajout d'un retry pour les requêtes sandbox

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
