### PR TITLE
(BSR)[API] ci: Change testing deployment time

### DIFF
--- a/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
+++ b/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
@@ -4,11 +4,13 @@ on:
   workflow_dispatch:
   schedule:
     # This cron is defined in UTC timezone. It means that it will run :
-    # - during summer hours between 8:30am - 7:30pm
-    # - during winter hours between 7:30am - 6:30pm
+    # - during summer hours between 8:28am - 7:28pm
+    # - during winter hours between 7:28am - 6:28pm
     # we cannot yet specify timezone : 
     # https://github.com/orgs/community/discussions/13454
-    - cron: "30 6-17 * * 1-5"
+    # Why 28? Choosing an exact hour or half-hour is discouraged by GitHub due to high load.
+    # Cron jobs might be delayed or even completely skipped.
+    - cron: "28 6-17 * * 1-5"
 
 permissions: write-all
 


### PR DESCRIPTION
## But de la pull request

```
The schedule event can be delayed during periods of high loads of GitHub Actions workflow runs. 
High load times include the start of every hour. 
If the load is sufficiently high enough, some queued jobs may be dropped. To decrease the chance of delay, schedule your workflow to run at a different time of the hour.
```
[source](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule)

We had workflow that were delayed by 10-15 minutes

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
