### PR TITLE
(PC-35492)[API] chore: rename celery ff to be mail specific

### DIFF
--- a/api/src/pcapi/core/external/sendinblue.py
+++ b/api/src/pcapi/core/external/sendinblue.py
@@ -124,12 +124,12 @@ def update_contact_email(user: users_models.User, old_email: str, new_email: str
     )
 
     if asynchronous:
-        if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_TASKS.is_active():
+        if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_MAILS.is_active():
             update_contact_attributes_task_celery.delay(contact_request.dict())
         else:
             update_contact_attributes_task_cloud_tasks.delay(contact_request)
     else:
-        if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_TASKS.is_active():
+        if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_MAILS.is_active():
             update_contact_attributes_task_celery(contact_request.dict())
         else:
             update_contact_attributes_task_cloud_tasks(contact_request)
@@ -160,7 +160,7 @@ def update_contact_attributes(
     )
 
     if asynchronous:
-        if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_TASKS.is_active():
+        if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_MAILS.is_active():
             update_contact_attributes_task_celery.delay(contact_request.dict())
         else:
             update_contact_attributes_task_cloud_tasks.delay(contact_request)

--- a/api/src/pcapi/core/mails/backends/sendinblue.py
+++ b/api/src/pcapi/core/mails/backends/sendinblue.py
@@ -57,12 +57,12 @@ class SendinblueBackend(BaseBackend):
                 use_pro_subaccount=data.template.use_pro_subaccount,
             )
             if data.template.use_priority_queue:
-                if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_TASKS.is_active():
+                if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_MAILS.is_active():
                     send_transactional_email_primary_task_celery.delay(payload.dict())
                 else:
                     send_transactional_email_primary_task_cloud_tasks.delay(payload)
             else:
-                if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_TASKS.is_active():
+                if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_MAILS.is_active():
                     send_transactional_email_secondary_task_celery.delay(payload.dict())
                 else:
                     send_transactional_email_secondary_task_cloud_tasks.delay(payload)
@@ -80,7 +80,7 @@ class SendinblueBackend(BaseBackend):
                 params=None,
                 tags=None,
             )
-            if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_TASKS.is_active():
+            if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_MAILS.is_active():
                 send_transactional_email_secondary_task_celery.delay(payload.dict())
             else:
                 send_transactional_email_secondary_task_cloud_tasks.delay(payload)

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -116,7 +116,9 @@ class FeatureToggle(enum.Enum):
     MOVE_OFFER_TEST = "Test le déplacement de n'importe quelle offre vers une autre venue"
     # For features under construction, a temporary feature flag must be named with the `WIP_` prefix
     WIP_2025_SIGN_UP = "Activer le nouveau parcours d’inscription au portail pro"
-    WIP_ASYNCHRONOUS_CELERY_TASKS = "Activer le backend de tâches asynchrone Celery pour les tâches qui le supporte"
+    WIP_ASYNCHRONOUS_CELERY_MAILS = (
+        "Activer le backend de tâches asynchrones Celery pour les tâches liées à l'envoi de mails"
+    )
     WIP_COLLAPSED_MEMORIZED_FILTERS = "Activer la fonction de masquage et de mémorisation des filtres en sessionStorage"
     WIP_DISABLE_CANCEL_BOOKING_NOTIFICATION = (
         "Désactiver la notification push Batch pour l'annulation d'une réservation"
@@ -217,7 +219,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.SEND_ALL_EMAILS_TO_EHP,
     FeatureToggle.SYNCHRONIZE_TITELIVE_API_MUSIC_PRODUCTS,
     FeatureToggle.WIP_2025_SIGN_UP,
-    FeatureToggle.WIP_ASYNCHRONOUS_CELERY_TASKS,
+    FeatureToggle.WIP_ASYNCHRONOUS_CELERY_MAILS,
     FeatureToggle.WIP_DISABLE_CANCEL_BOOKING_NOTIFICATION,
     FeatureToggle.WIP_DISABLE_NOTIFY_USERS_BOOKINGS_NOT_RETRIEVED,
     FeatureToggle.WIP_DISABLE_SEND_NOTIFICATIONS_FAVORITES_NOT_BOOKED,

--- a/api/tests/core/mails/mails_celery_test.py
+++ b/api/tests/core/mails/mails_celery_test.py
@@ -15,7 +15,7 @@ from pcapi.utils.module_loading import import_string
 
 
 @pytest.mark.usefixtures("db_session")
-@pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_TASKS=True)
+@pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_MAILS=True)
 class SendinblueBackendTest:
     recipients = ["lucy.ellingson@example.com", "avery.kelly@example.com"]
     bcc_recipients = ["catherine.clark@example.com", "tate.walker@example.com"]
@@ -146,7 +146,7 @@ class SendinblueBackendTest:
 
 
 @pytest.mark.usefixtures("db_session")
-@pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_TASKS=True)
+@pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_MAILS=True)
 class ToDevSendinblueBackendTest(SendinblueBackendTest):
     expected_sent_data_to_dev = sendinblue_tasks.SendTransactionalEmailRequest(
         recipients=["dev@example.com"],
@@ -235,7 +235,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         assert list(task_param.recipients) == [recipient]
 
 
-@pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_TASKS=True)
+@pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_MAILS=True)
 class SendTest:
     @pytest.mark.settings(IS_TESTING=True, EMAIL_BACKEND="pcapi.core.mails.backends.sendinblue.ToDevSendinblueBackend")
     @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")

--- a/api/tests/core/mails/transactional/test_send_transactional_email.py
+++ b/api/tests/core/mails/transactional/test_send_transactional_email.py
@@ -211,7 +211,7 @@ class TransactionalEmailWithTemplateTest:
         mock_send_transactional_email_task.assert_called_once()
 
     @pytest.mark.settings(EMAIL_BACKEND="pcapi.core.mails.backends.sendinblue.ToDevSendinblueBackend")
-    @pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_TASKS=True)
+    @pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_MAILS=True)
     @patch("pcapi.core.mails.backends.sendinblue.send_transactional_email_primary_task_celery.delay")
     def test_to_dev_send_email_confirmation_email_through_celery(self, mock_send_transactional_email_task, db_session):
         user = users_factories.UserFactory(email="john.celery@gmail.com")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35492

Renommage du feature flag pour bien indiquer le fait qu'il sera spécifique à l'envoi de mail et pouvoir contrôler le passage de différentes tâches à Celery.