### PR TITLE
(BSR)[API] chore: recaptcha failed has no reason to be an error on the platform

### DIFF
--- a/api/src/pcapi/routes/auth/discord.py
+++ b/api/src/pcapi/routes/auth/discord.py
@@ -171,7 +171,7 @@ def discord_signin_post() -> str | Response | None:
             minimal_score=settings.RECAPTCHA_MINIMAL_SCORE,
         )
     except (ReCaptchaException, InvalidRecaptchaTokenException) as exc:
-        logger.error("Recaptcha failed: %s", str(exc))
+        logger.warning("Recaptcha failed: %s", str(exc))
         raise ApiErrors({"recaptcha": "Erreur recaptcha"}, 401)
 
     try:


### PR DESCRIPTION
Je ne perçois pas utile de remonter les Recaptcha Failed dans Sentry ! On peut donc descendre le niveau de log à `warning`.
https://pass-culture.sentry.io/issues/33141295/?environment=production
