### PR TITLE
(PC-36168)[API] chore: Split move_collective_offer_venue into 2 distinct methods

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1846,8 +1846,8 @@ def move_offer(
     offer: models.Offer,
     destination_venue: offerers_models.Venue,
 ) -> None:
-    if not feature.FeatureToggle.MOVE_OFFER_TEST.is_active():
-        raise NotImplementedError("This feature is not yet available")
+    if not feature.FeatureToggle.VENUE_REGULARIZATION.is_active():
+        raise NotImplementedError("Activate VENUE_REGULARIZATION to use this feature")
 
     offer_id = offer.id
     original_venue = offer.venue

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -113,7 +113,7 @@ class FeatureToggle(enum.Enum):
     LOG_EMS_CINEMAS_AVAILABLE_FOR_SYNC = "Stocker dans Google Drive les cinémas EMS activables"
     ENABLE_PRO_FEEDBACK = "Activer l'envoi des commentaires du portail pro vers Harvestr"
     ENABLE_MOVIE_FESTIVAL_RATE = "Activer les tarifs spéciaux pour un festival cinéma"
-    MOVE_OFFER_TEST = "Test le déplacement de n'importe quelle offre vers une autre venue"
+    VENUE_REGULARIZATION = "Déplacement de n'importe quelle offre vers une autre venue"
     # For features under construction, a temporary feature flag must be named with the `WIP_` prefix
     WIP_2025_SIGN_UP = "Activer le nouveau parcours d’inscription au portail pro"
     WIP_ASYNCHRONOUS_CELERY_MAILS = (
@@ -217,7 +217,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.ENABLE_ZENDESK_SELL_CREATION,
     FeatureToggle.ID_CHECK_ADDRESS_AUTOCOMPLETION,
     FeatureToggle.LOG_EMS_CINEMAS_AVAILABLE_FOR_SYNC,
-    FeatureToggle.MOVE_OFFER_TEST,
+    FeatureToggle.VENUE_REGULARIZATION,
     FeatureToggle.SEND_ALL_EMAILS_TO_EHP,
     FeatureToggle.SYNCHRONIZE_TITELIVE_API_MUSIC_PRODUCTS,
     FeatureToggle.WIP_2025_SIGN_UP,

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -866,8 +866,8 @@ def get_collective_offer_price_form(collective_offer_id: int) -> utils.Backoffic
 @atomic()
 @utils.permission_required(perm_models.Permissions.ADVANCED_PRO_SUPPORT)
 def get_move_collective_offer_form(collective_offer_id: int) -> utils.BackofficeResponse:
-    if not feature.FeatureToggle.MOVE_OFFER_TEST.is_active():
-        raise feature.DisabledFeatureError("MOVE_OFFER_TEST is inactive")
+    if not feature.FeatureToggle.VENUE_REGULARIZATION.is_active():
+        raise feature.DisabledFeatureError("VENUE_REGULARIZATION is inactive")
 
     collective_offer = (
         db.session.query(educational_models.CollectiveOffer).filter_by(id=collective_offer_id).one_or_none()
@@ -927,5 +927,5 @@ def move_collective_offer(collective_offer_id: int) -> utils.BackofficeResponse:
         .options(sa_orm.joinedload(offerers_models.Venue.offererAddress))
     ).one()
 
-    collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+    collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
     return redirect(request.referrer or url_for("backoffice_web.collective_offer.list_collective_offers"), 303)

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -1188,7 +1188,7 @@ def get_offer_details(offer_id: int) -> utils.BackofficeResponse:
             pass
 
     move_offer_form = None
-    if FeatureToggle.MOVE_OFFER_TEST.is_active():
+    if FeatureToggle.VENUE_REGULARIZATION.is_active():
         try:
             venue_choices = offers_api.check_can_move_offer(offer)
             move_offer_form = forms.EditOfferVenueForm()
@@ -1551,7 +1551,7 @@ def edit_offer_venue(offer_id: int) -> utils.BackofficeResponse:
 @list_offers_blueprint.route("/<int:offer_id>/move-offer", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.ADVANCED_PRO_SUPPORT)
 def move_offer(offer_id: int) -> utils.BackofficeResponse:
-    if not FeatureToggle.MOVE_OFFER_TEST.is_active():
+    if not FeatureToggle.VENUE_REGULARIZATION.is_active():
         raise NotImplementedError("This feature is not active")
     offer_url = url_for("backoffice_web.offer.get_offer_details", offer_id=offer_id)
 

--- a/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/collective_offer/details.html
@@ -13,7 +13,7 @@
   {% if has_permission("PRO_FRAUD_ACTIONS") %}
     {{ action_bar_button("hand-thumbs-up", "Valider", modal_id="#validate-collective-offer-modal-" + collective_offer.id|string) }}
     {{ action_bar_button("hand-thumbs-down", "Rejeter", modal_id="#reject-collective-offer-modal-" + collective_offer.id|string) }}
-    {% if is_feature_active("MOVE_OFFER_TEST") %}
+    {% if is_feature_active("VENUE_REGULARIZATION") %}
       {{ action_bar_button("arrow-left-right", "Déplacer l'offre", modal_id="#move-collective-offer-modal-" + collective_offer.id|string) }}
     {% endif %}
   {% endif %}
@@ -135,7 +135,7 @@
   {% if has_permission("PRO_FRAUD_ACTIONS") %}
     {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_validate_collective_offer_form', collective_offer_id=collective_offer.id) , "validate-collective-offer-modal-" + collective_offer.id|string) }}
     {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_reject_collective_offer_form', collective_offer_id=collective_offer.id) , "reject-collective-offer-modal-" + collective_offer.id|string) }}
-    {% if is_feature_active("MOVE_OFFER_TEST") %}
+    {% if is_feature_active("VENUE_REGULARIZATION") %}
       {{ build_lazy_modal(url_for('backoffice_web.collective_offer.get_move_collective_offer_form', collective_offer_id=collective_offer.id) , "move-collective-offer-modal-" + collective_offer.id|string) }}
     {% endif %}
   {% endif %}

--- a/api/src/pcapi/scripts/move_offer/move_batch_offer.py
+++ b/api/src/pcapi/scripts/move_offer/move_batch_offer.py
@@ -124,7 +124,7 @@ def _move_individual_offers(origin_venue: offerers_models.Venue, destination_ven
 def _move_collective_offers(origin_venue: offerers_models.Venue, destination_venue: offerers_models.Venue) -> None:
     collective_offer_ids = []
     for collective_offer in origin_venue.collectiveOffers:
-        educational_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        educational_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
         collective_offer_ids.append(collective_offer.id)
     logger.info(
         "Collective offers' venue has changed",

--- a/api/tests/core/educational/api/test_move_collective_offer.py
+++ b/api/tests/core/educational/api/test_move_collective_offer.py
@@ -61,6 +61,7 @@ def create_offer_by_booking_state(venue, state):
     return collective_offer
 
 
+@pytest.mark.features(VENUE_REGULARIZATION=True)
 class MoveCollectiveOfferSuccessTest:
     def test_move_collective_offer_with_its_own_OA(self):
         """
@@ -72,7 +73,7 @@ class MoveCollectiveOfferSuccessTest:
         assert collective_offer.offererAddress != source_venue.offererAddress
         offer_OA_id = collective_offer.offererAddressId
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.offererAddressId == offer_OA_id
@@ -86,7 +87,7 @@ class MoveCollectiveOfferSuccessTest:
         source_venue = collective_offer.venue
         assert collective_offer.offererAddress == source_venue.offererAddress
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         # Same address, different OA, label is venue's common name
@@ -109,7 +110,7 @@ class MoveCollectiveOfferSuccessTest:
         assert collective_offer.offererAddress == source_venue.offererAddress
         assert destination_OA != collective_offer.offererAddress
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.offererAddress == destination_OA
@@ -123,7 +124,7 @@ class MoveCollectiveOfferSuccessTest:
         assert collective_offer.venue.current_pricing_point_link is None
         assert destination_venue.current_pricing_point_link is None
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.venue == destination_venue
@@ -143,7 +144,7 @@ class MoveCollectiveOfferSuccessTest:
         )
         collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.venue == destination_venue
@@ -155,7 +156,7 @@ class MoveCollectiveOfferSuccessTest:
         venue, destination_venue = venues_with_same_pricing_point
         collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.venue == destination_venue
@@ -167,7 +168,7 @@ class MoveCollectiveOfferSuccessTest:
         collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
         educational_factories.CollectiveStockFactory(collectiveOffer=collective_offer, startDatetime=yesterday)
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.venue == destination_venue
@@ -179,7 +180,7 @@ class MoveCollectiveOfferSuccessTest:
             collectiveStock__collectiveOffer=collective_offer, status=CollectiveBookingStatus.CONFIRMED
         )
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         db.session.refresh(collective_booking)
@@ -204,7 +205,7 @@ class MoveCollectiveOfferSuccessTest:
         )
         assert finance_event.venue == venue
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         db.session.refresh(collective_booking)
@@ -233,7 +234,7 @@ class MoveCollectiveOfferSuccessTest:
             event=finance_event,
         )
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         db.session.refresh(collective_booking)
@@ -250,7 +251,7 @@ class MoveCollectiveOfferSuccessTest:
             collectiveStock__collectiveOffer=collective_offer
         )
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         assert collective_offer.venue == destination_venue
         assert collective_booking.venue == destination_venue
@@ -274,7 +275,7 @@ class MoveCollectiveOfferSuccessTest:
             collectiveStock__collectiveOffer=collective_offer
         )
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         assert collective_offer.venue == destination_venue
         assert collective_booking.venue == destination_venue
@@ -301,7 +302,7 @@ class MoveCollectiveOfferSuccessTest:
             collectiveStock__collectiveOffer=collective_offer
         )
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         assert collective_offer.venue == destination_venue
         assert collective_booking.venue == destination_venue
@@ -315,7 +316,7 @@ class MoveCollectiveOfferSuccessTest:
         destination_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
         collective_offer = educational_factories.create_collective_offer_by_status(state, venue=venue)
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.venue == destination_venue
@@ -335,7 +336,7 @@ class MoveCollectiveOfferSuccessTest:
         destination_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
         collective_offer = create_offer_by_booking_state(venue, state)
 
-        collective_offer_api.move_collective_offer_venue(collective_offer, destination_venue, with_restrictions=False)
+        collective_offer_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.venue == destination_venue
@@ -343,6 +344,7 @@ class MoveCollectiveOfferSuccessTest:
         assert db.session.query(educational_models.CollectiveBooking).all()[0].venue == destination_venue
 
 
+@pytest.mark.features(VENUE_REGULARIZATION=True)
 class MoveCollectiveOfferFailTest:
     def test_move_collective_offer_with_different_pricing_point(self):
         venue = offerers_factories.VenueFactory()
@@ -362,9 +364,7 @@ class MoveCollectiveOfferFailTest:
         )
         collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
         with pytest.raises(api.exceptions.NoDestinationVenue):
-            collective_offer_api.move_collective_offer_venue(
-                collective_offer, invalid_destination_venue, with_restrictions=False
-            )
+            collective_offer_api.move_collective_offer_for_regularization(collective_offer, invalid_destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.venue != invalid_destination_venue
@@ -381,9 +381,7 @@ class MoveCollectiveOfferFailTest:
         )
         collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
         with pytest.raises(api.exceptions.NoDestinationVenue):
-            collective_offer_api.move_collective_offer_venue(
-                collective_offer, invalid_destination_venue, with_restrictions=False
-            )
+            collective_offer_api.move_collective_offer_for_regularization(collective_offer, invalid_destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.venue != invalid_destination_venue
@@ -405,9 +403,7 @@ class MoveCollectiveOfferFailTest:
         )
         collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
         with pytest.raises(api.exceptions.NoDestinationVenue):
-            collective_offer_api.move_collective_offer_venue(
-                collective_offer, invalid_destination_venue, with_restrictions=False
-            )
+            collective_offer_api.move_collective_offer_for_regularization(collective_offer, invalid_destination_venue)
 
         db.session.refresh(collective_offer)
         assert collective_offer.venue != invalid_destination_venue

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -5049,7 +5049,7 @@ class EditPriceCategoryTest:
 
 
 @pytest.mark.usefixtures("db_session")
-@pytest.mark.features(MOVE_OFFER_TEST=True)
+@pytest.mark.features(VENUE_REGULARIZATION=True)
 class MoveOfferTest:
     def test_move_physical_offer_without_pricing_point(self):
         """Moving an offer from a venue without pricing point to another venue

--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -1619,7 +1619,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
     # - fetch CollectiveOffer
     # - _is_collective_offer_price_editable
     expected_num_queries = 4
-    expected_num_queries_with_ff = expected_num_queries + 1  # FF MOVE_OFFER_TEST
+    expected_num_queries_with_ff = expected_num_queries + 1  # FF VENUE_REGULARIZATION
 
     def test_nominal(self, legit_user, authenticated_client):
         start_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
@@ -1781,7 +1781,7 @@ class GetCollectiveOfferDetailTest(GetEndpointHelper):
         descriptions = html_parser.extract_descriptions(response.data)
         assert descriptions["Entité juridique"] == "Offerer Top Acteur"
 
-    @pytest.mark.features(MOVE_OFFER_TEST=True)
+    @pytest.mark.features(VENUE_REGULARIZATION=True)
     def test_move_offer(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
         venue = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-36168

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
