### PR TITLE
(BSR)[API] fix: update session return type for correct IDE inference

### DIFF
--- a/api/src/pcapi/models/session_manager.py
+++ b/api/src/pcapi/models/session_manager.py
@@ -120,7 +120,7 @@ class DbClass:
         return current_app.extensions[EXTENSION_NAME]
 
     @property
-    def session(self) -> sa.orm.session.Session:
+    def session(self) -> SessionBase:
         session = getattr(g, "sqlalchemy_session", None)
         if session is None:
             session = self.session_maker(bind=self.engine)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

`sa.orm.session.Session` n'est pas correctement reconnu par VSCode pour l'inférence de type

Par exemple `db.session.query` se retrouve inféré en `Any`

Comme on importe déjà `sa.orm.session.Session` avec un alias, on l'utilise ici

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->


## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
