### PR TITLE
(PC-36532)[BO] fix: table manager comatibility with expandable lines …

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/components/forms/tom_select_field.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/forms/tom_select_field.html
@@ -13,11 +13,9 @@
           name="{{ field.name }}"
           data-original-name="{{ field.name }}"
           size="2"></select>
-  {% if not(field.tomselect_items and field.tomselect_items[0]) %}
-    <label class="pc-select-label label-element-form"
-           data-original-name="{{ field.name }}"
-           for="{{ tom_select_field_id }}">{{ field.label.text }}</label>
-  {% endif %}
+  <label class="pc-select-label label-element-form"
+         data-original-name="{{ field.name }}"
+         for="{{ tom_select_field_id }}">{{ field.label.text }}</label>
 </div>
 {% if field.field_list_compatibility %}
   <!-- (Almost) duplicated html for field list field widget -->

--- a/api/src/pcapi/static/backoffice/js/addons/pc-table-manager.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-table-manager.js
@@ -323,30 +323,33 @@ class PcTableManager extends PcAddOn {
     const oldConfigurationMap = {}
 
     $table.querySelectorAll("tr").forEach(($line) => {
-      configuration.columns.forEach((columnConfiguration) => {
-        // retrieve cell to move/update
-        let $cell
-        if (oldConfigurationMap[columnConfiguration.id] === undefined) {
-          for(let i=0; i < $line.children.length; i++){
-            if ($line.children[i].classList.contains(columnConfiguration.id)){
-              $cell = $line.children[i]
-              oldConfigurationMap[columnConfiguration.id] = i
-              break
+      // ignore lines with too few colonnes for pages like bookings
+      if($line.children.length >= (configuration.columns.length * 0.5)) {
+        configuration.columns.forEach((columnConfiguration) => {
+          // retrieve cell to move/update
+          let $cell
+          if (oldConfigurationMap[columnConfiguration.id] === undefined) {
+            for(let i=0; i < $line.children.length; i++){
+              if ($line.children[i].classList.contains(columnConfiguration.id)){
+                $cell = $line.children[i]
+                oldConfigurationMap[columnConfiguration.id] = i
+                break
+              }
+            }
+          } else {
+            $cell = $line.children[oldConfigurationMap[columnConfiguration.id]]
+          }
+          if ($cell){
+            // apply configuration
+            if(columnConfiguration.display){
+              $cell.classList.remove('d-none')
+              $line.appendChild($cell)
+            } else {
+              $cell.classList.add('d-none')
             }
           }
-        } else {
-          $cell = $line.children[oldConfigurationMap[columnConfiguration.id]]
-        }
-        if ($cell){
-          // apply configuration
-          if(columnConfiguration.display){
-            $cell.classList.remove('d-none')
-            $line.appendChild($cell)
-          } else {
-            $cell.classList.add('d-none')
-          }
-        }
-      })
+        })
+      }
     })
     $table.classList.remove('d-none')
   }


### PR DESCRIPTION
…(like in bookings)

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36532)

fix deux bugs:
- les tomselect vides n'avaient plus de labels (dans le premier commit)
- quand on masquait des colonnes a un tableau a accordéons (comme les tableaux des bookings) l'accordéon ne s'affichait plus au click sur le chevron. (second commit)