### PR TITLE
(BSR)[API] fix: use OA instead of Venue fields for departmentCode in …

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -295,6 +295,23 @@ class GetCollectiveOfferVenueResponseModel(BaseModel):
         json_encoders = {datetime: format_into_utc_date}
         allow_population_by_field_name = True
 
+    @classmethod
+    def from_orm(cls, venue: offerers_models.Venue) -> "GetCollectiveOfferVenueResponseModel":
+        if venue.offererAddress is not None:
+            department_code = venue.offererAddress.address.departmentCode
+        else:
+            # TODO(OA): remove this when the virtual venues are migrated
+            department_code = None
+
+        return cls(
+            departementCode=department_code,
+            id=venue.id,
+            managingOfferer=venue.managingOfferer,
+            name=venue.name,
+            publicName=venue.publicName,
+            imgUrl=venue.bannerUrl,
+        )
+
 
 class CollectiveOfferOfferVenueResponseModel(BaseModel):
     addressType: educational_models.OfferAddressType

--- a/api/tests/routes/pro/get_collective_offer_template_test.py
+++ b/api/tests/routes/pro/get_collective_offer_template_test.py
@@ -36,6 +36,13 @@ class Returns200Test:
         assert "iban" not in response_json["venue"]["managingOfferer"]
         assert "bic" not in response_json["venue"]["managingOfferer"]
         assert "validationStatus" not in response_json["venue"]["managingOfferer"]
+        assert response_json["venue"]["departementCode"] == offer.venue.offererAddress.address.departmentCode
+        assert response_json["venue"]["managingOfferer"] == {
+            "id": offer.venue.managingOffererId,
+            "name": offer.venue.managingOfferer.name,
+            "siren": offer.venue.managingOfferer.siren,
+            "allowedOnAdage": offer.venue.managingOfferer.allowedOnAdage,
+        }
         assert "stock" not in response_json
         assert "dateCreated" in response_json
         assert "educationalPriceDetail" in response_json

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -70,6 +70,13 @@ class Returns200Test:
         assert "iban" not in response_json["venue"]["managingOfferer"]
         assert "bic" not in response_json["venue"]["managingOfferer"]
         assert "validationStatus" not in response_json["venue"]["managingOfferer"]
+        assert response_json["venue"]["departementCode"] == offer.venue.offererAddress.address.departmentCode
+        assert response_json["venue"]["managingOfferer"] == {
+            "id": offer.venue.managingOffererId,
+            "name": offer.venue.managingOfferer.name,
+            "siren": offer.venue.managingOfferer.siren,
+            "allowedOnAdage": offer.venue.managingOfferer.allowedOnAdage,
+        }
         assert response_json["imageCredit"] is None
         assert response_json["imageUrl"] is None
         assert "dateCreated" in response_json


### PR DESCRIPTION
…GetCollectiveOfferVenueResponseModel

## But de la pull request

Ticket Jira (ou description si BSR) : utiliser OA au lieu de Venue pour les champs de localisation

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
