### PR TITLE
(PC-35515)[PRO] fix: Set specific color for locked button ternary.

### DIFF
--- a/pro/src/components/HeadlineOfferBanner/components/HeadlineOfferInformationDialog.module.scss
+++ b/pro/src/components/HeadlineOfferBanner/components/HeadlineOfferInformationDialog.module.scss
@@ -54,3 +54,7 @@
   vertical-align: middle;
   display: inline-block;
 }
+
+.button-icon {
+  color: var(--color-white);
+}

--- a/pro/src/components/HeadlineOfferBanner/components/HeadlineOfferInformationDialog.tsx
+++ b/pro/src/components/HeadlineOfferBanner/components/HeadlineOfferInformationDialog.tsx
@@ -28,6 +28,7 @@ export const HeadlineOfferInformationDialog = ({
       trigger={
         <Button
           className={triggerClassName}
+          iconClassName={styles['button-icon']}
           variant={ButtonVariant.TERNARY}
           icon={fullNextIcon}
           onClick={() => {

--- a/pro/src/ui-kit/Button/Button.module.scss
+++ b/pro/src/ui-kit/Button/Button.module.scss
@@ -129,7 +129,7 @@
     border: none;
     height: auto;
 
-    .button-icon {
+    &-icon {
       color: var(--color-icon-default);
     }
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35515

**Objectif**
Corriger l'affichage de la couleur du bouton ternary pour la bannière de l'offre à la une que j'ai cassé en appliquant les couleurs DS.

**Avant/après :**
![Capture d’écran 2025-04-04 à 15 31 03](https://github.com/user-attachments/assets/28fd6e04-9890-4084-bde6-bd7cb3969665)
<img width="843" alt="Capture d’écran 2025-04-04 à 16 00 33" src="https://github.com/user-attachments/assets/76fadc04-d2f4-402c-b54a-a077ca05d339" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
