### PR TITLE
(BSR)[API] refactor: rename fields of collective public api schema to…

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -626,7 +626,7 @@ def create_collective_offer_public(
         bookingLimitDatetime=body.booking_limit_datetime,
         price=body.total_price,
         numberOfTickets=body.number_of_tickets,
-        priceDetail=body.educational_price_detail,
+        priceDetail=body.price_detail,
     )
 
     offers_api.update_offer_fraud_information(offer=collective_offer, user=None)

--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -40,7 +40,7 @@ PATCH_NON_NULLABLE_FIELDS = (
     "interventionArea",
     "startDatetime",
     "endDatetime",
-    "totalPrice",
+    "price",
     "numberOfTickets",
     "audioDisabilityCompliant",
     "mentalDisabilityCompliant",

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -4,7 +4,6 @@ import decimal
 from typing import Any
 from typing import Sequence
 
-from pydantic.v1 import Field
 from pydantic.v1 import root_validator
 from pydantic.v1 import validator
 
@@ -268,9 +267,9 @@ class GetPublicCollectiveOfferResponseModel(BaseModel):
     startDatetime: str = fields.COLLECTIVE_OFFER_START_DATETIME
     endDatetime: str = fields.COLLECTIVE_OFFER_END_DATETIME
     bookingLimitDatetime: str = fields.COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME
-    totalPrice: decimal.Decimal = fields.COLLECTIVE_OFFER_TOTAL_PRICE
+    price: decimal.Decimal = fields.COLLECTIVE_OFFER_TOTAL_PRICE
     numberOfTickets: int = fields.COLLECTIVE_OFFER_NB_OF_TICKETS
-    educationalPriceDetail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL
+    priceDetail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL
     educationalInstitution: str | None = fields.EDUCATIONAL_INSTITUTION_UAI
     educationalInstitutionId: int | None = fields.EDUCATIONAL_INSTITUTION_ID
     # offerVenue will be replaced with location, for now we send both
@@ -285,6 +284,7 @@ class GetPublicCollectiveOfferResponseModel(BaseModel):
     class Config:
         extra = "forbid"
         orm_mode = True
+        allow_population_by_field_name = True
 
     @classmethod
     def from_orm(cls, offer: CollectiveOffer) -> "GetPublicCollectiveOfferResponseModel":
@@ -315,9 +315,9 @@ class GetPublicCollectiveOfferResponseModel(BaseModel):
             startDatetime=offer.collectiveStock.startDatetime.replace(microsecond=0).isoformat(),
             endDatetime=offer.collectiveStock.endDatetime.replace(microsecond=0).isoformat(),
             bookingLimitDatetime=offer.collectiveStock.bookingLimitDatetime.replace(microsecond=0).isoformat(),
-            totalPrice=offer.collectiveStock.price,
+            price=offer.collectiveStock.price,
             numberOfTickets=offer.collectiveStock.numberOfTickets,
-            educationalPriceDetail=offer.collectiveStock.priceDetail,
+            priceDetail=offer.collectiveStock.priceDetail,
             educationalInstitution=offer.institution.institutionId if offer.institution else None,
             educationalInstitutionId=offer.institution.id if offer.institution else None,
             offerVenue={  # type: ignore[arg-type]
@@ -370,7 +370,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
     booking_limit_datetime: datetime = fields.COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME
     total_price: decimal.Decimal = fields.COLLECTIVE_OFFER_TOTAL_PRICE
     number_of_tickets: int = fields.COLLECTIVE_OFFER_NB_OF_TICKETS
-    educational_price_detail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL
+    price_detail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL
     # link to educational institution
     educational_institution_id: int | None = fields.EDUCATIONAL_INSTITUTION_ID
     educational_institution: str | None = fields.EDUCATIONAL_INSTITUTION_UAI
@@ -380,7 +380,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
     _validate_start_datetime = start_datetime_validator("start_datetime")
     _validate_end_datetime = end_datetime_validator("end_datetime")
     _validate_booking_limit_datetime = booking_limit_datetime_validator("booking_limit_datetime")
-    _validate_educational_price_detail = price_detail_validator("educational_price_detail")
+    _validate_price_detail = price_detail_validator("price_detail")
     _validate_contact_phone = phone_number_validator("contact_phone")
     _validate_booking_emails = emails_validator("booking_emails")
     _validate_contact_email = email_validator("contact_email")
@@ -481,12 +481,7 @@ class PatchCollectiveOfferBodyModel(BaseModel):
     startDatetime: datetime | None = fields.COLLECTIVE_OFFER_START_DATETIME
     endDatetime: datetime | None = fields.COLLECTIVE_OFFER_END_DATETIME
     bookingLimitDatetime: datetime | None = fields.COLLECTIVE_OFFER_BOOKING_LIMIT_DATETIME
-    price: float | None = Field(
-        None,
-        description="Collective offer price (in €)",  # TODO: Harmonize with Creation
-        example=100.00,
-        alias="totalPrice",
-    )
+    price: float | None = fields.COLLECTIVE_OFFER_TOTAL_PRICE
     priceDetail: str | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL
     numberOfTickets: int | None = fields.COLLECTIVE_OFFER_NB_OF_TICKETS
     # educational_institution
@@ -495,7 +490,7 @@ class PatchCollectiveOfferBodyModel(BaseModel):
 
     _validate_number_of_tickets = number_of_tickets_validator("numberOfTickets")
     _validate_total_price = price_validator("price")
-    _validate_educational_price_detail = price_detail_validator("priceDetail")
+    _validate_price_detail = price_detail_validator("priceDetail")
     _validate_start_datetime = start_datetime_validator("startDatetime")
     _validate_end_datetime = end_datetime_validator("endDatetime")
     _validate_contact_phone = phone_number_validator("contactPhone")

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -280,7 +280,9 @@ class _FIELDS:
         description="Booking limit datetime. It must be anterior to the `start_datetime`. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime).",
         example=_example_datetime_with_tz,
     )
-    COLLECTIVE_OFFER_TOTAL_PRICE = Field(example=100.00, description="Collective offer price (in €)")
+    COLLECTIVE_OFFER_TOTAL_PRICE = Field(
+        example=100.00, description="Collective offer price (in €)", alias="totalPrice"
+    )
     COLLECTIVE_OFFER_NB_OF_TICKETS = Field(example=10, description="Number of tickets for your collective offer")
     COLLECTIVE_OFFER_EDUCATIONAL_PRICE_DETAIL = Field(
         description="The explanation of the offer price",

--- a/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
@@ -41,7 +41,11 @@ NON_REQUIRED_NON_NULLABLE_FIELDS_CUSTOM_ERROR = {
     "domains": "domains must have at least one value",
 }
 # the other fields have the same error message when null
-NON_REQUIRED_NON_NULLABLE_FIELDS = set(PATCH_NON_NULLABLE_FIELDS) - NON_REQUIRED_NON_NULLABLE_FIELDS_CUSTOM_ERROR.keys()
+NON_REQUIRED_NON_NULLABLE_FIELDS = (
+    set(PATCH_NON_NULLABLE_FIELDS)
+    - NON_REQUIRED_NON_NULLABLE_FIELDS_CUSTOM_ERROR.keys()
+    - {"price"}  # this one is aliased as totalPrice
+)
 
 # there is not DRAFT offer in public API
 # the HIDDEN status is for templates only once the WIP_ENABLE_COLLECTIVE_NEW_STATUS_PUBLIC_API FF is ON


### PR DESCRIPTION
… use alias

## But de la pull request

Ticket Jira (ou description si BSR) : on renomme les champs des schema `educationalPriceDetail` -> `priceDetail` et 
`totalPrice` -> `price` pour coller au nom de la colonne, en gardant les alias pour ne pas changer l'API publique

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
