### PR TITLE
(PC-36623)[PRO] fix: Add new indiv status.

### DIFF
--- a/pro/src/components/StatusLabel/StatusLabel.tsx
+++ b/pro/src/components/StatusLabel/StatusLabel.tsx
@@ -10,11 +10,12 @@ import strokeWarningIcon from 'icons/stroke-warning.svg'
 
 const OFFER_STATUS_PROPERTIES: Record<
   string,
-  {
-    variant: TagVariant
-    icon: string
-    label: string
-  }
+  | {
+      variant: TagVariant
+      icon: string
+      label: string
+    }
+  | undefined
 > = {
   [OfferStatus.EXPIRED]: {
     variant: TagVariant.ERROR,
@@ -51,6 +52,16 @@ const OFFER_STATUS_PROPERTIES: Record<
     icon: fullHideIcon,
     label: 'en pause',
   },
+  [OfferStatus.SCHEDULED]: {
+    variant: TagVariant.WARNING,
+    icon: fullHideIcon,
+    label: 'programmée',
+  },
+  [OfferStatus.PUBLISHED]: {
+    variant: TagVariant.WARNING,
+    icon: fullHideIcon,
+    label: 'publiée non réservable',
+  },
 }
 
 type StatusLabelProps = {
@@ -60,8 +71,8 @@ type StatusLabelProps = {
 export const StatusLabel = ({ status }: StatusLabelProps) => {
   return (
     <Tag
-      label={OFFER_STATUS_PROPERTIES[status].label}
-      variant={OFFER_STATUS_PROPERTIES[status].variant}
+      label={OFFER_STATUS_PROPERTIES[status]?.label || status}
+      variant={OFFER_STATUS_PROPERTIES[status]?.variant || TagVariant.DEFAULT}
     />
   )
 }

--- a/pro/src/components/StatusLabel/__specs__/StatusLabel.spec.tsx
+++ b/pro/src/components/StatusLabel/__specs__/StatusLabel.spec.tsx
@@ -38,4 +38,16 @@ describe('StatusLabel', () => {
     renderStatusLabel(OfferStatus.SOLD_OUT)
     expect(screen.getByText('épuisée')).toBeInTheDocument()
   })
+  it('should display "programmée" if offer is scheduled', () => {
+    renderStatusLabel(OfferStatus.SCHEDULED)
+    expect(screen.getByText('programmée')).toBeInTheDocument()
+  })
+  it('should display "publiée non réservable" if offer is published', () => {
+    renderStatusLabel(OfferStatus.PUBLISHED)
+    expect(screen.getByText('publiée non réservable')).toBeInTheDocument()
+  })
+  it('should display the original name of the status if it does not exist in the preset list', () => {
+    renderStatusLabel('TEST FAKE STATUS' as OfferStatus)
+    expect(screen.getByText('TEST FAKE STATUS')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36623)

On a ajouté des nouveaux statuts, atteignables uniquement sous FF. Si on essaie d'afficher un tag `StatusLabel` avec ces nouveaux statuts, l'app crash. 

- Ajout de 2 statuts individuels dans les tag des statuts
- Si le statut n'existe pas dans le front, afficher quand même un tag avec le nom de l'enum du statut

Pour reproduire : 
- Activer le FF `WIP_REFACTO_FUTURE_OFFER`
- Créer une offre indiv de type Event
- Ajouter une date de publication dans le futur


## 🖼️ Before & After Images

pas de changements graphiques
