### PR TITLE
(BSR)[API] test: use db.session.refresh() instead of db_session.refresh()

### DIFF
--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -2113,8 +2113,8 @@ class ArchiveOldBookingsTest:
         api.archive_old_bookings()
 
         # then
-        db_session.refresh(recent_booking)
-        db_session.refresh(old_booking)
+        db.session.refresh(recent_booking)
+        db.session.refresh(old_booking)
         assert not recent_booking.displayAsEnded
         assert old_booking.displayAsEnded
 
@@ -2141,9 +2141,9 @@ class ArchiveOldBookingsTest:
         api.archive_old_bookings()
 
         # then
-        db_session.refresh(recent_booking)
-        db_session.refresh(old_booking)
-        db_session.refresh(old_not_free_booking)
+        db.session.refresh(recent_booking)
+        db.session.refresh(old_booking)
+        db.session.refresh(old_not_free_booking)
         assert not recent_booking.displayAsEnded
         assert not old_not_free_booking.displayAsEnded
         assert old_booking.displayAsEnded
@@ -2175,8 +2175,8 @@ class ArchiveOldBookingsTest:
         api.archive_old_bookings()
 
         # then
-        db_session.refresh(recent_booking)
-        db_session.refresh(old_booking)
+        db.session.refresh(recent_booking)
+        db.session.refresh(old_booking)
         assert not recent_booking.displayAsEnded
         assert old_booking.displayAsEnded
 

--- a/api/tests/core/educational/test_integration.py
+++ b/api/tests/core/educational/test_integration.py
@@ -42,7 +42,7 @@ class EducationalWorkflowTest:
             assert collective_booking.status == educational_models.CollectiveBookingStatus.CONFIRMED
 
             # We need to expire all the objects to ensure the test session is in sync with the database when auto_mark_as_used_after_event is called
-            db_session.expire_all()
+            db.session.expire_all()
 
             # Mark the booking as used
             bookings_api.auto_mark_as_used_after_event()

--- a/api/tests/core/geography/test_models.py
+++ b/api/tests/core/geography/test_models.py
@@ -77,7 +77,7 @@ class AddressModelsTest:
                 departmentCode="7",
             )
 
-        db_session.rollback()
+        db.session.rollback()
 
         # More than 3 digits, should fail
         with pytest.raises(IntegrityError):

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -78,7 +78,7 @@ def test_new_offerer_auto_tagging(db_session, ape_code, expected_tag):
     offerers_api.auto_tag_new_offerer(offerer, siren_info, user)
 
     # then
-    db_session.refresh(offerer)
+    db.session.refresh(offerer)
     assert expected_tag in (tag.label for tag in offerer.tags)
 
 

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -104,7 +104,7 @@ class VenueBannerUrlTest:
 
         venue.bannerUrl = expected_banner_url
         repository.save(venue)
-        db_session.refresh(venue)
+        db.session.refresh(venue)
 
         assert venue.bannerUrl == expected_banner_url
         assert venue._bannerUrl == expected_banner_url
@@ -115,7 +115,7 @@ class VenueBannerUrlTest:
 
         venue.bannerUrl = expected_banner_url
         repository.save(venue)
-        db_session.refresh(venue)
+        db.session.refresh(venue)
 
         assert venue.bannerUrl == expected_banner_url
         assert venue._bannerUrl == expected_banner_url

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1435,7 +1435,7 @@ class UpdateStockQuantityToDnBookedQuantityTest:
         # when
         repository.update_stock_quantity_to_dn_booked_quantity(stock.id)
         # then
-        db_session.refresh(stock)
+        db.session.refresh(stock)
         assert stock.quantity == 6
 
 

--- a/api/tests/core/permissions/test_permissions_sync.py
+++ b/api/tests/core/permissions/test_permissions_sync.py
@@ -12,14 +12,14 @@ def test_sync_first_perms(db_session):
         BAR = "bar"
 
     db.session.query(perm_models.RolePermission).delete()
-    db_session.query(perm_models.Permission).delete()
-    assert db_session.query(perm_models.Permission.id).count() == 0
+    db.session.query(perm_models.Permission).delete()
+    assert db.session.query(perm_models.Permission.id).count() == 0
 
     # when
     perm_models.sync_enum_with_db_field(db_session, TestPermissions, "name", perm_models.Permission)
 
     # then
-    assert set(p.name for p in db_session.query(perm_models.Permission.name).all()) == set(
+    assert set(p.name for p in db.session.query(perm_models.Permission.name).all()) == set(
         p.name for p in TestPermissions
     )
 
@@ -32,16 +32,16 @@ def test_sync_new_perms(db_session):
         BAZ = "baz"
 
     db.session.query(perm_models.RolePermission).delete()
-    db_session.query(perm_models.Permission).delete()
-    db_session.add(perm_models.Permission(name="FOO"))
-    db_session.add(perm_models.Permission(name="BAR"))
-    assert db_session.query(perm_models.Permission.id).count() == 2
+    db.session.query(perm_models.Permission).delete()
+    db.session.add(perm_models.Permission(name="FOO"))
+    db.session.add(perm_models.Permission(name="BAR"))
+    assert db.session.query(perm_models.Permission.id).count() == 2
 
     # when
     perm_models.sync_enum_with_db_field(db_session, TestPermissions, "name", perm_models.Permission)
 
     # then
-    assert set(p.name for p in db_session.query(perm_models.Permission.name).all()) == set(
+    assert set(p.name for p in db.session.query(perm_models.Permission.name).all()) == set(
         p.name for p in TestPermissions
     )
 
@@ -53,11 +53,11 @@ def test_sync_removed_perms(db_session):
         BAR = "bar"
 
     db.session.query(perm_models.RolePermission).delete()
-    db_session.query(perm_models.Permission).delete()
-    db_session.add(perm_models.Permission(name="FOO"))
-    db_session.add(perm_models.Permission(name="BAR"))
-    db_session.add(perm_models.Permission(name="BAZ"))
-    assert db_session.query(perm_models.Permission.id).count() == 3
+    db.session.query(perm_models.Permission).delete()
+    db.session.add(perm_models.Permission(name="FOO"))
+    db.session.add(perm_models.Permission(name="BAR"))
+    db.session.add(perm_models.Permission(name="BAZ"))
+    assert db.session.query(perm_models.Permission.id).count() == 3
 
     # when
     with mock.patch.object(perm_models.logger, "warning") as warn_mock:
@@ -66,7 +66,7 @@ def test_sync_removed_perms(db_session):
     # then
     assert warn_mock.call_count == 1
     assert "BAZ" in warn_mock.call_args.args[2]
-    assert set(p.name for p in db_session.query(perm_models.Permission.name).all()) == {"FOO", "BAR", "BAZ"}
+    assert set(p.name for p in db.session.query(perm_models.Permission.name).all()) == {"FOO", "BAR", "BAZ"}
 
 
 def test_sync_new_roles(db_session):
@@ -77,12 +77,12 @@ def test_sync_new_roles(db_session):
         BAZ = "baz"
 
     db.session.query(perm_models.RolePermission).delete()
-    db_session.query(perm_models.Role).delete()
-    db_session.add(perm_models.Role(name="foo"))
-    assert db_session.query(perm_models.Role.id).count() == 1
+    db.session.query(perm_models.Role).delete()
+    db.session.add(perm_models.Role(name="foo"))
+    assert db.session.query(perm_models.Role.id).count() == 1
 
     # when
     perm_models.sync_enum_with_db_field(db_session, TestRoles, "value", perm_models.Role)
 
     # then
-    assert {p.name for p in db_session.query(perm_models.Role.name).all()} == {p.value for p in TestRoles}
+    assert {p.name for p in db.session.query(perm_models.Role.name).all()} == {p.value for p in TestRoles}

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -205,7 +205,7 @@ class HandleDmsApplicationTest:
         dms_subscription_api.handle_dms_application(dms_response)
 
         mock_process_in_progress.assert_not_called()
-        db_session.refresh(dms_fraud_check)
+        db.session.refresh(dms_fraud_check)
         assert (
             dms_fraud_check.source_data().get_latest_modification_datetime()
             == dms_response.latest_modification_datetime
@@ -474,7 +474,7 @@ class HandleDmsApplicationTest:
 
         dms_subscription_api.handle_dms_application(dms_response)
 
-        db_session.refresh(fraud_check)
+        db.session.refresh(fraud_check)
 
         assert fraud_check.reasonCodes == []
         assert fraud_check.reason is None

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -922,7 +922,7 @@ class UbbleWorkflowV1Test:
         ):
             ubble_subscription_api.update_ubble_workflow(fraud_check)
 
-        db_session.refresh(fraud_check)
+        db.session.refresh(fraud_check)
 
         assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.status == fraud_models.FraudCheckStatus.OK
@@ -967,7 +967,7 @@ class UbbleWorkflowV1Test:
         ):
             ubble_subscription_api.update_ubble_workflow(fraud_check)
 
-        db_session.refresh(fraud_check)
+        db.session.refresh(fraud_check)
 
         assert fraud_check.type == fraud_models.FraudCheckType.UBBLE
         assert fraud_check.status == fraud_models.FraudCheckStatus.KO

--- a/api/tests/routes/auth/discord_test.py
+++ b/api/tests/routes/auth/discord_test.py
@@ -129,7 +129,7 @@ class DiscordSigninTest:
         assert mock_add_to_server.call_args[0][0] == "access_token"
         assert mock_add_to_server.call_args[0][1] == "discord_user_id"
 
-        db_session.refresh(discord_user)
+        db.session.refresh(discord_user)
         assert discord_user.discordId == "discord_user_id"
 
     @unittest.mock.patch("pcapi.routes.auth.discord.discord_connector.get_user_id", return_value="discord_user_id")
@@ -257,7 +257,7 @@ class DiscordSigninTest:
 
         assert response.status_code == 303
 
-        db_session.refresh(discord_user)
+        db.session.refresh(discord_user)
         assert discord_user.discordId is None
 
     @unittest.mock.patch("pcapi.routes.auth.discord.discord_connector.get_user_id", return_value="discord_user_id")

--- a/api/tests/routes/pro/patch_offerer_bank_accounts_test.py
+++ b/api/tests/routes/pro/patch_offerer_bank_accounts_test.py
@@ -58,7 +58,7 @@ class OffererPatchBankAccountsTest:
         assert linked_venue["id"] == venue.id
         assert linked_venue["commonName"] == venue.common_name
 
-        db_session.refresh(bank_account)
+        db.session.refresh(bank_account)
 
         assert len(bank_account.venueLinks) == 1
 
@@ -105,7 +105,7 @@ class OffererPatchBankAccountsTest:
 
         assert response.status_code == 200
 
-        db_session.refresh(bank_account)
+        db.session.refresh(bank_account)
 
         assert len(bank_account.venueLinks) == 1
 
@@ -151,7 +151,7 @@ class OffererPatchBankAccountsTest:
         bank_account_response = response.json["bankAccounts"].pop()
         assert not bank_account_response["linkedVenues"]
 
-        db_session.refresh(bank_account)
+        db.session.refresh(bank_account)
 
         assert not bank_account.venueLinks
 
@@ -194,7 +194,7 @@ class OffererPatchBankAccountsTest:
         bank_account_response = response.json["bankAccounts"].pop()
         assert not bank_account_response["linkedVenues"]
 
-        db_session.refresh(bank_account)
+        db.session.refresh(bank_account)
 
         assert not bank_account.venueLinks
 
@@ -270,7 +270,7 @@ class OffererPatchBankAccountsTest:
         bank_account_response = response.json["bankAccounts"].pop()
         assert not bank_account_response["linkedVenues"]
 
-        db_session.refresh(bank_account)
+        db.session.refresh(bank_account)
 
         assert len(bank_account.venueLinks) == 3
 
@@ -396,7 +396,7 @@ class OffererPatchBankAccountsTest:
             assert linked_venue["id"] == venue.id
             assert linked_venue["commonName"] == venue.common_name
 
-        db_session.refresh(bank_account)
+        db.session.refresh(bank_account)
 
         assert len(bank_account.venueLinks) == 4
         assert (
@@ -587,11 +587,11 @@ class OffererPatchBankAccountsTest:
         assert linked_venue["commonName"] == venue.common_name
 
         # Should not alter any other offerer data
-        db_session.refresh(foreign_link)
+        db.session.refresh(foreign_link)
         assert foreign_link.timespan.upper is None
         assert foreign_link.bankAccount == foreign_bank_account
 
-        db_session.refresh(bank_account)
+        db.session.refresh(bank_account)
 
         assert len(bank_account.venueLinks) == 1
 

--- a/api/tests/routes/public/collective/endpoints/post_archive_collective_offers_test.py
+++ b/api/tests/routes/public/collective/endpoints/post_archive_collective_offers_test.py
@@ -5,6 +5,7 @@ from pcapi.core.educational import models
 from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.providers import factories as providers_factories
+from pcapi.models import db
 
 
 @pytest.fixture(name="venue_provider")
@@ -42,10 +43,10 @@ class Returns204Test:
         )
 
         assert response.status_code == 204
-        db_session.refresh(offer)
+        db.session.refresh(offer)
         assert offer.isArchived
 
-        db_session.refresh(not_modified_offer)
+        db.session.refresh(not_modified_offer)
         assert not_modified_offer.isActive is True
         assert not_modified_offer.isArchived is False
 
@@ -69,11 +70,11 @@ class Returns204Test:
 
         assert response.status_code == 204
         for offer in offers:
-            db_session.refresh(offer)
+            db.session.refresh(offer)
             assert offer.isActive is False
             assert offer.isArchived
 
-        db_session.refresh(not_modified_offer)
+        db.session.refresh(not_modified_offer)
         assert not_modified_offer.isActive is True
         assert not_modified_offer.isArchived is False
 
@@ -103,7 +104,7 @@ class Returns400Test:
 
         assert response.status_code == 400
         assert response.json == {"global": ["Cette action n'est pas autorisée sur une des offres"]}
-        db_session.refresh(offer)
+        db.session.refresh(offer)
         assert offer.isArchived is False
 
     def test_archive_archived_collective_offers(self, public_client, venue_provider, db_session):
@@ -115,7 +116,7 @@ class Returns400Test:
         )
 
         assert response.status_code == 400
-        db_session.refresh(offer)
+        db.session.refresh(offer)
         assert offer.isArchived is True
 
 
@@ -132,5 +133,5 @@ class Returns404Test:
 
         assert response.status_code == 404
         assert response.json == {"ids": f"Les offres suivantes n'ont pas été trouvées: {{{offer.id}}}"}
-        db_session.refresh(offer)
+        db.session.refresh(offer)
         assert offer.isArchived is False

--- a/api/tests/scripts/rebuild_staging/test_anonymize.py
+++ b/api/tests/scripts/rebuild_staging/test_anonymize.py
@@ -4,6 +4,7 @@ import re
 import sqlalchemy as sa
 
 import pcapi
+from pcapi.models import db
 
 
 ANONYMIZE_SQL_PATH = pathlib.Path(pcapi.__path__[0]) / "scripts" / "rebuild_staging" / "anonymize.sql"
@@ -30,4 +31,4 @@ class AnonymizeTest:
                 else:
                     sql.append(line)
         sql = "\n".join(sql)
-        db_session.execute(sa.text(sql))
+        db.session.execute(sa.text(sql))

--- a/api/tests/use_cases/save_venue_bank_informations_test.py
+++ b/api/tests/use_cases/save_venue_bank_informations_test.py
@@ -296,8 +296,8 @@ class BankAccountJourneyTest:
         assert len(status_history) == 2
         accepted_status_history = status_history[-1]
 
-        db_session.refresh(on_going_status_history)
-        db_session.refresh(bank_account)
+        db.session.refresh(on_going_status_history)
+        db.session.refresh(bank_account)
 
         assert on_going_status_history.timespan.upper is not None
         assert (
@@ -503,8 +503,8 @@ class BankAccountJourneyTest:
         assert len(status_history) == 2
         accepted_status_history = status_history[-1]
 
-        db_session.refresh(on_going_status_history)
-        db_session.refresh(bank_account)
+        db.session.refresh(on_going_status_history)
+        db.session.refresh(bank_account)
 
         assert on_going_status_history.timespan.upper is not None
         assert (


### PR DESCRIPTION
## But de la pull request

Dans les tests, remplacer l'usage d'appels via `db_session` par des appels via `db.session`, par homogénéité et dans le cadre du chantier sqlalchemy 2.

