### PR TITLE
(PC-35576)[PRO] fix: Allow non-rattached users to log in

### DIFF
--- a/pro/src/pages/SignIn/SignIn.tsx
+++ b/pro/src/pages/SignIn/SignIn.tsx
@@ -79,9 +79,20 @@ export const SignIn = (): JSX.Element => {
         captchaToken,
       })
 
-      const inisializeOffererIsOnboarded = async (offererId: number) => {
-        const response = await api.getOfferer(offererId)
-        dispatch(updateOffererIsOnboarded(response.isOnboarded))
+      const initializeOffererIsOnboarded = async (offererId: number) => {
+        try {
+          const response = await api.getOfferer(offererId)
+          dispatch(updateOffererIsOnboarded(response.isOnboarded))
+        } catch (e: unknown) {
+          if (isErrorAPIError(e) && e.status === 403) {
+            // Do nothing at this point,
+            // Because a 403 means that the user is waiting for a "rattachement" to the offerer,
+            // But we must let him sign in
+            return
+          }
+          // Else it's another error we should handle here at sign in
+          throw e
+        }
       }
 
       const offerers = await api.listOfferersNames()
@@ -97,12 +108,12 @@ export const SignIn = (): JSX.Element => {
               savedOffererId ? Number(savedOffererId) : firstOffererId
             )
           )
-          await inisializeOffererIsOnboarded(
+          await initializeOffererIsOnboarded(
             savedOffererId ? Number(savedOffererId) : firstOffererId
           )
         } else {
           dispatch(updateSelectedOffererId(firstOffererId))
-          await inisializeOffererIsOnboarded(firstOffererId)
+          await initializeOffererIsOnboarded(firstOffererId)
         }
       }
 
@@ -164,9 +175,10 @@ export const SignIn = (): JSX.Element => {
   ) : (
     <Layout
       layout={is2025SignUpEnabled ? 'sign-up' : 'logged-out'}
-      mainHeading={is2025SignUpEnabled
-        ? 'Connexion'
-        : 'Bienvenue sur l’espace partenaires culturels'
+      mainHeading={
+        is2025SignUpEnabled
+          ? 'Connexion'
+          : 'Bienvenue sur l’espace partenaires culturels'
       }
     >
       <MandatoryInfo areAllFieldsMandatory={true} />


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35576

Suite à un bug introduit avec l'onboarding didactique, cette PR le corrige en permettant à nouveau à un user en attente de rattachement à un offerer de pouvoir se connecter.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
