### PR TITLE
(BSR)[BO] fix: Init move collective offer form only once

### DIFF
--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -27,7 +27,6 @@ from pcapi.core.finance import models as finance_models
 from pcapi.core.mails import transactional as transactional_mails
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers import repository as offerers_repository
-from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
@@ -728,20 +727,6 @@ def get_collective_offer_details(collective_offer_id: int) -> utils.BackofficeRe
         flash("Cette offre collective n'existe pas", "warning")
         return redirect(url_for("backoffice_web.collective_offer.list_collective_offers"), code=303)
 
-    move_offer_form = None
-    if feature.FeatureToggle.MOVE_OFFER_TEST.is_active():
-        try:
-            venue_choices = offerers_repository.get_offerers_venues_with_pricing_point(
-                collective_offer.venue,
-                include_without_pricing_points=True,
-                only_similar_pricing_points=True,
-                filter_same_bank_account=True,
-            )
-            move_offer_form = forms.MoveCollectiveOfferForm()
-            move_offer_form.set_venue_choices(venue_choices)
-        except offers_exceptions.NoDestinationVenue:
-            pass
-
     is_collective_offer_price_editable = _is_collective_offer_price_editable(collective_offer)
 
     connect_as = get_connect_as(
@@ -758,7 +743,6 @@ def get_collective_offer_details(collective_offer_id: int) -> utils.BackofficeRe
         ),
         collective_offer=collective_offer,
         is_collective_offer_price_editable=is_collective_offer_price_editable,
-        move_offer_form=move_offer_form,
         connect_as=connect_as,
     )
 

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -35,7 +35,7 @@
                     <button class="btn btn-outline-primary lead fw-bold mt-2">Rejeter l'offre</button>
                   </a>
                   {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_reject_collective_offer_form', collective_offer_id=collective_offer.id) , "reject-collective-offer-modal-" + collective_offer.id|string) }}
-                  {% if move_offer_form %}
+                  {% if is_feature_active("MOVE_OFFER_TEST") %}
                     <a class=" px-3"
                        data-bs-toggle="modal"
                        data-bs-target="#move-collective-offer-modal-{{ collective_offer.id }}">


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

Suppression de la double initialisation du formulaire de déplacement d'offre collective.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
