### PR TITLE
(PC-36032)[API] fix: fill finance_incident that can not be null

### DIFF
--- a/api/src/pcapi/alembic/versions/20250317T120837_84f53732b4c7_add_not_null_constraint_on_finance-incident_origin_step_2_of_4.py
+++ b/api/src/pcapi/alembic/versions/20250317T120837_84f53732b4c7_add_not_null_constraint_on_finance-incident_origin_step_2_of_4.py
@@ -8,7 +8,7 @@ from pcapi import settings
 # pre/post deployment: post
 # revision identifiers, used by Alembic.
 revision = "84f53732b4c7"
-down_revision = "3f7aeffafcab"
+down_revision = "e9604328f24f"
 branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 

--- a/api/src/pcapi/alembic/versions/20250520T134953_e9604328f24f_fill_null_values_in_finance_incident_origin.py
+++ b/api/src/pcapi/alembic/versions/20250520T134953_e9604328f24f_fill_null_values_in_finance_incident_origin.py
@@ -1,0 +1,32 @@
+"""
+Fill null values in finance_incident.origin
+
+The 'Add NOT NULL constraint on "finance_incident.origin"' was making the origin column non-nullable, after having filled the empty values with a separate script.
+
+This migration will break in case the script has not been run first, thus this step added here
+"""
+
+from alembic import op
+
+from pcapi.core.finance.models import FinanceIncidentRequestOrigin
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "e9604328f24f"
+down_revision = "3f7aeffafcab"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    query = f"""
+        UPDATE finance_incident
+        SET origin = '{FinanceIncidentRequestOrigin.SUPPORT_PRO.value}'
+        WHERE finance_incident.origin IS NULL;
+        """
+    op.execute(query)
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Fixing the fact that this migrations was making the origin column non-nullable, after having filled the empty values with a script. 

This migration will break in case the script has not been run first, thus the fix here


Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-36032
