### PR TITLE
(BSR)[API] fix: old offers cleanup command: bounds

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1741,9 +1741,9 @@ def get_unbookable_unbooked_old_offer_ids(
     """
 
     if max_id is None:
-        max_id = models.Offer.query.order_by(models.Offer.id).first().id
+        max_id = models.Offer.query.order_by(models.Offer.id.desc()).first().id
 
     while min_id < max_id:
-        rows = db.session.execute(sa.text(query), {"min_id": min_id, "max_id": max_id + batch_size})
+        rows = db.session.execute(sa.text(query), {"min_id": min_id, "max_id": min_id + batch_size})
         yield from {row[0] for row in rows}
         min_id += batch_size


### PR DESCRIPTION
## But de la pull request

Fix de la commande de suppression des vieilles offres non réservables et non réservées :

1. la boucle qui fait itère progressivement sur les lignes des offres utilisait `max_id + batch_size` comme limite supérieure au lieu de `min_id + batch_size`... cette correction devrait nous éviter des requêtes qui vont viser des dizaines, voire des centaines, de millions d'offres...
2. si max_id était null (toujours dans la même fonction du `repository`), on allait chercher l'id maximum... en prenant celui de la toute première offre, donc le plus petit.
