### PR TITLE
(BSR)[API] fix: flaky test in sandbox index all offers

### DIFF
--- a/api/tests/sandboxes/scripts/test_save_sandbox.py
+++ b/api/tests/sandboxes/scripts/test_save_sandbox.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from unittest.mock import call
 from unittest.mock import patch
 
 import pytest
@@ -23,4 +24,4 @@ class IndexAllOffersTest:
 
         with patch("pcapi.core.search.reindex_offer_ids") as mock:
             _index_all_offers()
-            mock.assert_called_once_with([offer_1.id, offer_2.id, offer_3.id])
+            mock.assert_has_calls([call([offer_1.id, offer_2.id, offer_3.id])], any_order=True)


### PR DESCRIPTION
## But de la pull request

(BSR)[API] fix: flaky test in sandbox index all offers

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
