### PR TITLE
(BSR)[API] chore: delete sirenless offerers in staging

### DIFF
--- a/api/src/pcapi/scripts/delete_sirenless_offerers/main.py
+++ b/api/src/pcapi/scripts/delete_sirenless_offerers/main.py
@@ -1,0 +1,41 @@
+"""
+Job console documentation here: https://www.notion.so/passcultureapp/Documentation-Job-Console-769beeacd5a146de9c97b6f8ee544276
+Assumed path to the script (copy-paste in github actions):
+
+https://github.com/pass-culture/pass-culture-main/blob/BSR-delete-sirenless-offerers-in-staging/api/src/pcapi/scripts/delete_sirenless_offerers/main.py
+
+"""
+
+import argparse
+import logging
+
+from pcapi.app import app
+from pcapi.core.offerers.api import delete_offerer
+from pcapi.core.offerers.models import Offerer
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    offerers = db.session.query(Offerer).filter(Offerer.siren.is_(None)).all()
+    for offerer in offerers:
+        delete_offerer(offerer.id)
+
+
+if __name__ == "__main__":
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--not-dry", action="store_true")
+    args = parser.parse_args()
+
+    main()
+
+    if args.not_dry:
+        logger.info("Finished")
+        db.session.commit()
+    else:
+        logger.info("Finished dry run, rollback")
+        db.session.rollback()


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : seulement en staging

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
