### PR TITLE
(BSR)[API] fix: remove_free_beneficiary_role

### DIFF
--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -331,7 +331,7 @@ class User(PcObject, Base, Model, DeactivableMixin):
 
     def remove_free_beneficiary_role(self) -> None:
         if self.has_free_beneficiary_role:
-            self.roles.remove(UserRole.BENEFICIARY)
+            self.roles.remove(UserRole.FREE_BENEFICIARY)
 
     def remove_pro_role(self) -> None:
         if self.has_pro_role:


### PR DESCRIPTION
Correction triviale de `remove_free_beneficiary_role`