### PR TITLE
(PC-36182)[API] feat: implement `bookingAllowedDatetime` & `publicationDatetime` logic in public API products endpoints

### DIFF
--- a/api/documentation/src/pages/change-logs.md
+++ b/api/documentation/src/pages/change-logs.md
@@ -7,7 +7,6 @@ title: Pass Culture API change logs
 :::warning
 💡 Important notice some old resources are going to be removed in the coming months.
 
-- If you were using `/v2/venue/<venue_id>/stocks` to manage stocks, you will have to migrate to this endpoint : [/public/offers/v1/products/ean](/rest-api#tag/Product-Offer-Bulk-Operations/operation/PostProductOfferByEan). The endpoint `/v2/stock` will not be available anymore starting from September, the 31st 2024.
 - If you were using `/v2/bookings` to manage bookings, you will have to migrate to those endpoints [/public/bookings/v1/bookings](/rest-api#tag/Bookings).  The endpoint `/v2/bookings` will not be available anymore starting from June, the 30th 2025.
 
 **You can find a migration tutorial [here](/docs/tutorials/migrate-to-the-new-api).**
@@ -27,6 +26,11 @@ title: Pass Culture API change logs
   - Collective offers that are currently `isActive = false` and do not have a related booking will be archived. This does not apply to offers that are under review or rejected by the validation process.
   - **You can find details on the new status and the allowed actions [here](/docs/understanding-our-api/resources/collective-offers#collective-offer-status-and-allowed-actions).**
 :::
+
+## July 2025
+
+- You can specify a `publicationDatetime` and a `bookingAllowedDatetime` for your product offers in the [**Create Product Offer**](/rest-api#tag/Product-Offers/operation/PostProductOffer) and [**Update Product Offer**](/rest-api#tag/Product-Offers/operation/EditProduct) endpoints
+
 
 ## June 2025
 

--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -3413,6 +3413,7 @@
                     "quantity": {
                         "anyOf": [
                             {
+                                "exclusiveMinimum": 0,
                                 "type": "integer"
                             },
                             {
@@ -8724,6 +8725,7 @@
                     "quantity": {
                         "anyOf": [
                             {
+                                "exclusiveMinimum": 0,
                                 "type": "integer"
                             },
                             {

--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -2507,7 +2507,7 @@
                         "$ref": "#/components/schemas/Accessibility"
                     },
                     "bookingAllowedDatetime": {
-                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
                         "example": "2025-07-24T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
@@ -2800,7 +2800,7 @@
                         "title": "Accessibility"
                     },
                     "bookingAllowedDatetime": {
-                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
                         "example": "2025-07-24T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
@@ -3022,7 +3022,7 @@
                         "$ref": "#/components/schemas/AccessibilityResponse"
                     },
                     "bookingAllowedDatetime": {
-                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
                         "example": "2025-07-24T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
@@ -3413,7 +3413,7 @@
                     "quantity": {
                         "anyOf": [
                             {
-                                "exclusiveMinimum": 0,
+                                "minimum": 0,
                                 "type": "integer"
                             },
                             {
@@ -6714,7 +6714,7 @@
                         "$ref": "#/components/schemas/Accessibility"
                     },
                     "bookingAllowedDatetime": {
-                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
                         "example": "2025-07-24T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
@@ -6956,7 +6956,7 @@
                         "title": "Accessibility"
                     },
                     "bookingAllowedDatetime": {
-                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
                         "example": "2025-07-24T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
@@ -7191,7 +7191,7 @@
                         "$ref": "#/components/schemas/AccessibilityResponse"
                     },
                     "bookingAllowedDatetime": {
-                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
                         "example": "2025-07-24T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
@@ -8725,7 +8725,7 @@
                     "quantity": {
                         "anyOf": [
                             {
-                                "exclusiveMinimum": 0,
+                                "minimum": 0,
                                 "type": "integer"
                             },
                             {

--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -2506,6 +2506,14 @@
                     "accessibility": {
                         "$ref": "#/components/schemas/Accessibility"
                     },
+                    "bookingAllowedDatetime": {
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookingalloweddatetime",
+                        "type": "string"
+                    },
                     "bookingContact": {
                         "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
                         "example": "support@yourcompany.com",
@@ -2741,12 +2749,31 @@
                         "type": "array"
                     },
                     "publicationDate": {
-                        "description": "\nThe date and time when the offer will be published in the beneficiary application.\n\n- Must not be in the past\n- Time must be rounded to the nearest quarter-hour\n- Format: **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (timezone-aware datetime)\n",
+                        "description": "\nThe date and time when the offer becomes visible in the beneficiary application.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offers are published every 15 minutes. Therefore, a small delay may occur between the indicated datetime and the actual publication time.\n\n**Other options:**\n- If set to `\"now\"` (default value), the offer is published immediately (no delay).\n- If set to `null`, the offer will not be published.\n",
                         "example": "2025-07-24T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Publicationdate",
                         "type": "string"
+                    },
+                    "publicationDatetime": {
+                        "anyOf": [
+                            {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            {
+                                "enum": [
+                                    "now"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "default": "now",
+                        "description": "\nThe date and time when the offer becomes visible in the beneficiary application.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offers are published every 15 minutes. Therefore, a small delay may occur between the indicated datetime and the actual publication time.\n\n**Other options:**\n- If set to `\"now\"` (default value), the offer is published immediately (no delay).\n- If set to `null`, the offer will not be published.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "nullable": true,
+                        "title": "Publicationdatetime"
                     }
                 },
                 "required": [
@@ -2771,6 +2798,14 @@
                         "description": "Accessibility to disabled people. Leave fields undefined to keep current value",
                         "nullable": true,
                         "title": "Accessibility"
+                    },
+                    "bookingAllowedDatetime": {
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookingalloweddatetime",
+                        "type": "string"
                     },
                     "bookingContact": {
                         "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
@@ -2958,6 +2993,24 @@
                         "nullable": true,
                         "title": "Name",
                         "type": "string"
+                    },
+                    "publicationDatetime": {
+                        "anyOf": [
+                            {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            {
+                                "enum": [
+                                    "now"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "description": "\nThe date and time when the offer becomes visible in the beneficiary application.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offers are published every 15 minutes. Therefore, a small delay may occur between the indicated datetime and the actual publication time.\n\n**Other options:**\n- If set to `\"now\"` (default value), the offer is published immediately (no delay).\n- If set to `null`, the offer will not be published.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "nullable": true,
+                        "title": "Publicationdatetime"
                     }
                 },
                 "title": "EventOfferEdition",
@@ -2967,6 +3020,14 @@
                 "properties": {
                     "accessibility": {
                         "$ref": "#/components/schemas/AccessibilityResponse"
+                    },
+                    "bookingAllowedDatetime": {
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookingalloweddatetime",
+                        "type": "string"
                     },
                     "bookingContact": {
                         "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
@@ -3205,11 +3266,19 @@
                         "type": "array"
                     },
                     "publicationDate": {
-                        "description": "\nThe date and time when the offer will be published in the beneficiary application.\n\n- Must not be in the past\n- Time must be rounded to the nearest quarter-hour\n- Format: **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (timezone-aware datetime)\n",
+                        "description": "\nThe date and time when the offer becomes visible in the beneficiary application.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offers are published every 15 minutes. Therefore, a small delay may occur between the indicated datetime and the actual publication time.\n\n**Other options:**\n- If set to `\"now\"` (default value), the offer is published immediately (no delay).\n- If set to `null`, the offer will not be published.\n",
                         "example": "2025-07-24T14:00:00+02:00",
                         "format": "date-time",
                         "nullable": true,
                         "title": "Publicationdate",
+                        "type": "string"
+                    },
+                    "publicationDatetime": {
+                        "description": "\nThe date and time when the offer becomes visible in the beneficiary application.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offers are published every 15 minutes. Therefore, a small delay may occur between the indicated datetime and the actual publication time.\n\n**Other options:**\n- If set to `\"now\"` (default value), the offer is published immediately (no delay).\n- If set to `null`, the offer will not be published.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Publicationdatetime",
                         "type": "string"
                     },
                     "status": {
@@ -6643,6 +6712,14 @@
                     "accessibility": {
                         "$ref": "#/components/schemas/Accessibility"
                     },
+                    "bookingAllowedDatetime": {
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookingalloweddatetime",
+                        "type": "string"
+                    },
                     "bookingContact": {
                         "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
                         "example": "support@yourcompany.com",
@@ -6826,6 +6903,25 @@
                         "title": "Name",
                         "type": "string"
                     },
+                    "publicationDatetime": {
+                        "anyOf": [
+                            {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            {
+                                "enum": [
+                                    "now"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "default": "now",
+                        "description": "\nThe date and time when the offer becomes visible in the beneficiary application.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offers are published every 15 minutes. Therefore, a small delay may occur between the indicated datetime and the actual publication time.\n\n**Other options:**\n- If set to `\"now\"` (default value), the offer is published immediately (no delay).\n- If set to `null`, the offer will not be published.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "nullable": true,
+                        "title": "Publicationdatetime"
+                    },
                     "stock": {
                         "anyOf": [
                             {
@@ -6857,6 +6953,14 @@
                         "description": "Accessibility to disabled people. Leave fields undefined to keep current value",
                         "nullable": true,
                         "title": "Accessibility"
+                    },
+                    "bookingAllowedDatetime": {
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookingalloweddatetime",
+                        "type": "string"
                     },
                     "bookingContact": {
                         "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
@@ -7045,6 +7149,24 @@
                         "title": "Offerid",
                         "type": "integer"
                     },
+                    "publicationDatetime": {
+                        "anyOf": [
+                            {
+                                "format": "date-time",
+                                "type": "string"
+                            },
+                            {
+                                "enum": [
+                                    "now"
+                                ],
+                                "type": "string"
+                            }
+                        ],
+                        "description": "\nThe date and time when the offer becomes visible in the beneficiary application.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offers are published every 15 minutes. Therefore, a small delay may occur between the indicated datetime and the actual publication time.\n\n**Other options:**\n- If set to `\"now\"` (default value), the offer is published immediately (no delay).\n- If set to `null`, the offer will not be published.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "nullable": true,
+                        "title": "Publicationdatetime"
+                    },
                     "stock": {
                         "allOf": [
                             {
@@ -7066,6 +7188,14 @@
                 "properties": {
                     "accessibility": {
                         "$ref": "#/components/schemas/AccessibilityResponse"
+                    },
+                    "bookingAllowedDatetime": {
+                        "description": "\nThe date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Bookingalloweddatetime",
+                        "type": "string"
                     },
                     "bookingContact": {
                         "description": "Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
@@ -7348,6 +7478,14 @@
                         "description": "Offer title",
                         "example": "Le Petit Prince",
                         "title": "Name",
+                        "type": "string"
+                    },
+                    "publicationDatetime": {
+                        "description": "\nThe date and time when the offer becomes visible in the beneficiary application.\n\n**Constraints on datetime:**\n- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.\n- Must be a datetime in the future. Offers are published every 15 minutes. Therefore, a small delay may occur between the indicated datetime and the actual publication time.\n\n**Other options:**\n- If set to `\"now\"` (default value), the offer is published immediately (no delay).\n- If set to `null`, the offer will not be published.\n",
+                        "example": "2025-07-24T14:00:00+02:00",
+                        "format": "date-time",
+                        "nullable": true,
+                        "title": "Publicationdatetime",
                         "type": "string"
                     },
                     "status": {

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -893,6 +893,38 @@ def handle_event_stock_beginning_datetime_update(stock: models.Stock) -> None:
     _notify_beneficiaries_upon_stock_edit(stock, bookings)  # TODO: (tcoudray-pass, 16/04/2025) rename this function
 
 
+def finalize_offer(
+    offer: models.Offer,
+    publication_datetime: datetime.datetime | None,
+    booking_allowed_datetime: datetime.datetime | None,
+) -> models.Offer:
+    """
+    :publication_datetime     : /!\ must be a naive utc datetime
+    :booking_allowed_datetime : /!\ must be a naive utc datetime
+    """
+    offer.finalizationDatetime = get_naive_utc_now()
+
+    if publication_datetime:
+        publication_datetime = publication_datetime.replace(second=0, microsecond=0)
+        validation.check_publication_date(publication_datetime)
+        offer.publicationDatetime = publication_datetime
+        offer.isActive = publication_datetime <= get_naive_utc_now()
+
+    offer.bookingAllowedDatetime = booking_allowed_datetime
+
+    on_commit(partial(search.async_index_offer_ids, [offer.id], reason=search.IndexationReason.OFFER_PUBLICATION))
+    on_commit(
+        partial(
+            logger.info,
+            "Offer has been published",
+            extra={"offer_id": offer.id, "venue_id": offer.venueId, "offer_status": offer.status},
+            technical_message_id="offer.published",
+        )
+    )
+
+    return offer
+
+
 def publish_offer(
     offer: models.Offer,
     publication_datetime: datetime.datetime | None = None,
@@ -909,7 +941,7 @@ def publish_offer(
 
     if publication_datetime:
         publication_datetime = publication_datetime.replace(second=0, microsecond=0)
-    validation.check_publication_date(offer, publication_datetime)
+        validation.check_publication_date(publication_datetime)
 
     offer.bookingAllowedDatetime = booking_allowed_datetime
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -63,6 +63,8 @@ EDITABLE_FIELDS_FOR_INDIVIDUAL_OFFERS_API_PROVIDER = {
     "withdrawalDelay",
     "withdrawalType",
     "idAtProvider",
+    "bookingAllowedDatetime",
+    "publicationDatetime",
 } | EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER
 
 MAX_THUMBNAIL_SIZE = 10_000_000

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -789,35 +789,10 @@ def check_accessibility_compliance(
         raise exceptions.OfferException({"global": ["L’accessibilité de l’offre doit être définie"]})
 
 
-def check_publication_date(offer: models.Offer, publication_date: datetime.datetime | None) -> None:
-    if publication_date is None:
-        return
-
-    if offer.publicationDate is not None:
+def check_publication_date(publication_date: datetime.datetime) -> None:
+    if publication_date > date.get_naive_utc_now() + relativedelta(years=2):
         raise exceptions.OfferException(
-            {"publication_date": ["Cette offre est déjà programmée pour être publiée dans le futur"]}
-        )
-
-    if not offer.subcategory.is_event:
-        raise exceptions.OfferException(
-            {"publication_date": ["Seules les offres d’événements peuvent avoir une date de publication"]}
-        )
-
-    if publication_date.minute not in [0, 15, 30, 45]:
-        raise exceptions.OfferException(
-            {"publication_date": ["L’heure de publication ne peut avoir une précision supérieure au quart d'heure"]}
-        )
-
-    now = datetime.datetime.utcnow()
-    if publication_date < now:
-        raise exceptions.OfferException(
-            {"publication_date": ["Impossible de sélectionner une date de publication dans le passé"]}
-        )
-
-    years = 2
-    if publication_date > now + relativedelta(years=years):
-        raise exceptions.OfferException(
-            {"publication_date": [f"Impossible sélectionner une date de publication plus de {years} ans en avance"]}
+            {"publication_date": ["Impossible sélectionner une date de publication plus de 2 ans en avance"]}
         )
 
 

--- a/api/src/pcapi/routes/public/documentation_constants/descriptions.py
+++ b/api/src/pcapi/routes/public/documentation_constants/descriptions.py
@@ -100,7 +100,7 @@ The date and time when the offer becomes visible in the beneficiary application.
 """
 
 BOOKING_ALLOWED_DATETIME_FIELD_DESCRIPTION = """
-The date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published
+The date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published.
 
 **Constraints on datetime:**
 - Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.

--- a/api/src/pcapi/routes/public/documentation_constants/descriptions.py
+++ b/api/src/pcapi/routes/public/documentation_constants/descriptions.py
@@ -77,10 +77,32 @@ Booking status explanation:
 
 BEGINNING_DATETIME_FIELD_DESCRIPTION = "Beginning datetime of the event. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime)."
 BOOKING_LIMIT_DATETIME_FIELD_DESCRIPTION = "Datetime after which the offer can no longer be booked. The expected format is **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (standard format for timezone aware datetime)."
-PUBLICATION_DATETIME_FIELD_DESCRIPTION = """
+PUBLICATION_DATE_FIELD_DESCRIPTION = """
+[DEPRECATED] You should use `publicationDatetime` instead
+
 The date and time when the offer will be published in the beneficiary application.
 
 - Must not be in the past
 - Time must be rounded to the nearest quarter-hour
 - Format: **[ISO 8601](https://fr.wikipedia.org/wiki/ISO_8601)** (timezone-aware datetime)
+"""
+
+PUBLICATION_DATETIME_FIELD_DESCRIPTION = """
+The date and time when the offer becomes visible in the beneficiary application.
+
+**Constraints on datetime:**
+- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.
+- Must be a datetime in the future. Offers are published every 15 minutes. Therefore, a small delay may occur between the indicated datetime and the actual publication time.
+
+**Other options:**
+- If set to `"now"` (default value), the offer is published immediately (no delay).
+- If set to `null`, the offer will not be published.
+"""
+
+BOOKING_ALLOWED_DATETIME_FIELD_DESCRIPTION = """
+The date and time when the offer becomes bookable in the beneficiary application. If not set, the offer will be bookable as soon as it is published
+
+**Constraints on datetime:**
+- Must be a timezone-aware datetime in **[ISO 8601 format](https://fr.wikipedia.org/wiki/ISO_8601)**.
+- Must be a datetime in the future. Offer bookability is updated every 15 minutes. As a result, there may be a short delay between the specified datetime and the actual moment the offer becomes bookable.
 """

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -153,7 +153,21 @@ class _FIELDS:
         description="Recipient email to contact if there is an issue with booking the offer. Mandatory if the offer has withdrawable tickets.",
         example="support@yourcompany.com",
     )
-    OFFER_PUBLICATION_DATE = Field(
+    OFFER_PUBLICATION_DATETIME_WITH_DEFAULT = Field(
+        description=descriptions.PUBLICATION_DATETIME_FIELD_DESCRIPTION,
+        example=_example_datetime_with_tz,
+        default="now",
+    )
+    OFFER_PUBLICATION_DATETIME = Field(
+        description=descriptions.PUBLICATION_DATETIME_FIELD_DESCRIPTION,
+        example=_example_datetime_with_tz,
+    )
+    OFFER_BOOKING_ALLOWED_DATETIME = Field(
+        description=descriptions.BOOKING_ALLOWED_DATETIME_FIELD_DESCRIPTION,
+        example=_example_datetime_with_tz,
+        default=None,
+    )
+    DEPRECATED_OFFER_PUBLICATION_DATE = Field(
         description=descriptions.PUBLICATION_DATETIME_FIELD_DESCRIPTION,
         example=_example_datetime_with_tz,
     )

--- a/api/src/pcapi/routes/public/documentation_constants/fields.py
+++ b/api/src/pcapi/routes/public/documentation_constants/fields.py
@@ -239,6 +239,10 @@ class _FIELDS:
     BOOKING_STATUS = Field(description=descriptions.BOOKING_STATUS_DESCRIPTION, example="CONFIRMED")
 
     # Stock fields
+    STOCK_EDITION = Field(
+        description="If stock is set to null, all cancellable bookings (i.e not used) will be cancelled. To prevent from further bookings, you may alternatively set stock.quantity to the bookedQuantity (but not below).",
+    )
+
     STOCK_ID = Field(description="Stock id", example=45)
     QUANTITY = Field(
         description="Quantity of items currently available to pass Culture. Value `'unlimited'` is used for infinite quantity of items.",

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -826,6 +826,8 @@ def edit_product(body: serialization.ProductOfferEdition) -> serialization.Produ
             idAtProvider=get_field(offer, updates, "idAtProvider"),
             isDuo=get_field(offer, updates, "enableDoubleBookings", col="isDuo"),
             withdrawalDetails=get_field(offer, updates, "itemCollectionDetails", col="withdrawalDetails"),
+            publicationDatetime=get_field(offer, updates, "publicationDatetime"),
+            bookingAllowedDatetime=get_field(offer, updates, "bookingAllowedDatetime"),
         )  # type: ignore[call-arg]
         updated_offer = offers_api.update_offer(offer, offer_body, venue=venue, offerer_address=offerer_address)
         db.session.flush()

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -31,6 +31,7 @@ from pcapi.routes.public import spectree_schemas
 from pcapi.routes.public import utils as public_utils
 from pcapi.routes.public.documentation_constants import http_responses
 from pcapi.routes.public.documentation_constants import tags
+from pcapi.routes.public.individual_offers.v1.serializers import products as products_serializers
 from pcapi.routes.public.services import authorization
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
@@ -194,7 +195,7 @@ def get_event_titelive_music_types() -> serialization.GetTiteliveEventMusicTypes
         )
     ),
 )
-def post_product_offer(body: serialization.ProductOfferCreation) -> serialization.ProductOfferResponse:
+def post_product_offer(body: products_serializers.ProductOfferCreation) -> serialization.ProductOfferResponse:
     """
     Create Product Offer
 
@@ -780,7 +781,7 @@ def _check_offer_can_be_edited(offer: offers_models.Offer) -> None:
         )
     ),
 )
-def edit_product(body: serialization.ProductOfferEdition) -> serialization.ProductOfferResponse:
+def edit_product(body: products_serializers.ProductOfferEdition) -> serialization.ProductOfferResponse:
     """
     Update Product Offer
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -233,6 +233,13 @@ class OfferCreationBase(serialization.ConfiguredBaseModel):
     name: str = fields.OFFER_NAME_WITH_MAX_LENGTH
     withdrawal_details: str | None = WITHDRAWAL_DETAILS_FIELD
     id_at_provider: str | None = fields.ID_AT_PROVIDER_WITH_MAX_LENGTH
+    publication_datetime: datetime.datetime | serialization_utils.NOW_LITERAL | None = (
+        fields.OFFER_PUBLICATION_DATETIME_WITH_DEFAULT
+    )
+    booking_allowed_datetime: datetime.datetime | None = fields.OFFER_BOOKING_ALLOWED_DATETIME
+
+    _validate_publicationDatetime = serialization_utils.validate_datetime("publication_datetime")
+    _validate_bookingAllowedDatetime = serialization_utils.validate_datetime("booking_allowed_datetime")
 
 
 class Method(enum.Enum):
@@ -564,7 +571,7 @@ class EventOfferCreation(OfferCreationBase):
     location: PhysicalLocation | DigitalLocation | AddressLocation = fields.OFFER_LOCATION
     has_ticket: bool = fields.EVENT_HAS_TICKET
     price_categories: list[PriceCategoryCreation] | None = fields.PRICE_CATEGORIES_WITH_MAX_ITEMS
-    publication_date: datetime.datetime | None = fields.OFFER_PUBLICATION_DATE
+    publication_date: datetime.datetime | None = fields.DEPRECATED_OFFER_PUBLICATION_DATE
     enable_double_bookings: bool | None = fields.OFFER_ENABLE_DOUBLE_BOOKINGS_ENABLED
 
     @pydantic_v1.validator("price_categories")
@@ -615,6 +622,11 @@ class OfferEditionBase(serialization.ConfiguredBaseModel):
     id_at_provider: str | None = fields.ID_AT_PROVIDER_WITH_MAX_LENGTH
     name: OfferName | None = fields.OFFER_NAME
     location: PhysicalLocation | DigitalLocation | AddressLocation | None = fields.OFFER_LOCATION
+    publication_datetime: datetime.datetime | serialization_utils.NOW_LITERAL | None = fields.OFFER_PUBLICATION_DATETIME
+    booking_allowed_datetime: datetime.datetime | None = fields.OFFER_BOOKING_ALLOWED_DATETIME
+
+    _validate_publicationDatetime = serialization_utils.validate_datetime("publication_datetime")
+    _validate_bookingAllowedDatetime = serialization_utils.validate_datetime("booking_allowed_datetime")
 
     class Config:
         extra = "forbid"
@@ -764,6 +776,8 @@ class OfferResponse(serialization.ConfiguredBaseModel):
     )
     withdrawal_details: str | None = WITHDRAWAL_DETAILS_FIELD
     id_at_provider: str | None = fields.ID_AT_PROVIDER
+    publication_datetime: datetime.datetime | None = fields.OFFER_PUBLICATION_DATETIME
+    booking_allowed_datetime: datetime.datetime | None = fields.OFFER_BOOKING_ALLOWED_DATETIME
 
     @classmethod
     def get_location(cls, offer: offers_models.Offer) -> PhysicalLocation | DigitalLocation | AddressLocation:
@@ -790,6 +804,8 @@ class OfferResponse(serialization.ConfiguredBaseModel):
             status=offer.status,
             withdrawal_details=offer.withdrawalDetails,
             id_at_provider=offer.idAtProvider,
+            publication_datetime=offer.publicationDatetime,
+            booking_allowed_datetime=offer.bookingAllowedDatetime,
         )
 
 
@@ -827,7 +843,7 @@ class EventOfferResponse(OfferResponse, PriceCategoriesResponse):
     category_related_fields: event_category_reading_fields
     event_duration: int | None = fields.EVENT_DURATION
     has_ticket: bool = fields.EVENT_HAS_TICKET
-    publication_date: datetime.datetime | None = fields.OFFER_PUBLICATION_DATE
+    publication_date: datetime.datetime | None = fields.DEPRECATED_OFFER_PUBLICATION_DATE
 
     @classmethod
     def build_event_offer(cls, offer: offers_models.Offer) -> "EventOfferResponse":

--- a/api/src/pcapi/routes/public/individual_offers/v1/serializers/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serializers/products.py
@@ -1,0 +1,52 @@
+import datetime
+import typing
+
+import pydantic.v1 as pydantic_v1
+
+from pcapi.routes.public.documentation_constants.fields import fields
+from pcapi.routes.public.individual_offers.v1 import serialization as v1_serialization
+
+
+def _validate_stock_booking_limit_datetime_is_coherent_with_offer_dates(cls: typing.Any, values: dict) -> dict:
+    stock: v1_serialization.StockCreation | v1_serialization.StockEdition | None = values.get("stock")
+    publication_datetime: datetime.datetime | None = values.get("publication_datetime")
+    booking_allowed_datetime: datetime.datetime | None = values.get("booking_allowed_datetime")
+
+    if not stock or not stock.booking_limit_datetime:
+        return values
+
+    if publication_datetime and stock.booking_limit_datetime < publication_datetime:
+        raise ValueError("`stock.bookingLimitDatetime` must be after `publicationDatetime`")
+
+    if booking_allowed_datetime and stock.booking_limit_datetime < booking_allowed_datetime:
+        raise ValueError("`stock.bookingLimitDatetime` must be after `bookingAllowedDatetime`")
+
+    return values
+
+
+class ProductOfferEdition(v1_serialization.OfferEditionBase):
+    offer_id: int
+    category_related_fields: v1_serialization.product_category_edition_fields | None = pydantic_v1.Field(
+        None,
+        description="To override category related fields, the category must be specified, even if it cannot be changed. Other category related fields may be left undefined to keep their current value.",
+    )
+    stock: v1_serialization.StockEdition | None = fields.STOCK_EDITION
+    name: v1_serialization.OfferName | None = fields.OFFER_NAME
+    description: str | None = fields.OFFER_DESCRIPTION_WITH_MAX_LENGTH
+    enable_double_bookings: bool | None = fields.OFFER_ENABLE_DOUBLE_BOOKINGS_ENABLED
+
+    _validate_stock_booking_limit_datetime = pydantic_v1.root_validator(skip_on_failure=True, allow_reuse=True)(
+        _validate_stock_booking_limit_datetime_is_coherent_with_offer_dates
+    )
+
+
+class ProductOfferCreation(v1_serialization.OfferCreationBase):
+    category_related_fields: v1_serialization.product_category_creation_fields
+    stock: v1_serialization.StockCreation | None
+    location: (
+        v1_serialization.PhysicalLocation | v1_serialization.DigitalLocation | v1_serialization.AddressLocation
+    ) = fields.OFFER_LOCATION
+
+    _validate_stock_booking_limit_datetime = pydantic_v1.root_validator(skip_on_failure=True, allow_reuse=True)(
+        _validate_stock_booking_limit_datetime_is_coherent_with_offer_dates
+    )

--- a/api/src/pcapi/routes/public/individual_offers/v1/utils.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/utils.py
@@ -11,6 +11,7 @@ from pcapi.core.providers import models as providers_models
 from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.routes.public import utils as public_utils
+from pcapi.routes.public.individual_offers.v1.serializers import products as products_serializers
 from pcapi.utils import image_conversion
 from pcapi.validation.routes.users_authentifications import current_api_key
 
@@ -68,7 +69,7 @@ def check_venue_id_is_tied_to_api_key(venue_id: int | None) -> None:
 
 
 def check_offer_subcategory(
-    body: serialization.ProductOfferEdition | serialization.EventOfferEdition, offer_subcategory_id: str
+    body: products_serializers.ProductOfferEdition | serialization.EventOfferEdition, offer_subcategory_id: str
 ) -> None:
     if body.category_related_fields is not None and (
         body.category_related_fields.subcategory_id != offer_subcategory_id

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -154,5 +154,7 @@ def check_date_in_future_and_remove_timezone(value: datetime.datetime | NOW_LITE
     return no_tz_value
 
 
-def validate_datetime(field_name: str) -> classmethod:
-    return pydantic_v1.validator(field_name, pre=False, allow_reuse=True)(check_date_in_future_and_remove_timezone)
+def validate_datetime(field_name: str, always: bool = False) -> classmethod:
+    return pydantic_v1.validator(field_name, pre=False, allow_reuse=True, always=always)(
+        check_date_in_future_and_remove_timezone
+    )

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -865,64 +865,14 @@ class CheckBookingLimitDatetimeTest:
 
 
 class CheckPublicationDateTest:
-    @pytest.mark.parametrize(
-        "offer_factory,publication_date,expected_message",
-        [
-            (
-                offers_factories.ThingOfferFactory,
-                datetime.datetime.utcnow().replace(minute=0),
-                "Seules les offres d’événements peuvent avoir une date de publication",
-            ),
-            (
-                offers_factories.EventOfferFactory,
-                datetime.datetime.utcnow().replace(minute=16),
-                "L’heure de publication ne peut avoir une précision supérieure au quart d'heure",
-            ),
-            (
-                offers_factories.EventOfferFactory,
-                datetime.datetime.utcnow() + datetime.timedelta(days=750),
-                "Impossible de sélectionner une date de publication dans le passé",
-            ),
-            (
-                offers_factories.EventOfferFactory,
-                datetime.datetime.utcnow() - datetime.timedelta(days=1),
-                "Impossible sélectionner une date de publication plus de 2 ans en avance",
-            ),
-        ],
-    )
-    def test_check_publication_date_should_raise(self, offer_factory, publication_date, expected_message):
-        offer = offer_factory()
+    def test_check_publication_date_should_raise(self):
         with pytest.raises(exceptions.OfferException) as exc:
-            validation.check_publication_date(offer, publication_date)
-            assert exc.value.errors["publication_date"] == [expected_message]
-
-    def test_check_publication_date_should_raise_raise_because_already_set(self):
-        publication_date = datetime.datetime.utcnow().replace(minute=0) + datetime.timedelta(days=30)
-        offer = offers_factories.ThingOfferFactory(publicationDatetime=publication_date)
-        with pytest.raises(exceptions.OfferException) as exc:
-            validation.check_publication_date(offer, publication_date)
-            msg = "Cette offre est déjà programmée pour être publiée dans le futur"
-            assert exc.value.errors["publication_date"] == [msg]
+            validation.check_publication_date(datetime.datetime.utcnow() + datetime.timedelta(days=750))
 
     def test_check_publication_date_should_raise_not_raise(self):
-        offer = offers_factories.ThingOfferFactory()
-        publication_date = None
-        assert validation.check_publication_date(offer, publication_date) is None
-
-        offer = offers_factories.EventOfferFactory()
-        # TODO(jbaudet)[2025-05] fix: passing it as kwarg to factory does not seem to work
-        offer.publicationDatetime = None
-
-        publication_date = datetime.datetime.utcnow().replace(minute=0) + datetime.timedelta(days=30)
-        assert validation.check_publication_date(offer, publication_date) is None
-
         for i in [0, 15, 30, 45]:
-            offer = offers_factories.EventOfferFactory()
-            # TODO(jbaudet)[2025-05] fix: passing it as kwarg to factory does not seem to work
-            offer.publicationDatetime = None
-
             publication_date = datetime.datetime.utcnow().replace(minute=0) + datetime.timedelta(hours=1, minutes=i)
-            assert validation.check_publication_date(offer, publication_date) is None
+            assert validation.check_publication_date(publication_date) is None
 
 
 class CheckOffererIsEligibleForHeadlineOffersTest:

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -866,7 +866,7 @@ class CheckBookingLimitDatetimeTest:
 
 class CheckPublicationDateTest:
     def test_check_publication_date_should_raise(self):
-        with pytest.raises(exceptions.OfferException) as exc:
+        with pytest.raises(exceptions.OfferException):
             validation.check_publication_date(datetime.datetime.utcnow() + datetime.timedelta(days=750))
 
     def test_check_publication_date_should_raise_not_raise(self):

--- a/api/tests/routes/public/individual_offers/v1/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_event_test.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 
 import pytest
+import time_machine
 
 from pcapi.core import testing
 from pcapi.core.categories import subcategories
@@ -70,6 +72,7 @@ class GetEventTest(PublicAPIVenueEndpointHelper):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(event_id=event_offer_id))
             assert response.status_code == 404
 
+    @time_machine.travel(datetime(2025, 6, 25, 12, 30, tzinfo=timezone.utc), tick=False)
     def test_get_event(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         event_offer = self.setup_base_resource(venue=venue_provider.venue)
@@ -77,8 +80,8 @@ class GetEventTest(PublicAPIVenueEndpointHelper):
 
         with testing.assert_num_queries(self.num_queries_full):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(event_id=event_offer_id))
+            assert response.status_code == 200
 
-        assert response.status_code == 200
         assert response.json == {
             "accessibility": {
                 "audioDisabilityCompliant": False,
@@ -86,6 +89,7 @@ class GetEventTest(PublicAPIVenueEndpointHelper):
                 "motorDisabilityCompliant": False,
                 "visualDisabilityCompliant": False,
             },
+            "bookingAllowedDatetime": None,
             "bookingContact": None,
             "bookingEmail": None,
             "categoryRelatedFields": {"author": None, "category": "SEANCE_CINE", "stageDirector": None, "visa": None},
@@ -104,6 +108,7 @@ class GetEventTest(PublicAPIVenueEndpointHelper):
             "status": "SOLD_OUT",
             "hasTicket": False,
             "priceCategories": [],
+            "publicationDatetime": "2025-06-25T12:25:00Z",
             "idAtProvider": "Oh le bel id <3",
             "publicationDate": date_utils.format_into_utc_date(event_offer.publicationDatetime),
         }

--- a/api/tests/routes/public/individual_offers/v1/get_product_by_ean_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_product_by_ean_test.py
@@ -1,4 +1,7 @@
+import datetime
+
 import pytest
+import time_machine
 
 from pcapi.core import testing
 from pcapi.core.categories import subcategories
@@ -60,6 +63,7 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
             )
             assert response.status_code == 404
 
+    @time_machine.travel(datetime.datetime(2025, 6, 25, 12, 30, tzinfo=datetime.timezone.utc), tick=False)
     def test_valid_ean(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         venue = venue_provider.venue
@@ -81,6 +85,7 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
         assert response.json == {
             "products": [
                 {
+                    "bookingAllowedDatetime": None,
                     "bookingContact": None,
                     "bookingEmail": None,
                     "categoryRelatedFields": {
@@ -100,6 +105,7 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
                     "image": None,
                     "itemCollectionDetails": None,
                     "location": {"type": "physical", "venueId": product_offer.venueId},
+                    "publicationDatetime": "2025-06-25T12:25:00Z",
                     "name": "Vieux motard que jamais",
                     "status": "SOLD_OUT",
                     "stock": None,
@@ -108,6 +114,7 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
             ]
         }
 
+    @time_machine.travel(datetime.datetime(2025, 6, 25, 12, 30, tzinfo=datetime.timezone.utc), tick=False)
     def test_multiple_valid_eans(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         venue = venue_provider.venue
@@ -149,6 +156,8 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
         assert response.json == {
             "products": [
                 {
+                    "bookingAllowedDatetime": None,
+                    "publicationDatetime": "2025-06-25T12:25:00Z",
                     "bookingContact": None,
                     "bookingEmail": None,
                     "categoryRelatedFields": {
@@ -174,6 +183,8 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
                     "idAtProvider": None,
                 },
                 {
+                    "bookingAllowedDatetime": None,
+                    "publicationDatetime": "2025-06-25T12:25:00Z",
                     "bookingContact": None,
                     "bookingEmail": None,
                     "categoryRelatedFields": {
@@ -199,6 +210,8 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
                     "idAtProvider": None,
                 },
                 {
+                    "bookingAllowedDatetime": None,
+                    "publicationDatetime": "2025-06-25T12:25:00Z",
                     "bookingContact": None,
                     "bookingEmail": None,
                     "categoryRelatedFields": {
@@ -300,6 +313,7 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
 
         assert response.json == {"products": []}
 
+    @time_machine.travel(datetime.datetime(2025, 6, 25, 12, 30, tzinfo=datetime.timezone.utc), tick=False)
     def test_200_when_one_ean_in_list_not_found(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         venue = venue_provider.venue
@@ -323,6 +337,8 @@ class GetProductByEanTest(PublicAPIVenueEndpointHelper):
         assert response.json == {
             "products": [
                 {
+                    "bookingAllowedDatetime": None,
+                    "publicationDatetime": "2025-06-25T12:25:00Z",
                     "bookingContact": None,
                     "bookingEmail": None,
                     "categoryRelatedFields": {

--- a/api/tests/routes/public/individual_offers/v1/get_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_product_test.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 
 import pytest
+import time_machine
 
 from pcapi.core import testing
 from pcapi.core.bookings import factories as bookings_factories
@@ -60,6 +61,7 @@ class GetProductTest(PublicAPIVenueEndpointHelper):
             )
             assert response.status_code == 404
 
+    @time_machine.travel(datetime.datetime(2025, 6, 25, 12, 30, tzinfo=datetime.timezone.utc), tick=False)
     def test_product_without_stock(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         venue = venue_provider.venue
@@ -78,6 +80,8 @@ class GetProductTest(PublicAPIVenueEndpointHelper):
             assert response.status_code == 200
 
         assert response.json == {
+            "bookingAllowedDatetime": None,
+            "publicationDatetime": "2025-06-25T12:25:00Z",
             "bookingContact": None,
             "bookingEmail": None,
             "categoryRelatedFields": {"category": "CARTE_CINE_ILLIMITE"},

--- a/api/tests/routes/public/individual_offers/v1/patch_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/patch_product_test.py
@@ -491,6 +491,8 @@ class PatchProductTest(PublicAPIVenueEndpointHelper, ProductEndpointHelper):
                 },
                 {"__root__": ["`stock.bookingLimitDatetime` must be after `bookingAllowedDatetime`"]},
             ),
+            # additional properties not allowed
+            ({"tkilol": ""}, {"tkilol": ["extra fields not permitted"]}),
         ],
     )
     def test_incorrect_payload_should_return_400(self, client, partial_request_json, expected_response_json):

--- a/api/tests/routes/public/individual_offers/v1/post_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_event_test.py
@@ -699,25 +699,6 @@ class PostEventTest(PublicAPIVenueEndpointHelper):
         assert response.status_code == 400
         assert response.json == {"priceCategories": ["Price categories must be unique"]}
 
-    def test_future_event_400(self, client):
-        plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=True)
-
-        publication_date = datetime.utcnow().replace(minute=0, second=0) - timedelta(days=30)
-        response = client.with_explicit_token(plain_api_key).post(
-            self.endpoint_url,
-            json={
-                "categoryRelatedFields": {"category": "RENCONTRE"},
-                "accessibility": ACCESSIBILITY_FIELDS,
-                "location": {"type": "physical", "venueId": venue_provider.venueId},
-                "name": "Le champ des possibles",
-                "hasTicket": False,
-                "publicationDate": publication_date.isoformat(),
-            },
-        )
-
-        assert response.status_code == 400
-        assert response.json["publication_date"] == ["Impossible de sélectionner une date de publication dans le passé"]
-
     def test_should_raise_400_because_of_duplicated_price_category_ids_at_provider(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=True)
 

--- a/api/tests/routes/public/individual_offers/v1/post_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_event_test.py
@@ -219,7 +219,7 @@ class PostEventTest(PublicAPIVenueEndpointHelper):
         assert response.status_code == 400
         assert response.json == {"idAtProvider": ["`rolala` is already taken by another venue offer"]}
 
-    @time_machine.travel(now_datetime_with_tz, tick=False)
+    @time_machine.travel(datetime(2025, 6, 25, 12, 30, tzinfo=timezone.utc), tick=False)
     def test_event_creation_with_full_body(self, client, clear_tests_assets_bucket):
         plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=True)
 
@@ -278,8 +278,11 @@ class PostEventTest(PublicAPIVenueEndpointHelper):
         }
         assert created_offer.bookingEmail == "nicoj@example.com"
 
-        assert created_offer.finalizationDatetime == now_datetime_with_tz.replace(tzinfo=None)
-        assert created_offer.publicationDatetime == now_datetime_with_tz.replace(tzinfo=None)
+        # TODO : (tcoudray-pass, 12/06/25) Remove when future_offer is removed
+        assert created_offer.publicationDate == datetime(2025, 6, 25, 12, 30)
+        assert created_offer.finalizationDatetime == datetime(2025, 6, 25, 12, 30)
+        assert created_offer.publicationDatetime == datetime(2025, 6, 25, 12, 30)
+
         assert not created_offer.bookingAllowedDatetime
         assert created_offer.description == "Space is only noise if you can see"
         assert created_offer.externalTicketOfficeUrl == "https://maposaic.com"
@@ -303,6 +306,8 @@ class PostEventTest(PublicAPIVenueEndpointHelper):
         assert created_price_category.idAtProvider == "gold_triangle"
 
         assert response.json == {
+            "bookingAllowedDatetime": None,
+            "publicationDatetime": "2025-06-25T12:30:00Z",
             "accessibility": {
                 "audioDisabilityCompliant": False,
                 "mentalDisabilityCompliant": True,
@@ -317,7 +322,7 @@ class PostEventTest(PublicAPIVenueEndpointHelper):
                 "musicType": "ELECTRO-HOUSE",
                 "performer": "Nicolas Jaar",
             },
-            "publicationDate": date_utils.format_into_utc_date(now_datetime_with_tz),
+            "publicationDate": "2025-06-25T12:30:00Z",
             "description": "Space is only noise if you can see",
             "enableDoubleBookings": True,
             "eventDuration": 120,

--- a/api/tests/routes/public/individual_offers/v1/post_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_test.py
@@ -610,6 +610,8 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
                 },
                 {"__root__": ["`stock.bookingLimitDatetime` must be after `bookingAllowedDatetime`"]},
             ),
+            # additional properties not allowed
+            ({"tkilol": ""}, {"tkilol": ["extra fields not permitted"]}),
         ],
     )
     def test_incorrect_payload_should_return_400(self, client, partial_request_json, expected_response_json):

--- a/api/tests/routes/public/individual_offers/v1/post_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/post_product_test.py
@@ -30,8 +30,6 @@ ACCESSIBILITY_FIELDS = {
     "visualDisabilityCompliant": True,
 }
 
-now_datetime_with_tz = datetime.datetime.now(datetime.timezone.utc)
-
 
 @pytest.mark.usefixtures("db_session")
 class PostProductTest(PublicAPIVenueEndpointHelper):
@@ -69,7 +67,7 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         )
         assert response.status_code == 404
 
-    @time_machine.travel(now_datetime_with_tz, tick=False)
+    @time_machine.travel(datetime.datetime(2025, 6, 25, 12, 30, tzinfo=datetime.timezone.utc), tick=False)
     @mock.patch("pcapi.tasks.sendinblue_tasks.update_sib_pro_attributes_task")
     def test_physical_product_minimal_body(self, update_sib_pro_task_mock, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
@@ -88,8 +86,8 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         assert created_offer.mentalDisabilityCompliant is True
         assert created_offer.motorDisabilityCompliant is True
         assert created_offer.visualDisabilityCompliant is True
-        assert created_offer.publicationDatetime == now_datetime_with_tz.replace(tzinfo=None)
-        assert created_offer.finalizationDatetime == now_datetime_with_tz.replace(tzinfo=None)
+        assert created_offer.publicationDatetime == datetime.datetime(2025, 6, 25, 12, 30)
+        assert created_offer.finalizationDatetime == datetime.datetime(2025, 6, 25, 12, 30)
         assert not created_offer.bookingAllowedDatetime
         assert not created_offer.isDuo
         assert created_offer.bookingEmail is None
@@ -98,6 +96,8 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         assert created_offer.offererAddress.id == venue_provider.venue.offererAddress.id
 
         assert response.json == {
+            "bookingAllowedDatetime": None,
+            "publicationDatetime": "2025-06-25T12:30:00Z",
             "bookingContact": None,
             "bookingEmail": None,
             "categoryRelatedFields": {
@@ -123,7 +123,7 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
             "idAtProvider": None,
         }
 
-    @time_machine.travel(now_datetime_with_tz, tick=False)
+    @time_machine.travel(datetime.datetime(2025, 6, 25, 12, 30, tzinfo=datetime.timezone.utc), tick=False)
     def test_product_creation_with_full_body(self, client, clear_tests_assets_bucket):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
 
@@ -174,8 +174,8 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         assert created_offer.mentalDisabilityCompliant is True
         assert created_offer.motorDisabilityCompliant is False
         assert created_offer.visualDisabilityCompliant is False
-        assert created_offer.publicationDatetime == now_datetime_with_tz.replace(tzinfo=None)
-        assert created_offer.finalizationDatetime == now_datetime_with_tz.replace(tzinfo=None)
+        assert created_offer.publicationDatetime == datetime.datetime(2025, 6, 25, 12, 30)
+        assert created_offer.finalizationDatetime == datetime.datetime(2025, 6, 25, 12, 30)
         assert not created_offer.bookingAllowedDatetime
         assert created_offer.isDuo is False
         assert created_offer.bookingEmail == "spam@example.com"
@@ -201,6 +201,8 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
         )
 
         assert response.json == {
+            "bookingAllowedDatetime": None,
+            "publicationDatetime": "2025-06-25T12:30:00Z",
             "bookingContact": "contact@example.com",
             "bookingEmail": "spam@example.com",
             "categoryRelatedFields": {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket JIRA](https://passculture.atlassian.net/browse/PC-36182)

Dans cette PR :

- ajout de `bookingAllowedDatetime` & `publicationDatetime` dans le endpoint `post_product_offer`
- ajout de `bookingAllowedDatetime` & `publicationDatetime` dans le endpoint `edit_product`

## Change logs :
   ![image](https://github.com/user-attachments/assets/0f0d6c24-e27d-4e58-9c97-a4fb71c4a274)


## `bookingAllowedDatetime` doc :
![image](https://github.com/user-attachments/assets/5f7eceb4-e18b-4b68-ba3a-22c43999e70d)

## `publicationDatetime` doc :
![image](https://github.com/user-attachments/assets/40265ec8-ae8d-40d8-8802-7c3b798714f7)



