### PR TITLE
(PC-36545)[API] feat: move `bookingAllowedDatetime` & `publicationDatetime` from `patch_draft_offer` to `patch_offer`

### DIFF
--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -283,6 +283,8 @@ class UpdateOffer(BaseModel):
     withdrawal_delay: int | None = None
     withdrawal_details: str | None = None
     withdrawal_type: offers_models.WithdrawalTypeEnum | None = None
+    publicationDatetime: datetime.datetime | None
+    bookingAllowedDatetime: datetime.datetime | None
 
     is_active: bool | None = None
 

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -27,6 +27,7 @@ from pcapi.routes.serialization import collective_offers_serialize
 from pcapi.routes.serialization.address_serialize import AddressResponseIsLinkedToVenueModel
 from pcapi.routes.serialization.address_serialize import retrieve_address_info_from_oa
 from pcapi.serialization.utils import to_camel
+from pcapi.serialization.utils import validate_datetime
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
@@ -129,6 +130,11 @@ class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
     isDuo: bool | None
     durationMinutes: int | None
     shouldSendMail: bool | None
+    publicationDatetime: datetime.datetime | None
+    bookingAllowedDatetime: datetime.datetime | None
+
+    _validation_publication_datetime = validate_datetime("publicationDatetime")
+    _validation_bookings_allowed_datetime = validate_datetime("bookingAllowedDatetime")
 
     @validator("name", pre=True, allow_reuse=True)
     def validate_name(cls, name: str) -> str:

--- a/pro/src/apiClient/v1/models/PatchDraftOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchDraftOfferBodyModel.ts
@@ -3,12 +3,10 @@
 /* tslint:disable */
 /* eslint-disable */
 export type PatchDraftOfferBodyModel = {
-  bookingAllowedDatetime?: string | null;
   description?: string | null;
   durationMinutes?: number | null;
   extraData?: Record<string, any> | null;
   name?: string | null;
-  publicationDatetime?: string | null;
   subcategoryId?: string | null;
   url?: string | null;
 };

--- a/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchOfferBodyModel.ts
@@ -7,6 +7,7 @@ import type { WithdrawalTypeEnum } from './WithdrawalTypeEnum';
 export type PatchOfferBodyModel = {
   address?: AddressBodyModel | null;
   audioDisabilityCompliant?: boolean | null;
+  bookingAllowedDatetime?: string | null;
   bookingContact?: string | null;
   bookingEmail?: string | null;
   description?: string | null;
@@ -19,6 +20,7 @@ export type PatchOfferBodyModel = {
   mentalDisabilityCompliant?: boolean | null;
   motorDisabilityCompliant?: boolean | null;
   name?: string | null;
+  publicationDatetime?: string | null;
   shouldSendMail?: boolean | null;
   url?: string | null;
   visualDisabilityCompliant?: boolean | null;


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36545)

This PR brings 2 changes :

- Move `bookingAllowedDatetime` & `publicationDatetime` from `patch_draft_offer` to `patch_offer`
- `bookingAllowedDatetime` & `publicationDatetime` are now independant 
 
