### PR TITLE
(PC-36494)[PRO] feat: Use checkbox with description for duo checkbox …

### DIFF
--- a/pro/src/components/DuoCheckbox/DuoCheckbox.tsx
+++ b/pro/src/components/DuoCheckbox/DuoCheckbox.tsx
@@ -1,0 +1,26 @@
+import { forwardRef } from 'react'
+
+import { Checkbox, CheckboxProps } from 'design-system/Checkbox/Checkbox'
+import strokeDuoIcon from 'icons/stroke-duo.svg'
+
+export const DuoCheckbox = forwardRef<
+  HTMLInputElement,
+  Omit<CheckboxProps, 'label' | 'variant' | 'description' | 'asset'>
+>((props, ref) => {
+  return (
+    <Checkbox
+      description="Cette option permet au bénéficiaire du pass Culture de venir accompagné. La seconde place sera délivrée au même tarif que la première, quel que soit l’accompagnateur."
+      label="Accepter les réservations “Duo“"
+      variant="detailed"
+      sizing="fill"
+      asset={{
+        variant: 'icon',
+        src: strokeDuoIcon,
+      }}
+      {...props}
+      ref={ref}
+    />
+  )
+})
+
+DuoCheckbox.displayName = 'DuoCheckbox'

--- a/pro/src/components/IndividualOffer/PriceCategoriesScreen/PriceCategoriesScreen.tsx
+++ b/pro/src/components/IndividualOffer/PriceCategoriesScreen/PriceCategoriesScreen.tsx
@@ -15,6 +15,7 @@ import { useNotification } from 'commons/hooks/useNotification'
 import { useOfferWizardMode } from 'commons/hooks/useOfferWizardMode'
 import { isEqual } from 'commons/utils/isEqual'
 import { ConfirmDialog } from 'components/ConfirmDialog/ConfirmDialog'
+import { DuoCheckbox } from 'components/DuoCheckbox/DuoCheckbox'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import {
   UNIQUE_PRICE,
@@ -25,7 +26,6 @@ import {
 } from 'components/IndividualOffer/PriceCategoriesScreen/form/constants'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { RouteLeavingGuardIndividualOffer } from 'components/RouteLeavingGuardIndividualOffer/RouteLeavingGuardIndividualOffer'
-import { Checkbox } from 'design-system/Checkbox/Checkbox'
 import fullMoreIcon from 'icons/full-more.svg'
 import fullTrashIcon from 'icons/full-trash.svg'
 import strokeEuroIcon from 'icons/stroke-euro.svg'
@@ -34,7 +34,6 @@ import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant, IconPositionEnum } from 'ui-kit/Button/types'
 import { PriceInput } from 'ui-kit/formV2/PriceInput/PriceInput'
 import { TextInput } from 'ui-kit/formV2/TextInput/TextInput'
-import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 
 import { getSuccessMessage } from '../utils/getSuccessMessage'
 
@@ -408,23 +407,11 @@ export const PriceCategoriesScreen = ({
                 className={styles['duo-section']}
                 title="Réservations “Duo”"
               >
-                <FormLayout.Row
-                  sideComponent={
-                    <InfoBox>
-                      Cette option permet au bénéficiaire de venir accompagné.
-                      La seconde place sera délivrée au même tarif que la
-                      première, quel que soit l’accompagnateur.
-                    </InfoBox>
-                  }
-                >
-                  <Checkbox
-                    {...register('isDuo')}
-                    checked={Boolean(watch('isDuo'))}
-                    label="Accepter les réservations “Duo“"
-                    disabled={isDisabled}
-                    variant="detailed"
-                  />
-                </FormLayout.Row>
+                <DuoCheckbox
+                  {...register('isDuo')}
+                  checked={Boolean(watch('isDuo'))}
+                  disabled={isDisabled}
+                />
               </FormLayout.Section>
             </FormLayout>
           )}

--- a/pro/src/components/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategoriesForm.spec.tsx
+++ b/pro/src/components/IndividualOffer/PriceCategoriesScreen/__specs__/PriceCategoriesForm.spec.tsx
@@ -167,13 +167,13 @@ describe('PriceCategories', () => {
     renderPriceCategoriesForm(true, values)
 
     expect(
-      screen.getByLabelText('Accepter les réservations “Duo“')
+      screen.getByLabelText(/Accepter les réservations “Duo“/)
     ).toBeChecked()
     await userEvent.click(
-      screen.getByLabelText('Accepter les réservations “Duo“')
+      screen.getByLabelText(/Accepter les réservations “Duo“/)
     )
     expect(
-      screen.getByLabelText('Accepter les réservations “Duo“')
+      screen.getByLabelText(/Accepter les réservations “Duo“/)
     ).not.toBeChecked()
 
     await userEvent.click(
@@ -184,7 +184,7 @@ describe('PriceCategories', () => {
       priceCategories: [{ id: 2, label: 'Tarif unique' }],
     })
     expect(
-      screen.getByLabelText('Accepter les réservations “Duo“')
+      screen.getByLabelText(/Accepter les réservations “Duo“/)
     ).not.toBeChecked()
   })
 

--- a/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
+++ b/pro/src/components/IndividualOffer/StocksThing/StocksThing.tsx
@@ -20,11 +20,11 @@ import { useNotification } from 'commons/hooks/useNotification'
 import { useOfferWizardMode } from 'commons/hooks/useOfferWizardMode'
 import { getToday, getYearMonthDay, isDateValid } from 'commons/utils/date'
 import { getLocalDepartementDateTimeFromUtc } from 'commons/utils/timezone'
+import { DuoCheckbox } from 'components/DuoCheckbox/DuoCheckbox'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { FormLayoutDescription } from 'components/FormLayout/FormLayoutDescription'
 import { OFFER_WIZARD_STEP_IDS } from 'components/IndividualOfferNavigation/constants'
 import { RouteLeavingGuardIndividualOffer } from 'components/RouteLeavingGuardIndividualOffer/RouteLeavingGuardIndividualOffer'
-import { Checkbox } from 'design-system/Checkbox/Checkbox'
 import fullCodeIcon from 'icons/full-code.svg'
 import fullTrashIcon from 'icons/full-trash.svg'
 import strokeEuroIcon from 'icons/stroke-euro.svg'
@@ -35,7 +35,6 @@ import {
   QuantityInput,
 } from 'ui-kit/form/QuantityInput/QuantityInput'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
-import { InfoBox } from 'ui-kit/InfoBox/InfoBox'
 import { ListIconButton } from 'ui-kit/ListIconButton/ListIconButton'
 
 import { DialogStockThingDeleteConfirm } from '../DialogStockDeleteConfirm/DialogStockThingDeleteConfirm'
@@ -481,25 +480,13 @@ export const StocksThing = ({ offer }: StocksThingProps): JSX.Element => {
               className={styles['duo-section']}
               title="Réservations “Duo”"
             >
-              <FormLayout.Row
-                sideComponent={
-                  <InfoBox>
-                    Cette option permet au bénéficiaire de venir accompagné. La
-                    seconde place sera délivrée au même tarif que la première,
-                    quel que soit l’accompagnateur.
-                  </InfoBox>
+              <DuoCheckbox
+                checked={Boolean(formik.getFieldProps('isDuo').value)}
+                onChange={(e) =>
+                  formik.setFieldValue('isDuo', e.target.checked)
                 }
-              >
-                <Checkbox
-                  label="Accepter les réservations “Duo“"
-                  disabled={isDisabled}
-                  variant="detailed"
-                  checked={Boolean(formik.getFieldProps('isDuo').value)}
-                  onChange={(e) =>
-                    formik.setFieldValue('isDuo', e.target.checked)
-                  }
-                />
-              </FormLayout.Row>
+                disabled={isDisabled}
+              />
             </FormLayout.Section>
           </FormLayout>
         )}

--- a/pro/src/components/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
+++ b/pro/src/components/IndividualOffer/StocksThing/__specs__/StocksThing.spec.tsx
@@ -213,10 +213,10 @@ describe('screens:StocksThing', () => {
 
     await waitFor(() => {
       expect(api.createThingStock).toHaveBeenCalledWith({
-          offerId: offer.id,
-          bookingLimitDatetime: null,
-          price: 20,
-          quantity: null,
+        offerId: offer.id,
+        bookingLimitDatetime: null,
+        price: 20,
+        quantity: null,
       })
     })
     expect(screen.getByText('Next page')).toBeInTheDocument()
@@ -233,7 +233,7 @@ describe('screens:StocksThing', () => {
     })
     await userEvent.type(screen.getByLabelText('Prix *'), '20')
     await userEvent.click(
-      screen.getByLabelText('Accepter les réservations “Duo“')
+      screen.getByLabelText(/Accepter les réservations “Duo“/)
     )
     await userEvent.click(nextButton)
 
@@ -378,14 +378,15 @@ describe('screens:StocksThing', () => {
       await userEvent.click(screen.getByText('Enregistrer et continuer'))
       expect(api.createThingStock).toHaveBeenCalledWith({
         offerId: offer.id,
-  
+
         bookingLimitDatetime: null,
         price: 14.01,
         quantity: 5,
         activationCodes: ['ABH', 'JHB', 'IOP', 'KLM', 'MLK'],
-        activationCodesExpirationDatetime:
-          serializeThingBookingLimitDatetime(date, '75'),
-
+        activationCodesExpirationDatetime: serializeThingBookingLimitDatetime(
+          date,
+          '75'
+        ),
       })
     })
 

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx
@@ -25,7 +25,7 @@ const renderCinemaProviderForm = async (
     </Dialog.Root>
   )
 
-  await waitFor(() => screen.getByText('Accepter les réservations duo'))
+  await waitFor(() => screen.getByText('Accepter les réservations “Duo“'))
 }
 
 describe('GenericCinemaProviderForm', () => {
@@ -61,7 +61,7 @@ describe('GenericCinemaProviderForm', () => {
       await renderCinemaProviderForm(props)
 
       const isDuoCheckbox = screen.getByLabelText(
-        /Accepter les réservations duo/
+        /Accepter les réservations “Duo“/
       )
       expect(isDuoCheckbox).toBeInTheDocument()
       expect(isDuoCheckbox).toBeChecked()
@@ -129,7 +129,7 @@ describe('GenericCinemaProviderForm', () => {
       await renderCinemaProviderForm(props)
 
       const isDuoCheckbox = screen.getByLabelText(
-        /Accepter les réservations duo/
+        /Accepter les réservations “Duo“/
       )
       expect(isDuoCheckbox).not.toBeChecked()
     })

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.tsx
@@ -4,9 +4,8 @@ import { useForm } from 'react-hook-form'
 import { PostVenueProviderBody } from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
 import { SynchronizationEvents } from 'commons/core/FirebaseEvents/constants'
+import { DuoCheckbox } from 'components/DuoCheckbox/DuoCheckbox'
 import { FormLayout } from 'components/FormLayout/FormLayout'
-import { Checkbox } from 'design-system/Checkbox/Checkbox'
-import strokeDuoIcon from 'icons/stroke-duo.svg'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonVariant } from 'ui-kit/Button/types'
 import { Callout } from 'ui-kit/Callout/Callout'
@@ -121,16 +120,9 @@ export const GenericCinemaProviderForm = ({
         )}
 
         <FormLayout.Row>
-          <Checkbox
+          <DuoCheckbox
             {...register('isDuo')}
             checked={Boolean(watch('isDuo'))}
-            label="Accepter les réservations duo"
-            description="Cette option permet au bénéficiaire du pass Culture de venir accompagné. La seconde place sera délivrée au même tarif que la première, quel que soit l’accompagnateur."
-            variant="detailed"
-            asset={{
-              variant: 'icon',
-              src: strokeDuoIcon,
-            }}
           />
         </FormLayout.Row>
 

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/__specs__/GenericCinemaProviderEdit.spec.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/__specs__/GenericCinemaProviderEdit.spec.tsx
@@ -49,10 +49,12 @@ describe('GenericCinemaProviderEdit', () => {
     await renderComponent()
 
     expect(
-      screen.getByText('Accepter les réservations duo')
+      screen.getByText('Accepter les réservations “Duo“')
     ).toBeInTheDocument()
 
-    const isDuoCheckbox = screen.getByLabelText(/Accepter les réservations duo/)
+    const isDuoCheckbox = screen.getByLabelText(
+      /Accepter les réservations “Duo“/
+    )
     expect(isDuoCheckbox).toBeChecked()
   })
 
@@ -77,7 +79,9 @@ describe('GenericCinemaProviderEdit', () => {
   it('should allow toggling isDuo checkbox', async () => {
     await renderComponent()
 
-    const isDuoCheckbox = screen.getByLabelText(/Accepter les réservations duo/)
+    const isDuoCheckbox = screen.getByLabelText(
+      /Accepter les réservations “Duo“/
+    )
     expect(isDuoCheckbox).toBeChecked()
 
     await userEvent.click(isDuoCheckbox)

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/__specs__/VenueProviderCard.spec.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/VenueProviderList/__specs__/VenueProviderCard.spec.tsx
@@ -56,7 +56,7 @@ describe('VenueProviderCard', () => {
         screen.getByText('Modifier les paramètres de vos offres')
       ).toBeInTheDocument()
       expect(
-        screen.getByText('Accepter les réservations duo')
+        screen.getByText('Accepter les réservations “Duo“')
       ).toBeInTheDocument()
     })
 


### PR DESCRIPTION
…in stocks.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36494)

Remplacement de la checkbox + Infobox des réservations duo par une checkbox avec description.

Changements effectués dans la page Tarif d'une offre indiv (pour les offres dont la sous-catégorie peut être duo ex: dans la catégorie Musée...).

Revue design OK ✅ 

## 🖼️ Before & After Images

Before | After
:---: | :---:
![before](https://github.com/user-attachments/assets/31cfc448-000c-4915-8c77-57a2b8bc31bb) | ![after](https://github.com/user-attachments/assets/dc712499-cdc8-41d8-9caa-714ce7baaaf8)


