### PR TITLE
(PC-36191)[API] fix: do not crash on empty string in extra data

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -294,7 +294,7 @@ def serialize_extra_data(offer: offers_models.Offer) -> CategoryRelatedFields:
         serialized_data["musicType"] = TiteliveMusicTypeEnum(
             constants.TITELIVE_MUSIC_GENRES_BY_GTL_ID[gtl_id[:2] + "0" * 6]
         )
-    elif music_sub_type is not None:
+    elif music_sub_type:
         serialized_data["musicType"] = MusicTypeEnum(music.MUSIC_SUB_TYPES_BY_CODE[int(music_sub_type)].slug)
 
     # FIXME (mageoffray, 2023-12-14): some historical offers have no showSubType and only showType.

--- a/api/tests/routes/public/individual_offers/v1/get_events_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_events_test.py
@@ -169,3 +169,19 @@ class GetEventsTest(PublicAPIVenueEndpointHelper):
             assert response.status_code == 200
             assert len(response.json["events"]) == 1
             assert response.json["events"][0]["id"] == offer1.id
+
+    def should_not_fail_when_empty_string_in_extra_data(self, client):
+        plain_api_key, venue_provider = self.setup_active_venue_provider()
+        # Offer extraData inspired from real data, causing a bug
+        offers_factories.EventOfferFactory(
+            venue=venue_provider.venue,
+            extraData={
+                "musicSubType": "",
+                "musicType": "",
+                "performer": "Some dude",
+                "showSubType": "1102",
+                "showType": "1100",
+            },
+        )
+        response = client.with_explicit_token(plain_api_key).get(self.endpoint_url)
+        assert response.status_code == 200


### PR DESCRIPTION
## But de la pull request
Fix de [ce bug](https://pass-culture.sentry.io/issues/42366503/?alert_rule_id=155878&alert_type=issue&environment=production&notification_uuid=c76b5f7c-2346-4991-b36c-5044f3b6c9a3&project=4508776981069904&referrer=slack)

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-36191
