### PR TITLE
(PC-35371)[PRO] feat: Restrict <AddressSelect> results to streets with a number by default

### DIFF
--- a/pro/src/apiClient/adresse/apiAdresse.spec.ts
+++ b/pro/src/apiClient/adresse/apiAdresse.spec.ts
@@ -1,0 +1,212 @@
+import '@testing-library/jest-dom'
+import { vi, type Mock } from 'vitest'
+import { apiAdresse } from './apiAdresse'
+import { AdresseApiJson, FeaturePropertyType } from './types'
+
+const mockApiResponse: Partial<AdresseApiJson> = {
+  type: 'FeatureCollection',
+  version: 'draft',
+  features: [
+    {
+      geometry: {
+        coordinates: [2.4, 48.9],
+      },
+      properties: {
+        name: '15 Rue des Tests',
+        city: 'Paris',
+        id: '123',
+        label: '15 Rue des Tests 75001 Paris',
+        postcode: '75001',
+        type: 'housenumber' as FeaturePropertyType,
+        citycode: '75056',
+        context: 'Paris, Île-de-France',
+        district: '1er Arrondissement',
+        housenumber: '15',
+        importance: 0.6,
+        score: 0.98,
+        street: 'Rue des Tests',
+        x: 2.4,
+        y: 48.9,
+      },
+    },
+  ],
+}
+
+const mockEmptyApiResponse: Partial<AdresseApiJson> = {
+  type: 'FeatureCollection',
+  version: 'draft',
+  features: [],
+}
+
+const mockCityApiResponse: Partial<AdresseApiJson> = {
+  type: 'FeatureCollection',
+  version: 'draft',
+  features: [
+    {
+      geometry: {
+        coordinates: [2.4, 48.9],
+      },
+      properties: {
+        name: 'Paris',
+        city: 'Paris',
+        id: '75056',
+        label: 'Paris',
+        postcode: '75001',
+        type: 'municipality' as FeaturePropertyType,
+        citycode: '75056',
+        context: 'Île-de-France',
+        district: '',
+        housenumber: '',
+        importance: 1,
+        score: 1,
+        street: '',
+        x: 2.4,
+        y: 48.9,
+      },
+    },
+  ],
+}
+
+describe('apiAdresse', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('getDataFromAddressParts', () => {
+    it('should return formatted address data when address is found', async () => {
+      ;(global.fetch as Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockApiResponse),
+      })
+
+      const result = await apiAdresse.getDataFromAddressParts(
+        '15 Rue des Tests',
+        'Paris',
+        '75001'
+      )
+
+      expect(result).toEqual([
+        {
+          address: '15 Rue des Tests',
+          city: 'Paris',
+          id: '123',
+          latitude: 48.9,
+          longitude: 2.4,
+          label: '15 Rue des Tests 75001 Paris',
+          postalCode: '75001',
+        },
+      ])
+    })
+
+    it('should fallback to city search when no address is found', async () => {
+      ;(global.fetch as Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockEmptyApiResponse),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve(mockCityApiResponse),
+        })
+
+      const result = await apiAdresse.getDataFromAddressParts(
+        '15 Rue Inexistante',
+        'Paris',
+        '75001'
+      )
+
+      expect(result).toEqual([
+        {
+          address: 'Paris',
+          city: 'Paris',
+          id: '75056',
+          latitude: 48.9,
+          longitude: 2.4,
+          label: 'Paris',
+          postalCode: '75001',
+        },
+      ])
+    })
+
+    it('should throw an error when API request fails', async () => {
+      ;(global.fetch as Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        url: 'test-url',
+      })
+
+      await expect(
+        apiAdresse.getDataFromAddressParts('15 Rue des Tests', 'Paris', '75001')
+      ).rejects.toThrow('Échec de la requête test-url, code: 500')
+    })
+  })
+
+  describe('getDataFromAddress', () => {
+    it('should return formatted address data with default options', async () => {
+      ;(global.fetch as Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockApiResponse),
+      })
+
+      const result = await apiAdresse.getDataFromAddress('15 Rue des Tests')
+
+      expect(result).toEqual([
+        {
+          address: '15 Rue des Tests',
+          city: 'Paris',
+          id: '123',
+          latitude: 48.9,
+          longitude: 2.4,
+          label: '15 Rue des Tests 75001 Paris',
+          postalCode: '75001',
+        },
+      ])
+    })
+
+    it('should filter results by type when onlyTypes is specified', async () => {
+      const mixedResponse: Partial<AdresseApiJson> = {
+        type: 'FeatureCollection',
+        version: 'draft',
+        features: [
+          {
+            ...mockApiResponse.features![0],
+            properties: {
+              ...mockApiResponse.features![0].properties,
+              type: 'street' as FeaturePropertyType,
+            },
+          },
+          mockApiResponse.features![0],
+        ],
+      }
+
+      ;(global.fetch as Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mixedResponse),
+      })
+
+      const result = await apiAdresse.getDataFromAddress('15 Rue des Tests', {
+        onlyTypes: ['housenumber'],
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].address).toBe('15 Rue des Tests')
+    })
+
+    it('should respect custom limit parameter', async () => {
+      ;(global.fetch as Mock).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(mockApiResponse),
+      })
+
+      await apiAdresse.getDataFromAddress('15 Rue des Tests', { limit: 10 })
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('limit=10')
+      )
+    })
+  })
+})

--- a/pro/src/apiClient/adresse/apiAdresse.spec.ts
+++ b/pro/src/apiClient/adresse/apiAdresse.spec.ts
@@ -1,6 +1,5 @@
-import '@testing-library/jest-dom'
 import { vi, type Mock } from 'vitest'
-import { apiAdresse } from './apiAdresse'
+import { getDataFromAddress, getDataFromAddressParts } from './apiAdresse'
 import { AdresseApiJson, FeaturePropertyType } from './types'
 
 const mockApiResponse: Partial<AdresseApiJson> = {
@@ -83,7 +82,7 @@ describe('apiAdresse', () => {
         json: () => Promise.resolve(mockApiResponse),
       })
 
-      const result = await apiAdresse.getDataFromAddressParts(
+      const result = await getDataFromAddressParts(
         '15 Rue des Tests',
         'Paris',
         '75001'
@@ -113,7 +112,7 @@ describe('apiAdresse', () => {
           json: () => Promise.resolve(mockCityApiResponse),
         })
 
-      const result = await apiAdresse.getDataFromAddressParts(
+      const result = await getDataFromAddressParts(
         '15 Rue Inexistante',
         'Paris',
         '75001'
@@ -140,7 +139,7 @@ describe('apiAdresse', () => {
       })
 
       await expect(
-        apiAdresse.getDataFromAddressParts('15 Rue des Tests', 'Paris', '75001')
+        getDataFromAddressParts('15 Rue des Tests', 'Paris', '75001')
       ).rejects.toThrow('Échec de la requête test-url, code: 500')
     })
   })
@@ -152,7 +151,7 @@ describe('apiAdresse', () => {
         json: () => Promise.resolve(mockApiResponse),
       })
 
-      const result = await apiAdresse.getDataFromAddress('15 Rue des Tests')
+      const result = await getDataFromAddress('15 Rue des Tests')
 
       expect(result).toEqual([
         {
@@ -188,7 +187,7 @@ describe('apiAdresse', () => {
         json: () => Promise.resolve(mixedResponse),
       })
 
-      const result = await apiAdresse.getDataFromAddress('15 Rue des Tests', {
+      const result = await getDataFromAddress('15 Rue des Tests', {
         onlyTypes: ['housenumber'],
       })
 
@@ -202,7 +201,7 @@ describe('apiAdresse', () => {
         json: () => Promise.resolve(mockApiResponse),
       })
 
-      await apiAdresse.getDataFromAddress('15 Rue des Tests', { limit: 10 })
+      await getDataFromAddress('15 Rue des Tests', { limit: 10 })
 
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining('limit=10')

--- a/pro/src/apiClient/adresse/apiAdresse.ts
+++ b/pro/src/apiClient/adresse/apiAdresse.ts
@@ -40,44 +40,43 @@ const DEFAULTS_OPTIONS: AddressDataOptions = {
   onlyTypes: ['housenumber'], // Defaults will always list addresses with a number (e.g. "17 Rue de Paris …")
 }
 
-export const apiAdresse = {
-  getDataFromAddressParts: async (
-    street: string,
-    city: string,
-    postalCode: string,
-    limit = 5
-  ): Promise<Array<AdresseData>> => {
-    const url = `${API_ADRESSE_BASE_URL}/search/?limit=${limit}&q=${street} ${city} ${postalCode}`
+export const getDataFromAddressParts = async (
+  street: string,
+  city: string,
+  postalCode: string,
+  limit = 5
+): Promise<Array<AdresseData>> => {
+  const url = `${API_ADRESSE_BASE_URL}/search/?limit=${limit}&q=${street} ${city} ${postalCode}`
+  const response = await handleApiError(await fetch(url), 'GET', url)
+
+  if (response.features.length > 0) {
+    return formatAdressApiResponse(response)
+  } else {
+    const url = `${API_ADRESSE_BASE_URL}/search/?q=${city}&postcode=${postalCode}&type=municipality&autocomplete=0&limit=1`
     const response = await handleApiError(await fetch(url), 'GET', url)
+    return formatAdressApiResponse(response)
+  }
+}
 
-    if (response.features.length > 0) {
-      return formatAdressApiResponse(response)
-    } else {
-      const url = `${API_ADRESSE_BASE_URL}/search/?q=${city}&postcode=${postalCode}&type=municipality&autocomplete=0&limit=1`
-      const response = await handleApiError(await fetch(url), 'GET', url)
-      return formatAdressApiResponse(response)
-    }
-  },
-  getDataFromAddress: async (
-    address: string,
-    {
-      limit = DEFAULTS_OPTIONS.limit,
-      onlyTypes = DEFAULTS_OPTIONS.onlyTypes,
-    }: AddressDataOptions = DEFAULTS_OPTIONS
-  ): Promise<Array<AdresseData>> => {
-    const url = `${API_ADRESSE_BASE_URL}/search/?limit=${limit}&q=${address}`
-    const response = await handleApiError(await fetch(url), 'GET', url)
+export const getDataFromAddress = async (
+  address: string,
+  {
+    limit = DEFAULTS_OPTIONS.limit,
+    onlyTypes = DEFAULTS_OPTIONS.onlyTypes,
+  }: AddressDataOptions = DEFAULTS_OPTIONS
+): Promise<Array<AdresseData>> => {
+  const url = `${API_ADRESSE_BASE_URL}/search/?limit=${limit}&q=${address}`
+  const response = await handleApiError(await fetch(url), 'GET', url)
 
-    if (!onlyTypes) return formatAdressApiResponse(response)
+  if (!onlyTypes) return formatAdressApiResponse(response)
 
-    // Restrict results by API "types" if specifically asked
-    const filteredResponse = {
-      ...response,
-      features: response.features.filter((r) =>
-        onlyTypes.includes(r.properties.type)
-      ),
-    }
+  // Restrict results by API "types" if specifically asked
+  const filteredResponse = {
+    ...response,
+    features: response.features.filter((r) =>
+      onlyTypes.includes(r.properties.type)
+    ),
+  }
 
-    return formatAdressApiResponse(filteredResponse)
-  },
+  return formatAdressApiResponse(filteredResponse)
 }

--- a/pro/src/apiClient/adresse/types.ts
+++ b/pro/src/apiClient/adresse/types.ts
@@ -1,3 +1,11 @@
+// @docs : https://adresse.data.gouv.fr/outils/api-doc/adresse
+
+export type FeaturePropertyType =
+  | 'housenumber' // numéro « à la plaque »
+  | 'street' // position « à la voie », placé approximativement au centre de celle-ci
+  | 'locality' // lieu-dit
+  | 'municipality' // numéro « à la commune »'
+
 export interface FeatureAdresseApi {
   geometry: {
     coordinates: [number, number]
@@ -8,6 +16,16 @@ export interface FeatureAdresseApi {
     id: string
     label: string
     postcode: string
+    citycode: string
+    context: string
+    district: string
+    housenumber: string
+    importance: Number
+    score: Number
+    street: string
+    type: FeaturePropertyType
+    x: Number
+    y: Number
   }
 }
 

--- a/pro/src/apiClient/api.ts
+++ b/pro/src/apiClient/api.ts
@@ -25,4 +25,7 @@ const configAdage: OpenAPIConfig = {
 export const api = new AppClient(config).default
 export const apiContremarque = new AppClientV2(config).dPrCiEApiContremarque
 export const apiAdage = new AppClientAdage(configAdage).default
-export { apiAdresse } from 'apiClient/adresse/apiAdresse'
+export {
+  getDataFromAddress,
+  getDataFromAddressParts,
+} from 'apiClient/adresse/apiAdresse'

--- a/pro/src/commons/core/Venue/getSiretData.tsx
+++ b/pro/src/commons/core/Venue/getSiretData.tsx
@@ -1,4 +1,5 @@
-import { api, apiAdresse } from 'apiClient/api'
+import { getDataFromAddressParts } from 'apiClient/adresse/apiAdresse'
+import { api } from 'apiClient/api'
 import { isErrorAPIError } from 'apiClient/helpers'
 import { unhumanizeSiret } from 'commons/core/Venue/utils'
 import { validateSiret } from 'commons/core/Venue/validate'
@@ -49,7 +50,7 @@ const getSiretDataRequest = async (
       throw Error('SIRET invalide')
     }
     const { street, city, postalCode } = response.address
-    const addressData = await apiAdresse.getDataFromAddressParts(
+    const addressData = await getDataFromAddressParts(
       street,
       city,
       postalCode,

--- a/pro/src/components/Address/Address.spec.tsx
+++ b/pro/src/components/Address/Address.spec.tsx
@@ -3,7 +3,7 @@ import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import * as yup from 'yup'
 
-import { apiAdresse } from 'apiClient/adresse/apiAdresse'
+import * as apiAdresse from 'apiClient/adresse/apiAdresse'
 import { VenueSettingsFormValues } from 'pages/VenueSettings/types'
 import { Button } from 'ui-kit/Button/Button'
 

--- a/pro/src/components/Address/Address.tsx
+++ b/pro/src/components/Address/Address.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { apiAdresse } from 'apiClient/adresse/apiAdresse'
-import { AdresseData } from 'apiClient/adresse/types'
+import { AdresseData, FeaturePropertyType } from 'apiClient/adresse/types'
 import { SelectOption } from 'commons/custom_types/form'
 import { normalizeStrForAdressSearch } from 'commons/utils/searchPatternInOptions'
 import { serializeAdressData } from 'components/Address/serializer'
@@ -14,6 +14,7 @@ import { DEBOUNCE_TIME_BEFORE_REQUEST } from './constants'
 interface AddressProps {
   description?: string
   suggestionLimit?: number
+  onlyTypes?: FeaturePropertyType[]
   disabled?: boolean
   className?: string
 }
@@ -28,6 +29,7 @@ export interface AutocompleteItemProps {
 export const AddressSelect = ({
   description,
   suggestionLimit,
+  onlyTypes,
   disabled = false,
   className,
 }: AddressProps) => {
@@ -88,11 +90,11 @@ export const AddressSelect = ({
   const getSuggestions = async (search: string) => {
     if (search) {
       try {
-        const adressSuggestions = await apiAdresse.getDataFromAddress(
-          search,
-          suggestionLimit
-        )
-        return serializeAdressData(adressSuggestions)
+        const addressSuggestions = await apiAdresse.getDataFromAddress(search, {
+          limit: suggestionLimit,
+          onlyTypes,
+        })
+        return serializeAdressData(addressSuggestions)
       } catch {
         return []
       }

--- a/pro/src/components/Address/Address.tsx
+++ b/pro/src/components/Address/Address.tsx
@@ -2,7 +2,7 @@ import { FieldInputProps, useField, useFormikContext } from 'formik'
 import { useEffect, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
-import { apiAdresse } from 'apiClient/adresse/apiAdresse'
+import { getDataFromAddress } from 'apiClient/adresse/apiAdresse'
 import { AdresseData, FeaturePropertyType } from 'apiClient/adresse/types'
 import { SelectOption } from 'commons/custom_types/form'
 import { normalizeStrForAdressSearch } from 'commons/utils/searchPatternInOptions'
@@ -90,7 +90,7 @@ export const AddressSelect = ({
   const getSuggestions = async (search: string) => {
     if (search) {
       try {
-        const addressSuggestions = await apiAdresse.getDataFromAddress(search, {
+        const addressSuggestions = await getDataFromAddress(search, {
           limit: suggestionLimit,
           onlyTypes,
         })

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
@@ -59,7 +59,6 @@ export const OffererAuthenticationForm = (): JSX.Element => {
         />
         <AddressSelect
           description="À modifier si l’adresse postale de votre structure est différente de la raison sociale."
-          suggestionLimit={5}
           disabled={manuallySetAddress.value}
         />
         <Button

--- a/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationForm.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationForm.spec.tsx
@@ -3,7 +3,7 @@ import { userEvent } from '@testing-library/user-event'
 import { Form, Formik } from 'formik'
 import createFetchMock from 'vitest-fetch-mock'
 
-import { apiAdresse } from 'apiClient/adresse/apiAdresse'
+import * as apiAdresse from 'apiClient/adresse/apiAdresse'
 import {
   Offerer,
   SignupJourneyContext,

--- a/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
@@ -3,7 +3,7 @@ import { userEvent } from '@testing-library/user-event'
 import { Route, Routes } from 'react-router-dom'
 import createFetchMock from 'vitest-fetch-mock'
 
-import { apiAdresse } from 'apiClient/adresse/apiAdresse'
+import * as apiAdresse from 'apiClient/adresse/apiAdresse'
 import {
   SignupJourneyContext,
   SignupJourneyContextValues,
@@ -48,7 +48,7 @@ vi.spyOn(apiAdresse, 'getDataFromAddress').mockResolvedValue([
   },
 ])
 
-// Mock https://api-adresse.data.gouv.fr/search/?limit=${limit}&q=${address} called by apiAdresse.getDataFromAddress
+// Mock https://api-adresse.data.gouv.fr/search/?limit=${limit}&q=${address} called by getDataFromAddress
 fetchMock.mockResponse(
   JSON.stringify({
     features: [

--- a/pro/src/components/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -26,22 +26,20 @@ fetchMock.enableMocks()
 vi.spyOn(siretApiValidate, 'siretApiValidate').mockResolvedValue(null)
 
 // Mock l’appel à https://api-adresse.data.gouv.fr/search/?limit=${limit}&q=${address}
-// Appel fait dans apiAdresse.getDataFromAddress
+// Appel fait dans getDataFromAddress
 vi.mock('apiClient/adresse/apiAdresse', () => ({
-  apiAdresse: {
-    getDataFromAddressParts: () =>
-      Promise.resolve([
-        {
-          address: 'name',
-          city: 'city',
-          id: 'id',
-          latitude: 0,
-          longitude: 0,
-          label: 'label',
-          postalCode: 'postcode',
-        },
-      ]),
-  },
+  getDataFromAddressParts: () =>
+    Promise.resolve([
+      {
+        address: 'name',
+        city: 'city',
+        id: 'id',
+        latitude: 0,
+        longitude: 0,
+        label: 'label',
+        postalCode: 'postcode',
+      },
+    ]),
 }))
 
 const renderOffererScreen = (contextValue: SignupJourneyContextValues) => {

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionFormScreen.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionFormScreen.spec.tsx
@@ -4,7 +4,7 @@ import { Route, Routes } from 'react-router-dom'
 import { expect } from 'vitest'
 import createFetchMock from 'vitest-fetch-mock'
 
-import { apiAdresse } from 'apiClient/adresse/apiAdresse'
+import * as apiAdresse from 'apiClient/adresse/apiAdresse'
 import { api } from 'apiClient/api'
 import { ApiError, GetVenueResponseModel } from 'apiClient/v1'
 import { ApiRequestOptions } from 'apiClient/v1/core/ApiRequestOptions'
@@ -103,7 +103,7 @@ vi.spyOn(apiAdresse, 'getDataFromAddress').mockResolvedValue([
 ])
 
 // Mock l’appel à https://api-adresse.data.gouv.fr/search/?limit=${limit}&q=${address}
-// Appel fait dans apiAdresse.getDataFromAddress
+// Appel fait dans getDataFromAddress
 fetchMock.mockResponse(
   JSON.stringify({
     features: [

--- a/pro/src/pages/VenueSettings/SiretOrCommentFields/SiretOrCommentFields.tsx
+++ b/pro/src/pages/VenueSettings/SiretOrCommentFields/SiretOrCommentFields.tsx
@@ -76,13 +76,13 @@ export const SiretOrCommentFields = ({
       )
       await setFieldValue('name', response.values?.name)
       // getSuggestions pour récupérer les adresses
-      const adressSuggestions = await apiAdresse.getDataFromAddress(address)
+      const addressSuggestions = await apiAdresse.getDataFromAddress(address)
       await setFieldValue('search-addressAutocomplete', address)
       await setFieldValue('addressAutocomplete', address)
 
       handleAddressSelect(
         setFieldValue,
-        serializeAdressData(adressSuggestions)[0]
+        serializeAdressData(addressSuggestions)[0]
       )
     } catch {
       return

--- a/pro/src/pages/VenueSettings/SiretOrCommentFields/SiretOrCommentFields.tsx
+++ b/pro/src/pages/VenueSettings/SiretOrCommentFields/SiretOrCommentFields.tsx
@@ -1,7 +1,7 @@
 import { useFormikContext } from 'formik'
 import { useState } from 'react'
 
-import { apiAdresse } from 'apiClient/adresse/apiAdresse'
+import { getDataFromAddress } from 'apiClient/adresse/apiAdresse'
 import { getSiretData } from 'commons/core/Venue/getSiretData'
 import { humanizeSiret, unhumanizeSiret } from 'commons/core/Venue/utils'
 import { handleAddressSelect } from 'components/Address/Address'
@@ -76,7 +76,7 @@ export const SiretOrCommentFields = ({
       )
       await setFieldValue('name', response.values?.name)
       // getSuggestions pour récupérer les adresses
-      const addressSuggestions = await apiAdresse.getDataFromAddress(address)
+      const addressSuggestions = await getDataFromAddress(address)
       await setFieldValue('search-addressAutocomplete', address)
       await setFieldValue('addressAutocomplete', address)
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35371

S'assure que les résultats renvoyés par l'API Adresse disposent bel et bien de numéros de rue par défaut (dits des "**numéros à la plaque**" :

![image](https://github.com/user-attachments/assets/55142037-5023-46f3-a372-51388cb86d8f)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [x] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
