### PR TITLE
(PC-36646)[BO] fix: ForeignKeyViolation when a 'pro' user is deleted and has beneficiary update request

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 62d5ff24ee22 (pre) (head)
-902bdb2449b9 (post) (head)
+4b97dba7262f (post) (head)

--- a/api/src/pcapi/alembic/versions/20250620T113901_a35242268279_user_account_update_request_userId_on_delete_set_null.py
+++ b/api/src/pcapi/alembic/versions/20250620T113901_a35242268279_user_account_update_request_userId_on_delete_set_null.py
@@ -1,0 +1,30 @@
+"""Update foreign key user_account_update_request.userId: on delete set null (1/2)"""
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "a35242268279"
+down_revision = "902bdb2449b9"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        op.f("user_account_update_request_userId_fkey"), "user_account_update_request", type_="foreignkey"
+    )
+    op.create_foreign_key(
+        op.f("user_account_update_request_userId_fkey"),
+        "user_account_update_request",
+        "user",
+        ["userId"],
+        ["id"],
+        ondelete="SET NULL",
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/alembic/versions/20250620T113902_4b97dba7262f_validate_user_account_update_request_user_id.py
+++ b/api/src/pcapi/alembic/versions/20250620T113902_4b97dba7262f_validate_user_account_update_request_user_id.py
@@ -1,0 +1,25 @@
+"""Update foreign key user_account_update_request.userId: on delete set null (2/2)"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "4b97dba7262f"
+down_revision = "a35242268279"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET SESSION statement_timeout='300s'")
+    op.execute(
+        """ALTER TABLE user_account_update_request VALIDATE CONSTRAINT "user_account_update_request_userId_fkey" """
+    )
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -1021,7 +1021,7 @@ class UserAccountUpdateRequest(PcObject, Base, Model):
     email: str = sa.Column(sa.Text, nullable=False)
     birthDate = sa.Column(sa.Date, nullable=True)
     # User found from his/her email - may be null in case of wrong email
-    userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=True)
+    userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="SET NULL"), index=True, nullable=True)
     user: sa_orm.Mapped[User] = sa_orm.relationship(User, foreign_keys=[userId], backref="accountUpdateRequests")
     # One or several changes may be requested
     updateTypes: sa_orm.Mapped[list[UserAccountUpdateType]] = sa.Column(

--- a/api/tests/routes/backoffice/pro_users_test.py
+++ b/api/tests/routes/backoffice/pro_users_test.py
@@ -657,6 +657,9 @@ class DeleteProUserTest(PostEndpointHelper):
     ):
         user = users_factories.BeneficiaryFactory(roles=[users_models.UserRole.NON_ATTACHED_PRO])
         history_factories.SuspendedUserActionHistoryFactory(user=user)
+        uaur_id = users_factories.UserAccountUpdateRequestFactory(
+            user=user, updateTypes=[users_models.UserAccountUpdateType.ACCOUNT_HAS_SAME_INFO]
+        ).id
         user_id = user.id
         deposit_id = user.deposits[0].id
         beneficiary_fraud_check_id = user.beneficiaryFraudChecks[0].id
@@ -683,4 +686,11 @@ class DeleteProUserTest(PostEndpointHelper):
             .filter(history_models.ActionHistory.userId == user_id)
             .count()
             == 0
+        )
+        assert (
+            db.session.query(users_models.UserAccountUpdateRequest)
+            .filter(users_models.UserAccountUpdateRequest.id == uaur_id)
+            .one()
+            .userId
+            is None
         )


### PR DESCRIPTION
```
IntegrityError: (psycopg2.errors.ForeignKeyViolation) update or delete on table "user" violates foreign key constraint "user_account_update_request_userId_fkey" on table "user_account_update_request"
DETAIL:  Key (id)=(6600195) is still referenced from table "user_account_update_request".

[SQL: DELETE FROM "user" WHERE "user".id = %(id_1)s] [parameters: {'id_1': 6600195}]
(Background on this error at: https://sqlalche.me/e/14/gkpj) (9 additional frame(s) were not displayed)
...
  File "pcapi/routes/backoffice/utils.py", line 157, in wrapped
    return function(*args, **kwargs)
  File "pcapi/routes/backoffice/pro_users/blueprint.py", line 243, in delete
    db.session.query(users_models.User).filter(users_models.User.id == user_id).delete(synchronize_session=False)
```

Ticket Jira : https://passculture.atlassian.net/browse/PC-36646
Sentry : https://pass-culture.sentry.io/issues/47308019/
