### PR TITLE
(PC-35338)[API] feat: add migrations to validate constraints on stock

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 e9c8d83f71ce (pre) (head)
-cf1495e11a53 (post) (head)
+32bc8b20a0e1 (post) (head)

--- a/api/src/pcapi/alembic/versions/20250414T090046_32bc8b20a0e1_validate_event_opening_hours_constraints_on_stock.py
+++ b/api/src/pcapi/alembic/versions/20250414T090046_32bc8b20a0e1_validate_event_opening_hours_constraints_on_stock.py
@@ -1,0 +1,31 @@
+"""Validate 'stock_eventOpeningHoursId_fkey' and 'check_stock_with_opening_hours_does_not_have_beginningDatetime' constraints"""
+
+from alembic import op
+import sqlalchemy as sa
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "32bc8b20a0e1"
+down_revision = "cf1495e11a53"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(sa.text("SET SESSION statement_timeout = '300s'"))
+
+    op.execute(sa.text('ALTER TABLE stock VALIDATE CONSTRAINT "stock_eventOpeningHoursId_fkey";'))
+    op.execute(
+        sa.text(
+            'ALTER TABLE stock VALIDATE CONSTRAINT "check_stock_with_opening_hours_does_not_have_beginningDatetime";'
+        )
+    )
+
+    op.execute(sa.text(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}"))
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## But de la pull request

Ces deux contraintes `'stock_eventOpeningHoursId_fkey'` et `'check_stock_with_opening_hours_does_not_have_beginningDatetime'` ont déjà été validées en production via [ce script](https://github.com/pass-culture/pass-culture-main/pull/16884). Les migrations sont là pour valider ces contraintes sur les environnements de dev et de testing.

Ticket Jira : https://passculture.atlassian.net/browse/PC-35338

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
