### PR TITLE
(BSR)[ADAGE] fix: fix adage iframe routes error on location loading

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1402,7 +1402,7 @@ def get_collective_offer_templates_for_playlist_query(
         sa_orm.joinedload(educational_models.CollectivePlaylist.venue).joinedload(
             offerers_models.Venue.googlePlacesInfo
         ),
-    )
+    ).populate_existing()
     return query
 
 
@@ -1723,6 +1723,7 @@ def get_all_offer_template_by_redactor_id(redactor_id: int) -> list[educational_
             *_get_collective_offer_template_address_joinedload_with_expression(),
         )
         .filter(educational_models.EducationalRedactor.id == redactor_id)
+        .populate_existing()
         .all()
     )
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Voir les erreurs de CI ici par exemple : https://github.com/pass-culture/pass-culture-main/actions/runs/15780419013/job/44484713097#step:16:282

Dû a priori à des objets déjà chargés dans la session de test

Le populate_existing permet de s'assurer qu'on charge correctement les objets (OffererAddress notamment)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->


## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
