### PR TITLE
(PC-35616)[API] fix: batch payload for bulk events

### DIFF
--- a/api/src/pcapi/notifications/push/backends/batch.py
+++ b/api/src/pcapi/notifications/push/backends/batch.py
@@ -173,7 +173,7 @@ class BatchBackend:
 
         payload = [
             {
-                "id": track_event.user_id,
+                "id": str(track_event.user_id),
                 "events": [
                     {
                         "name": f"ue.{track_event.event_name.value}",

--- a/api/src/pcapi/notifications/push/backends/testing.py
+++ b/api/src/pcapi/notifications/push/backends/testing.py
@@ -70,7 +70,7 @@ class TestingBackend(LoggerBackend):
 
         payload = [
             {
-                "id": track_event.user_id,
+                "id": str(track_event.user_id),
                 "events": [
                     {
                         "name": f"ue.{track_event.event_name.value}",

--- a/api/src/pcapi/notifications/push/trigger_events.py
+++ b/api/src/pcapi/notifications/push/trigger_events.py
@@ -11,7 +11,7 @@ class BatchEvent(enum.Enum):
     HAS_UBBLE_KO_STATUS = "has_ubble_ko_status"
     HAS_BOOKED_OFFER = "has_booked_offer"
     RECREDIT_ACCOUNT_CANCELLATION = "recredit_account_cancellation"
-    FUTURE_OFFER_ACTIVATED = "Future_offer_activated"
+    FUTURE_OFFER_ACTIVATED = "future_offer_activated"
 
 
 class TrackBatchEventRequest(BaseModel):

--- a/api/tests/core/reminders/external/test_reminders_notifications.py
+++ b/api/tests/core/reminders/external/test_reminders_notifications.py
@@ -70,24 +70,25 @@ class NotifyUsersFutureOfferActivatedTest:
         }
         expected_payload = [
             {
-                "id": user_1.id,
+                "id": str(user_1.id),
                 "events": [
                     {
-                        "name": "ue.Future_offer_activated",
+                        "name": "ue.future_offer_activated",
                         "attributes": offer_attributes,
                     }
                 ],
             },
             {
-                "id": user_2.id,
+                "id": str(user_2.id),
                 "events": [
                     {
-                        "name": "ue.Future_offer_activated",
+                        "name": "ue.future_offer_activated",
                         "attributes": offer_attributes,
                     }
                 ],
             },
         ]
+
         future_offer_activated_event = next(event for event in push_testing.requests)
         event_payload = future_offer_activated_event["payload"]
         assert event_payload == expected_payload


### PR DESCRIPTION
## But de la pull request
Corriger la payload que l'on envoie à Batch pour les track events en bulk. L'id du user doit être une string et non un integer, il faut que je lise mieux les docs (je le copierai 100 fois) https://doc.batch.com/developer/api/mep/trigger-events-api/track-events#bulk-tracking

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35616

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
