### PR TITLE
bdalbianco/PC-35450: proper error when token is already used

### DIFF
--- a/api/src/pcapi/core/token/__init__.py
+++ b/api/src/pcapi/core/token/__init__.py
@@ -475,8 +475,14 @@ def validate_passwordless_token(token: str) -> dict:
         pipeline.get(redis_key)
         pipeline.delete(redis_key)
         results = pipeline.execute()
-    redis_value = json.loads(results[0])
 
+    if not results[0]:
+        logger.error(
+            "Token doesn’t exist or was already used. Token: %s",
+            token,
+        )
+        raise users_exceptions.InvalidToken
+    redis_value = json.loads(results[0])
     # The below statement are purely defensive code.
     # We should ALWAYS have a perfect match between
     # the payload of the token and what has been stored in the redis queue


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
