### PR TITLE
(BSR)[PRO] ci: Fix e2e navigation test.

### DIFF
--- a/pro/cypress/e2e/navigation.cy.ts
+++ b/pro/cypress/e2e/navigation.cy.ts
@@ -24,13 +24,8 @@ describe('Navigation', () => {
     cy.wait('@getVenue')
 
     cy.stepLog({ message: 'I scroll to my venue' })
-    cy.contains(
-      'h3',
-      /Votre page partenaire|Vos pages partenaire/
-    ).scrollIntoView()
-    cy.contains('h3', /Votre page partenaire|Vos pages partenaire/).should(
-      'be.visible'
-    )
+    cy.contains('h3', 'Prochaines étapes').scrollIntoView()
+    cy.contains('h3', 'Prochaines étapes').should('be.visible')
     cy.get('[id=content-wrapper]').then((el) => {
       expect(el.get(0).scrollTop).to.be.greaterThan(0)
     })


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Correction du test E2E de navigation. Le test vérifiait l'existence d'un titre qui est toujours présent, alors que le reste de la donnée ne l'est pas.
