### PR TITLE
(PC-36153)[BO] fix: can't set pricing point for venue without SIRET

### DIFF
--- a/api/src/pcapi/routes/backoffice/venues/forms.py
+++ b/api/src/pcapi/routes/backoffice/venues/forms.py
@@ -294,6 +294,8 @@ class RemovePricingPointForm(utils.PCForm):
 
 
 class PricingPointForm(utils.PCForm):
+    allow_self = True
+
     new_pricing_point = fields.PCSelectWithPlaceholderValueField(
         "Nouveau point de valorisation", choices=[], coerce=int
     )
@@ -303,9 +305,10 @@ class PricingPointForm(utils.PCForm):
         self.new_pricing_point.choices = [
             (offerer_venue.id, f"{offerer_venue.name} ({offerer_venue.siret})")
             for offerer_venue in venue.managingOfferer.managedVenues
-            if offerer_venue.siret and offerer_venue.id != venue.id
+            if offerer_venue.siret and (self.allow_self or offerer_venue.id != venue.id)
         ]
 
 
 class RemoveSiretForm(RemovePricingPointForm, PricingPointForm):
+    allow_self = False
     comment = fields.PCCommentField("Commentaire qui apparaîtra sur le partenaire culturel")

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -2969,6 +2969,21 @@ class SetPricingPointTest(PostEndpointHelper):
             == "Ce partenaire culturel a été lié à un point de valorisation"
         )
 
+    def test_set_pricing_point_as_self(self, authenticated_client):
+        venue_with_siret = offerers_factories.VenueFactory(pricing_point=None)
+        offerers_factories.VirtualVenueFactory(
+            managingOfferer=venue_with_siret.managingOfferer, pricing_point=venue_with_siret
+        )
+        response = self.post_to_endpoint(
+            authenticated_client,
+            venue_id=venue_with_siret.id,
+            form={"new_pricing_point": venue_with_siret.id},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200  # after redirect
+        assert venue_with_siret.current_pricing_point is venue_with_siret
+        assert html_parser.extract_alert(response.data) == "Ce partenaire culturel a été lié à un point de valorisation"
+
     def test_venue_not_found(self, authenticated_client):
         venue_with_siret = offerers_factories.VenueFactory()
         response = self.post_to_endpoint(


### PR DESCRIPTION
A venue without SIRET may have no pricing point after several changes (move SIRET, remove some useless venues, etc.) by support pro.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-36153

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
