### PR TITLE
(BSR)[API] refactor: remove unnecessary validator in public api Patch…

### DIFF
--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -481,12 +481,6 @@ class PatchCollectiveOfferBodyModel(BaseModel):
 
         return shared_offers.validate_students(students)
 
-    @validator("domains")
-    def validate_domains(cls, domains: list[int]) -> list[int]:  # TODO (jcicurel): check these validators
-        if len(domains) == 0:
-            raise ValueError("domains must have at least one value")
-        return domains
-
     @validator("formats")
     def validate_formats(cls, formats: list[EacFormat] | None) -> list[EacFormat]:
         if formats is None or len(formats) == 0:
@@ -506,10 +500,8 @@ class PatchCollectiveOfferBodyModel(BaseModel):
         return description
 
     @validator("domains")
-    def validate_domains_collective_offer_edition(
-        cls, domains: list[int] | None
-    ) -> list[int] | None:  # TODO (jcicurel): check these validators
-        if domains is None or (domains is not None and len(domains) == 0):
+    def validate_domains(cls, domains: list[int] | None) -> list[int]:
+        if domains is None or len(domains) == 0:
             raise ValueError("domains must have at least one value")
 
         return domains


### PR DESCRIPTION
…CollectiveOfferBodyModel

## But de la pull request

Ticket Jira (ou description si BSR) : 

On avait un validateur en trop sur le champ `domains` dans `PatchCollectiveOfferBodyModel`

Au passage, on supprime un test en doublon (`test_patch_offer_invalid_domain`), on ajoute les 2 cas de test domains = `None` et `[]` et on clean des tests qui envoient des champs non nécessaires

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
