### PR TITLE
(PC-36130)[PRO] fix: prevent using .gifs on ImageDragAndDrop component

### DIFF
--- a/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.spec.tsx
+++ b/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.spec.tsx
@@ -38,7 +38,7 @@ describe('ImageDragAndDrop', () => {
     expect(input).toHaveAttribute('type', 'file')
     expect(input).toHaveAttribute(
       'accept',
-      'image/*,.jpeg,.jpg,.png,.mpo,.webp'
+      'image/jpeg,.jpeg,.jpg,image/png,.png,image/mpo,.mpo,image/webp,.webp'
     )
   })
 

--- a/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
+++ b/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
@@ -28,6 +28,10 @@ const ALLOWED_IMAGE_TYPES = [
   },
 ]
 
+type MimeToExtensionsMap = {
+  [mimeType: string]: string[]
+}
+
 type FileWithDimensions = File & {
   width: number
   height: number
@@ -77,12 +81,12 @@ export const ImageDragAndDrop = ({
   const [isHovered, setIsHovered] = useState(false)
   const [isFocused, setIsFocused] = useState(false)
 
-  const imageExtensions = ALLOWED_IMAGE_TYPES.reduce(
-    (acc: string[], { extensions }) => {
-      acc.push(...extensions)
+  const accept: MimeToExtensionsMap = ALLOWED_IMAGE_TYPES.reduce(
+    (acc: MimeToExtensionsMap, { mime, extensions }) => {
+      acc[mime] = extensions
       return acc
     },
-    []
+    {}
   )
 
   const imageMimeTypes = ALLOWED_IMAGE_TYPES.reduce(
@@ -95,9 +99,7 @@ export const ImageDragAndDrop = ({
 
   const { inputRef, getRootProps, getInputProps, fileRejections } = useDropzone(
     {
-      accept: {
-        'image/*': imageExtensions,
-      },
+      accept,
       maxFiles: 1,
       maxSize: 10 * 1024 * 1024,
       onDragEnter: () => setIsDraggedOver(true),


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-36130

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~
- [X] J'ai fait la revue fonctionnelle de mon ticket

## The culprit
![snoopy](https://github.com/user-attachments/assets/8581d0e8-89e7-479e-bf89-8519d6aa3744)

