### PR TITLE
(BSR)[API] feat: use OA fields instead of Venue in adage iframe schema

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1400,6 +1400,9 @@ def get_collective_offer_templates_for_playlist_query(
             sa_orm.joinedload(educational_models.CollectiveOfferTemplate.venue, innerjoin=True).options(
                 sa_orm.joinedload(offerers_models.Venue.managingOfferer, innerjoin=True),
                 sa_orm.joinedload(offerers_models.Venue.googlePlacesInfo),
+                sa_orm.joinedload(offerers_models.Venue.offererAddress).joinedload(
+                    offerers_models.OffererAddress.address
+                ),
             ),
             sa_orm.joinedload(educational_models.CollectiveOfferTemplate.domains),
             *_get_collective_offer_template_address_joinedload_with_expression(),
@@ -1445,6 +1448,9 @@ def get_collective_offer_by_id_for_adage(offer_id: int) -> educational_models.Co
                     offerers_models.Offerer.isActive,
                 ),
                 sa_orm.joinedload(offerers_models.Venue.googlePlacesInfo),
+                sa_orm.joinedload(offerers_models.Venue.offererAddress).joinedload(
+                    offerers_models.OffererAddress.address
+                ),
             ),
             sa_orm.joinedload(educational_models.CollectiveOffer.domains),
             *_get_collective_offer_address_joinedload_with_expression(),
@@ -1461,15 +1467,16 @@ def _get_collective_offer_template_by_id_for_adage_base_query() -> BaseQuery:
         )
         .options(
             sa_orm.joinedload(educational_models.CollectiveOfferTemplate.nationalProgram),
-            sa_orm.joinedload(educational_models.CollectiveOfferTemplate.venue)
-            .joinedload(offerers_models.Venue.managingOfferer)
-            .load_only(
-                offerers_models.Offerer.name,
-                offerers_models.Offerer.validationStatus,
-                offerers_models.Offerer.isActive,
-            ),
-            sa_orm.joinedload(educational_models.CollectiveOfferTemplate.venue).joinedload(
-                offerers_models.Venue.googlePlacesInfo
+            sa_orm.joinedload(educational_models.CollectiveOfferTemplate.venue).options(
+                sa_orm.joinedload(offerers_models.Venue.managingOfferer).load_only(
+                    offerers_models.Offerer.name,
+                    offerers_models.Offerer.validationStatus,
+                    offerers_models.Offerer.isActive,
+                ),
+                sa_orm.joinedload(offerers_models.Venue.googlePlacesInfo),
+                sa_orm.joinedload(offerers_models.Venue.offererAddress).joinedload(
+                    offerers_models.OffererAddress.address
+                ),
             ),
             sa_orm.joinedload(educational_models.CollectiveOfferTemplate.domains),
             *_get_collective_offer_template_address_joinedload_with_expression(),
@@ -1716,6 +1723,9 @@ def get_all_offer_template_by_redactor_id(redactor_id: int) -> list[educational_
             sa_orm.joinedload(educational_models.CollectiveOfferTemplate.venue).options(
                 sa_orm.joinedload(offerers_models.Venue.managingOfferer),
                 sa_orm.joinedload(offerers_models.Venue.googlePlacesInfo),
+                sa_orm.joinedload(offerers_models.Venue.offererAddress).joinedload(
+                    offerers_models.OffererAddress.address
+                ),
             ),
             sa_orm.joinedload(educational_models.CollectiveOfferTemplate.domains),
             *_get_collective_offer_template_address_joinedload_with_expression(),
@@ -1813,6 +1823,9 @@ def get_offers_for_my_institution(uai: str) -> "sa_orm.Query[educational_models.
             sa_orm.joinedload(educational_models.CollectiveOffer.venue).options(
                 sa_orm.joinedload(offerers_models.Venue.managingOfferer),
                 sa_orm.joinedload(offerers_models.Venue.googlePlacesInfo),
+                sa_orm.joinedload(offerers_models.Venue.offererAddress).joinedload(
+                    offerers_models.OffererAddress.address
+                ),
             ),
             sa_orm.joinedload(educational_models.CollectiveOffer.institution),
             sa_orm.joinedload(educational_models.CollectiveOffer.teacher),

--- a/api/src/pcapi/routes/adage_iframe/serialization/offers.py
+++ b/api/src/pcapi/routes/adage_iframe/serialization/offers.py
@@ -70,10 +70,37 @@ class OfferVenueResponse(BaseModel):
 
     @classmethod
     def from_orm(cls, venue: offerers_models.Venue) -> "OfferVenueResponse":
-        venue.coordinates = {"latitude": venue.latitude, "longitude": venue.longitude}
-        venue.address = venue.street
-        result = super().from_orm(venue)
-        return result
+        if venue.offererAddress is not None:
+            source_address = venue.offererAddress.address
+            address = source_address.street
+            city = source_address.city
+            postal_code = source_address.postalCode
+            department_code = source_address.departmentCode
+            coordinates = common_models.Coordinates(
+                latitude=source_address.latitude, longitude=source_address.longitude
+            )
+        else:
+            # TODO(OA): remove this when the virtual venues are migrated
+            address = None
+            city = None
+            postal_code = None
+            department_code = None
+            coordinates = common_models.Coordinates(latitude=None, longitude=None)
+
+        return cls(
+            id=venue.id,
+            address=address,
+            city=city,
+            name=venue.name,
+            postalCode=postal_code,
+            departmentCode=department_code,
+            publicName=venue.publicName,
+            coordinates=coordinates,
+            managingOfferer=venue.managingOfferer,
+            adageId=venue.adageId,
+            distance=None,
+            imgUrl=venue.bannerUrl,
+        )
 
 
 class CollectiveOfferOfferVenue(BaseModel):

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -43,9 +43,10 @@ def offer_fixture():
 def expected_serialized_offer(offer, redactor, offer_venue=None):
     national_program = offer.nationalProgram
     is_favorite = offer.id in {offer.id for offer in redactor.favoriteCollectiveOfferTemplates}
+    address = offer.venue.offererAddress.address
     coordinates = {
-        "longitude": float(offer.venue.longitude),
-        "latitude": float(offer.venue.latitude),
+        "longitude": float(address.longitude),
+        "latitude": float(address.latitude),
     }
 
     return {
@@ -56,16 +57,16 @@ def expected_serialized_offer(offer, redactor, offer_venue=None):
         "name": offer.name,
         "venue": {
             "adageId": offer.venue.adageId,
-            "address": offer.venue.street,
-            "city": offer.venue.city,
+            "address": address.street,
+            "city": address.city,
             "coordinates": coordinates,
             "distance": None,
             "id": offer.venue.id,
             "imgUrl": offer.venue.bannerUrl,
             "managingOfferer": {"name": offer.venue.managingOfferer.name},
             "name": offer.venue.name,
-            "postalCode": offer.venue.postalCode,
-            "departmentCode": offer.venue.departementCode,
+            "postalCode": address.postalCode,
+            "departmentCode": address.departmentCode,
             "publicName": offer.venue.publicName,
         },
         "interventionArea": offer.interventionArea,

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -89,7 +89,7 @@ class CollectiveOfferTest:
                 "managingOfferer": {"name": offer.venue.managingOfferer.name},
                 "name": offer.venue.name,
                 "postalCode": "75002",
-                "departmentCode": offer.venue.departementCode,
+                "departmentCode": "75",
                 "publicName": offer.venue.publicName,
             },
             "audioDisabilityCompliant": False,

--- a/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution_test.py
@@ -55,7 +55,7 @@ class CollectiveOfferTest:
         stocks[2].collectiveOffer.dateArchived = datetime.utcnow() - timedelta(days=1)
         stocks[2].collectiveOffer.isActive = False
 
-        # cancelled booking should not appear in the result when the feature toggle is enabled
+        # cancelled booking should not appear in the result
         stock_with_cancelled_booking = educational_factories.CollectiveStockFactory(
             startDatetime=START_DATE,
             collectiveOffer__institution=institution,
@@ -75,12 +75,44 @@ class CollectiveOfferTest:
         assert response.status_code == 200
         response_data = sorted(response.json["collectiveOffers"], key=lambda offer: offer["id"])
         assert len(response_data) == 2, response_data
+
         assert response_data[0]["id"] == stocks[0].collectiveOffer.id
         assert response_data[0]["educationalInstitution"]["id"] == institution.id
         assert response_data[0]["stock"]["id"] == stocks[0].id
+        venue = stocks[0].collectiveOffer.venue
+        assert response_data[0]["venue"] == {
+            "adageId": None,
+            "address": "1 boulevard Poissonnière",
+            "city": "Paris",
+            "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
+            "distance": None,
+            "id": venue.id,
+            "imgUrl": None,
+            "managingOfferer": {"name": venue.managingOfferer.name},
+            "name": venue.name,
+            "postalCode": "75002",
+            "departmentCode": "75",
+            "publicName": venue.publicName,
+        }
+
         assert response_data[1]["id"] == stocks[1].collectiveOffer.id
         assert response_data[1]["educationalInstitution"]["id"] == institution.id
         assert response_data[1]["stock"]["id"] == stocks[1].id
+        venue = stocks[1].collectiveOffer.venue
+        assert response_data[1]["venue"] == {
+            "adageId": None,
+            "address": "1 boulevard Poissonnière",
+            "city": "Paris",
+            "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
+            "distance": None,
+            "id": venue.id,
+            "imgUrl": None,
+            "managingOfferer": {"name": venue.managingOfferer.name},
+            "name": venue.name,
+            "postalCode": "75002",
+            "departmentCode": "75",
+            "publicName": venue.publicName,
+        }
 
     def test_location_address_venue(self, eac_client):
         institution = educational_factories.EducationalInstitutionFactory(institutionId=UAI)

--- a/api/tests/routes/adage_iframe/get_favorites_test.py
+++ b/api/tests/routes/adage_iframe/get_favorites_test.py
@@ -60,7 +60,7 @@ class GetFavoriteOfferTest:
                         "managingOfferer": {"name": collective_offer_template.venue.managingOfferer.name},
                         "name": collective_offer_template.venue.name,
                         "postalCode": "75002",
-                        "departmentCode": collective_offer_template.venue.departementCode,
+                        "departmentCode": "75",
                         "publicName": collective_offer_template.venue.publicName,
                     },
                     "students": ["Lycée - Seconde"],


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : dans le schema `OfferVenueResponse`, utiliser les champs de OA au lieu de Venue pour la localisation

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
