### PR TITLE
(PC-36687)[API] feat: Update didactic onboarding for partners without Adage ID

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -3361,3 +3361,12 @@ def synchronize_from_ds_and_check_application(offerer_id: int) -> bool:
         .filter(offerers_models.Venue.collectiveDmsApplications.any())
     )
     return db.session.query(query.exists()).scalar()
+
+
+def is_allowed_on_adage(offerer_id: int) -> bool:
+    query = (
+        db.session.query(models.Offerer)
+        .filter(offerers_models.Offerer.id == offerer_id)
+        .filter(offerers_models.Offerer.allowedOnAdage.is_(True))
+    )
+    return db.session.query(query.exists()).scalar()

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -668,7 +668,9 @@ def get_offerer_and_extradata(offerer_id: int) -> models.Offerer | None:
             has_pending_bank_account_subquery.label("hasPendingBankAccount"),
             has_active_offers_subquery.label("hasActiveOffer"),
             has_bank_account_with_pending_corrections_subquery.label("hasBankAccountWithPendingCorrections"),
-            sa.or_(has_adage_id, has_collective_application, has_non_draft_offers).label("isOnboarded"),
+            sa.or_(
+                models.Offerer.allowedOnAdage.is_(True), has_adage_id, has_collective_application, has_non_draft_offers
+            ).label("isOnboarded"),
             has_headline_offer.label("hasHeadlineOffer"),
             has_partner_page.label("hasPartnerPage"),
         )

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -354,6 +354,14 @@ def get_offerer_eligibility(
     check_user_has_access_to_offerer(current_user, offerer_id)
 
     try:
+        is_allowed_on_adage = api.is_allowed_on_adage(offerer_id)
+        if is_allowed_on_adage:
+            return offerers_serialize.OffererEligibilityResponseModel(
+                offerer_id=offerer_id,
+                has_adage_id=False,
+                has_ds_application=None,
+                is_onboarded=True,
+            )
         has_adage_id = api.synchronize_from_adage_and_check_registration(offerer_id)
         if has_adage_id:
             return offerers_serialize.OffererEligibilityResponseModel(
@@ -391,5 +399,5 @@ def get_offerer_eligibility(
         offerer_id=offerer_id,
         has_adage_id=has_adage_id,
         has_ds_application=has_ds_application,
-        is_onboarded=has_adage_id or has_ds_application,
+        is_onboarded=is_allowed_on_adage or has_adage_id or has_ds_application,
     )

--- a/api/src/pcapi/sandboxes/scripts/getters/pro.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/pro.py
@@ -39,7 +39,7 @@ def create_new_pro_user_and_offerer_with_venue() -> dict:
 
 def create_regular_pro_user() -> dict:
     pro_user = users_factories.ProFactory.create()
-    offerer = offerers_factories.OffererFactory.create()
+    offerer = offerers_factories.OffererFactory.create(allowedOnAdage=False)
     offerers_factories.UserOffererFactory.create(user=pro_user, offerer=offerer)
     venue = offerers_factories.VenueFactory.create(name="Mon Lieu", managingOfferer=offerer, isPermanent=True)
     offerers_factories.VirtualVenueFactory.create(managingOfferer=offerer)
@@ -114,12 +114,14 @@ def create_regular_pro_user_with_virtual_offer() -> dict:
 
 def create_pro_user_with_financial_data() -> dict:
     pro_user = users_factories.ProFactory.create()
-    offerer_A = offerers_factories.OffererFactory.create()
+    offerer_A = offerers_factories.OffererFactory.create(allowedOnAdage=False)
     offerers_factories.UserOffererFactory.create(user=pro_user, offerer=offerer_A)
     offerers_factories.VenueFactory.create(name="Mon Lieu", managingOfferer=offerer_A)
     offerers_factories.VirtualVenueFactory.create(managingOfferer=offerer_A)
 
-    offerer_B = offerers_factories.OffererFactory.create(name="Structure avec informations bancaires")
+    offerer_B = offerers_factories.OffererFactory.create(
+        name="Structure avec informations bancaires", allowedOnAdage=False
+    )
     offerers_factories.UserOffererFactory.create(user=pro_user, offerer=offerer_B)
     venue_B = offerers_factories.VenueFactory.create(name="Mon Lieu", managingOfferer=offerer_B)
     offerers_factories.VirtualVenueFactory.create(managingOfferer=offerer_B)
@@ -136,7 +138,9 @@ def create_pro_user_with_financial_data() -> dict:
 def create_pro_user_with_financial_data_and_3_venues() -> dict:
     pro_user = users_factories.ProFactory.create()
 
-    offerer_C = offerers_factories.OffererFactory.create(name="Structure avec informations bancaires et 3 lieux")
+    offerer_C = offerers_factories.OffererFactory.create(
+        name="Structure avec informations bancaires et 3 lieux", allowedOnAdage=False
+    )
     offerers_factories.UserOffererFactory.create(user=pro_user, offerer=offerer_C)
     venue_C = offerers_factories.VenueFactory.create(name="Mon lieu 1", managingOfferer=offerer_C)
     venue_D = offerers_factories.VenueFactory.create(name="Mon lieu 2", managingOfferer=offerer_C)

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -209,28 +209,29 @@ class GetOffererTest:
         assert response.json["hasNonFreeOffer"] is True
 
     @pytest.mark.parametrize(
-        "offers_status,count_offer,adage_id,collective_ds_application,is_onboarded",
+        "allowed_on_adage,offers_status,count_offer,adage_id,collective_ds_application,is_onboarded",
         [
-            (offers_models.OfferValidationStatus.DRAFT, 1, None, None, False),
-            (offers_models.OfferValidationStatus.DRAFT, 3, None, None, False),
-            (offers_models.OfferValidationStatus.APPROVED, 1, None, None, True),
-            (offers_models.OfferValidationStatus.APPROVED, 3, None, None, True),
-            (None, 0, None, None, False),
-            (None, 0, "1", None, True),
-            (offers_models.OfferValidationStatus.DRAFT, 1, "1", None, True),
-            (offers_models.OfferValidationStatus.DRAFT, 3, "1", None, True),
-            (offers_models.OfferValidationStatus.DRAFT, 1, None, 1, True),
-            (None, 0, None, 1, True),
-            (None, 0, "1", 1, True),
-            (offers_models.OfferValidationStatus.DRAFT, 1, "1", 1, True),
-            (offers_models.OfferValidationStatus.DRAFT, 3, "1", 1, True),
+            (False, offers_models.OfferValidationStatus.DRAFT, 1, None, None, False),
+            (False, offers_models.OfferValidationStatus.DRAFT, 3, None, None, False),
+            (False, offers_models.OfferValidationStatus.APPROVED, 1, None, None, True),
+            (False, offers_models.OfferValidationStatus.APPROVED, 3, None, None, True),
+            (False, None, 0, None, None, False),
+            (False, None, 0, "1", None, True),
+            (False, offers_models.OfferValidationStatus.DRAFT, 1, "1", None, True),
+            (False, offers_models.OfferValidationStatus.DRAFT, 3, "1", None, True),
+            (False, offers_models.OfferValidationStatus.DRAFT, 1, None, 1, True),
+            (False, None, 0, None, 1, True),
+            (False, None, 0, "1", 1, True),
+            (False, offers_models.OfferValidationStatus.DRAFT, 1, "1", 1, True),
+            (False, offers_models.OfferValidationStatus.DRAFT, 3, "1", 1, True),
+            (True, None, 0, None, None, True),
         ],
     )
     def test_offerer_onboarding_status(
-        self, client, offers_status, count_offer, adage_id, collective_ds_application, is_onboarded
+        self, client, allowed_on_adage, offers_status, count_offer, adage_id, collective_ds_application, is_onboarded
     ):
         pro = users_factories.ProFactory()
-        offerer = offerers_factories.OffererFactory()
+        offerer = offerers_factories.OffererFactory(allowedOnAdage=allowed_on_adage)
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
 
         venue = offerers_factories.VenueFactory(managingOfferer=offerer, adageId=adage_id)


### PR DESCRIPTION
In some cases, a cultural partner has no Adage ID, has never filled an application on Démarche Simplifiée, and yet is authorized to publish educational offers. This cultural partner should not be included in the didactic onboarding funnel.

Jira story: https://passculture.atlassian.net/browse/PC-36687

- [x] Pair tested
