### PR TITLE
Pc 35558 creation stocks readonly

### DIFF
--- a/pro/src/components/IndividualOffer/StocksCalendarSummaryScreen/StocksCalendarSummaryScreen.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksCalendarSummaryScreen/StocksCalendarSummaryScreen.spec.tsx
@@ -1,0 +1,23 @@
+import { screen } from '@testing-library/react'
+
+import { OfferStatus } from 'apiClient/v1'
+import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
+
+import { StocksCalendarSummaryScreen } from './StocksCalendarSummaryScreen'
+
+describe('StocksCalendarSummaryScreen', () => {
+  it('should show an information banner if the offer is not disabled', () => {
+    renderWithProviders(
+      <StocksCalendarSummaryScreen
+        offer={getIndividualOfferFactory({ status: OfferStatus.ACTIVE })}
+      />
+    )
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Nouvelle fenêtre Comment reporter ou annuler un évènement ?',
+      })
+    )
+  })
+})

--- a/pro/src/components/IndividualOffer/StocksCalendarSummaryScreen/StocksCalendarSummaryScreen.tsx
+++ b/pro/src/components/IndividualOffer/StocksCalendarSummaryScreen/StocksCalendarSummaryScreen.tsx
@@ -1,0 +1,55 @@
+import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import { OFFER_WIZARD_MODE } from 'commons/core/Offers/constants'
+import { getIndividualOfferUrl } from 'commons/core/Offers/utils/getIndividualOfferUrl'
+import { isOfferDisabled } from 'commons/core/Offers/utils/isOfferDisabled'
+import { StocksCalendar } from 'components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar'
+import { getStockWarningText } from 'components/IndividualOffer/SummaryScreen/StockSection/StockSection'
+import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
+import { SummarySection } from 'components/SummaryLayout/SummarySection'
+import { Callout } from 'ui-kit/Callout/Callout'
+
+type StocksCalendarSummaryScreenProps = {
+  offer: GetIndividualOfferWithAddressResponseModel
+}
+
+const HOW_TO_CANCEL_EVENT_URL =
+  'https://aide.passculture.app/hc/fr/articles/4411992053649--Acteurs-Culturels-Comment-annuler-ou-reporter-un-%C3%A9v%C3%A9nement-'
+
+export function StocksCalendarSummaryScreen({
+  offer,
+}: StocksCalendarSummaryScreenProps) {
+  const editLink = getIndividualOfferUrl({
+    offerId: offer.id,
+    step: OFFER_WIZARD_STEP_IDS.STOCKS,
+    mode: OFFER_WIZARD_MODE.EDITION,
+  })
+
+  return (
+    <SummarySection
+      title="Calendrier"
+      editLink={editLink}
+      aria-label="Modifier le calendrier"
+    >
+      {getStockWarningText(offer)}
+
+      {!isOfferDisabled(offer.status) && (
+        <Callout
+          links={[
+            {
+              href: HOW_TO_CANCEL_EVENT_URL,
+              label: 'Comment reporter ou annuler un évènement ?',
+              isExternal: true,
+            },
+          ]}
+        >
+          Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne
+          peuvent pas le faire à moins de 48h de l’évènement. Vous pouvez
+          annuler un évènement en supprimant la ligne de stock associée. Cette
+          action est irréversible.
+        </Callout>
+      )}
+
+      <StocksCalendar offer={offer} mode={OFFER_WIZARD_MODE.READ_ONLY} />
+    </SummarySection>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.module.scss
@@ -1,38 +1,4 @@
 @use "styles/mixins/_rem.scss" as rem;
-@use "styles/mixins/_fonts.scss" as fonts;
-
-.container {
-  width: 100%;
-  padding: rem.torem(32px) 0;
-}
-
-.header {
-  display: flex;
-  align-items: center;
-  gap: rem.torem(32px);
-  flex-wrap: wrap;
-  margin-bottom: rem.torem(24px);
-}
-
-.title {
-  @include fonts.title2;
-}
-
-.no-stocks-content {
-  display: flex;
-  flex-direction: column;
-  gap: rem.torem(40px);
-  align-items: center;
-  margin-top: rem.torem(64px);
-}
-
-.icon {
-  width: rem.torem(73.24px);
-  height: rem.torem(73.24px);
-  color: var(--color-secondary);
-  position: relative;
-  z-index: 1;
-}
 
 .button {
   display: inline-block;

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { addDays } from 'date-fns'
 
 import { api } from 'apiClient/api'
+import { OFFER_WIZARD_MODE } from 'commons/core/Offers/constants'
 import {
   getIndividualOfferFactory,
   getOfferStockFactory,
@@ -37,9 +38,7 @@ function renderStocksCalendar(stocks = defaultStocks) {
     <>
       <StocksCalendar
         offer={getIndividualOfferFactory()}
-        handleNextStep={() => {}}
-        handlePreviousStep={() => {}}
-        departmentCode="56"
+        mode={OFFER_WIZARD_MODE.CREATION}
       />
       <Notification />
     </>

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarLayout/StocksCalendarLayout.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarLayout/StocksCalendarLayout.module.scss
@@ -1,0 +1,35 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.container {
+  width: 100%;
+  padding: rem.torem(32px) 0;
+}
+
+.title {
+  @include fonts.title2;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: rem.torem(32px);
+  flex-wrap: wrap;
+  margin-bottom: rem.torem(24px);
+}
+
+.no-stocks-content {
+  display: flex;
+  flex-direction: column;
+  gap: rem.torem(40px);
+  align-items: center;
+  margin-top: rem.torem(64px);
+}
+
+.icon {
+  width: rem.torem(73.24px);
+  height: rem.torem(73.24px);
+  color: var(--color-secondary);
+  position: relative;
+  z-index: 1;
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarLayout/StocksCalendarLayout.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarLayout/StocksCalendarLayout.tsx
@@ -1,0 +1,80 @@
+import { PropsWithChildren, useState } from 'react'
+
+import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import { OFFER_WIZARD_MODE } from 'commons/core/Offers/constants'
+import fullMoreIcon from 'icons/full-more.svg'
+import strokeAddCalendarIcon from 'icons/stroke-add-calendar.svg'
+import { Button } from 'ui-kit/Button/Button'
+import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
+import { Spinner } from 'ui-kit/Spinner/Spinner'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
+
+import { StocksCalendarForm } from '../StocksCalendarForm/StocksCalendarForm'
+
+import styles from './StocksCalendarLayout.module.scss'
+
+export function StocksCalendarLayout({
+  children,
+  offer,
+  hasStocks,
+  isLoading,
+  mode,
+  onAfterCloseDialog,
+}: PropsWithChildren<{
+  offer: GetIndividualOfferWithAddressResponseModel
+  hasStocks: boolean
+  isLoading: boolean
+  mode: OFFER_WIZARD_MODE
+  onAfterCloseDialog: () => void
+}>) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+  const getDialogBuilderButton = (buttonLabel: string) => (
+    <DialogBuilder
+      trigger={
+        <Button className={styles['button']} icon={fullMoreIcon}>
+          {buttonLabel}
+        </Button>
+      }
+      open={isDialogOpen}
+      onOpenChange={setIsDialogOpen}
+      variant="drawer"
+      title="Définir le calendrier de votre offre"
+    >
+      <StocksCalendarForm
+        offer={offer}
+        onAfterValidate={() => {
+          onAfterCloseDialog()
+          setIsDialogOpen(false)
+        }}
+      />
+    </DialogBuilder>
+  )
+
+  return (
+    <div className={styles['container']}>
+      {mode !== OFFER_WIZARD_MODE.READ_ONLY && (
+        //  When the mode is read only, the title is already inside the SummarySection layout
+        <div className={styles['header']}>
+          <h2 className={styles['title']}>Calendrier</h2>
+          {hasStocks &&
+            getDialogBuilderButton('Ajouter une ou plusieurs dates')}
+        </div>
+      )}
+      {isLoading && hasStocks && <Spinner className={styles['spinner']} />}
+      {children}
+      {!hasStocks && !isLoading && (
+        <div className={styles['no-stocks-content']}>
+          <div className={styles['icon-container']}>
+            <SvgIcon
+              alt=""
+              className={styles['icon']}
+              src={strokeAddCalendarIcon}
+            />
+          </div>
+          {getDialogBuilderButton('Définir le calendrier')}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.module.scss
@@ -64,6 +64,10 @@
 
     &:first-of-type {
       padding-left: rem.torem(16px);
+
+      .tbody-td-date {
+        margin-left: 0;
+      }
     }
 
     &:last-of-type {

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.spec.tsx
@@ -1,22 +1,54 @@
 import { render, screen } from '@testing-library/react'
 
-import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
+import { OFFER_WIZARD_MODE } from 'commons/core/Offers/constants'
+import {
+  getIndividualOfferFactory,
+  getOfferStockFactory,
+} from 'commons/utils/factories/individualApiFactories'
 
-import { StocksCalendarTable } from './StocksCalendarTable'
+import {
+  StocksCalendarTable,
+  StocksCalendarTableProps,
+} from './StocksCalendarTable'
+
+function renderStocksCalendarTable(
+  props: Partial<StocksCalendarTableProps> = {}
+) {
+  render(
+    <StocksCalendarTable
+      departmentCode="56"
+      checkedStocks={new Set()}
+      offer={getIndividualOfferFactory()}
+      onDeleteStocks={vi.fn()}
+      updateCheckedStocks={vi.fn()}
+      stocks={[
+        getOfferStockFactory({ id: 1 }),
+        getOfferStockFactory({ id: 2 }),
+      ]}
+      mode={OFFER_WIZARD_MODE.CREATION}
+      {...props}
+    />
+  )
+}
 
 describe('StocksCalendarTable', () => {
   it('should show a placeholder message when there is no stock displayed in the table', () => {
-    render(
-      <StocksCalendarTable
-        departmentCode="56"
-        checkedStocks={new Set()}
-        offer={getIndividualOfferFactory()}
-        onDeleteStocks={vi.fn()}
-        updateCheckedStocks={vi.fn()}
-        stocks={[]}
-      />
-    )
+    renderStocksCalendarTable({ stocks: [] })
 
     expect(screen.getByText('Aucune date trouvée')).toBeInTheDocument()
+  })
+
+  it('should not render stocks checkboxes options when the page is read only', () => {
+    renderStocksCalendarTable({ mode: OFFER_WIZARD_MODE.READ_ONLY })
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('should not render stocks deletion options when the page is read only', () => {
+    renderStocksCalendarTable({ mode: OFFER_WIZARD_MODE.READ_ONLY })
+
+    expect(
+      screen.queryByRole('button', { name: 'Supprimer le stock' })
+    ).not.toBeInTheDocument()
   })
 })

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksEventCreation.tsx
@@ -5,7 +5,6 @@ import { useSWRConfig } from 'swr'
 import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
 import { GET_OFFER_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { getIndividualOfferUrl } from 'commons/core/Offers/utils/getIndividualOfferUrl'
-import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useNotification } from 'commons/hooks/useNotification'
 import { useOfferWizardMode } from 'commons/hooks/useOfferWizardMode'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
@@ -15,7 +14,6 @@ import { ActionBar } from 'pages/IndividualOffer/components/ActionBar/ActionBar'
 import { getDepartmentCode } from '../utils/getDepartmentCode'
 
 import { HelpSection } from './HelpSection/HelpSection'
-import { StocksCalendar } from './StocksCalendar/StocksCalendar'
 import styles from './StocksEventCreation.module.scss'
 
 export interface StocksEventCreationProps {
@@ -25,10 +23,6 @@ export interface StocksEventCreationProps {
 export const StocksEventCreation = ({
   offer,
 }: StocksEventCreationProps): JSX.Element => {
-  //  TODO in OHO epic : rework the fetching of data so that stocks are retrieved from here
-  const isEventWithOpeningHoursEnabled = useActiveFeature(
-    'WIP_ENABLE_EVENT_WITH_OPENING_HOUR'
-  )
   const navigate = useNavigate()
   const { pathname } = useLocation()
   const isOnboarding = pathname.indexOf('onboarding') !== -1
@@ -52,7 +46,7 @@ export const StocksEventCreation = ({
 
   const handleNextStep = async () => {
     // Check that there is at least one stock left
-    if (!hasStocks && !isEventWithOpeningHoursEnabled) {
+    if (!hasStocks) {
       notify.error('Veuillez renseigner au moins une date')
       return
     }
@@ -73,39 +67,28 @@ export const StocksEventCreation = ({
   return (
     <>
       <div className={styles['container']}>
-        {isEventWithOpeningHoursEnabled ? (
-          <StocksCalendar
-            offer={offer}
-            handlePreviousStep={handlePreviousStep}
-            handleNextStep={handleNextStep}
-            departmentCode={departmentCode}
-          />
-        ) : (
-          <>
-            {hasStocks === false && (
-              <HelpSection className={styles['help-section']} />
-            )}
+        <>
+          {hasStocks === false && (
+            <HelpSection className={styles['help-section']} />
+          )}
 
-            <StocksEventList
-              priceCategories={offer.priceCategories ?? []}
-              departmentCode={departmentCode}
-              offer={offer}
-              onStocksLoad={setHasStocks}
-              canAddStocks
-            />
-          </>
-        )}
+          <StocksEventList
+            priceCategories={offer.priceCategories ?? []}
+            departmentCode={departmentCode}
+            offer={offer}
+            onStocksLoad={setHasStocks}
+            canAddStocks
+          />
+        </>
       </div>
-      {!isEventWithOpeningHoursEnabled && (
-        <ActionBar
-          isDisabled={false}
-          onClickPrevious={handlePreviousStep}
-          onClickNext={handleNextStep}
-          step={OFFER_WIZARD_STEP_IDS.STOCKS}
-          // now we submit in RecurrenceForm, StocksEventCreation could not be dirty
-          dirtyForm={false}
-        />
-      )}
+      <ActionBar
+        isDisabled={false}
+        onClickPrevious={handlePreviousStep}
+        onClickNext={handleNextStep}
+        step={OFFER_WIZARD_STEP_IDS.STOCKS}
+        // now we submit in RecurrenceForm, StocksEventCreation could not be dirty
+        dirtyForm={false}
+      />
     </>
   )
 }

--- a/pro/src/components/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/__specs__/StocksEventCreation.spec.tsx
@@ -190,24 +190,4 @@ describe('StocksEventCreation', () => {
     ).toBeInTheDocument()
     expect(api.upsertStocks).not.toHaveBeenCalled()
   })
-
-  it('should show the calendar form if the FF WIP_ENABLE_EVENT_WITH_OPENING_HOUR is enabled', async () => {
-    await renderStockEventCreation([], { offer: getIndividualOfferFactory() }, [
-      'WIP_ENABLE_EVENT_WITH_OPENING_HOUR',
-    ])
-
-    expect(
-      screen.getByRole('heading', { name: 'Calendrier' })
-    ).toBeInTheDocument()
-  })
-
-  it('should not show the action bar here when the FF WIP_ENABLE_EVENT_WITH_OPENING_HOUR is enabled', async () => {
-    await renderStockEventCreation([], { offer: getIndividualOfferFactory() }, [
-      'WIP_ENABLE_EVENT_WITH_OPENING_HOUR',
-    ])
-
-    expect(
-      screen.queryByRole('link', { name: 'Enregistrer et continuer' })
-    ).not.toBeInTheDocument()
-  })
 })

--- a/pro/src/pages/IndividualOfferWizard/Stocks/Stocks.tsx
+++ b/pro/src/pages/IndividualOfferWizard/Stocks/Stocks.tsx
@@ -1,8 +1,10 @@
 import { useIndividualOfferContext } from 'commons/context/IndividualOfferContext/IndividualOfferContext'
 import { OFFER_WIZARD_MODE } from 'commons/core/Offers/constants'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useOfferWizardMode } from 'commons/hooks/useOfferWizardMode'
 import { IndividualOfferLayout } from 'components/IndividualOffer/IndividualOfferLayout/IndividualOfferLayout'
 import { getTitle } from 'components/IndividualOffer/IndividualOfferLayout/utils/getTitle'
+import { StocksCalendar } from 'components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendar'
 import { StocksEventCreation } from 'components/IndividualOffer/StocksEventCreation/StocksEventCreation'
 import { StocksEventEdition } from 'components/IndividualOffer/StocksEventEdition/StocksEventEdition'
 import { StocksThing } from 'components/IndividualOffer/StocksThing/StocksThing'
@@ -11,6 +13,10 @@ import { Spinner } from 'ui-kit/Spinner/Spinner'
 export const Stocks = (): JSX.Element | null => {
   const { offer, publishedOfferWithSameEAN } = useIndividualOfferContext()
   const mode = useOfferWizardMode()
+
+  const isEventWithOpeningHoursEnabled = useActiveFeature(
+    'WIP_ENABLE_EVENT_WITH_OPENING_HOUR'
+  )
 
   // Here we display a spinner because when the router transitions from
   // Informations form to Stocks form the setOffer after the submit is not
@@ -21,6 +27,22 @@ export const Stocks = (): JSX.Element | null => {
     return <Spinner />
   }
 
+  const getStocksLayoutContent = () => {
+    if (!offer.isEvent) {
+      return <StocksThing offer={offer} />
+    }
+
+    if (isEventWithOpeningHoursEnabled) {
+      return <StocksCalendar offer={offer} mode={mode} />
+    }
+
+    return mode === OFFER_WIZARD_MODE.CREATION ? (
+      <StocksEventCreation offer={offer} />
+    ) : (
+      <StocksEventEdition offer={offer} />
+    )
+  }
+
   return (
     <IndividualOfferLayout
       offer={offer}
@@ -28,15 +50,7 @@ export const Stocks = (): JSX.Element | null => {
       mode={mode}
       venueHasPublishedOfferWithSameEan={Boolean(publishedOfferWithSameEAN)}
     >
-      {offer.isEvent ? (
-        mode === OFFER_WIZARD_MODE.CREATION ? (
-          <StocksEventCreation offer={offer} />
-        ) : (
-          <StocksEventEdition offer={offer} />
-        )
-      ) : (
-        <StocksThing offer={offer} />
-      )}
+      {getStocksLayoutContent()}
     </IndividualOfferLayout>
   )
 }

--- a/pro/src/pages/IndividualOfferWizard/StocksSummary/StocksSummary.tsx
+++ b/pro/src/pages/IndividualOfferWizard/StocksSummary/StocksSummary.tsx
@@ -1,8 +1,10 @@
 /* istanbul ignore file: DEBT, TO FIX */
 
 import { useIndividualOfferContext } from 'commons/context/IndividualOfferContext/IndividualOfferContext'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useOfferWizardMode } from 'commons/hooks/useOfferWizardMode'
 import { IndividualOfferLayout } from 'components/IndividualOffer/IndividualOfferLayout/IndividualOfferLayout'
+import { StocksCalendarSummaryScreen } from 'components/IndividualOffer/StocksCalendarSummaryScreen/StocksCalendarSummaryScreen'
 import { StocksSummaryScreen } from 'components/IndividualOffer/StocksSummaryScreen/StocksSummaryScreen'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { ActionBar } from 'pages/IndividualOffer/components/ActionBar/ActionBar'
@@ -12,13 +14,21 @@ const StocksSummary = (): JSX.Element | null => {
   const mode = useOfferWizardMode()
   const { offer } = useIndividualOfferContext()
 
+  const isEventWithOpeningHoursEnabled = useActiveFeature(
+    'WIP_ENABLE_EVENT_WITH_OPENING_HOUR'
+  )
+
   if (offer === null) {
     return <Spinner />
   }
 
   return (
     <IndividualOfferLayout title="Récapitulatif" offer={offer} mode={mode}>
-      <StocksSummaryScreen />
+      {isEventWithOpeningHoursEnabled && offer.isEvent ? (
+        <StocksCalendarSummaryScreen offer={offer} />
+      ) : (
+        <StocksSummaryScreen />
+      )}
       <ActionBar step={OFFER_WIZARD_STEP_IDS.SUMMARY} isDisabled={false} />
     </IndividualOfferLayout>
   )


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35558

**Objectif**
Mise en place de l'onglet "Calendrier" de la page de réumé d'une offre de type événement (read-only).

Pour ça et pour que toutes les pages de liste des stocks se basent sur la même table (création, read-only, edition à venir):
- Création d'un layout pour réutiliser la logique d'affichage du nouveau drawer de récurrence
- Passage des effets des actions dans StocksCalendarActionsBar
- Appel de `StocksCalendar` 2 fois : 1 fois pour le summary (readonly), et une fois depuis `Stocks` pour création/edition

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
