### PR TITLE
(BSR)[API] fix: remove unnecessary EmailStrOrEmpty custom field

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -573,19 +573,6 @@ class DateRangeOnCreateModel(DateRangeModel):
         return start
 
 
-from typing import Union
-
-from pydantic.v1.networks import validate_email
-
-
-class EmailStrOrEmpty(EmailStr):
-    @classmethod
-    def validate(cls, value: Union[str]) -> str | None:  # type: ignore[override]
-        if value == "":
-            return None
-        return validate_email(value)[1]
-
-
 class PostCollectiveOfferBodyModel(BaseModel):
     venue_id: int
     name: str
@@ -601,7 +588,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
     # offerVenue will be replaced with location, for now we accept one or the other (but not both)
     offer_venue: CollectiveOfferVenueBodyModel | None
     location: CollectiveOfferLocationModel | None
-    contact_email: EmailStrOrEmpty | None
+    contact_email: EmailStr | None
     contact_phone: str | None
     intervention_area: list[str] | None
     template_id: int | None
@@ -688,7 +675,6 @@ class PostCollectiveOfferBodyModel(BaseModel):
 
 class PostCollectiveOfferTemplateBodyModel(PostCollectiveOfferBodyModel):
     price_detail: PriceDetail | None
-    contact_email: EmailStr | None  # type: ignore[assignment]
     contact_url: AnyHttpUrl | None
     contact_form: educational_models.OfferContactFormEnum | None
     dates: DateRangeOnCreateModel | None

--- a/api/tests/routes/pro/post_collective_offers_test.py
+++ b/api/tests/routes/pro/post_collective_offers_test.py
@@ -520,6 +520,30 @@ class Returns400Test:
         assert response.json == {"bookingEmails": ["Un email doit etre renseigné."]}
         assert models.CollectiveOffer.query.count() == 0
 
+    def test_create_collective_offer_empty_contact_email(self, client):
+        venue = offerers_factories.VenueFactory()
+        offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com")
+
+        data = {**base_offer_payload(venue=venue), "contactEmail": ""}
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
+            response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
+
+        assert response.status_code == 400
+        assert response.json == {"contactEmail": ["Le format d'email est incorrect."]}
+        assert models.CollectiveOffer.query.count() == 0
+
+    def test_create_collective_offer_invalid_contact_email(self, client):
+        venue = offerers_factories.VenueFactory()
+        offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com")
+
+        data = {**base_offer_payload(venue=venue), "contactEmail": "test@test."}
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
+            response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
+
+        assert response.status_code == 400
+        assert response.json == {"contactEmail": ["Le format d'email est incorrect."]}
+        assert models.CollectiveOffer.query.count() == 0
+
     def test_create_collective_offer_no_intervention_area(self, client):
         venue = offerers_factories.VenueFactory()
         offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : côté front le champ `contactEmail` est required, on ne recevra donc pas ""

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
