### PR TITLE
(PC-36592)[BO] fix: tomselect display when empty and unfold

### DIFF
--- a/api/src/pcapi/static/backoffice/scss/pc/_utilities.scss
+++ b/api/src/pcapi/static/backoffice/scss/pc/_utilities.scss
@@ -93,3 +93,8 @@ tr:has([type="checkbox"]:checked) {
 .gap-1px {
   gap:1px !important;
 }
+
+.ts-control{
+  /* fix for tomselect bug */
+    min-height:2.25em;
+}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36592)

![image](https://github.com/user-attachments/assets/091a2fd2-78af-446e-8211-37f251aedb70)
apres:
![image](https://github.com/user-attachments/assets/d628e5a1-6672-4f6b-a609-280a99a86b6d)

