### PR TITLE
(PC-36051)[PRO] fix: Check if the price categories list has changed i…

### DIFF
--- a/pro/src/components/IndividualOffer/PriceCategoriesScreen/PriceCategoriesScreen.tsx
+++ b/pro/src/components/IndividualOffer/PriceCategoriesScreen/PriceCategoriesScreen.tsx
@@ -13,6 +13,7 @@ import { isOfferDisabled } from 'commons/core/Offers/utils/isOfferDisabled'
 import { isOfferAllocineSynchronized } from 'commons/core/Offers/utils/typology'
 import { useNotification } from 'commons/hooks/useNotification'
 import { useOfferWizardMode } from 'commons/hooks/useOfferWizardMode'
+import { isEqual } from 'commons/utils/isEqual'
 import { ConfirmDialog } from 'components/ConfirmDialog/ConfirmDialog'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import {
@@ -62,6 +63,11 @@ const hasFieldChange = (
     return initialpriceCategory[field] !== priceCategory[field]
   })
 
+/**
+ * @function arePriceCategoriesChanged
+ * Returns `true` if at least one of the initial price categories has changed
+ * and `false` otherwise (even if there are additional price cateogires in the values).
+ * */
 export const arePriceCategoriesChanged = (
   initialValues: PriceCategoriesFormValues,
   values: PriceCategoriesFormValues
@@ -158,8 +164,9 @@ export const PriceCategoriesScreen = ({
       isOnboarding,
     })
 
-    // Return when saving in edition with an empty form
-    const isFormEmpty = !arePriceCategoriesChanged(defaultValues, values)
+    // Return when saving in edition with no change and no addition to the list of price categories
+    const isFormEmpty = isEqual(defaultValues, values)
+
     if (isFormEmpty && mode === OFFER_WIZARD_MODE.EDITION) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       navigate(nextStepUrl)


### PR DESCRIPTION
…ncluding additions when submitting the price categories edition form.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-36051

**Objectif**
Corriger le fait qu'on ne peut pas ajouter de tarif dans l'édition d'une offre individuelle.
La fonction utilisée pour vérifier que le formulaire a changé ne vérifie que les modifications des tarifs existants, et ne prend pas en compte les tarifs qu'on ajoute. 

Donc si on ajoute un nouveau tarif sans modifier les anciens, le formulaire est considéré inchangé, et la requete n'est pas envoyée.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
