### PR TITLE
(PC-34669)[PRO] fix: hide stock delete/trashbin button instead of disable it in indiv. stocks

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
@@ -804,24 +804,25 @@ export const StocksEventEdition = ({
                               />
                             </td>
 
-                            <td
-                              className={cn(styles['stock-actions'])}
-                              data-label="Supprimer"
-                            >
-                              <Button
-                                variant={ButtonVariant.TERNARY}
-                                disabled={!stock.isDeletable || isDisabled}
-                                onClick={async () => {
-                                  if (stock.bookingsQuantity > 0) {
-                                    setStockToDeleteWithConfirmation(stock)
-                                  } else {
-                                    await onDeleteStock(stock)
-                                  }
-                                }}
-                                icon={fullTrashIcon}
-                                tooltipContent={<>Supprimer</>}
-                              />
-                            </td>
+                            {stock.isDeletable && !isDisabled && (
+                              <td
+                                className={cn(styles['stock-actions'])}
+                                data-label="Supprimer"
+                              >
+                                <Button
+                                  variant={ButtonVariant.TERNARY}
+                                  onClick={async () => {
+                                    if (stock.bookingsQuantity > 0) {
+                                      setStockToDeleteWithConfirmation(stock)
+                                    } else {
+                                      await onDeleteStock(stock)
+                                    }
+                                  }}
+                                  icon={fullTrashIcon}
+                                  tooltipContent={<>Supprimer</>}
+                                />
+                              </td>
+                            )}
                           </tr>
                         )
                       })}

--- a/pro/src/components/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventEdition/__specs__/StockEventEdition.spec.tsx
@@ -6,7 +6,6 @@ import {
 import { userEvent } from '@testing-library/user-event'
 import { Routes, Route } from 'react-router'
 
-
 import { api } from 'apiClient/api'
 import {
   ApiError,
@@ -282,10 +281,8 @@ describe('screens:StocksEventEdition', () => {
       { ...apiStocks[0], isEventDeletable: false },
     ])
 
-    vi.spyOn(api, 'deleteStock').mockResolvedValue({ id: 1 })
-    await userEvent.click(screen.getByRole('button', { name: 'Supprimer' }))
-    expect(api.deleteStock).not.toHaveBeenCalled()
-    expect(screen.getByLabelText('Tarif *')).toHaveValue(otherPriceCategoryId)
+    const deleteButton = screen.queryByRole('button', { name: 'Supprimer' })
+    expect(deleteButton).not.toBeInTheDocument()
   })
 
   it('should allow user to delete stock from a synchronized offer', async () => {

--- a/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
@@ -236,26 +236,28 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
     return result
   }
 
-  const actions: StockFormRowAction[] = [
-    {
-      callback: async () => {
-        if (
-          // tested but coverage don't see it.
-          /* istanbul ignore next */
-          mode === OFFER_WIZARD_MODE.EDITION &&
-          formik.values.stockId !== undefined &&
-          parseInt(formik.values.bookingsQuantity) > 0
-        ) {
-          setIsDeleteConfirmVisible(true)
-        } else {
-          await onConfirmDeleteStock()
-        }
-      },
-      label: 'Supprimer le stock',
-      disabled: false,
-      icon: fullTrashIcon,
-    },
-  ]
+  const actions: StockFormRowAction[] = isDisabled
+    ? []
+    : [
+        {
+          callback: async () => {
+            if (
+              // tested but coverage don't see it.
+              /* istanbul ignore next */
+              mode === OFFER_WIZARD_MODE.EDITION &&
+              formik.values.stockId !== undefined &&
+              parseInt(formik.values.bookingsQuantity) > 0
+            ) {
+              setIsDeleteConfirmVisible(true)
+            } else {
+              await onConfirmDeleteStock()
+            }
+          },
+          label: 'Supprimer le stock',
+          disabled: false,
+          icon: fullTrashIcon,
+        },
+      ]
 
   let description: string | JSX.Element
   let links
@@ -296,8 +298,6 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
       icon: fullCodeIcon,
     })
   }
-
-  actions[0].disabled = isDisabled
 
   if (offer.isDigital) {
     links = [


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-34669

## Vérifications

- [X] J'ai écrit les tests nécessaires
- [ ] ~J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire~
- [ ] ~J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.~
- [ ] ~J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data~
- [X] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket

## Screenshots
![Capture d’écran 2025-05-22 à 18 17 07](https://github.com/user-attachments/assets/9763b86a-bae6-4d96-adc9-bd24aebaab7b)

