### PR TITLE
(BSR)[API] fix: correctly change a collective offer venue in public a…

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -319,6 +319,11 @@ def patch_collective_offer_public(
         if not list_venueproviders:
             raise ApiErrors(errors={"venueId": ["aucun lieu de fournisseur n'a été trouvé."]}, status_code=403)
 
+        try:
+            educational_api_offer.move_collective_offer_venue(offer, venue)
+        except offers_exceptions.MoveOfferBaseException:
+            raise ApiErrors(errors={"venueId": ["L'offre ne peut pas être déplacée sur ce lieu."]}, status_code=400)
+
     if new_values.get("offerVenue"):
         if new_values["offerVenue"] == OfferAddressType.OFFERER_VENUE.value:
             venue = offerers_repository.find_venue_by_id(new_values["offerVenue"]["venuId"])


### PR DESCRIPTION
…pi patch

## But de la pull request

Ticket Jira (ou description si BSR) : il manque un certain nombre de vérifications + de la logique sur les objets liés quand on change le `venueId` d'une offre collective sur l'api publique

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
