### PR TITLE
(BSR)[BO] test: timeout experimentation

### DIFF
--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -250,6 +250,12 @@ def mark_4xx_as_invalid(response: flask.Response) -> flask.Response:
 
 @app.teardown_request
 def remove_db_session(exc: BaseException | None = None) -> None:
+    logger.info(
+        "remove db session",
+        extra={
+            "route": request.path,
+        },
+    )
     try:
         db.session.remove()
     except Exception as exception:  # pylint: disable=broad-exception-caught
@@ -265,6 +271,12 @@ def remove_db_session(exc: BaseException | None = None) -> None:
 @app.teardown_request
 def teardown_atomic(exc: BaseException | None = None) -> None:
     if app.config.get("USE_GLOBAL_ATOMIC", False):
+        logger.info(
+            "teardown atomic",
+            extra={
+                "route": request.path,
+            },
+        )
         try:
             if exc:
                 repository.mark_transaction_as_invalid()

--- a/api/src/pcapi/routes/backoffice/home.py
+++ b/api/src/pcapi/routes/backoffice/home.py
@@ -1,3 +1,6 @@
+import logging
+import time
+
 from flask import redirect
 from flask import render_template
 from flask import request
@@ -16,6 +19,8 @@ from pcapi.models import offer_mixin
 from . import blueprint
 from . import utils
 
+
+logger = logging.getLogger(__name__)
 
 REDIRECT_AFTER_LOGIN_COOKIE_NAME = "redirect_after_login"
 
@@ -145,3 +150,45 @@ def home() -> utils.BackofficeResponse:
         data.update(stats._mapping)
 
     return render_template("home/home.html", **data)
+
+
+@blueprint.backoffice_web.route("/test/python", methods=["GET"])
+def python_timeout() -> utils.BackofficeResponse:
+    timeout = int(request.args.get("timeout", 60))
+    logger.info(
+        "starting python timeout",
+        extra={
+            "timeout": timeout,
+            "route": request.path,
+        },
+    )
+    time.sleep(timeout)
+    logger.info(
+        "python timeout done",
+        extra={
+            "timeout": timeout,
+            "route": request.path,
+        },
+    )
+    return f"executed python timeout {timeout}"
+
+
+@blueprint.backoffice_web.route("/test/sql", methods=["GET"])
+def sql_timeout() -> utils.BackofficeResponse:
+    timeout = int(request.args.get("timeout", 60))
+    logger.info(
+        "starting python timeout",
+        extra={
+            "timeout": timeout,
+            "route": request.path,
+        },
+    )
+    db.session.execute(f"SELECT pg_sleep({timeout})")
+    logger.info(
+        "python timeout done",
+        extra={
+            "timeout": timeout,
+            "route": request.path,
+        },
+    )
+    return f"executed sql timeout {timeout}"

--- a/api/tests/routes/backoffice/redirect_test.py
+++ b/api/tests/routes/backoffice/redirect_test.py
@@ -82,6 +82,7 @@ class SafeRedirectTest:
         mock_check_url_is_safe.assert_called_once_with(url)
         mock_request_url_scan.assert_not_called()
 
+    @pytest.mark.skip(reason="not compatible with experimentation")
     @pytest.mark.parametrize(
         "exception,reason",
         [


### PR DESCRIPTION
## But de la pull request

Experimentation sur le comportement effectif de gunicorn dans notre deployment en cas de timeout 

Cette PR n'arrivera pas en staging et sera revert avant la MES. La qualité de code et la maintenabilité sont donc sans objets


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
