### PR TITLE
(PC-35736)[API] fix: clean old unbookable unbooked offers command

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -183,7 +183,9 @@ def get_capped_offers_for_filters(
     return offers
 
 
-def get_offers_by_publication_date(publication_date: datetime.datetime | None = None) -> tuple[BaseQuery, BaseQuery]:
+def get_offers_by_publication_date(
+    publication_date: datetime.datetime | None = None,
+) -> tuple[BaseQuery, BaseQuery]:
     if publication_date is None:
         publication_date = datetime.datetime.utcnow()
 
@@ -196,7 +198,10 @@ def get_offers_by_publication_date(publication_date: datetime.datetime | None = 
         sa.not_(models.FutureOffer.isSoftDeleted),
     )
     offer_ids_future = [future_offer.offerId for future_offer in future_offers_subquery]
-    return db.session.query(models.Offer).filter(models.Offer.id.in_(offer_ids_future)), future_offers_subquery
+    return (
+        db.session.query(models.Offer).filter(models.Offer.id.in_(offer_ids_future)),
+        future_offers_subquery,
+    )
 
 
 def get_offers_by_ids(user: users_models.User, offer_ids: list[int]) -> BaseQuery:
@@ -206,7 +211,10 @@ def get_offers_by_ids(user: users_models.User, offer_ids: list[int]) -> BaseQuer
             query.join(offerers_models.Venue)
             .join(offerers_models.Offerer)
             .join(offerers_models.UserOfferer)
-            .filter(offerers_models.UserOfferer.userId == user.id, offerers_models.UserOfferer.isValidated)
+            .filter(
+                offerers_models.UserOfferer.userId == user.id,
+                offerers_models.UserOfferer.isValidated,
+            )
         )
     query = query.filter(models.Offer.id.in_(offer_ids))
     return query
@@ -250,7 +258,11 @@ def get_offers_data_from_top_offers(top_offers: list[dict]) -> list[dict]:
     for offer in offers:
         if offer.id in offer_data_by_id:
             merged_data = {
-                **{"offerName": offer.name, "image": offer.image, "isHeadlineOffer": offer.is_headline_offer},
+                **{
+                    "offerName": offer.name,
+                    "image": offer.image,
+                    "isHeadlineOffer": offer.is_headline_offer,
+                },
                 **offer_data_by_id[offer.id],
             }
             merged_data_list.append(merged_data)
@@ -313,7 +325,9 @@ def get_offers_details(offer_ids: list[int]) -> BaseQuery:
             )
             .joinedload(offerers_models.Venue.managingOfferer)
             .load_only(
-                offerers_models.Offerer.name, offerers_models.Offerer.validationStatus, offerers_models.Offerer.isActive
+                offerers_models.Offerer.name,
+                offerers_models.Offerer.validationStatus,
+                offerers_models.Offerer.isActive,
             )
         )
         .options(sa_orm.joinedload(models.Offer.venue).joinedload(offerers_models.Venue.googlePlacesInfo))
@@ -342,7 +356,10 @@ def get_offers_details(offer_ids: list[int]) -> BaseQuery:
         .options(sa_orm.joinedload(models.Offer.headlineOffers))
         .outerjoin(models.Offer.lastProvider)
         .options(sa_orm.contains_eager(models.Offer.lastProvider).load_only(providers_models.Provider.localClass))
-        .filter(models.Offer.id.in_(offer_ids), models.Offer.validation == models.OfferValidationStatus.APPROVED)
+        .filter(
+            models.Offer.id.in_(offer_ids),
+            models.Offer.validation == models.OfferValidationStatus.APPROVED,
+        )
     )
 
 
@@ -367,7 +384,10 @@ def get_offers_by_filters(
             query.join(offerers_models.Venue)
             .join(offerers_models.Offerer)
             .join(offerers_models.UserOfferer)
-            .filter(offerers_models.UserOfferer.userId == user_id, offerers_models.UserOfferer.isValidated)
+            .filter(
+                offerers_models.UserOfferer.userId == user_id,
+                offerers_models.UserOfferer.isValidated,
+            )
         )
     if offerer_id is not None:
         if user_is_admin:
@@ -400,9 +420,13 @@ def get_offers_by_filters(
             db.session.query(models.Stock)
             .join(offer_alias)
             .outerjoin(
-                offerers_models.OffererAddress, offer_alias.offererAddressId == offerers_models.OffererAddress.id
+                offerers_models.OffererAddress,
+                offer_alias.offererAddressId == offerers_models.OffererAddress.id,
             )
-            .join(geography_models.Address, offerers_models.OffererAddress.addressId == geography_models.Address.id)
+            .join(
+                geography_models.Address,
+                offerers_models.OffererAddress.addressId == geography_models.Address.id,
+            )
             .filter(models.Stock.isSoftDeleted.is_(False))
             .filter(models.Stock.offerId == models.Offer.id)
         )
@@ -449,7 +473,10 @@ def get_collective_offers_by_filters(
             query.join(offerers_models.Venue)
             .join(offerers_models.Offerer)
             .join(offerers_models.UserOfferer)
-            .filter(offerers_models.UserOfferer.userId == user_id, offerers_models.UserOfferer.isValidated)
+            .filter(
+                offerers_models.UserOfferer.userId == user_id,
+                offerers_models.UserOfferer.isValidated,
+            )
         )
 
     if offerer_id is not None:
@@ -513,7 +540,10 @@ def get_collective_offers_by_filters(
             subquery = (
                 subquery.join(offerers_models.Offerer)
                 .join(offerers_models.UserOfferer)
-                .filter(offerers_models.UserOfferer.userId == user_id, offerers_models.UserOfferer.isValidated)
+                .filter(
+                    offerers_models.UserOfferer.userId == user_id,
+                    offerers_models.UserOfferer.isValidated,
+                )
             )
         q2 = subquery.subquery()
         query = query.join(q2, q2.c.collectiveOfferId == educational_models.CollectiveOffer.id)
@@ -549,7 +579,10 @@ def get_collective_offers_template_by_filters(
             query.join(offerers_models.Venue)
             .join(offerers_models.Offerer)
             .join(offerers_models.UserOfferer)
-            .filter(offerers_models.UserOfferer.userId == user_id, offerers_models.UserOfferer.isValidated)
+            .filter(
+                offerers_models.UserOfferer.userId == user_id,
+                offerers_models.UserOfferer.isValidated,
+            )
         )
     if offerer_id is not None:
         if user_is_admin:
@@ -600,7 +633,8 @@ def _filter_by_status(query: BaseQuery, status: str) -> BaseQuery:
 
 
 def _filter_collective_offers_by_statuses(
-    query: BaseQuery, statuses: list[educational_models.CollectiveOfferDisplayedStatus] | None
+    query: BaseQuery,
+    statuses: list[educational_models.CollectiveOfferDisplayedStatus] | None,
 ) -> BaseQuery:
     """
     Filter a SQLAlchemy query for CollectiveOffers based on a list of statuses.
@@ -803,7 +837,10 @@ def add_last_booking_status_to_collective_offer_query(
             educational_models.CollectiveBooking.status,
             educational_models.CollectiveBooking.cancellationReason,
         )
-        .outerjoin(educational_models.CollectiveBooking, educational_models.CollectiveStock.collectiveBookings)
+        .outerjoin(
+            educational_models.CollectiveBooking,
+            educational_models.CollectiveStock.collectiveBookings,
+        )
         .join(
             last_booking_query,
             sa.and_(
@@ -823,7 +860,9 @@ def add_last_booking_status_to_collective_offer_query(
     return subquery, query_with_booking
 
 
-def get_products_map_by_provider_reference(id_at_providers: list[str]) -> dict[str, models.Product]:
+def get_products_map_by_provider_reference(
+    id_at_providers: list[str],
+) -> dict[str, models.Product]:
     products = (
         db.session.query(models.Product)
         .filter(models.Product.can_be_synchronized)
@@ -850,7 +889,10 @@ def get_offers_map_by_id_at_provider(id_at_provider_list: list[str], venue: offe
     offers_map = {}
     for offer_id, offer_id_at_provider in (
         db.session.query(models.Offer.id, models.Offer.idAtProvider)
-        .filter(models.Offer.idAtProvider.in_(id_at_provider_list), models.Offer.venue == venue)
+        .filter(
+            models.Offer.idAtProvider.in_(id_at_provider_list),
+            models.Offer.venue == venue,
+        )
         .all()
     ):
         offers_map[offer_id_at_provider] = offer_id
@@ -863,7 +905,10 @@ def get_offers_map_by_venue_reference(id_at_provider_list: list[str], venue_id: 
     offer_id: int
     for offer_id, offer_id_at_provider in (
         db.session.query(models.Offer.id, models.Offer.idAtProvider)
-        .filter(models.Offer.venueId == venue_id, models.Offer.idAtProvider.in_(id_at_provider_list))
+        .filter(
+            models.Offer.venueId == venue_id,
+            models.Offer.idAtProvider.in_(id_at_provider_list),
+        )
         .all()
     ):
         offers_map[custom_keys.compute_venue_reference(offer_id_at_provider, venue_id)] = offer_id
@@ -1158,8 +1203,14 @@ def get_offer_reaction_count_subquery() -> sa.sql.selectable.ScalarSelect:
 def get_current_headline_offer(offerer_id: int) -> models.HeadlineOffer | None:
     return (
         db.session.query(models.HeadlineOffer)
-        .join(offerers_models.Venue, models.HeadlineOffer.venueId == offerers_models.Venue.id)
-        .join(offerers_models.Offerer, offerers_models.Venue.managingOffererId == offerers_models.Offerer.id)
+        .join(
+            offerers_models.Venue,
+            models.HeadlineOffer.venueId == offerers_models.Venue.id,
+        )
+        .join(
+            offerers_models.Offerer,
+            offerers_models.Venue.managingOffererId == offerers_models.Offerer.id,
+        )
         .filter(
             offerers_models.Offerer.id == offerer_id,
             models.HeadlineOffer.timespan.contains(datetime.datetime.utcnow()),
@@ -1174,7 +1225,10 @@ def get_inactive_headline_offers() -> list[models.HeadlineOffer]:
         .join(models.Offer, models.HeadlineOffer.offerId == models.Offer.id)
         .outerjoin(models.Mediation, models.Mediation.offerId == models.Offer.id)
         .outerjoin(models.Product, models.Offer.productId == models.Product.id)
-        .outerjoin(models.ProductMediation, models.ProductMediation.productId == models.Product.id)
+        .outerjoin(
+            models.ProductMediation,
+            models.ProductMediation.productId == models.Product.id,
+        )
         .filter(
             sa.or_(
                 models.Offer.status != offer_mixin.OfferStatus.ACTIVE,
@@ -1229,7 +1283,11 @@ def get_active_offer_by_venue_id_and_ean(venue_id: int, ean: str) -> models.Offe
     if len(offers) > 1:
         logger.warning(
             "EAN shared by more than one offer across a venue",
-            extra={"ean": ean, "venue_id": venue_id, "offers_ids": [offer.id for offer in offers]},
+            extra={
+                "ean": ean,
+                "venue_id": venue_id,
+                "offers_ids": [offer.id for offer in offers],
+            },
         )
 
     return offers[0]
@@ -1240,7 +1298,11 @@ def get_offer_by_id(offer_id: int, load_options: OFFER_LOAD_OPTIONS = ()) -> mod
         query = db.session.query(models.Offer).filter(models.Offer.id == offer_id)
         if "stock" in load_options:
             query = query.outerjoin(
-                models.Stock, sa.and_(models.Stock.offerId == offer_id, sa.not_(models.Stock.isSoftDeleted))
+                models.Stock,
+                sa.and_(
+                    models.Stock.offerId == offer_id,
+                    sa.not_(models.Stock.isSoftDeleted),
+                ),
             ).options(sa_orm.contains_eager(models.Offer.stocks))
         if "mediations" in load_options:
             query = query.options(sa_orm.joinedload(models.Offer.mediations))
@@ -1289,7 +1351,10 @@ def get_offer_by_id(offer_id: int, load_options: OFFER_LOAD_OPTIONS = ()) -> mod
             query = query.outerjoin(models.Offer.futureOffer).options(sa_orm.contains_eager(models.Offer.futureOffer))
         if "pending_bookings" in load_options:
             query = query.options(
-                sa_orm.with_expression(models.Offer.hasPendingBookings, get_pending_bookings_subquery(offer_id))
+                sa_orm.with_expression(
+                    models.Offer.hasPendingBookings,
+                    get_pending_bookings_subquery(offer_id),
+                )
             )
         if "event_opening_hours" in load_options:
             query = query.outerjoin(
@@ -1314,7 +1379,10 @@ def get_offer_and_extradata(offer_id: int) -> models.Offer | None:
     return (
         db.session.query(models.Offer)
         .filter(models.Offer.id == offer_id)
-        .outerjoin(models.Stock, sa.and_(models.Stock.offerId == offer_id, sa.not_(models.Stock.isSoftDeleted)))
+        .outerjoin(
+            models.Stock,
+            sa.and_(models.Stock.offerId == offer_id, sa.not_(models.Stock.isSoftDeleted)),
+        )
         .options(sa_orm.contains_eager(models.Offer.stocks))
         .options(sa_orm.joinedload(models.Offer.mediations))
         .options(sa_orm.joinedload(models.Offer.priceCategories).joinedload(models.PriceCategory.priceCategoryLabel))
@@ -1411,14 +1479,16 @@ def get_filtered_stocks(
         query = query.filter(
             sa.cast(
                 sa.func.timezone(
-                    offerers_models.Venue.timezone, sa.func.timezone("UTC", models.Stock.beginningDatetime)
+                    offerers_models.Venue.timezone,
+                    sa.func.timezone("UTC", models.Stock.beginningDatetime),
                 ),
                 sa.Time,
             )
             >= address_time.replace(second=0),
             sa.cast(
                 sa.func.timezone(
-                    offerers_models.Venue.timezone, sa.func.timezone("UTC", models.Stock.beginningDatetime)
+                    offerers_models.Venue.timezone,
+                    sa.func.timezone("UTC", models.Stock.beginningDatetime),
                 ),
                 sa.Time,
             )
@@ -1434,7 +1504,13 @@ def hard_delete_filtered_stocks(
     time: datetime.time | None = None,
     price_category_id: int | None = None,
 ) -> None:
-    subquery = get_filtered_stocks(offer=offer, venue=venue, date=date, time=time, price_category_id=price_category_id)
+    subquery = get_filtered_stocks(
+        offer=offer,
+        venue=venue,
+        date=date,
+        time=time,
+        price_category_id=price_category_id,
+    )
     subquery = subquery.with_entities(models.Stock.id)
     db.session.query(models.Stock).filter(models.Stock.id.in_(subquery)).delete(synchronize_session=False)
     db.session.flush()
@@ -1531,7 +1607,9 @@ def has_active_offer_with_ean(ean: str | None, venue: offerers_models.Venue, off
         # We should never be there (an ean or an ean must be given), in case we are alert sentry.
         logger.error("Could not search for an offer without ean")
     base_query = db.session.query(models.Offer).filter(
-        models.Offer.venue == venue, models.Offer.isActive.is_(True), models.Offer.ean == ean
+        models.Offer.venue == venue,
+        models.Offer.isActive.is_(True),
+        models.Offer.ean == ean,
     )
 
     if offer_id is not None:
@@ -1552,7 +1630,12 @@ def _log_deletion_error(_to_keep: models.Product, to_delete: models.Product) -> 
     logger.info("Failed to delete product %d", to_delete.id)
 
 
-@retry(exception=sa_exc.IntegrityError, exception_handler=_log_deletion_error, logger=logger, max_attempts=3)
+@retry(
+    exception=sa_exc.IntegrityError,
+    exception_handler=_log_deletion_error,
+    logger=logger,
+    max_attempts=3,
+)
 def merge_products(to_keep: models.Product, to_delete: models.Product) -> models.Product:
     # It has already happened that an offer is created by another SQL session
     # in between the transfer of the offers and the product deletion.
@@ -1571,7 +1654,9 @@ def merge_products(to_keep: models.Product, to_delete: models.Product) -> models
     return to_keep
 
 
-def venues_have_individual_and_collective_offers(venue_ids: list[int]) -> tuple[bool, bool]:
+def venues_have_individual_and_collective_offers(
+    venue_ids: list[int],
+) -> tuple[bool, bool]:
     return (
         db.session.query(
             db.session.query(offers_models.Offer).filter(offers_models.Offer.venueId.in_(venue_ids)).exists()
@@ -1613,57 +1698,52 @@ def get_unbookable_unbooked_old_offer_ids(
     cancelled).
     * An old offer is an offer that has been created more than a year ago.
     """
-    today = datetime.date.today()
-    a_year_ago = today - datetime.timedelta(days=365)
-
-    # find offer that MIGHT match: the outer join will also return
-    # some bookable stocks or even bookings. This query needs to be
-    # filtered.
-    old_offer_base_query = (
-        models.Offer.query.outerjoin(models.Offer.stocks)
-        .outerjoin(models.Stock.bookings)
-        .filter(models.Offer.dateUpdated < a_year_ago)
-        .filter(
-            sa.or_(
-                models.Stock.bookingLimitDatetime.is_(None),
-                models.Stock.isExpired.is_(True),  # type: ignore[attr-defined]
-                models.Stock.isSoldOut.is_(True),  # type: ignore[attr-defined]
-                models.Stock.id == None,
+    query = """
+        SELECT
+            offer.id
+        FROM
+            offer
+        WHERE
+            offer.id >= :min_id
+            AND offer.id < :max_id
+            AND offer."dateUpdated" < now() - interval '1 year'
+            -- offers without any bookable stock (either no stocks
+            -- at all, or no one with a quantity > 0)
+            AND offer.id NOT IN (
+                SELECT
+                    distinct(stock."offerId")
+                FROM
+                    stock
+                WHERE
+                    stock."offerId" >= :min_id
+                    AND stock."offerId" < :max_id
+                    AND stock."isSoftDeleted" IS NOT TRUE
+                    AND stock.quantity > 0
+                    AND (
+                        stock."bookingLimitDatetime" IS NULL
+                        OR stock."bookingLimitDatetime" > now()
+                    )
             )
-        )
-        .filter(bookings_models.Booking.id == None)
-        .with_entities(models.Offer.id)
-    )
-
-    # reverse query: find offer ids that have bookable stock or even
-    # a booking to filter `old_offer_base_query` results.
-    old_bookable_or_booked_offers_base_query = (
-        models.Offer.query.outerjoin(models.Offer.stocks)
-        .outerjoin(models.Stock.bookings)
-        .filter(models.Offer.dateUpdated < a_year_ago)
-        .filter(
-            sa.or_(
-                models.Stock.isExpired.is_(False),  # type: ignore[attr-defined]
-                models.Stock.isSoldOut.is_(False),  # type: ignore[attr-defined]
-                bookings_models.Booking.id.is_not(None),
+            -- offers without any linked booking
+            -- (event cancelled ones)
+            AND offer.id NOT IN (
+                SELECT
+                    distinct(stock."offerId")
+                FROM
+                    stock
+                LEFT JOIN
+                    booking on booking."stockId" = stock.id
+                WHERE
+                    stock."offerId" >= :min_id
+                    AND stock."offerId" < :max_id
+                    AND booking.id IS NOT NULL
             )
-        )
-        .filter(models.Stock.isSoftDeleted.is_not(True))
-        .filter(models.Stock.id.is_not(None))
-        .with_entities(models.Offer.id)
-    )
+    """
 
     if max_id is None:
         max_id = models.Offer.query.order_by(models.Offer.id).first().id
 
     while min_id < max_id:
-        _filter = [models.Offer.id >= min_id, models.Offer.id < min_id + batch_size]
-
-        filtering_query = old_bookable_or_booked_offers_base_query.filter(*_filter)
-        offer_ids_to_filter = {row[0] for row in filtering_query}
-
-        query = old_offer_base_query.filter(*_filter)
-        query = query.filter(models.Offer.id.notin_(offer_ids_to_filter))
-
-        yield from {row[0] for row in query}
+        rows = db.session.execute(sa.text(query), {"min_id": min_id, "max_id": max_id + batch_size})
+        yield from {row[0] for row in rows}
         min_id += batch_size

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -52,7 +52,9 @@ class GetCappedOffersForFiltersTest:
         # 1 to get offers
         with assert_num_queries(3):
             offers = repository.get_capped_offers_for_filters(
-                user_id=user_offerer.user.id, user_is_admin=user_offerer.user.has_admin_role, offers_limit=50
+                user_id=user_offerer.user.id,
+                user_is_admin=user_offerer.user.has_admin_role,
+                offers_limit=50,
             )
 
         assert len(offers) == 5
@@ -121,11 +123,13 @@ class GetCappedOffersForFiltersTest:
     def should_return_offers_of_given_subcategory_id(self):
         user_offerer = offerers_factories.UserOffererFactory()
         requested_offer = factories.OfferFactory(
-            subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id, venue__managingOfferer=user_offerer.offerer
+            subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
+            venue__managingOfferer=user_offerer.offerer,
         )
         # other offer
         factories.OfferFactory(
-            subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id, venue__managingOfferer=user_offerer.offerer
+            subcategoryId=subcategories.JEU_SUPPORT_PHYSIQUE.id,
+            venue__managingOfferer=user_offerer.offerer,
         )
 
         offers = repository.get_capped_offers_for_filters(
@@ -167,12 +171,16 @@ class GetCappedOffersForFiltersTest:
         assert offers[0].id == synced_offer.id
 
     @pytest.mark.usefixtures("db_session")
-    def should_not_return_event_offers_with_only_deleted_stock_if_filtering_by_time_period(self):
+    def should_not_return_event_offers_with_only_deleted_stock_if_filtering_by_time_period(
+        self,
+    ):
         # given
         pro = users_factories.ProFactory()
         offer_in_requested_time_period = factories.OfferFactory()
         factories.EventStockFactory(
-            offer=offer_in_requested_time_period, beginningDatetime=datetime.datetime(2020, 1, 2), isSoftDeleted=True
+            offer=offer_in_requested_time_period,
+            beginningDatetime=datetime.datetime(2020, 1, 2),
+            isSoftDeleted=True,
         )
 
         # When
@@ -372,7 +380,9 @@ class GetCappedOffersForFiltersTest:
             assert offer_for_requested_venue.id == offers[0].id
 
         @pytest.mark.usefixtures("db_session")
-        def should_not_return_offers_of_given_offerer_when_user_is_not_attached_to_it(self):
+        def should_not_return_offers_of_given_offerer_when_user_is_not_attached_to_it(
+            self,
+        ):
             # given
             pro = users_factories.ProFactory()
             offer_for_requested_offerer = factories.OfferFactory()
@@ -416,7 +426,9 @@ class GetCappedOffersForFiltersTest:
 
     class NameOrIsbnFilterTest:
         @pytest.mark.usefixtures("db_session")
-        def should_return_offer_which_name_equal_keyword_when_keyword_is_less_or_equal_than_3_letters(self):
+        def should_return_offer_which_name_equal_keyword_when_keyword_is_less_or_equal_than_3_letters(
+            self,
+        ):
             # given
             user_offerer = offerers_factories.UserOffererFactory()
             expected_offer = factories.OfferFactory(name="ocs", venue__managingOfferer=user_offerer.offerer)
@@ -441,7 +453,8 @@ class GetCappedOffersForFiltersTest:
             user_offerer = offerers_factories.UserOffererFactory()
             expected_offer = factories.OfferFactory(name="seras-tu là", venue__managingOfferer=user_offerer.offerer)
             another_expected_offer = factories.OfferFactory(
-                name="François, seras-tu là ?", venue__managingOfferer=user_offerer.offerer
+                name="François, seras-tu là ?",
+                venue__managingOfferer=user_offerer.offerer,
             )
             other_offer = factories.OfferFactory(name="étais-tu là", venue__managingOfferer=user_offerer.offerer)
 
@@ -508,7 +521,9 @@ class GetCappedOffersForFiltersTest:
             # given
             user_offerer = offerers_factories.UserOffererFactory()
             expected_offer = factories.OfferFactory(
-                name="seras-tu là", venue__managingOfferer=user_offerer.offerer, ean="1234567891234"
+                name="seras-tu là",
+                venue__managingOfferer=user_offerer.offerer,
+                ean="1234567891234",
             )
             # other offer
             factories.OfferFactory(
@@ -541,32 +556,46 @@ class GetCappedOffersForFiltersTest:
                 venue=self.other_venue, description="sold_out_offer_on_other_venue"
             )
             self.inactive_thing_offer_with_stock_with_remaining_quantity = factories.ThingOfferFactory(
-                venue=self.venue, isActive=False, description="inactive_thing_offer_with_stock_with_remaining_quantity"
+                venue=self.venue,
+                isActive=False,
+                description="inactive_thing_offer_with_stock_with_remaining_quantity",
             )
             self.inactive_thing_offer_without_remaining_quantity = factories.ThingOfferFactory(
-                venue=self.venue, isActive=False, description="inactive_thing_offer_without_remaining_quantity"
+                venue=self.venue,
+                isActive=False,
+                description="inactive_thing_offer_without_remaining_quantity",
             )
             self.inactive_thing_offer_without_stock = factories.ThingOfferFactory(
-                venue=self.venue, isActive=False, description="inactive_thing_offer_without_stock"
+                venue=self.venue,
+                isActive=False,
+                description="inactive_thing_offer_without_stock",
             )
             self.inactive_expired_event_offer = factories.EventOfferFactory(
-                venue=self.venue, isActive=False, description="inactive_expired_event_offer"
+                venue=self.venue,
+                isActive=False,
+                description="inactive_expired_event_offer",
             )
             self.active_thing_offer_with_one_stock_with_remaining_quantity = factories.ThingOfferFactory(
-                venue=self.venue, isActive=True, description="active_thing_offer_with_one_stock_with_remaining_quantity"
+                venue=self.venue,
+                isActive=True,
+                description="active_thing_offer_with_one_stock_with_remaining_quantity",
             )
             self.active_thing_offer_with_all_stocks_without_quantity = factories.ThingOfferFactory(
-                venue=self.venue, isActive=True, description="active_thing_offer_with_all_stocks_without_quantity"
+                venue=self.venue,
+                isActive=True,
+                description="active_thing_offer_with_all_stocks_without_quantity",
             )
             self.active_event_offer_with_stock_in_the_future_without_quantity = factories.EventOfferFactory(
-                venue=self.venue, description="active_event_offer_with_stock_in_the_future_without_quantity"
+                venue=self.venue,
+                description="active_event_offer_with_stock_in_the_future_without_quantity",
             )
             self.active_event_offer_with_one_stock_in_the_future_with_remaining_quantity = factories.EventOfferFactory(
                 venue=self.venue,
                 description="active_event_offer_with_one_stock_in_the_future_with_remaining_quantity",
             )
             self.sold_old_thing_offer_with_all_stocks_empty = factories.ThingOfferFactory(
-                venue=self.venue, description="sold_old_thing_offer_with_all_stocks_empty"
+                venue=self.venue,
+                description="sold_old_thing_offer_with_all_stocks_empty",
             )
             self.sold_out_event_offer_with_all_stocks_in_the_future_with_zero_remaining_quantity = (
                 factories.EventOfferFactory(
@@ -581,10 +610,12 @@ class GetCappedOffersForFiltersTest:
                 venue=self.venue, description="sold_out_event_offer_without_stock"
             )
             self.sold_out_event_offer_with_only_one_stock_soft_deleted = factories.EventOfferFactory(
-                venue=self.venue, description="sold_out_event_offer_with_only_one_stock_soft_deleted"
+                venue=self.venue,
+                description="sold_out_event_offer_with_only_one_stock_soft_deleted",
             )
             self.expired_event_offer_with_stock_in_the_past_without_quantity = factories.EventOfferFactory(
-                venue=self.venue, description="expired_event_offer_with_stock_in_the_past_without_quantity"
+                venue=self.venue,
+                description="expired_event_offer_with_stock_in_the_past_without_quantity",
             )
             self.expired_event_offer_with_all_stocks_in_the_past_with_remaining_quantity = factories.EventOfferFactory(
                 venue=self.venue,
@@ -610,12 +641,17 @@ class GetCappedOffersForFiltersTest:
             beneficiary = users_factories.BeneficiaryGrant18Factory(email="jane.doe@example.com")
             factories.ThingStockFactory(offer=self.sold_old_thing_offer_with_all_stocks_empty, quantity=0)
             factories.ThingStockFactory(
-                offer=self.active_thing_offer_with_one_stock_with_remaining_quantity, quantity=5
+                offer=self.active_thing_offer_with_one_stock_with_remaining_quantity,
+                quantity=5,
             )
             factories.ThingStockFactory(
-                offer=self.active_thing_offer_with_one_stock_with_remaining_quantity, quantity=0
+                offer=self.active_thing_offer_with_one_stock_with_remaining_quantity,
+                quantity=0,
             )
-            factories.ThingStockFactory(offer=self.active_thing_offer_with_all_stocks_without_quantity, quantity=None)
+            factories.ThingStockFactory(
+                offer=self.active_thing_offer_with_all_stocks_without_quantity,
+                quantity=None,
+            )
             factories.EventStockFactory(
                 offer=self.expired_event_offer_with_stock_in_the_past_without_quantity,
                 beginningDatetime=five_days_ago,
@@ -686,7 +722,10 @@ class GetCappedOffersForFiltersTest:
                 price=0,
             )
             bookings_factories.BookingFactory(user=beneficiary, stock=stock_all_booked)
-            factories.ThingStockFactory(offer=self.inactive_thing_offer_with_stock_with_remaining_quantity, quantity=4)
+            factories.ThingStockFactory(
+                offer=self.inactive_thing_offer_with_stock_with_remaining_quantity,
+                quantity=4,
+            )
             factories.EventStockFactory(
                 offer=self.active_event_offer_with_stock_in_the_future_without_quantity,
                 beginningDatetime=five_days_ago,
@@ -701,7 +740,9 @@ class GetCappedOffersForFiltersTest:
             )
             factories.ThingStockFactory(offer=self.inactive_thing_offer_without_remaining_quantity, quantity=0)
             factories.EventStockFactory(
-                offer=self.sold_out_event_offer_with_only_one_stock_soft_deleted, quantity=10, isSoftDeleted=True
+                offer=self.sold_out_event_offer_with_only_one_stock_soft_deleted,
+                quantity=10,
+                isSoftDeleted=True,
             )
             factories.ThingStockFactory(
                 offer=self.expired_thing_offer_with_a_stock_expired_with_remaining_quantity,
@@ -722,7 +763,9 @@ class GetCappedOffersForFiltersTest:
                 quantity=10,
             )
             self.draft_offer = factories.EventOfferFactory(
-                venue=self.venue, validation=offer_mixin.OfferValidationStatus.DRAFT, description="draft event offer"
+                venue=self.venue,
+                validation=offer_mixin.OfferValidationStatus.DRAFT,
+                description="draft event offer",
             )
 
         @pytest.mark.usefixtures("db_session")
@@ -732,7 +775,10 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = repository.get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="ACTIVE"
+                user_id=self.pro.id,
+                user_is_admin=self.pro.has_admin_role,
+                offers_limit=5,
+                status="ACTIVE",
             )
 
             # then
@@ -766,7 +812,10 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = repository.get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="INACTIVE"
+                user_id=self.pro.id,
+                user_is_admin=self.pro.has_admin_role,
+                offers_limit=5,
+                status="INACTIVE",
             )
 
             # then
@@ -800,7 +849,10 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = repository.get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=10, status="SOLD_OUT"
+                user_id=self.pro.id,
+                user_is_admin=self.pro.has_admin_role,
+                offers_limit=10,
+                status="SOLD_OUT",
             )
 
             # then
@@ -833,7 +885,10 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = repository.get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=10, status="SOLD_OUT"
+                user_id=self.pro.id,
+                user_is_admin=self.pro.has_admin_role,
+                offers_limit=10,
+                status="SOLD_OUT",
             )
 
             # then
@@ -842,13 +897,18 @@ class GetCappedOffersForFiltersTest:
             assert self.sold_out_event_offer_with_only_one_stock_soft_deleted.id in offer_ids
 
         @pytest.mark.usefixtures("db_session")
-        def should_return_offers_with_no_remaining_quantity_and_no_bookings_when_requesting_sold_out_status(self):
+        def should_return_offers_with_no_remaining_quantity_and_no_bookings_when_requesting_sold_out_status(
+            self,
+        ):
             # given
             self.init_test_data()
 
             # when
             offers = repository.get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="SOLD_OUT"
+                user_id=self.pro.id,
+                user_is_admin=self.pro.has_admin_role,
+                offers_limit=5,
+                status="SOLD_OUT",
             )
 
             # then
@@ -856,13 +916,18 @@ class GetCappedOffersForFiltersTest:
             assert self.sold_old_thing_offer_with_all_stocks_empty.id in offer_ids
 
         @pytest.mark.usefixtures("db_session")
-        def should_return_offers_with_no_remaining_quantity_in_the_future_when_requesting_sold_out_status(self):
+        def should_return_offers_with_no_remaining_quantity_in_the_future_when_requesting_sold_out_status(
+            self,
+        ):
             # given
             self.init_test_data()
 
             # when
             offers = repository.get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="SOLD_OUT"
+                user_id=self.pro.id,
+                user_is_admin=self.pro.has_admin_role,
+                offers_limit=5,
+                status="SOLD_OUT",
             )
 
             # then
@@ -870,13 +935,18 @@ class GetCappedOffersForFiltersTest:
             assert self.sold_out_event_offer_with_all_stocks_in_the_future_with_zero_remaining_quantity.id in offer_ids
 
         @pytest.mark.usefixtures("db_session")
-        def should_exclude_offers_with_cancelled_bookings_when_requesting_sold_out_status(self):
+        def should_exclude_offers_with_cancelled_bookings_when_requesting_sold_out_status(
+            self,
+        ):
             # given
             self.init_test_data()
 
             # when
             offers = repository.get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="SOLD_OUT"
+                user_id=self.pro.id,
+                user_is_admin=self.pro.has_admin_role,
+                offers_limit=5,
+                status="SOLD_OUT",
             )
 
             # then
@@ -890,7 +960,10 @@ class GetCappedOffersForFiltersTest:
 
             # when
             offers = repository.get_capped_offers_for_filters(
-                user_id=self.pro.id, user_is_admin=self.pro.has_admin_role, offers_limit=5, status="EXPIRED"
+                user_id=self.pro.id,
+                user_is_admin=self.pro.has_admin_role,
+                offers_limit=5,
+                status="EXPIRED",
             )
 
             # then
@@ -948,7 +1021,9 @@ class GetCappedOffersForFiltersTest:
             unexpired_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
 
             rejected_offer = factories.ThingOfferFactory(
-                validation=offer_mixin.OfferValidationStatus.REJECTED, name="Offre rejetée", isActive=False
+                validation=offer_mixin.OfferValidationStatus.REJECTED,
+                name="Offre rejetée",
+                isActive=False,
             )
             factories.StockFactory(bookingLimitDatetime=unexpired_booking_limit_date, offer=rejected_offer)
 
@@ -996,7 +1071,9 @@ class GetCappedOffersForFiltersTest:
             assert len(offers) == 1
 
         @pytest.mark.usefixtures("db_session")
-        def should_return_only_active_offer_on_specific_period_when_requesting_active_status_and_time_period(self):
+        def should_return_only_active_offer_on_specific_period_when_requesting_active_status_and_time_period(
+            self,
+        ):
             # given
             self.init_test_data()
 
@@ -1043,7 +1120,8 @@ class GetOffersByPublicationDateTest:
         )
         offer_to_publish_2 = factories.OfferFactory()
         future_offer_to_publish_2 = factories.FutureOfferFactory(
-            offer=offer_to_publish_2, publicationDate=publication_date - datetime.timedelta(minutes=13)
+            offer=offer_to_publish_2,
+            publicationDate=publication_date - datetime.timedelta(minutes=13),
         )
         # Simulates an Offer manually published then unpublished with a publicationDate within the range of 15 minutes considered, should not be returned by the function
         offer_manually_published = factories.OfferFactory()
@@ -1061,7 +1139,10 @@ class GetOffersByPublicationDateTest:
         assert offers_query.count() == 2
         assert offers_query.all() == [offer_to_publish_1, offer_to_publish_2]
         assert future_offers_query.count() == 2
-        assert future_offers_query.all() == [future_offer_to_publish_1, future_offer_to_publish_2]
+        assert future_offers_query.all() == [
+            future_offer_to_publish_1,
+            future_offer_to_publish_2,
+        ]
 
 
 @pytest.mark.usefixtures("db_session")
@@ -1132,14 +1213,18 @@ class IncomingEventStocksTest:
 
         offerer_address = offerers_factories.OffererAddressFactory(address=address_paris)
         offer = factories.OfferFactory(
-            venue__departementCode="75", venue__postalCode="75002", offererAddress=offerer_address
+            venue__departementCode="75",
+            venue__postalCode="75002",
+            offererAddress=offerer_address,
         )
         self.stock_today = factories.EventStockFactory(beginningDatetime=today, offer=offer)
         bookings_factories.BookingFactory.create_batch(2, stock=self.stock_today)
 
         overseas_offerer_address = offerers_factories.OffererAddressFactory(address=address_overseas)
         offer = factories.OfferFactory(
-            venue__departementCode="97", venue__postalCode="97180", offererAddress=overseas_offerer_address
+            venue__departementCode="97",
+            venue__postalCode="97180",
+            offererAddress=overseas_offerer_address,
         )
         self.stock_today_overseas = factories.EventStockFactory(beginningDatetime=today, offer=offer)
         bookings_factories.BookingFactory(stock=self.stock_today_overseas)
@@ -1193,7 +1278,9 @@ class IncomingEventStocksTest:
         assert set(stock_ids) == {self.stock_today_overseas.id}
 
     @time_machine.travel("2024-10-15 15:00:00")
-    def test_find_today_event_stock_ids_by_departments_with_address_different_than_the_venue(self):
+    def test_find_today_event_stock_ids_by_departments_with_address_different_than_the_venue(
+        self,
+    ):
         self.setup_stocks()
 
         today_min = datetime.datetime(2024, 10, 15, 8, 00)
@@ -1206,7 +1293,9 @@ class IncomingEventStocksTest:
         assert set(stock_ids) == {self.stock_today_overseas.id, self.stock_today.id}
 
     @time_machine.travel("2024-10-15 15:00:00")
-    def test_find_today_event_stock_ids_by_departments_with_address_different_than_the_venue_2(self):
+    def test_find_today_event_stock_ids_by_departments_with_address_different_than_the_venue_2(
+        self,
+    ):
         self.setup_stocks()
 
         today_min = datetime.datetime(2024, 10, 15, 8, 00)
@@ -1219,7 +1308,9 @@ class IncomingEventStocksTest:
         assert set(stock_ids) == {self.stock_today_overseas.id}
 
     @time_machine.travel("2024-10-15 15:00:00")
-    def test_find_today_event_stock_ids_by_departments_with_address_different_than_the_venue_3(self):
+    def test_find_today_event_stock_ids_by_departments_with_address_different_than_the_venue_3(
+        self,
+    ):
         self.setup_stocks()
 
         today_min = datetime.datetime(2024, 10, 15, 8, 00)
@@ -1232,7 +1323,9 @@ class IncomingEventStocksTest:
         assert set(stock_ids) == {self.stock_today.id}
 
     @time_machine.travel("2024-10-15 15:00:00")
-    def test_find_today_digital_stock_ids_by_departments_with_address_different_than_the_venue(self):
+    def test_find_today_digital_stock_ids_by_departments_with_address_different_than_the_venue(
+        self,
+    ):
         self.setup_stocks()
 
         # add digital offer
@@ -1253,7 +1346,10 @@ class IncomingEventStocksTest:
 
 @pytest.mark.usefixtures("db_session")
 class GetExpiredOffersTest:
-    interval = [datetime.datetime(2021, 1, 1, 0, 0), datetime.datetime(2021, 1, 2, 0, 0)]
+    interval = [
+        datetime.datetime(2021, 1, 1, 0, 0),
+        datetime.datetime(2021, 1, 2, 0, 0),
+    ]
     dt_before = datetime.datetime(2020, 12, 31)
     dt_within = datetime.datetime(2021, 1, 1)
     dt_after = datetime.datetime(2021, 1, 3)
@@ -1308,7 +1404,8 @@ class AvailableActivationCodeTest:
         stock = booking.stock
         factories.ActivationCodeFactory(booking=booking, stock=stock)  # booked_code
         factories.ActivationCodeFactory(
-            stock=stock, expirationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            stock=stock,
+            expirationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1),
         )  # expired code
 
         # WHEN THEN
@@ -1387,7 +1484,10 @@ class GetPaginatedActiveOfferIdsTest:
         offer2 = factories.OfferFactory(venue=venue)
         offer3 = factories.OfferFactory(venue=venue)
 
-        assert repository.get_paginated_active_offer_ids(batch_size=2, page=1) == [offer1.id, offer2.id]
+        assert repository.get_paginated_active_offer_ids(batch_size=2, page=1) == [
+            offer1.id,
+            offer2.id,
+        ]
         assert repository.get_paginated_active_offer_ids(batch_size=2, page=2) == [offer3.id]
 
     def test_exclude_inactive_offers(self):
@@ -1433,7 +1533,8 @@ class GetFilteredCollectiveOffersTest:
             status=educational_models.CollectiveBookingStatus.CANCELLED.value,
         )
         educational_factories.CollectiveBookingFactory(
-            collectiveStock=collective_stock_prebooked, status=educational_models.CollectiveBookingStatus.PENDING.value
+            collectiveStock=collective_stock_prebooked,
+            status=educational_models.CollectiveBookingStatus.PENDING.value,
         )
 
         collective_offer_cancelled = educational_factories.CollectiveOfferFactory(
@@ -1443,7 +1544,8 @@ class GetFilteredCollectiveOffersTest:
             collectiveOffer=collective_offer_cancelled
         )
         educational_factories.CollectiveBookingFactory(
-            collectiveStock=collective_stock_cancelled, status=educational_models.CollectiveBookingStatus.PENDING.value
+            collectiveStock=collective_stock_cancelled,
+            status=educational_models.CollectiveBookingStatus.PENDING.value,
         )
         educational_factories.CollectiveBookingFactory(
             collectiveStock=collective_stock_cancelled,
@@ -1463,10 +1565,12 @@ class GetFilteredCollectiveOffersTest:
             venue__managingOfferer=user_offerer.offerer
         )
         collective_stock_ended = educational_factories.CollectiveStockFactory(
-            collectiveOffer=collective_offer_ended, startDatetime=datetime.datetime(year=2000, month=1, day=1)
+            collectiveOffer=collective_offer_ended,
+            startDatetime=datetime.datetime(year=2000, month=1, day=1),
         )
         educational_factories.CollectiveBookingFactory(
-            collectiveStock=collective_stock_ended, status=educational_models.CollectiveBookingStatus.USED.value
+            collectiveStock=collective_stock_ended,
+            status=educational_models.CollectiveBookingStatus.USED.value,
         )
 
         offers = repository.get_collective_offers_by_filters(
@@ -1482,7 +1586,8 @@ class GetFilteredCollectiveOffersTest:
             venue__managingOfferer=user_offerer.offerer, formats=[EacFormat.CONCERT]
         )
         educational_factories.CollectiveOfferFactory(
-            venue__managingOfferer=user_offerer.offerer, formats=[EacFormat.CONFERENCE_RENCONTRE]
+            venue__managingOfferer=user_offerer.offerer,
+            formats=[EacFormat.CONFERENCE_RENCONTRE],
         )
 
         offers = repository.get_collective_offers_by_filters(
@@ -1515,7 +1620,8 @@ class GetFilteredCollectiveOffersTest:
         user_offerer = offerers_factories.UserOffererFactory()
 
         collective_offer_draft = educational_factories.CollectiveOfferFactory(
-            validation=offer_mixin.OfferValidationStatus.DRAFT.value, venue__managingOfferer=user_offerer.offerer
+            validation=offer_mixin.OfferValidationStatus.DRAFT.value,
+            venue__managingOfferer=user_offerer.offerer,
         )
 
         offers = repository.get_collective_offers_by_filters(user_id=user_offerer.userId, user_is_admin=False)
@@ -1538,20 +1644,26 @@ class GetFilteredCollectiveOffersTest:
 
         # expired offer without booking
         collective_offer_expired = educational_factories.CollectiveOfferFactory(
-            validation=offer_mixin.OfferValidationStatus.APPROVED.value, venue__managingOfferer=user_offerer.offerer
+            validation=offer_mixin.OfferValidationStatus.APPROVED.value,
+            venue__managingOfferer=user_offerer.offerer,
         )
 
         educational_factories.CollectiveStockFactory(
-            collectiveOffer=collective_offer_expired, startDatetime=future, bookingLimitDatetime=past
+            collectiveOffer=collective_offer_expired,
+            startDatetime=future,
+            bookingLimitDatetime=past,
         )
 
         # expired offer with pending booking
         collective_offer_prebooked_expired = educational_factories.CollectiveOfferFactory(
-            validation=offer_mixin.OfferValidationStatus.APPROVED.value, venue__managingOfferer=user_offerer.offerer
+            validation=offer_mixin.OfferValidationStatus.APPROVED.value,
+            venue__managingOfferer=user_offerer.offerer,
         )
 
         collective_stock_prebooked_expired = educational_factories.CollectiveStockFactory(
-            collectiveOffer=collective_offer_prebooked_expired, startDatetime=future, bookingLimitDatetime=past
+            collectiveOffer=collective_offer_prebooked_expired,
+            startDatetime=future,
+            bookingLimitDatetime=past,
         )
 
         educational_factories.CollectiveBookingFactory(
@@ -1568,7 +1680,10 @@ class GetFilteredCollectiveOffersTest:
         )
         offers_list = offers.all()
         assert len(offers_list) == 2
-        assert set(offers_list) == {collective_offer_expired, collective_offer_prebooked_expired}
+        assert set(offers_list) == {
+            collective_offer_expired,
+            collective_offer_prebooked_expired,
+        }
 
     @pytest.mark.parametrize(
         "offer_status",
@@ -1668,7 +1783,10 @@ class GetStocksListFiltersTest:
         beginning_datetime = datetime.datetime(2020, 10, 15, 0, 0, 0)
         offer = factories.OfferFactory()
         factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime)
-        factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime + datetime.timedelta(days=1))
+        factories.EventStockFactory(
+            offer=offer,
+            beginningDatetime=beginning_datetime + datetime.timedelta(days=1),
+        )
         # When
         stocks = repository.get_filtered_stocks(
             venue=offer.venue,
@@ -1709,8 +1827,14 @@ class GetStocksListFiltersTest:
         )
         offer = factories.OfferFactory(venue=venue)
         factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime)
-        factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime + datetime.timedelta(hours=1))
-        factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime + datetime.timedelta(minutes=1))
+        factories.EventStockFactory(
+            offer=offer,
+            beginningDatetime=beginning_datetime + datetime.timedelta(hours=1),
+        )
+        factories.EventStockFactory(
+            offer=offer,
+            beginningDatetime=beginning_datetime + datetime.timedelta(minutes=1),
+        )
 
         # When
         stocks = repository.get_filtered_stocks(
@@ -1748,7 +1872,9 @@ class GetStocksListFiltersTest:
         assert stocks.count() == 2
 
     @time_machine.travel("2020-02-20 01:00:00")
-    def test_filtered_stock_by_time_find_summer_and_winter_time_when_launch_in_winter(self):
+    def test_filtered_stock_by_time_find_summer_and_winter_time_when_launch_in_winter(
+        self,
+    ):
         # Given
         beginning_datetime_1 = datetime.datetime(2021, 3, 27, 2, 0, 0)
         beginning_datetime_2 = datetime.datetime(2021, 3, 28, 1, 0, 0)
@@ -1778,7 +1904,9 @@ class GetStocksListFiltersTest:
         assert stocks.count() == 3
 
     @time_machine.travel("2020-06-20 01:00:00")
-    def test_filtered_stock_by_time_find_summer_and_winter_time_when_launch_in_summer(self):
+    def test_filtered_stock_by_time_find_summer_and_winter_time_when_launch_in_summer(
+        self,
+    ):
         # Given
         beginning_datetime_1 = datetime.datetime(2021, 3, 13, 11, 0, 0)
         beginning_datetime_2 = datetime.datetime(2021, 3, 14, 10, 0, 0)
@@ -1813,10 +1941,12 @@ class GetStocksListFiltersTest:
         offer = factories.OfferFactory()
         first_stock = factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime)
         second_stock = factories.EventStockFactory(
-            offer=offer, beginningDatetime=beginning_datetime + datetime.timedelta(seconds=1)
+            offer=offer,
+            beginningDatetime=beginning_datetime + datetime.timedelta(seconds=1),
         )
         third_stock = factories.EventStockFactory(
-            offer=offer, beginningDatetime=beginning_datetime + datetime.timedelta(seconds=2)
+            offer=offer,
+            beginningDatetime=beginning_datetime + datetime.timedelta(seconds=2),
         )
 
         # When
@@ -1834,9 +1964,15 @@ class GetStocksListFiltersTest:
         stocks_limit_per_page = 1
         current_page = 2
         offer = factories.OfferFactory()
-        factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime - datetime.timedelta(seconds=1))
+        factories.EventStockFactory(
+            offer=offer,
+            beginningDatetime=beginning_datetime - datetime.timedelta(seconds=1),
+        )
         factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime)
-        factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime + datetime.timedelta(seconds=30))
+        factories.EventStockFactory(
+            offer=offer,
+            beginningDatetime=beginning_datetime + datetime.timedelta(seconds=30),
+        )
 
         # When
         filtered_stocks = repository.get_filtered_stocks(
@@ -1845,7 +1981,9 @@ class GetStocksListFiltersTest:
             order_by="BEGINNING_DATETIME",
         )
         stocks = repository.get_paginated_stocks(
-            stocks_query=filtered_stocks, stocks_limit_per_page=stocks_limit_per_page, page=current_page
+            stocks_query=filtered_stocks,
+            stocks_limit_per_page=stocks_limit_per_page,
+            page=current_page,
         )
 
         # Then
@@ -2118,7 +2256,9 @@ class GetHeadlineOfferFiltersTest:
         headline_offer_query_result = repository.get_inactive_headline_offers()
         assert headline_offer_query_result == []
 
-    def test_get_inactive_headline_offers_should_not_return_already_deactivated_headline_offer(self):
+    def test_get_inactive_headline_offers_should_not_return_already_deactivated_headline_offer(
+        self,
+    ):
         inactive_offer = factories.OfferFactory(isActive=False)
         inactive_offer_headline_offer = factories.HeadlineOfferFactory(offer=inactive_offer)
 
@@ -2139,7 +2279,8 @@ class GetHeadlineOfferFiltersTest:
         )
 
         headline_offer_query_result = sorted(
-            repository.get_inactive_headline_offers(), key=lambda headline_offer: headline_offer.id
+            repository.get_inactive_headline_offers(),
+            key=lambda headline_offer: headline_offer.id,
         )
 
         assert headline_offer_query_result == sorted(
@@ -2164,7 +2305,9 @@ class GetHeadlineOfferFiltersTest:
         headline_offer_query_result = repository.get_inactive_headline_offers()
         assert headline_offer_query_result == [headline_offer_without_mediation]
 
-    def test_get_offerer_active_headline_offer_even_not_yet_disabled_by_cron_for_active_offer(self):
+    def test_get_offerer_active_headline_offer_even_not_yet_disabled_by_cron_for_active_offer(
+        self,
+    ):
         offer = factories.OfferFactory(isActive=True)
         user_offerer = offerers_factories.UserOffererFactory()
         venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
@@ -2172,7 +2315,9 @@ class GetHeadlineOfferFiltersTest:
         headline_offer_query_result = repository.get_current_headline_offer(user_offerer.offerer.id)
         assert headline_offer_query_result == headline_offer
 
-    def test_get_offerer_active_headline_offer_even_not_yet_disabled_by_cron_for_inactive_offer(self):
+    def test_get_offerer_active_headline_offer_even_not_yet_disabled_by_cron_for_inactive_offer(
+        self,
+    ):
         offer = factories.OfferFactory(isActive=True)
         user_offerer = offerers_factories.UserOffererFactory()
         venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
@@ -2246,7 +2391,10 @@ class GetActiveOfferByVenueIdAndEanTest:
 
 
 @pytest.mark.usefixtures("db_session")
-@patch("pcapi.models.db.session.delete", side_effect=(sa_exc.IntegrityError(None, None, None), None))
+@patch(
+    "pcapi.models.db.session.delete",
+    side_effect=(sa_exc.IntegrityError(None, None, None), None),
+)
 def test_handles_offer_creation_while_product_merging(delete_mock):
     to_keep = factories.ProductFactory()
     to_delete = factories.ProductFactory()
@@ -2269,6 +2417,38 @@ class GetUnbookableUnbookedOldOfferIdsTest:
         ids = list(repository.get_unbookable_unbooked_old_offer_ids())
         assert ids == [offer.id]
 
+    def test_get_old_offer_with_an_expired_stock_with_quantity_is_matched(self):
+        offer = factories.StockFactory(
+            quantity=10,
+            bookingLimitDatetime=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2),
+            offer__dateCreated=self.a_year_ago,
+            offer__dateUpdated=self.a_year_ago,
+        ).offer
+
+        ids = list(repository.get_unbookable_unbooked_old_offer_ids())
+        assert ids == [offer.id]
+
+    def test_get_old_offer_with_an_ongoing_stock_without_any_quantity_is_matched(self):
+        offer = factories.StockFactory(
+            quantity=0,
+            offer__dateCreated=self.a_year_ago,
+            offer__dateUpdated=self.a_year_ago,
+        ).offer
+
+        ids = list(repository.get_unbookable_unbooked_old_offer_ids())
+        assert ids == [offer.id]
+
+    def test_get_old_offer_with_a_soft_deleted_stock_is_matched(self):
+        offer = factories.StockFactory(
+            isSoftDeleted=True,
+            quantity=10,
+            offer__dateCreated=self.a_year_ago,
+            offer__dateUpdated=self.a_year_ago,
+        ).offer
+
+        ids = list(repository.get_unbookable_unbooked_old_offer_ids())
+        assert ids == [offer.id]
+
     def test_get_old_offer_with_an_ongoing_stock_is_ignored(self):
         factories.StockFactory(offer__dateCreated=self.a_year_ago, offer__dateUpdated=self.a_year_ago)
         assert not list(repository.get_unbookable_unbooked_old_offer_ids())
@@ -2281,7 +2461,9 @@ class GetUnbookableUnbookedOldOfferIdsTest:
 
         assert not list(repository.get_unbookable_unbooked_old_offer_ids())
 
-    def test_get_old_offer_with_unbookable_and_bookable_stocks_and_a_booking_is_ignored(self):
+    def test_get_old_offer_with_unbookable_and_bookable_stocks_and_a_booking_is_ignored(
+        self,
+    ):
         offer = factories.OfferFactory(dateCreated=self.a_year_ago, dateUpdated=self.a_year_ago)
 
         # unbookable stock with an old booking
@@ -2294,14 +2476,16 @@ class GetUnbookableUnbookedOldOfferIdsTest:
 
     def test_get_old_offer_with_a_booking_is_ignored(self):
         bookings_factories.BookingFactory(
-            stock__offer__dateCreated=self.a_year_ago, stock__offer__dateUpdated=self.a_year_ago
+            stock__offer__dateCreated=self.a_year_ago,
+            stock__offer__dateUpdated=self.a_year_ago,
         )
 
         assert not list(repository.get_unbookable_unbooked_old_offer_ids())
 
     def test_get_old_offer_with_a_cancelled_booking_is_ignored(self):
         bookings_factories.CancelledBookingFactory(
-            stock__offer__dateCreated=self.a_year_ago, stock__offer__dateUpdated=self.a_year_ago
+            stock__offer__dateCreated=self.a_year_ago,
+            stock__offer__dateUpdated=self.a_year_ago,
         )
 
         assert not list(repository.get_unbookable_unbooked_old_offer_ids())
@@ -2315,7 +2499,8 @@ class GetUnbookableUnbookedOldOfferIdsTest:
 
         factories.OfferFactory()
         bookings_factories.BookingFactory(
-            stock__offer__dateCreated=self.a_year_ago, stock__offer__dateUpdated=self.a_year_ago
+            stock__offer__dateCreated=self.a_year_ago,
+            stock__offer__dateUpdated=self.a_year_ago,
         )
 
         ids = list(repository.get_unbookable_unbooked_old_offer_ids())


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35736

Fix de la précédente PR chargée de la création de la commande qui ne fonctionnait visiblement pas.
Difficile de savoir exactement pourquoi mais la manière dont était construite la requête avec différentes propriétés hybrides ne facilite pas les choses.

Cette PR propose de corriger la fonction de filtrage des offres avec une approche plus explicite via une requête SQL, en espérant que cela fonctionne comme prévu ensuite.
