### PR TITLE
(PC-36569)[PRO] feat: Hide withdrawaltype when the offer subcategory …

### DIFF
--- a/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
+++ b/pro/src/components/IndividualOffer/SummaryScreen/OfferSection/OfferSection.tsx
@@ -72,7 +72,14 @@ export const OfferSection = ({
       text: offerData.venuePublicName || offerData.venueName,
     },
     { title: 'Titre de l’offre', text: offerData.name },
-    { title: 'Description', text: !offerData.description ? '-' : <Markdown markdownText={offerData.description} /> },
+    {
+      title: 'Description',
+      text: !offerData.description ? (
+        '-'
+      ) : (
+        <Markdown markdownText={offerData.description} />
+      ),
+    },
   ].concat(
     offer.isDigital
       ? {

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/commons/__specs__/utils.spec.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/commons/__specs__/utils.spec.ts
@@ -75,7 +75,7 @@ describe('setDefaultInitialValuesFromOffer', () => {
       withdrawalDetails:
         DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES['withdrawalDetails'],
       withdrawalDelay: undefined,
-      withdrawalType: WithdrawalTypeEnum.NO_TICKET,
+      withdrawalType: undefined,
       bookingEmail: '',
       bookingContact: undefined,
       receiveNotificationEmails: false,

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/commons/utils.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/commons/utils.ts
@@ -1,6 +1,7 @@
 import {
   GetIndividualOfferResponseModel,
   type GetIndividualOfferWithAddressResponseModel,
+  SubcategoryResponseModel,
   VenueListItemResponseModel,
   WithdrawalTypeEnum,
 } from 'apiClient/v1'
@@ -22,11 +23,13 @@ import { UsefulInformationFormValues } from './types'
 interface SetDefaultInitialValuesFromOfferProps {
   offer?: GetIndividualOfferWithAddressResponseModel | null
   selectedVenue?: VenueListItemResponseModel | undefined
+  offerSubCategory?: SubcategoryResponseModel
 }
 
 export function setDefaultInitialValuesFromOffer({
   offer,
   selectedVenue = undefined,
+  offerSubCategory,
 }: SetDefaultInitialValuesFromOfferProps): UsefulInformationFormValues {
   if (!offer) {
     return DEFAULT_USEFUL_INFORMATION_INITIAL_VALUES
@@ -99,7 +102,11 @@ export function setDefaultInitialValuesFromOffer({
       offer.withdrawalDelay === null
         ? undefined
         : offer.withdrawalDelay?.toString(),
-    withdrawalType: offer.withdrawalType || WithdrawalTypeEnum.NO_TICKET,
+    withdrawalType:
+      offer.withdrawalType ||
+      (offerSubCategory?.canBeWithdrawable
+        ? WithdrawalTypeEnum.NO_TICKET
+        : undefined),
     accessibility: {
       [AccessibilityEnum.VISUAL]: offer.visualDisabilityCompliant || false,
       [AccessibilityEnum.MENTAL]: offer.mentalDisabilityCompliant || false,

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.spec.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { api } from 'apiClient/api'
-import { SubcategoryIdEnum, WithdrawalTypeEnum } from 'apiClient/v1'
+import { SubcategoryIdEnum } from 'apiClient/v1'
 import {
   IndividualOfferContext,
   IndividualOfferContextValues,
@@ -247,9 +247,9 @@ describe('screens:IndividualOffer::UsefulInformation', () => {
       externalTicketOfficeUrl: 'https://chuck.no',
       url: undefined,
       visualDisabilityCompliant: false,
-      withdrawalDelay: null,
+      withdrawalDelay: undefined,
       withdrawalDetails: 'My information',
-      withdrawalType: WithdrawalTypeEnum.NO_TICKET,
+      withdrawalType: undefined,
     })
   })
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.tsx
@@ -201,6 +201,7 @@ export const IndividualOfferInformationsScreen = ({
   const initialValues = setDefaultInitialValuesFromOffer({
     offer,
     selectedVenue,
+    offerSubCategory,
   })
   const previousInitialValues = usePrevious(initialValues)
   const initialValuesHasChanged = !isEqual(previousInitialValues, initialValues)

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/UsefulInformationForm/UsefulInformationForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/UsefulInformationForm/UsefulInformationForm.tsx
@@ -133,7 +133,7 @@ export const UsefulInformationForm = ({
               <RadioGroup
                 variant="detailed"
                 name="withdrawalType"
-                checkedOption={withdrawalType || WithdrawalTypeEnum.NO_TICKET}
+                checkedOption={withdrawalType}
                 group={
                   withdrawalType === WithdrawalTypeEnum.IN_APP
                     ? providedTicketWithdrawalTypeRadios


### PR DESCRIPTION
…cannot be withdrawn.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36569)

Ne pas afficher le type de retrait dans le récap d'une offre indiv si on ne peut de toute façon pas choisir de type de retrait sur la sous-catégorie choisie.

**Validation :**
Créer une offre indiv sur une sous-catégorie non éligible au choix des types de retrait (ex: un livre) → Vérifier que dans le parcours de création, le récap ne contient pas “Précisez la façon dont vous distribuerez les billets“ → publier l’offre → vérifier que dans la page offre publiée, la mention n’existe pas nn plus

Créer une offre indiv sur une sous-catégorie éligible (ex: événement musique live - concert), vérifier que la mention apparait dans les 2 cas précédents


## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
