### PR TITLE
(PC-35634)[API] feat: Venue attachment only for collectivity

### DIFF
--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -155,6 +155,7 @@ class FeatureToggle(enum.Enum):
     WIP_RESTRICT_VENUE_CREATION_TO_COLLECTIVITY = (
         "Autoriser l'ajout de nouvelle structure seulement pour les collectivités"
     )
+    WIP_RESTRICT_VENUE_ATTACHMENT_TO_COLLECTIVITY = "Autoriser le rattachement seulement pour les collectivités"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -229,6 +230,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_ENABLE_NEW_FINANCE_WORKFLOW,
     FeatureToggle.WIP_ENABLE_PRO_DIDACTIC_ONBOARDING_AB_TEST,
     FeatureToggle.WIP_IS_OPEN_TO_PUBLIC,
+    FeatureToggle.WIP_RESTRICT_VENUE_ATTACHMENT_TO_COLLECTIVITY,
     FeatureToggle.WIP_RESTRICT_VENUE_CREATION_TO_COLLECTIVITY,
     FeatureToggle.WIP_UBBLE_V2,
     # Please keep alphabetic order

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -159,8 +159,11 @@ def create_offerer(body: offerers_serialize.CreateOffererQueryModel) -> offerers
         # a large part of `user_offerer` business logic (see `api.create_offerer` below)
         # That check is needed here. Otherwise, we might try to create an already existing user_offerer
         raise ApiErrors(errors={"user_offerer": ["This user already belongs to this offerer"]})
-    user_offerer = api.create_offerer(current_user, body)
 
+    try:
+        user_offerer = api.create_offerer(current_user, body)
+    except offerers_exceptions.NotACollectivity:
+        raise ApiErrors(errors={"user_offerer": ["Attachment is allowed only for collectivity"]})
     return offerers_serialize.PostOffererResponseModel.from_orm(user_offerer.offerer)
 
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35634

New FF WIP_RESTRICT_VENUE_ATTACHEMENT_TO_COLLECTIVITY

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
