### PR TITLE
(BSR)[API] test: remove additionnal FF queries from tests

### DIFF
--- a/api/src/pcapi/core/testing.py
+++ b/api/src/pcapi/core/testing.py
@@ -1,3 +1,4 @@
+from collections import UserDict
 import collections.abc
 import contextlib
 import functools
@@ -207,35 +208,33 @@ class SettingsContext:
             setattr(settings, attr_name, value)
 
 
+class FeaturesCache(UserDict):
+    def refresh(self) -> None:
+        self.data = {f.name: f.isActive for f in db.session.query(Feature.name, Feature.isActive)}
+
+
 class FeaturesContext:
-    def __init__(self) -> None:
+    def __init__(self, cached_features: FeaturesCache) -> None:
         # Use `object.__setattr__` because `__setattr__` method is overriden
         object.__setattr__(self, "_initial_features", {})
+        object.__setattr__(self, "_cached_features", cached_features)
+        object.__setattr__(self, "_default_features", FeaturesCache(cached_features))
 
     def __setattr__(self, attr_name: str, value: typing.Any) -> None:
-        self._initial_features[attr_name] = (
-            db.session.query(Feature).filter(Feature.name == attr_name).with_entities(Feature.isActive).one().isActive
-        )
+        self._initial_features[attr_name] = self._cached_features[attr_name]
         db.session.query(Feature).filter(Feature.name == attr_name).update({"isActive": value})
         db.session.commit()
-        # Clear the feature cache on request if any
-        if flask.has_request_context():
-            if hasattr(flask.request, "_cached_features"):
-                del flask.request._cached_features
+        self._cached_features.refresh()
 
     def __getattr__(self, attr_name: str) -> typing.Any:
-        return (
-            db.session.query(Feature).filter(Feature.name == attr_name).with_entities(Feature.isActive).one().isActive
-        )
+        return self._cached_features[attr_name]
 
     def reset(self) -> None:
         for name, status in self._initial_features.items():
             db.session.query(Feature).filter_by(name=name).update({"isActive": status})
+        if self._initial_features:
             db.session.commit()
-        # Clear the feature cache on request if any
-        if flask.has_request_context():
-            if hasattr(flask.request, "_cached_features"):
-                del flask.request._cached_features
+        object.__setattr__(self, "_cached_features", FeaturesCache(self._default_features))
 
 
 @contextlib.contextmanager

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -602,13 +602,27 @@ class UbbleTestClient(TestClient):
         return f"{timestamp}:877-test-v1:{signature}"
 
 
-@pytest.fixture
-def features(request):
+@pytest.fixture(name="cached_features")
+def cached_features_fixture(db_session):
+    from pcapi.core.testing import FeaturesCache
+
+    cache = FeaturesCache()
+    cache.refresh()
+    yield cache
+
+
+@pytest.fixture()
+def features(request, cached_features, monkeypatch):
     from pcapi.core.testing import FeaturesContext
     from pcapi.models.feature import FeatureToggle
 
+    def new_is_active(self):
+        return cached_features[self.name]
+
+    monkeypatch.setattr(FeatureToggle, "is_active", new_is_active)
+
     marker = request.node.get_closest_marker("features")
-    _features = FeaturesContext()
+    _features = FeaturesContext(cached_features)
     if marker:
         if kwargs := marker.kwargs:
             if invalid_features := {feature for feature in kwargs if feature not in FeatureToggle._member_names_}:

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1947,7 +1947,6 @@ class AutoMarkAsUsedAfterEventTest:
         educational_factories.CollectiveBookingFactory(collectiveStock__startDatetime=event_date)
         educational_factories.CollectiveBookingFactory(collectiveStock__startDatetime=event_date)
 
-        # queries = 1  # feature flags are already cached by BeneficiaryGrant18Factory.beneficiaryImports
         queries = 1  # select individual bookings
         queries += 1  # select individual booking user achievements
         # fmt: off

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -770,7 +770,6 @@ class GetOfferBookingsByStatusCSVTest:
         bookings_factories.BookingFactory(stock=stock_2)
 
         queries = 0
-        # queries += 1  # feature flags are already cached by BeneficiaryGrant18Factory.beneficiaryImports
         queries += 1  # Get bookings
 
         offer_id = offer.id
@@ -825,7 +824,6 @@ class GetOfferBookingsByStatusCSVTest:
         bookings_factories.BookingFactory(stock=stock_2)
 
         queries = 0
-        # queries += 1  # feature flags are already cached by BeneficiaryGrant18Factory.beneficiaryImports
         queries += 1  # Get bookings
 
         offer_id = offer.id

--- a/api/tests/core/bookings/test_validation.py
+++ b/api/tests/core/bookings/test_validation.py
@@ -15,7 +15,6 @@ from pcapi.core.bookings.models import Booking
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 from pcapi.core.finance.models import DepositType
-from pcapi.models import db
 from pcapi.utils import repository
 
 
@@ -288,7 +287,7 @@ class InsufficientFundsSQLCheckTest:
         api.cancel_booking_by_beneficiary(user, booking_to_cancel)
         assert booking_to_cancel.status is BookingStatus.CANCELLED
 
-    def test_user_can_book_a_free_offer_even_if_expired_deposit(self):
+    def test_user_can_book_a_free_offer_even_if_expired_deposit(self, db_session):
         # The user once booked.
 
         booking = factories.BookingFactory()
@@ -300,9 +299,9 @@ class InsufficientFundsSQLCheckTest:
         # They should be able to book free offers
         stock = offers_factories.StockFactory(price=0)
         api.book_offer(user, stock.id, quantity=1)
-        assert db.session.query(models.Booking).filter(Booking.userId == user.id).count() == 2
+        assert db_session.query(models.Booking).filter(Booking.userId == user.id).count() == 2
 
-    def test_cannot_change_quantity_with_expired_deposit(self):
+    def test_cannot_change_quantity_with_expired_deposit(self, db_session):
         # The user once booked.
         booking = factories.BookingFactory(quantity=10)
         user = booking.user
@@ -314,12 +313,12 @@ class InsufficientFundsSQLCheckTest:
         # should prevent it.
         booking.quantity += 10
         with pytest.raises(sqlalchemy.exc.InternalError) as exc:
-            db.session.add(booking)
-            db.session.flush()
+            db_session.add(booking)
+            db_session.flush()
 
         assert "insufficientFunds" in str(exc.value)
 
-    def test_cannot_change_amount_with_expired_deposit(self):
+    def test_cannot_change_amount_with_expired_deposit(self, db_session):
         # The user once booked.
         booking = factories.BookingFactory(amount=10)
         user = booking.user
@@ -331,11 +330,11 @@ class InsufficientFundsSQLCheckTest:
         # should prevent it.
         booking.amount += 10
         with pytest.raises(sqlalchemy.exc.InternalError) as exc:
-            db.session.add(booking)
-            db.session.flush()
+            db_session.add(booking)
+            db_session.flush()
             assert "insufficientFunds" in exc.args[0]
 
-    def test_cannot_uncancel_with_expired_deposit(self):
+    def test_cannot_uncancel_with_expired_deposit(self, db_session):
         # The user once booked and cancelled their booking.
         booking = factories.CancelledBookingFactory()
         user = booking.user
@@ -347,8 +346,8 @@ class InsufficientFundsSQLCheckTest:
         # should prevent it.
         booking.uncancel_booking_set_used()
         with pytest.raises(sqlalchemy.exc.InternalError) as exc:
-            db.session.add(booking)
-            db.session.flush()
+            db_session.add(booking)
+            db_session.flush()
             assert "insufficientFunds" in exc.args[0]
 
 

--- a/api/tests/core/external/external_pro_test.py
+++ b/api/tests/core/external/external_pro_test.py
@@ -75,6 +75,7 @@ def test_update_external_pro_user_attributes(
     create_collective_offer,
     create_template_offer,
     create_collective_offer_meg,
+    features,
 ):
     email = "juste.leblanc@example.net"
 
@@ -379,7 +380,7 @@ def _check_user_without_validated_offerer(user):
     assert attributes.has_collective_offers is False
 
 
-def test_update_external_pro_booking_email_attributes():
+def test_update_external_pro_booking_email_attributes(features):
     email = "musee@example.net"
     offerer = offerers_factories.OffererFactory(siren="123456789", name="Musée")
     venue = offerers_factories.VenueFactory(
@@ -426,7 +427,7 @@ def test_update_external_pro_booking_email_attributes():
     assert attributes.has_bookings is False
 
 
-def test_update_external_pro_booking_email_attributes_for_permanent_venue_with_banner():
+def test_update_external_pro_booking_email_attributes_for_permanent_venue_with_banner(features):
     email = "musee@example.net"
     offerer = offerers_factories.OffererFactory(siren="123456789", name="Musée")
     offerers_factories.VenueFactory(
@@ -447,7 +448,7 @@ def test_update_external_pro_booking_email_attributes_for_permanent_venue_with_b
     assert attributes.has_banner_url is True
 
 
-def test_update_external_pro_booking_email_attributes_for_non_permanent_venue_with_banner():
+def test_update_external_pro_booking_email_attributes_for_non_permanent_venue_with_banner(features):
     email = "musee@example.net"
     offerer = offerers_factories.OffererFactory(siren="123456789", name="Musée")
     offerers_factories.VenueFactory(
@@ -468,7 +469,7 @@ def test_update_external_pro_booking_email_attributes_for_non_permanent_venue_wi
     assert attributes.has_banner_url is True
 
 
-def test_update_external_pro_booking_email_attributes_for_non_permanent_venue_without_banner():
+def test_update_external_pro_booking_email_attributes_for_non_permanent_venue_without_banner(features):
     email = "musee@example.net"
     offerer = offerers_factories.OffererFactory(siren="123456789", name="Musée")
     offerers_factories.VenueFactory(

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -3662,7 +3662,6 @@ class GenerateInvoicesTest:
 
 class GenerateInvoiceTest:
     EXPECTED_NUM_QUERIES = (
-        # 1   # feature flags are already cached by BeneficiaryGrant18Factory.beneficiaryImports
         1  # lock reimbursement point
         + 1  # select cashflows, pricings, pricing_lines, and custom_reimbursement_rules
         + 1  # select and lock ReferenceScheme

--- a/api/tests/core/finance/test_api_legacy.py
+++ b/api/tests/core/finance/test_api_legacy.py
@@ -2223,7 +2223,6 @@ class GenerateInvoicesTest:
 
 class GenerateInvoiceTest:
     EXPECTED_NUM_QUERIES = (
-        # 1   # feature flags are already cached by BeneficiaryGrant18Factory.beneficiaryImports
         1  # lock reimbursement point
         + 1  # select cashflows, pricings, pricing_lines, and custom_reimbursement_rules
         + 1  # select and lock ReferenceScheme

--- a/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
@@ -356,7 +356,6 @@ class OffererBookingRecapTest:
         _ = booking.stock.offer.venue.offererAddress.address
         _ = booking.user
         # 1 - SELECT venue with bank account
-        # 0 - SELECT feature (already cached by BeneficiaryGrant18Factory.beneficiaryImports)
         # 1 - SELECT external booking (might be preloaded ?)
         # 1 - SELECT activation code (might be preloaded ?)
         with assert_num_queries(3):
@@ -384,7 +383,6 @@ class OffererBookingRecapTest:
         _ = booking.stock.offer.venue.offererAddress.address
         _ = booking.user
         # 1 - SELECT venue with bank account
-        # 0 - SELECT feature (already cached by BeneficiaryGrant18Factory.beneficiaryImports)
         # 1 - SELECT external booking (might be preloaded ?)
         # 1 - SELECT activation code (might be preloaded ?)
         with assert_num_queries(3):

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -186,7 +186,7 @@ class ReindexOfferIdsTest:
 
         assert search_testing.search_store["offers"] == {}
 
-    def test_that_base_query_is_correct(self, app):
+    def test_that_base_query_is_correct(self, app, features):
         # Make sure that `get_base_query_for_offer_indexation` loads
         # all offers and related data that is expected by
         # `reindex_offer_ids()`.
@@ -204,7 +204,6 @@ class ReindexOfferIdsTest:
             app.redis_client.hset(redis_queues.REDIS_HASHMAP_INDEXED_OFFERS_NAME, offer_id, "")
 
         num_queries = 1  # base query for indexation
-        num_queries += 1  # FF
         num_queries += 1  # last30DaysBookings
 
         num_queries += 1  # venues from offers
@@ -295,7 +294,7 @@ class ReindexVenueIdsTest:
         search.reindex_venue_ids([venue.id])
         assert venue.id not in search_testing.search_store["venues"]
 
-    def test_no_unexpected_query_made(self):
+    def test_no_unexpected_query_made(self, features):
         venues = offerers_factories.VenueFactory.create_batch(3, isPermanent=True)
         venue_ids = [venue.id for venue in venues]
 

--- a/api/tests/core/testing/testing_test.py
+++ b/api/tests/core/testing/testing_test.py
@@ -3,6 +3,7 @@ import pytest
 import pcapi.core.bookings.models as bookings_models
 from pcapi import settings as pcapi_settings
 from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 
@@ -67,3 +68,15 @@ def test_override_features_as_context_manager(features):
 class OverrideFeaturesOnClassTest:
     def test_method_level_override(self):
         assert not FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA.is_active()
+
+
+def test_features_cached(features):
+    with assert_num_queries(0):
+        first_ff = list(FeatureToggle)[0].name
+        getattr(FeatureToggle, first_ff).is_active()
+
+
+def test_features_not_cached():
+    with assert_num_queries(1):
+        first_ff = list(FeatureToggle)[0].name
+        getattr(FeatureToggle, first_ff).is_active()

--- a/api/tests/routes/adage/v1/confirm_prebooking_test.py
+++ b/api/tests/routes/adage/v1/confirm_prebooking_test.py
@@ -32,12 +32,11 @@ class Returns200Test:
     # 1. select booking
     # 2. select deposit
     # 3. select stock.price sum
-    # 4. select FF
     # 5. update booking
-    expected_num_queries = 5
+    expected_num_queries = 4
 
     @time_machine.travel("2021-10-15 09:00:00", tick=False)
-    def test_confirm_collective_prebooking(self, client, caplog) -> None:
+    def test_confirm_collective_prebooking(self, client, caplog, features) -> None:
         redactor = EducationalRedactorFactory()
         educational_institution = EducationalInstitutionFactory()
         educational_year = EducationalYearFactory(adageId="1")
@@ -162,7 +161,7 @@ class Returns200Test:
         assert response.status_code == 200
 
     @time_machine.travel("2021-10-15 09:00:00")
-    def test_sufficient_ministry_fund(self, client) -> None:
+    def test_sufficient_ministry_fund(self, client, features) -> None:
         educational_institution = EducationalInstitutionFactory()
         educational_institution2 = EducationalInstitutionFactory()
         educational_institution3 = EducationalInstitutionFactory()
@@ -218,7 +217,7 @@ class Returns200Test:
         assert response.status_code == 200
 
     @time_machine.travel("2021-10-15 09:00:00")
-    def test_out_of_minitry_check_dates(self, client) -> None:
+    def test_out_of_minitry_check_dates(self, client, features) -> None:
         educational_institution = EducationalInstitutionFactory()
         educational_institution2 = EducationalInstitutionFactory()
 

--- a/api/tests/routes/adage/v1/get_educational_institution_test.py
+++ b/api/tests/routes/adage/v1/get_educational_institution_test.py
@@ -142,7 +142,7 @@ class Returns200Test:
             "prebookings": [{**expected_serialized_prebooking(booking), "address": "Somewhere in Paris"}],
         }
 
-    def test_get_educational_institution_num_queries(self, client):
+    def test_get_educational_institution_num_queries(self, client, features):
         redactor = EducationalRedactorFactory()
         educational_year = EducationalYearFactory()
         educational_institution = EducationalInstitutionFactory()

--- a/api/tests/routes/adage/v1/get_prebookings_test.py
+++ b/api/tests/routes/adage/v1/get_prebookings_test.py
@@ -12,7 +12,7 @@ from pcapi.core.testing import assert_num_queries
 from tests.routes.adage.v1.conftest import expected_serialized_prebooking
 
 
-@pytest.mark.usefixtures("db_session")
+@pytest.mark.usefixtures("db_session", "features")
 class Returns200Test:
     num_queries = 1  # fetch bookings
 

--- a/api/tests/routes/adage/v1/refuse_prebookings_test.py
+++ b/api/tests/routes/adage/v1/refuse_prebookings_test.py
@@ -20,7 +20,7 @@ from pcapi.models import db
 
 @pytest.mark.usefixtures("db_session")
 class Returns200Test:
-    def test_refuse_collective_booking(self, client):
+    def test_refuse_collective_booking(self, client, features):
         redactor = EducationalRedactorFactory(
             civility="M.",
             firstName="Jean",

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -782,8 +782,7 @@ class GetPublicAccountTest(GetEndpointHelper):
     # check if user is waiting to be anonymized
     # bookings
     # user tags (for tag account form display)
-    expected_num_queries = 6
-    expected_num_queries_with_ff = expected_num_queries + 1
+    expected_num_queries = 5
 
     class ReviewButtonTest(button_helpers.ButtonHelper):
         needed_permission = perm_models.Permissions.BENEFICIARY_MANUAL_REVIEW
@@ -840,12 +839,12 @@ class GetPublicAccountTest(GetEndpointHelper):
             return url_for("backoffice_web.public_accounts.get_public_account", user_id=user.id)
 
     @pytest.mark.parametrize("index,expected_badge", [(0, "Pass 17"), (1, "Ancien Pass 18"), (2, "Pass 18"), (3, None)])
-    def test_get_public_account(self, authenticated_client, index, expected_badge):
+    def test_get_public_account(self, authenticated_client, index, expected_badge, features):
         users = create_bunch_of_accounts()
         user = users[index]
 
         user_id = user.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -878,7 +877,7 @@ class GetPublicAccountTest(GetEndpointHelper):
             assert expected_badge in badges
         assert "Suspendu" not in badges
 
-    def test_get_suspended_public_account(self, legit_user, authenticated_client):
+    def test_get_suspended_public_account(self, legit_user, authenticated_client, features):
         user = users_factories.UserFactory(isActive=False)
         history_factories.ActionHistoryFactory(
             actionType=history_models.ActionType.USER_SUSPENDED,
@@ -889,7 +888,7 @@ class GetPublicAccountTest(GetEndpointHelper):
         )
 
         user_id = user.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -899,21 +898,21 @@ class GetPublicAccountTest(GetEndpointHelper):
         content = html_parser.content_as_text(response.data)
         assert "Date de suspension : 03/11/2023" in content
 
-    def test_get_public_account_with_unconfirmed_modified_email(self, authenticated_client):
+    def test_get_public_account_with_unconfirmed_modified_email(self, authenticated_client, features):
         user = users_factories.UserFactory()
         users_factories.EmailUpdateEntryFactory(user=user)
         users_factories.EmailConfirmationEntryFactory(user=user)
         users_factories.NewEmailSelectionEntryFactory(user=user)
         user_id = user.id
 
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
         parsed_html = html_parser.get_soup(response.data)
         assert parsed_html.find("i", class_="pc-email-changed-icon") is None
 
-    def test_get_public_account_with_confirmed_modified_email(self, authenticated_client):
+    def test_get_public_account_with_confirmed_modified_email(self, authenticated_client, features):
         user = users_factories.UserFactory()
         users_factories.EmailUpdateEntryFactory(user=user)
         users_factories.EmailConfirmationEntryFactory(user=user)
@@ -921,19 +920,19 @@ class GetPublicAccountTest(GetEndpointHelper):
         users_factories.EmailValidationEntryFactory(user=user)
         user_id = user.id
 
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
         parsed_html = html_parser.get_soup(response.data)
         assert parsed_html.find("i", class_="pc-email-changed-icon") is not None
 
-    def test_get_public_account_with_admin_modified_email(self, authenticated_client):
+    def test_get_public_account_with_admin_modified_email(self, authenticated_client, features):
         user = users_factories.UserFactory()
         users_factories.EmailAdminUpdateEntryFactory(user=user)
         user_id = user.id
 
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -950,7 +949,7 @@ class GetPublicAccountTest(GetEndpointHelper):
             ([fraud_models.FraudReasonCode.DUPLICATE_USER], "Duplicat de l'utilisateur {original_user_id}"),
         ),
     )
-    def test_get_public_account_with_resolved_duplicate(self, authenticated_client, reasonCodes, reason):
+    def test_get_public_account_with_resolved_duplicate(self, authenticated_client, reasonCodes, reason, features):
         first_name = "Jack"
         last_name = "Sparrow"
         email = "jsparrow@pirate.mail"
@@ -1010,21 +1009,21 @@ class GetPublicAccountTest(GetEndpointHelper):
         )
 
         duplicate_user_id = duplicate_user.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=duplicate_user_id))
             assert response.status_code == 200
 
         content = html_parser.content_as_text(response.data)
         assert f"User ID doublon : {original_user.id}" in content
 
-    def test_get_public_account_birth_dates(self, authenticated_client):
+    def test_get_public_account_birth_dates(self, authenticated_client, features):
         user = users_factories.UserFactory(
             dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, days=15),
             validatedBirthDate=datetime.datetime.utcnow() - relativedelta(years=17, days=15),
         )
         user_id = user.id
 
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -1048,7 +1047,7 @@ class GetPublicAccountTest(GetEndpointHelper):
         ],
     )
     def test_get_beneficiary_credit(
-        self, authenticated_client, user_factory, expected_remaining_text, expected_digital_remaining_text
+        self, authenticated_client, user_factory, expected_remaining_text, expected_digital_remaining_text, features
     ):
         beneficiary = user_factory()
 
@@ -1061,7 +1060,7 @@ class GetPublicAccountTest(GetEndpointHelper):
         )
 
         user_id = beneficiary.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -1077,7 +1076,7 @@ class GetPublicAccountTest(GetEndpointHelper):
         )
 
         user_id = free_beneficiary.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
 
         assert response.status_code == 200
@@ -1087,7 +1086,7 @@ class GetPublicAccountTest(GetEndpointHelper):
         _, _, _, _, random, _ = create_bunch_of_accounts()
         user_id = random.id
 
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -1100,7 +1099,9 @@ class GetPublicAccountTest(GetEndpointHelper):
             (users_factories.CaledonianBeneficiaryFactory, "20,00 € (2385 CFP)", "12,50 € (1490 CFP)"),
         ],
     )
-    def test_get_beneficiary_bookings(self, authenticated_client, user_factory, expected_price_1, expected_price_2):
+    def test_get_beneficiary_bookings(
+        self, authenticated_client, user_factory, expected_price_1, expected_price_2, features
+    ):
         user = user_factory()
         b1 = bookings_factories.CancelledBookingFactory(
             user=user,
@@ -1115,7 +1116,7 @@ class GetPublicAccountTest(GetEndpointHelper):
         bookings_factories.UsedBookingFactory()
 
         user_id = user.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -1159,19 +1160,19 @@ class GetPublicAccountTest(GetEndpointHelper):
         assert f"Notification du partenaire culturel : {b1.venue.bookingEmail}" in extra_rows[1]
         assert "Notification pour cette offre : booking.offer@example.com" in extra_rows[1]
 
-    def test_get_beneficiary_bookings_empty(self, authenticated_client):
+    def test_get_beneficiary_bookings_empty(self, authenticated_client, features):
         user = users_factories.BeneficiaryFactory()
         bookings_factories.UsedBookingFactory()
 
         user_id = user.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
         assert not html_parser.extract_table_rows(response.data, parent_class="bookings-tab-pane")
         assert "Aucune réservation à ce jour" in response.data.decode("utf-8")
 
-    def test_fraud_check_link(self, authenticated_client):
+    def test_fraud_check_link(self, authenticated_client, features):
         user = users_factories.BeneficiaryFactory()
         # modifiy the date for clearer tests
         old_dms = fraud_factories.BeneficiaryFraudCheckFactory(
@@ -1181,7 +1182,7 @@ class GetPublicAccountTest(GetEndpointHelper):
         )
 
         user_id = user.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -1212,7 +1213,7 @@ class GetPublicAccountTest(GetEndpointHelper):
             in main_dossier_card
         )
 
-    def test_get_public_account_history(self, legit_user, authenticated_client):
+    def test_get_public_account_history(self, legit_user, authenticated_client, features):
         # More than 30 days ago to have deterministic order because "Import ubble" is generated randomly between
         # -30 days and -1 day in BeneficiaryImportStatusFactory
         user = users_factories.BeneficiaryFactory(dateCreated=datetime.datetime.utcnow() - relativedelta(days=40))
@@ -1251,7 +1252,7 @@ class GetPublicAccountTest(GetEndpointHelper):
         repository.save(no_date_action)
 
         user_id = user.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -1314,11 +1315,11 @@ class GetPublicAccountTest(GetEndpointHelper):
         assert history_rows[8]["Commentaire"].startswith("Fraude suspicion")
         assert history_rows[8]["Auteur"] == legit_user.full_name
 
-    def test_get_public_account_anonymized_user(self, authenticated_client):
+    def test_get_public_account_anonymized_user(self, authenticated_client, features):
         user = users_factories.UserFactory(roles=[users_models.UserRole.ANONYMIZED])
 
         user_id = user.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 
@@ -1333,7 +1334,7 @@ class GetPublicAccountTest(GetEndpointHelper):
         tag2 = users_factories.UserTagFactory(label="Ambassadeur B")
         user = users_factories.UserFactory(tags=[tag1, tag2])
         user_id = user.id
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, user_id=user_id))
             assert response.status_code == 200
 

--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -1809,9 +1809,8 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
     # - fetch CollectiveOffer
     # - _is_collective_offer_price_editable
     expected_num_queries = 4
-    expected_num_queries_with_ff = expected_num_queries + 1  # FF VENUE_REGULARIZATION
 
-    def test_nominal(self, legit_user, authenticated_client):
+    def test_nominal(self, legit_user, authenticated_client, features):
         start_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         end_date = start_date + datetime.timedelta(days=28)
         provider = providers_factories.ProviderFactory(name="Cinéma Provider")
@@ -1832,7 +1831,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
             collectiveStock__collectiveOffer__provider=provider,
         )
         url = url_for(self.endpoint, collective_offer_id=collective_booking.collectiveStock.collectiveOffer.id)
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1883,28 +1882,28 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         )
         assert descriptions["Offre vitrine liée"] == "offre Vito Cortizone pour lieu que l'on ne peut refuser"
 
-    def test_processed_pricing(self, legit_user, authenticated_client):
+    def test_processed_pricing(self, legit_user, authenticated_client, features):
         pricing = finance_factories.CollectivePricingFactory(
             status=finance_models.PricingStatus.PROCESSED,
             collectiveBooking__collectiveStock__startDatetime=datetime.datetime(1970, 1, 1),
         )
         url = url_for(self.endpoint, collective_offer_id=pricing.collectiveBooking.collectiveStock.collectiveOffer.id)
 
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
         buttons = html_parser.extract(response.data, "button")
         assert "Ajuster le prix" not in buttons
 
-    def test_invoiced_pricing(self, legit_user, authenticated_client):
+    def test_invoiced_pricing(self, legit_user, authenticated_client, features):
         pricing = finance_factories.CollectivePricingFactory(
             status=finance_models.PricingStatus.INVOICED,
             collectiveBooking__collectiveStock__startDatetime=datetime.datetime(1970, 1, 1),
         )
         url = url_for(self.endpoint, collective_offer_id=pricing.collectiveBooking.collectiveStock.collectiveOffer.id)
 
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1927,7 +1926,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         buttons = html_parser.extract(response.data, "button")
         assert "Ajuster le prix" not in buttons
 
-    def test_get_validated_offer(self, legit_user, authenticated_client):
+    def test_get_validated_offer(self, legit_user, authenticated_client, features):
         event_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         validation_date = datetime.datetime.utcnow()
         collective_booking = educational_factories.CollectiveBookingFactory(
@@ -1937,7 +1936,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
             collectiveStock__collectiveOffer__lastValidationAuthor=legit_user,
         )
         url = url_for(self.endpoint, collective_offer_id=collective_booking.collectiveStock.collectiveOffer.id)
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1945,7 +1944,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         assert descriptions["Utilisateur de la dernière validation"] == legit_user.full_name
         assert descriptions["Date de dernière validation"] == format_date(validation_date, "%d/%m/%Y à %Hh%M")
 
-    def test_get_rejected_offer(self, legit_user, authenticated_client):
+    def test_get_rejected_offer(self, legit_user, authenticated_client, features):
         event_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         validation_date = datetime.datetime.utcnow()
         collective_booking = educational_factories.CollectiveBookingFactory(
@@ -1956,7 +1955,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
             collectiveStock__collectiveOffer__rejectionReason=educational_models.CollectiveOfferRejectionReason.MISSING_DESCRIPTION,
         )
         url = url_for(self.endpoint, collective_offer_id=collective_booking.collectiveStock.collectiveOffer.id)
-        with assert_num_queries(self.expected_num_queries_with_ff):
+        with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
@@ -1965,31 +1964,31 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         assert descriptions["Date de dernière validation"] == format_date(validation_date, "%d/%m/%Y à %Hh%M")
         assert descriptions["Raison de rejet"] == "Description manquante"
 
-    def test_collective_offer_with_offerer_confidence_rule(self, authenticated_client):
+    def test_collective_offer_with_offerer_confidence_rule(self, authenticated_client, features):
         rule = offerers_factories.ManualReviewOffererConfidenceRuleFactory(offerer__name="Offerer")
         collective_offer = educational_factories.CollectiveOfferFactory(venue__managingOfferer=rule.offerer)
 
         url = url_for(self.endpoint, collective_offer_id=collective_offer.id)
-        with assert_num_queries(self.expected_num_queries_with_ff - 1):  # no _is_collective_offer_price_editable
+        with assert_num_queries(self.expected_num_queries - 1):  # no _is_collective_offer_price_editable
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
         descriptions = html_parser.extract_descriptions(response.data)
         assert descriptions["Entité juridique"] == "Offerer Revue manuelle"
 
-    def test_collective_offer_with_venue_confidence_rule(self, authenticated_client):
+    def test_collective_offer_with_venue_confidence_rule(self, authenticated_client, features):
         rule = offerers_factories.ManualReviewVenueConfidenceRuleFactory(venue__name="Venue")
         collective_offer = educational_factories.CollectiveOfferFactory(venue=rule.venue)
 
         url = url_for(self.endpoint, collective_offer_id=collective_offer.id)
-        with assert_num_queries(self.expected_num_queries_with_ff - 1):  # no _is_collective_offer_price_editable
+        with assert_num_queries(self.expected_num_queries - 1):  # no _is_collective_offer_price_editable
             response = authenticated_client.get(url)
             assert response.status_code == 200
 
         descriptions = html_parser.extract_descriptions(response.data)
         assert descriptions["Partenaire culturel"] == "Venue Revue manuelle"
 
-    def test_collective_offer_with_top_acteur_offerer(self, authenticated_client):
+    def test_collective_offer_with_top_acteur_offerer(self, authenticated_client, features):
         collective_offer = educational_factories.CollectiveOfferFactory(
             venue__managingOfferer__name="Offerer",
             venue__managingOfferer__tags=[
@@ -1999,7 +1998,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         )
 
         url = url_for(self.endpoint, collective_offer_id=collective_offer.id)
-        with assert_num_queries(self.expected_num_queries_with_ff - 1):  # no _is_collective_offer_price_editable
+        with assert_num_queries(self.expected_num_queries - 1):  # no _is_collective_offer_price_editable
             response = authenticated_client.get(url)
             assert response.status_code == 200
 

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -861,6 +861,8 @@ class GetOffererStatsTest(GetEndpointHelper):
     # get offerer (1 query)
     # get offerers offers stats (6 query: 3 to check the quantity and 3 to get the data)
     expected_num_queries = 9
+    # -1 sql query replaced with clickhouse query
+    expected_num_queries_when_clickhouse_enabled = expected_num_queries - 1
 
     @pytest.mark.parametrize(
         "venue_factory,expected_revenue_text",
@@ -1086,6 +1088,7 @@ class GetOffererRevenueDetailsTest(GetEndpointHelper):
     # user
     # offerer
     expected_num_queries = 3
+    expected_num_queries_when_clickhouse_enabled = 3
 
     @patch(
         "pcapi.connectors.clickhouse.testing_backend.TestingBackend.run_query",
@@ -1679,6 +1682,7 @@ class GetOffererVenuesTest(GetEndpointHelper):
     # - venues with joined data (1 query)
     # - venue providers (selectinload: 1 query)
     expected_num_queries = 4
+    expected_num_queries = 3
 
     def test_get_managed_venues(self, authenticated_client, offerer):
         now = datetime.datetime.utcnow()
@@ -1741,7 +1745,7 @@ class GetOffererVenuesTest(GetEndpointHelper):
         assert rows[1]["Partenaire technique"] == ""
         assert rows[1]["Fraude"] == ""
 
-    def test_get_caledonian_managed_venues(self, authenticated_client):
+    def test_get_caledonian_managed_venues(self, authenticated_client, features):
         offerer = offerers_factories.CaledonianOffererFactory()
         venue = offerers_factories.CaledonianVenueFactory(managingOfferer=offerer)
         bank_account = finance_factories.BankAccountFactory(offerer=offerer, label="Compte NC")

--- a/api/tests/routes/native/v1/banner_test.py
+++ b/api/tests/routes/native/v1/banner_test.py
@@ -12,7 +12,7 @@ from pcapi.core.users import models as users_models
 from pcapi.utils.string import u_nbsp
 
 
-@pytest.mark.usefixtures("db_session")
+@pytest.mark.usefixtures("db_session", "features")
 class BannerTest:
     # - authenticated user
     # - user
@@ -72,7 +72,7 @@ class BannerTest:
         user = users_factories.UserFactory(dateOfBirth=dateOfBirth)
 
         client.with_token(email=user.email)
-        with assert_num_queries(self.expected_num_queries_without_subscription_check + 1):  # 1 FF checked
+        with assert_num_queries(self.expected_num_queries_without_subscription_check):
             response = client.get("/native/v1/banner?isGeolocated=false")
             assert response.status_code == 200
 
@@ -85,7 +85,7 @@ class BannerTest:
         )
 
         client.with_token(email=user.email)
-        with assert_num_queries(self.expected_num_queries_without_subscription_check + 1):  # credit v3 FF
+        with assert_num_queries(self.expected_num_queries_without_subscription_check):
             response = client.get("/native/v1/banner?isGeolocated=false")
             assert response.status_code == 200
 
@@ -102,7 +102,7 @@ class BannerTest:
 
         client.with_token(email=user.email)
         expected_num_queries = self.expected_num_queries_without_subscription_check + 1  # action_history
-        with assert_num_queries(expected_num_queries + 1):  # credit v3 FF
+        with assert_num_queries(expected_num_queries):
             response = client.get("/native/v1/banner?isGeolocated=false")
             assert response.status_code == 200
 
@@ -121,7 +121,7 @@ class BannerTest:
         )
 
         client.with_token(email=user.email)
-        with assert_num_queries(self.expected_num_queries_with_subscription_check + 2):  # action_history ; credit v3 FF
+        with assert_num_queries(self.expected_num_queries_with_subscription_check + 1):  # action_history
             response = client.get("/native/v1/banner?isGeolocated=false")
             assert response.status_code == 200
 
@@ -131,7 +131,7 @@ class BannerTest:
         user = users_factories.BeneficiaryGrant18Factory()
 
         client.with_token(email=user.email)
-        with assert_num_queries(self.expected_num_queries_without_subscription_check + 1):  # credit v3 FF
+        with assert_num_queries(self.expected_num_queries_without_subscription_check):
             response = client.get("/native/v1/banner?isGeolocated=true")
             assert response.status_code == 200
 
@@ -141,7 +141,7 @@ class BannerTest:
         user = users_factories.UserFactory(age=17)
 
         client.with_token(email=user.email)
-        with assert_num_queries(self.expected_num_queries_without_subscription_check + 1):  # credit v3 FF
+        with assert_num_queries(self.expected_num_queries_without_subscription_check):  # credit v3 FF
             response = client.get("/native/v1/banner?isGeolocated=false")
             assert response.status_code == 200
 
@@ -161,7 +161,7 @@ class BannerTest:
         fraud_factories.UbbleRetryFraudCheckFactory(user=user)
 
         client.with_token(email=user.email)
-        with assert_num_queries(self.expected_num_queries_with_subscription_check + 1):  # action_history
+        with assert_num_queries(self.expected_num_queries_with_subscription_check):
             response = client.get("/native/v1/banner")
             assert response.status_code == 200
 
@@ -177,9 +177,7 @@ class BannerTest:
         user = users_factories.ExUnderageBeneficiaryFactory()
 
         client.with_token(email=user.email)
-        with assert_num_queries(
-            self.expected_num_queries_without_subscription_check + 1
-        ):  # FF ENABLE_PHONE_VALIDATION checked
+        with assert_num_queries(self.expected_num_queries_without_subscription_check):
             response = client.get("/native/v1/banner")
             assert response.status_code == 200
 
@@ -199,9 +197,7 @@ class BannerTest:
         assert user.age == 18
 
         client.with_token(email=user.email)
-        with assert_num_queries(
-            self.expected_num_queries_without_subscription_check + 1
-        ):  # FF ENABLE_PHONE_VALIDATION checked
+        with assert_num_queries(self.expected_num_queries_without_subscription_check):
             response = client.get("/native/v1/banner")
             assert response.status_code == 200
 

--- a/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
+++ b/api/tests/routes/public/collective/endpoints/adage_mock/test_bookings.py
@@ -548,7 +548,7 @@ class BookCollectiveOfferTest(PublicAPIRestrictedEnvEndpointHelper):
         num_queries = 2  # Select API key + rollback
         super().test_should_raise_401_because_api_key_not_linked_to_provider(client, num_queries=num_queries)
 
-    def test_can_book_collective_offer(self, client):
+    def test_can_book_collective_offer(self, client, features):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         auth_client = client.with_explicit_token(plain_api_key)
 


### PR DESCRIPTION
## But de la pull request

Prefetch values from `Feature` model to avoid having them in `assert_num_queries` tests

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
