### PR TITLE
(PC-36481)[API] refactor: replace `db.session.query(Model).get(id)` b…

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
@@ -145,7 +145,7 @@ def build_saml_request_id_key(saml_request_id: str) -> str:
 
 
 def _get_mocked_user_for_performance_tests(user_id: str) -> models.EduconnectUser:
-    user = db.session.query(users_models.User).get(int(user_id))
+    user = db.session.get(users_models.User, int(user_id))
     mocked_saml_request_id = f"saml-request-id_perf-test_{user.id}"
     key = build_saml_request_id_key(mocked_saml_request_id)
     app.redis_client.set(name=key, value=user.id, ex=constants.EDUCONNECT_SAML_REQUEST_ID_TTL)

--- a/api/src/pcapi/core/CONTRIBUTING.md
+++ b/api/src/pcapi/core/CONTRIBUTING.md
@@ -69,7 +69,7 @@ def test_flush_inside_transaction():
     db.session.flush()
     venue_type_id = venue_type.id
     db.session.rollback()
-    assert db.session.query(offerers_models.VenueType).get(venue_type_id) is not None # the object is still present
+    assert db.session.get(offerers_models.VenueType, venue_type_id) is not None # the object is still present
 
 
 @conftest.clean_database

--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -1134,7 +1134,7 @@ def get_offer_event_venue(offer: AnyCollectiveOffer) -> offerers_models.Venue:
 
     # the offer takes place in a specific venue
     if address_type == educational_models.OfferAddressType.OFFERER_VENUE.value and offerer_venue_id:
-        venue = db.session.query(offerers_models.Venue).get(offerer_venue_id)
+        venue = db.session.get(offerers_models.Venue, offerer_venue_id)
     else:
         venue = None
 

--- a/api/src/pcapi/core/educational/api/playlists.py
+++ b/api/src/pcapi/core/educational/api/playlists.py
@@ -129,7 +129,7 @@ def synchronize_collective_playlist(playlist_type: educational_models.PlaylistTy
     for row in ctx.query().execute(page_size=BIGQUERY_PLAYLIST_BATCH_SIZE):
         current_institution_id = int(getattr(row, "institution_id"))
         if institution is None:
-            institution = db.session.query(educational_models.EducationalInstitution).get(current_institution_id)
+            institution = db.session.get(educational_models.EducationalInstitution, current_institution_id)
         if institution.id != current_institution_id:
             try:
                 with transaction():
@@ -137,7 +137,7 @@ def synchronize_collective_playlist(playlist_type: educational_models.PlaylistTy
             except Exception:
                 logger.exception("Failed to synchronize institution %s playlist from BigQuery", institution.id)
                 db.session.rollback()
-            institution = db.session.query(educational_models.EducationalInstitution).get(current_institution_id)
+            institution = db.session.get(educational_models.EducationalInstitution, current_institution_id)
             institution_rows = []
         institution_rows.append(row)
     # Don't forget to synchronize the latest institution

--- a/api/src/pcapi/core/educational/validation.py
+++ b/api/src/pcapi/core/educational/validation.py
@@ -107,7 +107,7 @@ def check_user_can_prebook_collective_stock(uai: str, stock: models.CollectiveSt
 
 
 def check_institution_id_exists(institution_id: int) -> models.EducationalInstitution:
-    institution = db.session.query(models.EducationalInstitution).get(institution_id)
+    institution = db.session.get(models.EducationalInstitution, institution_id)
     if not institution:
         raise exceptions.EducationalInstitutionNotFound()
     return institution

--- a/api/src/pcapi/core/external/compliance.py
+++ b/api/src/pcapi/core/external/compliance.py
@@ -28,7 +28,7 @@ def make_update_offer_compliance_score(payload: GetComplianceScoreRequest) -> No
     data_score, data_reasons = compliance_backend.get_score_from_compliance_api(payload)
 
     if data_score:
-        offer = db.session.query(offers_models.Offer).with_for_update().get(payload.offer_id)
+        offer = db.session.query(offers_models.Offer).with_for_update().filter_by(id=payload.offer_id).one_or_none()
         if offer is None:  # if offer is deleted before the task is run
             return
         statement = insert(offers_models.OfferCompliance).values(

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1655,7 +1655,7 @@ def find_reimbursement_rule(rule_reference: str | int) -> models.ReimbursementRu
             if rule_reference == regular_rule.description:
                 return regular_rule
     # CustomReimbursementRule.id
-    return db.session.query(models.CustomReimbursementRule).get(rule_reference)
+    return db.session.get(models.CustomReimbursementRule, rule_reference)
 
 
 def _make_invoice_lines(

--- a/api/src/pcapi/core/finance/backend/__init__.py
+++ b/api/src/pcapi/core/finance/backend/__init__.py
@@ -16,7 +16,7 @@ _backends = [
 
 def push_invoice(invoice_id: int) -> dict | None:
     backend = _get_backend()
-    invoice = db.session.query(finance_models.Invoice).get(invoice_id)
+    invoice = db.session.get(finance_models.Invoice, invoice_id)
     return backend.push_invoice(invoice)
 
 

--- a/api/src/pcapi/core/finance/backend/dummy.py
+++ b/api/src/pcapi/core/finance/backend/dummy.py
@@ -21,7 +21,7 @@ class DummyFinanceBackend(BaseFinanceBackend):
         return invoice.__dict__
 
     def get_bank_account(self, bank_account_id: int) -> dict:
-        bank_account = db.session.query(finance_models.BankAccount).get(bank_account_id)
+        bank_account = db.session.get(finance_models.BankAccount, bank_account_id)
         return bank_account.__dict__
 
     @property

--- a/api/src/pcapi/core/finance/commands.py
+++ b/api/src/pcapi/core/finance/commands.py
@@ -85,7 +85,7 @@ def generate_invoices(batch_id: int) -> None:
 
     This command can be run multiple times.
     """
-    batch = db.session.query(finance_models.CashflowBatch).get(batch_id)
+    batch = db.session.get(finance_models.CashflowBatch, batch_id)
     if not batch:
         print(f"Could not generate invoices for this batch, as it doesn't exist :{batch_id}")
         return

--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -449,7 +449,7 @@ def _handle_duplicate(fraud_items: list[models.FraudItem], fraud_check: models.B
     if not user.deposit or user.deposit.type != finance_models.DepositType.GRANT_15_17:
         return
 
-    duplicate_beneficiary = db.session.query(users_models.User).get(duplicate_beneficiary_id)
+    duplicate_beneficiary = db.session.get(users_models.User, duplicate_beneficiary_id)
     if not duplicate_beneficiary:
         return
 

--- a/api/src/pcapi/core/mails/transactional/pro/reset_password_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/reset_password_to_pro.py
@@ -23,7 +23,7 @@ def get_reset_password_to_pro_email_data(token: token_utils.Token) -> models.Tra
 
 
 def send_reset_password_email_to_pro(token: token_utils.Token) -> None:
-    user = db.session.query(users_models.User).get(token.user_id)
+    user = db.session.get(users_models.User, token.user_id)
     data = get_reset_password_to_pro_email_data(token)
     mails.send(recipients=[user.email], data=data)
 

--- a/api/src/pcapi/core/mails/transactional/users/reset_password.py
+++ b/api/src/pcapi/core/mails/transactional/users/reset_password.py
@@ -11,7 +11,7 @@ from pcapi.utils.urls import generate_firebase_dynamic_link
 def send_reset_password_email_to_user(
     token: token_utils.Token, reason: constants.SuspensionReason | None = None
 ) -> None:
-    user = db.session.query(users_models.User).get(token.user_id)
+    user = db.session.get(users_models.User, token.user_id)
     email_template = (
         TransactionalEmail.NEW_PASSWORD_REQUEST_FOR_SUSPICIOUS_LOGIN
         if reason == constants.SuspensionReason.SUSPICIOUS_LOGIN_REPORTED_BY_USER
@@ -22,7 +22,7 @@ def send_reset_password_email_to_user(
 
 
 def send_email_already_exists_email(token: token_utils.Token) -> None:
-    user = db.session.query(users_models.User).get(token.user_id)
+    user = db.session.get(users_models.User, token.user_id)
     data = get_reset_password_email_data(user, token, TransactionalEmail.EMAIL_ALREADY_EXISTS.value)
     mails.send(recipients=[user.email], data=data)
 

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -499,7 +499,7 @@ def create_venue(
         # Always enable collective features for new venues in integration
         # Update managing offerer now and not when it is created to avoid
         # some environment specific code spread here and there.
-        offerer = db.session.query(offerers_models.Offerer).get(venue.managingOffererId)
+        offerer = db.session.get(offerers_models.Offerer, venue.managingOffererId)
         if offerer:
             # if no offerer is found, venue won't be saved because of invalid
             # foreign key id. No need to handle this here, let it fail later.

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -401,7 +401,7 @@ def get_venues_educational_statuses() -> list[models.VenueEducationalStatus]:
 
 
 def get_venue_by_id(venue_id: int) -> models.Venue:
-    return db.session.query(models.Venue).get(venue_id)
+    return db.session.get(models.Venue, venue_id)
 
 
 def get_venues_by_ids(ids: typing.Collection[int]) -> typing.Collection[models.Venue]:

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -582,7 +582,7 @@ def activate_future_offers_and_remind_users() -> None:
     offer_ids = activate_future_offers()
 
     for offer_id in offer_ids:
-        offer = db.session.query(models.Offer).get(offer_id)
+        offer = db.session.get(models.Offer, offer_id)
         reminders_notifications.notify_users_future_offer_activated(offer=offer)
 
 

--- a/api/src/pcapi/core/subscription/dms/commands.py
+++ b/api/src/pcapi/core/subscription/dms/commands.py
@@ -23,7 +23,7 @@ def import_dms_application(application_number: int) -> None:
 @blueprint.cli.command("activate_user")
 @click.argument("user_id", type=int, required=True)
 def activate_user(user_id: int) -> None:
-    user = db.session.query(users_models.User).get(user_id)
+    user = db.session.get(users_models.User, user_id)
     if user is None:
         raise ValueError(f"User {user_id} not found")
     subscription_api.activate_beneficiary_if_no_missing_step(user)

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -381,7 +381,7 @@ def reset_password_with_token(new_password: str, encoded_reset_password_token: s
     token = None
     try:
         token = token_utils.Token.load_and_check(encoded_reset_password_token, token_utils.TokenType.RESET_PASSWORD)
-        user = db.session.query(models.User).get(token.user_id)
+        user = db.session.get(models.User, token.user_id)
     except exceptions.InvalidToken:
         raise ApiErrors({"token": ["Le token de changement de mot de passe est invalide."]})
 

--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -158,7 +158,7 @@ def request_email_update_with_credentials(user: models.User, new_email: str, pas
 def confirm_email_update_request_and_send_mail(encoded_token: str) -> None:
     """Confirm the email update request for the given user"""
     token = token_utils.Token.load_and_check(encoded_token, token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION)
-    user = db.session.query(models.User).get(token.user_id)
+    user = db.session.get(models.User, token.user_id)
     if not user:
         raise exceptions.InvalidToken()
     new_email = token.data["new_email"]
@@ -194,7 +194,7 @@ def confirm_new_email_selection_and_send_mail(user: models.User, encoded_new_mai
 def confirm_email_update_request(encoded_token: str) -> models.User:
     """Confirm the email update request for the given user"""
     token = token_utils.Token.load_and_check(encoded_token, token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION)
-    user = db.session.query(models.User).get(token.user_id)
+    user = db.session.get(models.User, token.user_id)
     if not user:
         raise exceptions.InvalidToken()
 
@@ -209,7 +209,7 @@ def cancel_email_update_request(encoded_token: str) -> None:
     """Cancel the email update request for the given user"""
 
     token = token_utils.Token.load_and_check(encoded_token, token_utils.TokenType.EMAIL_CHANGE_CONFIRMATION)
-    user = db.session.query(models.User).get(token.user_id)
+    user = db.session.get(models.User, token.user_id)
     if not user:
         raise exceptions.InvalidToken()
     new_email = token.data.get("new_email")
@@ -239,7 +239,7 @@ def validate_email_update_request(
     inputs safely.
     """
     email_update_validation_token = token_utils.Token.load_without_checking(encoded_email_validation_token)
-    user = db.session.query(models.User).get(email_update_validation_token.user_id)
+    user = db.session.get(models.User, email_update_validation_token.user_id)
     if not user:
         raise exceptions.UserDoesNotExist()
 
@@ -261,7 +261,7 @@ def validate_email_update_request(
     if recent_password_reset_token:
         recent_password_reset_token.expire()
 
-    return db.session.query(models.User).get(user.id)
+    return db.session.get(models.User, user.id)
 
 
 def request_email_update_from_pro(user: models.User, email: str, password: str) -> None:

--- a/api/src/pcapi/models/pc_object.py
+++ b/api/src/pcapi/models/pc_object.py
@@ -22,7 +22,7 @@ class BaseQuery(sa_orm.Query):
         return self.filter_by(id=obj_id).one_or_none()
 
     def get_or_404(self, obj_id: int) -> typing.Any:
-        obj = self.get(obj_id)
+        obj = self.filter_by(id=obj_id).one_or_none()
         if not obj:
             raise NotFound()
         return obj

--- a/api/src/pcapi/routes/auth/discord.py
+++ b/api/src/pcapi/routes/auth/discord.py
@@ -124,7 +124,7 @@ def update_discord_user(user_id: str, discord_id: str) -> None:
     if already_linked_user:
         raise users_exceptions.DiscordUserAlreadyLinked()
 
-    user: user_models.User = db.session.query(user_models.User).get(user_id)
+    user: user_models.User = db.session.get(user_models.User, user_id)
     discord_user = user.discordUser
 
     if discord_user is None:

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -148,7 +148,7 @@ def validate_user_email(body: serializers.ChangeBeneficiaryEmailBody) -> seriali
         # Returning an error message might help the end client find
         # existing email addresses through user enumeration attacks.
         token = token_utils.Token.load_without_checking(body.token)
-        user = db.session.query(users_models.User).get(token.user_id)
+        user = db.session.get(users_models.User, token.user_id)
 
     if user.is_eligible and not user.is_beneficiary:
         try:

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -147,7 +147,7 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
         raise ApiErrors({"token": ["Le token de validation d'email est invalide."]})
 
     token.expire()
-    user = db.session.query(User).get(token.user_id)
+    user = db.session.get(User, token.user_id)
 
     user.isEmailValidated = True
     repository.save(user)

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 @spectree_serialize(api=blueprint.api, response_model=BookOfferResponse, on_error_statuses=[400])
 @authenticated_and_active_user_required
 def book_offer(user: User, body: BookOfferRequest) -> BookOfferResponse:
-    stock = db.session.query(Stock).get(body.stock_id)
+    stock = db.session.get(Stock, body.stock_id)
     if not stock:
         logger.info("Could not book offer: stock does not exist", extra={"stock_id": body.stock_id})
         raise ApiErrors({"stock": "stock introuvable"}, status_code=400)

--- a/api/src/pcapi/routes/pro/bookings.py
+++ b/api/src/pcapi/routes/pro/bookings.py
@@ -86,7 +86,7 @@ def get_user_has_bookings() -> UserHasBookingResponse:
 )
 def export_bookings_for_offer_as_csv(offer_id: int, query: BookingsExportQueryModel) -> bytes:
     user = current_user._get_current_object()
-    offer = db.session.query(Offer).get(int(offer_id))
+    offer = db.session.get(Offer, int(offer_id))
 
     if not users_repository.has_access(user, offer.venue.managingOffererId):
         raise api_errors.ForbiddenError({"global": "You are not allowed to access this offer"})
@@ -118,7 +118,7 @@ def export_bookings_for_offer_as_csv(offer_id: int, query: BookingsExportQueryMo
 )
 def export_bookings_for_offer_as_excel(offer_id: int, query: BookingsExportQueryModel) -> bytes:
     user = current_user._get_current_object()
-    offer = db.session.query(Offer).get(int(offer_id))
+    offer = db.session.get(Offer, int(offer_id))
 
     if not users_repository.has_access(user, offer.venue.managingOffererId):
         raise api_errors.ForbiddenError({"global": "You are not allowed to access this offer"})
@@ -171,7 +171,7 @@ def get_bookings_excel(query: ListBookingsQueryModel) -> bytes:
 @spectree_serialize(response_model=EventDatesInfos, api=blueprint.pro_private_schema)
 def get_offer_price_categories_and_schedules_by_dates(offer_id: int) -> EventDatesInfos:
     user = current_user._get_current_object()
-    offer = db.session.query(Offer).get(offer_id)
+    offer = db.session.get(Offer, offer_id)
 
     if not users_repository.has_access(user, offer.venue.managingOffererId):
         raise api_errors.ForbiddenError({"global": "You are not allowed to access this offer"})

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -321,7 +321,8 @@ def patch_draft_offer(
             sa_orm.joinedload(models.Offer.venue).joinedload(offerers_models.Venue.managingOfferer),
             sa_orm.joinedload(models.Offer.product),
         )
-        .get(offer_id)
+        .filter_by(id=offer_id)
+        .one_or_none()
     )
     if not offer:
         raise api_errors.ResourceNotFoundError

--- a/api/src/pcapi/routes/public/individual_offers/v1/addresses.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/addresses.py
@@ -47,7 +47,7 @@ def get_address(
 
     Return an address by id
     """
-    address = db.session.query(geography_models.Address).get(address_id)
+    address = db.session.get(geography_models.Address, address_id)
     if not address:
         raise api_errors.ResourceNotFoundError({"address": "We could not find any address for the given `id`"})
 

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -125,7 +125,7 @@ def on_educonnect_authentication_response() -> Response:
         )
         return redirect(ERROR_PAGE_URL + urlencode(base_query_param), code=302)
 
-    user = db.session.query(users_models.User).get(user_id)
+    user = db.session.get(users_models.User, user_id)
 
     logger.info(
         "Received educonnect authentication response",

--- a/api/src/pcapi/routes/shared/passwords.py
+++ b/api/src/pcapi/routes/shared/passwords.py
@@ -65,7 +65,8 @@ def post_new_password(body: NewPasswordBodyModel) -> None:
         user = (
             db.session.query(users_models.User)
             .options(sa_orm.selectinload(users_models.User.deposits).selectinload(finance_models.Deposit.recredits))
-            .get(token.user_id)
+            .filter_by(id=token.user_id)
+            .one_or_none()
         )
     except users_exceptions.InvalidToken:
         errors = ApiErrors()

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -117,7 +117,7 @@ def _get_or_create_offerer_address(
 
     offer_venue = location_option["offerVenue"]
     if offer_venue["addressType"] == educational_models.OfferAddressType.OFFERER_VENUE:
-        target_venue = db.session.query(offerers_models.Venue).get(offer_venue["venueId"])
+        target_venue = db.session.get(offerers_models.Venue, offer_venue["venueId"])
 
         if location_option["isLocatedAtVenue"]:
             return target_venue.offererAddress

--- a/api/src/pcapi/scripts/booking/handle_expired_bookings.py
+++ b/api/src/pcapi/scripts/booking/handle_expired_bookings.py
@@ -112,7 +112,7 @@ def notify_users_of_expired_individual_bookings(expired_on: datetime.date | None
     user_ids = bookings_repository.find_user_ids_with_expired_individual_bookings(expired_on)
     notified_users_str = []
     for user_id in user_ids:
-        user = db.session.query(User).get(user_id)
+        user = db.session.get(User, user_id)
         transactional_mails.send_expired_bookings_to_beneficiary_email(
             user,
             bookings_repository.get_expired_individual_bookings_for_user(user),

--- a/api/src/pcapi/workers/apps_flyer_job.py
+++ b/api/src/pcapi/workers/apps_flyer_job.py
@@ -12,7 +12,7 @@ from pcapi.workers.decorators import job
 
 @job(worker.default_queue)
 def log_user_becomes_beneficiary_event_job(user_id: int) -> None:
-    user = db.session.query(User).get(user_id)
+    user = db.session.get(User, user_id)
     log_user_event(user, "af_complete_beneficiary")
 
     if 15 <= user.age <= 17:
@@ -24,7 +24,7 @@ def log_user_becomes_beneficiary_event_job(user_id: int) -> None:
 
 @job(worker.default_queue)
 def log_user_registration_event_job(user_id: int) -> None:
-    user = db.session.query(User).get(user_id)
+    user = db.session.get(User, user_id)
     if 15 <= user.age <= 18:
         log_user_event(user, f"af_complete_registration_{user.age}")
     elif user.age >= 19:

--- a/api/src/pcapi/workers/match_acceslibre_job.py
+++ b/api/src/pcapi/workers/match_acceslibre_job.py
@@ -7,5 +7,5 @@ from pcapi.workers.decorators import job
 
 @job(worker.low_queue)
 def match_acceslibre_job(venue_id: int) -> None:
-    if venue := db.session.query(offerers_models.Venue).get(venue_id):
+    if venue := db.session.get(offerers_models.Venue, venue_id):
         match_acceslibre(venue)

--- a/api/src/pcapi/workers/push_notification_job.py
+++ b/api/src/pcapi/workers/push_notification_job.py
@@ -43,6 +43,6 @@ def send_today_stock_notification(stock_id: int) -> None:
 
 @job(worker.default_queue)
 def send_offer_link_by_push_job(user_id: int, offer_id: int) -> None:
-    offer = db.session.query(Offer).get(offer_id)
+    offer = db.session.get(Offer, offer_id)
     notification_data = get_offer_notification_data(user_id, offer)
     send_transactional_notification(notification_data)

--- a/api/src/pcapi/workers/user_emails_job.py
+++ b/api/src/pcapi/workers/user_emails_job.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 @job(worker.default_queue)
 def send_booking_cancellation_emails_to_user_and_offerer_job(booking_id: int) -> None:
-    booking = db.session.query(Booking).get(booking_id)
+    booking = db.session.get(Booking, booking_id)
     if not booking:
         logger.error("Booking with id:%s not found", booking_id)
         return

--- a/api/tests/core/bookings/test_commands.py
+++ b/api/tests/core/bookings/test_commands.py
@@ -32,8 +32,8 @@ class ArchiveOldBookingsTest:
         run_command(app, "archive_old_bookings")
 
         # then
-        old_booking = db.session.query(bookings_models.Booking).get(old_booking_id)
-        recent_booking = db.session.query(bookings_models.Booking).get(recent_booking_id)
+        old_booking = db.session.get(bookings_models.Booking, old_booking_id)
+        recent_booking = db.session.get(bookings_models.Booking, recent_booking_id)
         assert old_booking.displayAsEnded
         assert not recent_booking.displayAsEnded
 
@@ -65,9 +65,9 @@ class ArchiveOldBookingsTest:
 
         # then
 
-        old_booking = db.session.query(bookings_models.Booking).get(old_booking_id)
-        old_not_free_booking = db.session.query(bookings_models.Booking).get(old_not_free_booking_id)
-        recent_booking = db.session.query(bookings_models.Booking).get(recent_booking_id)
+        old_booking = db.session.get(bookings_models.Booking, old_booking_id)
+        old_not_free_booking = db.session.get(bookings_models.Booking, old_not_free_booking_id)
+        recent_booking = db.session.get(bookings_models.Booking, recent_booking_id)
         assert not recent_booking.displayAsEnded
         assert not old_not_free_booking.displayAsEnded
         assert old_booking.displayAsEnded
@@ -102,7 +102,7 @@ class ArchiveOldBookingsTest:
         run_command(app, "archive_old_bookings")
 
         # then
-        recent_booking = db.session.query(bookings_models.Booking).get(recent_booking_id)
-        old_booking = db.session.query(bookings_models.Booking).get(old_booking_id)
+        recent_booking = db.session.get(bookings_models.Booking, recent_booking_id)
+        old_booking = db.session.get(bookings_models.Booking, old_booking_id)
         assert not recent_booking.displayAsEnded
         assert old_booking.displayAsEnded

--- a/api/tests/core/external/external_users_test.py
+++ b/api/tests/core/external/external_users_test.py
@@ -347,7 +347,7 @@ def test_get_user_attributes_underage_beneficiary_before_18(credit_spent: bool):
         BookingFactory(user=user, amount=finance_conf.GRANTED_DEPOSIT_AMOUNT_17, stock__offer=offer)
 
     # Before 18 years old
-    user = db.session.query(User).get(user.id)
+    user = db.session.get(User, user.id)
     attributes = get_user_attributes(user)
 
     assert attributes.is_beneficiary
@@ -365,7 +365,7 @@ def test_get_user_attributes_ex_underage_beneficiary_who_did_not_claim_credit_18
         )
 
     # At 18 years old
-    user = db.session.query(User).get(user.id)
+    user = db.session.get(User, user.id)
     attributes = get_user_attributes(user)
 
     assert attributes.is_beneficiary
@@ -383,7 +383,7 @@ def test_get_user_attributes_double_beneficiary():
         )
 
     # At 18 years old
-    user = db.session.query(User).get(user.id)
+    user = db.session.get(User, user.id)
     fraud_check = fraud_factories.BeneficiaryFraudCheckFactory(user=user, status=fraud_models.FraudCheckStatus.OK)
     user = subscription_api.activate_beneficiary_for_eligibility(
         user, fraud_check.get_detailed_source(), users_models.EligibilityType.AGE18

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -3969,7 +3969,7 @@ class PrepareInvoiceContextTest:
             bank_account_id=bank_account.id,
             cashflow_ids=cashflow_ids,
         )
-        batch = db.session.query(models.CashflowBatch).get(batch.id)
+        batch = db.session.get(models.CashflowBatch, batch.id)
 
         context = api._prepare_invoice_context(invoice, batch)
 
@@ -4036,7 +4036,7 @@ class PrepareInvoiceContextTest:
             bank_account_id=bank_account.id,
             cashflow_ids=cashflow_ids,
         )
-        batch = db.session.query(models.CashflowBatch).get(batch.id)
+        batch = db.session.get(models.CashflowBatch, batch.id)
 
         context = api._prepare_invoice_context(invoice, batch)
 

--- a/api/tests/core/finance/test_api_legacy.py
+++ b/api/tests/core/finance/test_api_legacy.py
@@ -2530,7 +2530,7 @@ class PrepareInvoiceContextTest:
             bank_account_id=bank_account.id,
             cashflow_ids=cashflow_ids,
         )
-        batch = db.session.query(models.CashflowBatch).get(batch.id)
+        batch = db.session.get(models.CashflowBatch, batch.id)
 
         context = api._prepare_invoice_context(invoice, batch)
 
@@ -2597,7 +2597,7 @@ class PrepareInvoiceContextTest:
             bank_account_id=bank_account.id,
             cashflow_ids=cashflow_ids,
         )
-        batch = db.session.query(models.CashflowBatch).get(batch.id)
+        batch = db.session.get(models.CashflowBatch, batch.id)
 
         context = api._prepare_invoice_context(invoice, batch)
 
@@ -2672,7 +2672,7 @@ class GenerateDebitNoteHtmlTest:
             cashflow_ids=cashflow_ids,
             is_debit_note=True,
         )
-        batch = db.session.query(models.CashflowBatch).get(batch.id)
+        batch = db.session.get(models.CashflowBatch, batch.id)
         invoice_html = api._generate_debit_note_html(invoice, batch)
 
         with open(self.TEST_FILES_PATH / "invoice" / expected_generated_file_name, "r", encoding="utf-8") as f:
@@ -2794,7 +2794,7 @@ class GenerateInvoiceHtmlTest:
             cashflow_ids=cashflow_ids,
         )
 
-        batch = db.session.query(models.CashflowBatch).get(batch.id)
+        batch = db.session.get(models.CashflowBatch, batch.id)
         invoice_html = api._generate_invoice_html(invoice, batch)
 
         expected_generated_file_name = "rendered_nc_invoice.html" if is_caledonian else "rendered_invoice.html"
@@ -2824,7 +2824,7 @@ class GenerateInvoiceHtmlTest:
 
     def test_basics(self, features, invoice_data):
         bank_account, stocks, venue = invoice_data
-        pricing_point = db.session.query(offerers_models.Venue).get(venue.current_pricing_point_id)
+        pricing_point = db.session.get(offerers_models.Venue, venue.current_pricing_point_id)
         only_educational_venue = offerers_factories.VenueFactory(
             name="Coiffeur collecTIF",
             pricing_point=pricing_point,

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -2231,7 +2231,7 @@ class VenueBannerTest:
         settings.LOCAL_STORAGE_DIR = pathlib.Path(tmpdir.dirname)
         offerers_api.save_venue_banner(user, venue, image_content, image_credit="none")
 
-        updated_venue = db.session.query(Venue).get(venue.id)
+        updated_venue = db.session.get(Venue, venue.id)
         with open(updated_venue.bannerUrl, mode="rb") as f:
             # test that image size has been reduced
             assert len(f.read()) < len(image_content)
@@ -2261,7 +2261,7 @@ class VenueBannerTest:
         settings.LOCAL_STORAGE_DIR = pathlib.Path(tmpdir.dirname)
         offerers_api.save_venue_banner(user, venue, image_content, image_credit="none")
 
-        updated_venue = db.session.query(Venue).get(venue.id)
+        updated_venue = db.session.get(Venue, venue.id)
         with open(updated_venue.bannerUrl, mode="rb") as f:
             # test that image size has been reduced
             assert len(f.read()) < len(image_content)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -975,16 +975,16 @@ class DeleteStockTest:
         db.session.expunge_all()
         stock = db.session.query(models.Stock).one()
         assert stock.isSoftDeleted
-        booking1 = db.session.query(bookings_models.Booking).get(booking1.id)
+        booking1 = db.session.get(bookings_models.Booking, booking1.id)
         assert booking1.status == bookings_models.BookingStatus.CANCELLED
         assert booking1.cancellationReason == bookings_models.BookingCancellationReasons.OFFERER
-        booking2 = db.session.query(bookings_models.Booking).get(booking2.id)
+        booking2 = db.session.get(bookings_models.Booking, booking2.id)
         assert booking2.status == bookings_models.BookingStatus.CANCELLED  # unchanged
         assert booking2.cancellationReason == bookings_models.BookingCancellationReasons.BENEFICIARY
-        booking3 = db.session.query(bookings_models.Booking).get(booking3.id)
+        booking3 = db.session.get(bookings_models.Booking, booking3.id)
         assert booking3.status == bookings_models.BookingStatus.CANCELLED  # cancel used booking for event offer
         assert booking3.cancellationReason == bookings_models.BookingCancellationReasons.OFFERER
-        booking4 = db.session.query(bookings_models.Booking).get(booking4.id)
+        booking4 = db.session.get(bookings_models.Booking, booking4.id)
         assert booking4.status == bookings_models.BookingStatus.USED  # unchanged
         assert booking4.cancellationDate is None
         assert booking4.pricings[0].status == finance_models.PricingStatus.PROCESSED  # unchanged
@@ -1036,16 +1036,16 @@ class DeleteStockTest:
         db.session.expunge_all()
         stock = db.session.query(models.Stock).one()
         assert stock.isSoftDeleted
-        booking1 = db.session.query(bookings_models.Booking).get(booking1.id)
+        booking1 = db.session.get(bookings_models.Booking, booking1.id)
         assert booking1.status == bookings_models.BookingStatus.CANCELLED
         assert booking1.cancellationReason == bookings_models.BookingCancellationReasons.OFFERER
-        booking2 = db.session.query(bookings_models.Booking).get(booking2.id)
+        booking2 = db.session.get(bookings_models.Booking, booking2.id)
         assert booking2.status == bookings_models.BookingStatus.CANCELLED  # unchanged
         assert booking2.cancellationReason == bookings_models.BookingCancellationReasons.BENEFICIARY
-        booking3 = db.session.query(bookings_models.Booking).get(booking3.id)
+        booking3 = db.session.get(bookings_models.Booking, booking3.id)
         assert booking3.status == bookings_models.BookingStatus.CANCELLED  # cancel used booking for event offer
         assert booking3.cancellationReason == bookings_models.BookingCancellationReasons.OFFERER
-        booking4 = db.session.query(bookings_models.Booking).get(booking4.id)
+        booking4 = db.session.get(bookings_models.Booking, booking4.id)
         assert booking4.status == bookings_models.BookingStatus.USED  # unchanged
         assert booking4.cancellationDate is None
         assert booking4.pricings[0].status == finance_models.PricingStatus.PROCESSED  # unchanged
@@ -2362,7 +2362,7 @@ class ActivateFutureOffersTest:
 
         offers_ids = api.activate_future_offers()
 
-        assert not db.session.query(models.Offer).get(offer.id).isActive
+        assert not db.session.get(models.Offer, offer.id).isActive
         mocked_async_index_offer_ids.assert_not_called()
         assert offers_ids == []
 
@@ -2375,8 +2375,8 @@ class ActivateFutureOffersTest:
         offers_ids = api.activate_future_offers(publication_date=publication_date)
 
         assert offers_ids == [offer.id]
-        assert db.session.query(models.Offer).get(offer.id).isActive
-        assert db.session.query(models.FutureOffer).get(future_offer.id).isSoftDeleted
+        assert db.session.get(models.Offer, offer.id).isActive
+        assert db.session.get(models.FutureOffer, future_offer.id).isSoftDeleted
 
         mocked_async_index_offer_ids.assert_called_once()
         assert set(mocked_async_index_offer_ids.call_args[0][0]) == set([offer.id])
@@ -2409,13 +2409,13 @@ class ActivateFutureOffersAndRemindUsersTest:
         mocked_async_index_offer_ids.assert_called_once()
         assert set(mocked_async_index_offer_ids.call_args[0][0]) == set([offer_1.id, offer_2.id])
 
-        assert db.session.query(models.Offer).get(offer_1.id).isActive
-        assert db.session.query(models.Offer).get(offer_2.id).isActive
-        assert not db.session.query(models.Offer).get(offer_3.id).isActive
+        assert db.session.get(models.Offer, offer_1.id).isActive
+        assert db.session.get(models.Offer, offer_2.id).isActive
+        assert not db.session.get(models.Offer, offer_3.id).isActive
 
-        assert db.session.query(models.FutureOffer).get(future_offer_1.id).isSoftDeleted
-        assert db.session.query(models.FutureOffer).get(future_offer_2.id).isSoftDeleted
-        assert not db.session.query(models.FutureOffer).get(future_offer_3.id).isSoftDeleted
+        assert db.session.get(models.FutureOffer, future_offer_1.id).isSoftDeleted
+        assert db.session.get(models.FutureOffer, future_offer_2.id).isSoftDeleted
+        assert not db.session.get(models.FutureOffer, future_offer_3.id).isSoftDeleted
 
 
 @pytest.mark.usefixtures("db_session")
@@ -5485,7 +5485,7 @@ class DeleteOffersAndAllRelatedObjectsTest:
         api.delete_offers_and_all_related_objects(offer_ids)
         assert_offers_have_been_completely_cleaned(offer_ids)
 
-        assert db.session.query(models.Offer).get(other_offer_id) is not None
+        assert db.session.get(models.Offer, other_offer_id) is not None
         assert db.session.query(models.Stock).filter_by(offerId=other_offer_id).one()
         assert other_offer_id in search_testing.search_store["offers"]
 
@@ -5566,5 +5566,5 @@ class DeleteUnbookableUnusedOldOffersTest:
         api.delete_unbookable_unbooked_old_offers()
         assert_offers_have_been_completely_cleaned([offer_id])
 
-        assert db.session.query(models.Offer).get(old_bookable_offer.id) is not None
-        assert db.session.query(models.Offer).get(recent_offer.id) is not None
+        assert db.session.get(models.Offer, old_bookable_offer.id) is not None
+        assert db.session.get(models.Offer, recent_offer.id) is not None

--- a/api/tests/core/offers/test_commands.py
+++ b/api/tests/core/offers/test_commands.py
@@ -20,7 +20,7 @@ class OfferCommandsTest:
 
         run_command(app, "delete_unbookable_unbooked_old_offers")
 
-        assert db.session.query(offers_models.Offer).get(offer_id) is not None
+        assert db.session.get(offers_models.Offer, offer_id) is not None
 
     @pytest.mark.features(ENABLE_OFFERS_AUTO_CLEANUP=True)
     @pytest.mark.usefixtures("clean_database")

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -506,7 +506,7 @@ class StockQuantityTest:
         repository.save(stock)
 
         # Then
-        assert db.session.query(models.Stock).get(stock.id).quantity == 3
+        assert db.session.get(models.Stock, stock.id).quantity == 3
 
     def test_quantity_update_with_more_than_sum_of_bookings(self):
         # Given
@@ -518,7 +518,7 @@ class StockQuantityTest:
         repository.save(stock)
 
         # Then
-        assert db.session.query(models.Stock).get(stock.id).quantity == 3
+        assert db.session.get(models.Stock, stock.id).quantity == 3
 
     def test_cannot_update_if_less_than_sum_of_bookings(self):
         # Given

--- a/api/tests/core/users/email/test_update.py
+++ b/api/tests/core/users/email/test_update.py
@@ -39,7 +39,7 @@ class RequestEmailUpdateTest:
 
         email_update.request_email_update_with_credentials(user, new_email, password)
 
-        reloaded_user = db.session.query(User).get(user.id)
+        reloaded_user = db.session.get(User, user.id)
         assert len(reloaded_user.email_history) == 1
 
         history = reloaded_user.email_history[0]
@@ -53,7 +53,7 @@ class RequestEmailUpdateTest:
 
         email_update.request_email_update(user)
 
-        reloaded_user = db.session.query(User).get(user.id)
+        reloaded_user = db.session.get(User, user.id)
         assert len(reloaded_user.email_history) == 1
 
         history = reloaded_user.email_history[0]

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -378,7 +378,7 @@ class ChangeUserEmailTest:
         returned_user = email_update.validate_email_update_request(token)
 
         # Then
-        reloaded_user = db.session.query(users_models.User).get(user.id)
+        reloaded_user = db.session.get(users_models.User, user.id)
         assert returned_user == reloaded_user
         assert reloaded_user.email == self.new_email
         assert db.session.query(users_models.User).filter_by(email=self.old_email).first() is None
@@ -405,10 +405,10 @@ class ChangeUserEmailTest:
             email_update.validate_email_update_request(token)
 
         # Then
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert user.email == "oldemail@mail.com"
 
-        other_user = db.session.query(users_models.User).get(other_user.id)
+        other_user = db.session.get(users_models.User, other_user.id)
         assert other_user.email == self.new_email
 
         single_sign_on = (
@@ -432,7 +432,7 @@ class ChangeUserEmailTest:
                     email_update.validate_email_update_request(token)
 
                 # Then
-                user = db.session.query(users_models.User).get(user.id)
+                user = db.session.get(users_models.User, user.id)
                 assert user.email == self.old_email
 
     def test_change_user_email_twice(self):
@@ -451,13 +451,13 @@ class ChangeUserEmailTest:
         # first call, email is updated as expected
         returned_user = email_update.validate_email_update_request(token)
 
-        reloaded_user = db.session.query(users_models.User).get(user.id)
+        reloaded_user = db.session.get(users_models.User, user.id)
         assert returned_user == reloaded_user
         assert reloaded_user.email == self.new_email
 
         # second call, no error, no update
         returned_user = email_update.validate_email_update_request(token)
-        reloaded_user = db.session.query(users_models.User).get(user.id)
+        reloaded_user = db.session.get(users_models.User, user.id)
         assert returned_user == reloaded_user
         assert reloaded_user.email == self.new_email
 
@@ -2032,7 +2032,7 @@ class NotifyUserBeforeDeletionUponSuspensionTest:
         users_api.notify_users_before_deletion_of_suspended_account()
 
         # then
-        user = db.session.query(users_models.User).get(suspension_to_be_detected.userId)
+        user = db.session.get(users_models.User, suspension_to_be_detected.userId)
         assert len(mails_testing.outbox) == 1
         assert mails_testing.outbox[0]["params"]["FIRSTNAME"] == user.firstName
         assert mails_testing.outbox[0]["To"] == user.email

--- a/api/tests/local_providers/chunk_manager_test.py
+++ b/api/tests/local_providers/chunk_manager_test.py
@@ -67,8 +67,8 @@ def test_save_chunks_update_1_offer_in_chunk():
     db.session.expunge(offer)
     save_chunks(chunk_to_insert={}, chunk_to_update=chunk_to_update)
 
-    assert db.session.query(Offer).get(offer.id).isDuo
-    assert not db.session.query(Offer).get(other_offer.id).isDuo
+    assert db.session.get(Offer, offer.id).isDuo
+    assert not db.session.get(Offer, other_offer.id).isDuo
 
 
 def test_save_chunks_update_2_offers_and_1_stock_in_chunk():

--- a/api/tests/routes/backoffice/accounts_test.py
+++ b/api/tests/routes/backoffice/accounts_test.py
@@ -5243,7 +5243,7 @@ class DeleteAccountTagTest(PostEndpointHelper):
 
         assert response.status_code == 303
         assert set(db.session.query(users_models.UserTag).all()) == {tags[0], tags[2]}
-        assert db.session.query(users_models.User).get(user.id).tags == [tags[2]]
+        assert db.session.query(users_models.User).filter_by(id=user.id).one().tags == [tags[2]]
 
     def test_delete_non_existing_tag(self, authenticated_client):
         tag = users_factories.UserTagFactory()

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -1163,7 +1163,7 @@ class ValidateEmailTest:
         refresh_response = client.post("/native/v1/refresh_access_token", json={})
         assert refresh_response.status_code == 200
 
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert user.email == self.new_email
 
     @patch("pcapi.core.subscription.dms.api.try_dms_orphan_adoption")
@@ -1209,7 +1209,7 @@ class ValidateEmailTest:
         refresh_response = client.post("/native/v1/refresh_access_token", json={})
         assert refresh_response.status_code == 200
 
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert user.email == self.old_email
 
     def test_expired_token(self, app, client):
@@ -1223,7 +1223,7 @@ class ValidateEmailTest:
                 assert response.status_code == 400
                 assert response.json["code"] == "INVALID_TOKEN"
 
-                user = db.session.query(users_models.User).get(user.id)
+                user = db.session.get(users_models.User, user.id)
                 assert user.email == self.old_email
 
 
@@ -1466,7 +1466,7 @@ class SendPhoneValidationCodeTest:
         response = client.post("/native/v1/validate_phone_number", json={"code": token.encoded_token})
 
         assert response.status_code == 204
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert user.is_phone_validated
 
     @pytest.mark.settings(MAX_SMS_SENT_FOR_PHONE_VALIDATION=1)
@@ -1679,7 +1679,7 @@ class ValidatePhoneNumberTest:
         response = client.post("/native/v1/validate_phone_number", {"code": token.encoded_token})
 
         assert response.status_code == 204
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert user.is_phone_validated
         assert not user.has_beneficiary_role
 
@@ -1706,7 +1706,7 @@ class ValidatePhoneNumberTest:
         response = client.post("/native/v1/validate_phone_number", {"code": first_token.encoded_token})
 
         assert response.status_code == 400
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert not user.is_phone_validated
 
         assert int(app.redis_client.get(f"phone_validation_attempts_user_{user.id}")) == 1
@@ -1732,7 +1732,7 @@ class ValidatePhoneNumberTest:
         response = client.post("/native/v1/validate_phone_number", {"code": token.encoded_token})
 
         assert response.status_code == 204
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert user.is_phone_validated
         assert user.has_beneficiary_role
 
@@ -1825,7 +1825,7 @@ class ValidatePhoneNumberTest:
         assert fraud_check.type == fraud_models.FraudCheckType.PHONE_VALIDATION
         assert fraud_check.reasonCodes == [fraud_models.FraudReasonCode.PHONE_VALIDATION_ATTEMPTS_LIMIT_REACHED]
 
-        assert not db.session.query(users_models.User).get(user.id).is_phone_validated
+        assert not db.session.get(users_models.User, user.id).is_phone_validated
         assert token_utils.SixDigitsToken.token_exists(token_utils.TokenType.PHONE_VALIDATION, user.id)
 
     def test_expired_code(self, client):
@@ -1840,7 +1840,7 @@ class ValidatePhoneNumberTest:
             assert response.status_code == 400
             assert response.json["code"] == "INVALID_VALIDATION_CODE"
 
-            assert not db.session.query(users_models.User).get(user.id).is_phone_validated
+            assert not db.session.get(users_models.User, user.id).is_phone_validated
             assert token_utils.SixDigitsToken.token_exists(token_utils.TokenType.PHONE_VALIDATION, user.id)
 
     def test_validate_phone_number_with_already_validated_phone(self, client):
@@ -1857,7 +1857,7 @@ class ValidatePhoneNumberTest:
         response = client.post("/native/v1/validate_phone_number", {"code": token.encoded_token})
 
         assert response.status_code == 400
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert not user.is_phone_validated
 
 

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -1135,7 +1135,7 @@ class CancelBookingTest:
 
         assert response.status_code == 204
 
-        booking = db.session.query(Booking).get(booking.id)
+        booking = db.session.get(Booking, booking.id)
         assert booking.status == BookingStatus.CANCELLED
         assert booking.cancellationReason == BookingCancellationReasons.BENEFICIARY
         assert len(mails_testing.outbox) == 1
@@ -1151,7 +1151,7 @@ class CancelBookingTest:
 
         assert response.status_code == 204
 
-        booking = db.session.query(Booking).get(booking.id)
+        booking = db.session.get(Booking, booking.id)
         assert len(push_testing.requests) == 3
         assert push_testing.requests[0] == {
             "can_be_asynchronously_retried": True,

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -134,7 +134,7 @@ class OffersTest:
                 response = client.get(f"/native/v1/offer/{offer_id}")
                 assert response.status_code == 200
 
-        offer = db.session.query(Offer).get(offer.id)
+        offer = db.session.get(Offer, offer.id)
         assert offer.ean == ean
         assert "ean" not in offer.extraData
         assert response.json["id"] == offer.id

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -136,7 +136,7 @@ class UpdateProfileTest:
 
         assert response.status_code == 204
 
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert not user.is_beneficiary
         assert user.firstName == "John"
         assert user.lastName == "Doe"
@@ -344,7 +344,7 @@ class UpdateProfileTest:
 
         assert response.status_code == 204
 
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert user.firstName == "Alexandra"
         assert user.lastName == "Stan"
         assert user.has_beneficiary_role

--- a/api/tests/routes/pro/patch_all_offers_active_status_test.py
+++ b/api/tests/routes/pro/patch_all_offers_active_status_test.py
@@ -32,8 +32,8 @@ class Returns204Test:
             response = client.patch("/offers/all-active-status", json=data)
 
         assert response.status_code == 202
-        offer_1: Offer = db.session.query(Offer).get(offer1.id)
-        offer_2: Offer = db.session.query(Offer).get(offer2.id)
+        offer_1: Offer = db.session.get(Offer, offer1.id)
+        offer_2: Offer = db.session.get(Offer, offer2.id)
 
         assert offer_1.isActive
         assert offer_1.publicationDatetime == now_without_tz
@@ -55,8 +55,8 @@ class Returns204Test:
         response = client.patch("/offers/all-active-status", json=data)
 
         assert response.status_code == 202
-        offer_1: Offer = db.session.query(Offer).get(offer1.id)
-        offer_2: Offer = db.session.query(Offer).get(offer2.id)
+        offer_1: Offer = db.session.get(Offer, offer1.id)
+        offer_2: Offer = db.session.get(Offer, offer2.id)
         assert not offer_1.isActive
         assert not offer_1.publicationDatetime
         assert not offer_1.bookingAllowedDatetime
@@ -120,11 +120,11 @@ class Returns204Test:
 
         assert response.status_code == 202
 
-        matching_offer_1 = db.session.query(Offer).get(matching_offer1.id)
-        matching_offer_2 = db.session.query(Offer).get(matching_offer2.id)
-        offer_out_of_date_range = db.session.query(Offer).get(offer_out_of_date_range.id)
-        offer_on_other_venue = db.session.query(Offer).get(offer_on_other_venue.id)
-        offer_with_not_matching_name = db.session.query(Offer).get(offer_with_not_matching_name.id)
+        matching_offer_1 = db.session.get(Offer, matching_offer1.id)
+        matching_offer_2 = db.session.get(Offer, matching_offer2.id)
+        offer_out_of_date_range = db.session.get(Offer, offer_out_of_date_range.id)
+        offer_on_other_venue = db.session.get(Offer, offer_on_other_venue.id)
+        offer_with_not_matching_name = db.session.get(Offer, offer_with_not_matching_name.id)
 
         assert not matching_offer_1.isActive
         assert not matching_offer_1.publicationDatetime
@@ -225,8 +225,8 @@ class Returns204Test:
         data = {"isActive": True, "offererAddressId": offerer_address.id}
         response = authentified_client.patch("/offers/all-active-status", json=data)
         assert response.status_code == 202
-        offer1 = db.session.query(Offer).get(offer1.id)
-        offer2 = db.session.query(Offer).get(offer2.id)
+        offer1 = db.session.get(Offer, offer1.id)
+        offer2 = db.session.get(Offer, offer2.id)
         assert offer1.isActive
         assert not offer2.isActive
 
@@ -254,9 +254,9 @@ class ActivateFutureOffersTest:
             mock_notify_users_future_offer_activated.assert_has_calls([call(offer_to_publish_2)])
 
         assert response.status_code == 202
-        assert db.session.query(Offer).get(offer_to_publish_1.id).isActive
-        assert db.session.query(Offer).get(offer_to_publish_2.id).isActive
-        assert not db.session.query(Offer).get(offer_to_publish_3.id).isActive
+        assert db.session.get(Offer, offer_to_publish_1.id).isActive
+        assert db.session.get(Offer, offer_to_publish_2.id).isActive
+        assert not db.session.get(Offer, offer_to_publish_3.id).isActive
 
     def test_deactivate_future_offers(self, client):
         offer_published_1 = offers_factories.OfferFactory()
@@ -277,5 +277,5 @@ class ActivateFutureOffersTest:
             mock_notify_users_future_offer_activated.assert_not_called()
 
         assert response.status_code == 202
-        assert not db.session.query(Offer).get(offer_published_1.id).isActive
-        assert not db.session.query(Offer).get(offer_published_2.id).isActive
+        assert not db.session.get(Offer, offer_published_1.id).isActive
+        assert not db.session.get(Offer, offer_published_2.id).isActive

--- a/api/tests/routes/pro/patch_bulk_update_event_stocks_test.py
+++ b/api/tests/routes/pro/patch_bulk_update_event_stocks_test.py
@@ -262,7 +262,7 @@ class Returns200Test:
         )
 
         assert response.status_code == 200
-        updated_booking = db.session.query(bookings_models.Booking).get(booking.id)
+        updated_booking = db.session.get(bookings_models.Booking, booking.id)
         assert updated_booking.status is not bookings_models.BookingStatus.USED
         assert updated_booking.dateUsed is None
         assert updated_booking.cancellationLimitDate == booking.cancellationLimitDate
@@ -303,7 +303,7 @@ class Returns200Test:
         )
 
         assert response.status_code == 200
-        updated_booking = db.session.query(bookings_models.Booking).get(booking.id)
+        updated_booking = db.session.get(bookings_models.Booking, booking.id)
         assert updated_booking.status is bookings_models.BookingStatus.USED
         assert updated_booking.dateUsed == date_used_in_48_hours
 

--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -108,7 +108,7 @@ class Returns200Test:
             "name": payload_ctx.national_program.name,
         }
 
-        updated_offer = db.session.query(models.CollectiveOfferTemplate).get(offer_id)
+        updated_offer = db.session.get(models.CollectiveOfferTemplate, offer_id)
         assert updated_offer.name == "New name"
         assert updated_offer.mentalDisabilityCompliant
         assert updated_offer.priceDetail == "pouet"
@@ -1122,7 +1122,7 @@ class Returns403Test:
         assert response.json["global"] == [
             "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]
-        assert db.session.query(models.CollectiveOfferTemplate).get(offer.id).name == "Old name"
+        assert db.session.get(models.CollectiveOfferTemplate, offer.id).name == "Old name"
 
     def test_replacing_venue_with_different_offerer(self, client):
         offer_ctx = build_offer_context()

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -97,7 +97,7 @@ class Returns200Test:
         assert response.json["nationalProgram"] == {"id": national_program.id, "name": national_program.name}
         assert not response.json["isTemplate"]
 
-        updated_offer = db.session.query(models.CollectiveOffer).get(offer.id)
+        updated_offer = db.session.get(models.CollectiveOffer, offer.id)
         assert updated_offer.name == "New name"
         assert updated_offer.mentalDisabilityCompliant
         assert updated_offer.contactEmail == "toto@example.com"
@@ -1038,7 +1038,7 @@ class Returns403Test:
         assert response.json["global"] == [
             "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]
-        assert db.session.query(models.CollectiveOffer).get(offer.id).name == "Old name"
+        assert db.session.get(models.CollectiveOffer, offer.id).name == "Old name"
 
     def test_patch_collective_offer_replacing_venue_with_different_offerer(self, client):
         # Given

--- a/api/tests/routes/pro/patch_collective_offers_active_status_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_active_status_test.py
@@ -9,7 +9,7 @@ from pcapi.core.offerers import factories as offerers_factories
 
 @pytest.mark.usefixtures("db_session")
 class Returns403Test:
-    def test_patch_active_status(self, client):
+    def test_patch_set_active_status(self, client):
         offer = CollectiveOfferFactory()
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
 
@@ -22,7 +22,11 @@ class Returns403Test:
         assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
         assert offer.isActive is True
 
-        offer.isActive = False
+    def test_patch_set_inactive_status(self, client):
+        offer = CollectiveOfferFactory(isActive=False)
+        offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
+
+        client = client.with_session_auth("pro@example.com")
         data = {"ids": [offer.id], "isActive": True}
         with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = client.patch("/collective/offers/active-status", json=data)

--- a/api/tests/routes/pro/patch_collective_offers_template_active_status_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_template_active_status_test.py
@@ -31,8 +31,8 @@ class Returns204Test:
 
         # Then
         assert response.status_code == 204
-        assert db.session.query(CollectiveOfferTemplate).get(offer1.id).isActive
-        assert db.session.query(CollectiveOfferTemplate).get(offer2.id).isActive
+        assert db.session.get(CollectiveOfferTemplate, offer1.id).isActive
+        assert db.session.get(CollectiveOfferTemplate, offer2.id).isActive
 
     def when_deactivating_existing_offers(self, client):
         # Given
@@ -50,8 +50,8 @@ class Returns204Test:
 
         # Then
         assert response.status_code == 204
-        assert not db.session.query(CollectiveOfferTemplate).get(offer1.id).isActive
-        assert not db.session.query(CollectiveOfferTemplate).get(offer2.id).isActive
+        assert not db.session.get(CollectiveOfferTemplate, offer1.id).isActive
+        assert not db.session.get(CollectiveOfferTemplate, offer2.id).isActive
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/patch_collective_stock_test.py
+++ b/api/tests/routes/pro/patch_collective_stock_test.py
@@ -56,7 +56,7 @@ class Return200Test:
 
         # Then
         assert response.status_code == 200
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
         assert edited_stock.startDatetime == datetime(2022, 1, 17, 22)
         assert edited_stock.bookingLimitDatetime == datetime(2021, 12, 31, 20)
         assert edited_stock.price == 1500
@@ -102,7 +102,7 @@ class Return200Test:
 
         # Then
         assert response.status_code == 200
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
         assert edited_stock.startDatetime == datetime(2021, 12, 18, 00)
         assert edited_stock.bookingLimitDatetime == datetime(2021, 12, 18, 00)
 
@@ -142,7 +142,7 @@ class Return200Test:
         response = client.patch(f"/collective/stocks/{stock.id}", json=stock_edition_payload)
 
         assert response.status_code == 200
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
         assert edited_stock.startDatetime == datetime(2022, 1, 17, 22)
         assert edited_stock.bookingLimitDatetime == datetime(2021, 12, 1)
         assert edited_stock.price == 1500
@@ -180,8 +180,8 @@ class Return200Test:
 
         # Then
         assert response.status_code == 200
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
-        edited_booking = db.session.query(CollectiveBooking).get(booking.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
+        edited_booking = db.session.get(CollectiveBooking, booking.id)
         assert edited_stock.startDatetime == datetime(2021, 12, 18)
         assert edited_stock.bookingLimitDatetime == datetime(2021, 12, 1)
         assert edited_stock.price == 1500
@@ -199,7 +199,8 @@ class Return200Test:
     @time_machine.travel("2020-11-17 15:00:00")
     @pytest.mark.settings(ADAGE_API_URL="https://adage_base_url")
     def test_edit_collective_stock_does_not_send_notification_when_no_modification(self, client):
-        # Given
+        # patch_offer_test
+
         stock = educational_factories.CollectiveStockFactory(
             startDatetime=datetime(2021, 12, 18),
             price=1200,
@@ -257,7 +258,7 @@ class Return200Test:
         client.patch(f"/collective/stocks/{collective_stock.id}", json=stock_edition_payload)
 
         # Then
-        edited_collective_booking = db.session.query(CollectiveBooking).get(collective_booking.id)
+        edited_collective_booking = db.session.get(CollectiveBooking, collective_booking.id)
         assert edited_collective_booking.educationalYearId == educational_year_2022_2023.adageId
 
     def test_edit_collective_stock_update_booking_limit_date_with_expired_booking(self, client):
@@ -357,7 +358,7 @@ class Return400Test:
 
         # Then
         assert response.status_code == 400
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
         assert edited_stock.numberOfTickets == 32
 
     @time_machine.travel("2020-11-17 15:00:00")
@@ -385,7 +386,7 @@ class Return400Test:
 
         # Then
         assert response.status_code == 400
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
         assert edited_stock.price == 1200
 
     @time_machine.travel("2020-11-17 15:00:00")
@@ -413,7 +414,7 @@ class Return400Test:
 
         # Then
         assert response.status_code == 400
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
         assert edited_stock.bookingLimitDatetime == stock.bookingLimitDatetime
 
     @time_machine.travel("2020-11-17 15:00:00")
@@ -562,7 +563,7 @@ class Return400Test:
 
         # Then
         assert response.status_code == 400
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
         assert edited_stock.startDatetime == startDatetime
         assert edited_stock.endDatetime == endDatetime
 
@@ -616,7 +617,7 @@ class Return400Test:
             assert response.status_code == 400
             assert response.json == {"code": "START_AND_END_EDUCATIONAL_YEAR_DIFFERENT"}
 
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
         assert edited_stock.startDatetime == startDatetime
         assert edited_stock.endDatetime == endDatetime
 
@@ -651,8 +652,8 @@ class Return400Test:
             # query += 1 -> load session
             # query += 1 -> load user
             # query += 1 -> load existing stock
+            # query += 1 -> load existing offerer
             # query += 1 -> ensure the offerer is VALIDATED
-            # query += 1 -> check the number of existing stock for the offer id
             # query += 1 -> find education year for start date
             # query += 1 -> rollback
             # query += 1 -> load existing stock after rollback
@@ -662,7 +663,7 @@ class Return400Test:
             # Then
             assert response.status_code == 400
             assert response.json == {"code": "START_EDUCATIONAL_YEAR_MISSING"}
-            edited_stock = db.session.query(CollectiveStock).get(stock.id)
+            edited_stock = db.session.get(CollectiveStock, stock.id)
             assert edited_stock.startDatetime == startDatetime
             assert edited_stock.endDatetime == endDatetime
 
@@ -700,8 +701,8 @@ class Return400Test:
             # query += 1 -> load session
             # query += 1 -> load user
             # query += 1 -> load existing stock
+            # query += 1 -> load offerer
             # query += 1 -> ensure the offerer is VALIDATED
-            # query += 1 -> check the number of existing stock for the offer id
             # query += 1 -> find education year for start date
             # query += 1 -> find education year for end date
             # query += 1 -> rollback
@@ -712,7 +713,7 @@ class Return400Test:
             # Then
             assert response.status_code == 400
             assert response.json == {"code": "END_EDUCATIONAL_YEAR_MISSING"}
-            edited_stock = db.session.query(CollectiveStock).get(stock.id)
+            edited_stock = db.session.get(CollectiveStock, stock.id)
             assert edited_stock.startDatetime == startDatetime
             assert edited_stock.endDatetime == endDatetime
 
@@ -734,6 +735,6 @@ class Return400Test:
         assert response.json == {
             "educationalStock": ["La date de fin de l'évènement ne peut précéder la date de début."]
         }
-        edited_stock = db.session.query(CollectiveStock).get(stock.id)
+        edited_stock = db.session.get(CollectiveStock, stock.id)
         assert edited_stock.startDatetime == start.replace(tzinfo=None)
         assert edited_stock.endDatetime == start.replace(tzinfo=None)

--- a/api/tests/routes/pro/patch_draft_offer_test.py
+++ b/api/tests/routes/pro/patch_draft_offer_test.py
@@ -48,7 +48,7 @@ class Returns200Test:
         assert response.json["venue"]["id"] == offer.venue.id
         assert response.json["productId"] == None
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.name == "New name"
         assert updated_offer.subcategoryId == subcategories.ABO_PLATEFORME_VIDEO.id
         assert updated_offer.description == "New description"
@@ -73,7 +73,7 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json["id"] == offer.id
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.ean == "2222222222222"
         assert updated_offer.extraData == {}
 
@@ -99,7 +99,7 @@ class Returns200Test:
         assert response.json["venue"]["id"] == offer.venue.id
         assert response.json["productId"] == None
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.name == "New name"
         assert updated_offer.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert updated_offer.description == "New description"
@@ -127,7 +127,7 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json["id"] == offer.id
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.extraData == {"stageDirector": "Greta Gerwig"}
 
     def test_patch_draft_offer_with_empty_extra_data(self, client):
@@ -165,7 +165,7 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json["id"] == offer.id
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.extraData == {
             "author": "",
             "gtl_id": "",
@@ -247,7 +247,7 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json["id"] == offer.id
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.extraData == {
             "cast": ["Joan Baez", "Joe Cocker", "David Crosby"],
             "eidr": "10.5240/ADBD-3CAA-43A0-7BF0-86E2-K",
@@ -513,7 +513,7 @@ class Returns403Test:
         assert response.status_code == 403
         msg = "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         assert response.json["global"] == [msg]
-        assert db.session.query(Offer).get(offer.id).name == "Old name"
+        assert db.session.get(Offer, offer.id).name == "Old name"
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/patch_offer_test.py
+++ b/api/tests/routes/pro/patch_offer_test.py
@@ -55,7 +55,7 @@ class Returns200Test:
         assert response.json["id"] == offer.id
         assert response.json["venue"]["id"] == offer.venue.id
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.name == "New name"
         assert updated_offer.externalTicketOfficeUrl == "http://example.net"
         assert updated_offer.mentalDisabilityCompliant
@@ -283,7 +283,7 @@ class Returns200Test:
         assert response.json["id"] == offer.id
         assert response.json["venue"]["id"] == offer.venue.id
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.extraData["gtl_id"] == "01010101"
         assert updated_offer.extraData["author"] == "Kewis Larol"
         assert updated_offer.mentalDisabilityCompliant
@@ -307,7 +307,7 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json["id"] == offer.id
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.extraData == {}
         assert updated_offer.ean == "1111111111111"
 
@@ -328,7 +328,7 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json["id"] == offer.id
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.ean == "1111111111111"
         assert updated_offer.extraData == {}
 
@@ -400,7 +400,7 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json["id"] == offer.id
 
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         assert updated_offer.name == "New name"
         assert updated_offer.extraData == {
             "cast": ["Joan Baez", "Joe Cocker", "David Crosby"],
@@ -494,7 +494,7 @@ class Returns200Test:
 
         assert response.status_code == 200, response.json
         assert response.json["id"] == offer.id
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         address = updated_offer.offererAddress.address
         if address_update_exist:
             assert updated_offer.offererAddress == existant_oa
@@ -586,7 +586,7 @@ class Returns200Test:
 
         assert response.status_code == 200
         assert response.json["id"] == offer.id
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         address = updated_offer.offererAddress.address
         assert updated_offer.offererAddress.label == "Marais Salins de Kô"
         assert address.street == data["address"]["street"]
@@ -629,7 +629,7 @@ class Returns200Test:
 
         assert response.status_code == 200
         assert response.json["id"] == offer.id
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         address = updated_offer.offererAddress.address
         assert updated_offer.offererAddress.label == "Marais Salins de Kô"
         assert address.street == data["address"]["street"]
@@ -704,7 +704,7 @@ class Returns200Test:
         response = client.with_session_auth("user@example.com").patch(f"/offers/{offer.id}", json=data)
         assert response.status_code == 200
         assert response.json["id"] == offer.id
-        updated_offer = db.session.query(Offer).get(offer.id)
+        updated_offer = db.session.get(Offer, offer.id)
         address = updated_offer.offererAddress.address
         if not is_manual:
             assert updated_offer.offererAddress.label is None
@@ -734,7 +734,7 @@ class Returns200Test:
         response = client.with_session_auth("user@example.com").patch(f"/offers/{offer.id}", json=data)
 
         assert response.status_code == 200
-        offer = db.session.query(Offer).get(offer.id)
+        offer = db.session.get(Offer, offer.id)
         assert offer.withdrawalDetails == "Veuillez récuperer vos billets à l'accueil :)"
         assert offer.withdrawalType == WithdrawalTypeEnum.NO_TICKET
 
@@ -1112,7 +1112,7 @@ class Returns403Test:
         assert response.json["global"] == [
             "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
         ]
-        assert db.session.query(Offer).get(offer.id).name == "Old name"
+        assert db.session.get(Offer, offer.id).name == "Old name"
 
 
 class Returns404Test:

--- a/api/tests/routes/pro/patch_offers_active_status_test.py
+++ b/api/tests/routes/pro/patch_offers_active_status_test.py
@@ -32,8 +32,8 @@ class Returns204Test:
 
         # Then
         assert response.status_code == 204
-        offer_1 = db.session.query(Offer).get(offer1.id)
-        offer_2 = db.session.query(Offer).get(offer2.id)
+        offer_1 = db.session.get(Offer, offer1.id)
+        offer_2 = db.session.get(Offer, offer2.id)
         assert offer_1.isActive
         assert offer1.publicationDatetime
         assert offer1.publicationDatetime == offer1.bookingAllowedDatetime
@@ -64,12 +64,12 @@ class Returns204Test:
 
         # Then
         assert response.status_code == 204
-        first_offer = db.session.query(Offer).get(offer.id)
+        first_offer = db.session.get(Offer, offer.id)
         assert first_offer.finalizationDatetime == finalization_datetime.replace(tzinfo=None)
         assert not first_offer.isActive
         assert not first_offer.publicationDatetime
         assert not first_offer.bookingAllowedDatetime
-        assert not db.session.query(Offer).get(synchronized_offer.id).isActive
+        assert not db.session.get(Offer, synchronized_offer.id).isActive
 
     def test_only_approved_offers_patch(self, client):
         approved_offer = offers_factories.OfferFactory(isActive=False)
@@ -145,9 +145,9 @@ class ActivateFutureOffersTest:
             )
 
         assert response.status_code == 204
-        assert db.session.query(Offer).get(offer_to_publish_1.id).isActive
-        assert db.session.query(Offer).get(offer_to_publish_2.id).isActive
-        assert not db.session.query(Offer).get(offer_to_publish_3.id).isActive
+        assert db.session.get(Offer, offer_to_publish_1.id).isActive
+        assert db.session.get(Offer, offer_to_publish_2.id).isActive
+        assert not db.session.get(Offer, offer_to_publish_3.id).isActive
 
     def test_deactivate_future_offers(self, client):
         offer_published_1 = offers_factories.OfferFactory()
@@ -169,5 +169,5 @@ class ActivateFutureOffersTest:
             mock_notify_users_future_offer_activated.assert_not_called()
 
         assert response.status_code == 204
-        assert not db.session.query(Offer).get(offer_published_1.id).isActive
-        assert not db.session.query(Offer).get(offer_published_2.id).isActive
+        assert not db.session.get(Offer, offer_published_1.id).isActive
+        assert not db.session.get(Offer, offer_published_2.id).isActive

--- a/api/tests/routes/pro/patch_publish_offer_test.py
+++ b/api/tests/routes/pro/patch_publish_offer_test.py
@@ -68,7 +68,7 @@ class Returns200Test:
 
         assert response.status_code == 200
         content = response.json
-        offer: offers_models.Offer = db.session.query(offers_models.Offer).get(stock.offer.id)
+        offer: offers_models.Offer = db.session.get(offers_models.Offer, stock.offer.id)
         assert offer.finalizationDatetime
         assert offer.finalizationDatetime == offer.bookingAllowedDatetime
         assert offer.finalizationDatetime == offer.publicationDatetime
@@ -115,7 +115,7 @@ class Returns200Test:
         )
         assert response.status_code == 200
         content = response.json
-        offer: offers_models.Offer = db.session.query(offers_models.Offer).get(stock.offer.id)
+        offer: offers_models.Offer = db.session.get(offers_models.Offer, stock.offer.id)
         assert offer.validation == OfferValidationStatus.APPROVED
         assert offer.lastValidationPrice is None
         assert offer.finalizationDatetime
@@ -156,7 +156,7 @@ class Returns200Test:
             )
 
         assert response.status_code == 200
-        offer = db.session.query(offers_models.Offer).get(stock.offer.id)
+        offer = db.session.get(offers_models.Offer, stock.offer.id)
         assert offer.publicationDate == local_datetime_to_default_timezone(publication_date, "Europe/Paris").replace(
             microsecond=0, tzinfo=None
         )
@@ -170,7 +170,7 @@ class Returns200Test:
 
         assert response.status_code == 200
         content = response.json
-        offer = db.session.query(offers_models.Offer).get(stock.offer.id)
+        offer = db.session.get(offers_models.Offer, stock.offer.id)
         assert offer.finalizationDatetime == first_finalization_datetime
         assert offer.finalizationDatetime <= offer.bookingAllowedDatetime
         assert offer.finalizationDatetime <= offer.publicationDatetime
@@ -197,7 +197,7 @@ class Returns400Test:
 
         assert response.status_code == 400
         assert response.json["offer"] == "Cette offre n’a pas de stock réservable"
-        offer = db.session.query(offers_models.Offer).get(offer.id)
+        offer = db.session.get(offers_models.Offer, offer.id)
         assert offer.validation == OfferValidationStatus.DRAFT
 
     def test_patch_publish_offer_with_non_bookable_stock(
@@ -219,7 +219,7 @@ class Returns400Test:
 
         assert response.status_code == 400
         assert response.json["offer"] == "Cette offre n’a pas de stock réservable"
-        offer = db.session.query(offers_models.Offer).get(stock.offerId)
+        offer = db.session.get(offers_models.Offer, stock.offerId)
         assert offer.validation == OfferValidationStatus.DRAFT
 
     def test_patch_publish_future_offer(
@@ -248,7 +248,7 @@ class Returns400Test:
 
         assert response.status_code == 400
         assert response.json["publication_date"] == ["Impossible de sélectionner une date de publication dans le passé"]
-        offer = db.session.query(offers_models.Offer).get(stock.offerId)
+        offer = db.session.get(offers_models.Offer, stock.offerId)
         assert offer.validation == OfferValidationStatus.DRAFT
 
     def test_cannot_publish_offer_if_ean_is_already_used(

--- a/api/tests/routes/pro/patch_venue_collective_data_test.py
+++ b/api/tests/routes/pro/patch_venue_collective_data_test.py
@@ -50,7 +50,7 @@ class Returns200Test:
 
         # then
         assert response.status_code == 200
-        venue = db.session.query(offerers_models.Venue).get(venue_id)
+        venue = db.session.get(offerers_models.Venue, venue_id)
         assert venue.collectiveDomains == [domain]
         assert venue.collectiveStudents == [educational_models.StudentLevels.COLLEGE4]
         assert venue.collectiveNetwork == ["network1", "network2"]
@@ -100,7 +100,7 @@ class Returns200Test:
 
         # then
         assert response.status_code == 200
-        venue = db.session.query(offerers_models.Venue).get(venue_id)
+        venue = db.session.get(offerers_models.Venue, venue_id)
         assert venue.collectiveDomains == []
         assert venue.collectiveStudents == []
         assert venue.collectiveNetwork == []
@@ -145,7 +145,7 @@ class Returns200Test:
 
         # then
         assert response.status_code == 200
-        venue = db.session.query(offerers_models.Venue).get(venue_id)
+        venue = db.session.get(offerers_models.Venue, venue_id)
         assert venue.collectiveDomains == [domain]
         assert venue.collectiveStudents == [educational_models.StudentLevels.COLLEGE4]
         assert venue.collectiveNetwork == ["network3"]

--- a/api/tests/routes/pro/patch_venue_test.py
+++ b/api/tests/routes/pro/patch_venue_test.py
@@ -84,7 +84,7 @@ class Returns200Test:
 
         # then
         assert response.status_code == 200
-        new_venue = db.session.query(offerers_models.Venue).get(venue_id)
+        new_venue = db.session.get(offerers_models.Venue, venue_id)
         assert venue.publicName == "Ma librairie"
         assert venue.venueTypeCode == offerers_models.VenueTypeCode.BOOKSTORE
         assert response.json["street"] == venue.street
@@ -203,7 +203,7 @@ class Returns200Test:
         offerer_address = (
             db.session.query(offerers_models.OffererAddress).order_by(offerers_models.OffererAddress.id.desc()).first()
         )
-        old_oa = db.session.query(offerers_models.OffererAddress).get(venue_oa_id)
+        old_oa = db.session.get(offerers_models.OffererAddress, venue_oa_id)
         address = offerer_address.address
         assert old_oa.label == "old name"
         assert venue.offererAddressId == offerer_address.id
@@ -605,7 +605,7 @@ class Returns200Test:
 
         # then
         assert response.status_code == 200
-        venue = db.session.query(offerers_models.Venue).get(venue_id)
+        venue = db.session.get(offerers_models.Venue, venue_id)
         assert venue.publicName == "Ma librairie"
         assert venue.audioDisabilityCompliant == None
         assert venue.mentalDisabilityCompliant == None
@@ -899,7 +899,7 @@ class Returns200Test:
         http_client = client.with_session_auth(email=user.email)
         http_client.patch(f"/venues/{venue.id}", json=venue_data)
 
-        venue = db.session.query(offerers_models.Venue).get(venue.id)
+        venue = db.session.get(offerers_models.Venue, venue.id)
         assert venue.audioDisabilityCompliant
         assert venue.mentalDisabilityCompliant
         assert venue.motorDisabilityCompliant is False
@@ -943,7 +943,7 @@ class Returns200Test:
         http_client = client.with_session_auth(email=user_offerer.user.email)
         http_client.patch(f"/venues/{venue.id}", json=venue_data)
 
-        venue = db.session.query(offerers_models.Venue).get(venue.id)
+        venue = db.session.get(offerers_models.Venue, venue.id)
         assert venue.contact
         assert venue.contact.phone_number == "+33788888888"
         assert venue.contact.email == venue_data["contact"]["email"]
@@ -961,7 +961,7 @@ class Returns200Test:
         http_client = client.with_session_auth(email=user_offerer.user.email)
         http_client.patch(f"/venues/{venue.id}", json=venue_data)
 
-        venue = db.session.query(offerers_models.Venue).get(venue.id)
+        venue = db.session.get(offerers_models.Venue, venue.id)
         assert venue.contact.website == "https://new.website.com"
         mock_request_url_scan.assert_called_once_with(venue_data["contact"]["website"], skip_if_recent_scan=True)
 

--- a/api/tests/routes/pro/post_change_password_test.py
+++ b/api/tests/routes/pro/post_change_password_test.py
@@ -28,7 +28,7 @@ class Returns200Test:
         response = client.post("/users/password", json=data)
 
         # then
-        user = db.session.query(users_models.User).get(user_id)
+        user = db.session.get(users_models.User, user_id)
         assert user.checkPassword("N3W_p4ssw0rd") is True
         assert response.status_code == 204
         assert len(mails_testing.outbox) == 1

--- a/api/tests/routes/pro/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/post_collective_offers_template_test.py
@@ -117,7 +117,7 @@ class Returns200Test:
         assert response.status_code == 201
 
         offer_id = response.json["id"]
-        offer = db.session.query(models.CollectiveOfferTemplate).get(offer_id)
+        offer = db.session.get(models.CollectiveOfferTemplate, offer_id)
 
         assert offer.bookingEmails == ["offer1@example.com", "offer2@example.com"]
         assert offer.venue == venue
@@ -157,7 +157,7 @@ class Returns200Test:
         assert response.status_code == 201
 
         offer_id = response.json["id"]
-        offer = db.session.query(models.CollectiveOfferTemplate).get(offer_id)
+        offer = db.session.get(models.CollectiveOfferTemplate, offer_id)
 
         assert offer.contactEmail is None
         assert offer.contactPhone == "01 99 00 25 68"

--- a/api/tests/routes/pro/post_collective_offers_test.py
+++ b/api/tests/routes/pro/post_collective_offers_test.py
@@ -110,7 +110,7 @@ class Returns200Test:
         assert response.status_code == 201
 
         offer_id = response.json["id"]
-        offer = db.session.query(models.CollectiveOffer).get(offer_id)
+        offer = db.session.get(models.CollectiveOffer, offer_id)
 
         assert_offer_values(offer, data, user, offerer)
 
@@ -132,7 +132,7 @@ class Returns200Test:
         assert response.status_code == 201
 
         offer_id = response.json["id"]
-        offer = db.session.query(models.CollectiveOffer).get(offer_id)
+        offer = db.session.get(models.CollectiveOffer, offer_id)
 
         assert_offer_values(offer, data, user, offerer)
 
@@ -169,7 +169,7 @@ class Returns200Test:
 
         assert response.status_code == 201
 
-        offer = db.session.query(models.CollectiveOffer).get(response.json["id"])
+        offer = db.session.get(models.CollectiveOffer, response.json["id"])
         assert offer.students == [models.StudentLevels.ECOLES_MARSEILLE_MATERNELLE]
 
     @pytest.mark.features(ENABLE_MARSEILLE=False)

--- a/api/tests/routes/pro/post_collective_stock_test.py
+++ b/api/tests/routes/pro/post_collective_stock_test.py
@@ -43,8 +43,8 @@ class Return200Test:
         # Then
         assert response.status_code == 201
         response_dict = response.json
-        created_stock: CollectiveStock = db.session.query(CollectiveStock).get(response_dict["id"])
-        offer = db.session.query(CollectiveOffer).get(offer.id)
+        created_stock: CollectiveStock = db.session.get(CollectiveStock, response_dict["id"])
+        offer = db.session.get(CollectiveOffer, offer.id)
         assert offer.id == created_stock.collectiveOfferId
         assert created_stock.price == decimal.Decimal("1500.12")
         assert created_stock.priceDetail == "Détail du prix"
@@ -82,8 +82,8 @@ class Return200Test:
         # Then
         assert response.status_code == 201
         response_dict = response.json
-        created_stock: CollectiveStock = db.session.query(CollectiveStock).get(response_dict["id"])
-        offer = db.session.query(CollectiveOffer).get(offer.id)
+        created_stock: CollectiveStock = db.session.get(CollectiveStock, response_dict["id"])
+        offer = db.session.get(CollectiveOffer, offer.id)
         assert offer.id == created_stock.collectiveOfferId
         assert created_stock.price == decimal.Decimal("1500.12")
         assert created_stock.priceDetail == "Détail du prix"

--- a/api/tests/routes/pro/post_draft_offer_test.py
+++ b/api/tests/routes/pro/post_draft_offer_test.py
@@ -28,7 +28,7 @@ class Returns201Test:
 
         response_dict = response.json
         offer_id = response_dict["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.isActive is False
         assert response_dict["venue"]["id"] == offer.venue.id
         assert response_dict["name"] == "Celeste"
@@ -71,7 +71,7 @@ class Returns201Test:
 
         response_dict = response.json
         offer_id = response_dict["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert response_dict["isDuo"] == True
         assert not offer.product
 
@@ -97,7 +97,7 @@ class Returns201Test:
 
         response_dict = response.json
         offer_id = response_dict["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.isActive is False
         assert response_dict["venue"]["id"] == offer.venue.id
         assert response_dict["name"] == "Celeste"
@@ -126,7 +126,7 @@ class Returns201Test:
 
         response_dict = response.json
         offer_id = response_dict["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.isActive is False
         assert response_dict["venue"]["id"] == offer.venue.id
         assert response_dict["name"] == "Celeste"
@@ -150,7 +150,7 @@ class Returns201Test:
 
         response_dict = response.json
         offer_id = response_dict["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.isActive is False
         assert response_dict["venue"]["id"] == offer.venue.id
         assert response_dict["name"] == "Celeste"
@@ -181,7 +181,7 @@ class Returns201Test:
 
         response_dict = response.json
         offer_id = response_dict["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.isActive is False
         assert response_dict["venue"]["id"] == offer.venue.id
         assert response_dict["name"] == "Celeste"
@@ -213,7 +213,7 @@ class Returns201Test:
 
         assert response.status_code == 201
 
-        offer = db.session.query(Offer).get(response.json["id"])
+        offer = db.session.get(Offer, response.json["id"])
         assert offer.audioDisabilityCompliant is True
         assert offer.mentalDisabilityCompliant is True
         assert offer.motorDisabilityCompliant is False
@@ -238,7 +238,7 @@ class Returns201Test:
 
         assert response.status_code == 201
 
-        offer = db.session.query(Offer).get(response.json["id"])
+        offer = db.session.get(Offer, response.json["id"])
         assert offer.audioDisabilityCompliant is None
         assert offer.mentalDisabilityCompliant is None
         assert offer.motorDisabilityCompliant is None
@@ -264,7 +264,7 @@ class Returns201Test:
 
         assert response.status_code == 201
 
-        offer = db.session.query(Offer).get(response.json["id"])
+        offer = db.session.get(Offer, response.json["id"])
         assert offer.audioDisabilityCompliant == True
         assert offer.mentalDisabilityCompliant == False
         assert offer.motorDisabilityCompliant == True

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -30,7 +30,7 @@ class Returns200Test:
         }
         response = client.with_session_auth("user@example.com").post("/offers", json=data)
         offer_id = response.json["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         response_dict = response.json
         assert offer.isActive is False
         assert response_dict["venue"]["id"] == offer.venue.id
@@ -65,7 +65,7 @@ class Returns200Test:
         # Then
         assert response.status_code == 201
         offer_id = response.json["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.bookingContact == "offer@example.com"
         assert offer.bookingEmail == "offer@example.com"
         assert offer.publicationDate is None
@@ -135,7 +135,7 @@ class Returns200Test:
         # Then
         assert response.status_code == 201
         offer_id = response.json["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.offererAddress.address == offerer_address.address
         assert offer.offererAddress.label == oa_label
         assert not offer.offererAddress.address.isManualEdition
@@ -177,7 +177,7 @@ class Returns200Test:
         # Then
         assert response.status_code == 201
         offer_id = response.json["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.offererAddress.address != offerer_address.address
         assert offer.offererAddress.label == oa_label
         assert not offer.offererAddress.address.isManualEdition
@@ -219,7 +219,7 @@ class Returns200Test:
         # Then
         assert response.status_code == 201
         offer_id = response.json["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.offererAddress.address.isManualEdition
         assert offer.offererAddress.label == oa_label
         assert not offer.offererAddress.address.banId
@@ -249,7 +249,7 @@ class Returns200Test:
         # Then
         assert response.status_code == 201
         offer_id = response.json["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.bookingEmail == "offer@example.com"
         assert offer.subcategoryId == subcategories.JEU_EN_LIGNE.id
         assert offer.venue == venue
@@ -287,7 +287,7 @@ class Returns200Test:
         assert "ean" not in response.json
 
         offer_id = response.json["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.subcategoryId == subcategories.LIVRE_PAPIER.id
         assert offer.venue == venue
         assert offer.ean == "1234567890112"
@@ -317,7 +317,7 @@ class Returns200Test:
 
         # Then
         offer_id = response.json["id"]
-        offer = db.session.query(Offer).get(offer_id)
+        offer = db.session.get(Offer, offer_id)
         assert offer.withdrawalDetails == "Veuillez récuperer vos billets à l'accueil :)"
         assert offer.withdrawalType == WithdrawalTypeEnum.NO_TICKET
 

--- a/api/tests/routes/public/booking_token/v2/patch_booking_keep_by_token_test.py
+++ b/api/tests/routes/public/booking_token/v2/patch_booking_keep_by_token_test.py
@@ -159,7 +159,7 @@ class Returns410Test:
         response = client.with_session_auth(user.email).patch(url)
 
         # Then
-        booking = db.session.query(Booking).get(booking.id)
+        booking = db.session.get(Booking, booking.id)
         assert response.status_code == 410
         assert response.json["booking"] == ["Cette réservation a été annulée"]
         assert booking.status is BookingStatus.CANCELLED

--- a/api/tests/routes/public/booking_token/v2/patch_booking_use_by_token_test.py
+++ b/api/tests/routes/public/booking_token/v2/patch_booking_use_by_token_test.py
@@ -99,7 +99,7 @@ class Returns403Test:
             assert response.json["user"] == [
                 "Vous n’avez pas les droits suffisants pour valider cette contremarque car cette réservation n'a pas été faite sur une de vos offres, ou que votre rattachement à la structure est encore en cours de validation"
             ]
-            booking = db.session.query(Booking).get(booking.id)
+            booking = db.session.get(Booking, booking.id)
             assert booking.status == BookingStatus.CONFIRMED
 
         def test_when_offerer_is_closed(self, client):
@@ -112,7 +112,7 @@ class Returns403Test:
 
             assert response.status_code == 403
             assert response.json["booking"] == ["Vous ne pouvez plus valider de contremarque sur une structure fermée"]
-            booking = db.session.query(Booking).get(booking.id)
+            booking = db.session.get(Booking, booking.id)
             assert booking.status == BookingStatus.CONFIRMED
 
 
@@ -142,7 +142,7 @@ class Returns410Test:
         # Then
         assert response.status_code == 410
         assert response.json["booking_cancelled"] == ["Cette réservation a été annulée"]
-        booking = db.session.query(Booking).get(booking.id)
+        booking = db.session.get(Booking, booking.id)
         assert booking.status == BookingStatus.CANCELLED
 
     def test_when_user_is_logged_in_and_booking_has_been_cancelled_already(self, client):
@@ -159,5 +159,5 @@ class Returns410Test:
         # Then
         assert response.status_code == 410
         assert response.json["booking_cancelled"] == ["Cette réservation a été annulée"]
-        booking = db.session.query(Booking).get(booking.id)
+        booking = db.session.get(Booking, booking.id)
         assert booking.status == BookingStatus.CANCELLED

--- a/api/tests/routes/public/individual_offers/v1/post_product_by_ean_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_by_ean_test.py
@@ -700,6 +700,6 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
 
         assert response.status_code == 204
 
-        updated_stock = db.session.query(offers_models.Stock).get(stock.id)
+        updated_stock = db.session.get(offers_models.Stock, stock.id)
         assert updated_stock.price == 0
         assert updated_stock.quantity == 3

--- a/api/tests/routes/shared/post_reset_password_test.py
+++ b/api/tests/routes/shared/post_reset_password_test.py
@@ -94,7 +94,7 @@ class Returns204Test:
 
         # then
         assert response.status_code == 204
-        user = db.session.query(User).get(user.id)
+        user = db.session.get(User, user.id)
 
     @patch("pcapi.routes.shared.passwords.check_web_recaptcha_token", return_value=None)
     def when_email_is_known(self, check_recaptcha_token_is_valid_mock, client, db_session):
@@ -107,7 +107,7 @@ class Returns204Test:
 
         # then
         assert response.status_code == 204
-        user = db.session.query(User).get(user.id)
+        user = db.session.get(User, user.id)
         assert token_utils.Token.token_exists(token_utils.TokenType.RESET_PASSWORD, user.id)
         now = datetime.utcnow()
         assert (

--- a/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
+++ b/api/tests/scripts/beneficiary/import_dms_accepted_applications_test.py
@@ -432,7 +432,7 @@ class RunIntegrationTest:
 
         assert db.session.query(users_models.User).count() == 2
 
-        user = db.session.query(users_models.User).get(user.id)
+        user = db.session.get(users_models.User, user.id)
         assert len(user.beneficiaryFraudChecks) == 1
         fraud_check = user.beneficiaryFraudChecks[0]
         assert fraud_check.type == fraud_models.FraudCheckType.DMS


### PR DESCRIPTION
…y `db.session.get(Model, id)` for migration to SqlAlchemy 2.0 and removing flask-sqlalchemy

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36481)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->


## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
