### PR TITLE
(PC-36483)[API] feat: use `EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS` in `synchronize_venue_provider`

### DIFF
--- a/api/src/pcapi/connectors/ems.py
+++ b/api/src/pcapi/connectors/ems.py
@@ -57,13 +57,18 @@ class EMSScheduleConnector(AbstractEMSConnector):
         return settings.EMS_API_URL
 
     def get_schedules(self, version: int = 0) -> ems_serializers.ScheduleResponse:
-        response = requests.get(url=self.build_url(), auth=self.build_auth(), params=self.build_query_params(version))
+        response = requests.get(
+            url=self.build_url(),
+            auth=self.build_auth(),
+            params=self.build_query_params(version),
+            timeout=settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
+        )
 
         self._check_response_is_ok(response)
         return pydantic_v1.parse_obj_as(ems_serializers.ScheduleResponse, response.json())
 
     def get_movie_poster_from_api(self, image_url: str) -> bytes:
-        api_response = requests.get(image_url)
+        api_response = requests.get(image_url, timeout=settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS)
 
         if api_response.status_code != 200:
             raise EMSAPIException(
@@ -78,7 +83,12 @@ class EMSSitesConnector(AbstractEMSConnector):
         return settings.EMS_SITES_API_URL
 
     def get_available_sites(self, version: int = 0) -> list[ems_serializers.Site]:
-        response = requests.get(url=self.build_url(), auth=self.build_auth(), params=self.build_query_params(version))
+        response = requests.get(
+            url=self.build_url(),
+            auth=self.build_auth(),
+            params=self.build_query_params(version),
+            timeout=settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
+        )
 
         self._check_response_is_ok(response)
         serialized_site_response = pydantic_v1.parse_obj_as(ems_serializers.SitesResponse, response.json())

--- a/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
@@ -6,6 +6,7 @@ from typing import Iterator
 
 import PIL
 
+from pcapi import settings
 from pcapi.connectors import thumb_storage
 from pcapi.connectors.serialization import boost_serializers
 from pcapi.core.categories import subcategories
@@ -254,15 +255,15 @@ class BoostStocks(LocalProvider):
         return True
 
     def _get_showtimes(self) -> list[boost_serializers.ShowTime4]:
-        client_boost = BoostClientAPI(self.cinema_id)
+        client_boost = BoostClientAPI(self.cinema_id, request_timeout=settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS)
         return client_boost.get_showtimes()
 
     def _get_boost_movie_poster(self, image_url: str) -> bytes:
-        client_boost = BoostClientAPI(self.cinema_id)
+        client_boost = BoostClientAPI(self.cinema_id, request_timeout=settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS)
         return client_boost.get_movie_poster(image_url)
 
     def _get_cinema_attributs(self) -> list[boost_serializers.CinemaAttribut]:
-        client_boost = BoostClientAPI(self.cinema_id)
+        client_boost = BoostClientAPI(self.cinema_id, request_timeout=settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS)
         return client_boost.get_cinemas_attributs()
 
 

--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -59,6 +59,7 @@ class CDSStocks(LocalProvider):
             account_id=self.accountId,
             api_url=self.apiUrl,
             cinema_api_token=self.apiToken,
+            request_timeout=settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
         )
         self.movies: Iterator[MediaCDS] = iter(self.client_cds.get_venue_movies())
         self.media_options = self.client_cds.get_media_options()

--- a/api/src/pcapi/local_providers/cinema_providers/cgr/cgr_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cgr/cgr_stocks.py
@@ -11,6 +11,7 @@ import pcapi.core.offers.exceptions as offers_exceptions
 import pcapi.core.offers.models as offers_models
 import pcapi.core.offers.repository as offers_repository
 import pcapi.core.providers.models as providers_models
+from pcapi import settings
 from pcapi.connectors import thumb_storage
 from pcapi.connectors.cgr.cgr import get_movie_poster_from_api
 from pcapi.connectors.serialization import cgr_serializers
@@ -43,7 +44,9 @@ class CGRStocks(LocalProvider):
         super().__init__(venue_provider)
         self.venue = venue_provider.venue
         self.cinema_id = venue_provider.venueIdAtOfferProvider
-        self.cgr_client_api = CGRClientAPI(self.cinema_id)
+        self.cgr_client_api = CGRClientAPI(
+            self.cinema_id, request_timeout=settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS
+        )
         self.isDuo = bool(venue_provider.isDuoOffers)
         self.films: Iterator[cgr_serializers.Film] = iter(self.cgr_client_api.get_films())
         self.last_offer: offers_models.Offer | None = None


### PR DESCRIPTION


## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36483)


## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
