### PR TITLE
(PC-36568)[API] fix: exception when retrieving empty booking emails from BigQuery

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/pro_email_churned_40_days_ago.py
+++ b/api/src/pcapi/connectors/big_query/queries/pro_email_churned_40_days_ago.py
@@ -12,6 +12,8 @@ class ChurnedProEmail(BaseQuery):
             `{settings.BIG_QUERY_TABLE_BASENAME}.marketing_pro_email_churned_40_days_ago`
         where
             cast(execution_date as date) = current_date()
+            and venue_booking_email is not null
+            and TRIM(venue_booking_email) != ''
     """
 
     model = ProEmailModel

--- a/api/src/pcapi/connectors/big_query/queries/pro_no_bookings_since_40_days_ago.py
+++ b/api/src/pcapi/connectors/big_query/queries/pro_no_bookings_since_40_days_ago.py
@@ -12,6 +12,8 @@ class NoBookingsProEmail(BaseQuery):
             `{settings.BIG_QUERY_TABLE_BASENAME}.marketing_pro_email_last_booking_40_days_ago`
         where
             cast(execution_date as date) = current_date()
+            and venue_booking_email is not null
+            and TRIM(venue_booking_email) != ''
     """
 
     model = ProEmailModel


### PR DESCRIPTION
Ticket Jira : https://passculture.atlassian.net/browse/PC-36568
Sentry : https://pass-culture.sentry.io/issues/36402599/?environment=production

La correction reprend la même condition que dans https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/connectors/big_query/queries/marketing.py.