### PR TITLE
(PC-35697)[PRO] feat: Use the adress api data instead of the siret one.

### DIFF
--- a/pro/src/commons/core/Venue/getSiretData.tsx
+++ b/pro/src/commons/core/Venue/getSiretData.tsx
@@ -63,12 +63,12 @@ const getSiretDataRequest = async (
     const longitude = addressData[0].longitude
     return {
       values: {
-        address: response.address.street,
-        city: response.address.city,
+        address: addressData[0].address,
+        city: addressData[0].city,
         latitude: latitude,
         longitude: longitude,
         name: response.name,
-        postalCode: response.address.postalCode,
+        postalCode: addressData[0].postalCode,
         siret: response.siret,
         apeCode: response.ape_code,
         legalCategoryCode: response.legal_category_code,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35697

- Afficher l'adresse récupérée de l'api adresse, et non pas celle de l'api siret/siren.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
