### PR TITLE
(BSR)[API] fix: remove flawed fix for the session issue

### DIFF
--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -259,8 +259,6 @@ def remove_db_session(exc: BaseException | None = None) -> None:
             },
             exc_info=True,
         )
-        del db.session
-        logger.error("Deleted Session object")
 
 
 @app.teardown_request
@@ -272,8 +270,6 @@ def teardown_atomic(exc: BaseException | None = None) -> None:
             session_management._manage_session()
             db.session.autoflush = True
         except Exception as exception:
-            # this may break the session's internal states but we will detroy it anyway
-            db.session.connection().execute("ROLLBACK")
             logger.error(
                 "An error happened while managing the transaction",
                 extra={


### PR DESCRIPTION
## But de la pull request

retiait de deux tentative de corrections.

la premiere (dans `remove_db_session`) mennait a un crash si elle était appelé (mais en pratique ne peut pas être appelée)
la seconde a fait la preuve de son innutilitée.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
