### PR TITLE
(BSR)[API] fix: avoid circular import

### DIFF
--- a/api/src/pcapi/core/bookings/validation.py
+++ b/api/src/pcapi/core/bookings/validation.py
@@ -10,7 +10,6 @@ from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offers import repository as offers_repository
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
-from pcapi.core.users.api import get_domains_credit
 from pcapi.core.users.models import User
 from pcapi.models import db
 
@@ -80,6 +79,8 @@ def check_expenses_limits(user: User, requested_amount: Decimal, offer: Offer) -
     """Raise an error if the requested amount would exceed the user's
     expense limits.
     """
+    from pcapi.core.users.api import get_domains_credit  # avoid circular import
+
     domains_credit = get_domains_credit(user)
     deposit = user.deposit
     if not domains_credit or not deposit:


### PR DESCRIPTION
But : éviter les erreurs d'import circulaire sur users.api, notamment dans les scripts.

```
Traceback (most recent call last):
  File "/usr/src/app/src/pcapi/scripts/.../main.py", line 16, in <module>
    from pcapi.core.users import api as users_api
  File "/usr/src/app/src/pcapi/core/users/api.py", line 31, in <module>
    import pcapi.core.offerers.api as offerers_api
  File "/usr/src/app/src/pcapi/core/offerers/api.py", line 32, in <module>
    import pcapi.core.offers.api as offers_api
  File "/usr/src/app/src/pcapi/core/offers/api.py", line 22, in <module>
    import pcapi.core.bookings.api as bookings_api
  File "/usr/src/app/src/pcapi/core/bookings/api.py", line 62, in <module>
    from . import validation
  File "/usr/src/app/src/pcapi/core/bookings/validation.py", line 13, in <module>
    from pcapi.core.users.api import get_domains_credit
ImportError: cannot import name 'get_domains_credit' from partially initialized module 'pcapi.core.users.api' (most likely due to a circular import) (/usr/src/app/src/pcapi/core/users/api.py)
```