### PR TITLE
(IC-183)[API] ci: use github app for pull request environments

### DIFF
--- a/.github/workflows/dev_on_dispatch_delete_pullrequest_deployment.yaml
+++ b/.github/workflows/dev_on_dispatch_delete_pullrequest_deployment.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   delete-pullrequest-deployment:
-    name: "Delete PR deployment" 
+    name: "Delete PR deployment"
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -17,28 +17,41 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: "Authentification to Google"
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
       # Get github api token
       - name: "Get secrets (github)"
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        id: "secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
-            API_TOKEN_GITHUB:passculture-metier-ehp/passculture-main-sa-access-token
             DEPLOYMENT_SA:passculture-metier-ehp/pcapi-testing_deploy-service-account
             DEPLOYMENT_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/gcp_metier_ehp_workload_identity_provider
 
+      - name: Authenticate through github app ghactionci
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: github-token
+        with:
+          app-id: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_ID }}
+          private-key: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          # Liste des repositories à cloner
+          repositories: |
+            pass-culture-deployment
+            pass-culture-main
+            rendered-manifests
+            pc-connect
+          permission-contents: write
       # Checkout rendered-manifests repository
       - uses: actions/checkout@v4
         with:
           repository: pass-culture/rendered-manifests
-          token: ${{ steps.secrets.outputs.API_TOKEN_GITHUB }}
+          token: ${{ steps.github-token.outputs.token }}
           path: ./rendered-manifests
-          ref: 'pcapi/pullrequests'
+          ref: "pcapi/pullrequests"
 
       - name: "Delete PR deployment"
         run: |
@@ -56,7 +69,7 @@ jobs:
           fi
 
       - name: "Authentification to Google"
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
           service_account: ${{ steps.secrets.outputs.DEPLOYMENT_SA }}
           workload_identity_provider: ${{ steps.secrets.outputs.DEPLOYMENT_WORKLOAD_IDENTITY_PROVIDER }}
@@ -66,7 +79,7 @@ jobs:
         with:
           cluster_scope: metier
           cluster_environment: ehp
-          api_token_github: ${{ steps.secrets.outputs.API_TOKEN_GITHUB }}
+          api_token_github: ${{ steps.github-token.outputs.token }}
 
       - name: "Wait for argocd applications to be deleted; delete namespace"
         continue-on-error: true

--- a/.github/workflows/dev_on_dispatch_deploy_pullrequests.yml
+++ b/.github/workflows/dev_on_dispatch_deploy_pullrequests.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       sandbox:
-        description: 'Sandbox installed'
+        description: "Sandbox installed"
         required: true
-        default: 'empty'
+        default: "empty"
         type: choice
         options:
           - empty
           - industrial
       front-only:
-        description: 'Deploy only frontend (skip API deploy)'
+        description: "Deploy only frontend (skip API deploy)"
         required: false
         default: false
         type: boolean
@@ -24,9 +24,9 @@ env:
 
 jobs:
   deploy-preview-env-init:
-    name: 'Init'
+    name: "Init"
     runs-on: ubuntu-latest
-    outputs: 
+    outputs:
       # checksum-tag is the sha1sum of the api folder. It is used to tag the docker image
       checksum-tag: ${{ steps.pcapi-tags.outputs.checksum-tag }}
       # resource_label names every resources created by this workflow. It is the sha1sum of the branch name
@@ -134,11 +134,11 @@ jobs:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-
   deploy-api:
     name: "Deploy pullrequest"
     runs-on: ubuntu-latest
-    needs: [deploy-preview-env-init, push-pcapi, deploy-pro-on-firebase-preview-env]
+    needs:
+      [deploy-preview-env-init, push-pcapi, deploy-pro-on-firebase-preview-env]
     if: always() && !failure() && !cancelled() && inputs.front-only == false
     environment: pullrequest
     permissions:
@@ -149,25 +149,39 @@ jobs:
         with:
           ref: ${{github.ref}}
       - name: "Authentification to Google"
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
       # Get github api token that will be used to commit and push api_version to pass-culture-deployment repository
       - name: "Get secrets (github)"
-        id: 'secrets'
-        uses: 'google-github-actions/get-secretmanager-secrets@v2'
+        id: "secrets"
+        uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
-            API_TOKEN_GITHUB:passculture-metier-ehp/passculture-main-sa-access-token
             DEPLOYMENT_SA:passculture-metier-ehp/pcapi-testing_deploy-service-account
             DEPLOYMENT_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/gcp_metier_ehp_workload_identity_provider
 
-      - name: "Authentification to Google"
-        uses: 'google-github-actions/auth@v2'
+      - name: Authenticate through github app ghactionci
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: github-token
         with:
-          service_account : ${{ steps.secrets.outputs.DEPLOYMENT_SA }}
+          app-id: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_ID }}
+          private-key: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          # Liste des repositories à cloner
+          repositories: |
+            pass-culture-deployment
+            pass-culture-main
+            rendered-manifests
+            pc-connect
+          permission-contents: write
+
+      - name: "Authentification to Google"
+        uses: "google-github-actions/auth@v2"
+        with:
+          service_account: ${{ steps.secrets.outputs.DEPLOYMENT_SA }}
           workload_identity_provider: ${{ steps.secrets.outputs.DEPLOYMENT_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: "Connect to cluster"
@@ -175,14 +189,14 @@ jobs:
         with:
           cluster_scope: metier
           cluster_environment: ehp
-          api_token_github: ${{ steps.secrets.outputs.API_TOKEN_GITHUB }}
+          api_token_github: ${{ steps.github-token.outputs.token }}
 
       # Checkout pass-culture-deployment repository containing pcapi helm value files
       - uses: actions/checkout@v4.2.1
         with:
           repository: pass-culture/pass-culture-deployment
           ref: master
-          token: ${{ steps.secrets.outputs.API_TOKEN_GITHUB }}
+          token: ${{ steps.github-token.outputs.token }}
           path: ./pass-culture-deployment
 
       # Get pcapi secrets from source code, to be passed later as a helmfile parameter.
@@ -198,7 +212,7 @@ jobs:
           PCAPI_SECRETS=secrets={$(echo $PCAPI_SECRETS | sed -r 's/ /,/g')}
           echo "PCAPI_SECRETS=$PCAPI_SECRETS" >> "$GITHUB_OUTPUT"
 
-      # Create pullrequest namespace and externalsecret containing pgsql credentials 
+      # Create pullrequest namespace and externalsecret containing pgsql credentials
       - name: "Installing Pullrequest deployment prerequisites"
         run: |
           set -e
@@ -226,9 +240,9 @@ jobs:
 
       # We have to reauthenticate to GCP because render-manifests removes previous authenthication
       - name: "Authentification to Google"
-        uses: 'google-github-actions/auth@v2'
+        uses: "google-github-actions/auth@v2"
         with:
-          service_account : ${{ steps.secrets.outputs.DEPLOYMENT_SA }}
+          service_account: ${{ steps.secrets.outputs.DEPLOYMENT_SA }}
           workload_identity_provider: ${{ steps.secrets.outputs.DEPLOYMENT_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: "Connect to cluster"
@@ -236,7 +250,7 @@ jobs:
         with:
           cluster_scope: metier
           cluster_environment: ehp
-          api_token_github: ${{ steps.secrets.outputs.API_TOKEN_GITHUB }}
+          api_token_github: ${{ steps.github-token.outputs.token }}
 
       # Wait for ApplicationSet Controller to create applications
       # TODO : Change to webhook once appset controller ingress gets proper Health endpoint

--- a/.github/workflows/dev_on_pull_request_closed.yml
+++ b/.github/workflows/dev_on_pull_request_closed.yml
@@ -26,10 +26,24 @@ jobs:
         uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
-            API_TOKEN_GITHUB:passculture-metier-ehp/passculture-main-sa-access-token
             FIREBASE_SERVICE_ACCOUNT_TESTING:passculture-metier-ehp/pc_pro_testing_firebase_json
             DEPLOYMENT_SA:passculture-metier-ehp/pcapi-testing_deploy-service-account
             DEPLOYMENT_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/gcp_metier_ehp_workload_identity_provider
+
+      - name: Authenticate through github app ghactionci
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: github-token
+        with:
+          app-id: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_ID }}
+          private-key: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          # Liste des repositories à cloner
+          repositories: |
+            pass-culture-deployment
+            pass-culture-main
+            rendered-manifests
+            pc-connect
+          permission-contents: write
 
       # Set up Cloud SDK
       - name: "Set up Cloud SDK"
@@ -41,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: pass-culture/rendered-manifests
-          token: ${{ steps.secrets.outputs.API_TOKEN_GITHUB }}
+          token: ${{ steps.github-token.outputs.token }}
           path: ./rendered-manifests
           ref: "pcapi/pullrequests"
 
@@ -71,7 +85,7 @@ jobs:
         with:
           cluster_scope: metier
           cluster_environment: ehp
-          api_token_github: ${{ steps.secrets.outputs.API_TOKEN_GITHUB }}
+          api_token_github: ${{ steps.github-token.outputs.token }}
 
       - name: "Wait for argocd applications to be deleted; delete namespace"
         continue-on-error: true

--- a/.github/workflows/dev_on_schedule_delete_pullrequest_deployments.yml
+++ b/.github/workflows/dev_on_schedule_delete_pullrequest_deployments.yml
@@ -5,7 +5,7 @@ on:
     # This cron is defined in UTC timezone. It means that it will run :
     # - during summer hours between 7:27am - 7:27pm
     # - during winter hours between 6:27am - 6:27pm
-    # we cannot yet specify timezone : 
+    # we cannot yet specify timezone :
     # https://github.com/orgs/community/discussions/13454
     # Why 27? Choosing an exact hour or half-hour is discouraged by GitHub due to high load.
     # Cron jobs might be delayed or even completely skipped.
@@ -34,15 +34,29 @@ jobs:
         uses: "google-github-actions/get-secretmanager-secrets@v2"
         with:
           secrets: |-
-            API_TOKEN_GITHUB:passculture-metier-ehp/passculture-main-sa-access-token
             DEPLOYMENT_SA:passculture-metier-ehp/pcapi-testing_deploy-service-account
             DEPLOYMENT_WORKLOAD_IDENTITY_PROVIDER:passculture-metier-ehp/gcp_metier_ehp_workload_identity_provider
+
+      - name: Authenticate through github app ghactionci
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: github-token
+        with:
+          app-id: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_ID }}
+          private-key: ${{ secrets.PASSCULTURE_GITHUB_ACTION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          # Liste des repositories à cloner
+          repositories: |
+            pass-culture-deployment
+            pass-culture-main
+            rendered-manifests
+            pc-connect
+          permission-contents: write
 
       # Checkout rendered-manifests repository
       - uses: actions/checkout@v4
         with:
           repository: pass-culture/rendered-manifests
-          token: ${{ steps.secrets.outputs.API_TOKEN_GITHUB }}
+          token: ${{ steps.github-token.outputs.token }}
           path: ./rendered-manifests
           ref: "pcapi/pullrequests"
 
@@ -63,7 +77,7 @@ jobs:
         with:
           cluster_scope: metier
           cluster_environment: ehp
-          api_token_github: ${{ steps.secrets.outputs.API_TOKEN_GITHUB }}
+          api_token_github: ${{ steps.github-token.outputs.token }}
 
       - name: "Delete PR deployments"
         run: |


### PR DESCRIPTION
## But de la pull request

Ticket Jira [IC-183](https://www.notion.so/passcultureapp/Github-Auth-Utiliser-l-authent-par-app-Github-pass-culture-main-1ebad4e0ff988002be3cc950f7c3fc38?source=copy_link)

Exemple de pipeline qui marche : https://github.com/pass-culture/pass-culture-main/actions/runs/15349390431/job/43193465622

