### PR TITLE
(PC-35876)[BO] perf: avoid DB requests when serving static files

### DIFF
--- a/api/src/pcapi/utils/login_manager.py
+++ b/api/src/pcapi/utils/login_manager.py
@@ -38,6 +38,10 @@ def get_request_authorization() -> werkzeug.datastructures.Authorization | None:
 
 @app.login_manager.user_loader  # type: ignore[attr-defined]
 def get_user_with_id(user_id: str) -> users_models.User | None:
+    if flask.request.path.startswith("/static/"):
+        # No DB request to serve static files
+        return None
+
     flask.session.permanent = True
     session_uuid = flask.session.get("session_uuid")
     try:

--- a/api/tests/routes/backoffice/static_test.py
+++ b/api/tests/routes/backoffice/static_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pcapi.core.testing import assert_num_queries
+
+
+pytestmark = [
+    pytest.mark.usefixtures("db_session"),
+    pytest.mark.backoffice,
+]
+
+
+class StaticTest:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/static/backoffice/favicon/favicon_default.ico",
+            "/static/backoffice/css/bootstrap-icons@1.11.0/font/bootstrap-icons.css",
+            "/static/backoffice/fonts/Inter-VariableFont_opsz,wght.ttf",
+        ],
+    )
+    def test_static_file_should_not_make_db_request(self, authenticated_client, path):
+        with assert_num_queries(0):
+            response = authenticated_client.get(path)
+            assert response.status_code == 200


### PR DESCRIPTION
## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-35876

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
