### PR TITLE
(PC-35958)[API] feat: update max length for offer description

### DIFF
--- a/api/documentation/src/pages/change-logs.md
+++ b/api/documentation/src/pages/change-logs.md
@@ -16,6 +16,7 @@ title: Pass Culture API change logs
 ## May 2025
 
 - A new endpoint has been added to archive collective offers : [**Archive collective offers**](/rest-api#tag/Collective-Offers/operation/ArchiveCollectiveOffers). See the following for details on the different collective offer statuses [**here**](/docs/understanding-our-api/resources/collective-offers#collective-offer-status-and-allowed-actions).
+- You can now specify a `description` that is up to 10 000 characters long (endpoints : [**Create Event Offer**](/rest-api#tag/Event-Offers/operation/PostEventOffer), [**Update Event Offer**](/rest-api#tag/Event-Offers/operation/EditEvent), [**Create Product Offer**](/rest-api#tag/Product-Offers/operation/PostProductOffer), [**Update Product Offer**](/rest-api#tag/Product-Offers/operation/EditProduct))
 
 ## February 2025
 

--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -2514,7 +2514,7 @@
                     "description": {
                         "description": "Offer description",
                         "example": "A great book for kids and old kids.",
-                        "maxLength": 1000,
+                        "maxLength": 10000,
                         "nullable": true,
                         "title": "Description",
                         "type": "string"
@@ -2749,7 +2749,7 @@
                     "description": {
                         "description": "Offer description",
                         "example": "A great book for kids and old kids.",
-                        "maxLength": 1000,
+                        "maxLength": 10000,
                         "nullable": true,
                         "title": "Description",
                         "type": "string"
@@ -6520,7 +6520,7 @@
                     "description": {
                         "description": "Offer description",
                         "example": "A great book for kids and old kids.",
-                        "maxLength": 1000,
+                        "maxLength": 10000,
                         "nullable": true,
                         "title": "Description",
                         "type": "string"
@@ -6736,6 +6736,7 @@
                     "description": {
                         "description": "Offer description",
                         "example": "A great book for kids and old kids.",
+                        "maxLength": 10000,
                         "nullable": true,
                         "title": "Description",
                         "type": "string"

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -140,7 +140,7 @@ class _FIELDS:
     OFFER_DESCRIPTION_WITH_MAX_LENGTH = Field(
         description="Offer description",
         example="A great book for kids and old kids.",
-        max_length=1000,
+        max_length=10000,
     )
     OFFER_BOOKING_EMAIL = Field(
         description="Recipient email for notifications about bookings, cancellations, etc.",

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -632,7 +632,7 @@ class ProductOfferEdition(OfferEditionBase):
     )
     stock: StockEdition | None = STOCK_EDITION_FIELD
     name: OfferName | None = fields.OFFER_NAME
-    description: str | None = fields.OFFER_DESCRIPTION
+    description: str | None = fields.OFFER_DESCRIPTION_WITH_MAX_LENGTH
     enable_double_bookings: bool | None = fields.OFFER_ENABLE_DOUBLE_BOOKINGS_ENABLED
 
     class Config:


### PR DESCRIPTION
## But de la pull request

<img width="1069" alt="image" src="https://github.com/user-attachments/assets/d09855c8-d604-4c84-8042-6e1002a93f8f" />

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35958

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
