### PR TITLE
(BSR)[ADAGE] feat: use OA field instead of Venue for location in adag…

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1399,8 +1399,9 @@ def get_collective_offer_templates_for_playlist_query(
             sa_orm.joinedload(educational_models.CollectiveOfferTemplate.domains),
             *_get_collective_offer_template_address_joinedload_with_expression(),
         ),
-        sa_orm.joinedload(educational_models.CollectivePlaylist.venue).joinedload(
-            offerers_models.Venue.googlePlacesInfo
+        sa_orm.joinedload(educational_models.CollectivePlaylist.venue).options(
+            sa_orm.joinedload(offerers_models.Venue.googlePlacesInfo),
+            sa_orm.joinedload(offerers_models.Venue.offererAddress).joinedload(offerers_models.OffererAddress.address),
         ),
     ).populate_existing()
     return query

--- a/api/src/pcapi/routes/adage_iframe/playlists.py
+++ b/api/src/pcapi/routes/adage_iframe/playlists.py
@@ -212,7 +212,8 @@ def get_local_offerers_playlist(
                 publicName=item.venue.publicName,
                 name=item.venue.name,
                 distance=format_distance(item.distanceInKm),
-                city=item.venue.city,
+                # TODO(OA): remove this when the virtual venues are migrated
+                city=item.venue.offererAddress.address.city if item.venue.offererAddress else None,
                 id=item.venue.id,
             )
             for item in playlist_items
@@ -242,7 +243,8 @@ def get_new_offerers_playlist(
                 publicName=item.venue.publicName,
                 name=item.venue.name,
                 distance=format_distance(item.distanceInKm),
-                city=item.venue.city,
+                # TODO(OA): remove this when the virtual venues are migrated
+                city=item.venue.offererAddress.address.city if item.venue.offererAddress else None,
                 id=item.venue.id,
             )
             for item in playlist_items

--- a/api/tests/routes/adage_iframe/playlist_test.py
+++ b/api/tests/routes/adage_iframe/playlist_test.py
@@ -380,11 +380,13 @@ class SharedOfferersPlaylistTests:
             assert response_venue["id"] == venues[idx].id
             assert response_venue["distance"] == expected_distance
             assert response_venue["imgUrl"] == IMAGE_URL
+            assert response_venue["city"] == venues[idx].offererAddress.address.city
 
         # item above
         assert response_venues[-1]["id"] == venues[-1].id
         assert response_venues[-1]["distance"] == 150
         assert response_venues[-1]["imgUrl"] == IMAGE_URL
+        assert response_venues[-1]["city"] == venues[-1].offererAddress.address.city
 
     def test_no_data(self, client):
         iframe_client = _get_iframe_client(client)


### PR DESCRIPTION
…e playlists

## 🎯 Related Ticket or 🔧 Changes Made

Utiliser `venue.OA.address.city` au lieu de `venue.city` dans les routes playlist adage

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->
