### PR TITLE
(BSR) ci: some changes and a fix

### DIFF
--- a/.github/workflows/dev_on_dispatch_release_build.yml
+++ b/.github/workflows/dev_on_dispatch_release_build.yml
@@ -142,7 +142,7 @@ jobs:
                         image_url: "https://github.com/${{github.actor}}.png"
                         alt_text: "image de profil Github de ${{github.actor}}"
                       - type: "mrkdwn"
-                        text: "<https://github.com/${{github.actor}}|*${{github.actor}}*>"
+                        text: "*${{github.actor}}*"
                   - type: "section"
                     text:
                       type: "mrkdwn"

--- a/.github/workflows/dev_on_dispatch_release_build_hotfix.yml
+++ b/.github/workflows/dev_on_dispatch_release_build_hotfix.yml
@@ -149,7 +149,7 @@ jobs:
                         image_url: "https://github.com/${{github.actor}}.png"
                         alt_text: "image de profil Github de ${{github.actor}}"
                       - type: "mrkdwn"
-                        text: "<https://github.com/${{github.actor}}|*${{github.actor}}*>"
+                        text: "*${{github.actor}}*"
                   - type: "section"
                     text:
                       type: "mrkdwn"

--- a/.github/workflows/dev_on_dispatch_release_deploy.yml
+++ b/.github/workflows/dev_on_dispatch_release_deploy.yml
@@ -153,11 +153,11 @@ jobs:
                         image_url: "https://github.com/${{github.actor}}.png"
                         alt_text: "image de profil Github de ${{github.actor}}"
                       - type: "mrkdwn"
-                        text: "<https://github.com/${{github.actor}}|*${{github.actor}}*>"
+                        text: "*${{github.actor}}*"
                   - type: "section"
                     text:
                       type: "mrkdwn"
-                      text: " Le déploiement de la version `v${{ needs.version.outputs.APP_VERSION }}` a ${{ fromJSON('["réussi", "échoué"]')[env.WORKFLOW_CONCLUSION != 'success'] }} sur `${{ github.event.inputs.target_environment }}`"
+                      text: "Le <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|déploiement> de la version `v${{ needs.version.outputs.APP_VERSION }}` a ${{ fromJSON('["réussi", "échoué"]')[env.WORKFLOW_CONCLUSION != 'success'] }} sur `${{ github.event.inputs.target_environment }}`"
       - name: "Post success on #shérif"
         if: env.WORKFLOW_CONCLUSION == 'success'
         uses: slackapi/slack-github-action@v2.0.0
@@ -179,6 +179,6 @@ jobs:
                   - type: "section"
                     text:
                       type: "mrkdwn"
-                      text: "La version `v${{ needs.version.outputs.APP_VERSION }}` a été déployée sur `${{ github.event.inputs.target_environment }}"
+                      text: "La version `v${{ needs.version.outputs.APP_VERSION }}` a été <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|déployée> sur `${{ github.event.inputs.target_environment }}`"
 
 

--- a/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
+++ b/.github/workflows/dev_on_schedule_deploy_main_and_pro.yml
@@ -182,31 +182,14 @@ jobs:
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
   slack-notify:
-    name: "Slack notification"
-    runs-on: ubuntu-22.04
-    if: ${{ failure() }}
+    name: "Post failure notification on #alertes-deploiement"
     needs: deploy-to-testing
-    steps:
-      - uses: technote-space/workflow-conclusion-action@v3
-      - name: "Slack Notification"
-        if: ${{ failure() && github.ref == 'refs/heads/master'  }}
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          method: chat.postMessage
-          token: ${{ steps.secrets.outputs.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{vars.SLACK_ALERTES_DEPLOIEMENT_CHANNEL_ID}}
-            attachments:
-              - color: "#36A64F"
-                blocks:
-                  - type: "context"
-                    elements:
-                      - type: "image"
-                        image_url: "https://github.com/${{github.actor}}.png"
-                        alt_text: "image de profil Github de ${{github.actor}}"
-                      - type: "mrkdwn"
-                        text: "*${{github.actor}}*"
-                  - type: "section"
-                    text:
-                      type: "mrkdwn"
-                      text: ":github-failure: Le <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|déploiement> de `master` sur `testing` a échoué"
+    if: ${{ needs.deploy-to-testing.result='failure' }}
+    uses: ./.github/workflows/dev_on_workflow_post_slack_message.yml
+    with:
+      channel: ${{vars.SLACK_ALERTES_DEPLOIEMENT_CHANNEL_ID}}
+      color: "#A30002"
+      message: ":github-failure: Le <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|déploiement> de `master` sur `testing` a échoué"
+    secrets:
+      GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}


### PR DESCRIPTION
## But de la pull request

- Corriger la condition d'exécution d'un step.
  `if failure()` en début de job est vrai si un job précédent du workflow a échoué tandis que `if failure()` en début de step s'exécute si un step précédent au sein du job a échoué.
- Au passage, on améliore la mise en forme de certains messages.