### PR TITLE
(BSR)[API] chore: remove xfail on test

### DIFF
--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1634,14 +1634,6 @@ class CancelForFraudTest:
 
 @pytest.mark.usefixtures("db_session")
 class CancelBookingTest:
-    # Test `_cancel_booking()` internal function.
-
-    # The following test fails because `pytest_flask_sqlalchemy`
-    # introduces extra `SAVEPOINT` queries that change the behaviour
-    # of `ROLLBACK` queries. When run in tests, the `ROLLBACK` in
-    # `_cancel_booking()` does not roll back anything. When run
-    # outside tests, though, the `ROLLBACK` works well.
-    @pytest.mark.xfail
     def test_cancel_already_used_no_override(self):
         finance_event = finance_factories.UsedBookingFinanceEventFactory(
             status=finance_models.FinanceEventStatus.PRICED,


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : On a supprimé pytest-flask-sqlalchemy, ça devrait marcher maintenant non ?

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
