### PR TITLE
(PC-35702)[API] fix: use cursor instead of offset for pagination in Sirene API

### DIFF
--- a/api/tests/connectors/sirene_test.py
+++ b/api/tests/connectors/sirene_test.py
@@ -314,12 +314,12 @@ def test_error_handling_on_non_json_response():
 def test_get_siren_closed_at_date():
     with requests_mock.Mocker() as mock:
         mock.get(
-            "https://api.insee.fr/entreprises/sirene/V3.11/siren?q=dateDernierTraitementUniteLegale:2025-01-21+AND+periode(etatAdministratifUniteLegale:C+AND+changementEtatAdministratifUniteLegale:true)&champs=siren,dateDebut,dateFin,etatAdministratifUniteLegale&debut=0&nombre=1000",
+            "https://api.insee.fr/entreprises/sirene/V3.11/siren?q=dateDernierTraitementUniteLegale:2025-01-21+AND+periode(etatAdministratifUniteLegale:C+AND+changementEtatAdministratifUniteLegale:true)&champs=siren,dateDebut,dateFin,etatAdministratifUniteLegale&curseur=*&nombre=1000",
             status_code=200,
             json=sirene_test_data.RESPONSE_CLOSED_SIREN_PAGE1,
         )
         mock.get(
-            "https://api.insee.fr/entreprises/sirene/V3.11/siren?q=dateDernierTraitementUniteLegale:2025-01-21+AND+periode(etatAdministratifUniteLegale:C+AND+changementEtatAdministratifUniteLegale:true)&champs=siren,dateDebut,dateFin,etatAdministratifUniteLegale&debut=3&nombre=1000",
+            "https://api.insee.fr/entreprises/sirene/V3.11/siren?q=dateDernierTraitementUniteLegale:2025-01-21+AND+periode(etatAdministratifUniteLegale:C+AND+changementEtatAdministratifUniteLegale:true)&champs=siren,dateDebut,dateFin,etatAdministratifUniteLegale&curseur=AoEpODg5Mjg4Mzc5&nombre=1000",
             status_code=200,
             json=sirene_test_data.RESPONSE_CLOSED_SIREN_PAGE2,
         )

--- a/api/tests/connectors/sirene_test_data.py
+++ b/api/tests/connectors/sirene_test_data.py
@@ -1019,6 +1019,8 @@ RESPONSE_CLOSED_SIREN_PAGE1 = {
         "total": 5,
         "debut": 0,
         "nombre": 3,
+        "curseur": "*",
+        "curseurSuivant": "AoEpODg5Mjg4Mzc5",
     },
     "unitesLegales": [
         {
@@ -1055,6 +1057,8 @@ RESPONSE_CLOSED_SIREN_PAGE2 = {
         "total": 5,
         "debut": 3,
         "nombre": 2,
+        "curseur": "AoEpODg5Mjg4Mzc5",
+        "curseurSuivant": "AoEpODg5Mjg4Mzc5",
     },
     "unitesLegales": [
         {


### PR DESCRIPTION
Otherwise, it fails after 10000th result with error 400: {
  "header": {
    "statut": 400,
    "message": "valeur maximale pour le paramètre debut: 10000. Récupérez les fichiers exhaustifs sur https:\\www.data.gouv.fr ou utilisez la fonctionnalité curseur."
  }
}

Documentation: https://www.sirene.fr/static-resources/documentation/multi_pagination_curseur_311.html

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-35702

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
