### PR TITLE
(BSR)[API] Refacto offer exceptions

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -1,15 +1,11 @@
 import typing
 
-from pcapi.domain.client_exceptions import ClientError
+from pcapi.core.core_exception import CoreException
 from pcapi.models.api_errors import ApiErrors
 
 
-class TooLateToDeleteStock(ClientError):
-    def __init__(self) -> None:
-        super().__init__(
-            "global",
-            "L'évènement s'est terminé il y a plus de deux jours, la suppression est impossible.",
-        )
+class OfferException(CoreException):
+    pass
 
 
 class ImageValidationError(Exception):
@@ -96,142 +92,6 @@ class MissingImage(ImageValidationError):
         super().__init__("Nous n'avons pas réceptionné l'image, merci d'essayer à nouveau.")
 
 
-class OfferCreationBaseException(ClientError):
-    pass
-
-
-class PriceCategoryCreationBaseException(ClientError):
-    pass
-
-
-class StockEditBaseException(ClientError):
-    pass
-
-
-class OfferCannotBeDuo(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__("enableDoubleBookings", "the category chosen does not allow double bookings")
-
-
-class UnknownOfferSubCategory(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "subcategory",
-            "La sous-catégorie de cette offre est inconnue",
-        )
-
-
-class SubCategoryIsInactive(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "subcategory",
-            "Une offre ne peut être créée ou éditée en utilisant cette sous-catégorie",
-        )
-
-
-class CannotSetIdAtProviderWithoutAProvider(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "idAtProvider",
-            "Une offre ne peut être créée ou éditée avec un idAtProvider si elle n'a pas de provider",
-        )
-
-
-class IdAtProviderAlreadyTakenByAnotherVenueOffer(OfferCreationBaseException):
-    def __init__(self, id_at_provider: str) -> None:
-        super().__init__(
-            "idAtProvider",
-            f"`{id_at_provider}` is already taken by another venue offer",
-        )
-
-
-class IdAtProviderAlreadyTakenByAnotherOfferPriceCategory(PriceCategoryCreationBaseException):
-    def __init__(self, id_at_provider: str) -> None:
-        super().__init__(
-            "idAtProvider",
-            f"`{id_at_provider}` is already taken by another offer price category",
-        )
-
-
-class IdAtProviderAlreadyTakenByAnotherOfferStock(StockEditBaseException):
-    def __init__(self, id_at_provider: str) -> None:
-        super().__init__(
-            "idAtProvider",
-            f"`{id_at_provider}` is already taken by another offer stock",
-        )
-
-
-class NoDelayWhenEventWithdrawalTypeHasNoTicket(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "offer",
-            "Il ne peut pas y avoir de délai de retrait lorsqu'il s'agit d'un évènement sans ticket",
-        )
-
-
-class EventWithTicketMustHaveDelay(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "offer",
-            "Un évènement avec ticket doit avoir un délai de renseigné",
-        )
-
-
-class NonLinkedProviderCannotHaveInAppTicket(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "offer",
-            "Vous devez supporter l'interface de billeterie pour créer des offres avec billet",
-        )
-
-
-class WithdrawableEventOfferMustHaveWithdrawal(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "offer",
-            "Une offre qui a un ticket retirable doit avoir un type de retrait renseigné",
-        )
-
-
-class WithdrawableEventOfferMustHaveBookingContact(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "offer",
-            "Une offre qui a un ticket retirable doit avoir l'email du contact de réservation",
-        )
-
-
-class ExtraDataValueNotAllowed(OfferCreationBaseException):
-    pass
-
-
-class OfferAlreadyExists(OfferCreationBaseException):
-    def __init__(self, field: str) -> None:
-        super().__init__(
-            field, f"Une offre avec cet {field.upper()} existe déjà. Vous pouvez la retrouver dans l’onglet Offres."
-        )
-
-
-class EanFormatException(OfferCreationBaseException):
-    pass
-
-
-class EanInOfferNameException(OfferCreationBaseException):
-    def __init__(self) -> None:
-        super().__init__(
-            "name",
-            "Le titre d'une offre ne peut contenir l'EAN",
-        )
-
-
-class ProductNotFoundForOfferCreation(OfferCreationBaseException):
-    pass
-
-
-class FutureOfferException(OfferCreationBaseException):
-    pass
-
-
 class ThumbnailStorageError(ApiErrors):
     status_code = 500
 
@@ -252,12 +112,10 @@ class ReportMalformed(OfferReportError):
     code = "REPORT_MALFORMED"
 
 
-class BookingLimitDatetimeTooLate(OfferCreationBaseException):
+class BookingLimitDatetimeTooLate(OfferException):  # (tcoudray-pass, 14/05/2025) TODO: Remove
     def __init__(self) -> None:
-        super().__init__(
-            "bookingLimitDatetime",
-            "The bookingLimitDatetime must be before the beginning of the event",
-        )
+        super().__init__()
+        self.add_error("bookingLimitDatetime", "The bookingLimitDatetime must be before the beginning of the event")
 
 
 class OfferNotFound(Exception):
@@ -290,25 +148,6 @@ class TiteLiveAPINotExistingEAN(Exception):
 
 class NotUpdateProductOrOffers(Exception):
     pass
-
-
-class OfferEditionBaseException(ClientError):
-    pass
-
-
-class RejectedOrPendingOfferNotEditable(OfferEditionBaseException):
-    def __init__(self) -> None:
-        super().__init__("global", "Les offres refusées ou en attente de validation ne sont pas modifiables")
-
-
-class OfferMustHaveAccessibility(OfferEditionBaseException):
-    def __init__(self) -> None:
-        super().__init__("global", "L’accessibilité de l’offre doit être définie")
-
-
-class OfferWithProductShouldNotUpdateExtraData(OfferEditionBaseException):
-    def __init__(self) -> None:
-        super().__init__("global", "Les extraData des offres avec produit ne sont pas modifiables")
 
 
 class MoveOfferBaseException(Exception):
@@ -344,16 +183,6 @@ class NoDestinationVenue(MoveOfferBaseException):
 class ForbiddenDestinationVenue(MoveOfferBaseException):
     def __init__(self) -> None:
         super().__init__("Ce partenaire culturel n'est pas éligible au transfert de l'offre")
-
-
-class OffererVirtualVenueNotFound(Exception):
-    def __init__(self) -> None:
-        super().__init__("Votre structure ne possède aucun lieu numérique")
-
-
-class OfferVenueShouldNotBeVirtual(Exception):
-    def __init__(self) -> None:
-        super().__init__("Une offre physique ne peut être associée à un lieu numérique")
 
 
 class BookingsHaveOtherPricingPoint(MoveOfferBaseException):

--- a/api/src/pcapi/models/api_errors.py
+++ b/api/src/pcapi/models/api_errors.py
@@ -1,6 +1,7 @@
 import json
 import typing
 
+from pcapi.core.core_exception import CoreException
 from pcapi.domain.client_exceptions import ClientError
 
 
@@ -19,7 +20,7 @@ class ApiErrors(Exception):
         else:
             self.errors[field] = [error]
 
-    def add_client_error(self, client_error: ClientError) -> None:
+    def add_client_error(self, client_error: ClientError | CoreException) -> None:
         self.errors |= client_error.errors
 
     def check_min_length(self, field: str, value: str, length: int) -> None:

--- a/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -39,8 +39,8 @@ def restize_api_errors(error: ApiErrors) -> ApiErrorResponse:
     return app.generate_error_response(error.errors), error.status_code or 400
 
 
-@app.errorhandler(offers_exceptions.TooLateToDeleteStock)
-def restize_too_late_to_delete_stock(error: offers_exceptions.TooLateToDeleteStock) -> ApiErrorResponse:
+@app.errorhandler(offers_exceptions.OfferException)
+def restize_offer_exception(error: offers_exceptions.OfferException) -> ApiErrorResponse:
     mark_transaction_as_invalid()
     return app.generate_error_response(error.errors), 400
 

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -289,8 +289,10 @@ def edit_collective_offer(
         raise ApiErrors({"offer": "This collective offer status does not allow editing details"}, 403)
     except educational_exceptions.CollectiveOfferIsPublicApi:
         raise ApiErrors({"global": ["Collective offer created by public API is only editable via API."]}, 403)
-    except offers_exceptions.OfferEditionBaseException as error:
-        raise ApiErrors(error.errors, status_code=400)
+    except (
+        offers_exceptions.OfferException
+    ) as error:  # (tcoudray-pass, 14/05/2025) TODO: Refactor, should not raise this kind of error
+        raise ApiErrors(error.errors)
 
     offer = educational_repository.get_collective_offer_by_id(offer_id)
     return collective_offers_serialize.GetCollectiveOfferResponseModel.from_orm(offer)
@@ -347,8 +349,10 @@ def edit_collective_offer_template(
         raise ApiErrors({"code": "EDUCATIONAL_DOMAIN_NOT_FOUND"}, status_code=404)
 
     # edition errors
-    except offers_exceptions.OfferEditionBaseException as error:
-        raise ApiErrors(error.errors, status_code=400)
+    except (
+        offers_exceptions.OfferException
+    ) as error:  # (tcoudray-pass, 14/05/2025) TODO: Refactor, should not raise this kind of error
+        raise ApiErrors(error.errors)
     except educational_exceptions.CollectiveOfferTemplateForbiddenAction:
         raise ApiErrors({"global": ["Cette action n'est pas autorisée sur cette offre"]}, 403)
     except educational_exceptions.UpdateCollectiveOfferTemplateError as err:

--- a/api/src/pcapi/routes/pro/collective_stocks.py
+++ b/api/src/pcapi/routes/pro/collective_stocks.py
@@ -88,18 +88,21 @@ def edit_collective_stock(
         raise ApiErrors(
             {"educationalStock": ["La date de fin de l'évènement ne peut précéder la date de début."]}, status_code=400
         )
-    except offers_exceptions.BookingLimitDatetimeTooLate:
+    except (
+        offers_exceptions.BookingLimitDatetimeTooLate
+    ):  # (tcoudray-pass, 14/05/2025) TODO: Refactor, educational_api should not raise this kind of error
         raise ApiErrors(
             {"educationalStock": ["La date limite de confirmation ne peut être fixée après la date de l évènement"]},
-            status_code=400,
         )
     except educational_exceptions.PriceRequesteCantBedHigherThanActualPrice:
         raise ApiErrors(
             {"educationalStock": "Le prix demandé ne peux être supérieur aux prix actuel si l'offre a été confirmée."},
             status_code=403,
         )
-    except offers_exceptions.OfferEditionBaseException as error:
-        raise ApiErrors(error.errors, status_code=400)
+    except (
+        offers_exceptions.OfferException,
+    ) as error:  # (tcoudray-pass, 14/05/2025) TODO: Refactor, should not raise this kind of error
+        raise ApiErrors(error.errors)
     except educational_exceptions.StartAndEndEducationalYearDifferent:
         raise ApiErrors({"code": "START_AND_END_EDUCATIONAL_YEAR_DIFFERENT"}, status_code=400)
     except educational_exceptions.StartEducationalYearMissing:

--- a/api/src/pcapi/routes/pro/stocks.py
+++ b/api/src/pcapi/routes/pro/stocks.py
@@ -157,7 +157,7 @@ def bulk_create_event_stocks(
         raise api_errors.ApiErrors(
             {"stocks": ["La date limite de réservation ne peut être postérieure à la date de début de l'évènement"]},
         )
-    except offers_exceptions.OfferEditionBaseException as error:
+    except offers_exceptions.OfferException as error:
         raise api_errors.ApiErrors(error.errors)
 
     return stock_serialize.StocksResponseModel(stocks_count=created_stocks_count)
@@ -218,7 +218,7 @@ def bulk_update_event_stocks(
         raise api_errors.ApiErrors(
             {"stocks": ["La date limite de réservation ne peut être postérieure à la date de début de l'évènement"]},
         )
-    except offers_exceptions.OfferEditionBaseException as error:
+    except offers_exceptions.OfferException as error:
         raise api_errors.ApiErrors(error.errors)
 
     # Done once we are sure all stocks have been successfully edited
@@ -246,6 +246,6 @@ def delete_stock(stock_id: int) -> stock_serialize.StockIdResponseModel:
     check_user_has_access_to_offerer(current_user, offerer_id)
     try:
         offers_api.delete_stock(stock, current_user.real_user.id, current_user.is_impersonated)
-    except offers_exceptions.OfferEditionBaseException as error:
+    except offers_exceptions.OfferException as error:
         raise api_errors.ApiErrors(error.errors)
     return stock_serialize.StockIdResponseModel.from_orm(stock)

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -90,7 +90,7 @@ class CreateCollectiveOfferStocksTest:
             educationalPriceDetail="hello",
         )
 
-        with pytest.raises(offers_exceptions.RejectedOrPendingOfferNotEditable) as error:
+        with pytest.raises(offers_exceptions.OfferException) as error:
             educational_api_stock.create_collective_stock(stock_data=created_stock_data)
 
         assert error.value.errors == {

--- a/api/tests/core/offers/test_schemas.py
+++ b/api/tests/core/offers/test_schemas.py
@@ -120,7 +120,7 @@ class PatchDraftOfferBodyModelTest:
         )
 
     def test_patch_offer_with_invalid_subcategory(self):
-        with pytest.raises(offers_exceptions.UnknownOfferSubCategory) as error:
+        with pytest.raises(offers_exceptions.OfferException) as error:
             _ = PatchDraftOfferBodyModel(
                 name="I solemnly swear that my intentions are evil",
                 subcategoryId="Misconduct fullfield",

--- a/api/tests/routes/pro/patch_publish_offer_test.py
+++ b/api/tests/routes/pro/patch_publish_offer_test.py
@@ -279,5 +279,5 @@ class Returns400Test:
 
         assert response.status_code == 400
         assert response.json == {
-            "ean": ["Une offre avec cet EAN existe déjà. Vous pouvez la retrouver dans l’onglet Offres."]
+            "ean": ["Une offre avec cet EAN existe déjà. Vous pouvez la retrouver dans l'onglet Offres."]
         }

--- a/api/tests/routes/pro/post_price_categories_test.py
+++ b/api/tests/routes/pro/post_price_categories_test.py
@@ -287,4 +287,4 @@ class Returns400Test:
         response = client.with_session_auth("user@example.com").post(f"/offers/{offer.id}/price_categories", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"offer": ["Offer is not editable (because rejected or pending)"]}
+        assert response.json == {"global": ["Les offres refusées ou en attente de validation ne sont pas modifiables"]}

--- a/api/tests/routes/public/individual_offers/v1/post_product_by_ean_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_by_ean_test.py
@@ -363,7 +363,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
             "ean": book_product.ean,
             "venue_id": venue.id,
             "provider_id": api_key.provider.id,
-            "exc": "RejectedOrPendingOfferNotEditable",
+            "exc": "OfferException",
         }
         assert response.status_code == 204
 


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : Cette PR vise à réduire le nombre d'exceptions définies au niveau de `core.offers.exceptions` pour simplifier le code.


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
