### PR TITLE
(BSR)[API] refactor: use sa and sa_orm instead of db to declare models

### DIFF
--- a/api/src/pcapi/core/chronicles/models.py
+++ b/api/src/pcapi/core/chronicles/models.py
@@ -11,7 +11,6 @@ from pcapi.core.offers.models import Product
 from pcapi.core.users.models import User
 from pcapi.models import Base
 from pcapi.models import Model
-from pcapi.models import db
 from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.pc_object import PcObject
 from pcapi.utils import db as db_utils
@@ -81,9 +80,9 @@ class Chronicle(PcObject, Base, Model, DeactivableMixin):
     userId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True, index=True)
     user: sa_orm.Mapped["User"] = sa_orm.relationship("User", foreign_keys=[userId], backref="chronicles")
 
-    __content_ts_vector__ = db.Column(
+    __content_ts_vector__ = sa.Column(
         db_utils.TSVector(),
-        db.Computed("to_tsvector('french', content)", persisted=True),
+        sa.Computed("to_tsvector('french', content)", persisted=True),
         nullable=False,
         name="__content_ts_vector__",
     )

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -299,7 +299,7 @@ class Venue(PcObject, Base, Model, HasThumbMixin, AccessibilityMixin, SoftDeleta
     thumb_path_component = "venues"
 
     criteria: sa_orm.Mapped[list["criteria_models.Criterion"]] = sa_orm.relationship(
-        "Criterion", backref=db.backref("venue_criteria", lazy="dynamic"), secondary=VenueCriterion.__table__
+        "Criterion", backref=sa_orm.backref("venue_criteria", lazy="dynamic"), secondary=VenueCriterion.__table__
     )
 
     dmsToken: str = sa.Column(sa.Text, nullable=False, unique=True)

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -704,7 +704,7 @@ class Offer(PcObject, Base, Model, DeactivableMixin, ValidationMixin, Accessibil
         "OfferCompliance", back_populates="offer", uselist=False
     )
     criteria: sa_orm.Mapped[list["Criterion"]] = sa_orm.relationship(
-        "Criterion", backref=db.backref("criteria", lazy="dynamic"), secondary=OfferCriterion.__table__
+        "Criterion", backref=sa_orm.backref("criteria", lazy="dynamic"), secondary=OfferCriterion.__table__
     )
     dateCreated: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
     dateModifiedAtLastProvider = sa.Column(sa.DateTime, nullable=True, default=datetime.datetime.utcnow)


### PR DESCRIPTION
## But de la pull request

ne plus utiliser le binding de sqlalchemy et sqlalchemy_orm sur l'objet db pour la déclaration des models.

Ce binding n'apporte rien en dehors de nous lier a flask_sqlalchemy

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
