### PR TITLE
(PC-35533)[PRO] feat: Add tracker on stocks tables sort buttons.

### DIFF
--- a/pro/src/commons/core/FirebaseEvents/constants.ts
+++ b/pro/src/commons/core/FirebaseEvents/constants.ts
@@ -74,6 +74,7 @@ export enum Events {
   UPDATED_EVENT_STOCK_FILTERS = 'hasUpdatedEventStockFilters',
   CLICKED_VALIDATE_ADD_RECURRENCE_DATES = 'hasClickedValidateAddRecurrenceDates',
   FAKE_DOOR_VIDEO_INTERESTED = 'fakeDoorVideoInterested',
+  CLICKED_SORT_STOCKS_TABLE = 'hasClickedSortStocksTable',
 }
 
 export enum VenueEvents {

--- a/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
@@ -176,6 +176,16 @@ export const StocksEventEdition = ({
     setShouldBlockPreviousPageNavigationFormIsDirty,
   ] = useState(false)
 
+  function sortTableColumn(col: StocksOrderedBy) {
+    logEvent(Events.CLICKED_SORT_STOCKS_TABLE, {
+      formType: 'edition',
+      sortBy: col,
+      offerId: offer.id,
+      venueId: offer.venue.id,
+    })
+    onColumnHeaderClick(col)
+  }
+
   const loadStocksFromCurrentFilters = useCallback(
     () =>
       api.getStocks(
@@ -490,7 +500,7 @@ export const StocksEventEdition = ({
 
                           <SortArrow
                             onClick={() =>
-                              onColumnHeaderClick(StocksOrderedBy.DATE)
+                              sortTableColumn(StocksOrderedBy.DATE)
                             }
                             sortingMode={
                               currentSortingColumn === StocksOrderedBy.DATE
@@ -523,7 +533,7 @@ export const StocksEventEdition = ({
 
                           <SortArrow
                             onClick={() =>
-                              onColumnHeaderClick(StocksOrderedBy.TIME)
+                              sortTableColumn(StocksOrderedBy.TIME)
                             }
                             sortingMode={
                               currentSortingColumn === StocksOrderedBy.TIME
@@ -555,9 +565,7 @@ export const StocksEventEdition = ({
 
                           <SortArrow
                             onClick={() =>
-                              onColumnHeaderClick(
-                                StocksOrderedBy.PRICE_CATEGORY_ID
-                              )
+                              sortTableColumn(StocksOrderedBy.PRICE_CATEGORY_ID)
                             }
                             sortingMode={
                               currentSortingColumn ===
@@ -597,7 +605,7 @@ export const StocksEventEdition = ({
 
                           <SortArrow
                             onClick={() =>
-                              onColumnHeaderClick(
+                              sortTableColumn(
                                 StocksOrderedBy.BOOKING_LIMIT_DATETIME
                               )
                             }
@@ -626,7 +634,7 @@ export const StocksEventEdition = ({
 
                           <SortArrow
                             onClick={() =>
-                              onColumnHeaderClick(
+                              sortTableColumn(
                                 StocksOrderedBy.REMAINING_QUANTITY
                               )
                             }
@@ -655,7 +663,7 @@ export const StocksEventEdition = ({
 
                           <SortArrow
                             onClick={() =>
-                              onColumnHeaderClick(
+                              sortTableColumn(
                                 StocksOrderedBy.DN_BOOKED_QUANTITY
                               )
                             }

--- a/pro/src/components/StocksEventList/StocksEventList.tsx
+++ b/pro/src/components/StocksEventList/StocksEventList.tsx
@@ -112,6 +112,16 @@ export const StocksEventList = ({
   const { page, previousPage, nextPage, pageCount, firstPage } =
     usePaginationWithSearchParams(STOCKS_PER_PAGE, stocksCountWithFilters)
 
+  function sortTableColumn(col: StocksOrderedBy) {
+    logEvent(Events.CLICKED_SORT_STOCKS_TABLE, {
+      formType: readonly ? 'readonly' : 'creation',
+      sortBy: col,
+      offerId: offer.id,
+      venueId: offer.venue.id,
+    })
+    onColumnHeaderClick(col)
+  }
+
   // Effects
   const loadStocksFromCurrentFilters = () =>
     api.getStocks(
@@ -392,7 +402,7 @@ export const StocksEventList = ({
                   <span className={styles['header-name']}>Date</span>
 
                   <SortArrow
-                    onClick={() => onColumnHeaderClick(StocksOrderedBy.DATE)}
+                    onClick={() => sortTableColumn(StocksOrderedBy.DATE)}
                     sortingMode={
                       currentSortingColumn === StocksOrderedBy.DATE
                         ? currentSortingMode
@@ -420,7 +430,7 @@ export const StocksEventList = ({
                   <span className={styles['header-name']}>Horaire</span>
 
                   <SortArrow
-                    onClick={() => onColumnHeaderClick(StocksOrderedBy.TIME)}
+                    onClick={() => sortTableColumn(StocksOrderedBy.TIME)}
                     sortingMode={
                       currentSortingColumn === StocksOrderedBy.TIME
                         ? currentSortingMode
@@ -448,7 +458,7 @@ export const StocksEventList = ({
 
                   <SortArrow
                     onClick={() =>
-                      onColumnHeaderClick(StocksOrderedBy.PRICE_CATEGORY_ID)
+                      sortTableColumn(StocksOrderedBy.PRICE_CATEGORY_ID)
                     }
                     sortingMode={
                       currentSortingColumn === StocksOrderedBy.PRICE_CATEGORY_ID
@@ -487,9 +497,7 @@ export const StocksEventList = ({
 
                   <SortArrow
                     onClick={() =>
-                      onColumnHeaderClick(
-                        StocksOrderedBy.BOOKING_LIMIT_DATETIME
-                      )
+                      sortTableColumn(StocksOrderedBy.BOOKING_LIMIT_DATETIME)
                     }
                     sortingMode={
                       currentSortingColumn ===
@@ -509,7 +517,7 @@ export const StocksEventList = ({
 
                   <SortArrow
                     onClick={() =>
-                      onColumnHeaderClick(StocksOrderedBy.REMAINING_QUANTITY)
+                      sortTableColumn(StocksOrderedBy.REMAINING_QUANTITY)
                     }
                     sortingMode={
                       currentSortingColumn ===
@@ -532,7 +540,7 @@ export const StocksEventList = ({
 
                     <SortArrow
                       onClick={() =>
-                        onColumnHeaderClick(StocksOrderedBy.DN_BOOKED_QUANTITY)
+                        sortTableColumn(StocksOrderedBy.DN_BOOKED_QUANTITY)
                       }
                       sortingMode={
                         currentSortingColumn ===


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35533

**Objectif**
Ajouter un tracker sur le tri des tables de création/edition/read only des stocks pour étudier l'utilité de la feature. On regarde l'usage que sur l'ancienne interface (je suis par conséquent tenté de ne pas couvrir les tests des fonctions de tri existantes qui vont disparaitre sous peu).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
