### PR TITLE
(BSR)[BO] fix: remove useless subquery to fix two warnings

### DIFF
--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -248,7 +248,7 @@ JOIN_DICT: dict[str, list[dict[str, typing.Any]]] = {
 
 def _get_collective_offer_ids_query(form: forms.GetCollectiveOfferAdvancedSearchForm) -> BaseQuery:
     base_query, _, _, warnings = utils.generate_search_query(
-        query=db.session.query(educational_models.CollectiveOffer),
+        query=db.session.query(educational_models.CollectiveOffer.id),
         search_parameters=form.search.data,
         fields_definition=SEARCH_FIELD_TO_PYTHON,
         joins_definition=JOIN_DICT,
@@ -263,7 +263,7 @@ def _get_collective_offer_ids_query(form: forms.GetCollectiveOfferAdvancedSearch
         )
 
     # +1 to check if there are more results than requested
-    return base_query.with_entities(educational_models.CollectiveOffer.id).limit(form.limit.data + 1)
+    return base_query.limit(form.limit.data + 1)
 
 
 def _get_collective_offers(
@@ -287,7 +287,7 @@ def _get_collective_offers(
             educational_models.CollectiveOffer,
             rules_subquery.label("rules"),
         )
-        .filter(educational_models.CollectiveOffer.id.in_(_get_collective_offer_ids_query(form).subquery()))
+        .filter(educational_models.CollectiveOffer.id.in_(_get_collective_offer_ids_query(form)))
         .join(offerers_models.Venue)
         .join(offerers_models.Offerer)
         .outerjoin(educational_models.CollectiveOffer.collectiveStock)

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -910,9 +910,9 @@ def add_user_offerer_and_validate(offerer_id: int) -> utils.BackofficeResponse:
         .filter(
             users_models.User.id == form.pro_user_id.data,
             users_models.User.id.not_in(
-                db.session.query(offerers_models.UserOfferer.userId)
-                .filter(offerers_models.UserOfferer.offererId == offerer_id)
-                .subquery()
+                db.session.query(offerers_models.UserOfferer.userId).filter(
+                    offerers_models.UserOfferer.offererId == offerer_id
+                )
             ),
         )
         .limit(1)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

résolution de 2 warning lié a l'usage non pertinent de deux `.subquery()`