### PR TITLE
(BSR)[API] feat: move deprecated mention of public api offerVenue field

### DIFF
--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -4495,7 +4495,13 @@
                         "type": "string"
                     },
                     "offerVenue": {
-                        "$ref": "#/components/schemas/OfferVenueModel"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/OfferVenueModel"
+                            }
+                        ],
+                        "description": "[\u26a0\ufe0f DEPRECATED] Use the 'location' attribute instead of 'offerVenue'.",
+                        "title": "Offervenue"
                     },
                     "startDatetime": {
                         "description": "Collective offer start datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime). When creating a collective offer, the value of `startDatetime` will be copied to `endDatetime` if `endDatetime` is not provided.",
@@ -5578,7 +5584,7 @@
                                 "$ref": "#/components/schemas/OfferAddressType"
                             }
                         ],
-                        "description": "\n[DEPRECATED] Use the 'location' attribute instead of 'offerVenue'.\n- `offererVenue` means a db-known venue (`venueId` field is then mandatory).\n- `other` means that the address should be specified using the `otherAddress` field (which becomes mandatory).\n- `school` means that the event takes place inside the educational institution (the other two fields becomes meaningless).\n",
+                        "description": "\n- `offererVenue` means a db-known venue (`venueId` field is then mandatory).\n- `other` means that the address should be specified using the `otherAddress` field (which becomes mandatory).\n- `school` means that the event takes place inside the educational institution (the other two fields becomes meaningless).\n",
                         "example": "offererVenue"
                     },
                     "otherAddress": {
@@ -6096,13 +6102,14 @@
                         "type": "integer"
                     },
                     "offerVenue": {
-                        "anyOf": [
+                        "allOf": [
                             {
                                 "$ref": "#/components/schemas/OfferVenueModel"
                             }
                         ],
+                        "description": "[\u26a0\ufe0f DEPRECATED] Use the 'location' attribute instead of 'offerVenue'.",
                         "nullable": true,
-                        "title": "OfferVenueModel"
+                        "title": "Offervenue"
                     },
                     "startDatetime": {
                         "description": "Collective offer start datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime). When creating a collective offer, the value of `startDatetime` will be copied to `endDatetime` if `endDatetime` is not provided.",
@@ -6356,13 +6363,14 @@
                         "type": "integer"
                     },
                     "offerVenue": {
-                        "anyOf": [
+                        "allOf": [
                             {
                                 "$ref": "#/components/schemas/OfferVenueModel"
                             }
                         ],
+                        "description": "[\u26a0\ufe0f DEPRECATED] Use the 'location' attribute instead of 'offerVenue'.",
                         "nullable": true,
-                        "title": "OfferVenueModel"
+                        "title": "Offervenue"
                     },
                     "startDatetime": {
                         "description": "Collective offer start datetime. It cannot be a date in the past. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime). When creating a collective offer, the value of `startDatetime` will be copied to `endDatetime` if `endDatetime` is not provided.",

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -314,7 +314,7 @@ class GetPublicCollectiveOfferResponseModel(BaseModel):
     educationalInstitution: str | None = fields.EDUCATIONAL_INSTITUTION_UAI
     educationalInstitutionId: int | None = fields.EDUCATIONAL_INSTITUTION_ID
     # offerVenue will be replaced with location, for now we send both
-    offerVenue: OfferVenueModel
+    offerVenue: OfferVenueModel = fields.COLLECTIVE_OFFER_VENUE
     location: CollectiveOfferLocation | None = fields.COLLECTIVE_OFFER_LOCATION
     imageCredit: str | None = fields.IMAGE_CREDIT
     imageUrl: str | None = fields.IMAGE_URL
@@ -400,7 +400,7 @@ class PostCollectiveOfferBodyModel(BaseModel):
     mental_disability_compliant: bool = fields.MENTAL_DISABILITY_COMPLIANT_WITH_DEFAULT
     motor_disability_compliant: bool = fields.MOTOR_DISABILITY_COMPLIANT_WITH_DEFAULT
     visual_disability_compliant: bool = fields.VISUAL_DISABILITY_COMPLIANT_WITH_DEFAULT
-    offer_venue: OfferVenueModel | None
+    offer_venue: OfferVenueModel | None = fields.COLLECTIVE_OFFER_VENUE
     location: CollectiveOfferLocation | None = fields.COLLECTIVE_OFFER_LOCATION
     is_active: bool | None = fields.COLLECTIVE_OFFER_IS_ACTIVE
     image_file: str | None = fields.IMAGE_FILE
@@ -522,7 +522,7 @@ class PatchCollectiveOfferBodyModel(BaseModel):
     contactPhone: str | None = fields.COLLECTIVE_OFFER_CONTACT_PHONE
     domains: list[int] | None = fields.COLLECTIVE_OFFER_EDUCATIONAL_DOMAINS
     students: list[str] | None = fields.COLLECTIVE_OFFER_STUDENT_LEVELS
-    offerVenue: OfferVenueModel | None
+    offerVenue: OfferVenueModel | None = fields.COLLECTIVE_OFFER_VENUE
     location: CollectiveOfferLocation | None = fields.COLLECTIVE_OFFER_LOCATION
     interventionArea: list[str] | None = fields.COLLECTIVE_OFFER_INTERVENTION_AREA
     durationMinutes: int | None = fields.DURATION_MINUTES

--- a/api/src/pcapi/routes/public/documentation_constants/descriptions.py
+++ b/api/src/pcapi/routes/public/documentation_constants/descriptions.py
@@ -42,7 +42,6 @@ You have **three options** for the location:
 """
 
 OFFER_VENUE_ADDRESS_TYPE_DESCRIPTION = """
-[DEPRECATED] Use the 'location' attribute instead of 'offerVenue'.
 - `offererVenue` means a db-known venue (`venueId` field is then mandatory).
 - `other` means that the address should be specified using the `otherAddress` field (which becomes mandatory).
 - `school` means that the event takes place inside the educational institution (the other two fields becomes meaningless).

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -387,6 +387,7 @@ class _FIELDS:
         description="Can the offerer create collective offers?",
         example=True,
     )
+    COLLECTIVE_OFFER_VENUE = Field(description="[⚠️ DEPRECATED] Use the 'location' attribute instead of 'offerVenue'.")
     OFFER_VENUE_ADDRESS_TYPE = Field(
         description=descriptions.OFFER_VENUE_ADDRESS_TYPE_DESCRIPTION,
         example="offererVenue",


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : on place la mention DEPRECATED au niveau du champ offerVenue directement au lieu de addressType

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
