### PR TITLE
(PC-35707) fix: do not deserialize unused ubble field

### DIFF
--- a/api/src/pcapi/connectors/serialization/ubble_serializers.py
+++ b/api/src/pcapi/connectors/serialization/ubble_serializers.py
@@ -77,7 +77,6 @@ class UbbleV2IdentificationResponse(pydantic_v1.BaseModel):
     external_applicant_id: str | None
     user_journey_id: str
     status: UbbleIdentificationStatus
-    declared_data: UbbleDeclaredData
     links: UbbleLinks = pydantic_v1.Field(alias="_links")
     documents: list[UbbleDocument]
     response_codes: list[UbbleResponseCode]


### PR DESCRIPTION
`declared_data` must be sent to Ubble but we do not do anything with this field. This field can be missing when the identity check is cancelled, so we do not deserialize it to avoid crashing.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35707
