### PR TITLE
(BSR)[PRO] fix: multiselect legend tag should be fieldset's first child

### DIFF
--- a/pro/src/ui-kit/MultiSelect/MultiSelect.stories.tsx
+++ b/pro/src/ui-kit/MultiSelect/MultiSelect.stories.tsx
@@ -37,9 +37,9 @@ const defaultOptions = [
 
 const defaultProps = {
   options: defaultOptions,
-  legend: 'Département',
   label: 'Sélectionner un département',
   onSelectedOptionsChanged: () => {},
+  buttonLabel: 'Départements',
 }
 
 export const Default: StoryObj<typeof MultiSelect> = {

--- a/pro/src/ui-kit/MultiSelect/MultiSelect.tsx
+++ b/pro/src/ui-kit/MultiSelect/MultiSelect.tsx
@@ -207,17 +207,14 @@ export const MultiSelect = forwardRef(
 
     return (
       <fieldset className={styles.container} onBlur={onBlur} ref={forwardedRef}>
-        {label && (
-          <label className={styles['container-label']}>
-            {label} {required && asterisk && '*'}
-          </label>
-        )}
+        <legend className={styles['container-label']}>
+          {label} {required && asterisk && '*'}
+        </legend>
         <div className={cn(className, styles['container-input'])}>
           <div ref={containerRef}>
             <MultiSelectTrigger
               id={id}
               buttonLabel={buttonLabel}
-              fieldLabel={label}
               isOpen={isOpen}
               toggleDropdown={toggleDropdown}
               selectedCount={selectedItems.length}

--- a/pro/src/ui-kit/MultiSelect/MultiSelectTrigger.tsx
+++ b/pro/src/ui-kit/MultiSelect/MultiSelectTrigger.tsx
@@ -12,7 +12,6 @@ type MultiSelectTriggerProps = {
   selectedCount: number
   toggleDropdown: () => void
   buttonLabel: string
-  fieldLabel: string
   disabled?: boolean
   error?: string
 }
@@ -23,13 +22,11 @@ export const MultiSelectTrigger = ({
   selectedCount,
   toggleDropdown,
   buttonLabel,
-  fieldLabel,
   disabled,
   error,
 }: MultiSelectTriggerProps): JSX.Element => {
   return (
     <>
-      <legend className={styles['visually-hidden']}>{fieldLabel}</legend>
       <button
         type="button"
         className={cn(styles['trigger'], {

--- a/pro/src/ui-kit/MultiSelect/__specs__/MultiSelectTrigger.spec.tsx
+++ b/pro/src/ui-kit/MultiSelect/__specs__/MultiSelectTrigger.spec.tsx
@@ -20,7 +20,6 @@ describe('<MultiSelectTrigger />', () => {
       <MultiSelectTrigger
         id="1"
         toggleDropdown={mockToggleDropdown}
-        fieldLabel={'Select Options'}
         buttonLabel={'Options Label'}
         disabled={disabled}
         isOpen={isOpen}


### PR DESCRIPTION
## But de la pull request

Corriger la structure du composant Multiselect d'après ces retours : https://github.com/pass-culture/pass-culture-main/pull/17405#discussion_r2081146540

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
