### PR TITLE
(PC-35964)[API] feat: add offer migration to add new columns

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-c2065c857c35 (pre) (head)
+541fcbeb419e (pre) (head)
 54e6167683c9 (post) (head)

--- a/api/src/pcapi/alembic/versions/20250521T143840_541fcbeb419e_add_datetime_columns_in_offer.py
+++ b/api/src/pcapi/alembic/versions/20250521T143840_541fcbeb419e_add_datetime_columns_in_offer.py
@@ -1,0 +1,24 @@
+"""Add finalizationDatetime, publicationDatetime, bookingAllowedDatetime in offer table"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "541fcbeb419e"
+down_revision = "c2065c857c35"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("offer", sa.Column("finalizationDatetime", sa.DateTime(), nullable=True))
+    op.add_column("offer", sa.Column("publicationDatetime", sa.DateTime(), nullable=True))
+    op.add_column("offer", sa.Column("bookingAllowedDatetime", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("offer", "bookingAllowedDatetime")
+    op.drop_column("offer", "publicationDatetime")
+    op.drop_column("offer", "finalizationDatetime")

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -711,6 +711,11 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
     dateUpdated: datetime.datetime = sa.Column(
         sa.DateTime, nullable=True, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
     )
+
+    finalizationDatetime: sa_orm.Mapped[datetime.datetime | None] = sa.Column(sa.DateTime, nullable=True)
+    publicationDatetime: sa_orm.Mapped[datetime.datetime | None] = sa.Column(sa.DateTime, nullable=True)
+    bookingAllowedDatetime: sa_orm.Mapped[datetime.datetime | None] = sa.Column(sa.DateTime, nullable=True)
+
     _description = sa.Column("description", sa.Text, nullable=True)
     _durationMinutes = sa.Column("durationMinutes", sa.Integer, nullable=True)
     ean = sa.Column(sa.Text, nullable=True, index=True)


### PR DESCRIPTION
Migration creates `finalizationDatetime`, `publicationDatetime` & `bookingAllowedDatetime`

## But de la pull request

Ticket Jira (étape 1) : https://passculture.atlassian.net/browse/PC-35964

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
