### PR TITLE
(BSR)[API] feat: add diff display when running set_algolia_settings i…

### DIFF
--- a/api/src/pcapi/core/search/commands/settings.py
+++ b/api/src/pcapi/core/search/commands/settings.py
@@ -73,18 +73,19 @@ def _set_settings(index: SearchIndex, path: str, dry: bool = True) -> list[str]:
     outputs = []
 
     if dry:
-        outputs.append(f"settings wil be read from {path}")
+        outputs.append(f"settings will be read from {path}")
         outputs.append(f"settings will be applied to {index.name} Algolia index")
 
-    else:
-        old_settings = index.get_settings()
-        with open(path, "r", encoding="utf-8") as fp:
-            new_settings = json.load(fp)
+    old_settings = index.get_settings()
+    with open(path, "r", encoding="utf-8") as fp:
+        new_settings = json.load(fp)
 
-        diff = _get_dict_diff(old_settings, new_settings)
-        outputs.append(diff)
+    diff = _get_dict_diff(old_settings, new_settings)
+    outputs.append(diff)
 
+    if not dry:
         index.set_settings(new_settings)
+
     return outputs
 
 


### PR DESCRIPTION
…n dry run

## But de la pull request

Ticket Jira (ou description si BSR) : actuellement on affiche la différence entre la config Algolia et le fichier uniquement en dry-run = False, ce serait utile de l'avoir également en dry-run

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
