### PR TITLE
(BSR)[BO] fix: correctly display 'move offer' button's label in collective offer v2 page

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details_v2.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details_v2.html
@@ -13,7 +13,7 @@
     {{ action_bar_button("hand-thumbs-up", "Valider", modal_id="#validate-collective-offer-modal-" + collective_offer.id|string) }}
     {{ action_bar_button("hand-thumbs-down", "Rejeter", modal_id="#reject-collective-offer-modal-" + collective_offer.id|string) }}
     {% if move_offer_form %}
-      {{ action_bar_button("hand-thumbs-down", "Rejeter", modal_id="#move-collective-offer-modal-" + collective_offer.id|string) }}
+      {{ action_bar_button("arrow-left-right", "Déplacer l'offre", modal_id="#move-collective-offer-modal-" + collective_offer.id|string) }}
     {% endif %}
   {% endif %}
 {% endblock action_buttons %}

--- a/api/tests/routes/backoffice/collective_offer_details_test.py
+++ b/api/tests/routes/backoffice/collective_offer_details_test.py
@@ -427,3 +427,17 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
 
         descriptions = html_parser.extract_descriptions(response.data)
         assert descriptions["Entité juridique"] == "Offerer Top Acteur"
+
+    @pytest.mark.features(MOVE_OFFER_TEST=True)
+    def test_move_offer(self, authenticated_client):
+        offerer = offerers_factories.OffererFactory()
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
+        collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
+
+        url = url_for(self.endpoint, collective_offer_id=collective_offer.id)
+
+        response = authenticated_client.get(url)
+        assert response.status_code == 200
+
+        buttons = html_parser.extract(response.data, "button")
+        assert "Déplacer l'offre" in buttons


### PR DESCRIPTION

## But de la pull request

Corriger le label du bouton "Déplacer l'offre" dans la page "Détails de l'offre collective"

Avant : 

<img width="575" alt="Capture d’écran 2025-04-14 à 11 45 57" src="https://github.com/user-attachments/assets/0f8e08fc-eb78-4fde-9a16-d0cf0b20285a" />


Après : 

<img width="633" alt="Capture d’écran 2025-04-14 à 11 46 24" src="https://github.com/user-attachments/assets/092e4a70-c9de-4edd-8e99-29a704e0a36a" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
