### PR TITLE
(PC-35639)[API] fix: cannot set stock date in the past

### DIFF
--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -19,7 +19,6 @@ from pcapi.models.api_errors import ResourceGoneError
 from pcapi.repository import transaction
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import stock_serialize
-from pcapi.serialization import utils as serialization_utils
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils.rest import check_user_has_access_to_offerer
 
@@ -134,16 +133,8 @@ def upsert_stocks(body: stock_serialize.StocksUpsertBodyModel) -> stock_serializ
                         existing_stocks[stock_to_edit.id],
                         price=stock_to_edit.price,
                         quantity=stock_to_edit.quantity,
-                        beginning_datetime=(
-                            serialization_utils.as_utc_without_timezone(stock_to_edit.beginning_datetime)
-                            if stock_to_edit.beginning_datetime
-                            else None
-                        ),
-                        booking_limit_datetime=(
-                            serialization_utils.as_utc_without_timezone(stock_to_edit.booking_limit_datetime)
-                            if stock_to_edit.booking_limit_datetime
-                            else None
-                        ),
+                        beginning_datetime=stock_to_edit.beginning_datetime,
+                        booking_limit_datetime=stock_to_edit.booking_limit_datetime,
                         price_category=price_categories.get(stock_to_edit.price_category_id, None),
                     )
                     if edited_stock:

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -484,13 +484,24 @@ def _create_or_update_ean_offers(
                 # FIXME (mageoffray, 2023-05-26): stock upserting optimisation
                 # Stocks are edited one by one for now, we need to improve edit_stock to remove the repository.session.add()
                 # It will be done before the release of this API
+
+                # TODO(jbaudet-pass): remove call to .replace(): it should not
+                # be needed.
+                # Why? Because input checks remove the timezone information as
+                # it is not expected after... but StockEdition needs a
+                # timezone-aware datetime object.
+                # -> datetimes are not always handleded the same way.
+                # -> it can be messy.
+                booking_limit = stock_data["booking_limit_datetime"]
+                booking_limit = booking_limit.replace(tzinfo=datetime.timezone.utc) if booking_limit else None
+
                 _upsert_product_stock(
                     offer_to_update_by_ean[ean],
                     serialization.StockEdition(
                         **{
                             "price": stock_data["price"],
                             "quantity": stock_data["quantity"],
-                            "booking_limit_datetime": stock_data["booking_limit_datetime"],
+                            "booking_limit_datetime": booking_limit,
                         }
                     ),
                     provider,

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -458,6 +458,8 @@ class BaseStockEdition(serialization.ConfiguredBaseModel):
     booking_limit_datetime: datetime.datetime | None = fields.BOOKING_LIMIT_DATETIME
     quantity: pydantic_v1.StrictInt | UNLIMITED_LITERAL | None = fields.QUANTITY
 
+    _validate_booking_limit_datetime = serialization_utils.validate_datetime("booking_limit_datetime")
+
     @pydantic_v1.validator("quantity")
     def quantity_must_be_in_range(cls, quantity: int | str | None) -> int | str | None:
         if isinstance(quantity, int):
@@ -660,11 +662,7 @@ class EventStockEdition(BaseStockEdition):
     price_category_id: int | None = fields.PRICE_CATEGORY_ID
     id_at_provider: str | None = fields.ID_AT_PROVIDER_WITH_MAX_LENGTH
 
-    @pydantic_v1.validator("beginning_datetime")
-    def format_beginning_datetime(cls, value: datetime.datetime | None) -> datetime.datetime | None:
-        if not value:
-            return None
-        return serialization_utils.as_utc_without_timezone(value)
+    _validate_beginning_datetime = serialization_utils.validate_datetime("beginning_datetime")
 
 
 class EventOfferEdition(OfferEditionBase):

--- a/api/src/pcapi/routes/serialization/stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/stock_serialize.py
@@ -7,6 +7,7 @@ from pydantic.v1 import validator
 from pcapi.core.offers import models
 import pcapi.core.offers.validation as offers_validation
 from pcapi.routes.serialization import BaseModel
+import pcapi.serialization.utils as serialization_utils
 from pcapi.serialization.utils import to_camel
 from pcapi.utils.date import format_into_utc_date
 
@@ -23,6 +24,12 @@ class StockCreationBodyModel(BaseModel):
     price_category_id: int | None
     quantity: int | None = Field(None, ge=0, le=models.Stock.MAX_STOCK_QUANTITY)
 
+    _validate_beginning_datetime = serialization_utils.validate_datetime("beginning_datetime")
+    _validate_booking_limit_datetime = serialization_utils.validate_datetime("booking_limit_datetime")
+    _validate_activation_codes_expiration_datetime = serialization_utils.validate_datetime(
+        "activation_codes_expiration_datetime"
+    )
+
     class Config:
         alias_generator = to_camel
         json_encoders = {datetime: format_into_utc_date}
@@ -36,6 +43,9 @@ class StockEditionBodyModel(BaseModel):
     price: decimal.Decimal | None
     price_category_id: int | None
     quantity: int | None = Field(None, ge=0, le=models.Stock.MAX_STOCK_QUANTITY)
+
+    _validate_beginning_datetime = serialization_utils.validate_datetime("beginning_datetime")
+    _validate_booking_limit_datetime = serialization_utils.validate_datetime("booking_limit_datetime")
 
     class Config:
         alias_generator = to_camel


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35639

Limiter la modification des dates de stocks : ne pas permettre de renseigner une (nouvelle) date dans le passé.
Ce fix concerne le portail PRO et l'API publique.
