### PR TITLE
(PC-35347)[API] chore: Enforce NULL values for description, durationM…

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 215ee3f02614 (pre) (head)
-e9cf3954ed3b (post) (head)
+021efec9912b (post) (head)

--- a/api/src/pcapi/alembic/versions/20250423T172540_021efec9912b_add_not_null_constraint_on_offer_productId_validate_step.py
+++ b/api/src/pcapi/alembic/versions/20250423T172540_021efec9912b_add_not_null_constraint_on_offer_productId_validate_step.py
@@ -1,0 +1,22 @@
+"""Add NOT NULL constraint on "offer.productId" VALIDATE step"""
+
+from alembic import op
+from pcapi import settings
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "021efec9912b"
+down_revision = "d565d2035871"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout = '2600s'")
+        op.execute('ALTER TABLE "offer" VALIDATE CONSTRAINT "check_offer_linked_to_product_constraint"')
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/alembic/versions/20250423T172540_d565d2035871_add_not_null_constraint_on_offer_productId_not_valid_step.py
+++ b/api/src/pcapi/alembic/versions/20250423T172540_d565d2035871_add_not_null_constraint_on_offer_productId_not_valid_step.py
@@ -1,0 +1,27 @@
+"""Add NOT NULL constraint on "offer.productId" NOT VALID step"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "d565d2035871"
+down_revision = "e9cf3954ed3b"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE "offer" DROP CONSTRAINT IF EXISTS "check_offer_linked_to_product_constraint";
+        ALTER TABLE "offer" ADD CONSTRAINT "check_offer_linked_to_product_constraint" CHECK (
+            ("productId" IS NOT NULL AND description IS NULL AND "durationMinutes" IS NULL AND ("jsonData" IS NULL OR "jsonData"::text = 'null'))
+            OR "productId" IS NULL
+        ) NOT VALID;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("check_offer_linked_to_product_constraint", table_name="offer")


### PR DESCRIPTION
…inutes, and jsonData in Offer when associated with a Product

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
