### PR TITLE
(PC-35694)[PRO] fix: focus on image drag and drop uploader

### DIFF
--- a/pro/src/commons/hooks/usePrevious.ts
+++ b/pro/src/commons/hooks/usePrevious.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react'
+
+export const usePrevious = <T>(value: T): T | undefined => {
+  const ref = useRef<T>()
+  useEffect(() => {
+    ref.current = value
+  })
+  return ref.current
+}

--- a/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
+++ b/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames'
-import { useState } from 'react'
+import { ForwardedRef, forwardRef, useState } from 'react'
 import { useDropzone } from 'react-dropzone'
 
 import fullValidateIcon from 'icons/full-validate.svg'
@@ -69,36 +69,39 @@ interface ImageDragAndDropProps {
   }
 }
 
-export const ImageDragAndDrop = ({
-  className,
-  onClick,
-  onDropOrSelected,
-  onError,
-  disabled,
-  minSizes,
-}: ImageDragAndDropProps) => {
-  const [isDraggedOver, setIsDraggedOver] = useState(false)
-  const [isHovered, setIsHovered] = useState(false)
-  const [isFocused, setIsFocused] = useState(false)
-
-  const accept: MimeToExtensionsMap = ALLOWED_IMAGE_TYPES.reduce(
-    (acc: MimeToExtensionsMap, { mime, extensions }) => {
-      acc[mime] = extensions
-      return acc
-    },
-    {}
-  )
-
-  const imageMimeTypes = ALLOWED_IMAGE_TYPES.reduce(
-    (acc: string[], { mime }) => {
-      acc.push(mime)
-      return acc
-    },
-    []
-  )
-
-  const { inputRef, getRootProps, getInputProps, fileRejections } = useDropzone(
+export const ImageDragAndDrop = forwardRef(
+  (
     {
+      className,
+      onClick,
+      onDropOrSelected,
+      onError,
+      disabled,
+      minSizes,
+    }: ImageDragAndDropProps,
+    dragAndDropInputRef: ForwardedRef<HTMLInputElement>
+  ) => {
+    const [isDraggedOver, setIsDraggedOver] = useState(false)
+    const [isHovered, setIsHovered] = useState(false)
+    const [isFocused, setIsFocused] = useState(false)
+
+    const accept: MimeToExtensionsMap = ALLOWED_IMAGE_TYPES.reduce(
+      (acc: MimeToExtensionsMap, { mime, extensions }) => {
+        acc[mime] = extensions
+        return acc
+      },
+      {}
+    )
+
+    const imageMimeTypes = ALLOWED_IMAGE_TYPES.reduce(
+      (acc: string[], { mime }) => {
+        acc.push(mime)
+        return acc
+      },
+      []
+    )
+
+    const { getRootProps, getInputProps, fileRejections } = useDropzone({
       accept,
       maxFiles: 1,
       maxSize: 10 * 1024 * 1024,
@@ -197,153 +200,165 @@ export const ImageDragAndDrop = ({
 
         return null
       },
-    }
-  )
+    })
 
-  const rootProps = getRootProps()
-  // role="presentation" on <div> is redundant,
-  // input should be the only focusable element.
-  delete rootProps.role
-  delete rootProps.tabIndex
+    const rootProps = getRootProps()
+    // role="presentation" on <div> is redundant,
+    // input should be the only focusable element.
+    delete rootProps.role
+    delete rootProps.tabIndex
 
-  const inputProps = getInputProps()
-  // restore input focusability to allow keyboard navigation,
-  // and let us define input style.
-  inputProps.tabIndex = 0
-  inputProps.disabled = disabled
-  delete inputProps.style
+    const inputProps = getInputProps()
+    // restore input focusability to allow keyboard navigation,
+    // and let us define input style.
+    inputProps.tabIndex = 0
+    inputProps.disabled = disabled
+    delete inputProps.style
 
-  const errors = fileRejections.reduce(
-    (acc, rejections) => {
-      const { errors } = rejections
+    const errors = fileRejections.reduce(
+      (acc, rejections) => {
+        const { errors } = rejections
 
-      acc.hasWrongType = errors.some((e) => e.code === 'file-invalid-type')
-      acc.hasWrongSize = errors.some((e) => e.code === 'file-too-large')
-      acc.hasWrongWidth = errors.some(
-        (e) => e.code === 'file-invalid-dimensions-width'
-      )
-      acc.hasWrongHeight = errors.some(
-        (e) => e.code === 'file-invalid-dimensions-height'
-      )
+        acc.hasWrongType = errors.some((e) => e.code === 'file-invalid-type')
+        acc.hasWrongSize = errors.some((e) => e.code === 'file-too-large')
+        acc.hasWrongWidth = errors.some(
+          (e) => e.code === 'file-invalid-dimensions-width'
+        )
+        acc.hasWrongHeight = errors.some(
+          (e) => e.code === 'file-invalid-dimensions-height'
+        )
 
-      return acc
-    },
-    {
-      hasWrongType: false,
-      hasWrongSize: false,
-      hasWrongWidth: false,
-      hasWrongHeight: false,
-    }
-  )
-  const hasError =
-    errors.hasWrongSize ||
-    errors.hasWrongType ||
-    errors.hasWrongWidth ||
-    errors.hasWrongHeight
+        return acc
+      },
+      {
+        hasWrongType: false,
+        hasWrongSize: false,
+        hasWrongWidth: false,
+        hasWrongHeight: false,
+      }
+    )
+    const hasError =
+      errors.hasWrongSize ||
+      errors.hasWrongType ||
+      errors.hasWrongWidth ||
+      errors.hasWrongHeight
 
-  return (
-    <div className={cn(styles['image-drag-and-drop-container'])}>
-      <div
-        data-testid="image-drag-and-drop"
-        {...rootProps}
-        className={cn(
-          styles['image-drag-and-drop'],
-          {
-            [styles['image-drag-and-drop-dragged-over']]: isDraggedOver,
-            [styles['image-drag-and-drop-hovered']]: isHovered,
-            [styles['image-drag-and-drop-focused']]: isFocused,
-            [styles['image-drag-and-drop-error']]: hasError,
-            [styles['image-drag-and-drop-disabled']]: disabled,
-          },
-          className
-        )}
-      >
-        {isDraggedOver ? (
-          <SvgIcon src={fullValidateIcon} alt="" width="24" />
-        ) : (
-          <SvgIcon src={strokePicture} alt="" width="58" viewBox="0 0 58 58" />
-        )}
-        <div className={styles['image-drag-and-drop-text']}>
+    return (
+      <div className={cn(styles['image-drag-and-drop-container'])}>
+        <div
+          data-testid="image-drag-and-drop"
+          {...rootProps}
+          className={cn(
+            styles['image-drag-and-drop'],
+            {
+              [styles['image-drag-and-drop-dragged-over']]: isDraggedOver,
+              [styles['image-drag-and-drop-hovered']]: isHovered,
+              [styles['image-drag-and-drop-focused']]: isFocused,
+              [styles['image-drag-and-drop-error']]: hasError,
+              [styles['image-drag-and-drop-disabled']]: disabled,
+            },
+            className
+          )}
+        >
           {isDraggedOver ? (
-            <>Déposez votre image ici</>
+            <SvgIcon src={fullValidateIcon} alt="" width="24" />
           ) : (
-            <>
-              <span>Glissez et déposez votre image</span>
-              <span>
-                {' ou '}
-                <label
-                  id="drag-and-drop-label"
-                  className={styles['image-drag-and-drop-text-highlight']}
-                >
-                  Importez une image
-                </label>
-                <input
-                  {...inputProps}
-                  aria-labelledby="drag-and-drop-label"
-                  aria-describedby="drag-and-drop-description"
-                  aria-invalid={hasError}
-                  className={cn(styles['image-drag-and-drop-input'], {
-                    [styles['image-drag-and-drop-input-error']]: hasError,
-                    [styles['image-drag-and-drop-input-disabled']]: disabled,
-                  })}
-                  onMouseEnter={() => setIsHovered(true)}
-                  onMouseLeave={() => setIsHovered(false)}
-                  onFocus={() => setIsFocused(true)}
-                  onBlur={() => setIsFocused(false)}
-                  onClick={(e) => {
-                    e.stopPropagation()
+            <SvgIcon
+              src={strokePicture}
+              alt=""
+              width="58"
+              viewBox="0 0 58 58"
+            />
+          )}
+          <div className={styles['image-drag-and-drop-text']}>
+            {isDraggedOver ? (
+              <>Déposez votre image ici</>
+            ) : (
+              <>
+                <span>Glissez et déposez votre image</span>
+                <span>
+                  {' ou '}
+                  <label
+                    id="drag-and-drop-label"
+                    className={styles['image-drag-and-drop-text-highlight']}
+                  >
+                    Importez une image
+                  </label>
+                  <input
+                    {...inputProps}
+                    ref={dragAndDropInputRef}
+                    aria-labelledby="drag-and-drop-label"
+                    aria-describedby="drag-and-drop-description"
+                    aria-invalid={hasError}
+                    className={cn(styles['image-drag-and-drop-input'], {
+                      [styles['image-drag-and-drop-input-error']]: hasError,
+                      [styles['image-drag-and-drop-input-disabled']]: disabled,
+                    })}
+                    onMouseEnter={() => setIsHovered(true)}
+                    onMouseLeave={() => setIsHovered(false)}
+                    onFocus={() => setIsFocused(true)}
+                    onBlur={() => setIsFocused(false)}
+                    onClick={(e) => {
+                      e.stopPropagation()
 
-                    // Clear the input value to allow re-uploading the same file.
-                    if (inputRef.current) {
-                      inputRef.current.value = ''
-                      inputRef.current.dispatchEvent(
-                        new Event('input', { bubbles: true })
-                      )
-                    }
+                      // Clear the input value to allow re-uploading the same file.
+                      if (
+                        dragAndDropInputRef &&
+                        typeof dragAndDropInputRef !== 'function' &&
+                        dragAndDropInputRef.current
+                      ) {
+                        dragAndDropInputRef.current.value = ''
+                        dragAndDropInputRef.current.dispatchEvent(
+                          new Event('input', { bubbles: true })
+                        )
+                      }
 
-                    onClick?.()
-                  }}
-                />
-              </span>
-            </>
+                      onClick?.()
+                    }}
+                  />
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+        <div
+          id="drag-and-drop-description"
+          className={styles['image-drag-and-drop-description']}
+          role="alert"
+          aria-relevant="additions"
+        >
+          <ImageConstraintCheck
+            label="Formats acceptés"
+            constraint="JPG, JPEG, PNG, mpo, webP"
+            hasError={errors.hasWrongType}
+            errorMessage="Le format de l’image n’est pas valide"
+          />
+          <ImageConstraintCheck
+            label="Poids maximal du fichier"
+            constraint="10 Mo"
+            hasError={errors.hasWrongSize}
+            errorMessage="Le poids du fichier est trop lourd"
+          />
+          {minSizes?.height && (
+            <ImageConstraintCheck
+              label="Hauteur minimum"
+              constraint={`${minSizes.height} px`}
+              hasError={errors.hasWrongHeight}
+              errorMessage={`L’image doit faire au moins ${minSizes.height} pixels de haut`}
+            />
+          )}
+          {minSizes?.width && (
+            <ImageConstraintCheck
+              label="Largeur minimum"
+              constraint={`${minSizes.width} px`}
+              hasError={errors.hasWrongWidth}
+              errorMessage={`L’image doit faire au moins ${minSizes.width} pixels de large`}
+            />
           )}
         </div>
       </div>
-      <div
-        id="drag-and-drop-description"
-        className={styles['image-drag-and-drop-description']}
-        role="alert"
-        aria-relevant="additions"
-      >
-        <ImageConstraintCheck
-          label="Formats acceptés"
-          constraint="JPG, JPEG, PNG, mpo, webP"
-          hasError={errors.hasWrongType}
-          errorMessage="Le format de l’image n’est pas valide"
-        />
-        <ImageConstraintCheck
-          label="Poids maximal du fichier"
-          constraint="10 Mo"
-          hasError={errors.hasWrongSize}
-          errorMessage="Le poids du fichier est trop lourd"
-        />
-        {minSizes?.height && (
-          <ImageConstraintCheck
-            label="Hauteur minimum"
-            constraint={`${minSizes.height} px`}
-            hasError={errors.hasWrongHeight}
-            errorMessage={`L’image doit faire au moins ${minSizes.height} pixels de haut`}
-          />
-        )}
-        {minSizes?.width && (
-          <ImageConstraintCheck
-            label="Largeur minimum"
-            constraint={`${minSizes.width} px`}
-            hasError={errors.hasWrongWidth}
-            errorMessage={`L’image doit faire au moins ${minSizes.width} pixels de large`}
-          />
-        )}
-      </div>
-    </div>
-  )
-}
+    )
+  }
+)
+
+ImageDragAndDrop.displayName = 'ImageDragAndDrop'

--- a/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.tsx
+++ b/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.tsx
@@ -52,10 +52,17 @@ export const ImageDragAndDropUploader = ({
   const [draftImage, setDraftImage] = useState<File | undefined>(undefined)
   const previousDraftImage = usePrevious(draftImage)
 
+  const [refToFocusOnClose, setRefToFocusOnClose] = useState<
+    React.RefObject<HTMLElement> | undefined
+  >(inputDragAndDropRef)
+
   const hasImage = imageUrl && originalImageUrl
   const shouldDisplayActions = hasImage && !hideActionButtons
 
   useEffect(() => {
+    // This is to manage the focus when ImageDragAndDropUploader is re-rendered
+    // after an image deletion (after a button action click, not as a result
+    // of a deletion from the modal options)
     if (previousDraftImage && !draftImage) {
       inputDragAndDropRef.current?.focus()
     }
@@ -64,6 +71,7 @@ export const ImageDragAndDropUploader = ({
   const onImageDeleteHandler = () => {
     setIsModalImageOpen(false)
     setDraftImage(undefined)
+    setRefToFocusOnClose(inputDragAndDropRef)
     onImageDelete()
     notify.success('L’image a bien été supprimée')
   }
@@ -71,6 +79,7 @@ export const ImageDragAndDropUploader = ({
   const onImageUploadHandler = (values: OnImageUploadArgs) => {
     setIsModalImageOpen(false)
     setDraftImage(values.imageFile)
+    setRefToFocusOnClose(updateImageRef)
     onImageUpload(values)
     notify.success('Votre image a bien été enregistrée')
   }
@@ -117,8 +126,7 @@ export const ImageDragAndDropUploader = ({
               </Button>
             )
           }
-          refToFocusOnClose={inputDragAndDropRef}
-          preferNonNullRefToFocusOnClose
+          refToFocusOnClose={refToFocusOnClose}
         />
         {shouldDisplayActions && (
           <Button

--- a/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.tsx
+++ b/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.tsx
@@ -1,7 +1,8 @@
 import cn from 'classnames'
-import { useRef, useState } from 'react'
+import { useRef, useState, useEffect } from 'react'
 
 import { useNotification } from 'commons/hooks/useNotification'
+import { usePrevious } from 'commons/hooks/usePrevious'
 import {
   UploadImageValues,
   UploaderModeEnum,
@@ -44,18 +45,26 @@ export const ImageDragAndDropUploader = ({
 }: ImageDragAndDropUploaderProps) => {
   const notify = useNotification()
   const updateImageRef = useRef<HTMLButtonElement>(null)
+  const inputDragAndDropRef = useRef<HTMLInputElement>(null)
+
   const { imageUrl, originalImageUrl } = initialValues
   const [isModalImageOpen, setIsModalImageOpen] = useState(false)
   const [draftImage, setDraftImage] = useState<File | undefined>(undefined)
+  const previousDraftImage = usePrevious(draftImage)
 
   const hasImage = imageUrl && originalImageUrl
   const shouldDisplayActions = hasImage && !hideActionButtons
+
+  useEffect(() => {
+    if (previousDraftImage && !draftImage) {
+      inputDragAndDropRef.current?.focus()
+    }
+  }, [draftImage, previousDraftImage])
 
   const onImageDeleteHandler = () => {
     setIsModalImageOpen(false)
     setDraftImage(undefined)
     onImageDelete()
-    setDraftImage(undefined)
     notify.success('L’image a bien été supprimée')
   }
 
@@ -108,6 +117,8 @@ export const ImageDragAndDropUploader = ({
               </Button>
             )
           }
+          refToFocusOnClose={inputDragAndDropRef}
+          preferNonNullRefToFocusOnClose
         />
         {shouldDisplayActions && (
           <Button
@@ -125,6 +136,7 @@ export const ImageDragAndDropUploader = ({
       </div>
       {!hasImage && (
         <ImageDragAndDrop
+          ref={inputDragAndDropRef}
           className={dragAndDropClassName}
           onDropOrSelected={(draftImage) => {
             onImageDropOrSelected?.()

--- a/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.tsx
+++ b/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.tsx
@@ -15,7 +15,6 @@ import fullEditIcon from 'icons/full-edit.svg'
 import fullTrashIcon from 'icons/full-trash.svg'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
-import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './ImageDragAndDropUploader.module.scss'
@@ -56,6 +55,7 @@ export const ImageDragAndDropUploader = ({
     setIsModalImageOpen(false)
     setDraftImage(undefined)
     onImageDelete()
+    setDraftImage(undefined)
     notify.success('L’image a bien été supprimée')
   }
 
@@ -86,10 +86,16 @@ export const ImageDragAndDropUploader = ({
           [styles['image-uploader-actions-visible']]: shouldDisplayActions,
         })}
       >
-        <DialogBuilder
+        <ModalImageUpsertOrEdit
+          mode={mode}
+          onImageUpload={onImageUploadHandler}
+          onImageDelete={onImageDeleteHandler}
+          initialValues={{
+            draftImage,
+            ...initialValues,
+          }}
           onOpenChange={setIsModalImageOpen}
           open={isModalImageOpen}
-          variant="drawer"
           trigger={
             shouldDisplayActions && (
               <Button
@@ -102,17 +108,7 @@ export const ImageDragAndDropUploader = ({
               </Button>
             )
           }
-        >
-          <ModalImageUpsertOrEdit
-            mode={mode}
-            onImageUpload={onImageUploadHandler}
-            onImageDelete={onImageDeleteHandler}
-            initialValues={{
-              draftImage,
-              ...initialValues,
-            }}
-          />
-        </DialogBuilder>
+        />
         {shouldDisplayActions && (
           <Button
             onClick={onImageDeleteHandler}

--- a/pro/src/components/ImageUploader/components/ButtonImageEdit/ButtonImageEdit.tsx
+++ b/pro/src/components/ImageUploader/components/ButtonImageEdit/ButtonImageEdit.tsx
@@ -13,7 +13,6 @@ import fullEditIcon from 'icons/full-edit.svg'
 import fullMoreIcon from 'icons/full-more.svg'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
-import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import style from './ButtonImageEdit.module.scss'
@@ -57,48 +56,42 @@ export const ButtonImageEdit = ({
   }
 
   return (
-    <>
-      <DialogBuilder
-        onOpenChange={setIsModalImageOpen}
-        open={isModalImageOpen}
-        variant="drawer"
-        trigger={
-          imageUrl || originalImageUrl ? (
-            <Button
-              onClick={onClickButtonImageAdd}
-              variant={ButtonVariant.TERNARY}
-              aria-label="Modifier l’image"
-              icon={fullEditIcon}
-            >
-              {children ?? 'Modifier'}
-            </Button>
-          ) : (
-            <button
-              className={cn(style['button-image-add'], {
-                [style['add-image-venue']]: mode === UploaderModeEnum.VENUE,
-                [style['add-image-offer']]:
-                  mode === UploaderModeEnum.OFFER ||
-                  mode === UploaderModeEnum.OFFER_COLLECTIVE,
-              })}
-              onClick={onClickButtonImageAdd}
-              type="button"
-              disabled={disableForm}
-            >
-              <>
-                <SvgIcon src={fullMoreIcon} alt="" className={style['icon']} />
-                <span className={style['label']}>Ajouter une image</span>
-              </>
-            </button>
-          )
-        }
-      >
-        <ModalImageUpsertOrEdit
-          mode={mode}
-          onImageUpload={onImageUploadHandler}
-          onImageDelete={handleImageDelete}
-          initialValues={initialValues}
-        />
-      </DialogBuilder>
-    </>
+    <ModalImageUpsertOrEdit
+      mode={mode}
+      onImageUpload={onImageUploadHandler}
+      onImageDelete={handleImageDelete}
+      initialValues={initialValues}
+      onOpenChange={setIsModalImageOpen}
+      open={isModalImageOpen}
+      trigger={
+        imageUrl || originalImageUrl ? (
+          <Button
+            onClick={onClickButtonImageAdd}
+            variant={ButtonVariant.TERNARY}
+            aria-label="Modifier l’image"
+            icon={fullEditIcon}
+          >
+            {children ?? 'Modifier'}
+          </Button>
+        ) : (
+          <button
+            className={cn(style['button-image-add'], {
+              [style['add-image-venue']]: mode === UploaderModeEnum.VENUE,
+              [style['add-image-offer']]:
+                mode === UploaderModeEnum.OFFER ||
+                mode === UploaderModeEnum.OFFER_COLLECTIVE,
+            })}
+            onClick={onClickButtonImageAdd}
+            type="button"
+            disabled={disableForm}
+          >
+            <>
+              <SvgIcon src={fullMoreIcon} alt="" className={style['icon']} />
+              <span className={style['label']}>Ajouter une image</span>
+            </>
+          </button>
+        )
+      }
+    />
   )
 }

--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.module.scss
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.module.scss
@@ -54,12 +54,6 @@
     align-items: flex-start;
   }
 
-  &-header {
-    @include fonts.title3;
-
-    margin-bottom: rem.torem(16px);
-  }
-
   &-right {
     @include fonts.body-s;
 

--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
@@ -1,4 +1,3 @@
-import * as Dialog from '@radix-ui/react-dialog'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
@@ -15,6 +14,7 @@ const onImageUpload = vi.fn()
 const onImageDelete = vi.fn()
 
 const defaultProps: ModalImageUpsertOrEditProps = {
+  open: true,
   mode: UploaderModeEnum.OFFER,
   onImageUpload,
   onImageDelete,
@@ -38,13 +38,7 @@ const renderModalImageCrop = (props: ModalImageUpsertOrEditTestProps = {}) => {
     ...props,
   }
 
-  return renderWithProviders(
-    <Dialog.Root defaultOpen>
-      <Dialog.Content aria-describedby={undefined}>
-        <ModalImageUpsertOrEdit {...finalProps} />
-      </Dialog.Content>
-    </Dialog.Root>
-  )
+  return renderWithProviders(<ModalImageUpsertOrEdit {...finalProps} />)
 }
 
 describe('ModalImageUpsertOrEdit', () => {

--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.tsx
@@ -19,7 +19,10 @@ import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { Callout } from 'ui-kit/Callout/Callout'
 import { CalloutVariant } from 'ui-kit/Callout/types'
-import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
+import {
+  DialogBuilder,
+  DialogBuilderProps,
+} from 'ui-kit/DialogBuilder/DialogBuilder'
 import { TextInput } from 'ui-kit/formV2/TextInput/TextInput'
 import { Spinner } from 'ui-kit/Spinner/Spinner'
 
@@ -40,7 +43,8 @@ export interface OnImageUploadArgs {
   credit: string | null
 }
 
-export interface ModalImageUpsertOrEditProps {
+export interface ModalImageUpsertOrEditProps
+  extends Omit<DialogBuilderProps, 'children'> {
   mode: UploaderModeEnum
   onImageUpload: (values: OnImageUploadArgs) => void
   onImageDelete?: () => void
@@ -52,6 +56,7 @@ export const ModalImageUpsertOrEdit = ({
   onImageUpload,
   onImageDelete,
   initialValues = {},
+  ...dialogBuilderProps
 }: ModalImageUpsertOrEditProps): JSX.Element | null => {
   const { logEvent } = useAnalytics()
   const { draftImage, ...previouslyUploadedImage } = initialValues
@@ -127,6 +132,10 @@ export const ModalImageUpsertOrEdit = ({
       setImageFromUrl(previouslyUploadedImageUrl)
     }
   }, [previouslyUploadedImageUrl, notification])
+
+  useEffect(() => {
+    setImage(draftImage)
+  }, [draftImage])
 
   const onImageReplace = () => {
     setImage(undefined)
@@ -207,120 +216,121 @@ export const ModalImageUpsertOrEdit = ({
   const onImageSave = () => handleImageChange(onEditedImageSave)
 
   return (
-    <form className={style['modal-image-crop']}>
-      <div className={style['modal-image-crop-content']}>
-        <Dialog.Title asChild>
-          <h1 className={style['modal-image-crop-header']}>
-            Modifier une image
-          </h1>
-        </Dialog.Title>
-        <p className={style['modal-image-crop-right']}>
-          En utilisant ce contenu, je certifie que je suis propriétaire ou que
-          je dispose des autorisations nécessaires pour l’utilisation de
-          celui-ci.
-        </p>
-        {image && (
-          <>
-            {isPaintingImage && <Spinner />}
-            <div
-              className={cn(
-                style['modal-image-crop-subwrapper'],
-                isPaintingImage && style['modal-image-crop-editor-loading']
-              )}
-            >
-              <div className={style['modal-image-crop-editor']}>
-                <ImageEditor
-                  ref={editorRef}
-                  {...imageEditorConfig}
-                  image={image}
-                  initialPosition={editorInitialPosition}
-                  initialScale={scale}
-                  onChangeDone={onImageEditorChange}
-                  onImagePainted={onImagePainted}
-                />
-                <div className={style['modal-image-crop-actions']}>
-                  <Button
-                    icon={fullDownloadIcon}
-                    onClick={onImageReplace}
-                    variant={ButtonVariant.TERNARY}
-                  >
-                    Remplacer l’image
-                  </Button>
-                  <Dialog.Close asChild>
+    <DialogBuilder
+      {...dialogBuilderProps}
+      title="Modifier une image"
+      variant="drawer"
+    >
+      <form className={style['modal-image-crop']}>
+        <div className={style['modal-image-crop-content']}>
+          <p className={style['modal-image-crop-right']}>
+            En utilisant ce contenu, je certifie que je suis propriétaire ou que
+            je dispose des autorisations nécessaires pour l’utilisation de
+            celui-ci.
+          </p>
+          {image && (
+            <>
+              {isPaintingImage && <Spinner />}
+              <div
+                className={cn(
+                  style['modal-image-crop-subwrapper'],
+                  isPaintingImage && style['modal-image-crop-editor-loading']
+                )}
+              >
+                <div className={style['modal-image-crop-editor']}>
+                  <ImageEditor
+                    ref={editorRef}
+                    {...imageEditorConfig}
+                    image={image}
+                    initialPosition={editorInitialPosition}
+                    initialScale={scale}
+                    onChangeDone={onImageEditorChange}
+                    onImagePainted={onImagePainted}
+                  />
+                  <div className={style['modal-image-crop-actions']}>
                     <Button
-                      icon={fullTrashIcon}
-                      onClick={onImageDelete}
+                      icon={fullDownloadIcon}
+                      onClick={onImageReplace}
                       variant={ButtonVariant.TERNARY}
                     >
-                      Supprimer l’image
+                      Remplacer l’image
                     </Button>
-                  </Dialog.Close>
+                    <Dialog.Close asChild>
+                      <Button
+                        icon={fullTrashIcon}
+                        onClick={onImageDelete}
+                        variant={ButtonVariant.TERNARY}
+                      >
+                        Supprimer l’image
+                      </Button>
+                    </Dialog.Close>
+                  </div>
                 </div>
+                {previewImageUrl && <AppPreview imageUrl={previewImageUrl} />}
               </div>
-              {previewImageUrl && <AppPreview imageUrl={previewImageUrl} />}
-            </div>
-            {shouldDisplayWarningCallout && (
-              <Callout
-                className={style['modal-image-crop-callout']}
-                variant={CalloutVariant.WARNING}
-              >
-                <div>
-                  La qualité de votre image n’est pas optimale.
-                  <br />
-                  Le format recommandé :
-                  <ul className={style['modal-image-crop-callout-list']}>
-                    <li>Largeur minimale de l’image : 400 px</li>
-                    <li>Hauteur minimale de l’image : 600 px</li>
-                  </ul>
-                </div>
-              </Callout>
-            )}
-            <TextInput
-              count={credit.length}
-              className={cn(
-                style['modal-image-crop-credit'],
-                isPaintingImage && style['modal-image-crop-credit-loading']
+              {shouldDisplayWarningCallout && (
+                <Callout
+                  className={style['modal-image-crop-callout']}
+                  variant={CalloutVariant.WARNING}
+                >
+                  <div>
+                    La qualité de votre image n’est pas optimale.
+                    <br />
+                    Le format recommandé :
+                    <ul className={style['modal-image-crop-callout-list']}>
+                      <li>Largeur minimale de l’image : 400 px</li>
+                      <li>Hauteur minimale de l’image : 600 px</li>
+                    </ul>
+                  </div>
+                </Callout>
               )}
-              label="Crédit de l’image"
-              maxLength={255}
-              value={credit}
-              onChange={(e) => setCredit(e.target.value)}
-              name="credit"
-              type="text"
+              <TextInput
+                count={credit.length}
+                className={cn(
+                  style['modal-image-crop-credit'],
+                  isPaintingImage && style['modal-image-crop-credit-loading']
+                )}
+                label="Crédit de l’image"
+                maxLength={255}
+                value={credit}
+                onChange={(e) => setCredit(e.target.value)}
+                name="credit"
+                type="text"
+              />
+            </>
+          )}
+          {!image && (
+            <ImageDragAndDrop
+              onDropOrSelected={onImageReplacementDropOrSelected}
+              {...(mode !== UploaderModeEnum.OFFER
+                ? {
+                    minSizes: {
+                      width: 600,
+                      height: 400,
+                    },
+                  }
+                : {})}
             />
-          </>
-        )}
-        {!image && (
-          <ImageDragAndDrop
-            onDropOrSelected={onImageReplacementDropOrSelected}
-            {...(mode !== UploaderModeEnum.OFFER
-              ? {
-                  minSizes: {
-                    width: 600,
-                    height: 400,
-                  },
-                }
-              : {})}
-          />
-        )}
-      </div>
-      <DialogBuilder.Footer>
-        <div className={style['modal-image-crop-footer']}>
-          <Dialog.Close asChild>
-            <Button variant={ButtonVariant.SECONDARY}>Annuler</Button>
-          </Dialog.Close>
-          <Button
-            type="submit"
-            onClick={(e) => {
-              e.preventDefault()
-              onImageSave()
-            }}
-            disabled={!image}
-          >
-            Enregistrer
-          </Button>
+          )}
         </div>
-      </DialogBuilder.Footer>
-    </form>
+        <DialogBuilder.Footer>
+          <div className={style['modal-image-crop-footer']}>
+            <Dialog.Close asChild>
+              <Button variant={ButtonVariant.SECONDARY}>Annuler</Button>
+            </Dialog.Close>
+            <Button
+              type="submit"
+              onClick={(e) => {
+                e.preventDefault()
+                onImageSave()
+              }}
+              disabled={!image}
+            >
+              Enregistrer
+            </Button>
+          </div>
+        </DialogBuilder.Footer>
+      </form>
+    </DialogBuilder>
   )
 }

--- a/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOffersTable/components/IndividualOfferRow/components/HeadlineOfferImageDialogs.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOffersTable/components/IndividualOfferRow/components/HeadlineOfferImageDialogs.tsx
@@ -20,7 +20,6 @@ import {
 import { getStoredFilterConfig } from 'components/OffersTable/OffersTableSearch/utils'
 import strokeVisualArtIcon from 'icons/stroke-visual-art.svg'
 import { computeIndividualApiFilters } from 'pages/IndividualOffers/utils/computeIndividualApiFilters'
-import { DialogBuilder } from 'ui-kit/DialogBuilder/DialogBuilder'
 
 type HeadlineOfferImageDialogsProps = {
   isFirstDialogOpen: boolean
@@ -122,16 +121,12 @@ export const HeadlineOfferImageDialogs = ({
         title="Ajoutez une image pour mettre votre offre à la une"
         open={isFirstDialogOpen}
       />
-      <DialogBuilder
+      <ModalImageUpsertOrEdit
+        mode={UploaderModeEnum.OFFER}
+        onImageUpload={onImageUpload}
         open={isImageUploaderOpen}
         onOpenChange={() => setIsImageUploaderOpen(false)}
-        variant="drawer"
-      >
-        <ModalImageUpsertOrEdit
-          mode={UploaderModeEnum.OFFER}
-          onImageUpload={onImageUpload}
-        />
-      </DialogBuilder>
+      />
     </>
   )
 }

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
@@ -46,15 +46,7 @@ export type DialogBuilderProps = {
   className?: string
   variant?: DialogVariant
   /**
-   * Either the auto focus on the trigger element when the dialog is closed
-   * is disabled or not. This should generally be tied to the `refToFocusOnClose` prop.
-   * This can be useful when trigger element is not a button (e.g. an input, like in the ImageDragAndDropUploader).
-   * @default false
-   */
-  preferNonNullRefToFocusOnClose?: boolean
-  /**
    * Ref of the element to focus on when the dialog is closed.
-   * This needs to be used in conjunction with the `disableAutoFocusOnTrigger` prop, set to true.
    * If refToFocusOnClose.current is null, the trigger element will be focused as a fallback.
    */
   refToFocusOnClose?: React.RefObject<HTMLElement>
@@ -90,7 +82,6 @@ export function DialogBuilder({
   closeButtonClassName,
   className,
   variant = 'default',
-  preferNonNullRefToFocusOnClose = false,
   refToFocusOnClose,
 }: DialogBuilderProps) {
   const contentRef = useRef<HTMLDivElement>(null)
@@ -133,18 +124,15 @@ export function DialogBuilder({
                 e.preventDefault()
               }
             }}
-            {...(preferNonNullRefToFocusOnClose
-              ? {
-                  onCloseAutoFocus: (ev: any) => {
-                    if (!refToFocusOnClose?.current) {
-                      return
-                    } else {
-                      ev.preventDefault()
-                      refToFocusOnClose.current.focus()
-                    }
-                  },
-                }
-              : {})}
+            onCloseAutoFocus={(ev: any) => {
+              ev.preventDefault()
+
+              if (!refToFocusOnClose) {
+                return
+              }
+
+              refToFocusOnClose.current?.focus()
+            }}
           >
             <DialogBuilderCloseButton
               closeButtonClassName={closeButtonClassName}

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
@@ -45,6 +45,19 @@ export type DialogBuilderProps = {
    */
   className?: string
   variant?: DialogVariant
+  /**
+   * Either the auto focus on the trigger element when the dialog is closed
+   * is disabled or not. This should generally be tied to the `refToFocusOnClose` prop.
+   * This can be useful when trigger element is not a button (e.g. an input, like in the ImageDragAndDropUploader).
+   * @default false
+   */
+  preferNonNullRefToFocusOnClose?: boolean
+  /**
+   * Ref of the element to focus on when the dialog is closed.
+   * This needs to be used in conjunction with the `disableAutoFocusOnTrigger` prop, set to true.
+   * If refToFocusOnClose.current is null, the trigger element will be focused as a fallback.
+   */
+  refToFocusOnClose?: React.RefObject<HTMLElement>
 }
 
 /**
@@ -77,6 +90,8 @@ export function DialogBuilder({
   closeButtonClassName,
   className,
   variant = 'default',
+  preferNonNullRefToFocusOnClose = false,
+  refToFocusOnClose,
 }: DialogBuilderProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   return (
@@ -118,6 +133,18 @@ export function DialogBuilder({
                 e.preventDefault()
               }
             }}
+            {...(preferNonNullRefToFocusOnClose
+              ? {
+                  onCloseAutoFocus: (ev: any) => {
+                    if (!refToFocusOnClose?.current) {
+                      return
+                    } else {
+                      ev.preventDefault()
+                      refToFocusOnClose.current.focus()
+                    }
+                  },
+                }
+              : {})}
           >
             <DialogBuilderCloseButton
               closeButtonClassName={closeButtonClassName}


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35694

## Objectifs
- Gérer les reprises de focus après annulation / enregistrement / suppression d'image.
- Utiliser le DialogBuilder afin d'exploiter sa propriété `title`.

## Vérifications

- [ ] ~J'ai écrit les tests nécessaires~
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [ ] ~J'ai ajouté des screenshots pour d'éventuels changements graphiques~
- [X] J'ai fait la revue fonctionnelle de mon ticket
