### PR TITLE
(BSR)[API] fix: delete old unusable offers: add missing @atomic()

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -2232,6 +2232,7 @@ def delete_offers_related_objects(offer_ids: typing.Collection[int]) -> None:
     delete_mediations(offer_ids)
 
 
+@atomic()
 def delete_offers_and_all_related_objects(offer_ids: typing.Collection[int], offer_chunk_size: int = 16) -> None:
     """Delete a set of offers and all of their related objects and
     unindex them all. Each removal is done by batch which runs inside


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35736

Ajout d'un `@atomic()` manquant : sans, rien n'est sauvegardé (le _context manager_ `atomic()` ne fonctionne pas comme prévu s'il n'y a un décorateur `@atomic` utilisé plus haut)
