### PR TITLE
(BSR)[PRO] fix: Margin inbetween offer detail form fields.

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsForm.module.scss
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsForm.module.scss
@@ -1,5 +1,5 @@
 @use "styles/mixins/_rem.scss" as rem;
 
-.url-input {
+.row {
   margin-top: rem.torem(16px);
 }

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsForm.tsx
@@ -78,7 +78,7 @@ export const DetailsForm = ({
     <>
       <FormLayout.Section title="À propos de votre offre">
         {showAddVenueBanner && (
-          <FormLayout.Row>
+          <FormLayout.Row className={styles['row']}>
             <Callout
               links={[
                 {
@@ -99,7 +99,7 @@ export const DetailsForm = ({
         {!showAddVenueBanner && (
           <>
             {venuesOptions.length > 1 && (
-              <FormLayout.Row>
+              <FormLayout.Row className={styles['row']}>
                 <Select
                   label="Qui propose l’offre ?"
                   options={venuesOptions}
@@ -123,7 +123,7 @@ export const DetailsForm = ({
                 />
               </FormLayout.Row>
             )}
-            <FormLayout.Row>
+            <FormLayout.Row className={styles['row']}>
               <TextInput
                 count={watch('name').length}
                 label="Titre de l’offre"
@@ -134,7 +134,10 @@ export const DetailsForm = ({
                 disabled={readOnlyFields.includes('name')}
               />
             </FormLayout.Row>
-            <FormLayout.Row sideComponent={<MarkdownInfoBox />}>
+            <FormLayout.Row
+              sideComponent={<MarkdownInfoBox />}
+              className={styles['row']}
+            >
               <TextArea
                 label="Description"
                 maxLength={10000}
@@ -152,7 +155,7 @@ export const DetailsForm = ({
                     réservé votre offre sur l’application pass Culture.
                   </InfoBox>
                 }
-                className={styles['url-input']}
+                className={styles['row']}
               >
                 <TextInput
                   label="URL d’accès à l’offre"


### PR DESCRIPTION
## But de la pull request

**Objectif**
Corriger les marges du form de détail d'une offre après remplacement de formik par react-hook-form.

Avant/après :
<img width="424" alt="Capture d’écran 2025-05-27 à 14 04 32" src="https://github.com/user-attachments/assets/f1cdb4f0-da6e-4770-aad4-d45754445464" />
<img width="413" alt="Capture d’écran 2025-05-27 à 14 04 11" src="https://github.com/user-attachments/assets/1c588848-3dd0-409a-b9ee-65c6a0f6b04c" />


## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
