### PR TITLE
(PC-35537)[API] feat: Add address to me endpoint

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -197,6 +197,7 @@ class UserProfileGetterDict(GetterDict):
 class UserProfileResponse(ConfiguredBaseModel):
     achievements: list[achievements_serialization.AchievementResponse]
     activity_id: profile_options.ActivityIdEnum | None
+    address: str | None = pydantic_v1.Field(None, alias="street")
     birth_date: datetime.date | None
     booked_offers: dict[str, int]
     city: str | None

--- a/api/tests/routes/native/openapi_test.py
+++ b/api/tests/routes/native/openapi_test.py
@@ -2415,6 +2415,7 @@ def test_public_api(client):
                         "roles": {"items": {"$ref": "#/components/schemas/UserRole"}, "type": "array"},
                         "showEligibleCard": {"title": "Showeligiblecard", "type": "boolean"},
                         "status": {"$ref": "#/components/schemas/YoungStatusResponse"},
+                        "street": {"nullable": True, "title": "Street", "type": "string"},
                         "subscriptionMessage": {
                             "anyOf": [{"$ref": "#/components/schemas/SubscriptionMessage"}],
                             "nullable": True,

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -91,8 +91,9 @@ class AccountTest:
             "firstName": "john",
             "lastName": "doe",
             "phoneNumber": "+33102030405",
-            "city": "Annecy",
+            "address": "123 rue de la paix",
             "postalCode": "74000",
+            "city": "Annecy",
             "needsToFillCulturalSurvey": True,
         }
         user = users_factories.BeneficiaryGrant18Factory(
@@ -122,6 +123,10 @@ class AccountTest:
 
         EXPECTED_DATA = {
             "id": user.id,
+            "email": self.identifier,
+            "firstName": "john",
+            "lastName": "doe",
+            "phoneNumber": "+33102030405",
             "bookedOffers": {str(booking.stock.offer.id): booking.id},
             "domainsCredit": {
                 "all": {"initial": 30000, "remaining": 17655},
@@ -139,6 +144,7 @@ class AccountTest:
             "hasPassword": True,
             "isBeneficiary": True,
             "isEligibleForBeneficiaryUpgrade": False,
+            "needsToFillCulturalSurvey": True,
             "roles": ["BENEFICIARY"],
             "recreditAmountToShow": None,
             "requiresIdCheck": True,
@@ -152,8 +158,10 @@ class AccountTest:
             "activityId": users_models.ActivityEnum.STUDENT.name,
             "currency": "EUR",
             "achievements": [],
+            "street": "123 rue de la paix",
+            "postalCode": "74000",
+            "city": "Annecy",
         }
-        EXPECTED_DATA.update(USER_DATA)
 
         assert response.json == EXPECTED_DATA
 


### PR DESCRIPTION
## Description

Cette PR ajoute le champ **address** de l’utilisateur à l’endpoint **me** (`GET /native/v1/me`). Auparavant, la réponse ne comprenait pas l’adresse postale de l’utilisateur ; cette évolution permet aux clients de recevoir le champ `address` en complément des données de localisation existantes.

## Ticket associé

* **JIRA** : [[PC-35537](https://passculture.atlassian.net/browse/PC-35537)](https://passculture.atlassian.net/browse/PC-35537)

## Modifications

1. **Sérialisation**

   * **Fichier** : `api/src/pcapi/routes/native/v1/serialization/account.py`
   * **Mise à jour** :

     * Ajout de l’attribut `address: str | None` au modèle `UserProfileResponse` pour sérialiser le champ `address` dans la réponse de l’API.

2. **Tests**

   * **Fichier** : `api/tests/routes/native/v1/account_test.py`
   * **Mise à jour** :

     * Renforcement du test `test_get_user_profile` pour vérifier la présence et la valeur correcte des champs `address` et `postalCode` dans la réponse JSON.
     * Adaptation des données attendues pour inclure :

       ```json
       "address": "123 rue de la paix",
       "postalCode": "74000",
       "city": "Annecy"
       ```

## Remarques

* Le champ `address` est optionnel (`null` si non renseigné).
* Changement non bloquant, car le champ est nullable et vaut `None` par défaut lorsqu’il n’est pas fourni.

[PC-35537]: https://passculture.atlassian.net/browse/PC-35537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ