### PR TITLE
(PC-36237)[API] fix: add image check to prevent decompression bomb in `create_thumb`

### DIFF
--- a/api/src/pcapi/connectors/thumb_storage.py
+++ b/api/src/pcapi/connectors/thumb_storage.py
@@ -1,5 +1,6 @@
 from pcapi import settings
 from pcapi.core import object_storage
+from pcapi.core.offers import validation as offers_validation
 from pcapi.models.has_thumb_mixin import HasThumbMixin
 from pcapi.utils.image_conversion import CropParams
 from pcapi.utils.image_conversion import ImageRatio
@@ -17,6 +18,7 @@ def create_thumb(
     keep_ratio: bool = False,
     object_id: str | None = None,
 ) -> None:
+    offers_validation.check_image(image_as_bytes, min_height=None, min_width=None)
     if keep_ratio:
         image_as_bytes = process_original_image(image_as_bytes)
     else:

--- a/api/src/pcapi/core/providers/titelive_api.py
+++ b/api/src/pcapi/core/providers/titelive_api.py
@@ -9,6 +9,7 @@ import PIL
 import pydantic.v1 as pydantic
 
 import pcapi.core.offers.api as offers_api
+import pcapi.core.offers.exceptions as offers_exceptions
 import pcapi.core.providers.constants as providers_constants
 import pcapi.core.providers.models as providers_models
 import pcapi.core.providers.repository as providers_repository
@@ -246,7 +247,12 @@ class TiteliveSearchTemplate(abc.ABC, typing.Generic[TiteliveWorkType]):
                             object_id=image_id,
                         )
                 db.session.commit()
-            except (requests.ExternalAPIException, PIL.UnidentifiedImageError, OSError) as e:
+            except (
+                requests.ExternalAPIException,
+                PIL.UnidentifiedImageError,
+                OSError,
+                offers_exceptions.ImageValidationError,
+            ) as e:
                 db.session.rollback()
                 logger.error(
                     "Error while downloading Titelive image",


### PR DESCRIPTION
`synchronize_cgr_stocks` job was failing due to this error

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-XXXXX

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
