### PR TITLE
(BSR)[API] chore: readd warning on as_scalar use

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -240,9 +240,6 @@ filterwarnings = [
     # Mark warnings as errors
     "error",
     # -------------- Temporary ignored warnings due to SLQAlchemy bump to 1.4 -------------- #
-    # FIXME (lixxday, 2022/06/09)
-    # Warning on deprecated sqla function as_scalar()
-    "ignore:The Query.as_scalar\\(\\) method is deprecated and will be removed in a future release:sqlalchemy.exc.SADeprecationWarning",
     # Warning on SELECT with IN. Fix: pass a select() construct explicitly
     "ignore:Coercing Subquery object into a select\\(\\) for use in IN\\(\\):sqlalchemy.exc.SAWarning",
     # ---------------------------- #

--- a/api/src/pcapi/models/beneficiary_import.py
+++ b/api/src/pcapi/models/beneficiary_import.py
@@ -103,7 +103,7 @@ class BeneficiaryImport(PcObject, Base, Model):
             .filter(BeneficiaryImportStatus.beneficiaryImportId == cls.id)
             .order_by(sa.desc(BeneficiaryImportStatus.date))
             .limit(1)
-            .as_scalar()
+            .scalar()
         )
 
     def _last_status(self) -> BeneficiaryImportStatus:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : Je supprime le dernier as_scalar() du code pour remettre le warning SQL

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
