### PR TITLE
(BSR)[API] fix: remove nonexistent field in collective offers algolia…

### DIFF
--- a/api/src/pcapi/algolia_settings_collective_offers.json
+++ b/api/src/pcapi/algolia_settings_collective_offers.json
@@ -54,8 +54,7 @@
     "unordered(venue.name)",
     "unordered(venue.publicName)",
     "unordered(offerer.name)",
-    "unordered(offer.description)",
-    "unordered(distinct)"
+    "unordered(offer.description)"
   ],
   "numericAttributesForFiltering": null
 }


### PR DESCRIPTION
… config

## But de la pull request

Ticket Jira (ou description si BSR) : le champ "distinct" n'existe pas dans l'index collective-offers

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
