### PR TITLE
(BSR)[API] fix: use venue address to get department code in get colle…

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -540,8 +540,11 @@ def get_collective_offers_for_filters(
     query = query.order_by(educational_models.CollectiveOffer.dateCreated.desc())
     offers = (
         query.options(
-            sa_orm.joinedload(educational_models.CollectiveOffer.venue).joinedload(
-                offerers_models.Venue.managingOfferer
+            sa_orm.joinedload(educational_models.CollectiveOffer.venue).options(
+                sa_orm.joinedload(offerers_models.Venue.managingOfferer),
+                sa_orm.joinedload(offerers_models.Venue.offererAddress).joinedload(
+                    offerers_models.OffererAddress.address
+                ),
             )
         )
         .options(
@@ -588,8 +591,11 @@ def get_collective_offers_template_for_filters(
 
     offers = (
         query.options(
-            sa_orm.joinedload(educational_models.CollectiveOfferTemplate.venue).joinedload(
-                offerers_models.Venue.managingOfferer
+            sa_orm.joinedload(educational_models.CollectiveOfferTemplate.venue).options(
+                sa_orm.joinedload(offerers_models.Venue.managingOfferer),
+                sa_orm.joinedload(offerers_models.Venue.offererAddress).joinedload(
+                    offerers_models.OffererAddress.address
+                ),
             )
         )
         .limit(offers_limit)

--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -197,7 +197,7 @@ def _serialize_offer_paginated(
         stocks=serialized_stocks,  # type: ignore[arg-type]
         booking=last_booking,
         thumbUrl=None,
-        venue=_serialize_venue(offer.venue),  # type: ignore[arg-type]
+        venue=_serialize_venue(offer.venue),
         status=offer.status.name,
         displayedStatus=offer.displayedStatus,
         allowedActions=offer.allowedActions,
@@ -233,15 +233,21 @@ def _serialize_stock(stock: educational_models.CollectiveStock | None = None) ->
     }
 
 
-def _serialize_venue(venue: offerers_models.Venue) -> dict:
-    return {
-        "id": venue.id,
-        "isVirtual": venue.isVirtual,
-        "name": venue.name,
-        "offererName": venue.managingOfferer.name,
-        "publicName": venue.publicName,
-        "departementCode": venue.departementCode,
-    }
+def _serialize_venue(venue: offerers_models.Venue) -> base_serializers.ListOffersVenueResponseModel:
+    if venue.offererAddress is not None:
+        department_code = venue.offererAddress.address.departmentCode
+    else:
+        # TODO(OA): remove this when the virtual venues are migrated
+        department_code = None
+
+    return base_serializers.ListOffersVenueResponseModel(
+        id=venue.id,
+        isVirtual=venue.isVirtual,
+        name=venue.name,
+        offererName=venue.managingOfferer.name,
+        publicName=venue.publicName,
+        departementCode=department_code,
+    )
 
 
 def _get_serialize_last_booking(


### PR DESCRIPTION
…ctive offers

## But de la pull request

Ticket Jira (ou description si BSR) : on utilise `venue.offererAddress.address` plutôt que `venue` pour récupérer `departmentCode`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
