### PR TITLE
(PC-35331)[API] script: delete two special events

### DIFF
--- a/api/src/pcapi/scripts/delete_special_event/main.py
+++ b/api/src/pcapi/scripts/delete_special_event/main.py
@@ -1,0 +1,24 @@
+from pcapi.app import app
+from pcapi.core.operations import models
+from pcapi.repository.session_management import atomic
+
+
+ID_TO_DELETE = (15, 16)
+
+
+@atomic()
+def delete_events() -> None:
+    response_query = models.SpecialEventResponse.query.filter(models.SpecialEventResponse.eventId.in_(ID_TO_DELETE))
+    models.SpecialEventAnswer.query.filter(
+        models.SpecialEventAnswer.responseId.in_(response_query.with_entities(models.SpecialEventResponse.id))
+    ).delete(synchronize_session=False)
+    response_query.delete(synchronize_session=False)
+    models.SpecialEventQuestion.query.filter(models.SpecialEventQuestion.eventId.in_(ID_TO_DELETE)).delete(
+        synchronize_session=False
+    )
+    models.SpecialEvent.query.filter(models.SpecialEvent.id.in_(ID_TO_DELETE)).delete(synchronize_session=False)
+
+
+if __name__ == "__main__":
+    with app.app_context():
+        delete_events()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35331

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
