### PR TITLE
(BSR)[BO] fix: Mise à jour collective offer template V1 et V2 pour afficher l'option "déplacer l'offre" correctement

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -39,7 +39,7 @@
                     <a class=" px-3"
                        data-bs-toggle="modal"
                        data-bs-target="#move-collective-offer-modal-{{ collective_offer.id }}">
-                      <button class="btn btn-outline-primary lead fw-bold mt-2">Changer le partenaire culturel</button>
+                      <button class="btn btn-outline-primary lead fw-bold mt-2">Déplacer l'offre</button>
                     </a>
                     {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_move_collective_offer_form', collective_offer_id=collective_offer.id) , "move-collective-offer-modal-" + collective_offer.id|string) }}
                   {% endif %}

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details_v2.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details_v2.html
@@ -13,7 +13,7 @@
   {% if has_permission("PRO_FRAUD_ACTIONS") %}
     {{ action_bar_button("hand-thumbs-up", "Valider", modal_id="#validate-collective-offer-modal-" + collective_offer.id|string) }}
     {{ action_bar_button("hand-thumbs-down", "Rejeter", modal_id="#reject-collective-offer-modal-" + collective_offer.id|string) }}
-    {% if move_offer_form %}
+    {% if is_feature_active("MOVE_OFFER_TEST") %}
       {{ action_bar_button("arrow-left-right", "Déplacer l'offre", modal_id="#move-collective-offer-modal-" + collective_offer.id|string) }}
     {% endif %}
   {% endif %}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

~~Suppression d'un test pas très pertinent :~~

~~Le test vérifiait la présence du bouton "Changer le partenaire culturel". La condition d'affichage du bouton était sur la présence d'une venue éligible. Ce bouton est désormais présent sous condition FF MOVE_OFFER_TEST = True. Ça devient beaucoup moins pertinent de le tester.~~

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
