### PR TITLE
(PC-35565)[API] fix: eligibility for next recredit from 16 to 17 year old

### DIFF
--- a/api/src/pcapi/core/users/eligibility_api.py
+++ b/api/src/pcapi/core/users/eligibility_api.py
@@ -206,8 +206,14 @@ def is_eligible_for_next_recredit_activation_steps(user: users_models.User) -> b
     if not user.is_beneficiary:
         return user.is_eligible
 
-    if not user.has_beneficiary_role:
+    if user.has_beneficiary_role:
+        return False
+
+    if user.has_underage_beneficiary_role:
         return user.is_18_or_above_eligible
+
+    if user.has_free_beneficiary_role:
+        return user.is_underage_eligible or user.is_18_or_above_eligible
 
     return False
 

--- a/api/tests/core/users/test_eligibility.py
+++ b/api/tests/core/users/test_eligibility.py
@@ -349,6 +349,42 @@ class EligibilityForNextRecreditActivationStepsTest:
 
         assert can_do_next_activation_steps
 
+    @pytest.mark.parametrize("age", [17, 18])
+    def test_next_recredit_steps_from_free_eligibility_to_underage_or_eighteen(self, age):
+        user = users_factories.UserFactory(age=age, roles=[users_models.UserRole.FREE_BENEFICIARY])
+
+        can_do_next_activation_steps = eligibility_api.is_eligible_for_next_recredit_activation_steps(user)
+
+        assert can_do_next_activation_steps
+
+    def test_next_recredit_steps_from_underage_eligibility_to_eighteen(self):
+        user = users_factories.UserFactory(age=18, roles=[users_models.UserRole.UNDERAGE_BENEFICIARY])
+
+        can_do_next_activation_steps = eligibility_api.is_eligible_for_next_recredit_activation_steps(user)
+
+        assert can_do_next_activation_steps
+
+    def test_next_recredit_steps_not_available_for_sixteen_free_beneficiary(self):
+        user = users_factories.UserFactory(age=16, roles=[users_models.UserRole.FREE_BENEFICIARY])
+
+        can_do_next_activation_steps = eligibility_api.is_eligible_for_next_recredit_activation_steps(user)
+
+        assert not can_do_next_activation_steps
+
+    def test_next_recredit_steps_not_available_for_seventeen_underage_beneficiary(self):
+        user = users_factories.UserFactory(age=17, roles=[users_models.UserRole.UNDERAGE_BENEFICIARY])
+
+        can_do_next_activation_steps = eligibility_api.is_eligible_for_next_recredit_activation_steps(user)
+
+        assert not can_do_next_activation_steps
+
+    def test_next_recredit_steps_not_available_for_eighteen_beneficiary(self):
+        user = users_factories.UserFactory(roles=[users_models.UserRole.BENEFICIARY])
+
+        can_do_next_activation_steps = eligibility_api.is_eligible_for_next_recredit_activation_steps(user)
+
+        assert not can_do_next_activation_steps
+
 
 class EligibilityDatesTest:
     @pytest.mark.features(WIP_FREE_ELIGIBILITY=False)


### PR DESCRIPTION
Going from a `FREE_GRANT` deposit to a `GRANT_17_18` should be considered as an eligibility upgrade for the app.

## But de la pull request

Ticket Jira (ou description si BSR) : https://passculture.atlassian.net/browse/PC-35565
