### PR TITLE
(PC-36484)[BO] feat: display account tag in special operation and accounts pages

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1058,6 +1058,9 @@ def _filter_user_accounts(accounts: BaseQuery, search_term: str) -> BaseQuery:
 
 def search_public_account(search_query: str) -> BaseQuery:
     public_accounts = get_public_account_base_query()
+    public_accounts = public_accounts.options(
+        sa_orm.joinedload(models.User.tags).load_only(models.UserTag.id, models.UserTag.name, models.UserTag.label),
+    )
 
     return _filter_user_accounts(public_accounts, search_query)
 

--- a/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
@@ -63,6 +63,8 @@ def search_bo_users() -> utils.BackofficeResponse:
         sa_orm.joinedload(users_models.User.action_history),
         # deposits is used to compute the role tag in the card; joinedload to avoid N+1 query
         sa_orm.joinedload(users_models.User.deposits),
+        # tags is used to display the account tag in the card; joinedload to avoid N+1 query
+        sa_orm.joinedload(users_models.User.tags),
     )
 
     paginated_rows = paginate(

--- a/api/src/pcapi/routes/backoffice/templates/components/search/result_card.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/search/result_card.html
@@ -1,12 +1,18 @@
-{% from "components/badges.html" import build_pro_user_status_badge %}
+{% import "components/badges.html" as badges %}
 <div class="card shadow">
   <div class="card-body">
     <h5 class="mb-3">
-      {% if not row.isActive %}{{ row.isActive | format_state | format_badge("primary") }}{% endif %}
-      {% for role in row.roles %}{{ role | format_role(deposits=row.deposits) | format_badge("primary") }}{% endfor %}
-      {% if result_type == "user" %}
-        {# only set for pro user, don't fetch from user_offerer for others #}
-        {{ build_pro_user_status_badge(row) }}
+      {% if not row.isActive or row.roles or (result_type != "user" and row.tags) or (result_type == "user" and (row.proValidationStatus.value in ("VALIDATED", "PENDING", "NEW"))) %}
+        {% call badges.badges_container() %}
+          {% if not row.isActive %}{{ row.isActive | format_state | format_badge("primary") }}{% endif %}
+          {% for role in row.roles %}{{ role | format_role(deposits=row.deposits) | format_badge("primary") }}{% endfor %}
+          {% if result_type == "user" %}
+            {# only set for pro user, don't fetch from user_offerer for others #}
+            {{ badges.build_pro_user_status_badge(row) }}
+          {% else %}
+            {% for tag in row.tags %}{{ tag | format_badge("secondary") }}{% endfor %}
+          {% endif %}
+        {% endcall %}
       {% endif %}
     </h5>
     {% if result_type == "user" %}

--- a/api/src/pcapi/routes/backoffice/templates/operations/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/operations/details.html
@@ -63,6 +63,7 @@
   <th>Candidatures totales</th>
   <th>Participations effectives</th>
   <th>Éligibilité</th>
+  <th>Tags</th>
   <th>Date de réponse</th>
 {% endblock table_header %}
 {% block table_body %}
@@ -142,6 +143,13 @@
           {% for role in response.user.roles %}{{ role | format_role(deposits=response.user.deposits) | format_badge("primary") }}{% endfor %}
         {% else %}
           -
+        {% endif %}
+      </td>
+      <td>
+        {% if response.user and row.account_tags %}
+          {% call badges.badges_container() %}
+            {% for tag in row.account_tags %}{{ tag | format_badge("secondary") }}{% endfor %}
+          {% endcall %}
         {% endif %}
       </td>
       <td>{{ response.dateSubmitted | format_date_time }}</td>

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_special_events.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_special_events.py
@@ -3,6 +3,7 @@ import logging
 
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.operations import factories as operations_factories
+from pcapi.core.users import factories as users_factories
 
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,8 @@ def create_special_events() -> None:
 
 
 def _create_special_event_with_date() -> None:
+    tag_book_club = users_factories.UserTagFactory(label="Membre du book club")
+    tag_cine_club = users_factories.UserTagFactory(label="Membre du ciné club")
     event_date = datetime.date.today() + datetime.timedelta(days=15)
     event = operations_factories.SpecialEventFactory.create(
         externalId="fake00001", title="Jeu concours : gagne une place de concert", eventDate=event_date
@@ -38,7 +41,9 @@ def _create_special_event_with_date() -> None:
         title="Explique-nous pourquoi tu souhaites être sélectionné !",
     )
 
-    good_response = operations_factories.SpecialEventResponseFactory.create(event=event)
+    good_response = operations_factories.SpecialEventResponseFactory.create(
+        event=event, user__tags=[tag_book_club, tag_cine_club]
+    )
     operations_factories.SpecialEventAnswerFactory.create(
         responseId=good_response.id, questionId=date_question.id, text="Oui !"
     )
@@ -49,7 +54,7 @@ def _create_special_event_with_date() -> None:
         responseId=good_response.id, questionId=why_question.id, text="Parce que j'adore la squad interne !"
     )
 
-    terrible_response = operations_factories.SpecialEventResponseFactory.create(event=event)
+    terrible_response = operations_factories.SpecialEventResponseFactory.create(event=event, user__tags=[tag_book_club])
     operations_factories.SpecialEventAnswerFactory.create(
         responseId=terrible_response.id, questionId=date_question.id, text="Non, je boude."
     )
@@ -57,7 +62,7 @@ def _create_special_event_with_date() -> None:
         responseId=terrible_response.id, questionId=why_question.id, text="Je veux pas parce que je boude."
     )
 
-    long_response = operations_factories.SpecialEventResponseFactory.create(event=event)
+    long_response = operations_factories.SpecialEventResponseFactory.create(event=event, user__tags=[tag_cine_club])
     operations_factories.SpecialEventAnswerFactory.create(
         responseId=long_response.id, questionId=date_question.id, text="Je suis tout à fait disponible"
     )

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -1798,7 +1798,7 @@ class CreateOverpaymentTest(PostEndpointHelper):
         alerts = soup.find_all("div", class_="alert")
         assert len(alerts) == 1
         alert = alerts[0]
-        assert html_parser._filter_whitespaces(alert.text) == "Un nouvel incident a été créé pour 1 réservation."
+        assert html_parser.filter_whitespaces(alert.text) == "Un nouvel incident a été créé pour 1 réservation."
         url_tags = alert.find_all("a")
         assert len(url_tags) == 1
         url_tag = url_tags[0]


### PR DESCRIPTION

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36484)

Display account tags in:
 - Accounts search page
 - Special operation responses page


## 🖼️ Images


<img width="1007" alt="Capture d’écran 2025-06-17 à 09 44 56" src="https://github.com/user-attachments/assets/754dbd78-5408-4e18-b8ac-9379d242bd96" />


<img width="1340" alt="Capture d’écran 2025-06-16 à 16 38 24" src="https://github.com/user-attachments/assets/9c2963f3-7d80-4f8d-803e-9171d2d73080" />
