### PR TITLE
(PC-35739)[PRO] feat: Redirect to a 404 page with a specific message …

### DIFF
--- a/pro/src/commons/context/IndividualOfferContext/IndividualOfferContext.tsx
+++ b/pro/src/commons/context/IndividualOfferContext/IndividualOfferContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState } from 'react'
-import { useParams } from 'react-router-dom'
-import useSWR from 'swr'
+import { useNavigate, useParams } from 'react-router-dom'
+import useSWR, { useSWRConfig } from 'swr'
 
 import { api } from 'apiClient/api'
 import {
@@ -51,11 +51,24 @@ export const IndividualOfferContextProvider = ({
     offerId: string
   }>()
 
+  const SWRConfig = useSWRConfig()
+
+  const navigate = useNavigate()
+
   const offerQuery = useSWR(
     offerId && offerId !== 'creation'
       ? [GET_OFFER_QUERY_KEY, Number(offerId)]
       : null,
-    ([, offerIdParam]) => api.getOffer(offerIdParam)
+    ([, offerIdParam]) => api.getOffer(offerIdParam),
+    {
+      onError: (error, key) => {
+        if (error.status === 404) {
+          navigate('/404', { state: { from: 'offer' } })
+          return
+        }
+        SWRConfig.onError(error, key, SWRConfig)
+      },
+    }
   )
   const offer = offerQuery.data
 

--- a/pro/src/commons/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
+++ b/pro/src/commons/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
@@ -14,12 +14,15 @@ import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
 import { IndividualOfferContextProvider } from '../IndividualOfferContext'
 
+const mockNavigate = vi.fn()
+
 vi.mock('react-router-dom', async () => ({
   ...(await vi.importActual('react-router-dom')),
   useLocation: vi.fn(),
   useParams: () => ({
     offerId: '1',
   }),
+  useNavigate: () => mockNavigate,
 }))
 
 const apiOffer: GetIndividualOfferWithAddressResponseModel =
@@ -94,5 +97,21 @@ describe('IndividualOfferContextProvider', () => {
     renderIndividualOfferContextProvider()
 
     expect(await screen.findByText('Test inner content')).toBeInTheDocument()
+  })
+
+  it('should redirect to an error page when the offer does not exist', async () => {
+    vi.spyOn(api, 'getOffer').mockRejectedValueOnce({
+      status: 404,
+    })
+
+    renderIndividualOfferContextProvider()
+
+    await waitFor(() => {
+      expect(api.getCategories).toHaveBeenCalled()
+    })
+
+    expect(mockNavigate).toHaveBeenLastCalledWith('/404', {
+      state: { from: 'offer' },
+    })
   })
 })

--- a/pro/src/pages/Errors/NotFound/NotFound.tsx
+++ b/pro/src/pages/Errors/NotFound/NotFound.tsx
@@ -1,3 +1,5 @@
+import { useLocation } from 'react-router-dom'
+
 import stroke404Icon from 'icons/stroke-404.svg'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
@@ -11,31 +13,39 @@ type NotFoundProps = {
   redirect?: string
 }
 
-export const NotFound = ({ redirect = '/accueil' }: NotFoundProps) => (
-  <main className={styles['not-found']} id="content">
-    <div className={styles['not-found-gradient-container']}>
-      <BackgroundGradientSVG />
-    </div>
+export const NotFound = ({ redirect = '/accueil' }: NotFoundProps) => {
+  const { state } = useLocation()
 
-    <div className={styles['not-found-content']}>
-      <SvgIcon
-        src={stroke404Icon}
-        alt=""
-        className={styles['no-match-icon']}
-        width="350"
-      />
-      <h1 className={styles['title']}>Oh non !</h1>
-      <p>Cette page n’existe pas.</p>
-      <ButtonLink
-        className={styles['nm-redirection-link']}
-        variant={ButtonVariant.SECONDARY}
-        to={redirect}
-      >
-        Retour à la page d’accueil
-      </ButtonLink>
-    </div>
-  </main>
-)
+  return (
+    <main className={styles['not-found']} id="content">
+      <div className={styles['not-found-gradient-container']}>
+        <BackgroundGradientSVG />
+      </div>
+
+      <div className={styles['not-found-content']}>
+        <SvgIcon
+          src={stroke404Icon}
+          alt=""
+          className={styles['no-match-icon']}
+          width="350"
+        />
+        <h1 className={styles['title']}>Oh non !</h1>
+        <p>
+          {state?.from === 'offer'
+            ? 'Cette offre n’existe pas ou a été supprimée.'
+            : 'Cette page n’existe pas.'}
+        </p>
+        <ButtonLink
+          className={styles['nm-redirection-link']}
+          variant={ButtonVariant.SECONDARY}
+          to={redirect}
+        >
+          Retour à la page d’accueil
+        </ButtonLink>
+      </div>
+    </main>
+  )
+}
 
 // Lazy-loaded by react-router-dom
 // ts-unused-exports:disable-next-line

--- a/pro/src/pages/Errors/NotFound/__specs__/NotFound.spec.tsx
+++ b/pro/src/pages/Errors/NotFound/__specs__/NotFound.spec.tsx
@@ -1,8 +1,14 @@
 import { screen } from '@testing-library/react'
+import * as router from 'react-router-dom'
 
 import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
 import { NotFound } from '../NotFound'
+
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useLocation: () => ({ state: {} }),
+}))
 
 describe('src | components | pages | NotFound', () => {
   it('should display a message notifying the user they are on a wrong path and add a link to home', () => {
@@ -25,5 +31,17 @@ describe('src | components | pages | NotFound', () => {
 
     // then
     expect(screen.getByRole('link')).toHaveAttribute('href', '/mon/autre/url')
+  })
+
+  it('should display a specific error message when an offer was not found', () => {
+    vi.spyOn(router, 'useLocation').mockReturnValueOnce({
+      state: { from: 'offer' },
+    } as router.Location)
+
+    renderWithProviders(<NotFound />)
+
+    expect(
+      screen.getByText('Cette offre n’existe pas ou a été supprimée.')
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
…when the offer was not found.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35739

**Objectif**
Redirect vers une page 404 avec un message spéfifique quand on accède à une page d'une offre individuelle qui n'existe pas (ou plus).

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
