### PR TITLE
(PC-35343)[API] chore: stop writing ean in product extraData

### DIFF
--- a/api/src/pcapi/connectors/titelive.py
+++ b/api/src/pcapi/connectors/titelive.py
@@ -209,7 +209,6 @@ def get_new_product_from_ean13(ean: str) -> offers_models.Product:
         thumbCount=article.get("image", 0),  # 0 or 1
         extraData=offers_models.OfferExtraData(
             author=oeuvre.get("auteurs", ""),
-            ean=ean,
             prix_livre=article["prix"],
             collection=article.get("collection"),
             comic_series=article.get("serie"),

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1537,6 +1537,7 @@ def fetch_or_update_product_with_titelive_data(titelive_product: models.Product)
 
     if titelive_product.extraData:
         product.extraData = {**old_extra_data, **titelive_product.extraData}
+        product.extraData.pop("ean", None)
 
     return product
 

--- a/api/src/pcapi/core/providers/titelive_book_search.py
+++ b/api/src/pcapi/core/providers/titelive_book_search.py
@@ -255,7 +255,6 @@ def build_book_extra_data(article: TiteLiveBookArticle, authors: list) -> offers
         dispo_label=article.libelledispo,
         dispo=article.dispo,
         distributeur=article.distributeur,
-        ean=article.gencod,
         editeur=article.editeur,
         gtl_id=gtl_id,
         langue=article.langue,

--- a/api/src/pcapi/core/providers/titelive_music_search.py
+++ b/api/src/pcapi/core/providers/titelive_music_search.py
@@ -151,7 +151,6 @@ def build_music_extra_data(
         date_parution=article.dateparution.isoformat() if article.dateparution else None,
         dispo=article.dispo,
         distributeur=article.distributeur,
-        ean=article.gencod,
         editeur=article.editeur,
         gtl_id=gtl_id,
         musicSubType=str(music_subtype.code),


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35343

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
