### PR TITLE
(BSR)[API] feat: rename param to avoid click warning

### DIFF
--- a/api/src/pcapi/scripts/sandbox.py
+++ b/api/src/pcapi/scripts/sandbox.py
@@ -11,7 +11,7 @@ blueprint = Blueprint(__name__, __name__)
 @blueprint.cli.command("sandbox")
 @click.option("-n", "--name", help="Sandbox name", default="classic")
 @click.option("-c", "--clean", help="Clean database first", default="true")
-@click.option("-c", "--clean-bucket", help="Clean mediation bucket", default="false")
+@click.option("-cb", "--clean-bucket", help="Clean mediation bucket", default="false")
 def sandbox(name: str, clean: str, clean_bucket: str) -> None:
     if settings.CAN_RUN_SANDBOX:
         with_clean = clean == "true"


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

On a des warnings au lancement de la sandbox :
```
docker exec pc-api bash -c "cd /usr/src/app/ && flask sandbox -n industrial"
/home/pcapi/.local/lib/python3.11/site-packages/click/core.py:1193: UserWarning: The parameter -c is used more than once. Remove its duplicate as parameters should be unique.
```
Je les corrige

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
