### PR TITLE
(PC-35949)[API] feat: Move FinanceIncident to the new venue during regularisation

### DIFF
--- a/api/src/pcapi/scripts/move_offer/move_batch_offer.py
+++ b/api/src/pcapi/scripts/move_offer/move_batch_offer.py
@@ -8,6 +8,7 @@ import click
 from pcapi.core import search
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational.api import offer as educational_api
+from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers import repository as offerers_repository
 from pcapi.core.offers import api as offer_api
@@ -155,6 +156,12 @@ def _move_price_category_label(origin_venue: offerers_models.Venue, destination_
     ).update({"venueId": destination_venue.id}, synchronize_session=False)
 
 
+def _move_finance_incident(origin_venue: offerers_models.Venue, destination_venue: offerers_models.Venue) -> None:
+    db.session.query(finance_models.FinanceIncident).filter(
+        finance_models.FinanceIncident.venueId == origin_venue.id
+    ).update({"venueId": destination_venue.id}, synchronize_session=False)
+
+
 def _move_all_venue_offers(dry_run: bool, origin: int | None, destination: int | None) -> None:
     invalid_venues = []
     for row in _get_venue_rows(origin, destination):
@@ -183,6 +190,7 @@ def _move_all_venue_offers(dry_run: bool, origin: int | None, destination: int |
             _move_collective_offer_template(origin_venue, destination_venue)
             _move_collective_offer_playlist(origin_venue, destination_venue)
             _move_price_category_label(origin_venue, destination_venue)
+            _move_finance_incident(origin_venue, destination_venue)
             if not dry_run:
                 db.session.commit()
                 search.reindex_venue_ids([origin_venue_id])


### PR DESCRIPTION
FI are linked to Booking through BookingFinanceIncident and must move to keep data consistency

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35949

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
