### PR TITLE
(BSR) CI : fix check-image-exists and build image if not

### DIFF
--- a/.github/workflows/dev_on_dispatch_deploy_pullrequests.yml
+++ b/.github/workflows/dev_on_dispatch_deploy_pullrequests.yml
@@ -24,6 +24,7 @@ jobs:
     outputs: 
       checksum-tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
       resource_label: ${{ steps.set_resource_label.outputs.resource_label }}
+      pcapi-exists: ${{ steps.check-checksum-tag.outputs.tag-exists }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -96,6 +97,7 @@ jobs:
   build-pcapi:
     name: "[pcapi] build docker image."
     needs: [deploy-preview-env-init]
+    if: needs.deploy-preview-env-init.outputs.pcapi-exists == 'false'
     uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
     with:
       ref: ${{ github.sha }}
@@ -108,6 +110,7 @@ jobs:
   push-pcapi:
     name: "Push pcapi docker image to registry"
     needs: [deploy-preview-env-init, build-pcapi]
+    if: needs.deploy-preview-env-init.outputs.pcapi-exists == 'false'
     uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
     with:
       image: pcapi

--- a/.github/workflows/dev_on_dispatch_deploy_pullrequests.yml
+++ b/.github/workflows/dev_on_dispatch_deploy_pullrequests.yml
@@ -47,13 +47,6 @@ jobs:
           echo "API_TAG=$API_TAG"
           echo $PUSH_TAGS >> "$GITHUB_OUTPUT"
           echo $API_TAG >> "$GITHUB_OUTPUT"
-      - name: "pcapi"
-        id: check-checksum-tag
-        run: ./.github/workflows/scripts/check-image-tag-exists.sh
-        env:
-          image: pcapi
-          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
-          token: ${{ steps.openid-auth.outputs.access_token }}
       - name: "Authentification to Google"
         uses: "google-github-actions/auth@v2"
         with:
@@ -75,6 +68,13 @@ jobs:
           token_format: "access_token"
           workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
+      - name: "pcapi"
+        id: check-checksum-tag
+        run: ./.github/workflows/scripts/check-image-tag-exists.sh
+        env:
+          image: pcapi
+          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+          token: ${{ steps.openid-auth.outputs.access_token }}
 
   deploy-pro-on-firebase-preview-env:
     name: "[PRO] Deploy PR version for validation pr preview backend"

--- a/.github/workflows/dev_on_pull_request_workflow.yml
+++ b/.github/workflows/dev_on_pull_request_workflow.yml
@@ -101,13 +101,6 @@ jobs:
           registry: "europe-west1-docker.pkg.dev"
           username: "oauth2accesstoken"
           password: "${{ steps.openid-auth.outputs.access_token }}"
-      - name: "pcapi"
-        id: check-checksum-tag
-        run: bash ./.github/workflows/scripts/check-image-tag-exists.sh
-        env:
-          image: pcapi
-          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
-          token: ${{ steps.openid-auth.outputs.access_token }}
       - name: "Publish Summary"
         run: |
           {
@@ -119,8 +112,6 @@ jobs:
             echo "| [api-documentation] content changed  | ${{ steps.check-api-documentation-changes.outputs.any_modified }} |"
             echo "| [pro] content changed                | ${{ steps.check-pro-changes.outputs.any_modified }} |"
             echo "| [dependencies] content changed       | ${{ steps.check-dependencies-changes.outputs.any_modified }} |"
-            echo "| [pcapi] image tag                    | ${{ steps.pcapi-tags.outputs.checksum-tag }} |"
-            echo "| [pcapi] image already exists         | ${{ steps.check-checksum-tag.outputs.tag-exists }} |"
           } >> $GITHUB_STEP_SUMMARY
 
   build-pcapi-tests:

--- a/.github/workflows/dev_on_pull_request_workflow.yml
+++ b/.github/workflows/dev_on_pull_request_workflow.yml
@@ -74,33 +74,6 @@ jobs:
           echo "API_TAG=$API_TAG"
           echo $PUSH_TAGS >> "$GITHUB_OUTPUT"
           echo $API_TAG >> "$GITHUB_OUTPUT"
-      - name: "Authentification to Google"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Get Secret"
-        id: "secrets"
-        uses: "google-github-actions/get-secretmanager-secrets@v2"
-        with:
-          secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
-      - name: "OpenID Connect Authentication"
-        id: "openid-auth"
-        uses: "google-github-actions/auth@v2"
-        with:
-          create_credentials_file: false
-          token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - name: "Docker login"
-        id: "docker-login"
-        uses: "docker/login-action@v3"
-        with:
-          registry: "europe-west1-docker.pkg.dev"
-          username: "oauth2accesstoken"
-          password: "${{ steps.openid-auth.outputs.access_token }}"
       - name: "Publish Summary"
         run: |
           {

--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -99,28 +99,12 @@ jobs:
           registry: "europe-west1-docker.pkg.dev"
           username: "oauth2accesstoken"
           password: "${{ steps.openid-auth.outputs.access_token }}"
-      - name: "pcapi"
-        id: check-checksum-tag
-        run: ./.github/workflows/scripts/check-image-tag-exists.sh
-        env:
-          image: pcapi
-          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
-          token: ${{ steps.openid-auth.outputs.access_token }}
-      - name: "pcapi-console"
-        id: check-console-checksum-tag
-        run: ./.github/workflows/scripts/check-image-tag-exists.sh
-        env:
-          image: pcapi-console
-          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
-          token: ${{ steps.openid-auth.outputs.access_token }}
       - name: "Summary"
         run: |
           echo "[api] folder changed : ${{ steps.check-api-changes.outputs.any_modified }}"
           echo "[algolia] folder changed : ${{ steps.check-algolia-config-changes.outputs.any_modified }}"
           echo "[pcapi] push-tags : ${{ steps.pcapi-tags.outputs.push-tags }}"
           echo "[pcapi] checksum-tag : ${{ steps.pcapi-tags.outputs.checksum-tag }}"
-          echo "[pcapi] image tag ${{ steps.pcapi-tags.outputs.checksum-tag }} exists : ${{ steps.check-checksum-tag.outputs.tag-exists }}"
-          echo "[pcapi-console] image tag ${{ steps.pcapi-tags.outputs.checksum-tag }} exists : ${{ steps.check-console-checksum-tag.outputs.tag-exists }}"
 
   check-folders-changes:
     # Perform all changes checks at once to remove the need for multiple checkouts accross jobs

--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -72,33 +72,6 @@ jobs:
           echo "API_TAG=$API_TAG"
           echo $PUSH_TAGS >> "$GITHUB_OUTPUT"
           echo $API_TAG >> "$GITHUB_OUTPUT"
-      - name: "Authentification to Google"
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
-      - name: "Get Secret"
-        id: "secrets"
-        uses: "google-github-actions/get-secretmanager-secrets@v2"
-        with:
-          secrets: |-
-            ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/passculture-main-gcp-workload-identity-provider
-            ARTIFACT_REGISTRY_SERVICE_ACCOUNT:passculture-metier-ehp/passculture-main-artifact-registry-service-account
-      - name: "OpenID Connect Authentication"
-        id: "openid-auth"
-        uses: "google-github-actions/auth@v2"
-        with:
-          create_credentials_file: false
-          token_format: "access_token"
-          workload_identity_provider: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ steps.secrets.outputs.ARTIFACT_REGISTRY_SERVICE_ACCOUNT }}
-      - name: "Docker login"
-        id: "docker-login"
-        uses: "docker/login-action@v3"
-        with:
-          registry: "europe-west1-docker.pkg.dev"
-          username: "oauth2accesstoken"
-          password: "${{ steps.openid-auth.outputs.access_token }}"
       - name: "Summary"
         run: |
           echo "[api] folder changed : ${{ steps.check-api-changes.outputs.any_modified }}"

--- a/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
+++ b/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
@@ -22,8 +22,10 @@ env:
 jobs:
   pcapi-init-job:
     runs-on: ubuntu-latest
-    outputs:
-      checksum-tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+    outputs: 
+        checksum-tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+        pcapi-exists: ${{ steps.check-checksum-tag.outputs.tag-exists }}
+        pcapi-console-exists: ${{ steps.check-console-checksum-tag.outputs.tag-exists }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,6 +97,7 @@ jobs:
   build-pcapi:
     name: "[pcapi] build docker image."
     needs: [pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.pcapi-exists == 'false'
     uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
     with:
       ref: ${{ github.sha }}
@@ -107,7 +110,7 @@ jobs:
   build-pcapi-console:
     name: "[pcapi-console] build docker image."
     needs: [pcapi-init-job]
-    if: |
+    if: needs.pcapi-init-job.outputs.pcapi-console-exists == 'false'
     uses: ./.github/workflows/dev_on_workflow_build_docker_image.yml
     with:
       ref: ${{ github.sha }}
@@ -120,6 +123,7 @@ jobs:
   push-pcapi:
     name: "Push pcapi docker image to registry"
     needs: [build-pcapi, pcapi-init-job]
+    if: needs.pcapi-init-job.outputs.pcapi-exists == 'false'
     uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
     with:
       image: pcapi
@@ -134,6 +138,7 @@ jobs:
     name: "Push pcapi-console docker image to registry"
     needs: [build-pcapi-console, pcapi-init-job]
     uses: ./.github/workflows/dev_on_workflow_push_docker_image.yml
+    if: needs.pcapi-init-job.outputs.pcapi-console-exists == 'false'
     with:
       image: pcapi-console
       commit-hash: ${{ github.sha }}

--- a/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
+++ b/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
@@ -41,14 +41,6 @@ jobs:
           echo "API_TAG=$API_TAG"
           echo $PUSH_TAGS >> "$GITHUB_OUTPUT"
           echo $API_TAG >> "$GITHUB_OUTPUT"
-      # Check checksum tag is not working well, we have a 401 during api call
-      - name: "pcapi"
-        id: check-checksum-tag
-        run: ./.github/workflows/scripts/check-image-tag-exists.sh
-        env:
-          image: pcapi
-          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
-          token: ${{ steps.openid-auth.outputs.access_token }}
       - name: "Authentification to Google"
         uses: "google-github-actions/auth@v2"
         with:
@@ -77,11 +69,18 @@ jobs:
           registry: "europe-west1-docker.pkg.dev"
           username: "oauth2accesstoken"
           password: "${{ steps.openid-auth.outputs.access_token }}"
-      - name: "pcapi-console"
+      - name: "check pcapi-console image exists"
         id: check-console-checksum-tag
         run: ./.github/workflows/scripts/check-image-tag-exists.sh
         env:
           image: pcapi-console
+          tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
+          token: ${{ steps.openid-auth.outputs.access_token }}
+      - name: "check pcapi image exists"
+        id: check-checksum-tag
+        run: ./.github/workflows/scripts/check-image-tag-exists.sh
+        env:
+          image: pcapi
           tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
           token: ${{ steps.openid-auth.outputs.access_token }}
       - name: "Summary"


### PR DESCRIPTION
## But de la pull request

The only time we build pcapi and pcapi-console are during testing deployment. Clean other workflows.
This will be a small improvment for testing deployment since image changes nearly every hour. It might save ~3/4 minutes for PR deployment if image stays the same

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
