### PR TITLE
(PC-36185)[BO] fix: disable underage manual review on eighteen years old

### DIFF
--- a/api/src/pcapi/core/fraud/api.py
+++ b/api/src/pcapi/core/fraud/api.py
@@ -594,9 +594,6 @@ def handle_ok_manual_review(
     try:
         subscription_api.activate_beneficiary_for_eligibility(user, fraud_check.get_detailed_source(), eligibility)
 
-    except subscription_exceptions.InvalidEligibilityTypeException as err:
-        raise EligibilityError(f"L'éligibilité '{eligibility.value}' n'est pas applicable à cet utilisateur") from err
-
     except subscription_exceptions.InvalidAgeException as err:
         err_msg = (
             "L'âge de l'utilisateur à l'inscription n'a pas pu être déterminé"

--- a/api/src/pcapi/core/subscription/exceptions.py
+++ b/api/src/pcapi/core/subscription/exceptions.py
@@ -6,10 +6,6 @@ class IneligiblePostalCodeException(SubscriptionException):
     pass
 
 
-class InvalidEligibilityTypeException(SubscriptionException):
-    pass
-
-
 class InvalidAgeException(SubscriptionException):
     def __init__(self, age: int | None) -> None:
         super().__init__()

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -283,7 +283,6 @@ def _update_user_information(
     user.remove_admin_role()
 
     db.session.add(user)
-    db.session.flush()
 
     return user
 

--- a/api/src/pcapi/core/users/exceptions.py
+++ b/api/src/pcapi/core/users/exceptions.py
@@ -121,3 +121,15 @@ class UserNotEligible(DiscordException):
 
 class UnknownDepositType(Exception):
     pass
+
+
+class InvalidEligibilityTypeException(Exception):
+    pass
+
+
+class UnderageEligibilityWhenAlreadyEighteenException(InvalidEligibilityTypeException):
+    pass
+
+
+class PreDecreeEligibilityWhenPostDecreeBeneficiaryException(InvalidEligibilityTypeException):
+    pass

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -970,6 +970,8 @@ def format_eligibility_type(eligibility_type: users_models.EligibilityType) -> s
             return "Ancien Pass 18"
         case users_models.EligibilityType.AGE17_18:
             return "Pass 17-18"
+        case users_models.EligibilityType.FREE:
+            return "Pass 15-16"
         case _:
             return eligibility_type.value
 

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -1352,7 +1352,6 @@ class BeneficiaryInformationUpdateTest:
 
         # when
         beneficiary = users_api.update_user_information_from_external_source(user, beneficiary_information)
-        db.session.refresh(user)
 
         # Then
         assert beneficiary.lastName == "Doe"

--- a/api/tests/repository/test_transaction.py
+++ b/api/tests/repository/test_transaction.py
@@ -31,6 +31,15 @@ class AtomicTest:
         assert db.session.query(UserSession).count() == 0
 
     @pytest.mark.usefixtures("clean_database")
+    def test_atomic_rolls_back_invalid_transaction(self):
+        with atomic():
+            user_session = UserSession(userId=1, uuid=uuid.uuid4())
+            db.session.add(user_session)
+            mark_transaction_as_invalid()
+
+        assert db.session.query(UserSession).count() == 0
+
+    @pytest.mark.usefixtures("clean_database")
     def test_atomic_is_reentrant(self):
         user_session = UserSession(userId=1, uuid=uuid.uuid4())
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36185)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

Avant cette PR, il est possible d'effectuer une revue manuelle `UNDERAGE` (mineur pré-décret) à un bénéficiaire de 18 ans, ce qui entraîne un comportement un peu louche : le bénéficiaire est crédité du crédit 18 post-décret (150€). Pour éviter toute confusion, cette PR désactive la revue manuelle `UNDERAGE` sur tous les comptes qui ont plus de 18 ans.

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
