### PR TITLE
(PC-35736)[API] feat: offer command: delete old unbookable offers

### DIFF
--- a/api/src/pcapi/core/offers/commands.py
+++ b/api/src/pcapi/core/offers/commands.py
@@ -1,3 +1,5 @@
+import click
+
 import pcapi.core.offers.api as offers_api
 from pcapi.scheduled_tasks.decorators import log_cron_with_transaction
 from pcapi.utils.blueprint import Blueprint
@@ -16,3 +18,12 @@ def activate_future_offers() -> None:
 @log_cron_with_transaction
 def set_upper_timespan_of_inactive_headline_offers() -> None:
     offers_api.set_upper_timespan_of_inactive_headline_offers()
+
+
+@blueprint.cli.command("delete_unbookable_unbooked_old_offers")
+@click.argument("min_offer_id", required=False, type=int, default=0)
+@click.argument("max_offer_id", required=False, type=int, default=None)
+@click.argument("offer_chunk_size", required=False, type=int, default=16)
+@log_cron_with_transaction
+def delete_unbookable_unbooked_old_offers(min_offer_id: int, max_offer_id: int | None, offer_chunk_size: int) -> None:
+    offers_api.delete_unbookable_unbooked_old_offers(min_offer_id, max_offer_id, offer_chunk_size)

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -543,7 +543,7 @@ def delete_thumbnail(offer_id: int) -> None:
 
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
-    offers_api.delete_mediation(offer=offer)
+    offers_api.delete_mediations([offer_id])
 
 
 @private_api.route("/offers/categories", methods=["GET"])


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35736

Ajout d'une commande qui permet de faire du nettoyage dans la table des offres, càd supprimer les offres créées il y a plus d'un an ET qui n'ont pas de stock utilisable (supprimé ou dont la date limite de réservation est dépassée) ET qui n'ont aucune réservation.
