### PR TITLE
(BSR)[API] fix: flaky test in sandbox index all offers

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-215ee3f02614 (pre) (head)
+052c063a3fd5 (pre) (head)
 e9cf3954ed3b (post) (head)

--- a/api/src/pcapi/alembic/versions/20250424T082440_052c063a3fd5_add_soft_delete_future_offers.py
+++ b/api/src/pcapi/alembic/versions/20250424T082440_052c063a3fd5_add_soft_delete_future_offers.py
@@ -1,0 +1,24 @@
+"""Add isSoftDeleted column to future_offer model
+add_soft_delete_future_offers
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "052c063a3fd5"
+down_revision = "215ee3f02614"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "future_offer", sa.Column("isSoftDeleted", sa.Boolean(), server_default=sa.text("false"), nullable=False)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("future_offer", "isSoftDeleted")

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -56,6 +56,7 @@ from pcapi.core.providers.constants import TITELIVE_MUSIC_GENRES_BY_GTL_ID
 import pcapi.core.providers.exceptions as providers_exceptions
 import pcapi.core.providers.models as providers_models
 from pcapi.core.providers.repository import get_provider_by_local_class
+from pcapi.core.reminders.external import reminders_notifications
 import pcapi.core.users.models as users_models
 from pcapi.models import db
 from pcapi.models import feature
@@ -543,10 +544,24 @@ def create_event_opening_hours(
     return event_opening_hours
 
 
-def activate_future_offers(publication_date: datetime.datetime | None = None) -> None:
-    query = offers_repository.get_offers_by_publication_date(publication_date=publication_date)
-    query = offers_repository.exclude_offers_from_inactive_venue_provider(query)
-    batch_update_offers(query, {"isActive": True})
+def activate_future_offers(publication_date: datetime.datetime | None = None) -> tuple[list[int], list[int]]:
+    offer_query, future_offer_query = offers_repository.get_offers_by_publication_date(
+        publication_date=publication_date
+    )
+    offer_query = offers_repository.exclude_offers_from_inactive_venue_provider(offer_query)
+    batch_update_offers(offer_query, {"isActive": True})
+    return [offer.id for offer in offer_query], [future_offer.id for future_offer in future_offer_query]
+
+
+def activate_future_offers_and_remind_users() -> None:
+    with transaction():
+        offer_ids, future_offer_ids = activate_future_offers()
+        future_offer_query = db.session.query(models.FutureOffer).filter(models.FutureOffer.id.in_(future_offer_ids))
+        future_offer_query.update({"isSoftDeleted": True}, synchronize_session="fetch")
+
+    for offer_id in offer_ids:
+        offer = db.session.query(models.Offer).get(offer_id)
+        reminders_notifications.notify_users_future_offer_activated(offer=offer)
 
 
 def set_upper_timespan_of_inactive_headline_offers() -> None:

--- a/api/src/pcapi/core/offers/commands.py
+++ b/api/src/pcapi/core/offers/commands.py
@@ -1,5 +1,4 @@
 import pcapi.core.offers.api as offers_api
-from pcapi.core.reminders.external import reminders_notifications
 from pcapi.scheduled_tasks.decorators import log_cron_with_transaction
 from pcapi.utils.blueprint import Blueprint
 
@@ -10,8 +9,7 @@ blueprint = Blueprint(__name__, __name__)
 @blueprint.cli.command("activate_future_offers")
 @log_cron_with_transaction
 def activate_future_offers() -> None:
-    offers_api.activate_future_offers()
-    reminders_notifications.notify_users_for_future_offers_activations()
+    offers_api.activate_future_offers_and_remind_users()
 
 
 @blueprint.cli.command("set_upper_timespan_of_inactive_headline_offers")

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -555,7 +555,7 @@ class EventWeekDayOpeningHours(PcObject, Base, Model):
     )
 
 
-class FutureOffer(PcObject, Base, Model):
+class FutureOffer(PcObject, Base, Model, SoftDeletableMixin):
     __tablename__ = "future_offer"
 
     offerId: int = sa.Column(

--- a/api/src/pcapi/core/reminders/external/reminders_notifications.py
+++ b/api/src/pcapi/core/reminders/external/reminders_notifications.py
@@ -2,20 +2,10 @@ import logging
 
 from pcapi.core.external.batch import send_users_reminders_for_offer
 from pcapi.core.offers.models import Offer
-from pcapi.core.offers.repository import exclude_offers_from_inactive_venue_provider
-from pcapi.core.offers.repository import get_offers_by_publication_date
 from pcapi.core.reminders.repository import get_user_ids_with_reminders
 
 
 logger = logging.getLogger(__name__)
-
-
-def notify_users_for_future_offers_activations() -> None:
-    query = get_offers_by_publication_date()
-    query = exclude_offers_from_inactive_venue_provider(query)
-
-    for offer in query:
-        notify_users_future_offer_activated(offer=offer)
 
 
 def notify_users_future_offer_activated(offer: Offer) -> None:

--- a/api/tests/core/reminders/external/test_reminders_notifications.py
+++ b/api/tests/core/reminders/external/test_reminders_notifications.py
@@ -1,42 +1,12 @@
-from datetime import datetime
-from datetime import timedelta
 import logging
-from unittest.mock import call
-from unittest.mock import patch
 
 import pytest
 
 from pcapi.core.offers import factories as offer_factories
 from pcapi.core.reminders import factories
-from pcapi.core.reminders.external.reminders_notifications import notify_users_for_future_offers_activations
 from pcapi.core.reminders.external.reminders_notifications import notify_users_future_offer_activated
 from pcapi.core.users import factories as users_factories
 from pcapi.notifications.push import testing as push_testing
-
-
-@pytest.mark.usefixtures("db_session")
-class NotifyUsersFutureOffersActivationsTest:
-    def test_notify_users_for_future_offers_activations(self):
-
-        offer = offer_factories.OfferFactory(isActive=False)
-        publication_date = datetime.utcnow() - timedelta(minutes=14)
-        offer_factories.FutureOfferFactory(offer=offer, publicationDate=publication_date)
-
-        offer_2 = offer_factories.OfferFactory(isActive=False)
-        publication_date_2 = datetime.utcnow() - timedelta(minutes=10)
-        offer_factories.FutureOfferFactory(offer=offer_2, publicationDate=publication_date_2)
-
-        offer_3 = offer_factories.OfferFactory(isActive=False)
-        publication_date_3 = datetime.utcnow() - timedelta(minutes=15)
-        offer_factories.FutureOfferFactory(offer=offer_3, publicationDate=publication_date_3)
-
-        with patch(
-            "pcapi.core.reminders.external.reminders_notifications.notify_users_future_offer_activated"
-        ) as notify_users_future_offer_activated_mock:
-            notify_users_for_future_offers_activations()
-            notify_users_future_offer_activated_mock.assert_has_calls(
-                [call(offer=offer), call(offer=offer_2)], any_order=True
-            )
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/sandboxes/scripts/test_save_sandbox.py
+++ b/api/tests/sandboxes/scripts/test_save_sandbox.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from unittest.mock import call
 from unittest.mock import patch
 
 import pytest
@@ -23,4 +24,4 @@ class IndexAllOffersTest:
 
         with patch("pcapi.core.search.reindex_offer_ids") as mock:
             _index_all_offers()
-            mock.assert_called_once_with([offer_1.id, offer_2.id, offer_3.id])
+            mock.assert_has_calls([call([offer_1.id, offer_2.id, offer_3.id])], any_order=True)


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : supprimer la flakyness du test de l'indexation des offres dans la sandbox

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
