### PR TITLE
(PC-35956)[BO] feat: Allow BO users to create venue without siret

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -11,6 +11,7 @@ from datetime import date
 from datetime import datetime
 from datetime import timedelta
 from math import ceil
+from typing import Optional
 
 import jwt
 import pytz
@@ -443,11 +444,17 @@ def upsert_venue_opening_hours(venue: models.Venue, opening_hours: serialize_bas
     return venue
 
 
-def create_venue(venue_data: venues_serialize.PostVenueBodyModel, author: users_models.User) -> models.Venue:
+def create_venue(
+    venue_data: venues_serialize.PostVenueBodyModel,
+    author: users_models.User,
+    offerer_address: Optional[models.OffererAddress] = None,
+) -> models.Venue:
     venue = models.Venue()
     address = venue_data.address
 
-    if utils_regions.NON_DIFFUSIBLE_TAG in address.street:
+    if offerer_address:
+        pass
+    elif utils_regions.NON_DIFFUSIBLE_TAG in address.street:
         address_info = api_adresse.get_municipality_centroid(address.city, address.postalCode)
         address_info.street = utils_regions.NON_DIFFUSIBLE_TAG
         address = get_or_create_address(

--- a/api/src/pcapi/routes/backoffice/pro/forms.py
+++ b/api/src/pcapi/routes/backoffice/pro/forms.py
@@ -75,6 +75,25 @@ class CompactProSearchForm(ProSearchForm):
     departments = fields.PCSelectMultipleField("Départements", choices=area_choices, search_inline=True)
 
 
+class CreateVenueWithoutSIRETForm(FlaskForm):
+    public_name = fields.PCStringField(
+        "Nom d'usage du partenaire culturel",
+        validators=(
+            wtforms.validators.DataRequired("Information obligatoire"),
+            wtforms.validators.Length(max=255, message="doit contenir au maximum %(max)d caractères"),
+        ),
+    )
+    attachement_venue = fields.PCSelectWithPlaceholderValueField("SIRET de rattachement", choices=[], coerce=int)
+
+    def __init__(self, offerer: offerers_models.Offerer, *args: typing.Any, **kwargs: typing.Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.attachement_venue.choices = [
+            (offerer_venue.id, f"{offerer_venue.siret} ({offerer_venue.common_name})")
+            for offerer_venue in offerer.managedVenues
+            if offerer_venue.siret
+        ]
+
+
 class CreateOffererForm(FlaskForm):
     email = fields.PCEmailField("Adresse email du compte pro")
     siret = fields.PCSiretField("SIRET")

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/managed_venues.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/managed_venues.html
@@ -1,7 +1,15 @@
 {% from "components/badges.html" import build_fraudulent_booking_badge %}
 {% import "components/links.html" as links with context %}
 {% from "components/connect_as.html" import build_connect_as_link %}
+{% from "components/turbo/lazy_modal.html" import build_lazy_modal with context %}
 <turbo-frame id="offerer_venues_frame">
+{% if has_permission("CREATE_PRO_ENTITY") %}
+  <button class="btn btn-outline-primary-subtle-bg mt-2"
+          data-bs-toggle="modal"
+          data-bs-target="#create-venue-modal"
+          type="button">Ajouter un partenaire sans SIRET</button>
+  {{ build_lazy_modal(url_for('backoffice_web.offerer.get_create_venue_without_siret_form', offerer_id=offerer_id) , "create-venue-modal") }}
+{% endif %}
 <table class="table table-hover my-4">
   <thead>
     <tr>


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-35956)

Il est désormais possible de créer une venue sans SIRET dans le BO. Cette création se base sur une venue avec SIRET, reprend toutes ses informations sauf le nom d'usage qui est à remplir dans le formulaire.

- Ajout d'un formulaire
- Ajout d'une nouvelle route
- Mise à jour des templates

## 🖼️ Before & After Images

Ajout du bouton permettant la création d'un partenaire culturel sans siret 

![image](https://github.com/user-attachments/assets/783d28e3-930f-48aa-9c16-8b072c7ee275)

![image](https://github.com/user-attachments/assets/d8f9afc5-1281-42ce-8bde-12e2990198eb)
