### PR TITLE
(PC-36279)[API] fix: do not send emails for free beneficiaries

### DIFF
--- a/api/src/pcapi/core/mails/transactional/users/accepted_as_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/users/accepted_as_beneficiary.py
@@ -5,6 +5,7 @@ from pcapi.core.finance.conf import get_credit_amount_per_age_and_eligibility
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.users.eligibility_api import get_pre_decree_or_current_eligibility
+from pcapi.core.users.models import EligibilityType
 from pcapi.core.users.models import User
 
 
@@ -26,5 +27,8 @@ def get_accepted_as_beneficiary_email_v3_data(user: User) -> models.Transactiona
 
 
 def send_accepted_as_beneficiary_email(user: User) -> None:
+    if user.eligibility == EligibilityType.FREE:
+        return
+
     data = get_accepted_as_beneficiary_email_v3_data(user)
     mails.send(recipients=[user.email], data=data)

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -1939,6 +1939,7 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.has_free_beneficiary_role
         assert user.deposit.type == finance_models.DepositType.GRANT_FREE
         assert not user.deposit.recredits
+        assert not mails_testing.outbox
 
     def test_user_with_old_fraud_checks_get_correct_deposit_and_role(self):
         """


### PR DESCRIPTION
Free offers beneficiaries should not receive the email congratuling them for the 150€ credit unlock.

While waiting for the new email to send instead, we disable the currently sent email for those beneficiaries.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-36279
