### PR TITLE
(PC-35058)[PRO] feat: Hide the opening hours form for ineligible offers.

### DIFF
--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -54,6 +54,7 @@ class SubcategoryResponseModel(BaseModel):
     reimbursement_rule: str
     is_selectable: bool
     can_be_withdrawable: bool
+    can_have_opening_hours: bool
 
     class Config:
         alias_generator = to_camel

--- a/api/tests/routes/pro/get_categories_test.py
+++ b/api/tests/routes/pro/get_categories_test.py
@@ -5,13 +5,14 @@ import pytest
 from pcapi.core.categories import pro_categories
 from pcapi.core.categories.subcategories import ABO_BIBLIOTHEQUE
 from pcapi.core.categories.subcategories import CINE_PLEIN_AIR
+from pcapi.core.categories.subcategories import VISITE
 from pcapi.core.testing import assert_num_queries
 import pcapi.core.users.factories as users_factories
 
 
 @patch(
     "pcapi.core.categories.subcategories.ALL_SUBCATEGORIES",
-    (ABO_BIBLIOTHEQUE, CINE_PLEIN_AIR),
+    (ABO_BIBLIOTHEQUE, CINE_PLEIN_AIR, VISITE),
 )
 @patch(
     "pcapi.core.categories.pro_categories.ALL_CATEGORIES",
@@ -59,6 +60,7 @@ class Returns200Test:
                     "isPhysicalDeposit": True,
                     "reimbursementRule": "STANDARD",
                     "isSelectable": True,
+                    "canHaveOpeningHours": False,
                 },
                 {
                     "id": "CINE_PLEIN_AIR",
@@ -75,6 +77,24 @@ class Returns200Test:
                     "isPhysicalDeposit": False,
                     "reimbursementRule": "STANDARD",
                     "isSelectable": True,
+                    "canHaveOpeningHours": False,
+                },
+                {
+                    "id": "VISITE",
+                    "categoryId": "MUSEE",
+                    "proLabel": "Visite",
+                    "appLabel": "Visite",
+                    "isEvent": True,
+                    "conditionalFields": [],
+                    "canExpire": False,
+                    "canBeDuo": True,
+                    "canBeWithdrawable": False,
+                    "onlineOfflinePlatform": "OFFLINE",
+                    "isDigitalDeposit": False,
+                    "isPhysicalDeposit": False,
+                    "reimbursementRule": "STANDARD",
+                    "isSelectable": True,
+                    "canHaveOpeningHours": True,
                 },
             ],
         }

--- a/pro/src/apiClient/v1/models/SubcategoryResponseModel.ts
+++ b/pro/src/apiClient/v1/models/SubcategoryResponseModel.ts
@@ -7,6 +7,7 @@ export type SubcategoryResponseModel = {
   canBeDuo: boolean;
   canBeWithdrawable: boolean;
   canExpire: boolean;
+  canHaveOpeningHours: boolean;
   categoryId: string;
   conditionalFields: Array<string>;
   id: string;

--- a/pro/src/commons/utils/factories/individualApiFactories.ts
+++ b/pro/src/commons/utils/factories/individualApiFactories.ts
@@ -278,6 +278,7 @@ export const subcategoryFactory = (
   reimbursementRule: REIMBURSEMENT_RULES.STANDARD,
   isSelectable: true,
   canExpire: true,
+  canHaveOpeningHours: false,
   isDigitalDeposit: false,
   isPhysicalDeposit: true,
   ...customSubcategory,

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormMultipleDays/StocksCalendarFormMultipleDays.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormMultipleDays/StocksCalendarFormMultipleDays.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 
 import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import { useIndividualOfferContext } from 'commons/context/IndividualOfferContext/IndividualOfferContext'
 import { weekDays } from 'components/IndividualOffer/StocksEventCreation/form/constants'
 import { StocksCalendarFormValues } from 'components/IndividualOffer/StocksEventCreation/form/types'
 import { Checkbox } from 'ui-kit/formV2/Checkbox/Checkbox'
@@ -31,6 +32,12 @@ export function StocksCalendarFormMultipleDays({
   const hasAtLEastOneWeekDaySelected = form
     .watch('multipleDaysWeekDays')
     .find((d) => d.checked)
+
+  const { subCategories } = useIndividualOfferContext()
+
+  const canHaveNoEndDate = subCategories.find(
+    (cat) => cat.id === offer.subcategoryId
+  )?.canHaveOpeningHours
 
   useEffect(() => {
     //  When the selected dates change, update the checked weekdays
@@ -96,15 +103,17 @@ export function StocksCalendarFormMultipleDays({
           disabled={form.watch('multipleDaysHasNoEndDate')}
         />
 
-        <Checkbox
-          label="Pas de date de fin"
-          className={styles['checkbox-field-layout']}
-          {...form.register('multipleDaysHasNoEndDate')}
-          onChange={async (e) => {
-            form.setValue('multipleDaysEndDate', undefined)
-            await form.register('multipleDaysHasNoEndDate').onChange(e)
-          }}
-        />
+        {canHaveNoEndDate && (
+          <Checkbox
+            label="Pas de date de fin"
+            className={styles['checkbox-field-layout']}
+            {...form.register('multipleDaysHasNoEndDate')}
+            onChange={async (e) => {
+              form.setValue('multipleDaysEndDate', undefined)
+              await form.register('multipleDaysHasNoEndDate').onChange(e)
+            }}
+          />
+        )}
       </div>
 
       {hasEndDateOrNeverEnds && (

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarFormTimeAndPrice.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarFormTimeAndPrice.spec.tsx
@@ -1,8 +1,14 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { FormProvider, useForm } from 'react-hook-form'
 
-import { getIndividualOfferFactory } from 'commons/utils/factories/individualApiFactories'
+import { api } from 'apiClient/api'
+import { SubcategoryIdEnum } from 'apiClient/v1'
+import { IndividualOfferContextProvider } from 'commons/context/IndividualOfferContext/IndividualOfferContext'
+import {
+  getIndividualOfferFactory,
+  subcategoryFactory,
+} from 'commons/utils/factories/individualApiFactories'
 import { renderWithProviders } from 'commons/utils/renderWithProviders'
 import {
   DurationTypeOption,
@@ -12,8 +18,17 @@ import {
 
 import { StocksCalendarFormTimeAndPrice } from './StocksCalendarFormTimeAndPrice'
 
+vi.mock('apiClient/api', () => ({
+  api: {
+    getCategories: vi.fn(),
+  },
+}))
+
 function renderStocksCalendarFormTimeAndPrice(
-  defaultOptions?: Partial<StocksCalendarFormValues>
+  defaultOptions?: Partial<StocksCalendarFormValues>,
+  offer = getIndividualOfferFactory({
+    subcategoryId: SubcategoryIdEnum.SALON,
+  })
 ) {
   function StocksCalendarFormTimeAndPriceWrapper() {
     const form = useForm<StocksCalendarFormValues>({
@@ -28,12 +43,11 @@ function renderStocksCalendarFormTimeAndPrice(
     })
 
     return (
-      <FormProvider {...form}>
-        <StocksCalendarFormTimeAndPrice
-          form={form}
-          offer={getIndividualOfferFactory()}
-        />
-      </FormProvider>
+      <IndividualOfferContextProvider>
+        <FormProvider {...form}>
+          <StocksCalendarFormTimeAndPrice form={form} offer={offer} />
+        </FormProvider>
+      </IndividualOfferContextProvider>
     )
   }
 
@@ -41,8 +55,25 @@ function renderStocksCalendarFormTimeAndPrice(
 }
 
 describe('StocksCalendarFormTimeAndPrice', () => {
-  it('should show a time slot type radio group choice', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'getCategories').mockResolvedValue({
+      categories: [],
+      subcategories: [
+        subcategoryFactory({
+          id: SubcategoryIdEnum.SALON,
+          canHaveOpeningHours: true,
+        }),
+      ],
+    })
+  })
+
+  it('should show a time slot type radio group choice', async () => {
     renderStocksCalendarFormTimeAndPrice()
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
     expect(
       screen.getByLabelText('Le public doit se présenter :')
     ).toBeInTheDocument()
@@ -54,6 +85,11 @@ describe('StocksCalendarFormTimeAndPrice', () => {
       timeSlotType: TimeSlotTypeOption.OPENING_HOURS,
       multipleDaysHasNoEndDate: true,
     })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
     expect(
       screen.queryByText(
         'En n’indiquant pas de date de fin, vous ne pouvez pas choisir l’option horaires précis.'
@@ -67,5 +103,22 @@ describe('StocksCalendarFormTimeAndPrice', () => {
         'En n’indiquant pas de date de fin, vous ne pouvez pas choisir l’option horaires précis.'
       )
     ).toBeInTheDocument()
+  })
+
+  it('should hide the time slot type choice if the offer is not eligible to opening hours', async () => {
+    renderStocksCalendarFormTimeAndPrice(
+      {
+        durationType: DurationTypeOption.MULTIPLE_DAYS_WEEKS,
+      },
+      getIndividualOfferFactory({ subcategoryId: SubcategoryIdEnum.CONFERENCE })
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Chargement en cours')).not.toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByLabelText('Le public doit se présenter :')
+    ).not.toBeInTheDocument()
   })
 })

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarFormTimeAndPrice.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarFormTimeAndPrice.tsx
@@ -1,6 +1,7 @@
 import { UseFormReturn } from 'react-hook-form'
 
 import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
+import { useIndividualOfferContext } from 'commons/context/IndividualOfferContext/IndividualOfferContext'
 import {
   DurationTypeOption,
   StocksCalendarFormValues,
@@ -27,6 +28,26 @@ export function StocksCalendarFormTimeAndPrice({
     form.watch('durationType') === DurationTypeOption.MULTIPLE_DAYS_WEEKS &&
     form.watch('timeSlotType') === TimeSlotTypeOption.SPECIFIC_TIME &&
     form.watch('multipleDaysHasNoEndDate')
+
+  const { subCategories } = useIndividualOfferContext()
+
+  const isOfferEligibleToOpeningHours = subCategories.find(
+    (cat) => cat.id === offer.subcategoryId
+  )?.canHaveOpeningHours
+
+  if (!isOfferEligibleToOpeningHours) {
+    return (
+      <>
+        <div className={styles['time-slots']}>
+          <StocksCalendarFormSpecificTimeSlots form={form} />
+        </div>
+        <StocksCalendarFormPriceCategoryAndLimitDates
+          form={form}
+          offer={offer}
+        />
+      </>
+    )
+  }
 
   return (
     <>
@@ -74,18 +95,34 @@ export function StocksCalendarFormTimeAndPrice({
             )}
           </div>
 
-          <div className={styles['pricing-categories']}>
-            <StocksCalendarPriceCategories
-              form={form}
-              priceCategories={offer.priceCategories}
-            />
-          </div>
-
-          <div className={styles['limit-dates']}>
-            <StocksCalendarLimitDates form={form} />
-          </div>
+          <StocksCalendarFormPriceCategoryAndLimitDates
+            form={form}
+            offer={offer}
+          />
         </>
       )}
+    </>
+  )
+}
+
+function StocksCalendarFormPriceCategoryAndLimitDates({
+  form,
+  offer,
+}: {
+  form: UseFormReturn<StocksCalendarFormValues>
+  offer: GetIndividualOfferWithAddressResponseModel
+}) {
+  return (
+    <>
+      <div className={styles['pricing-categories']}>
+        <StocksCalendarPriceCategories
+          form={form}
+          priceCategories={offer.priceCategories}
+        />
+      </div>
+      <div className={styles['limit-dates']}>
+        <StocksCalendarLimitDates form={form} />
+      </div>
     </>
   )
 }

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTable.spec.tsx
@@ -11,6 +11,12 @@ import {
   StocksCalendarTableProps,
 } from './StocksCalendarTable'
 
+vi.mock('apiClient/api', () => ({
+  api: {
+    getCategories: vi.fn(),
+  },
+}))
+
 function renderStocksCalendarTable(
   props: Partial<StocksCalendarTableProps> = {}
 ) {


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35058

**Objectif**
N'afficher le choix d'horaire "Horaire précis"/"Plage horaire" dans le form de récurrence uniquement quand l'offre a une sous-catégorie éligible.

**FF à activer**
WIP_ENABLE_EVENT_WITH_OPENING_HOUR

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
