### PR TITLE
(BSR)[API] refactor: move national program validation in educational

### DIFF
--- a/api/src/pcapi/core/educational/exceptions.py
+++ b/api/src/pcapi/core/educational/exceptions.py
@@ -107,14 +107,6 @@ class CollectiveStockNotFound(Exception):
     pass
 
 
-class EducationalDomainsNotFound(Exception):
-    pass
-
-
-class EducationalDomainNotFound(Exception):
-    pass
-
-
 class EducationalInstitutionNotFound(Exception):
     pass
 
@@ -211,10 +203,6 @@ class CantGetImageFromUrl(Exception):
     pass
 
 
-class NationalProgramNotFound(Exception):
-    pass
-
-
 class NoAdageInstitution(Exception):
     pass
 
@@ -249,4 +237,29 @@ class EndEducationalYearMissing(Exception):
 
 
 class EndDatetimeBeforeStartDatetime(Exception):
+    pass
+
+
+# DOMAINS / NATIONAL PROGRAMS
+class EducationalDomainsNotFound(Exception):
+    pass
+
+
+class EducationalDomainNotFound(Exception):
+    pass
+
+
+class MissingDomains(Exception):
+    pass
+
+
+class NationalProgramNotFound(Exception):
+    pass
+
+
+class IllegalNationalProgram(Exception):
+    pass
+
+
+class InactiveNationalProgram(Exception):
     pass

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -3,7 +3,6 @@ import decimal
 from io import BytesIO
 import logging
 import re
-import typing
 import warnings
 
 from PIL import Image
@@ -18,7 +17,6 @@ from pcapi.core.categories.genres import music
 from pcapi.core.categories.genres import show
 from pcapi.core.categories.subcategories import ExtraDataFieldEnum
 from pcapi.core.educational import models as educational_models
-import pcapi.core.educational.api.national_program as np_api
 from pcapi.core.finance import repository as finance_repository
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.schemas import VenueTypeCode
@@ -852,50 +850,6 @@ def check_for_duplicated_price_categories(
 class OfferValidationError(Exception):
     field = "all"
     msg = "Invalid"
-
-
-class UnknownNationalProgram(OfferValidationError):
-    field = "national_program"
-    msg = "National program unknown"
-
-
-class InactiveNationalProgram(OfferValidationError):
-    field = "national_program"
-    msg = "National program inactive"
-
-
-class IllegalNationalProgram(OfferValidationError):
-    field = "national_program"
-    msg = "National program known, but can't be used in this context"
-
-
-class MissingDomains(OfferValidationError):
-    field = "domains"
-    msg = "Domains can't be null if national program is set"
-
-
-def validate_national_program(
-    national_program_id: int | None,
-    domains: typing.Sequence[educational_models.EducationalDomain] | None,
-    check_program_is_active: bool = True,
-) -> None:
-    if not national_program_id:
-        return
-
-    if not domains:
-        raise MissingDomains()
-
-    national_program = np_api.get_national_program(national_program_id)
-
-    if not national_program:
-        raise UnknownNationalProgram()
-
-    if check_program_is_active and not national_program.isActive:
-        raise InactiveNationalProgram()
-
-    valid_national_program_ids = {np.id for domain in domains for np in domain.nationalPrograms}
-    if national_program_id not in valid_national_program_ids:
-        raise IllegalNationalProgram()
 
 
 def check_offerer_is_eligible_for_headline_offers(offerer_id: int) -> None:

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -232,19 +232,19 @@ def create_collective_offer(
             {"code": "COLLECTIVE_OFFER_TEMPLATE_NOT_FOUND"},
             status_code=404,
         )
-    except (educational_exceptions.NationalProgramNotFound, offers_validation.UnknownNationalProgram):
+    except educational_exceptions.NationalProgramNotFound:
         logger.info(
             "Could not create offer: national program not found",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
         )
         raise ApiErrors({"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_NOT_FOUND"}, status_code=400)
-    except offers_validation.IllegalNationalProgram:
+    except educational_exceptions.IllegalNationalProgram:
         logger.info(
             "Could not create offer: invalid national program",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
         )
         raise ApiErrors({"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_INVALID"}, status_code=400)
-    except offers_validation.InactiveNationalProgram:
+    except educational_exceptions.InactiveNationalProgram:
         logger.info(
             "Could not create offer: inactive national program",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
@@ -296,15 +296,15 @@ def edit_collective_offer(
         raise ApiErrors({"venueId": "The venue does not exist."}, 404)
     except educational_exceptions.CollectiveOfferIsPublicApi:
         raise ApiErrors({"global": ["Collective offer created by public API is only editable via API."]}, 403)
-    except (educational_exceptions.NationalProgramNotFound, offers_validation.UnknownNationalProgram):
+    except educational_exceptions.NationalProgramNotFound:
         raise ApiErrors({"global": ["National program not found"]}, 400)
-    except offers_validation.IllegalNationalProgram:
+    except educational_exceptions.IllegalNationalProgram:
         logger.info(
             "Could not update offer: invalid national program",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
         )
         raise ApiErrors({"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_INVALID"}, status_code=400)
-    except offers_validation.InactiveNationalProgram:
+    except educational_exceptions.InactiveNationalProgram:
         logger.info(
             "Could not create offer: inactive national program",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
@@ -384,15 +384,15 @@ def edit_collective_offer_template(
         raise ApiErrors({"venueId": "New venue needs to have the same offerer"}, 403)
     except offers_exceptions.SubcategoryNotEligibleForEducationalOffer:
         raise ApiErrors({"subcategoryId": "this subcategory is not educational"}, 400)
-    except (educational_exceptions.NationalProgramNotFound, offers_validation.UnknownNationalProgram):
+    except educational_exceptions.NationalProgramNotFound:
         raise ApiErrors({"global": ["National program not found"]}, 400)
-    except offers_validation.IllegalNationalProgram:
+    except educational_exceptions.IllegalNationalProgram:
         logger.info(
             "Could not update offer: invalid national program",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
         )
         raise ApiErrors({"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_INVALID"}, status_code=400)
-    except offers_validation.InactiveNationalProgram:
+    except educational_exceptions.InactiveNationalProgram:
         logger.info(
             "Could not create offer: inactive national program",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
@@ -655,19 +655,19 @@ def create_collective_offer_template(
             extra={"offer_name": body.name, "venue_id": body.venue_id, "template_id": body.template_id},
         )
         raise ApiErrors({"code": "COLLECTIVE_OFFER_TEMPLATE_NOT_FOUND"}, status_code=404)
-    except (educational_exceptions.NationalProgramNotFound, offers_validation.UnknownNationalProgram):
+    except educational_exceptions.NationalProgramNotFound:
         logger.info(
             "Could not create offer: national program not found",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
         )
         raise ApiErrors({"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_NOT_FOUND"}, status_code=400)
-    except offers_validation.IllegalNationalProgram:
+    except educational_exceptions.IllegalNationalProgram:
         logger.info(
             "Could not create offer: invalid national program",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},
         )
         raise ApiErrors({"code": "COLLECTIVE_OFFER_NATIONAL_PROGRAM_INVALID"}, status_code=400)
-    except offers_validation.InactiveNationalProgram:
+    except educational_exceptions.InactiveNationalProgram:
         logger.info(
             "Could not create offer: inactive national program",
             extra={"offer_name": body.name, "nationalProgramId": body.nationalProgramId},

--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -213,11 +213,17 @@ def post_collective_offer_public(
             errors={"educationalInstitutionId": ["L'établissement scolaire n'est pas actif."]},
             status_code=403,
         )
+
+    # domains / national_program errors
     except educational_exceptions.EducationalDomainsNotFound:
-        raise ApiErrors(
-            errors={"domains": ["Domaine scolaire non trouvé."]},
-            status_code=404,
-        )
+        raise ApiErrors(errors={"domains": ["Domaine scolaire non trouvé."]}, status_code=404)
+    except educational_exceptions.NationalProgramNotFound:
+        raise ApiErrors(errors={"nationalProgramId": ["Dispositif national non trouvé."]}, status_code=404)
+    except educational_exceptions.IllegalNationalProgram:
+        raise ApiErrors(errors={"nationalProgramId": ["Dispositif national non valide."]}, status_code=400)
+    except educational_exceptions.InactiveNationalProgram:
+        raise ApiErrors(errors={"nationalProgramId": ["Dispositif national inactif."]}, status_code=400)
+
     except offers_exceptions.UnknownOfferSubCategory:
         raise ApiErrors(
             errors={"subcategoryId": ["Sous-catégorie non trouvée."]},
@@ -489,13 +495,17 @@ def patch_collective_offer_public(
             },
             status_code=404,
         )
+
+    # domains / national_program errors
     except educational_exceptions.EducationalDomainsNotFound:
-        raise ApiErrors(
-            errors={
-                "domains": ["Domaine scolaire non trouvé."],
-            },
-            status_code=404,
-        )
+        raise ApiErrors(errors={"domains": ["Domaine scolaire non trouvé."]}, status_code=404)
+    except educational_exceptions.NationalProgramNotFound:
+        raise ApiErrors(errors={"nationalProgramId": ["Dispositif national non trouvé."]}, status_code=404)
+    except educational_exceptions.IllegalNationalProgram:
+        raise ApiErrors(errors={"nationalProgramId": ["Dispositif national non valide."]}, status_code=400)
+    except educational_exceptions.InactiveNationalProgram:
+        raise ApiErrors(errors={"nationalProgramId": ["Dispositif national inactif."]}, status_code=400)
+
     except (
         educational_exceptions.CollectiveOfferNotEditable,
         educational_exceptions.CollectiveOfferStockBookedAndBookingNotPending,

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -371,7 +371,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
         educational_validation.check_collective_offer_description_length_is_valid(description)
         return description
 
-    @validator("domains", pre=True)
+    @validator("domains")
     def validate_domains(cls, domains: list[str]) -> list[str]:
         if len(domains) == 0:
             raise ValueError("domains must have at least one value")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : déplacement de validation et exceptions sur national_program dans core/educational

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
