### PR TITLE
(BSR)[API] fix: Handle batch emoji variation selector

### DIFF
--- a/api/src/pcapi/core/external/batch_utils.py
+++ b/api/src/pcapi/core/external/batch_utils.py
@@ -14,8 +14,8 @@ def _get_cluster_length(cluster: str) -> tuple[int, int]:
     count = 0
     char_length = 0
     for char in cluster:
-        # Skip zero-width joiners and variation selectors
-        if char in {"\u200d", "\ufe0f"}:
+        # Skip zero-width joiners only
+        if char == "\u200d":
             continue
         # Skip skin tone modifiers (range U+1F3FB to U+1F3FF)
         if 0x1F3FB <= ord(char) <= 0x1F3FF:

--- a/api/tests/core/external/batch_utils_test.py
+++ b/api/tests/core/external/batch_utils_test.py
@@ -31,7 +31,7 @@ def test_batch_length_complex_emojis():
     # Each complex emoji sequence counts differently:
     # 👨‍👩‍👧‍👦 (family) = 8 (4 people joined)
     # 👩🏽‍💻 (woman technologist with medium skin tone) = 4
-    # 🏳️‍🌈 (rainbow flag) = 4
+    # 🏳️‍🌈 (rainbow flag) = 4 (+ 1 for the variation selector)
     # 👨🏾‍🦰 (man with afro and medium-dark skin tone) = 4
     # 🫂 (people hugging) = 2
     # 🇫🇷 (flag) = 4
@@ -39,8 +39,8 @@ def test_batch_length_complex_emojis():
     # 🦾 (mechanical arm) = 2
     # 🧬 (dna) = 2
     # 🎭 (performing arts) = 2
-    # Total expected length = 34
-    assert batch_length(s) == 34
+    # Total expected length = 35
+    assert batch_length(s) == 35
 
 
 def test_shorten_for_batch_no_truncation():
@@ -107,3 +107,13 @@ def test_shorten_for_batch_complex_emojis():
     max_length = 20
     result = shorten_for_batch(s, max_length, preserve_words=True)
     assert result == "👨‍👩‍👧‍👦👩🏽‍💻🏳️‍🌈..."
+
+
+def test_shorten_for_batch_variation_selector():
+    assert batch_length("🗝️") == 3  # 2 for the keycap and 1 for the variation selector
+    s = "🗝️Escape Game à Paris - Entretien avec Gustave Eiffel | Tarif sur le site de l'offre"
+    max_length = 64
+    result = shorten_for_batch(s, max_length)
+    assert result.endswith("...")
+    assert result == "🗝️Escape Game à Paris - Entretien avec Gustave Eiffel | Tari..."
+    assert batch_length(result) <= max_length


### PR DESCRIPTION
## 🐛 Correction du comptage Batch pour les emojis avec variation selector
### Contexte
L’API Batch impose une limite stricte sur la longueur des chaînes, en comptant les emojis selon des règles spécifiques :
- Chaque emoji compte pour 2 caractères.
- Les variation selectors (\ufe0f) sont comptés comme un caractère supplémentaire.
- Les Zero Width Joiners (\u200d) ne sont pas comptés.

Notre implémentation précédente ignorait les variation selectors, ce qui pouvait entraîner des erreurs 400 côté Batch pour certains titres ou noms d’offres contenant des emojis complexes.

### Changements apportés
- Correction de la fonction batch_length :
	- Le variation selector (\ufe0f) n’est plus ignoré et est compté comme un caractère non-emoji.
	- Le Zero Width Joiner (\u200d) reste ignoré, conformément au comportement attendu.
- Ajout d’un test unitaire pour vérifier que batch_length("🗝️") retourne bien 3, comme attendu par Batch.