### PR TITLE
(PC-36333)[API] fix: avoid push bank account crash if offerer's street is null

### DIFF
--- a/api/src/pcapi/core/finance/backend/cegid.py
+++ b/api/src/pcapi/core/finance/backend/cegid.py
@@ -149,7 +149,7 @@ class CegidFinanceBackend(BaseFinanceBackend):
                     "Country": {"value": "FR"},
                     "City": {"value": bank_account.offerer.city},
                     "PostalCode": {"value": bank_account.offerer.postalCode},
-                    "AddressLine1": {"value": bank_account.offerer.street[:50]},
+                    "AddressLine1": {"value": (bank_account.offerer.street or "")[:50]},
                     "State": {"value": bank_account.offerer.departementCode},
                 },
             },


### PR DESCRIPTION

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-36333

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
