### PR TITLE
(BSR)[API] fix: do not apply algolia replicas config when there is no…

### DIFF
--- a/api/src/pcapi/core/search/commands/settings.py
+++ b/api/src/pcapi/core/search/commands/settings.py
@@ -80,6 +80,11 @@ def _set_settings(index: SearchIndex, path: str, dry: bool = True) -> list[str]:
     with open(path, "r", encoding="utf-8") as fp:
         new_settings = json.load(fp)
 
+    # we define "replicas" in some files but we want to apply the setting only on an index which already has replicas
+    # e.g in testing or integration there is currently no replicas
+    if "replicas" not in old_settings and "replicas" in new_settings:
+        del new_settings["replicas"]
+
     diff = _get_dict_diff(old_settings, new_settings)
     outputs.append(diff)
 

--- a/api/tests/core/search/test_commands_settings.py
+++ b/api/tests/core/search/test_commands_settings.py
@@ -74,6 +74,74 @@ class AlgoliaSettingsTest:
         assert len(outputs) == 1  # diff
 
     @pytest.mark.parametrize("index_type", list(commands_settings.IndexTypes))
+    def test_set_settings_without_replicas(self, index_type):
+        index = commands_settings._get_index_client(index_type)
+        config_path = commands_settings._get_index_default_file(index_type)
+        # replicas is present in file but not in current config -> will not be applied
+        old_index_settings = {"random_field": "random_value"}
+        config_file_content = {"replicas": ["my_replica"], "random_field": "other_value"}
+
+        with (
+            requests_mock.Mocker() as requests_mocker,
+            mock.patch("builtins.open", return_value=StringIO(json.dumps(config_file_content, indent=4))) as mock_open,
+        ):
+            requests_mocker.register_uri(
+                "GET",
+                f"https://{index.app_id}-dsn.algolia.net/1/indexes/{index.name}/settings",
+                json=old_index_settings,
+                complete_qs=False,
+            )
+            requests_mocker.register_uri(
+                "PUT",
+                f"https://{index.app_id}.algolia.net/1/indexes/{index.name}/settings",
+                json={"updatedAt": "2013-08-21T13:20:18.960Z", "taskID": 10210332},
+                complete_qs=False,
+            )
+
+            outputs = commands_settings._set_settings(index, config_path, dry=False)
+
+        assert requests_mocker.call_count == 2
+        mock_open.assert_called_once_with(commands_settings._get_index_default_file(index_type), "r", encoding="utf-8")
+        put_request = requests_mocker.request_history[1]
+        assert put_request.text == json.dumps(
+            {key: value for key, value in config_file_content.items() if key != "replicas"}
+        )
+        assert len(outputs) == 1  # diff
+
+    @pytest.mark.parametrize("index_type", list(commands_settings.IndexTypes))
+    def test_set_settings_with_replicas(self, index_type):
+        index = commands_settings._get_index_client(index_type)
+        config_path = commands_settings._get_index_default_file(index_type)
+        # replicas is present in file and in current config -> will be applied
+        old_index_settings = {"replicas": ["my_replica"], "random_field": "random_value"}
+        config_file_content = {"replicas": ["my_new_replica"], "random_field": "other_value"}
+
+        with (
+            requests_mock.Mocker() as requests_mocker,
+            mock.patch("builtins.open", return_value=StringIO(json.dumps(config_file_content, indent=4))) as mock_open,
+        ):
+            requests_mocker.register_uri(
+                "GET",
+                f"https://{index.app_id}-dsn.algolia.net/1/indexes/{index.name}/settings",
+                json=old_index_settings,
+                complete_qs=False,
+            )
+            requests_mocker.register_uri(
+                "PUT",
+                f"https://{index.app_id}.algolia.net/1/indexes/{index.name}/settings",
+                json={"updatedAt": "2013-08-21T13:20:18.960Z", "taskID": 10210332},
+                complete_qs=False,
+            )
+
+            outputs = commands_settings._set_settings(index, config_path, dry=False)
+
+        assert requests_mocker.call_count == 2
+        mock_open.assert_called_once_with(commands_settings._get_index_default_file(index_type), "r", encoding="utf-8")
+        put_request = requests_mocker.request_history[1]
+        assert put_request.text == json.dumps(config_file_content)
+        assert len(outputs) == 1  # diff
+
+    @pytest.mark.parametrize("index_type", list(commands_settings.IndexTypes))
     def test_dry_settings_retrieval_actually_does_nothing(self, index_type):
         index = commands_settings._get_index_client(index_type)
 


### PR DESCRIPTION
… current replicas on the index

## But de la pull request

Ticket Jira (ou description si BSR) : on applique depuis peu la config algolia en testing et integration quand un changement est détecté dans un des fichiers de conf. On a actuellement un erreur en testing et integration car les index pour `offers` et `venues` n'ont pas de replicas, mais le fichier a ce champ renseigné (qui doit être appliqué en staging et prod).

Pour éviter l'erreur, on retirer la clef "replicas" de la config à appliquer si le champ n'est pas présent dans la config actuelle de l'index

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
