### PR TITLE
(PC-35782)[API] fix: new venue provider: sync movies only

### DIFF
--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -24,21 +24,43 @@ def get_venue_provider_list(venue_id: int) -> list[models.VenueProvider]:
     return (
         db.session.query(models.VenueProvider)
         .filter_by(venueId=venue_id)
-        .options(sa_orm.joinedload(models.VenueProvider.provider).joinedload(models.Provider.offererProvider))
+        .options(
+            sa_orm.joinedload(models.VenueProvider.provider).joinedload(
+                models.Provider.offererProvider
+            )
+        )
         .all()
     )
 
 
-def get_active_venue_providers_by_provider(provider_id: int) -> list[models.VenueProvider]:
-    return db.session.query(models.VenueProvider).filter_by(providerId=provider_id, isActive=True).all()
+def get_active_venue_providers_by_provider(
+    provider_id: int,
+) -> list[models.VenueProvider]:
+    return (
+        db.session.query(models.VenueProvider)
+        .filter_by(providerId=provider_id, isActive=True)
+        .all()
+    )
 
 
-def get_venue_provider_by_venue_and_provider_ids(venue_id: int, provider_id: int) -> models.VenueProvider | None:
-    return db.session.query(models.VenueProvider).filter_by(venueId=venue_id, providerId=provider_id).one_or_none()
+def get_venue_provider_by_venue_and_provider_ids(
+    venue_id: int, provider_id: int
+) -> models.VenueProvider | None:
+    return (
+        db.session.query(models.VenueProvider)
+        .filter_by(venueId=venue_id, providerId=provider_id)
+        .one_or_none()
+    )
 
 
-def get_provider_enabled_for_pro_by_id(provider_id: int | None) -> models.Provider | None:
-    return db.session.query(models.Provider).filter_by(id=provider_id, isActive=True, enabledForPro=True).one_or_none()
+def get_provider_enabled_for_pro_by_id(
+    provider_id: int | None,
+) -> models.Provider | None:
+    return (
+        db.session.query(models.Provider)
+        .filter_by(id=provider_id, isActive=True, enabledForPro=True)
+        .one_or_none()
+    )
 
 
 def get_active_provider_by_id(provider_id: int) -> models.Provider | None:
@@ -46,7 +68,11 @@ def get_active_provider_by_id(provider_id: int) -> models.Provider | None:
 
 
 def get_provider_by_local_class(local_class: str) -> models.Provider:
-    return db.session.query(models.Provider).filter_by(localClass=local_class).one_or_none()
+    return (
+        db.session.query(models.Provider)
+        .filter_by(localClass=local_class)
+        .one_or_none()
+    )
 
 
 def get_provider_by_name(name: str) -> models.Provider:
@@ -72,21 +98,32 @@ def get_available_providers(venue: Venue) -> BaseQuery:
 
     if local_classes_to_exclude:
         query = query.filter(
-            models.Provider.localClass.notin_(local_classes_to_exclude) | models.Provider.localClass.is_(None)
+            models.Provider.localClass.notin_(local_classes_to_exclude)
+            | models.Provider.localClass.is_(None)
         )
     return query.order_by(models.Provider.name)
 
 
 def get_allocine_theater(venue: Venue) -> models.AllocineTheater | None:
-    return db.session.query(models.AllocineTheater).filter_by(siret=venue.siret).one_or_none()
+    return (
+        db.session.query(models.AllocineTheater)
+        .filter_by(siret=venue.siret)
+        .one_or_none()
+    )
 
 
 def get_allocine_pivot(venue: Venue) -> models.AllocinePivot | None:
     return db.session.query(models.AllocinePivot).filter_by(venue=venue).one_or_none()
 
 
-def get_cinema_provider_pivot_for_venue(venue: Venue) -> models.CinemaProviderPivot | None:
-    return db.session.query(models.CinemaProviderPivot).filter_by(venue=venue).one_or_none()
+def get_cinema_provider_pivot_for_venue(
+    venue: Venue,
+) -> models.CinemaProviderPivot | None:
+    return (
+        db.session.query(models.CinemaProviderPivot)
+        .filter_by(venue=venue)
+        .one_or_none()
+    )
 
 
 def get_cds_cinema_details(cinema_id: str) -> models.CDSCinemaDetails:
@@ -151,12 +188,17 @@ def bump_ems_sync_version(version: int, venues_provider_to_sync: Iterable[int]) 
     ids: list[Sequence[int]] = (
         db.session.query(models.EMSCinemaDetails)
         .join(models.CinemaProviderPivot)
-        .join(models.VenueProvider, models.CinemaProviderPivot.providerId == models.VenueProvider.providerId)
+        .join(
+            models.VenueProvider,
+            models.CinemaProviderPivot.providerId == models.VenueProvider.providerId,
+        )
         .filter(models.VenueProvider.id.in_(venues_provider_to_sync))
         .with_entities(models.EMSCinemaDetails.id)
         .all()
     )
-    db.session.bulk_update_mappings(models.EMSCinemaDetails, [{"id": id, "lastVersion": version} for (id,) in ids])
+    db.session.bulk_update_mappings(
+        models.EMSCinemaDetails, [{"id": id, "lastVersion": version} for (id,) in ids]
+    )
 
 
 def get_ems_oldest_sync_version() -> int:
@@ -170,14 +212,19 @@ def get_ems_oldest_sync_version() -> int:
     version = (
         db.session.query(func.min(models.EMSCinemaDetails.lastVersion))
         .join(models.CinemaProviderPivot)
-        .join(models.VenueProvider, models.CinemaProviderPivot.providerId == models.VenueProvider.providerId)
+        .join(
+            models.VenueProvider,
+            models.CinemaProviderPivot.providerId == models.VenueProvider.providerId,
+        )
         .filter(models.VenueProvider.isActive)
         .scalar()
     )
     return version
 
 
-def get_pivot_for_id_at_provider(id_at_provider: str, provider_id: int) -> models.CinemaProviderPivot | None:
+def get_pivot_for_id_at_provider(
+    id_at_provider: str, provider_id: int
+) -> models.CinemaProviderPivot | None:
     pivot = (
         db.session.query(models.CinemaProviderPivot)
         .filter(
@@ -193,7 +240,9 @@ def is_cinema_external_ticket_applicable(offer: offers_models.Offer) -> bool:
     return bool(
         offer.subcategory.id == subcategories.SEANCE_CINE.id
         and offer.lastProviderId
-        and db.session.query(get_cinema_venue_provider_query(offer.venueId).exists()).scalar()
+        and db.session.query(
+            get_cinema_venue_provider_query(offer.venueId).exists()
+        ).scalar()
     )
 
 
@@ -202,7 +251,11 @@ def get_providers_venues(provider_id: int) -> BaseQuery:
         db.session.query(Venue)
         .join(models.VenueProvider)
         .outerjoin(models.VenueProvider.externalUrls)
-        .options(sa_orm.contains_eager(Venue.venueProviders).contains_eager(models.VenueProvider.externalUrls))
+        .options(
+            sa_orm.contains_eager(Venue.venueProviders).contains_eager(
+                models.VenueProvider.externalUrls
+            )
+        )
         .filter(models.VenueProvider.providerId == provider_id)
     )
 
@@ -239,8 +292,8 @@ def get_future_events_requiring_ticketing_system(
     venue: models.Venue | None = None,
 ) -> list[offers_models.Offer]:
     # base query
-    future_provider_events_with_ticketing_query = _get_future_provider_events_requiring_a_ticketing_system_query(
-        provider
+    future_provider_events_with_ticketing_query = (
+        _get_future_provider_events_requiring_a_ticketing_system_query(provider)
     )
 
     if venue:

--- a/api/tests/routes/pro/post_venue_provider_test.py
+++ b/api/tests/routes/pro/post_venue_provider_test.py
@@ -24,9 +24,7 @@ from tests.local_providers.cinema_providers.cds import fixtures as cds_fixtures
 class Returns201Test:
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.venue_provider_job.delay")
-    def test_when_venue_provider_is_successfully_created(
-        self, mock_synchronize_venue_provider, client
-    ):
+    def test_when_venue_provider_is_successfully_created(self, mock_synchronize_venue_provider, client):
         # Given
         venue = offerers_factories.VenueFactory(siret="12345678912345")
         user = user_factories.ProFactory()
@@ -59,15 +57,11 @@ class Returns201Test:
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.venue_provider_job.delay")
-    def test_when_movie_provider_is_successfully_created(
-        self, mock_synchronize_venue_provider, client
-    ):
+    def test_when_movie_provider_is_successfully_created(self, mock_synchronize_venue_provider, client):
         venue = offerers_factories.VenueFactory(siret="12345678912345")
         user = user_factories.ProFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=venue.managingOfferer)
-        provider = providers_factories.CGRCinemaProviderPivotFactory(
-            venue=venue
-        ).provider
+        provider = providers_factories.CGRCinemaProviderPivotFactory(venue=venue).provider
 
         venue_provider_data = {"providerId": provider.id, "venueId": venue.id}
         auth_request = client.with_session_auth(email=user.email)
@@ -113,13 +107,9 @@ class Returns201Test:
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.synchronize_venue_provider")
-    def test_when_add_allocine_stocks_provider_for_venue_without_siret(
-        self, mock_synchronize_venue_provider, client
-    ):
+    def test_when_add_allocine_stocks_provider_for_venue_without_siret(self, mock_synchronize_venue_provider, client):
         # Given
-        venue = offerers_factories.VenueWithoutSiretFactory(
-            managingOfferer__siren="775671464"
-        )
+        venue = offerers_factories.VenueWithoutSiretFactory(managingOfferer__siren="775671464")
         user = user_factories.ProFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=venue.managingOfferer)
         providers_factories.AllocinePivotFactory(venue=venue)
@@ -148,9 +138,7 @@ class Returns201Test:
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.venue_provider_job.delay")
-    def test_when_no_regression_on_format(
-        self, mock_synchronize_venue_provider, client
-    ):
+    def test_when_no_regression_on_format(self, mock_synchronize_venue_provider, client):
         # Given
         venue = offerers_factories.VenueFactory(siret="12345678912345")
         user = user_factories.ProFactory()
@@ -192,9 +180,7 @@ class Returns201Test:
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.venue_provider_job.delay")
-    def test_when_venue_id_at_offer_provider_is_ignored_for_pro(
-        self, mock_synchronize_venue_provider, client
-    ):
+    def test_when_venue_id_at_offer_provider_is_ignored_for_pro(self, mock_synchronize_venue_provider, client):
         # Given
         venue = offerers_factories.VenueFactory(siret="12345678912345")
         user = user_factories.ProFactory()
@@ -225,13 +211,9 @@ class Returns201Test:
     def test_when_add_same_provider(self, client):
         # Given
         provider = providers_factories.PublicApiProviderFactory()
-        venue_provider = providers_factories.VenueProviderFactory(
-            provider=provider, venueIdAtOfferProvider=None
-        )
+        venue_provider = providers_factories.VenueProviderFactory(provider=provider, venueIdAtOfferProvider=None)
         user = user_factories.ProFactory()
-        offerers_factories.UserOffererFactory(
-            user=user, offerer=venue_provider.venue.managingOfferer
-        )
+        offerers_factories.UserOffererFactory(user=user, offerer=venue_provider.venue.managingOfferer)
 
         client = client.with_session_auth(email=user.email)
         venue_provider_data = {
@@ -248,32 +230,20 @@ class Returns201Test:
         assert venue_provider.venue.venueProviders == [venue_provider]
 
     @pytest.mark.usefixtures("db_session")
-    @patch(
-        "pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows"
-    )
-    @patch(
-        "pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies"
-    )
+    @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies")
     @patch("pcapi.settings.CDS_API_URL", "fakeUrl/")
-    def test_create_venue_provider_for_cds_cinema(
-        self, mock_get_venue_movies, mock_get_shows, requests_mock, client
-    ):
+    def test_create_venue_provider_for_cds_cinema(self, mock_get_venue_movies, mock_get_shows, requests_mock, client):
         # Given
         venue = offerers_factories.VenueFactory()
         user = user_factories.ProFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=venue.managingOfferer)
         client = client.with_session_auth(email=user.email)
-        provider = (
-            db.session.query(Provider)
-            .filter(Provider.localClass == "CDSStocks")
-            .first()
-        )
+        provider = db.session.query(Provider).filter(Provider.localClass == "CDSStocks").first()
 
         cds_pivot = CinemaProviderPivotFactory(venue=venue, provider=provider)
         providers_factories.CDSCinemaDetailsFactory(
-            cinemaProviderPivot=cds_pivot,
-            cinemaApiToken="test_token",
-            accountId="test_account",
+            cinemaProviderPivot=cds_pivot, cinemaApiToken="test_token", accountId="test_account"
         )
 
         venue_provider_data = {
@@ -317,14 +287,10 @@ class Returns201Test:
                     remaining_place=77,
                     internet_remaining_place=10,
                     showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[
-                        ShowTariffCDS(tariff=IdObjectCDS(id=4))
-                    ],
+                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
                     screen=IdObjectCDS(id=1),
                     media=IdObjectCDS(id=123),
-                    shows_mediaoptions_collection=[
-                        ShowsMediaoptionsCDS(media_options_id=IdObjectCDS(id=12))
-                    ],
+                    shows_mediaoptions_collection=[ShowsMediaoptionsCDS(media_options_id=IdObjectCDS(id=12))],
                 ),
                 "price": 5,
                 "price_label": "pass Culture",
@@ -339,14 +305,10 @@ class Returns201Test:
                     remaining_place=78,
                     internet_remaining_place=11,
                     showtime=datetime(2022, 7, 1, 12, 00, 00),
-                    shows_tariff_pos_type_collection=[
-                        ShowTariffCDS(tariff=IdObjectCDS(id=4))
-                    ],
+                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
                     screen=IdObjectCDS(id=1),
                     media=IdObjectCDS(id=51),
-                    shows_mediaoptions_collection=[
-                        ShowsMediaoptionsCDS(media_options_id=IdObjectCDS(id=12))
-                    ],
+                    shows_mediaoptions_collection=[ShowsMediaoptionsCDS(media_options_id=IdObjectCDS(id=12))],
                 ),
                 "price": 6,
                 "price_label": "pass Culture",
@@ -362,16 +324,12 @@ class Returns201Test:
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.workers.venue_provider_job.synchronize_ems_venue_provider")
-    def test_create_venue_provider_for_ems_cinema(
-        self, mocked_synchronize_ems_venue_provider, requests_mock, client
-    ):
+    def test_create_venue_provider_for_ems_cinema(self, mocked_synchronize_ems_venue_provider, requests_mock, client):
         venue = offerers_factories.VenueFactory()
         user = user_factories.ProFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=venue.managingOfferer)
         ems_provider = providers_repository.get_provider_by_local_class("EMSStocks")
-        pivot = providers_factories.CinemaProviderPivotFactory(
-            venue=venue, provider=ems_provider
-        )
+        pivot = providers_factories.CinemaProviderPivotFactory(venue=venue, provider=ems_provider)
         providers_factories.EMSCinemaDetailsFactory(cinemaProviderPivot=pivot)
 
         client = client.with_session_auth(email=user.email)
@@ -546,9 +504,7 @@ class Returns404Test:
 class ConnectProviderToVenueTest:
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.core.providers.api.connect_venue_to_provider")
-    def test_should_inject_the_appropriate_repository_to_the_usecase(
-        self, mocked_connect_venue_to_provider, client
-    ):
+    def test_should_inject_the_appropriate_repository_to_the_usecase(self, mocked_connect_venue_to_provider, client):
         # Given
         venue = offerers_factories.VenueFactory(siret="12345678912345")
         user = user_factories.ProFactory()
@@ -612,23 +568,16 @@ class ConnectProviderToVenueTest:
         user = user_factories.ProFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=venue.managingOfferer)
         provider = providers_factories.ProviderFactory(
-            name="Technical provider",
-            localClass=None,
-            isActive=True,
-            enabledForPro=True,
+            name="Technical provider", localClass=None, isActive=True, enabledForPro=True
         )
-        providers_factories.OffererProviderFactory(
-            offerer=venue.managingOfferer, provider=provider
-        )
+        providers_factories.OffererProviderFactory(offerer=venue.managingOfferer, provider=provider)
 
         venue_provider_data = {
             "providerId": provider.id,
             "venueId": venue.id,
         }
 
-        response = client.with_session_auth(email=user.email).post(
-            "/venueProviders", json=venue_provider_data
-        )
+        response = client.with_session_auth(email=user.email).post("/venueProviders", json=venue_provider_data)
 
         assert response.status_code == 201
         assert len(venue.venueProviders) == 1
@@ -647,23 +596,16 @@ class ConnectProviderToVenueTest:
         user = user_factories.ProFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=venue.managingOfferer)
         provider = providers_factories.ProviderFactory(
-            name="Technical provider",
-            localClass=None,
-            isActive=True,
-            enabledForPro=True,
+            name="Technical provider", localClass=None, isActive=True, enabledForPro=True
         )
-        providers_factories.OffererProviderFactory(
-            offerer=venue.managingOfferer, provider=provider
-        )
+        providers_factories.OffererProviderFactory(offerer=venue.managingOfferer, provider=provider)
 
         venue_provider_data = {
             "providerId": provider.id,
             "venueId": venue.id,
         }
 
-        response = client.with_session_auth(email=user.email).post(
-            "/venueProviders", json=venue_provider_data
-        )
+        response = client.with_session_auth(email=user.email).post("/venueProviders", json=venue_provider_data)
 
         assert response.status_code == 201
         assert len(venue.venueProviders) == 1


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35782

[Portail PRO] Lors de l'activation d'un synchronisation, la condition qui permet de décider si on lance une tâche de synchronisation n'est pas à jour : il faudrait vérifier que la synchronisation concerne un cinéma puisque c'est uniquement ce type de synchronisation que la tâche lancée accepte. 

-> le portail pro lance beaucoup (pas tant que ça non plus) de tâches qui déclenchent très vite une erreur, pour rien. Cette PR vise à réduire le bruit généré sur Sentry.
