### PR TITLE
(PC-36685)[API] fix: catch request.exceptions.JSONDecodeError in requests response

### DIFF
--- a/api/src/pcapi/connectors/acceslibre.py
+++ b/api/src/pcapi/connectors/acceslibre.py
@@ -5,7 +5,6 @@ Further explanations at: https://schema.data.gouv.fr/MTES-MCT/acceslibre-schema/
 """
 
 import enum
-import json
 import logging
 import time
 from datetime import datetime
@@ -553,7 +552,7 @@ class AcceslibreBackend(BaseBackend):
         if response.status_code == 200:
             try:
                 return response.json()
-            except json.JSONDecodeError:
+            except requests.exceptions.JSONDecodeError:
                 logger.error(
                     "Got non-JSON or malformed JSON response from AccesLibre",
                     extra={"url": response.url, "response": response.content},

--- a/api/src/pcapi/connectors/api_adresse.py
+++ b/api/src/pcapi/connectors/api_adresse.py
@@ -301,7 +301,7 @@ class ApiAdresseBackend(BaseBackend):
         response = self._request("GET", url, params=params, timeout=3)
         try:
             data = response.json()
-        except json.JSONDecodeError:
+        except requests.exceptions.JSONDecodeError:
             raise AdresseApiException("Unexpected non-JSON response from Adresse API")
         return data
 

--- a/api/src/pcapi/connectors/boost.py
+++ b/api/src/pcapi/connectors/boost.py
@@ -1,6 +1,5 @@
 import datetime
 import enum
-import json
 import logging
 from typing import Any
 
@@ -83,7 +82,7 @@ def login(cinema_details: BoostCinemaDetails, ignore_device: bool = True) -> str
         try:
             content = response.json()
             message = content.get("message", "")
-        except json.JSONDecodeError:
+        except requests.exceptions.JSONDecodeError:
             message = response.content
         raise BoostLoginException(
             f"Unexpected {response.status_code} response from Boost login API on {response.request.url}: {message}"
@@ -270,7 +269,7 @@ def _extract_message_from_response(response: requests.Response) -> str:
     try:
         content = response.json()
         message = content.get("message", "")
-    except json.JSONDecodeError:
+    except requests.exceptions.JSONDecodeError:
         message = response.content
     return message
 

--- a/api/src/pcapi/connectors/ems.py
+++ b/api/src/pcapi/connectors/ems.py
@@ -47,7 +47,7 @@ class AbstractEMSConnector:
         try:
             content = response.json()
             message = content.get("message", "")
-        except json.JSONDecodeError:
+        except requests.exceptions.JSONDecodeError:
             message = response.content
         return message
 

--- a/api/src/pcapi/connectors/entreprise/backends/api_entreprise.py
+++ b/api/src/pcapi/connectors/entreprise/backends/api_entreprise.py
@@ -131,7 +131,7 @@ class EntrepriseBackend(BaseBackend):
                     error_message = errors[0]["detail"]
                 except TypeError:
                     error_message = errors[0]
-            except json.JSONDecodeError:
+            except requests.exceptions.JSONDecodeError:
                 errors = None
                 error_message = None
 
@@ -157,7 +157,7 @@ class EntrepriseBackend(BaseBackend):
             raise exceptions.ApiException(error_message)
         try:
             return response.json()
-        except json.JSONDecodeError:
+        except requests.exceptions.JSONDecodeError:
             raise exceptions.ApiException(f"Unexpected non-JSON response from Sirene API: {url}")
 
     def _cached_get(self, subpath: str) -> dict:

--- a/api/src/pcapi/connectors/entreprise/backends/insee.py
+++ b/api/src/pcapi/connectors/entreprise/backends/insee.py
@@ -51,7 +51,7 @@ class InseeBackend(BaseBackend):
             raise exceptions.ApiException(f"Unexpected {response.status_code} response from Sirene API: {url}")
         try:
             return response.json()
-        except json.JSONDecodeError:
+        except requests.exceptions.JSONDecodeError:
             raise exceptions.ApiException(f"Unexpected non-JSON response from Sirene API: {url}")
 
     def _cached_get(self, subpath: str) -> dict:

--- a/api/src/pcapi/connectors/typeform.py
+++ b/api/src/pcapi/connectors/typeform.py
@@ -4,7 +4,6 @@ API Documentation: https://www.typeform.com/developers/
 """
 
 import hashlib
-import json
 import logging
 import typing
 from datetime import datetime
@@ -197,7 +196,7 @@ class TypeformBackend(BaseBackend):
 
         try:
             data = response.json()
-        except json.JSONDecodeError:
+        except requests.exceptions.JSONDecodeError:
             raise TypeformApiException("Unexpected non-JSON response from Typeform API")
         return data
 

--- a/api/src/pcapi/connectors/virustotal.py
+++ b/api/src/pcapi/connectors/virustotal.py
@@ -7,7 +7,6 @@ Our very basic usage does not really require a module.
 """
 
 import base64
-import json
 import logging
 import time
 
@@ -103,7 +102,7 @@ class VirusTotalBackend(BaseBackend):
             raise VirusTotalApiException(f"Unexpected {response.status_code} response from VirusTotal API: {url}")
         try:
             data = response.json()
-        except json.JSONDecodeError:
+        except requests.exceptions.JSONDecodeError:
             raise VirusTotalApiException("Unexpected non-JSON response from VirusTotal API")
         return data
 

--- a/api/src/pcapi/core/educational/adage_backends/adage.py
+++ b/api/src/pcapi/core/educational/adage_backends/adage.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import traceback
 import typing
-from json import JSONDecodeError
 
 from pydantic.v1 import parse_obj_as
 
@@ -50,7 +49,7 @@ class AdageHttpClient(AdageClient):
     ) -> exceptions.AdageException:
         try:
             json_response = api_response.json()
-        except JSONDecodeError:
+        except requests.exceptions.JSONDecodeError:
             return exceptions.AdageException(
                 message=f"Error while reading Adage API json response - status code: {api_response.status_code}",
                 status_code=api_response.status_code,

--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -1,6 +1,5 @@
 import datetime
 import functools
-import json
 import logging
 
 import pydantic.v1 as pydantic_v1
@@ -207,7 +206,7 @@ def book_event_ticket(
 
     try:
         parsed_response = pydantic_v1.parse_obj_as(serialize.ExternalEventBookingResponse, response.json())
-    except (pydantic_v1.ValidationError, json.JSONDecodeError) as err:
+    except (pydantic_v1.ValidationError, requests.exceptions.JSONDecodeError) as err:
         logger.exception(
             "Could not parse external booking response",
             extra={"status_code": response.status_code, "response": response.text, "error": err},
@@ -309,7 +308,7 @@ def cancel_event_ticket(
             if is_booking_saved:
                 new_quantity -= len(barcodes)
             stock.quantity = new_quantity
-    except (ValueError, json.JSONDecodeError, pydantic_v1.ValidationError):
+    except (ValueError, requests.exceptions.JSONDecodeError, pydantic_v1.ValidationError):
         logger.exception(
             "Could not parse external booking cancel response",
             extra={"status_code": response.status_code, "response": response.text},


### PR DESCRIPTION
Ticket Jira : https://passculture.atlassian.net/browse/PC-36685
Sentry : https://pass-culture.sentry.io/issues/33110805/

`Response.json()` capture `json.JSONDecodeError` et lève l'exception `requests.exceptions.JSONDecodeError` (héritant de `RequestsException`). Ainsi il faut capture la "bonne" `JSONDecodeError` dans la réponse.

Référence : https://github.com/psf/requests/blob/v2.32.4/src/requests/models.py#L947