### PR TITLE
(BSR)[BO] fix: hide referrer when opening external link from BO

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/accounts/update_requests_list.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/update_requests_list.html
@@ -20,6 +20,7 @@
   Demandes de modifications – démarche <a href="{{ link }}"
     class="link-primary"
     target="_blank"
+    rel="noreferrer noopener"
     title="Ouvrir la démarche DS">{{ procedure_id }}
   <i class="bi bi-box-arrow-up-right">
   </i>

--- a/api/src/pcapi/routes/backoffice/templates/admin/roles.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/roles.html
@@ -36,6 +36,7 @@
                       {% set link = "https://groups.google.com/a/passculture.app/g/backoffice-" + get_setting('ENV') + "-" + role.name + "/members" %}
                       <a href="{{ link }}"
                          target="_blank"
+                         rel="noreferrer noopener"
                          class="link-primary"
                          title="Voir les membres du groupe Google">
                         <i class="bi bi-google"></i>

--- a/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
+++ b/api/src/pcapi/routes/backoffice/templates/bank_account/get.html
@@ -24,6 +24,7 @@
               {% if dms_stats %}
                 <a href="{{ dms_stats.url }}"
                    target="_blank"
+                   rel="noreferrer noopener"
                    class="card-link">
                   <button class="btn btn-outline-primary lead fw-bold mt-2 mx-3"
                           type="button">ACCÉDER AU DOSSIER DMS CB</button>

--- a/api/src/pcapi/routes/backoffice/templates/components/links.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/links.html
@@ -106,11 +106,13 @@
   {% if rid7 %}
     <a href="https://data.gouv.nc/explore/dataset/entreprises-actives-au-ridet/table/?q={{ rid7 }}"
        target="_blank"
+       rel="noreferrer noopener"
        title="Rechercher dans l'open data de la Nouvelle Calédonie"
        class="link-primary">{{ rid7 }} <i class="bi bi-box-arrow-up-right"></i></a>
   {% else %}
     <a href="https://annuaire-entreprises.data.gouv.fr/entreprise/{{ offerer.siren }}"
        target="_blank"
+       rel="noreferrer noopener"
        title="Visualiser dans l'Annuaire des Entreprises"
        class="link-primary">{{ offerer.siren }} <i class="bi bi-box-arrow-up-right"></i></a>
   {% endif %}
@@ -121,6 +123,7 @@
   {% elif venue.siret %}
     <a href="https://annuaire-entreprises.data.gouv.fr/etablissement/{{ venue.siret }}"
        target="_blank"
+       rel="noreferrer noopener"
        title="Visualiser dans l'Annuaire des Entreprises"
        class="link-primary">{{ venue.siret }} <i class="bi bi-box-arrow-up-right"></i></a>
   {% endif %}
@@ -128,6 +131,7 @@
 {% macro build_search_company_external_link(terms) %}
   <a href="https://annuaire-entreprises.data.gouv.fr/rechercher?terme={{ terms }}"
      target="_blank"
+     rel="noreferrer noopener"
      title="Rechercher dans l'Annuaire des Entreprises"
      class="link-primary">{{ terms }} <i class="bi bi-box-arrow-up-right"></i></a>
 {% endmacro %}
@@ -135,6 +139,7 @@
   {% set ban_path = address.banId or '#18/' + address.latitude|string + '/' + address.longitude|string %}
   <a href="https://adresse.data.gouv.fr/base-adresse-nationale/{{ ban_path }}"
      target="_blank"
+     rel="noreferrer noopener"
      data-bs-toggle="tooltip"
      data-bs-placement="top"
      data-bs-title="Accéder à data.gouv"
@@ -149,23 +154,27 @@
   <a href="{{ link }}"
      class="link-primary"
      target="_blank"
+     rel="noreferrer noopener"
      title="Ouvrir le dossier DS">{{ prefix }}{{ ds_dossier_id }} <i class="bi bi-box-arrow-up-right"></i></a>
 {% endmacro %}
 {% macro build_dms_adage_application_external_link(collective_dms_application) %}
   <a href="https://www.demarches-simplifiees.fr/procedures/{{ collective_dms_application.procedure }}/dossiers/{{ collective_dms_application.application }}"
      target="_blank"
+     rel="noreferrer noopener"
      title="Visualiser le dossier Démarches Simplifiées ADAGE"
      class="link-primary">{{ collective_dms_application.application }} <i class="bi bi-box-arrow-up-right"></i></a>
 {% endmacro %}
 {% macro build_safe_redirect_link(url) %}
   <a href="{{ url_for('backoffice_web.safe_redirect', url=url) }}"
      target="_blank"
+     rel="noreferrer noopener"
      title="Ouvrir le site web externe"
      class="link-primary">{{ url }} <i class="bi bi-box-arrow-up-right"></i></a>
 {% endmacro %}
 {% macro build_zendesk_ticket_external_link(zendesk_id) %}
   <a href=" https://passculture.zendesk.com/agent/tickets/{{ zendesk_id }}"
      target="_blank"
+     rel="noreferrer noopener"
      title="Visualiser le ticket Zendesk de la demande"
      class="link-primary">{{ zendesk_id }} <i class="bi bi-box-arrow-up-right"></i></a>
 {% endmacro %}

--- a/api/src/pcapi/routes/backoffice/templates/dev/components.html
+++ b/api/src/pcapi/routes/backoffice/templates/dev/components.html
@@ -82,7 +82,8 @@
         <td>
           <a href="https://passculture.app"
              class="link-primary"
-             target="_blank">lien vers un autre site <i class="bi bi-box-arrow-up-right"></i></a>
+             target="_blank"
+             rel="noreferrer noopener">lien vers un autre site <i class="bi bi-box-arrow-up-right"></i></a>
         </td>
       </tr>
       <tr>

--- a/api/src/pcapi/routes/backoffice/templates/operations/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/operations/details.html
@@ -232,7 +232,8 @@
        data-bs-toggle="tooltip"
        data-bs-placement="top"
        data-bs-title="Voir le formulaire sur Typeform"
-       target="_blank">
+       target="_blank"
+       rel="noreferrer noopener">
       Accès Typeform
       <i class="bi bi-box-arrow-up-right"></i>
     </a>

--- a/api/src/pcapi/routes/backoffice/templates/operations/list_events.html
+++ b/api/src/pcapi/routes/backoffice/templates/operations/list_events.html
@@ -27,6 +27,7 @@
       <td>
         <a href="https://admin.typeform.com/form/{{ special_event.externalId }}/create"
            target="_blank"
+           rel="noreferrer noopener"
            title="Ouvrir dans Typeform"
            class="link-primary">
         {{ special_event.externalId }} <i class="bi bi-box-arrow-up-right"></i></a>


### PR DESCRIPTION
## But de la pull request

Ne pas envoyer nos URL internes du BO en _referrer_ lorsqu'on sort du BO.
C'était déjà dans quelques liens externes, je généralise.

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
