### PR TITLE
(BSR)[BO] fix: 'move offer' modal in collective offer details v2 page

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details_v2.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details_v2.html
@@ -135,7 +135,7 @@
   {% if has_permission("PRO_FRAUD_ACTIONS") %}
     {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_validate_collective_offer_form', collective_offer_id=collective_offer.id) , "validate-collective-offer-modal-" + collective_offer.id|string) }}
     {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_reject_collective_offer_form', collective_offer_id=collective_offer.id) , "reject-collective-offer-modal-" + collective_offer.id|string) }}
-    {% if move_offer_form %}
+    {% if is_feature_active("MOVE_OFFER_TEST") %}
       {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_move_collective_offer_form', collective_offer_id=collective_offer.id) , "move-collective-offer-modal-" + collective_offer.id|string) }}
     {% endif %}
   {% endif %}

--- a/api/tests/routes/backoffice/collective_offer_details_test.py
+++ b/api/tests/routes/backoffice/collective_offer_details_test.py
@@ -441,3 +441,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
 
         buttons = html_parser.extract(response.data, "button")
         assert "Déplacer l'offre" in buttons
+        assert (
+            html_parser.get_tag(response.data, tag="div", id=f"move-collective-offer-modal-{collective_offer.id}")
+            is not None
+        )

--- a/api/tests/routes/backoffice/helpers/html_parser.py
+++ b/api/tests/routes/backoffice/helpers/html_parser.py
@@ -4,6 +4,9 @@ import typing
 from bs4 import BeautifulSoup
 
 
+sentinel = ...
+
+
 def _filter_whitespaces(text: str) -> str:
     return re.sub(r"\s+", " ", text.strip())
 
@@ -143,12 +146,14 @@ def extract_alert(html_content: str, raise_if_not_found: bool = True) -> str | N
     return _filter_whitespaces(alert.text)
 
 
-def get_tag(html_content: str, class_: str, tag: str = "div", **attrs: typing.Any) -> str:
+def get_tag(html_content: str, class_: str = sentinel, tag: str = "div", **attrs: typing.Any) -> str:
     """
     Find a tag given its class
     """
     soup = get_soup(html_content)
-    found_tag = soup.find(tag, class_=class_, **attrs)
+    if class_ is not sentinel:
+        attrs["class_"] = class_
+    found_tag = soup.find(tag, **attrs)
     assert found_tag is not None
 
     return found_tag.encode("utf-8")


### PR DESCRIPTION
## But de la pull request

Fix de l'affichage de la modal "déplacer l'offre" dans la page détails de l'offre collective v2

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
