### PR TITLE
Pc 35965 suantity input within form

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarForm.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarForm.tsx
@@ -45,7 +45,6 @@ export function StocksCalendarForm({
       specificTimeSlots: [{ slot: '' }],
       pricingCategoriesQuantities: [
         {
-          isUnlimited: true,
           //  If there's only one price category, the default should be that one
           priceCategory:
             offer.priceCategories?.length === 1
@@ -107,7 +106,11 @@ export function StocksCalendarForm({
 
   return (
     <FormProvider {...form}>
-      <form className={styles['form']} onSubmit={form.handleSubmit(onSubmit)}>
+      <form
+        className={styles['form']}
+        onSubmit={form.handleSubmit(onSubmit)}
+        noValidate
+      >
         <ScrollToFirstHookFormErrorAfterSubmit />
         <div className={styles['form-content']}>
           <MandatoryInfo />

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormMultipleDays/StocksCalendarFormMultipleDays.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormMultipleDays/StocksCalendarFormMultipleDays.spec.tsx
@@ -43,7 +43,7 @@ function renderStocksCalendarFormMultipleDays(
         durationType: DurationTypeOption.MULTIPLE_DAYS_WEEKS,
         timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
         specificTimeSlots: [{ slot: '' }],
-        pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+        pricingCategoriesQuantities: [{ priceCategory: '' }],
         oneDayDate: '',
         multipleDaysWeekDays: weekDays.map((d) => ({
           label: d.label,

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormOneDay/StocksCalendarFormOneDay.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormOneDay/StocksCalendarFormOneDay.spec.tsx
@@ -34,7 +34,7 @@ function renderStocksCalendarFormOneDay(
         durationType: DurationTypeOption.ONE_DAY,
         timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
         specificTimeSlots: [{ slot: '' }],
-        pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+        pricingCategoriesQuantities: [{ priceCategory: '' }],
         oneDayDate: '',
         ...defaultOptions,
       },

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarFormSpecificTimeSlots/StocksCalendarFormSpecificTimeSlots.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarFormSpecificTimeSlots/StocksCalendarFormSpecificTimeSlots.spec.tsx
@@ -20,7 +20,7 @@ function renderStocksCalendarFormSpecificTimeSlots(
         durationType: DurationTypeOption.ONE_DAY,
         timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
         specificTimeSlots: [{ slot: '' }],
-        pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+        pricingCategoriesQuantities: [{ priceCategory: '' }],
         oneDayDate: '',
         ...defaultOptions,
       },

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarFormTimeAndPrice.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarFormTimeAndPrice.spec.tsx
@@ -36,7 +36,7 @@ function renderStocksCalendarFormTimeAndPrice(
         durationType: DurationTypeOption.ONE_DAY,
         timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
         specificTimeSlots: [{ slot: '' }],
-        pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+        pricingCategoriesQuantities: [{ priceCategory: '' }],
         oneDayDate: '',
         ...defaultOptions,
       },

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarPriceCategories/StocksCalendarPriceCategories.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarPriceCategories/StocksCalendarPriceCategories.module.scss
@@ -27,26 +27,4 @@
   &-legend {
     @include a11y.visually-hidden;
   }
-
-  &-quantity {
-    width: rem.torem(150px);
-
-    &-label {
-      margin-bottom: rem.torem(8px);
-      display: inline-block;
-    }
-
-    &-error {
-      margin-top: rem.torem(8px);
-    }
-  }
-
-  &-category {
-    flex-grow: 1;
-  }
-
-  &-unlimited,
-  &-trash {
-    margin-top: calc(var(--typography-body-line-height) + rem.torem(8px));
-  }
 }

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarPriceCategories/StocksCalendarPriceCategories.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarPriceCategories/StocksCalendarPriceCategories.spec.tsx
@@ -20,7 +20,7 @@ function renderStocksCalendarPriceCategories(
         durationType: DurationTypeOption.ONE_DAY,
         timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
         specificTimeSlots: [{ slot: '' }],
-        pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+        pricingCategoriesQuantities: [{ priceCategory: '' }],
         oneDayDate: '',
         ...defaultOptions,
       },

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarPriceCategories/StocksCalendarPriceCategories.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarForm/StocksCalendarFormTimeAndPrice/StocksCalendarPriceCategories/StocksCalendarPriceCategories.tsx
@@ -1,4 +1,3 @@
-import { useId } from 'react'
 import { useFieldArray, UseFormReturn } from 'react-hook-form'
 
 import { GetIndividualOfferWithAddressResponseModel } from 'apiClient/v1'
@@ -8,9 +7,7 @@ import fullMoreIcon from 'icons/full-more.svg'
 import fullTrashIcon from 'icons/full-trash.svg'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
-import { BaseInput } from 'ui-kit/form/shared/BaseInput/BaseInput'
-import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
-import { Checkbox } from 'ui-kit/formV2/Checkbox/Checkbox'
+import { QuantityInput } from 'ui-kit/formV2/QuantityInput/QuantityInput'
 import { Select } from 'ui-kit/formV2/Select/Select'
 
 import styles from './StocksCalendarPriceCategories.module.scss'
@@ -28,22 +25,11 @@ export function StocksCalendarPriceCategories({
 
   const priceCategoriesOptions = getPriceCategoryOptions(priceCategories)
 
-  const quantityErrorsId = useId()
-
   return (
     <>
       <h2 className={styles['title']}>Places et tarifs</h2>
       <div className={styles['price-categories']}>
         {fields.map((pricingPointQuantity, index) => {
-          const registeredUnlimitedCheckbox = form.register(
-            `pricingCategoriesQuantities.${index}.isUnlimited`
-          )
-
-          const registeredQuantity = form.register(
-            `pricingCategoriesQuantities.${index}.quantity`
-          )
-
-          const quantityErrorId = `${quantityErrorsId}-${pricingPointQuantity.id}`
           const quantityErrorMessage =
             form.formState.errors.pricingCategoriesQuantities?.[index]?.quantity
               ?.message
@@ -56,78 +42,39 @@ export function StocksCalendarPriceCategories({
               <legend className={styles['price-category-row-legend']}>
                 Places et tarifs {index + 1} sur {fields.length}
               </legend>
-              <div className={styles['price-category-row-quantity']}>
-                <label
-                  className={styles['price-category-row-quantity-label']}
-                  htmlFor={`pricingCategoriesQuantities.${index}.quantity`}
-                >
-                  Nombre de places
-                </label>
-                <BaseInput
-                  type="number"
-                  min={0}
-                  {...registeredQuantity}
-                  aria-describedby={quantityErrorId}
-                  onChange={async (e) => {
-                    if (e.target.value) {
-                      form.setValue(
-                        `pricingCategoriesQuantities.${index}.isUnlimited`,
-                        false
-                      )
-                    }
-
-                    if (e.target.value === '') {
-                      form.setValue(
-                        `pricingCategoriesQuantities.${index}.isUnlimited`,
-                        true
-                      )
-                    }
-                    await registeredQuantity.onChange(e)
-                  }}
-                />
-                <div role="alert" id={quantityErrorId}>
-                  {quantityErrorMessage && (
-                    <FieldError
-                      className={styles['price-category-row-quantity-error']}
-                      name={`pricingCategoriesQuantities.${index}.quantity`}
-                    >
-                      {quantityErrorMessage}
-                    </FieldError>
+              <div className={styles['price-category-row']}>
+                <QuantityInput
+                  minimum={0}
+                  error={quantityErrorMessage}
+                  label="Nombre de places"
+                  value={form.watch(
+                    `pricingCategoriesQuantities.${index}.quantity`
                   )}
-                </div>
-              </div>
-              <Checkbox
-                label="Illimité"
-                className={styles['price-category-row-unlimited']}
-                {...registeredUnlimitedCheckbox}
-                onChange={async (e) => {
-                  await registeredUnlimitedCheckbox.onChange(e)
-
-                  if (e.target.checked) {
+                  onChange={(e) =>
                     form.setValue(
                       `pricingCategoriesQuantities.${index}.quantity`,
-                      undefined
+                      e.target.value ? Number(e.target.value) : undefined
                     )
                   }
-                }}
-              />
-              <Select
-                className={styles['price-category-row-category']}
-                options={priceCategoriesOptions}
-                required
-                label="Tarif"
-                defaultOption={{
-                  label: 'Sélectionner un tarif',
-                  value: '',
-                }}
-                {...form.register(
-                  `pricingCategoriesQuantities.${index}.priceCategory`
-                )}
-                error={
-                  form.formState.errors.pricingCategoriesQuantities?.[index]
-                    ?.priceCategory?.message
-                }
-              />
+                />
+                <Select
+                  className={styles['price-category-row-category']}
+                  options={priceCategoriesOptions}
+                  required
+                  label="Tarif"
+                  defaultOption={{
+                    label: 'Sélectionner un tarif',
+                    value: '',
+                  }}
+                  {...form.register(
+                    `pricingCategoriesQuantities.${index}.priceCategory`
+                  )}
+                  error={
+                    form.formState.errors.pricingCategoriesQuantities?.[index]
+                      ?.priceCategory?.message
+                  }
+                />
+              </div>
               {fields.length > 1 && (
                 <div className={styles['price-category-row-trash']}>
                   <Button
@@ -162,7 +109,7 @@ export function StocksCalendarPriceCategories({
           variant={ButtonVariant.TERNARY}
           icon={fullMoreIcon}
           onClick={() => {
-            append({ isUnlimited: true, priceCategory: '' })
+            append({ priceCategory: '' })
             const inputToFocus = `pricingCategoriesQuantities.${fields.length}.quantity`
 
             // The input we want to focus has not been rendered first

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/StocksCalendarTableEditStock.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/StocksCalendarTableEditStock.module.scss
@@ -52,21 +52,4 @@
   align-items: center;
   gap: rem.torem(16px);
   display: flex;
-
-  &-quantity {
-    width: rem.torem(150px);
-
-    &-label {
-      margin-bottom: rem.torem(8px);
-      display: inline-block;
-    }
-  }
-
-  &-unlimited {
-    margin-top: calc(var(--typography-body-line-height) + rem.torem(8px));
-  }
-}
-
-.error {
-  margin-top: rem.torem(8px);
 }

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/StocksCalendarTableEditStock.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/StocksCalendarTableEditStock.tsx
@@ -13,10 +13,8 @@ import { getPriceCategoryOptions } from 'components/IndividualOffer/StocksEventE
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
-import { BaseCheckbox } from 'ui-kit/form/shared/BaseCheckbox/BaseCheckbox'
-import { BaseInput } from 'ui-kit/form/shared/BaseInput/BaseInput'
-import { FieldError } from 'ui-kit/form/shared/FieldError/FieldError'
 import { DatePicker } from 'ui-kit/formV2/DatePicker/DatePicker'
+import { QuantityInput } from 'ui-kit/formV2/QuantityInput/QuantityInput'
 import { Select } from 'ui-kit/formV2/Select/Select'
 import { TimePicker } from 'ui-kit/formV2/TimePicker/TimePicker'
 
@@ -33,7 +31,6 @@ export type EditStockFormValues = {
   priceCategory: string
   bookingLimitDate: string
   quantity?: number
-  isUnlimited: boolean
 }
 
 export type StocksCalendarTableEditStockProps = {
@@ -60,13 +57,18 @@ export function StocksCalendarTableEditStock({
     )
   }
 
-  const quantityInputId = useId()
   const descriptionId = useId()
+
+  const quantity = form.watch(`quantity`)
 
   return (
     <FormProvider {...form}>
       <MandatoryInfo />
-      <form className={styles['form']} onSubmit={form.handleSubmit(onSubmit)}>
+      <form
+        className={styles['form']}
+        onSubmit={form.handleSubmit(onSubmit)}
+        noValidate
+      >
         <div className={styles['content']}>
           <div className={styles['row']}>
             <DatePicker
@@ -88,41 +90,17 @@ export function StocksCalendarTableEditStock({
           <h2 className={styles['title']}>Places et tarifs</h2>
           <div className={styles['row']}>
             <div className={styles['price-category-row']}>
-              <div className={styles['price-category-row-quantity']}>
-                <label
-                  htmlFor={quantityInputId}
-                  className={styles['price-category-row-quantity-label']}
-                >
-                  Nombre de places
-                </label>
-                <BaseInput
-                  type="number"
-                  min={0}
-                  id={quantityInputId}
-                  {...form.register('quantity')}
-                  onChange={(e) => {
-                    if (e.target.value) {
-                      form.setValue('isUnlimited', false)
-                    }
-                  }}
-                />
-                <div role="alert">
-                  {form.formState.errors.quantity && (
-                    <FieldError name="quantity" className={styles['error']}>
-                      {form.formState.errors.quantity.message}
-                    </FieldError>
-                  )}
-                </div>
-              </div>
-              <BaseCheckbox
-                label="Illimité"
-                className={styles['price-category-row-unlimited']}
-                {...form.register('isUnlimited')}
-                onChange={(e) => {
-                  if (e.target.checked) {
-                    form.setValue('quantity', undefined)
-                  }
-                }}
+              <QuantityInput
+                minimum={0}
+                error={form.formState.errors.quantity?.message}
+                label="Nombre de places"
+                value={quantity}
+                onChange={(e) =>
+                  form.setValue(
+                    `quantity`,
+                    e.target.value ? Number(e.target.value) : undefined
+                  )
+                }
               />
             </div>
             <Select

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/specs/validationSchema.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/specs/validationSchema.spec.tsx
@@ -10,7 +10,6 @@ describe('validationSchema with FF WIP_ENABLE_EVENT_WITH_OPENING_HOUR', () => {
     date: addDays(new Date(), 2).toISOString().split('T')[0],
     bookingLimitDate: addDays(new Date(), 1).toISOString().split('T')[0],
     quantity: 12,
-    isUnlimited: false,
     priceCategory: '1',
     time: '12:12',
   }

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/utils.ts
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/utils.ts
@@ -45,7 +45,6 @@ export function getStockFormDefaultValues(
       stock.quantity === null || stock.quantity === undefined
         ? undefined
         : stock.quantity - stock.bookingsQuantity,
-    isUnlimited: stock.quantity === null,
   }
 }
 

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/validationSchema.ts
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/validationSchema.ts
@@ -34,13 +34,5 @@ export const validationSchema = yup.object<EditStockFormValues>().shape({
     .max(
       MAX_STOCKS_QUANTITY,
       'Veuillez modifier la quantité. Celle-ci ne peut pas être supérieure à 1 million'
-    )
-    .when('isUnlimited', {
-      is: false,
-      then: (schema) =>
-        schema.required(
-          'Veuillez indiquer un nombre de places, ou bien cocher la case "Illimité"'
-        ),
-    }),
-  isUnlimited: yup.boolean().required(),
+    ),
 })

--- a/pro/src/components/IndividualOffer/StocksEventCreation/form/__specs__/validationSchema.spec.ts
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/form/__specs__/validationSchema.spec.ts
@@ -145,7 +145,7 @@ describe('validationSchema with FF WIP_ENABLE_EVENT_WITH_OPENING_HOUR', () => {
   const defaultValues: StocksCalendarFormValues = {
     durationType: DurationTypeOption.ONE_DAY,
     oneDayDate: addDays(new Date(), 1).toISOString().split('T')[0],
-    pricingCategoriesQuantities: [{ priceCategory: '1', isUnlimited: true }],
+    pricingCategoriesQuantities: [{ priceCategory: '1' }],
     specificTimeSlots: [{ slot: '00:00' }],
     timeSlotType: TimeSlotTypeOption.SPECIFIC_TIME,
     multipleDaysStartDate: addDays(new Date(), 1).toISOString().split('T')[0],
@@ -206,7 +206,7 @@ describe('validationSchema with FF WIP_ENABLE_EVENT_WITH_OPENING_HOUR', () => {
       description: 'invalid form for missing price category',
       formValues: {
         ...defaultValues,
-        pricingCategoriesQuantities: [{ isUnlimited: true, priceCategory: '' }],
+        pricingCategoriesQuantities: [{ quantity: 12, priceCategory: '' }],
       },
       expectedErrors: ['Veuillez renseigner un tarif'],
     },
@@ -228,18 +228,6 @@ describe('validationSchema with FF WIP_ENABLE_EVENT_WITH_OPENING_HOUR', () => {
       },
       expectedErrors: [
         'Veuillez modifier la quantité. Celle-ci ne peut pas être supérieure à 1 million',
-      ],
-    },
-    {
-      description: 'invalid form for missing quantity',
-      formValues: {
-        ...defaultValues,
-        pricingCategoriesQuantities: [
-          { quantity: undefined, isUnlimited: false, priceCategory: '1' },
-        ],
-      },
-      expectedErrors: [
-        'Veuillez indiquer un nombre de places, ou bien cocher la case "Illimité"',
       ],
     },
     {

--- a/pro/src/components/IndividualOffer/StocksEventCreation/form/types.ts
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/form/types.ts
@@ -65,7 +65,6 @@ export type StocksCalendarFormValues = {
   specificTimeSlots: { slot: string }[]
   pricingCategoriesQuantities: {
     quantity?: number
-    isUnlimited?: boolean
     priceCategory: string
   }[]
   bookingLimitDateInterval?: number

--- a/pro/src/components/IndividualOffer/StocksEventCreation/form/validationSchema.ts
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/form/validationSchema.ts
@@ -263,7 +263,6 @@ export const validationSchema = yup.object().shape({
     .of(
       yup.object().shape({
         priceCategory: yup.string().required('Veuillez renseigner un tarif'),
-        isUnlimited: yup.bool(),
         quantity: yup
           .number()
           .transform((value) => (Number.isNaN(value) ? undefined : value))
@@ -271,14 +270,7 @@ export const validationSchema = yup.object().shape({
           .max(
             MAX_STOCKS_QUANTITY,
             'Veuillez modifier la quantité. Celle-ci ne peut pas être supérieure à 1 million'
-          )
-          .when('isUnlimited', {
-            is: false,
-            then: (schema) =>
-              schema.required(
-                'Veuillez indiquer un nombre de places, ou bien cocher la case "Illimité"'
-              ),
-          }),
+          ),
       })
     ),
   bookingLimitDateInterval: yup

--- a/pro/src/ui-kit/formV2/QuantityInput/QuantityInput.module.scss
+++ b/pro/src/ui-kit/formV2/QuantityInput/QuantityInput.module.scss
@@ -1,13 +1,3 @@
-@use "styles/mixins/_fonts.scss" as fonts;
-@use "styles/variables/_forms.scss" as forms;
-@use "styles/mixins/_forms.scss" as formsM;
-@use "styles/mixins/_rem.scss" as rem;
-@use "styles/mixins/_a11y.scss" as a11y;
-
-.input-layout-small-label {
-  @include fonts.body-accent-xs;
-
-  display: block;
-  min-height: forms.$input-label-min-height;
-  margin-bottom: forms.$label-small-space-before-input;
+.quantity-row {
+  width: auto;
 }

--- a/pro/src/ui-kit/formV2/QuantityInput/QuantityInput.spec.tsx
+++ b/pro/src/ui-kit/formV2/QuantityInput/QuantityInput.spec.tsx
@@ -8,13 +8,13 @@ const renderQuantityInput = (props: QuantityInputProps) => {
 }
 
 const LABELS = {
-  input: /Quantité/,
-  checkbox: /Illimité/,
+  input: 'Quantité',
+  checkbox: 'Illimité',
 }
 
 describe('QuantityInput', () => {
   it('should display an input and a checkbox', () => {
-    renderQuantityInput({})
+    renderQuantityInput({ label: LABELS.input })
 
     expect(
       screen.getByRole('spinbutton', { name: LABELS.input })
@@ -25,7 +25,7 @@ describe('QuantityInput', () => {
   })
 
   it('should display the checkbox disabled when the input is disabled', () => {
-    renderQuantityInput({ disabled: true })
+    renderQuantityInput({ label: LABELS.input, disabled: true })
 
     const input = screen.getByRole('spinbutton', { name: LABELS.input })
     expect(input).toBeDisabled()
@@ -36,7 +36,7 @@ describe('QuantityInput', () => {
 
   it('should execute the onChange callback when the input value changes', async () => {
     const onChange = vi.fn()
-    renderQuantityInput({ onChange })
+    renderQuantityInput({ label: LABELS.input, onChange })
 
     const input = screen.getByRole('spinbutton', { name: LABELS.input })
     await userEvent.type(input, '1')
@@ -44,7 +44,8 @@ describe('QuantityInput', () => {
   })
 
   it('should empty the input value when the checkbox is checked', async () => {
-    renderQuantityInput({})
+    const onChange = vi.fn()
+    renderQuantityInput({ label: LABELS.input, onChange: onChange, value: 1 })
 
     const input = screen.getByRole('spinbutton', { name: LABELS.input })
     const checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
@@ -53,12 +54,15 @@ describe('QuantityInput', () => {
     expect(input).toHaveValue(1)
 
     await userEvent.click(checkbox)
-    expect(checkbox).toBeChecked()
-    expect(input).toHaveValue(null)
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ value: '' }),
+      })
+    )
   })
 
   it('should uncheck the checkbox when the input value is set', async () => {
-    renderQuantityInput({})
+    renderQuantityInput({ label: LABELS.input, value: 1 })
 
     let input = screen.getByRole('spinbutton', { name: LABELS.input })
     let checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
@@ -69,12 +73,11 @@ describe('QuantityInput', () => {
   })
 
   it('should check the checkbox when the input value is emptied manually', async () => {
-    renderQuantityInput({})
+    renderQuantityInput({ label: LABELS.input, value: 1 })
 
     const input = screen.getByRole('spinbutton', { name: LABELS.input })
     const checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
 
-    await userEvent.type(input, '1')
     expect(input).toHaveValue(1)
 
     await userEvent.clear(input)
@@ -82,9 +85,9 @@ describe('QuantityInput', () => {
     expect(checkbox).toBeChecked()
   })
 
-  it('should move focus to the input when the checkbox is unchecked and init the input with the minimum', async () => {
-    const min = '10'
-    renderQuantityInput({ min })
+  it('should move focus to the input when the checkbox is unchecked', async () => {
+    const minimum = 10
+    renderQuantityInput({ label: LABELS.input, minimum, value: undefined })
 
     const input = screen.getByRole('spinbutton', { name: LABELS.input })
     const checkbox = screen.getByRole('checkbox', { name: LABELS.checkbox })
@@ -92,6 +95,5 @@ describe('QuantityInput', () => {
     await userEvent.click(checkbox)
     expect(checkbox).not.toBeChecked()
     expect(input).toHaveFocus()
-    expect(input).toHaveValue(parseInt(min))
   })
 })

--- a/pro/src/ui-kit/formV2/QuantityInput/QuantityInput.stories.tsx
+++ b/pro/src/ui-kit/formV2/QuantityInput/QuantityInput.stories.tsx
@@ -1,6 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { PropsWithChildren } from 'react'
+import { FormProvider, useForm, useFormContext } from 'react-hook-form'
 
 import { QuantityInput } from './QuantityInput'
+
+const Wrapper = ({ children }: PropsWithChildren) => {
+  const hookForm = useForm<{ myField?: number }>({
+    defaultValues: { myField: 100 },
+  })
+
+  return (
+    <FormProvider {...hookForm}>
+      <form>{children}</form>
+    </FormProvider>
+  )
+}
 
 const meta: Meta<typeof QuantityInput> = {
   title: 'ui-kit/formsV2/QuantityInput',
@@ -30,5 +44,37 @@ export const Required: Story = {
     name: 'quantity',
     label: 'Quantité',
     required: true,
+  },
+}
+
+export const WithinForm: Story = {
+  args: {
+    name: 'quantity',
+    label: 'Quantity',
+    minimum: 10,
+  },
+  decorators: [
+    (Story: any) => (
+      <Wrapper>
+        <Story />
+      </Wrapper>
+    ),
+  ],
+  render: (args: any) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { setValue, watch } = useFormContext<{ myField?: number }>()
+
+    return (
+      <QuantityInput
+        {...args}
+        value={watch('myField')}
+        onChange={(e) => {
+          setValue(
+            'myField',
+            e.target.value ? Number(e.target.value) : undefined
+          )
+        }}
+      ></QuantityInput>
+    )
   },
 }


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35965

**Objectif**
Utiliser le `QuantityInput` du formV2 dans les nouveaux formulaires `react-hook-form` d'ajout et édition de stocks indiv.

Pou pouvoir controller le composant depuis le formulaire, il a fallu ajouter la prop `value`. Et au passage : 
- Ajout d'une story pour l'utilisation du composant dans un formulaire
- Update des props pour ressembler aux autres composants de formV2 (label, onBlur, asterisk, error, minimum, maximum & suppression des props qui doivent être évitées)

Le 2e commit implémente le composant dans les formulaires de stock en question.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
