### PR TITLE
(PC-35960)[API] feat: future publication: update patch draft offer

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -261,6 +261,9 @@ def update_draft_offer(offer: models.Offer, body: offers_schemas.PatchDraftOffer
             offer.subcategoryId, formatted_extra_data, offer.venue, is_from_private_api=True, offer=offer, ean=body_ean
         )
 
+    changes = {key: {"old": getattr(offer, key), "new": new_value} for key, new_value in updates.items()}
+    on_commit(partial(logger.info, "update draft offer", extra={"offer": offer.id, "changes": changes}))
+
     for key, value in updates.items():
         if key == "extraData":
             if offer.product:

--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -192,6 +192,10 @@ class PatchDraftOfferBodyModel(BaseModel):
     description: str | None = Field(max_length=OFFER_DESCRIPTION_MAX_LENGTH)
     extra_data: dict[str, typing.Any] | None = None
     duration_minutes: int | None = None
+    publicationDatetime: datetime.datetime | None
+    bookingAllowedDatetime: datetime.datetime | None
+
+    _validate_publication_datetime = serialization_utils.validate_datetime("publicationDatetime")
 
     @validator("name", pre=True)
     def validate_name(cls, name: str, values: dict) -> str:
@@ -204,6 +208,40 @@ class PatchDraftOfferBodyModel(BaseModel):
 
         check_offer_subcategory_is_valid(subcategory_id)
         return subcategory_id
+
+    @root_validator(pre=True)
+    def validate_publication_dt_and_booking_allowed_dt_set_together(cls, values: dict) -> dict:
+        publication_dt = values.get("publicationDatetime")
+        booking_allowed_dt = values.get("bookingAllowedDatetime")
+
+        if publication_dt and booking_allowed_dt:
+            return values
+
+        if not publication_dt and not booking_allowed_dt:
+            return values
+
+        raise ValueError("either both `publicationDatetime` and `bookingAllowedDatetime` are set or both are null")
+
+    @validator("bookingAllowedDatetime")
+    def validate_booking_allowed_datetime(
+        cls, bookingAllowedDatetime: datetime.datetime | None, values: dict
+    ) -> datetime.datetime | None:
+        booking_allowed_dt = serialization_utils.check_date_in_future_and_remove_timezone(bookingAllowedDatetime)
+        if not booking_allowed_dt:
+            return None
+
+        try:
+            publication_dt = values["publicationDatetime"]
+        except KeyError:
+            # publicationDatetime cannot be null at this point, therefore, if
+            # it is missing it means that it did not pass parsing/validation.
+            # There is no need to raise it again in another way.
+            return booking_allowed_dt
+
+        if publication_dt > booking_allowed_dt:
+            raise ValueError("must be after `publicationDatetime`")
+
+        return booking_allowed_dt
 
     class Config:
         alias_generator = serialization_utils.to_camel

--- a/pro/src/apiClient/v1/models/PatchDraftOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchDraftOfferBodyModel.ts
@@ -3,10 +3,12 @@
 /* tslint:disable */
 /* eslint-disable */
 export type PatchDraftOfferBodyModel = {
+  bookingAllowedDatetime?: string | null;
   description?: string | null;
   durationMinutes?: number | null;
   extraData?: Record<string, any> | null;
   name?: string | null;
+  publicationDatetime?: string | null;
   subcategoryId?: string | null;
   url?: string | null;
 };


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35960

Permettre l'ajout des dates de publication et de d'ouverture des réservations pour une offre, sur le portail PRO.
Ces deux dates sont obligatoires, ne peuvent être dans le passé et la date d'ouverture des réservation ne peut être avant celle de publication.
