### PR TITLE
(BSR)[API] refactor: rewrite ended collective offer factory in two se…

### DIFF
--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -546,20 +546,20 @@ class BookedCollectiveOfferFactory(CollectiveOfferBaseFactory):
         ConfirmedCollectiveBookingFactory.create(collectiveStock=stock)
 
 
+class EndedCollectiveOfferConfirmedBookingFactory(CollectiveOfferBaseFactory):
+    @factory.post_generation
+    def create_booking(self, _create: bool, _extracted: typing.Any, **kwargs: typing.Any) -> None:
+        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        stock = CollectiveStockFactory.create(startDatetime=yesterday, collectiveOffer=self)
+        ConfirmedCollectiveBookingFactory.create(collectiveStock=stock)
+
+
 class EndedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
-    def booking_is_confirmed(self, _create: bool, booking_is_confirmed: bool = False, **kwargs: typing.Any) -> None:
-        if booking_is_confirmed:
-            yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
-        else:
-            yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=3)
-
+    def create_booking(self, _create: bool, _extracted: typing.Any, **kwargs: typing.Any) -> None:
+        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=3)
         stock = CollectiveStockFactory.create(startDatetime=yesterday, collectiveOffer=self)
-
-        if booking_is_confirmed:
-            ConfirmedCollectiveBookingFactory.create(collectiveStock=stock)
-        else:
-            UsedCollectiveBookingFactory.create(collectiveStock=stock)
+        UsedCollectiveBookingFactory.create(collectiveStock=stock)
 
 
 class ReimbursedCollectiveOfferFactory(CollectiveOfferBaseFactory):

--- a/api/tests/core/educational/api/test_edit_collective_offer_stock.py
+++ b/api/tests/core/educational/api/test_edit_collective_offer_stock.py
@@ -284,7 +284,7 @@ class EditCollectiveOfferStocksTest:
         assert offer.collectiveStock.numberOfTickets == 1200
 
     def test_can_lower_price_and_edit_price_details_ended(self):
-        offer = educational_factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offer = educational_factories.EndedCollectiveOfferConfirmedBookingFactory()
 
         new_price = offer.collectiveStock.price - 100
         new_stock_data = collective_stock_serialize.CollectiveStockEditionBodyModel(
@@ -365,7 +365,7 @@ class ReturnErrorTest:
             )
 
     def test_cannot_increase_price_ended(self):
-        offer = educational_factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offer = educational_factories.EndedCollectiveOfferConfirmedBookingFactory()
         price = offer.collectiveStock.price
         new_stock_data = collective_stock_serialize.CollectiveStockEditionBodyModel(totalPrice=price + 100)
 
@@ -392,7 +392,7 @@ class ReturnErrorTest:
                 )
 
     def test_cannot_edit_dates_ended(self):
-        offer = educational_factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offer = educational_factories.EndedCollectiveOfferConfirmedBookingFactory()
 
         new_date = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=5)
         for date_field in ("bookingLimitDatetime", "startDatetime", "endDatetime"):

--- a/api/tests/core/educational/test_models.py
+++ b/api/tests/core/educational/test_models.py
@@ -719,7 +719,7 @@ class CollectiveOfferAllowedActionsTest:
         assert offer.allowedActions == list(ALLOWED_ACTIONS_BY_DISPLAYED_STATUS[status])
 
     def test_get_ended_offer_allowed_actions(self):
-        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offer = factories.EndedCollectiveOfferConfirmedBookingFactory()
 
         assert offer.displayedStatus == CollectiveOfferDisplayedStatus.ENDED
         assert offer.allowedActions == [
@@ -748,9 +748,7 @@ class CollectiveOfferAllowedActionsTest:
         }
 
     def test_get_offer_ended_allowed_actions_public_api(self):
-        offer = factories.EndedCollectiveOfferFactory(
-            booking_is_confirmed=True, provider=providers_factories.ProviderFactory()
-        )
+        offer = factories.EndedCollectiveOfferConfirmedBookingFactory(provider=providers_factories.ProviderFactory())
 
         assert offer.displayedStatus == CollectiveOfferDisplayedStatus.ENDED
         assert offer.allowedActions == [
@@ -810,9 +808,7 @@ class CollectiveOfferAllowedActionsTest:
         assert offer.allowedActionsForPublicApi == []
 
     def test_get_ended_offer_allowed_actions_for_public_api(self):
-        offer = factories.EndedCollectiveOfferFactory(
-            booking_is_confirmed=True, provider=providers_factories.ProviderFactory()
-        )
+        offer = factories.EndedCollectiveOfferConfirmedBookingFactory(provider=providers_factories.ProviderFactory())
 
         assert offer.displayedStatus == CollectiveOfferDisplayedStatus.ENDED
         assert offer.allowedActionsForPublicApi == [

--- a/api/tests/routes/pro/delete_image_collective_offers_test.py
+++ b/api/tests/routes/pro/delete_image_collective_offers_test.py
@@ -87,7 +87,7 @@ class DeleteImageFromFileTest:
         assert response.json == {"global": ["Cette action n'est pas autorisée sur cette offre"]}
 
     def test_delete_image_ended(self, client):
-        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offer = factories.EndedCollectiveOfferConfirmedBookingFactory()
         offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
 
         response = client.with_session_auth(email="user@example.com").delete(f"/collective/offers/{offer.id}/image")

--- a/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
+++ b/api/tests/routes/pro/patch_cancel_collective_offer_booking_test.py
@@ -99,7 +99,7 @@ class Returns204Test:
         assert offer.collectiveStock.collectiveBookings[0].status == models.CollectiveBookingStatus.CANCELLED
 
     def test_cancel_ended(self, client):
-        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offer = factories.EndedCollectiveOfferConfirmedBookingFactory()
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
 
         client = client.with_session_auth("pro@example.com")

--- a/api/tests/routes/pro/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_test.py
@@ -1119,7 +1119,7 @@ class Returns403Test:
         assert offer.description == previous_description
 
     def test_patch_collective_offer_ended(self, client):
-        offer = educational_factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offer = educational_factories.EndedCollectiveOfferConfirmedBookingFactory()
         offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
 
         previous_name = offer.name

--- a/api/tests/routes/pro/patch_collective_offers_archive_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_archive_test.py
@@ -85,7 +85,7 @@ class Returns204Test:
         assert offer.isActive == offer_was_active
 
     def test_archive_offer_ended(self, client):
-        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offer = factories.EndedCollectiveOfferConfirmedBookingFactory()
         venue = offer.venue
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offerer)

--- a/api/tests/routes/pro/patch_collective_offers_educational_institution_test.py
+++ b/api/tests/routes/pro/patch_collective_offers_educational_institution_test.py
@@ -131,7 +131,7 @@ class Returns403Test:
 
     def test_change_institution_ended(self, client) -> None:
         institution1 = factories.EducationalInstitutionFactory()
-        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True, institution=institution1)
+        offer = factories.EndedCollectiveOfferConfirmedBookingFactory(institution=institution1)
         offerers_factories.UserOffererFactory(user__email="pro@example.com", offerer=offer.venue.managingOfferer)
         institution2 = factories.EducationalInstitutionFactory()
 

--- a/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
+++ b/api/tests/routes/pro/post_duplicate_collective_offer_and_stock_test.py
@@ -202,7 +202,7 @@ class Returns200Test:
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
-        offer = educational_factories.EndedCollectiveOfferFactory(booking_is_confirmed=True, venue=venue)
+        offer = educational_factories.EndedCollectiveOfferConfirmedBookingFactory(venue=venue)
 
         response = client.with_session_auth("user@example.com").post(f"/collective/offers/{offer.id}/duplicate")
 

--- a/api/tests/routes/pro/post_image_collective_offers_test.py
+++ b/api/tests/routes/pro/post_image_collective_offers_test.py
@@ -70,7 +70,7 @@ class AttachCollectiveOfferImageTest:
         assert (UPLOAD_FOLDER / offer._get_image_storage_id()).exists() is False
 
     def test_attach_image_ended(self, client):
-        offer = factories.EndedCollectiveOfferFactory(booking_is_confirmed=True)
+        offer = factories.EndedCollectiveOfferConfirmedBookingFactory()
         offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
 
         auth_client = client.with_session_auth(email="user@example.com")

--- a/api/tests/routes/public/collective/endpoints/patch_collective_booking_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_booking_test.py
@@ -74,7 +74,7 @@ class CancelCollectiveBookingTest(PublicAPIVenueEndpointHelper):
 
     def test_cancel_offer_ended(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
-        offer = educational_factories.EndedCollectiveOfferFactory(venue=venue_provider.venue, booking_is_confirmed=True)
+        offer = educational_factories.EndedCollectiveOfferConfirmedBookingFactory(venue=venue_provider.venue)
         [booking] = offer.collectiveStock.collectiveBookings
 
         response = client.with_explicit_token(plain_api_key).patch(self.endpoint_url.format(booking_id=booking.id))


### PR DESCRIPTION
…parate factories

## 🎯 Related Ticket or 🔧 Changes Made

On a actuellement un argument `booking_is_confirmed` sur la factory `EndedCollectiveOfferFactory`

L'usage n'est pas très clair, je définis une factory séparée pour que ce soit plus lisible

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->


## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
