### PR TITLE
(BSR)[API] fix: do not set id when creating national program in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -21,10 +21,11 @@ from pcapi.core.providers import models as providers_models
 from pcapi.core.users import factories as user_factory
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.sandboxes.scripts.creators.industrial.create_industrial_eac_data.create_collective_api_provider import (
+    create_collective_api_provider,
+)
 from pcapi.utils import db as db_utils
 from pcapi.utils.image_conversion import DO_NOT_CROP
-
-from .create_collective_api_provider import create_collective_api_provider
 
 
 class LocationOption(typing.TypedDict):
@@ -1044,10 +1045,11 @@ def create_booking_base_list(
 def create_domains(
     national_programs: typing.Sequence[educational_models.NationalProgram],
 ) -> list[educational_models.EducationalDomain]:
-    college_au_cinema = [np for np in national_programs if np.id == 1]
-    lyceens_apprentis_au_cinema = [np for np in national_programs if np.id == 3]
-    olympiade_culturelle = [np for np in national_programs if np.id == 4]
-    jeunes_en_librairie = [np for np in national_programs if np.id == 6]
+    college_au_cinema = [np for np in national_programs if np.name == "Collège au cinéma"]
+    lyceens_apprentis_au_cinema = [np for np in national_programs if np.name == "Lycéens et apprentis au cinéma"]
+    olympiade_culturelle = [np for np in national_programs if np.name == "Olympiade culturelle de PARIS 2024"]
+    jeunes_en_librairie = [np for np in national_programs if np.name == "Jeunes en librairie"]
+
     return [
         educational_factories.EducationalDomainFactory(
             name="Architecture", id=1, nationalPrograms=olympiade_culturelle
@@ -1099,11 +1101,10 @@ def create_domains(
 
 def create_national_programs() -> list[educational_models.NationalProgram]:
     return [
-        educational_factories.NationalProgramFactory(name="collège au cinéma", id=1),
-        educational_factories.NationalProgramFactory(name="Lycéens et apprentis au cinéma", id=3),
-        educational_factories.NationalProgramFactory(name="Olympiade culturelle de PARIS 2024", id=4, isActive=False),
-        educational_factories.NationalProgramFactory(name="Théâtre au collège", id=5),
-        educational_factories.NationalProgramFactory(name="Jeunes en librairie", id=6),
+        educational_factories.NationalProgramFactory(name="Collège au cinéma"),
+        educational_factories.NationalProgramFactory(name="Lycéens et apprentis au cinéma"),
+        educational_factories.NationalProgramFactory(name="Jeunes en librairie"),
+        educational_factories.NationalProgramFactory(name="Olympiade culturelle de PARIS 2024", isActive=False),
     ]
 
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : les id fixes dans l'appel à NationalProgramFactory donnent une erreur si l'on essaie de créer un nouveau national program (erreur d'unicité sur la clé primaire)

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
