### PR TITLE
(PC-36229)[API] feat: update `patch_offers_active_status` & `patch_publish_offer`

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -897,27 +897,35 @@ def publish_offer(
     offer: models.Offer,
     publication_date: datetime.datetime | None = None,
 ) -> models.Offer:
+    finalization_date = datetime.datetime.now(datetime.timezone.utc)
+
+    if not offer.finalizationDatetime:
+        offer.finalizationDatetime = finalization_date
+
     publication_date = _format_publication_date(publication_date, offer.venue.timezone)
     validation.check_publication_date(offer, publication_date)
 
     if ean := offer.ean:
         validation.check_other_offer_with_ean_does_not_exist(ean, offer.venue, offer.id)
 
-    if publication_date is not None:
+    if publication_date is not None:  # i.e. pro user schedules the publication in the future
         offer.isActive = False
+        offer.publicationDatetime = publication_date
+        offer.bookingAllowedDatetime = publication_date
+
+        # (tcoudray-pass, 23/05/2025) Remove when publicationDatetime is used instead of future_offer
         future_offer = models.FutureOffer(offerId=offer.id, publicationDate=publication_date)
         db.session.add(future_offer)
-    else:
+    else:  # i.e. pro user publishes the offer right away
+        offer.isActive = True
+        offer.publicationDatetime = finalization_date
+        offer.bookingAllowedDatetime = finalization_date
+
+        # (tcoudray-pass, 23/05/2025) Remove when publicationDatetime is used instead of future_offer
         if offer.publicationDate:
             offers_repository.delete_future_offer(offer.id)
 
-        on_commit(
-            partial(
-                search.async_index_offer_ids,
-                [offer.id],
-                reason=search.IndexationReason.OFFER_PUBLICATION,
-            )
-        )
+        on_commit(partial(search.async_index_offer_ids, [offer.id], reason=search.IndexationReason.OFFER_PUBLICATION))
         logger.info(
             "Offer has been published",
             extra={"offer_id": offer.id, "venue_id": offer.venueId, "offer_status": offer.status},


### PR DESCRIPTION

Those 2 routes now updates `offer.publicationDatetime` & `offer.bookingAllowedDatetime`

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-36229

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
