### PR TITLE
(PC-36233)[PRO] fix: user should join/create new venues

### DIFF
--- a/pro/src/components/SignupJourneyForm/Offerers/Offerers.tsx
+++ b/pro/src/components/SignupJourneyForm/Offerers/Offerers.tsx
@@ -51,6 +51,12 @@ export const Offerers = (): JSX.Element => {
   const isLocalAuthority = MAYBE_LOCAL_AUTHORITY_APE_CODE.includes(
     offerer?.apeCode ?? ''
   )
+  const restrictVenueCreationToCollectivity = useActiveFeature(
+    'WIP_RESTRICT_VENUE_CREATION_TO_COLLECTIVITY'
+  )
+  const restrictVenueAttachmentToCollectivity = useActiveFeature(
+    'WIP_RESTRICT_VENUE_ATTACHMENT_TO_COLLECTIVITY'
+  )
 
   /* istanbul ignore next: redirect to offerer if there is no siret */
   const {
@@ -184,12 +190,17 @@ export const Offerers = (): JSX.Element => {
             </Button>
           )}
         </div>
-        <Button variant={ButtonVariant.SECONDARY} onClick={doLinkUserToOfferer}>
-          Rejoindre cet espace
-        </Button>
+        {(!restrictVenueAttachmentToCollectivity || isLocalAuthority) && (
+          <Button
+            variant={ButtonVariant.SECONDARY}
+            onClick={doLinkUserToOfferer}
+          >
+            Rejoindre cet espace
+          </Button>
+        )}
       </div>
 
-      {isLocalAuthority && (
+      {(!restrictVenueCreationToCollectivity || isLocalAuthority) && (
         <>
           <div className={cn(styles['wrong-offerer-title'], styles['title-4'])}>
             Vous souhaitez ajouter une nouvelle structure à cet espace ?


### PR DESCRIPTION
Joining and creating new venues should be available to everybody *if*:

- WIP_RESTRICT_VENUE_CREATION_TO_COLLECTIVITY
- WIP_RESTRICT_VENUE_ATTACHMENT_TO_COLLECTIVITY

are off. If they are on, it should only be possible for ape code 84.11Z - ie collectivities.

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-36233

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [x] J'ai fait la revue fonctionnelle de mon ticket
