### PR TITLE
(PC-35226)[API] test: fix sandbox (data)

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_institutions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_institutions.py
@@ -122,7 +122,11 @@ def create_institutions() -> list[educational_models.EducationalInstitution]:
                 institutionType="ECOLE ÉLÉMENTAIRE",
                 name="CLAIR SOLEIL",
                 city="MARSEILLE",
-                programs=[program],
+                programAssociations=[
+                    educational_factories.EducationalInstitutionProgramAssociationFactory(
+                        program=program,
+                    )
+                ],
                 postalCode="13014",
             ),
             educational_factories.EducationalInstitutionFactory(institutionId="0921935D"),


### PR DESCRIPTION
## But de la pull request

Réparation de la sandbox data suite au ticket Jira : https://passculture.atlassian.net/browse/PC-35226
Sentry : https://pass-culture.sentry.io/issues/36376435/

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
