### PR TITLE
(PC-36121)[API] chore: remove get_venue_street function

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/common.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/common.py
@@ -25,7 +25,3 @@ def get_offer_withdrawal_type(booking: Booking) -> str | None:
 
 def get_offerer_name(booking: Booking) -> str:
     return booking.stock.offer.venue.managingOfferer.name
-
-
-def get_venue_street(booking: Booking) -> str:
-    return booking.stock.offer.venue.street


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36121)


<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

Removal of unused function get_venue_street that used deprecated venue.street information.
