### PR TITLE
(BSR)[API] fix: correctly test get offer api endpoint (test_returns_an_event_stock_with_opening_hours)

### DIFF
--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -232,6 +232,7 @@ class Returns200Test:
             "withdrawalDelay": 60 * 30,
         }
 
+    @time_machine.travel("2025-04-14 12:00:00", tick=False)
     def test_returns_an_event_stock_with_opening_hours(self, client):
         user_offerer = offerers_factories.UserOffererFactory()
         offer = offers_factories.EventOfferFactory(venue__managingOfferer=user_offerer.offerer)
@@ -269,8 +270,8 @@ class Returns200Test:
                 "SATURDAY": [{"open": "10:00:00", "close": "13:00:00"}, {"open": "14:00:00", "close": "19:30:00"}],
                 "SUNDAY": [{"open": "10:00:00", "close": "13:00:00"}, {"open": "14:00:00", "close": "19:30:00"}],
             },
-            "startDatetime": datetime.strftime(start, "%Y-%m-%dT%H:%M:%S.%fZ"),
-            "endDatetime": datetime.strftime(end, "%Y-%m-%dT%H:%M:%S.%fZ"),
+            "startDatetime": datetime.strftime(start, "%Y-%m-%dT%H:%M:%SZ"),
+            "endDatetime": datetime.strftime(end, "%Y-%m-%dT%H:%M:%SZ"),
         }
 
     @time_machine.travel("2019-10-15 00:00:00")


### PR DESCRIPTION
## But de la pull request

Correction du test `test_returns_an_event_stock_with_opening_hours`


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
