### PR TITLE
(BSR)[API] feat: silence noisy fontTools logs

### DIFF
--- a/api/src/pcapi/core/logging.py
+++ b/api/src/pcapi/core/logging.py
@@ -279,6 +279,7 @@ def _silence_noisy_loggers() -> None:
     logging.getLogger("gql.transport.requests").setLevel(logging.WARNING)
     # fontTools is used by weasyprint
     logging.getLogger("fontTools.subset").setLevel(logging.WARNING)
+    logging.getLogger("fontTools.ttLib.ttFont").setLevel(logging.WARNING)
     # model overriding skips a lot of bindings
     logging.getLogger("transitions").setLevel(logging.ERROR)
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Le "subset" n'attrape pas ou plus tous les logs bruyants de fontTools, donc on adapte, pour éviter le spam à la génération des invoices

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
