### PR TITLE
(BSR)[API] fix: Do not log an error at sync time when a form has been deleted on Typeform side

### DIFF
--- a/api/src/pcapi/core/operations/api.py
+++ b/api/src/pcapi/core/operations/api.py
@@ -93,6 +93,9 @@ def retrieve_special_event_from_typeform(event: models.SpecialEvent) -> None:
         update_form_title_from_typeform(event_id=event_id, event_title=event.title, form=form)
         questions = update_form_questions_from_typeform(event_id=event_id, form=form)
         download_responses_from_typeform(event_id=event_id, event_external_id=event_external_id, questions=questions)
+    except typeform.NotFoundException:
+        # form does no longer exist, ignore
+        pass
     except Exception:  # pylint: disable=broad-except
         logger.error(
             "An error happened while retrieving special event",


### PR DESCRIPTION
## But de la pull request

Sentry : https://pass-culture.sentry.io/pass-culture/api/events/c69e0cf27c534954878469962531ed8d/

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
