### PR TITLE
Pc 35481 sort filter stocks table

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.module.scss
@@ -46,3 +46,11 @@
 .pagination {
   margin: rem.torem(24px) 0;
 }
+
+.filters {
+  margin-bottom: rem.torem(32px);
+}
+
+.count {
+  margin-bottom: rem.torem(8px);
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.spec.tsx
@@ -189,4 +189,28 @@ describe('StocksCalendar', () => {
 
     expect(screen.getByText('Page 1/3'))
   })
+
+  it('should show the total number of stocks', async () => {
+    renderStocksCalendar(
+      Array(50)
+        .fill(null)
+        .map((_, index) => getOfferStockFactory({ id: index }))
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
+    expect(screen.getByText('50 dates')).toBeInTheDocument()
+  })
+
+  it('should not show the total number of stocks if there is none', async () => {
+    renderStocksCalendar([])
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
+    expect(screen.queryByText(/ dates/)).not.toBeInTheDocument()
+  })
 })

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.tsx
@@ -2,9 +2,14 @@ import { useState } from 'react'
 import useSWR, { mutate } from 'swr'
 
 import { api } from 'apiClient/api'
-import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import {
+  GetIndividualOfferWithAddressResponseModel,
+  StocksOrderedBy,
+} from 'apiClient/v1'
 import { GET_STOCKS_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { useNotification } from 'commons/hooks/useNotification'
+import { pluralize } from 'commons/utils/pluralize'
+import { convertTimeFromVenueTimezoneToUtc } from 'commons/utils/timezone'
 import fullMoreIcon from 'icons/full-more.svg'
 import strokeAddCalendarIcon from 'icons/stroke-add-calendar.svg'
 import { Button } from 'ui-kit/Button/Button'
@@ -13,8 +18,11 @@ import { Pagination } from 'ui-kit/Pagination/Pagination'
 import { Spinner } from 'ui-kit/Spinner/Spinner'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
+import { StocksTableFilters, StocksTableSort } from '../form/types'
+
 import styles from './StocksCalendar.module.scss'
 import { StocksCalendarActionsBar } from './StocksCalendarActionsBar/StocksCalendarActionsBar'
+import { StocksCalendarFilters } from './StocksCalendarFilters/StocksCalendarFilters'
 import { StocksCalendarForm } from './StocksCalendarForm/StocksCalendarForm'
 import { StocksCalendarTable } from './StocksCalendarTable/StocksCalendarTable'
 
@@ -34,18 +42,32 @@ export function StocksCalendar({
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [page, setPage] = useState(1)
   const [checkedStocks, setCheckedStocks] = useState(new Set<number>())
+  const [appliedFilters, setAppliedFilters] = useState<StocksTableFilters>({})
+  const [appliedSort, setAppliedSort] = useState<StocksTableSort>({
+    sort: StocksOrderedBy.DATE,
+  })
   const notify = useNotification()
 
+  const queryKeys: [
+    string,
+    number,
+    number,
+    StocksTableFilters,
+    StocksTableSort,
+  ] = [GET_STOCKS_QUERY_KEY, offer.id, page, appliedFilters, appliedSort]
+
   const { data, isLoading } = useSWR(
-    [GET_STOCKS_QUERY_KEY, offer.id, page],
-    ([, offerId, pageNum]) =>
+    queryKeys,
+    ([, offerId, pageNum, filters, sortType]) =>
       api.getStocks(
         offerId,
-        null,
-        null,
-        null,
-        undefined,
-        undefined,
+        filters.date || undefined,
+        filters.time
+          ? convertTimeFromVenueTimezoneToUtc(filters.time, departmentCode)
+          : undefined,
+        filters.priceCategoryId ? Number(filters.priceCategoryId) : undefined,
+        sortType.sort,
+        sortType.orderByDesc,
         pageNum || 1,
         STOCKS_PER_PAGE
       ),
@@ -76,7 +98,7 @@ export function StocksCalendar({
         ? 'Une date a été supprimée'
         : `${ids.length} dates ont été supprimées`
     )
-    await mutate([GET_STOCKS_QUERY_KEY, offer.id, page])
+    await mutate(queryKeys)
   }
 
   const stocks = data?.stocks || []
@@ -96,7 +118,7 @@ export function StocksCalendar({
       <StocksCalendarForm
         offer={offer}
         onAfterValidate={async () => {
-          await mutate([GET_STOCKS_QUERY_KEY, offer.id, page], data, {
+          await mutate(queryKeys, data, {
             revalidate: true,
           })
 
@@ -114,10 +136,31 @@ export function StocksCalendar({
           getDialogBuilderButton('Ajouter une ou plusieurs dates')}
       </div>
 
-      {isLoading && <Spinner className={styles['spinner']} />}
+      {isLoading && !data?.hasStocks && (
+        <Spinner className={styles['spinner']} />
+      )}
 
       {data?.hasStocks && (
-        <>
+        <div className={styles['content']}>
+          <div className={styles['filters']}>
+            <StocksCalendarFilters
+              priceCategories={offer.priceCategories}
+              filters={appliedFilters}
+              sortType={appliedSort}
+              onUpdateFilters={setAppliedFilters}
+              onUpdateSort={(sort, desc) => {
+                setAppliedSort({
+                  sort: sort ? sort : undefined,
+                  orderByDesc: Boolean(desc),
+                })
+              }}
+            />
+          </div>
+          {data.stockCount > 0 && (
+            <div className={styles['count']}>
+              {pluralize(data.stockCount, 'date')}
+            </div>
+          )}
           <StocksCalendarTable
             stocks={stocks}
             offer={offer}
@@ -138,7 +181,7 @@ export function StocksCalendar({
               }
             />
           </div>
-        </>
+        </div>
       )}
 
       {!data?.hasStocks && !isLoading && (

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarFilters/StocksCalendarFilters.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarFilters/StocksCalendarFilters.module.scss
@@ -1,0 +1,27 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: rem.torem(16px);
+  align-items: center;
+}
+
+.time-picker {
+  width: rem.torem(110px);
+}
+
+.reset-button {
+  margin-top: calc(var(--typography-body-line-height) + rem.torem(8px));
+}
+
+.separator {
+  border-left: 1px solid var(--separator-color-default);
+  margin-top: calc(var(--typography-body-line-height) + rem.torem(8px));
+  height: rem.torem(40px);
+}
+
+.sort-select,
+.place-category-select {
+  max-width: rem.torem(189px);
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarFilters/StocksCalendarFilters.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarFilters/StocksCalendarFilters.spec.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { addDays } from 'date-fns'
+
+import { StocksCalendarFilters } from './StocksCalendarFilters'
+
+describe('StocksCalendarFilters', () => {
+  it('should update the sort type', async () => {
+    const updateSortMock = vi.fn()
+
+    render(
+      <StocksCalendarFilters
+        filters={{}}
+        onUpdateFilters={vi.fn()}
+        onUpdateSort={updateSortMock}
+        sortType={{}}
+      />
+    )
+
+    await userEvent.selectOptions(
+      screen.getByLabelText('Trier par'),
+      'Date décroissante'
+    )
+
+    expect(updateSortMock).toHaveBeenLastCalledWith('DATE', true)
+
+    await userEvent.selectOptions(
+      screen.getByLabelText('Trier par'),
+      'Aucun tri'
+    )
+
+    expect(updateSortMock).toHaveBeenLastCalledWith('', false)
+  })
+
+  it('should update filters values', async () => {
+    const updateFiltersMock = vi.fn()
+
+    render(
+      <StocksCalendarFilters
+        filters={{}}
+        onUpdateFilters={updateFiltersMock}
+        onUpdateSort={vi.fn()}
+        sortType={{}}
+        priceCategories={[{ id: 1, label: 'Tarif 1', price: 1 }]}
+      />
+    )
+
+    const typedDate = addDays(new Date(), 1).toISOString().split('T')[0]
+
+    await userEvent.type(screen.getByLabelText('Date'), typedDate)
+
+    expect(updateFiltersMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        date: typedDate,
+      })
+    )
+
+    await userEvent.type(screen.getByLabelText('Horaire'), '00:00')
+
+    expect(updateFiltersMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        time: '00:00',
+      })
+    )
+
+    await userEvent.selectOptions(screen.getByLabelText('Tarif'), '1')
+
+    expect(updateFiltersMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        priceCategoryId: '1',
+      })
+    )
+  })
+
+  it('should reset filters', async () => {
+    const updateFiltersMock = vi.fn()
+
+    render(
+      <StocksCalendarFilters
+        filters={{ time: '00:00' }}
+        onUpdateFilters={updateFiltersMock}
+        onUpdateSort={vi.fn()}
+        sortType={{}}
+      />
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Réinitialiser les filtres' })
+    )
+
+    expect(updateFiltersMock).toHaveBeenLastCalledWith({})
+  })
+})

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarFilters/StocksCalendarFilters.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarFilters/StocksCalendarFilters.tsx
@@ -1,0 +1,112 @@
+import { StocksOrderedBy } from 'apiClient/v1'
+import { PriceCategoryResponseModel } from 'apiClient/v1/models/PriceCategoryResponseModel'
+import { getPriceCategoryOptions } from 'components/IndividualOffer/StocksEventEdition/getPriceCategoryOptions'
+import fullRefreshIcon from 'icons/full-refresh.svg'
+import { Button } from 'ui-kit/Button/Button'
+import { ButtonVariant } from 'ui-kit/Button/types'
+import { DatePicker } from 'ui-kit/formV2/DatePicker/DatePicker'
+import { Select } from 'ui-kit/formV2/Select/Select'
+import { TimePicker } from 'ui-kit/formV2/TimePicker/TimePicker'
+
+import { StocksTableFilters, StocksTableSort } from '../../form/types'
+
+import styles from './StocksCalendarFilters.module.scss'
+
+const stockTableSortTypes: {
+  name: string
+  sort: StocksOrderedBy
+  orderByDesc: boolean
+}[] = [
+  { name: 'Date décroissante', sort: StocksOrderedBy.DATE, orderByDesc: true },
+  { name: 'Date croissante', sort: StocksOrderedBy.DATE, orderByDesc: false },
+  {
+    name: 'Place décroissante',
+    sort: StocksOrderedBy.DN_BOOKED_QUANTITY,
+    orderByDesc: true,
+  },
+  {
+    name: 'Place croissante',
+    sort: StocksOrderedBy.DN_BOOKED_QUANTITY,
+    orderByDesc: false,
+  },
+  {
+    name: 'Date limite de réservation décroissante',
+    sort: StocksOrderedBy.BOOKING_LIMIT_DATETIME,
+    orderByDesc: true,
+  },
+  {
+    name: 'Date limite de réservation croissante',
+    sort: StocksOrderedBy.BOOKING_LIMIT_DATETIME,
+    orderByDesc: false,
+  },
+]
+
+export const StocksCalendarFilters = ({
+  priceCategories,
+  filters,
+  sortType,
+  onUpdateFilters,
+  onUpdateSort,
+}: {
+  priceCategories?: Array<PriceCategoryResponseModel> | null
+  filters: StocksTableFilters
+  sortType: StocksTableSort
+  onUpdateFilters: (filters: StocksTableFilters) => void
+  onUpdateSort: (sort?: StocksTableSort['sort'], orderByDesc?: boolean) => void
+}) => {
+  const hasFiltersApplied = Object.values(filters).some(Boolean)
+  return (
+    <div className={styles['container']}>
+      <Select
+        label="Trier par"
+        name="sort"
+        options={stockTableSortTypes.map((type) => ({
+          label: type.name,
+          value: `${type.sort}${type.orderByDesc ? ' desc' : ''}`,
+        }))}
+        value={`${sortType.sort || ''}${sortType.orderByDesc ? ' desc' : ''}`}
+        onChange={(e) => {
+          const [sort, orderByDesc] = e.target.value.split(' ')
+          onUpdateSort(sort as StocksTableSort['sort'], orderByDesc === 'desc')
+        }}
+        defaultOption={{ label: 'Aucun tri', value: '' }}
+        className={styles['sort-select']}
+      />
+      <div className={styles['separator']}></div>
+      <DatePicker
+        label="Date"
+        name="date"
+        value={filters.date || ''}
+        onChange={(e) => onUpdateFilters({ ...filters, date: e.target.value })}
+      />
+      <TimePicker
+        label="Horaire"
+        name="time"
+        className={styles['time-picker']}
+        value={filters.time || ''}
+        onChange={(e) => onUpdateFilters({ ...filters, time: e.target.value })}
+      />
+      <Select
+        label="Tarif"
+        className={styles['place-category-select']}
+        name="price-category"
+        options={getPriceCategoryOptions(priceCategories)}
+        defaultOption={{ label: 'Tous les tarifs', value: '' }}
+        value={filters.priceCategoryId || ''}
+        onChange={(e) =>
+          onUpdateFilters({ ...filters, priceCategoryId: e.target.value })
+        }
+      />
+      {hasFiltersApplied && (
+        <Button
+          icon={fullRefreshIcon}
+          onClick={() => onUpdateFilters({})}
+          variant={ButtonVariant.TERNARY}
+          className={styles['reset-button']}
+        >
+          Réinitialiser les filtres
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.module.scss
@@ -2,6 +2,22 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_a11y.scss" as a11y;
 
+.no-data {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: rem.torem(8px);
+
+  &-icon {
+    width: rem.torem(88px);
+    color: var(--color-icon-subtle);
+  }
+}
+
+.bold {
+  @include fonts.body-accent;
+}
+
 .table {
   width: 100%;
   border-bottom: rem.torem(1px) solid var(--color-border-subtle);

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.spec.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+
+import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
+
+import { StocksCalendarTable } from './StocksCalendarTable'
+
+describe('StocksCalendarTable', () => {
+  it('should show a placeholder message when there is no stock displayed in the table', () => {
+    render(
+      <StocksCalendarTable
+        departmentCode="56"
+        checkedStocks={new Set()}
+        offer={getIndividualOfferFactory()}
+        onDeleteStocks={vi.fn()}
+        updateCheckedStocks={vi.fn()}
+        stocks={[]}
+      />
+    )
+
+    expect(screen.getByText('Aucune date trouvée')).toBeInTheDocument()
+  })
+})

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.tsx
@@ -5,8 +5,10 @@ import {
 import { formatLocalTimeDateString } from 'commons/utils/timezone'
 import { getPriceCategoryName } from 'components/IndividualOffer/StocksEventEdition/getPriceCategoryOptions'
 import fullTrashIcon from 'icons/full-trash.svg'
+import strokeSearchIcon from 'icons/stroke-search.svg'
 import { Checkbox } from 'ui-kit/formV2/Checkbox/Checkbox'
 import { ListIconButton } from 'ui-kit/ListIconButton/ListIconButton'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './StocksCalendarTable.module.scss'
 
@@ -33,6 +35,22 @@ export function StocksCalendarTable({
       newChecked.add(stockId)
     }
     updateCheckedStocks(newChecked)
+  }
+
+  if (stocks.length === 0) {
+    return (
+      <div className={styles['no-data']}>
+        <SvgIcon
+          src={strokeSearchIcon}
+          alt=""
+          className={styles['no-data-icon']}
+        />
+        <p className={styles['bold']}>Aucune date trouvée</p>
+        <p>
+          Vous pouvez modifier vos filtres pour lancer une nouvelle recherche
+        </p>
+      </div>
+    )
   }
 
   return (

--- a/pro/src/components/IndividualOffer/StocksEventCreation/form/types.ts
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/form/types.ts
@@ -1,3 +1,5 @@
+import { StocksOrderedBy } from 'apiClient/v1'
+
 export enum RecurrenceType {
   UNIQUE = 'UNIQUE',
   DAILY = 'DAILY',
@@ -67,4 +69,15 @@ export type StocksCalendarFormValues = {
     priceCategory: string
   }[]
   bookingLimitDateInterval?: number
+}
+
+export type StocksTableFilters = {
+  date?: string
+  time?: string
+  priceCategoryId?: string
+}
+
+export type StocksTableSort = {
+  sort?: StocksOrderedBy
+  orderByDesc?: boolean
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35481

**Objectif**
Ajouter le nouveau tri et les nouveaux filtres à la table des stocks en création d'événement.

**FF à activer**
WIP_ENABLE_EVENT_WITH_OPENING_HOUR

**Screens**
<img width="883" alt="Capture d’écran 2025-04-08 à 10 59 08" src="https://github.com/user-attachments/assets/145b9d58-661a-484b-af9b-b3643a97ff9e" />
<img width="882" alt="Capture d’écran 2025-04-08 à 10 59 20" src="https://github.com/user-attachments/assets/5c2dd059-8d92-4bc0-ad55-c93505bcbcc3" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
