### PR TITLE
(BSR)[API] ci: Deploy ops after testing to avoid git concurrency

### DIFF
--- a/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
+++ b/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
@@ -160,7 +160,7 @@ jobs:
 
   deploy-to-ops:
     name: "Deploy to ops"
-    needs: [pcapi-init-job, push-pcapi-console, push-pcapi]
+    needs: [pcapi-init-job, push-pcapi-console, push-pcapi, deploy-to-testing]
     uses: ./.github/workflows/dev_on_workflow_deploy.yml
     with:
       environment: ops


### PR DESCRIPTION
## But de la pull request
During deployment we push the new version to deployment repo, if testing and ops deployment push at the same time this error can occur https://github.com/pass-culture/pass-culture-main/actions/runs/14353873169/job/40239114908


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
