### PR TITLE
(PC-35792)[BO] fix: exception when clearing latitude/longitude in update venue

### DIFF
--- a/api/src/pcapi/routes/backoffice/venues/forms.py
+++ b/api/src/pcapi/routes/backoffice/venues/forms.py
@@ -65,8 +65,8 @@ class EditVenueForm(EditVirtualVenueForm):
             wtforms.validators.Length(min=1, max=50, message="doit contenir entre %(min)d et %(max)d caractères"),
         ),
     )
-    latitude = fields.PCOptHiddenField("Latitude")
-    longitude = fields.PCOptHiddenField("Longitude")
+    latitude = fields.PCHiddenField("Latitude")
+    longitude = fields.PCHiddenField("Longitude")
     ban_id = fields.PCOptHiddenField("Identifiant Base Adresse Nationale")
     is_manual_address = fields.PCOptHiddenField("Édition manuelle de l'adresse")
     venue_type_code = fields.PCSelectWithPlaceholderValueField(

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -1744,6 +1744,8 @@ class UpdateVenueTest(PostEndpointHelper):
             ("latitude", "98.87004"),
             ("longitude", "2.3785O"),
             ("longitude", "237.850"),
+            ("latitude", ""),
+            ("longitude", ""),
         ],
     )
     def test_update_venue_with_validation_error(self, authenticated_client, field, value):


### PR DESCRIPTION
`TypeError: type NoneType doesn't define __round__ method`

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-35792

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
