### PR TITLE
(PC-35700)[API] feat: New route to send invite again

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2527,6 +2527,20 @@ def invite_member(offerer: models.Offerer, email: str, current_user: users_model
     transactional_mails.send_offerer_attachment_invitation([email], offerer, existing_user)
 
 
+def invite_member_again(offerer: models.Offerer, email: str) -> None:
+    existing_invited_email = (
+        db.session.query(models.OffererInvitation)
+        .filter(models.OffererInvitation.offererId == offerer.id)
+        .filter(models.OffererInvitation.email == email)
+        .one_or_none()
+    )
+
+    if not existing_invited_email or existing_invited_email.status == models.InvitationStatus.ACCEPTED:
+        raise exceptions.InviteAgainImpossibleException()
+
+    transactional_mails.send_offerer_attachment_invitation([email], offerer)
+
+
 def get_offerer_members(offerer: models.Offerer) -> list[tuple[str, OffererMemberStatus]]:
     users_offerers = (
         db.session.query(models.UserOfferer)

--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -146,6 +146,13 @@ class EmailAlreadyInvitedException(ClientError):
         super().__init__("EmailAlreadyInvitedException", "Une invitation a déjà été envoyée à ce collaborateur")
 
 
+class InviteAgainImpossibleException(ClientError):
+    def __init__(self) -> None:
+        super().__init__(
+            "InviteAgainImpossibleException", "Impossible de renvoyer une invitation pour ce collaborateur"
+        )
+
+
 class UserAlreadyAttachedToOffererException(ClientError):
     def __init__(self) -> None:
         super().__init__("UserAlreadyAttachedToOffererException", "Ce collaborateur est déjà membre de votre structure")

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -117,6 +117,19 @@ def invite_member(offerer_id: int, body: offerers_serialize.InviteMemberQueryMod
         raise ApiErrors({"email": "Ce collaborateur est déjà membre de votre structure"})
 
 
+@private_api.route("/offerers/<int:offerer_id>/invite-again", methods=["POST"])
+@atomic()
+@login_required
+@spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
+def invite_member_again(offerer_id: int, body: offerers_serialize.InviteMemberQueryModel) -> None:
+    check_user_has_access_to_offerer(current_user, offerer_id)
+    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    try:
+        api.invite_member_again(offerer, body.email)
+    except offerers_exceptions.InviteAgainImpossibleException:
+        raise ApiErrors({"email": "Impossible de renvoyer une invitation pour ce collaborateur"})
+
+
 @private_api.route("/offerers/<int:offerer_id>/members", methods=["GET"])
 @atomic()
 @login_required

--- a/api/tests/routes/pro/post_offerer_invite_member_again_test.py
+++ b/api/tests/routes/pro/post_offerer_invite_member_again_test.py
@@ -1,0 +1,89 @@
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offerers.models as offerers_models
+import pcapi.core.users.factories as users_factories
+from pcapi.models import db
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns200Test:
+    def test_post_invite_member_again(self, client):
+        pro_user = users_factories.ProFactory(email="pro.user@example.com")
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+        offerers_factories.OffererInvitationFactory(user=pro_user, offerer=offerer, email="new.user@example.com")
+
+        data = {"email": "new.user@example.com"}
+
+        response = client.with_session_auth("pro.user@example.com").post(
+            f"/offerers/{offerer.id}/invite-again", json=data
+        )
+
+        assert response.status_code == 204
+        assert db.session.query(offerers_models.OffererInvitation).one()
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns400Test:
+    def test_invitation_does_not_already_exist(self, client):
+        pro_user = users_factories.ProFactory(email="pro.user@example.com")
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+
+        data = {"email": "new.user@example.com"}
+
+        response = client.with_session_auth("pro.user@example.com").post(
+            f"/offerers/{offerer.id}/invite-again", json=data
+        )
+
+        assert response.status_code == 400
+        assert response.json == {"email": "Impossible de renvoyer une invitation pour ce collaborateur"}
+
+    def test_invitation_is_validated(self, client):
+        pro_user = users_factories.ProFactory(email="pro.user@example.com")
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+        offerers_factories.OffererInvitationFactory(
+            user=pro_user,
+            offerer=offerer,
+            email="new.user@example.com",
+            status=offerers_models.InvitationStatus.ACCEPTED,
+        )
+
+        data = {"email": "new.user@example.com"}
+
+        response = client.with_session_auth("pro.user@example.com").post(
+            f"/offerers/{offerer.id}/invite-again", json=data
+        )
+
+        assert response.status_code == 400
+        assert response.json == {"email": "Impossible de renvoyer une invitation pour ce collaborateur"}
+
+    def test_user_offerer_already_exists(self, client):
+        pro_user = users_factories.ProFactory(email="pro.user@example.com")
+        pro_user2 = users_factories.ProFactory(email="pro.user2@example.com")
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+        offerers_factories.UserOffererFactory(user=pro_user2, offerer=offerer)
+
+        data = {"email": "pro.user2@example.com"}
+
+        response = client.with_session_auth("pro.user@example.com").post(
+            f"/offerers/{offerer.id}/invite-again", json=data
+        )
+
+        assert response.status_code == 400
+        assert response.json == {"email": "Impossible de renvoyer une invitation pour ce collaborateur"}
+
+    def test_user_has_not_access_to_offerer(self, client):
+        pro_user = users_factories.ProFactory(email="pro.user@example.com")
+        offerer = offerers_factories.OffererFactory(id=1)
+        offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
+        offerers_factories.OffererInvitationFactory(user=pro_user, offerer=offerer, email="new.user@example.com")
+
+        data = {"email": "new.user@example.com"}
+
+        response = client.with_session_auth("pro.user@example.com").post("/offerers/2/invite", json=data)
+
+        assert response.status_code == 403

--- a/api/tests/routes/pro/post_offerer_invite_member_test.py
+++ b/api/tests/routes/pro/post_offerer_invite_member_test.py
@@ -26,7 +26,7 @@ class Returns200Test:
 
 @pytest.mark.usefixtures("db_session")
 class Returns400Test:
-    def test_inivitation_already_exists(self, client):
+    def test_invitation_already_exists(self, client):
         pro_user = users_factories.ProFactory(email="pro.user@example.com")
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1484,6 +1484,31 @@ export class DefaultService {
     });
   }
   /**
+   * invite_member_again <POST>
+   * @param offererId
+   * @param requestBody
+   * @returns void
+   * @throws ApiError
+   */
+  public inviteMemberAgain(
+    offererId: number,
+    requestBody?: InviteMemberQueryModel,
+  ): CancelablePromise<void> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/offerers/{offerer_id}/invite-again',
+      path: {
+        'offerer_id': offererId,
+      },
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
    * get_offerer_members <GET>
    * @param offererId
    * @returns GetOffererMembersResponseModel OK


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35700

L'objectif est de proposer une solution simple pour les pro pour renvoyer des invitations perdues.
Seules les invitations "en attente" sans user, ni user offerer associés peuvent être renvoyées.
Une erreur générique est renvoyée au front car le bouton CTA ne sera proposé que si le renvoi est possible.

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
