### PR TITLE
(BSR)[API] fix: opening hours: some variables were... not... defined...

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -2112,7 +2112,7 @@ def update_event_opening_hours(
 
     Warning: no update nor insert will be committed by this function.
     """
-    offers_validation.check_event_opening_hours_can_be_updated(offer, opening_hours, body)
+    offers_validation.check_event_opening_hours_can_be_updated(event.offer, event, update_body)
 
     if update_body.startDatetime:
         event.startDatetime = update_body.startDatetime


### PR DESCRIPTION
## But de la pull request

Il semblerait qu'une PR a été terminée un peu vite... avant que certaines vérifications ne soient lancées.
Je ne dirai bien évidemment pas par qui.

Cette PR vient réparer cette erreur : certaines variables dans une obscure fonction n'étaient pas définies, ce qui provoque un *léger* dysfonctionnement.
