### PR TITLE
(BSR)[API] fix: Fix sandbox, remove reuse mediation

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/utils/storage_utils.py
+++ b/api/src/pcapi/sandboxes/scripts/utils/storage_utils.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 
 from pcapi.connectors.thumb_storage import create_thumb
-from pcapi.core.object_storage import FileNotFound
-from pcapi.core.object_storage import get_public_object
 from pcapi.core.object_storage import store_public_object
 from pcapi.models import Model
 import pcapi.sandboxes
@@ -12,11 +10,6 @@ from pcapi.utils.human_ids import humanize
 def store_public_object_from_sandbox_assets(folder: str, model: Model, subcategory_id: str) -> Model:
     mimes_by_folder = {"spreadsheets": "application/CSV", "thumbs": "image/jpeg", "zips": "application/zip"}
     thumb_id = humanize(model.id)
-    try:
-        get_public_object(folder, model.thumb_path_component + "/" + thumb_id)
-        return model
-    except FileNotFound:
-        pass
     thumbs_folder_path = Path(pcapi.sandboxes.__path__[0]) / "thumbs"
     picture_path = str(thumbs_folder_path / "mediations" / subcategory_id) + ".jpg"
     with open(picture_path, mode="rb") as thumb_file:


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

Suppression de l'option de réutilisation des mediations du bucket lors de la création de la sandbox.  

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
