### PR TITLE
(PC-35871)[API] fix: move_offer should use a non venue OA

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -1184,6 +1184,14 @@ def move_collective_offer_venue(
         .all()
     )
 
+    # Use a different OA if the offer uses the venue's OA
+    source_venue = collective_offer.venue
+    if collective_offer.offererAddress and collective_offer.offererAddress == source_venue.offererAddress:
+        destination_oa = offerers_api.get_or_create_offerer_address(
+            source_venue.managingOffererId, source_venue.offererAddress.addressId, source_venue.common_name
+        )
+        db.session.add(destination_oa)
+        collective_offer.offererAddress = destination_oa
     collective_offer.venue = destination_venue
     db.session.add(collective_offer)
 

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -584,7 +584,7 @@ class CollectiveOfferOnAddressVenueLocationFactory(PublishedCollectiveOfferFacto
 class CollectiveOfferOnOtherAddressLocationFactory(PublishedCollectiveOfferFactory):
     locationType = models.CollectiveLocationType.ADDRESS
     offererAddress = factory.SubFactory(
-        offerers_factories.OffererAddressFactory, offerer=factory.SelfAttribute("venue.managingOfferer")
+        offerers_factories.OffererAddressFactory, offerer=factory.SelfAttribute("..venue.managingOfferer")
     )
 
     offerVenue = factory.LazyAttribute(

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1849,6 +1849,7 @@ def move_offer(
         raise NotImplementedError("This feature is not yet available")
 
     offer_id = offer.id
+    original_venue = offer.venue
 
     venue_choices = check_can_move_offer(offer)
 
@@ -1884,6 +1885,14 @@ def move_offer(
         for price_category_label in original_price_category_labels
     }
     with transaction():
+        # Use a different OA if the offer uses the venue's OA
+        if offer.offererAddress and offer.offererAddress == original_venue.offererAddress:
+            destination_oa = offerers_api.get_or_create_offerer_address(
+                original_venue.managingOffererId, original_venue.offererAddress.addressId, original_venue.common_name
+            )
+            db.session.add(destination_oa)
+            offer.offererAddress = destination_oa
+
         offer.venue = destination_venue
         db.session.add(offer)
 


### PR DESCRIPTION
OA was designed so that if a venue change location, the offers would stay on the OA and the OA would use the venue's common name. Let's reuse this when moving offer as the end goal is to remove the venue anyway.

## But de la pull request

Ticket Jira: https://passculture.atlassian.net/browse/PC-35871

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
