### PR TITLE
(BSR)[BO] fix: lieu -> partenaire culturel

### DIFF
--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -92,12 +92,12 @@ ACTION_TYPE_TO_STRING = {
     history_models.ActionType.FINANCE_INCIDENT_GENERATE_DEBIT_NOTE: "Une note de débit va être générée",
     history_models.ActionType.FINANCE_INCIDENT_CHOOSE_DEBIT_NOTE: "Choix note de débit",
     # Actions related to a venue:
-    history_models.ActionType.VENUE_CREATED: "Lieu créé",
-    history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_DEPRECATED: "Lieu dissocié d'un compte bancaire",
-    history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED: "Lieu associé à un compte bancaire",
+    history_models.ActionType.VENUE_CREATED: "Partenaire culturel créé",
+    history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_DEPRECATED: "Partenaire culturel dissocié d'un compte bancaire",
+    history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED: "Partenaire culturel associé à un compte bancaire",
     history_models.ActionType.LINK_VENUE_PROVIDER_UPDATED: "Lien avec le partenaire technique modifié",
     history_models.ActionType.LINK_VENUE_PROVIDER_DELETED: "Suppression du lien avec le partenaire technique",
-    history_models.ActionType.SYNC_VENUE_TO_PROVIDER: "Synchronisation du lieu avec un partenaire technique",
+    history_models.ActionType.SYNC_VENUE_TO_PROVIDER: "Synchronisation du partenaire culturel avec un partenaire technique",
     # Permissions role changes:
     history_models.ActionType.ROLE_PERMISSIONS_CHANGED: "Modification des permissions du rôle",
     # RGPD scripts

--- a/api/tests/routes/backoffice/bank_account_test.py
+++ b/api/tests/routes/backoffice/bank_account_test.py
@@ -232,7 +232,7 @@ class GetBankAccountHistoryTest(GetEndpointHelper):
 
         rows = html_parser.extract_table_rows(response.data)
         assert len(rows) == 1
-        assert rows[0]["Type"] == "Lieu associé à un compte bancaire"
+        assert rows[0]["Type"] == "Partenaire culturel associé à un compte bancaire"
         assert f"Partenaire culturel : {venue.common_name}" in rows[0]["Commentaire"]
         assert url_for("backoffice_web.venue.get", venue_id=venue.id) in str(response.data)
         assert rows[0]["Date/Heure"].startswith(action.actionDate.strftime("Le %d/%m/%Y à "))
@@ -271,13 +271,13 @@ class GetBankAccountHistoryTest(GetEndpointHelper):
         rows = html_parser.extract_table_rows(response.data)
         assert len(rows) == 2
 
-        assert rows[0]["Type"] == "Lieu dissocié d'un compte bancaire"
+        assert rows[0]["Type"] == "Partenaire culturel dissocié d'un compte bancaire"
         assert f"Partenaire culturel : {venue.common_name}" in rows[0]["Commentaire"]
         assert url_for("backoffice_web.venue.get", venue_id=venue.id) in str(response.data)
         assert rows[0]["Date/Heure"].startswith(unlink_action.actionDate.strftime("Le %d/%m/%Y à "))
         assert rows[0]["Auteur"] == legit_user.full_name
 
-        assert rows[1]["Type"] == "Lieu associé à un compte bancaire"
+        assert rows[1]["Type"] == "Partenaire culturel associé à un compte bancaire"
         assert f"Partenaire culturel : {venue.common_name}" in rows[0]["Commentaire"]
         assert url_for("backoffice_web.venue.get", venue_id=venue.id) in str(response.data)
         assert rows[1]["Date/Heure"].startswith(link_action.actionDate.strftime("Le %d/%m/%Y à "))


### PR DESCRIPTION
## But de la pull request

Une _venue_ était encore nommée « lieu » dans les actions.

## Vérifications

- [x] J'ai corrigé les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
