### PR TITLE
(PC-36332)[API] feat: Change playlist url to return unbookable offers

### DIFF
--- a/api/src/pcapi/routes/institutional/playlist.py
+++ b/api/src/pcapi/routes/institutional/playlist.py
@@ -22,7 +22,7 @@ def get_offers_by_tag(tag_name: str) -> serializers.OffersResponse:
         .join(offers_models.Offer.stocks)
         .filter(
             criteria_models.Criterion.name == tag_name,
-            offers_models.Offer.is_released_and_bookable,
+            offers_models.Offer.isReleased,
         )
         .options(
             sa_orm.joinedload(offers_models.Offer.stocks),

--- a/api/tests/routes/institutional/playlist_test.py
+++ b/api/tests/routes/institutional/playlist_test.py
@@ -59,7 +59,7 @@ class PlaylistTest:
         assert response.status_code == 200, response.json
         assert response.json == []
 
-    def test_unbookable_offers_are_ignored(self, client):
+    def test_unbookable_offers_are_not_ignored(self, client):
         yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         unbookable_offer = offers_factories.EventOfferFactory()
         offers_factories.EventStockFactory(offer=unbookable_offer, isSoftDeleted=True)
@@ -71,7 +71,18 @@ class PlaylistTest:
         response = client.get(f"/institutional/playlist/{criterion.name}")
 
         assert response.status_code == 200, response.json
-        assert response.json == []
+        assert response.json == [
+            {
+                "id": unbookable_offer.id,
+                "image": None,
+                "name": unbookable_offer.name,
+                "stocks": [],
+                "venue": {
+                    "id": unbookable_offer.venue.id,
+                    "commonName": unbookable_offer.venue.common_name,
+                },
+            }
+        ]
 
     def test_unbookable_stocks_are_ignored(self, client):
         yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)


### PR DESCRIPTION
### Description

Cette PR modifie la logique de filtrage pour les playlists institutionnelles. Auparavant, une offre devait être à la fois `released` (publiée) et `bookable` (réservable) pour apparaître. Désormais, le seul critère est que l'offre soit `released`.

https://passculture.atlassian.net/browse/PC-36332

### Changements effectués

- **API (`api/src/pcapi/routes/institutional/playlist.py`)**:
  - La requête a été mise à jour pour ne plus filtrer sur `is_released_and_bookable`, mais uniquement sur l'état `_released` de l'offre.
  - Cela signifie que des offres publiées mais sans stock disponible (ou avec des stocks expirés) seront maintenant incluses dans les résultats.

- **Tests (`api/tests/routes/institutional/playlist_test.py`)**:
  - Le test `test_unbookable_offers_are_ignored` a été mis à jour pour refléter ce nouveau comportement.
  - Il a été renommé en `test_unbookable_offers_are_not_ignored` pour plus de clarté.
  - Le test vérifie maintenant qu'une offre sans stock réservable est bien retournée par l'API, mais avec une liste de `stocks` vide.