### PR TITLE
(BSR)[API] chore: remove versions to avoid warnings

### DIFF
--- a/docker-compose-backend-workers.yml
+++ b/docker-compose-backend-workers.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   postgres:
     extends:

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   postgres:
     image: postgis/postgis:15-3.4-alpine


### PR DESCRIPTION
## But de la pull request

Ticket Jira (ou description si BSR) : Pour éviter `WARN[0000] /Users/.../pass-culture-main/docker-compose-backend.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion`

## Vérifications

- [ ] J'ai écrit les tests nécessaires
- [ ] J'ai mis à jour le fichier des [plans de tests](https://docs.google.com/spreadsheets/d/12I9f68L312xEE8lKFN7LsBHO2M_tcBBMSs0Be6qCQ98/edit) du portail pro si nécessaire
- [ ] J'ai mis à jour [la liste des routes et des titres](https://www.notion.so/passcultureapp/Titre-des-pages-de-l-espace-Pro-f4e490619bc54010adeb67c86d5e6a40?pvs=4) de pages du portail pro si j'en ai rajouté/modifié ou supprimé une.
- [ ] J'ai [relu attentivement les migrations](https://www.notion.so/passcultureapp/Clarifier-les-pratiques-de-migration-de-BDD-5f8edeba57ed4a17b80c847a74def027), en particulier pour éviter les _locks_, et je préviens les équipes Shérif et Data
- [ ] J'ai ajouté des screenshots pour d'éventuels changements graphiques
- [ ] J'ai fait la revue fonctionnelle de mon ticket
