### PR TITLE
(PC-36561)[API] fix: catch JSONDecodeError in cancel_event_ticket

### DIFF
--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -309,7 +309,7 @@ def cancel_event_ticket(
             if is_booking_saved:
                 new_quantity -= len(barcodes)
             stock.quantity = new_quantity
-    except (ValueError, pydantic_v1.ValidationError):
+    except (ValueError, json.JSONDecodeError, pydantic_v1.ValidationError):
         logger.exception(
             "Could not parse external booking cancel response",
             extra={"status_code": response.status_code, "response": response.text},


### PR DESCRIPTION
Ticket Jira : https://passculture.atlassian.net/browse/PC-36561
Sentry : https://pass-culture.sentry.io/issues/33110805/?environment=production (749 alertes)

Capturer `JSONDecodeError` dans `cancel_event_ticket` comme c'est déjà fait dans `book_event_ticket`, ainsi on aura le contenu dans les logs pour investiguer.