### PR TITLE
(BSR)[API] feat: update atomic to have the same behavior with the con…

### DIFF
--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -64,7 +64,7 @@ def setup_atomic() -> None:
     Must be before `setup_sentry_before_request` as it use the user and therefore call the db
     """
     if app.config.get("USE_GLOBAL_ATOMIC", False):
-        session_management._mark_session_management()
+        session_management._mark_session_as_managed()
         db.session.autoflush = False
 
 
@@ -269,7 +269,7 @@ def teardown_atomic(exc: BaseException | None = None) -> None:
         try:
             if exc:
                 session_management.mark_transaction_as_invalid()
-            session_management._manage_session()
+            session_management._finalize_managed_session()
             db.session.autoflush = True
         except Exception as exception:
             # this may break the session's internal states but we will detroy it anyway


### PR DESCRIPTION
…text manager and the decorator

## But de la pull request

Modification de la class atomic pour que le context manager soit exactement équivalent au contexte manager quel que soit la situation. 

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
