### PR TITLE
(PC-36257)[API] fix: Removed flush to avoid updating collectiveOffers iterable when looping over it in move_batch_offer command

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -1344,8 +1344,6 @@ def move_collective_offer_for_regularization(
     collective_bookings_to_update.update({"venueId": destination_venue.id}, synchronize_session=False)
     db.session.add_all(collective_bookings_to_update)
 
-    db.session.flush()
-
 
 def move_collective_offer_venue(
     collective_offer: educational_models.CollectiveOffer,

--- a/api/src/pcapi/scripts/move_offer/move_batch_offer.py
+++ b/api/src/pcapi/scripts/move_offer/move_batch_offer.py
@@ -128,7 +128,8 @@ def _move_individual_offers(origin_venue: offerers_models.Venue, destination_ven
 
 def _move_collective_offers(origin_venue: offerers_models.Venue, destination_venue: offerers_models.Venue) -> None:
     collective_offer_ids = []
-    for collective_offer in origin_venue.collectiveOffers:
+    collective_offer_list = list(origin_venue.collectiveOffers)
+    for collective_offer in collective_offer_list:
         educational_api.move_collective_offer_for_regularization(collective_offer, destination_venue)
         collective_offer_ids.append(collective_offer.id)
     logger.info(


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-36257

