### PR TITLE
(PC-36388)[PRO] feat: add banner dms for collective offer

### DIFF
--- a/pro/src/pages/OfferType/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
@@ -15,6 +15,7 @@ import strokeDuplicateOfferIcon from 'icons/stroke-duplicate-offer.svg'
 import strokeNewOfferIcon from 'icons/stroke-new-offer.svg'
 import strokeTemplateOfferIcon from 'icons/stroke-template-offer.svg'
 import { Callout } from 'ui-kit/Callout/Callout'
+import { CalloutVariant } from 'ui-kit/Callout/types'
 import { RadioGroup } from 'ui-kit/formV2/RadioGroup/RadioGroup'
 
 import styles from './CollectiveOfferType.module.scss'
@@ -124,18 +125,43 @@ export const CollectiveOfferType = ({ offerer }: CollectiveOfferTypeProps) => {
           </Callout>
         )}
 
-      {!offerer?.allowedOnAdage && lastDmsApplication && (
-        <Callout
-          links={[
-            {
-              href: `/structures/${queryOffererId}/lieux/${lastDmsApplication.venueId}/collectif`,
-              label: 'Voir ma demande de référencement',
-            },
-          ]}
-        >
-          Vous avez une demande de référencement en cours de traitement
-        </Callout>
-      )}
+      {!offerer?.allowedOnAdage &&
+        (lastDmsApplication ? (
+          <Callout
+            className={styles['pending-offerer-callout']}
+            variant={CalloutVariant.INFO}
+            links={[
+              {
+                href: `/structures/${queryOffererId}/lieux/${lastDmsApplication.venueId}/collectif`,
+                label: 'Voir ma demande de référencement',
+              },
+            ]}
+          >
+            Vous avez une demande de référencement en cours de traitement
+          </Callout>
+        ) : (
+          <Callout
+            className={styles['pending-offerer-callout']}
+            links={[
+              {
+                href: 'https://www.demarches-simplifiees.fr/commencer/demande-de-referencement-sur-adage',
+                label: 'Faire une demande de référencement',
+                isExternal: true,
+              },
+              {
+                href: 'https://aide.passculture.app/hc/fr/articles/5700215550364',
+                label:
+                  'Ma demande de référencement a été acceptée mais je ne peux toujours pas créer d’offres collectives',
+                isExternal: true,
+              },
+            ]}
+            variant={CalloutVariant.ERROR}
+          >
+            Pour proposer des offres à destination d’un groupe scolaire, vous
+            devez être référencé auprès du ministère de l’Éducation Nationale et
+            du ministère de la Culture.
+          </Callout>
+        ))}
     </>
   )
 }

--- a/pro/src/pages/OfferType/OfferType/__specs__/OfferType.spec.tsx
+++ b/pro/src/pages/OfferType/OfferType/__specs__/OfferType.spec.tsx
@@ -357,4 +357,20 @@ describe('OfferType', () => {
 
     expect(await screen.findByText('Chargement en cours')).toBeInTheDocument()
   })
+
+  it('should display DS banner if structure not allowed on adage and last ds reference request not found ', async () => {
+    vi.spyOn(api, 'getOfferer').mockResolvedValue({
+      ...defaultGetOffererResponseModel,
+      allowedOnAdage: false,
+    })
+    renderOfferTypes('123')
+
+    await userEvent.click(
+      screen.getByRole('radio', { name: 'À un groupe scolaire' })
+    )
+
+    expect(
+      await screen.findByText('Faire une demande de référencement')
+    ).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36388)

Une bannière avait été supprimé, on l'a remet. C'était pour afficher une bannière rouge lorsque la structure ne peut pas créer d'offres collective (pas autoriser sur adage et aucun dossier DS)