### PR TITLE
(PC-35445) refactor: do not call get_wallet_balance during user update

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -453,7 +453,11 @@ class User(PcObject, Base, Model, DeactivableMixin):
 
     @property
     def has_active_deposit(self) -> bool:
-        return self.deposit.expirationDate > datetime.utcnow() if self.deposit else False  # type: ignore[operator]
+        if not self.deposit:
+            return False
+        if not self.deposit.expirationDate:
+            return True
+        return self.deposit.expirationDate > datetime.utcnow()
 
     @property
     def is_eligible(self) -> bool:
@@ -615,15 +619,6 @@ class User(PcObject, Base, Model, DeactivableMixin):
     def is_beneficiary(cls) -> BooleanClauseList:  # pylint: disable=no-self-argument
         return expression.or_(
             cls.roles.contains([UserRole.BENEFICIARY]), cls.roles.contains([UserRole.UNDERAGE_BENEFICIARY])
-        )
-
-    @property
-    def has_remaining_credit(self) -> bool:
-        today = datetime.combine(date.today(), datetime.min.time())
-        return (
-            self.deposit is not None
-            and (self.deposit.expirationDate is None or self.deposit.expirationDate > today)
-            and self.wallet_balance > 0
         )
 
     @property

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -1134,7 +1134,7 @@ class CancelBookingTest:
         booking = booking_factories.BookingFactory(user=user)
 
         client = client.with_token(self.identifier)
-        with assert_num_queries(27):
+        with assert_num_queries(26):
             response = client.post(f"/native/v1/bookings/{booking.id}/cancel")
 
         assert response.status_code == 204
@@ -1150,7 +1150,7 @@ class CancelBookingTest:
         booking = booking_factories.BookingFactory(user=user)
 
         client = client.with_token(self.identifier)
-        with assert_num_queries(27):
+        with assert_num_queries(26):
             response = client.post(f"/native/v1/bookings/{booking.id}/cancel")
 
         assert response.status_code == 204


### PR DESCRIPTION
get_wallet_balance likes to crash after expiring a deposit and creating a new one. Since we update the beneficiary's external attribute just after granting the new deposit, we work around this tendency to crash by not calling get_wallet_balance.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35445
