### PR TITLE
(PC-36338)[API] fix: re-onboarding of previously rejected offerer with several venues

### DIFF
--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -2925,7 +2925,13 @@ class CreateFromOnboardingDataTest:
 
     def test_previously_rejected_siren_same_user(self):
         offerer = offerers_factories.RejectedOffererFactory(siren="853318459")
-        rejected_venue_id = offerers_factories.VenueFactory(managingOfferer=offerer, siret="85331845900031").id
+        rejected_venue = offerers_factories.VenueFactory(
+            managingOfferer=offerer, siret="85331845900031", pricing_point="self"
+        )
+        rejected_venue_id = rejected_venue.id
+        rejected_venue_id_without_siret = offerers_factories.VenueWithoutSiretFactory(
+            managingOfferer=offerer, pricing_point=rejected_venue
+        ).id
         user = users_factories.NonAttachedProFactory()
         rejected_user_offerer = offerers_factories.RejectedUserOffererFactory(user=user, offerer=offerer)
 
@@ -2943,7 +2949,7 @@ class CreateFromOnboardingDataTest:
 
         assert len(offerer.managedVenues) == 1
         venue = offerer.managedVenues[0]
-        assert venue.id != rejected_venue_id
+        assert venue.id not in (rejected_venue_id, rejected_venue_id_without_siret)
         assert venue.publicName == onboarding_data.publicName
 
         actions = db.session.query(history_models.ActionHistory).all()


### PR DESCRIPTION
```
Exception was CannotDeleteVenueUsedAsPricingPointException:
...
  File "pcapi/routes/pro/offerers.py", line 206, in save_new_onboarding_data
    user_offerer = api.create_from_onboarding_data(current_user, body)
  File "pcapi/core/offerers/api.py", line 2258, in create_from_onboarding_data
    user_offerer = create_offerer(user, offerer_creation_info, new_onboarding_info)
  File "pcapi/core/offerers/api.py", line 1019, in create_offerer
    delete_venue(venue_id)
  File "pcapi/core/offerers/api.py", line 558, in delete_venue
    raise exceptions.CannotDeleteVenueUsedAsPricingPointException()
```

## But de la pull request

Ticket Jira : https://passculture.atlassian.net/browse/PC-36338

## Vérifications

- [x] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
