### PR TITLE
(PC-35623)[API] fix: Pending FinanceEvent raised error when move from one venue to another

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1888,11 +1888,12 @@ def move_offer(
 
             finance_event = booking.finance_events[0] if booking.finance_events else None
             if finance_event:
+                pricingOrderingDate = finance_api.get_pricing_ordering_date(booking)
                 finance_event.venueId = destination_venue.id
                 finance_event.pricingPointId = destination_pricing_point_id
                 if finance_event.status == finance_models.FinanceEventStatus.PENDING:
                     finance_event.status = finance_models.FinanceEventStatus.READY
-                    finance_event.pricingOrderingDate = finance_api.get_pricing_ordering_date(booking)
+                    finance_event.pricingOrderingDate = pricingOrderingDate
                 db.session.add(finance_event)
             db.session.add(booking)
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -4864,3 +4864,25 @@ class MoveOfferTest:
         ):
             assert bookings_models.Booking.query.count() == 1
             assert bookings_models.Booking.query.all()[0].venue == new_venue
+
+    def test_move_offer_with_booking_with_pending_finance_event(self):
+        new_venue = offerers_factories.VenueFactory(pricing_point="self")
+        venue = offerers_factories.VenueFactory(pricing_point=new_venue, managingOfferer=new_venue.managingOfferer)
+
+        offer = factories.OfferFactory(venue=venue)
+        stock = factories.StockFactory(offer=offer, quantity=2)
+        booking = bookings_factories.UsedBookingFactory(stock=stock)
+        finance_factories.FinanceEventFactory(
+            booking=booking,
+            pricingOrderingDate=stock.beginningDatetime,
+            status=finance_models.FinanceEventStatus.PENDING,
+            venue=venue,
+            pricingPoint=None,
+        )
+
+        api.move_offer(offer, new_venue)
+
+        db.session.refresh(offer)
+        assert offer.venue == new_venue
+        assert bookings_models.Booking.query.count() == 1
+        assert bookings_models.Booking.query.all()[0].venue == new_venue


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35623

Un probable auto flush de SQLAlchemy arrivant trop tôt permet un FinanceEvent pending (sans pricingPoint) de devenir ready sans pricingPoint.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
