### PR TITLE
(BSR)[API] fix: check for non-nullable fields in public api collectiv…

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -27,6 +27,31 @@ from pcapi.validation.routes.users_authentifications import current_api_key
 from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
+PATCH_NON_NULLABLE_FIELDS = (
+    "name",
+    "venueId",
+    "contactEmail",
+    "contactPhone",
+    "description",
+    "domains",
+    "students",
+    "offerVenue",
+    "interventionArea",
+    "startDatetime",
+    "endDatetime",
+    "totalPrice",
+    "numberOfTickets",
+    "audioDisabilityCompliant",
+    "mentalDisabilityCompliant",
+    "motorDisabilityCompliant",
+    "visualDisabilityCompliant",
+    "isActive",
+    "educationalInstitution",
+    "educationalInstitutionId",
+    "formats",
+)
+
+
 @blueprints.public_api.route("/v2/collective/offers/", methods=["GET"])
 @atomic()
 @provider_api_key_required
@@ -266,29 +291,7 @@ def patch_collective_offer_public(
     image_file = False
     # checking data
     educational_validation.validate_offer_venue(body.offerVenue)
-    non_nullable_fields = [
-        "name",
-        "venueId",
-        "contactEmail",
-        "contactPhone",
-        "description",
-        "domains",
-        "students",
-        "offerVenue",
-        "interventionArea",
-        "startDatetime",
-        "endDatetime",
-        "totalPrice",
-        "numberOfTickets",
-        "audioDisabilityCompliant",
-        "mentalDisabilityCompliant",
-        "motorDisabilityCompliant",
-        "visualDisabilityCompliant",
-        "isActive",
-        "educational_institution_id",
-        "formats",
-    ]
-    for field in non_nullable_fields:
+    for field in PATCH_NON_NULLABLE_FIELDS:
         if field in new_values and new_values[field] is None:
             raise api_errors.ApiErrors(
                 errors={field: ["Ce champ peut ne pas être présent mais ne peut pas être null."]}, status_code=400

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -518,14 +518,17 @@ class PatchCollectiveOfferBodyModel(BaseModel):
 
     @validator("name", allow_reuse=True)
     def validate_name(cls, name: str | None) -> str | None:
-        assert name is not None and name.strip() != ""
+        if name is None or name.strip() == "":
+            raise ValueError("name cannot be empty")
+
         educational_validation.check_collective_offer_name_length_is_valid(name)
         return name
 
     @validator("description")
     def validate_description(cls, description: str | None) -> str | None:
-        assert description is not None
-        educational_validation.check_collective_offer_description_length_is_valid(description)
+        if description is not None:
+            educational_validation.check_collective_offer_description_length_is_valid(description)
+
         return description
 
     @validator("domains")


### PR DESCRIPTION
…e offer PATCH

## But de la pull request

Ticket Jira (ou description si BSR) : 

- Correction sur la liste des champs non-nullable au PATCH : "educationalInstitution" et "educationalInstitutionId" n'étaient pas correctement renseignés
- Ajout de tests pour les cas "champs non-nullable reçu avec valeur None"
- Retrait d'assert dans le schema

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
