### PR TITLE
Revert d97e9c2

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2641,30 +2641,6 @@ def synchronize_accessibility_with_acceslibre(
     logger.info("Accessibility data synchronization with acceslibre complete successfully")
 
 
-def get_venues_close_to_public_with_accesibility_provider() -> list[models.Venue]:
-    return (
-        offerers_models.Venue.query.join(offerers_models.Venue.accessibilityProvider)
-        .filter(offerers_models.Venue.isOpenToPublic.is_(False))
-        .options(sa.orm.contains_eager(offerers_models.Venue.accessibilityProvider))
-        .all()
-    )
-
-
-def desynchronize_venues_close_to_public_with_accessibility_provider(dry_run: bool) -> None:
-    venues_to_desynchronize = get_venues_close_to_public_with_accesibility_provider()
-    for venue in venues_to_desynchronize:
-        db.session.delete(venue.accessibilityProvider)
-        if not dry_run:
-            try:
-                db.session.commit()
-            except sa.exc.SQLAlchemyError:
-                logger.exception("Could not desynchronize venue %d", venue.id)
-                db.session.rollback()
-        else:
-            db.session.rollback()
-    logger.info("Accessibility desynchronization for venues close to public complete successfully")
-
-
 def synchronize_venues_with_acceslibre(venue_ids: list[int], dry_run: bool) -> None:
     """
     For venues in venue_ids list, we look for a match at acceslibre and synchronize the

--- a/api/src/pcapi/core/offerers/commands.py
+++ b/api/src/pcapi/core/offerers/commands.py
@@ -172,12 +172,6 @@ def synchronize_accessibility_with_acceslibre(
     )
 
 
-@blueprint.cli.command("desynchronize_venues_close_to_public_accessibility_with_acceslibre")
-@click.option("--dry-run", type=bool, default=False)
-def desynchronize_venues_close_to_public_accessibility_with_acceslibre(dry_run: bool = False) -> None:
-    offerers_api.desynchronize_venues_close_to_public_with_accessibility_provider(dry_run=dry_run)
-
-
 @blueprint.cli.command("synchronize_venues_with_acceslibre")
 @click.argument("venue_ids", type=int, nargs=-1, required=True)
 @click.option("--dry-run", type=bool, default=True)

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -2878,20 +2878,6 @@ class AccessibilityProviderTest:
         assert venue_2.external_accessibility_url == "https://mon.adresse/mon-slug"
         assert venue_2.external_accessibility_id == "mon-slug"
 
-    def test_desynchronize_venues_with_acceslibre(self):
-        venue_1 = offerers_factories.VenueFactory(isOpenToPublic=False)
-        venue_2 = offerers_factories.VenueFactory(isOpenToPublic=True)
-        offerers_api.set_accessibility_provider_id(venue_1)
-        offerers_api.set_accessibility_provider_id(venue_2)
-
-        offerers_api.desynchronize_venues_close_to_public_with_accessibility_provider(dry_run=False)
-
-        db.session.refresh(venue_1)
-        db.session.refresh(venue_2)
-
-        assert not venue_1.accessibilityProvider
-        assert venue_2.accessibilityProvider.externalAccessibilityId == "mon-lieu-chez-acceslibre"
-
 
 class GetOffererConfidenceLevelTest:
     def test_no_rule(self):


### PR DESCRIPTION
Reverts (PC-34831)[API] feat: Clean unecessary accesibility provider for venues close to public when run commande synchronize_accessibility_with_acceslibre"

This reverts commit d97e9c2d401580708cd76e3148fd063105c59045.

This is unnecessary since swtiching a venue to "not open to public" removes it's accessibility Provider