### PR TITLE
(BSR)[API] fix: delete old offers commands: ignore&continue on error

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1290,7 +1290,7 @@ def offer_has_timestamped_stocks(offer_id: int) -> bool:
 
 
 def get_unbookable_unbooked_old_offer_ids(
-    min_id: int = 0, max_id: int | None = None, batch_size: int = 10_000
+    min_id: int = 0, max_id: int | None = None, batch_size: int = 5_000
 ) -> typing.Generator[int, None, None]:
     """Find unbookable unbooked old offer ids.
 


### PR DESCRIPTION
## But de la pull request

Amélioration concernant le script de suppression des vieilles offres non réservables et non réservées : ne pas s'arrêter en cas d'erreur de suppression.
