### PR TITLE
(BSR)[API] fix: add missing atomic in collective public api PATCH

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -224,6 +224,7 @@ def post_collective_offer_public(
 
 
 @blueprints.public_api.route("/v2/collective/offers/<int:offer_id>", methods=["PATCH"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,

--- a/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
@@ -36,6 +36,10 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
     endpoint_method = "patch"
     default_path_params = {"offer_id": 1}
 
+    def test_should_raise_401_because_api_key_not_linked_to_provider(self, client):
+        num_queries = 2  # Select API key + rollback
+        super().test_should_raise_401_because_api_key_not_linked_to_provider(client, num_queries=num_queries)
+
     def test_should_raise_404_because_has_no_access_to_venue(self, client):
         pass
 
@@ -1180,6 +1184,10 @@ class UpdateOfferVenueTest(PublicAPIVenueEndpointHelper):
     endpoint_method = "patch"
     default_path_params = {"offer_id": 1}
 
+    def test_should_raise_401_because_api_key_not_linked_to_provider(self, client):
+        num_queries = 2  # Select API key + rollback
+        super().test_should_raise_401_because_api_key_not_linked_to_provider(client, num_queries=num_queries)
+
     def test_change_to_offerer_venue(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
 
@@ -1456,6 +1464,10 @@ class UpdatePriceTest(PublicAPIVenueEndpointHelper):
     endpoint_url = "/v2/collective/offers/{offer_id}"
     endpoint_method = "patch"
     default_path_params = {"offer_id": 1}
+
+    def test_should_raise_401_because_api_key_not_linked_to_provider(self, client):
+        num_queries = 2  # Select API key + rollback
+        super().test_should_raise_401_because_api_key_not_linked_to_provider(client, num_queries=num_queries)
 
     def test_should_raise_404_because_has_no_access_to_venue(self, client):
         pass


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : la route a été mise à jour mais oubli du décorateur

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
