### PR TITLE
(BSR)[API] refactor: add tablename to all models

### DIFF
--- a/api/src/pcapi/connectors/dms/models.py
+++ b/api/src/pcapi/connectors/dms/models.py
@@ -12,6 +12,7 @@ from pcapi.models.pc_object import PcObject
 
 
 class LatestDmsImport(PcObject, Base, Model):
+    __tablename__ = "latest_dms_import"
     procedureId = sa.Column(sa.Integer, nullable=False)
     latestImportDatetime: datetime.datetime = sa.Column(sa.DateTime, nullable=False)
     isProcessing = sa.Column(sa.Boolean, nullable=False)

--- a/api/src/pcapi/core/artist/models.py
+++ b/api/src/pcapi/core/artist/models.py
@@ -37,6 +37,7 @@ class ArtistProductLink(PcObject, Base, Model):
 
 
 class Artist(PcObject, Base, Model):
+    __tablename__ = "artist"
     id = sa.Column(sa.Text, primary_key=True, nullable=False, default=lambda _: str(uuid.uuid4()))
     name = sa.Column(sa.Text, nullable=False, index=True)
     description = sa.Column(sa.Text)
@@ -60,6 +61,7 @@ class ArtistAlias(PcObject, Base, Model):
     in order to be able to compare the data from different sources
     """
 
+    __tablename__ = "artist_alias"
     artist_id = sa.Column(sa.Text, sa.ForeignKey("artist.id", ondelete="CASCADE"), nullable=False, index=True)
     artist_alias_name = sa.Column(sa.Text)
     artist_cluster_id = sa.Column(sa.Text)

--- a/api/src/pcapi/core/bookings/models.py
+++ b/api/src/pcapi/core/bookings/models.py
@@ -99,6 +99,7 @@ class BookingRecreditType(enum.Enum):
 
 
 class ExternalBooking(PcObject, Base, Model):
+    __tablename__ = "external_booking"
     bookingId: int = sa.Column(sa.BigInteger, sa.ForeignKey("booking.id"), index=True, nullable=False)
 
     booking: sa_orm.Mapped["Booking"] = sa_orm.relationship(
@@ -589,6 +590,7 @@ sa.event.listen(Booking.__table__, "after_create", sa.DDL(Booking.trig_update_ca
 
 
 class FraudulentBookingTag(PcObject, Base, Model):
+    __tablename__ = "fraudulent_booking_tag"
     dateCreated: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
 
     bookingId: int = sa.Column(sa.BigInteger, sa.ForeignKey("booking.id"), index=True, nullable=False, unique=True)

--- a/api/src/pcapi/core/chronicles/models.py
+++ b/api/src/pcapi/core/chronicles/models.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class ProductChronicle(PcObject, Base, Model):
-    __table_name__ = "product_chronicle"
+    __tablename__ = "product_chronicle"
     productId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("product.id", ondelete="CASCADE"), index=True, nullable=False
     )
@@ -38,7 +38,7 @@ class ProductChronicle(PcObject, Base, Model):
 
 
 class OfferChronicle(PcObject, Base, Model):
-    __table_name__ = "offer_chronicle"
+    __tablename__ = "offer_chronicle"
     offerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id", ondelete="CASCADE"), index=True, nullable=False)
     chronicleId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("chronicle.id", ondelete="CASCADE"), index=True, nullable=False

--- a/api/src/pcapi/core/criteria/models.py
+++ b/api/src/pcapi/core/criteria/models.py
@@ -20,6 +20,7 @@ class CriterionCategoryMapping(PcObject, Base, Model):
 
 
 class Criterion(PcObject, Base, Model):
+    __tablename__ = "criterion"
     name: str = sa.Column(sa.String(140), nullable=False, unique=True)
     description = sa.Column(sa.Text, nullable=True)
     startDateTime = sa.Column(sa.DateTime, nullable=True)
@@ -34,6 +35,7 @@ class Criterion(PcObject, Base, Model):
 
 
 class VenueCriterion(PcObject, Base, Model):
+    __tablename__ = "venue_criterion"
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id", ondelete="CASCADE"), index=True, nullable=False)
     criterionId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("criterion.id", ondelete="CASCADE"), nullable=False, index=True
@@ -49,7 +51,7 @@ class VenueCriterion(PcObject, Base, Model):
 
 
 class OfferCriterion(PcObject, Base, Model):
-    __table_name__ = "offer_criterion"
+    __tablename__ = "offer_criterion"
     offerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id", ondelete="CASCADE"), index=True, nullable=False)
     criterionId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("criterion.id", ondelete="CASCADE"), index=True, nullable=False

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -1987,6 +1987,7 @@ class DomainToNationalProgram(PcObject, models.Base, models.Model):
     programs but not twice the same.
     """
 
+    __tablename__ = "domain_to_national_program"
     domainId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("educational_domain.id", ondelete="CASCADE"), index=True, nullable=False
     )
@@ -2081,6 +2082,7 @@ sa.event.listen(
 
 
 class CollectiveOfferRequest(PcObject, models.Base, models.Model):
+    __tablename__ = "collective_offer_request"
     _phoneNumber: str | None = sa.Column(sa.String(30), nullable=True, name="phoneNumber")
 
     requestedDate: datetime.date | None = sa.Column(sa.Date, nullable=True)
@@ -2137,6 +2139,7 @@ class NationalProgram(PcObject, models.Base, models.Model):
     collective offers (templates) within a coherent frame.
     """
 
+    __tablename__ = "national_program"
     name: str = sa.Column(sa.Text, unique=True)
     dateCreated: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
     domains: sa_orm.Mapped[list["EducationalDomain"]] = sa_orm.relationship(
@@ -2156,6 +2159,7 @@ class NationalProgramOfferLinkHistory(PcObject, models.Base, models.Model):
     program or not.
     """
 
+    __tablename__ = "national_program_offer_link_history"
     dateCreated: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
     collectiveOfferId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("collective_offer.id", ondelete="CASCADE"), nullable=False
@@ -2172,6 +2176,7 @@ class NationalProgramOfferTemplateLinkHistory(PcObject, models.Base, models.Mode
     program or not.
     """
 
+    __tablename__ = "national_program_offer_template_link_history"
     dateCreated: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
     collectiveOfferTemplateId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("collective_offer_template.id", ondelete="CASCADE"), nullable=False
@@ -2189,6 +2194,7 @@ class EducationalInstitutionProgramAssociation(models.Base, models.Model):
     EducationalInstitutionProgram (many-to-many)
     """
 
+    __tablename__ = "educational_institution_program_association"
     institutionId: int = sa.Column(
         sa.BigInteger,
         sa.ForeignKey("educational_institution.id", ondelete="CASCADE"),
@@ -2223,6 +2229,7 @@ class EducationalInstitutionProgramAssociation(models.Base, models.Model):
 
 
 class EducationalInstitutionProgram(PcObject, models.Base, models.Model):
+    __tablename__ = "educational_institution_program"
     # technical name
     name: str = sa.Column(sa.Text, nullable=False, unique=True)
     # public (printable) name - if something different from name is needed
@@ -2231,6 +2238,7 @@ class EducationalInstitutionProgram(PcObject, models.Base, models.Model):
 
 
 class CollectivePlaylist(PcObject, models.Base, models.Model):
+    __tablename__ = "collective_playlist"
     type: str = sa.Column(db_utils.MagicEnum(PlaylistType), nullable=False)
     distanceInKm: float = sa.Column(sa.Float, nullable=True)
 
@@ -2255,6 +2263,7 @@ class CollectivePlaylist(PcObject, models.Base, models.Model):
 
 
 class AdageVenueAddress(PcObject, models.Base, models.Model):
+    __tablename__ = "adage_venue_address"
     adageId: str | None = sa.Column(sa.Text, nullable=True, unique=True)
     adageInscriptionDate: datetime.datetime | None = sa.Column(sa.DateTime, nullable=True)
     venueId: int | None = sa.Column(

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -51,6 +51,7 @@ class DepositType(enum.Enum):
 
 
 class Deposit(PcObject, Base, Model):
+    __tablename__ = "deposit"
     amount: decimal.Decimal = sa.Column(sa.Numeric(10, 2), nullable=False)
 
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False)
@@ -134,6 +135,7 @@ class RecreditType(enum.Enum):
 
 
 class Recredit(PcObject, Base, Model):
+    __tablename__ = "recredit"
     depositId: int = sa.Column(sa.BigInteger, sa.ForeignKey("deposit.id"), nullable=False)
 
     deposit: sa_orm.Mapped[Deposit] = sa_orm.relationship(
@@ -234,6 +236,7 @@ class BankAccountApplicationStatus(enum.Enum):
 
 
 class BankAccount(PcObject, Base, Model, DeactivableMixin):
+    __tablename__ = "bank_account"
     label: str = sa.Column(sa.String(100), nullable=False)
     offererId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("offerer.id", ondelete="CASCADE"), index=True, nullable=False
@@ -269,6 +272,7 @@ class BankAccount(PcObject, Base, Model, DeactivableMixin):
 
 
 class BankAccountStatusHistory(PcObject, Base, Model):
+    __tablename__ = "bank_account_status_history"
     bankAccountId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("bank_account.id", ondelete="CASCADE"), index=True, nullable=False
     )
@@ -289,6 +293,7 @@ class BankAccountStatusHistory(PcObject, Base, Model):
 
 
 class FinanceEvent(PcObject, Base, Model):
+    __tablename__ = "finance_event"
     creationDate: datetime.datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
     # In most cases, `valueDate` is `Booking.dateUsed` but it's useful
     # to denormalize it here: many queries use this column and we thus
@@ -383,11 +388,13 @@ class CashflowPricing(Base, Model):
     thus be linked to two cashflows.
     """
 
+    __tablename__ = "cashflow_pricing"
     cashflowId: int = sa.Column(sa.BigInteger, sa.ForeignKey("cashflow.id"), index=True, primary_key=True)
     pricingId: int = sa.Column(sa.BigInteger, sa.ForeignKey("pricing.id"), index=True, primary_key=True)
 
 
 class Pricing(PcObject, Base, Model):
+    __tablename__ = "pricing"
     status: PricingStatus = sa.Column(db_utils.MagicEnum(PricingStatus), index=True, nullable=False)
 
     bookingId = sa.Column(sa.BigInteger, sa.ForeignKey("booking.id"), index=True, nullable=True)
@@ -478,6 +485,7 @@ class Pricing(PcObject, Base, Model):
 
 
 class PricingLine(PcObject, Base, Model):
+    __tablename__ = "pricing_line"
     pricingId = sa.Column(sa.BigInteger, sa.ForeignKey("pricing.id"), index=True, nullable=True)
     pricing: sa_orm.Mapped[Pricing] = sa_orm.relationship("Pricing", foreign_keys=[pricingId], back_populates="lines")
 
@@ -492,6 +500,7 @@ class PricingLog(PcObject, Base, Model):
     changes.
     """
 
+    __tablename__ = "pricing_log"
     pricingId: int = sa.Column(sa.BigInteger, sa.ForeignKey("pricing.id"), index=True, nullable=False)
     pricing: sa_orm.Mapped[Pricing] = sa_orm.relationship("Pricing", foreign_keys=[pricingId], back_populates="logs")
 
@@ -573,6 +582,8 @@ class CustomReimbursementRule(PcObject, ReimbursementRule, Base, Model):
     An offer may be linked to more than one reimbursement rules, but
     only one rule can be valid at a time.
     """
+
+    __tablename__ = "custom_reimbursement_rule"
 
     offerId = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id"), nullable=True)
 
@@ -700,6 +711,7 @@ sa.event.listen(CustomReimbursementRule.__table__, "after_create", sa.DDL(Custom
 class InvoiceCashflow(Base, Model):
     """An association table between invoices and cashflows for their many-to-many relationship."""
 
+    __tablename__ = "invoice_cashflow"
     invoiceId: int = sa.Column(sa.BigInteger, sa.ForeignKey("invoice.id"), index=True, primary_key=True)
     cashflowId: int = sa.Column(sa.BigInteger, sa.ForeignKey("cashflow.id"), index=True, primary_key=True)
 
@@ -719,6 +731,7 @@ class Cashflow(PcObject, Base, Model):
     Cashflows with zero amount are there to enable generating invoices lines with 100% offerer contribution
     """
 
+    __tablename__ = "cashflow"
     creationDate: datetime.datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
     status: CashflowStatus = sa.Column(db_utils.MagicEnum(CashflowStatus), index=True, nullable=False)
 
@@ -754,6 +767,7 @@ class CashflowLog(PcObject, Base, Model):
     changes.
     """
 
+    __tablename__ = "cashflow_log"
     cashflowId: int = sa.Column(sa.BigInteger, sa.ForeignKey("cashflow.id"), index=True, nullable=False)
     cashflow: sa_orm.Mapped[Cashflow] = sa_orm.relationship(
         "Cashflow", foreign_keys=[cashflowId], back_populates="logs"
@@ -771,12 +785,14 @@ class CashflowBatch(PcObject, Base, Model):
     same time (in a single file).
     """
 
+    __tablename__ = "cashflow_batch"
     creationDate: datetime.datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
     cutoff: datetime.datetime = sa.Column(sa.DateTime, nullable=False, unique=True)
     label: str = sa.Column(sa.Text, nullable=False, unique=True)
 
 
 class InvoiceLine(PcObject, Base, Model):
+    __tablename__ = "invoice_line"
     invoiceId: int = sa.Column(sa.BigInteger, sa.ForeignKey("invoice.id"), index=True, nullable=False)
     invoice: sa_orm.Mapped["Invoice"] = sa_orm.relationship("Invoice", foreign_keys=[invoiceId], back_populates="lines")
     label: str = sa.Column(sa.Text, nullable=False)
@@ -823,6 +839,7 @@ class Invoice(PcObject, Base, Model):
     of their related pricings.
     """
 
+    __tablename__ = "invoice"
     date: datetime.datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
     reference: str = sa.Column(sa.Text, nullable=False, unique=True)
     bankAccountId = sa.Column(sa.BigInteger, sa.ForeignKey("bank_account.id"), index=True, nullable=True)
@@ -855,6 +872,7 @@ class Invoice(PcObject, Base, Model):
 # with these models since 2022-01-01. These models have been replaced
 # by `Pricing`, `Cashflow` and other models listed above.
 class Payment(PcObject, Base, Model):
+    __tablename__ = "payment"
     bookingId = sa.Column(sa.BigInteger, sa.ForeignKey("booking.id"), index=True, nullable=True)
     booking: sa_orm.Mapped["bookings_models.Booking"] = sa_orm.relationship(
         "Booking", foreign_keys=[bookingId], backref="payments"
@@ -929,6 +947,7 @@ class TransactionStatus(enum.Enum):
 # `PaymentStatus` is deprecated. See comment above `Payment` model for
 # further details.
 class PaymentStatus(PcObject, Base, Model):
+    __tablename__ = "payment_status"
     paymentId: int = sa.Column(sa.BigInteger, sa.ForeignKey("payment.id"), index=True, nullable=False)
     payment: sa_orm.Mapped[Payment] = sa_orm.relationship("Payment", foreign_keys=[paymentId], backref="statuses")
     date: datetime.datetime = sa.Column(
@@ -941,6 +960,7 @@ class PaymentStatus(PcObject, Base, Model):
 # `PaymentMessage` is deprecated. See comment above `Payment` model
 # for further details.
 class PaymentMessage(PcObject, Base, Model):
+    __tablename__ = "payment_message"
     name: str = sa.Column(sa.String(50), unique=True, nullable=False)
     checksum: bytes = sa.Column(sa.LargeBinary(32), unique=True, nullable=False)
 
@@ -968,6 +988,7 @@ class FinanceIncidentRequestOrigin(enum.Enum):
 
 
 class FinanceIncident(PcObject, Base, Model):
+    __tablename__ = "finance_incident"
     kind: IncidentType = sa.Column(
         sa.Enum(IncidentType, native_enum=False, create_contraint=False),
         nullable=False,
@@ -1091,6 +1112,7 @@ class FinanceIncident(PcObject, Base, Model):
 
 
 class BookingFinanceIncident(PcObject, Base, Model):
+    __tablename__ = "booking_finance_incident"
     bookingId = sa.Column(sa.BigInteger, sa.ForeignKey("booking.id"), index=True, nullable=True)
     booking: sa_orm.Mapped["bookings_models.Booking | None"] = sa_orm.relationship(
         "Booking", foreign_keys=[bookingId], backref="incidents"

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -662,6 +662,7 @@ class BeneficiaryFraudCheck(PcObject, Base, Model):
 class OrphanDmsApplication(PcObject, Base, Model):
     # This model is used to store fraud checks that were not associated with a user.
     # This is mainly used for the DMS fraud check, when the user is not yet created, or in case of a failure.
+    __tablename__ = "orphan_dms_application"
     application_id: int = sa.Column(sa.BigInteger, primary_key=True)  # refers to DMS application "number"
     dateCreated = sa.Column(
         sa.DateTime, nullable=True, default=datetime.datetime.utcnow
@@ -714,6 +715,7 @@ class BlacklistedDomainName(PcObject, Base, Model):
     logged inside the action_history table.
     """
 
+    __tablename__ = "blacklisted_domain_name"
     domain: str = sa.Column(sa.Text, nullable=False, unique=True)
     dateCreated: datetime.datetime = sa.Column(
         sa.DateTime, nullable=False, default=datetime.datetime.utcnow, server_default=sa.func.now()
@@ -725,6 +727,7 @@ class ProductWhitelist(PcObject, Base, Model):
     Contains the whitelisted EAN
     """
 
+    __tablename__ = "product_whitelist"
     title: str = sa.Column(sa.Text, nullable=False)
     ean: str = sa.Column(sa.String(length=13), nullable=False, unique=True, index=True)
     dateCreated: datetime.datetime = sa.Column(

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -810,6 +810,7 @@ class GooglePlacesInfo(PcObject, Base, Model):
 
 
 class AccessibilityProvider(PcObject, Base, Model):
+    __tablename__ = "accessibility_provider"
     venueId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("venue.id", ondelete="CASCADE"), index=True, nullable=False, unique=True
     )
@@ -901,6 +902,7 @@ class VenuePricingPointLink(Base, Model):
     period during which this link is active.
     """
 
+    __tablename__ = "venue_pricing_point_link"
     id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=True, nullable=False)
     venue: sa_orm.Mapped[Venue] = sa_orm.relationship(
@@ -932,6 +934,7 @@ class VenueBankAccountLink(PcObject, Base, Model):
     However, we want to keep tracks of the history, hence that table.
     """
 
+    __tablename__ = "venue_bank_account_link"
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id", ondelete="CASCADE"), index=True, nullable=False)
     venue: sa_orm.Mapped[Venue] = sa_orm.relationship(
         "Venue", foreign_keys=[venueId], back_populates="bankAccountLinks"
@@ -1002,6 +1005,7 @@ class Offerer(
     ValidationStatusMixin,
     DeactivableMixin,
 ):
+    __tablename__ = "offerer"
     dateCreated: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
 
     name: str = sa.Column(sa.String(140), nullable=False)
@@ -1133,7 +1137,7 @@ class Offerer(
 
 
 class UserOfferer(PcObject, Base, Model, ValidationStatusMixin):
-    __table_name__ = "user_offerer"
+    __tablename__ = "user_offerer"
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), primary_key=True)
     user: sa_orm.Mapped["users_models.User"] = sa_orm.relationship(
         "User", foreign_keys=[userId], back_populates="UserOfferers"
@@ -1156,6 +1160,7 @@ class UserOfferer(PcObject, Base, Model, ValidationStatusMixin):
 
 
 class ApiKey(PcObject, Base, Model):
+    __tablename__ = "api_key"
     offererId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offerer.id"), index=True, nullable=False)
     offerer: sa_orm.Mapped[Offerer] = sa_orm.relationship("Offerer", foreign_keys=[offererId], backref="apiKeys")
     providerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("provider.id", ondelete="CASCADE"), index=True)

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -158,6 +158,7 @@ class GcuCompatibilityType(enum.Enum):
 
 
 class Product(PcObject, Base, Model, HasThumbMixin, ProvidableMixin):
+    __tablename__ = "product"
     description = sa.Column(sa.Text, nullable=True)
     durationMinutes = sa.Column(sa.Integer, nullable=True)
     extraData: OfferExtraData | None = sa.Column("jsonData", sa_mutable.MutableDict.as_mutable(postgresql.JSONB))
@@ -1480,6 +1481,7 @@ class BookMacroSection(PcObject, Base, Model):
 
 
 class PriceCategoryLabel(PcObject, Base, Model):
+    __tablename__ = "price_category_label"
     label: str = sa.Column(sa.Text(), nullable=False)
     priceCategories: sa_orm.Mapped[list["PriceCategory"]] = sa_orm.relationship(
         "PriceCategory", back_populates="priceCategoryLabel"
@@ -1497,6 +1499,7 @@ class PriceCategoryLabel(PcObject, Base, Model):
 
 
 class PriceCategory(PcObject, Base, Model):
+    __tablename__ = "price_category"
     offerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id", ondelete="CASCADE"), index=True, nullable=False)
     offer: sa_orm.Mapped["Offer"] = sa_orm.relationship("Offer", back_populates="priceCategories")
     price: decimal.Decimal = sa.Column(

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -139,6 +139,7 @@ class RolePermission(PcObject, Base, Model):
     many-to-many relationship
     """
 
+    __tablename__ = "role_permission"
     roleId: int = sa.Column(sa.BigInteger, sa.ForeignKey("role.id", ondelete="CASCADE"))
     permissionId: int = sa.Column(sa.BigInteger, sa.ForeignKey("permission.id", ondelete="CASCADE"))
     __table_args__ = (sa.UniqueConstraint("roleId", "permissionId", name="role_permission_roleId_permissionId_key"),)

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -23,6 +23,7 @@ if typing.TYPE_CHECKING:
 
 
 class Provider(PcObject, Base, Model, DeactivableMixin):
+    __tablename__ = "provider"
     name: str = sa.Column(sa.String(90), index=True, nullable=False)
 
     localClass = sa.Column(sa.String(60), nullable=True, unique=True)
@@ -76,6 +77,7 @@ class VenueProviderExternalUrls(PcObject, Base, Model, DeactivableMixin):
     Stores external Urls specific for a Venue. It will be set by providers via API.
     """
 
+    __tablename__ = "venue_provider_external_urls"
     venueProviderId: int = sa.Column(
         sa.BigInteger, sa.ForeignKey("venue_provider.id", ondelete="CASCADE"), nullable=False, unique=True
     )
@@ -104,6 +106,7 @@ class VenueProviderExternalUrls(PcObject, Base, Model, DeactivableMixin):
 class VenueProvider(PcObject, Base, Model, DeactivableMixin):
     """Stores specific sync settings for a Venue, and whether it is active"""
 
+    __tablename__ = "venue_provider"
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), nullable=False)
 
     venue: sa_orm.Mapped["Venue"] = sa_orm.relationship("Venue", foreign_keys=[venueId])
@@ -188,6 +191,7 @@ class VenueProvider(PcObject, Base, Model, DeactivableMixin):
 class CinemaProviderPivot(PcObject, Base, Model):
     """Stores whether a Venue has requested to be synced with a Provider"""
 
+    __tablename__ = "cinema_provider_pivot"
     venueId = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=False, nullable=False, unique=True)
 
     venue: sa_orm.Mapped["Venue | None"] = sa_orm.relationship(
@@ -219,6 +223,7 @@ class CinemaProviderPivot(PcObject, Base, Model):
 class CDSCinemaDetails(PcObject, Base, Model):
     """Stores info on the specific login details of a cinema synced with CDS"""
 
+    __tablename__ = "cds_cinema_details"
     cinemaProviderPivotId = sa.Column(
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
@@ -254,6 +259,7 @@ class VenueProviderCreationPayload:
 
 
 class AllocinePivot(PcObject, Base, Model):
+    __tablename__ = "allocine_pivot"
     venueId: int = sa.Column(sa.BigInteger, sa.ForeignKey("venue.id"), index=False, nullable=False, unique=True)
 
     venue: sa_orm.Mapped["Venue"] = sa_orm.relationship(Venue, foreign_keys=[venueId], backref="allocinePivot")
@@ -264,6 +270,7 @@ class AllocinePivot(PcObject, Base, Model):
 
 
 class AllocineTheater(PcObject, Base, Model):
+    __tablename__ = "allocine_theater"
     siret = sa.Column(sa.String(14), nullable=True, unique=True)
 
     theaterId: str = sa.Column(sa.String(20), nullable=False, unique=True)
@@ -282,6 +289,7 @@ class LocalProviderEventType(enum.Enum):
 
 
 class LocalProviderEvent(PcObject, Base, Model):
+    __tablename__ = "local_provider_event"
     providerId: int = sa.Column(sa.BigInteger, sa.ForeignKey("provider.id"), nullable=False)
     provider: sa_orm.Mapped["Provider"] = sa_orm.relationship("Provider", foreign_keys=[providerId])
     date: datetime.datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.datetime.utcnow)
@@ -292,6 +300,7 @@ class LocalProviderEvent(PcObject, Base, Model):
 class BoostCinemaDetails(PcObject, Base, Model):
     """Stores info on the specific login details of a cinema synced with Boost"""
 
+    __tablename__ = "boost_cinema_details"
     cinemaProviderPivotId = sa.Column(
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
@@ -306,6 +315,7 @@ class BoostCinemaDetails(PcObject, Base, Model):
 class CGRCinemaDetails(PcObject, Base, Model):
     """Stores info on the specific login details of a cinema synced with CGR"""
 
+    __tablename__ = "cgr_cinema_details"
     cinemaProviderPivotId = sa.Column(
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )
@@ -320,6 +330,7 @@ class CGRCinemaDetails(PcObject, Base, Model):
 class EMSCinemaDetails(PcObject, Base, Model):
     """Stores info on the specific login details of a cinema synced with EMS"""
 
+    __tablename__ = "ems_cinema_details"
     cinemaProviderPivotId = sa.Column(
         sa.BigInteger, sa.ForeignKey("cinema_provider_pivot.id"), index=False, nullable=True, unique=True
     )

--- a/api/src/pcapi/core/reactions/models.py
+++ b/api/src/pcapi/core/reactions/models.py
@@ -20,6 +20,7 @@ class ReactionTypeEnum(enum.Enum):
 
 
 class Reaction(PcObject, Base, Model):
+    __tablename__ = "reaction"
     reactionType = sa.Column(MagicEnum(ReactionTypeEnum), nullable=False)
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True)
     user: sa_orm.Mapped["User"] = sa_orm.relationship("User", back_populates="reactions")

--- a/api/src/pcapi/core/reference/models.py
+++ b/api/src/pcapi/core/reference/models.py
@@ -44,6 +44,7 @@ class ReferenceScheme(Base, Model):
     was used twice.
     """
 
+    __tablename__ = "reference_scheme"
     id: int = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)
     # known names and prefixes are:
     #   - invoice.reference: F

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -1122,6 +1122,7 @@ class UserAccountUpdateRequest(PcObject, Base, Model):
 
 
 class UserSession(PcObject, Base, Model):
+    __tablename__ = "user_session"
     userId: int = sa.Column(sa.BigInteger, nullable=False)
     uuid: UUID = sa.Column(postgresql.UUID(as_uuid=True), unique=True, nullable=False)
 

--- a/api/src/pcapi/models/beneficiary_import.py
+++ b/api/src/pcapi/models/beneficiary_import.py
@@ -33,6 +33,7 @@ class BeneficiaryImport(PcObject, Base, Model):
     When this data is either transferred to the new model or deleted, we can remove this model.
     """
 
+    __tablename__ = "beneficiary_import"
     applicationId = sa.Column(sa.BigInteger, nullable=True)
 
     beneficiaryId = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=True)

--- a/api/src/pcapi/models/beneficiary_import_status.py
+++ b/api/src/pcapi/models/beneficiary_import_status.py
@@ -35,6 +35,8 @@ class BeneficiaryImportStatus(PcObject, Base, Model):
     When this data is either transferred to the new model or deleted, we can remove this model.
     """
 
+    __tablename__ = "beneficiary_import_status"
+
     def __repr__(self) -> str:
         author = self.author.full_name if self.author else "import automatisé"
         updated_at = datetime.strftime(self.date, "%d/%m/%Y")

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -176,6 +176,7 @@ class FeatureToggle(enum.Enum):
 
 
 class Feature(PcObject, Base, Model, DeactivableMixin):
+    __tablename__ = "feature"
     name: str = Column(Text, unique=True, nullable=False)
     description: str = Column(String(300), nullable=False)
 


### PR DESCRIPTION
## But de la pull request

ajouter un nom de table a tout les models pour éviter de se reposer sur flask_sqlalchemy pour les générer.

Attention bien vérifier qu'il n'y a pas d'inversion entre une table et un model

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
