### PR TITLE
(PC-36088)[API] fix: don't commit individual offers one by one

### DIFF
--- a/api/src/pcapi/scripts/move_offer/move_batch_offer.py
+++ b/api/src/pcapi/scripts/move_offer/move_batch_offer.py
@@ -1,4 +1,5 @@
 import csv
+from functools import partial
 import logging
 import os
 import typing
@@ -13,6 +14,9 @@ from pcapi.core.offerers import repository as offerers_repository
 from pcapi.core.offers import api as offer_api
 from pcapi.core.offers import models as offer_models
 from pcapi.models import db
+from pcapi.repository.session_management import atomic
+from pcapi.repository.session_management import mark_transaction_as_invalid
+from pcapi.repository.session_management import on_commit
 from pcapi.utils.blueprint import Blueprint
 
 
@@ -154,6 +158,7 @@ def _move_price_category_label(origin_venue: offerers_models.Venue, destination_
     ).update({"venueId": destination_venue.id}, synchronize_session=False)
 
 
+@atomic()
 def _move_all_venue_offers(dry_run: bool, origin: int | None, destination: int | None) -> None:
     invalid_venues = []
     for row in _get_venue_rows(origin, destination):
@@ -182,11 +187,16 @@ def _move_all_venue_offers(dry_run: bool, origin: int | None, destination: int |
             _move_collective_offer_playlist(origin_venue, destination_venue)
             _move_price_category_label(origin_venue, destination_venue)
             if not dry_run:
-                db.session.commit()
-                search.reindex_venue_ids([origin_venue_id])
-                logger.info("Transfert done for venue %d to venue %d", origin_venue_id, destination_venue_id)
+                on_commit(
+                    partial(
+                        search.reindex_venue_ids,
+                        [origin_venue_id],
+                    )
+                )
+                logger.info("Transfer done for venue %d to venue %d", origin_venue_id, destination_venue_id)
             else:
                 db.session.flush()
+                mark_transaction_as_invalid()
     _extract_invalid_venues_to_csv(invalid_venues)
 
 


### PR DESCRIPTION
move_offer has a transaction block. Since the script is outside an atomic bloc, the transaction block will commit as soon as it is exited.
Adding the atomic block globally will change how the transaction block works and will not commit the changes.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-36088

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
