### PR TITLE
(PC-36128)[PRO] fix: dispay ean disabled text input on creation mode, once details is submitted and re-displayed

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/commons/utils.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/commons/utils.ts
@@ -263,31 +263,30 @@ export function setFormReadOnlyFields(
   offer: GetIndividualOfferResponseModel | null,
   isProductBased?: boolean
 ): string[] {
-  if (isProductBased && offer === null) {
-    const editableFields = ['venueId']
+  const allFields: string[] = Object.keys(DEFAULT_DETAILS_FORM_VALUES)
+  const hasPendingOrRejectedStatus =
+    offer && [OfferStatus.REJECTED, OfferStatus.PENDING].includes(offer.status)
 
-    return Object.keys(DEFAULT_DETAILS_FORM_VALUES).filter(
-      (field) => !editableFields.includes(field)
-    )
-  }
-
-  if (isProductBased && offer !== null) {
-    return Object.keys(DEFAULT_DETAILS_FORM_VALUES)
-  }
-
+  // Offer is still a draft / being created.
   if (offer === null) {
+    // An EAS search was performed, so the form is product based.
+    // Multiple fields are read-only.
+    if (isProductBased) {
+      const editableFields = ['venueId']
+
+      return allFields.filter((field) => !editableFields.includes(field))
+    }
+
     return []
+  } else if (
+    isProductBased ||
+    isOfferSynchronized(offer) ||
+    hasPendingOrRejectedStatus
+  ) {
+    return allFields
+  } else {
+    return ['categoryId', 'subcategoryId', 'venueId']
   }
-
-  if ([OfferStatus.REJECTED, OfferStatus.PENDING].includes(offer.status)) {
-    return Object.keys(DEFAULT_DETAILS_FORM_VALUES)
-  }
-
-  if (isOfferSynchronized(offer)) {
-    return Object.keys(DEFAULT_DETAILS_FORM_VALUES)
-  }
-
-  return ['categoryId', 'subcategoryId', 'venueId']
 }
 
 export const serializeExtraData = (formValues: DetailsFormValues) => {

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.tsx
@@ -24,8 +24,8 @@ type EanSearchForm = {
 }
 
 export type DetailsEanSearchProps = {
-  isDirtyDraftOffer: boolean
-  productId?: string
+  isDraftOffer: boolean
+  isProductBased: boolean
   subcategoryId: string
   initialEan?: string
   eanSubmitError?: string
@@ -34,8 +34,8 @@ export type DetailsEanSearchProps = {
 }
 
 export const DetailsEanSearch = ({
-  isDirtyDraftOffer,
-  productId,
+  isDraftOffer,
+  isProductBased,
   subcategoryId,
   initialEan,
   eanSubmitError,
@@ -47,9 +47,8 @@ export const DetailsEanSearch = ({
   const [wasCleared, setWasCleared] = useState(false)
   const [subcatError, setSubcatError] = useState<string | null>(null)
 
-  const isProductBased = !!productId
-  const isDirtyDraftOfferProductBased = isDirtyDraftOffer && isProductBased
-  const isDirtyDraftOfferNotProductBased = isDirtyDraftOffer && !isProductBased
+  const isDraftOfferProductBased = isDraftOffer && isProductBased
+  const isDraftOfferNotProductBased = isDraftOffer && !isProductBased
 
   const {
     register,
@@ -84,12 +83,12 @@ export const DetailsEanSearch = ({
   }, [eanSubmitError, setError])
 
   useEffect(() => {
-    if (isDirtyDraftOfferNotProductBased && isSubCategoryCD(subcategoryId)) {
+    if (isDraftOfferNotProductBased && isSubCategoryCD(subcategoryId)) {
       setSubcatError('Les offres de type CD doivent être liées à un produit.')
     } else {
       setSubcatError(null)
     }
-  }, [isDirtyDraftOfferNotProductBased, subcategoryId])
+  }, [isDraftOfferNotProductBased, subcategoryId])
 
   const onSearch = async (data: EanSearchForm) => {
     if (data.eanSearch) {
@@ -126,7 +125,7 @@ export const DetailsEanSearch = ({
 
   const shouldButtonBeDisabled =
     isProductBased || !ean || !isValid || !!apiError || isLoading
-  const displayClearButton = isDirtyDraftOfferProductBased
+  const displayClearButton = isDraftOfferProductBased
 
   const cumulativeError = subcatError
     ? `${subcatError}\n${errors.eanSearch?.message || ''}`
@@ -178,11 +177,7 @@ export const DetailsEanSearch = ({
           </div>
         </div>
         <div role="status" className={styles['details-ean-search-callout']}>
-          {isProductBased && (
-            <EanSearchCallout
-              isDirtyDraftOfferProductBased={isDirtyDraftOfferProductBased}
-            />
-          )}
+          {isProductBased && <EanSearchCallout isDraftOffer={isDraftOffer} />}
         </div>
       </FormLayout>
     </form>

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsForm.tsx
@@ -168,6 +168,7 @@ export const DetailsForm = ({
         onImageDelete={onImageDelete}
         onImageDropOrSelected={logOnImageDropOrSelected}
         hideActionButtons={isProductBased}
+        isDisabled={isProductBased}
       />
       {!showAddVenueBanner && (
         <Subcategories

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsSubForm/DetailsSubForm.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsSubForm/DetailsSubForm.spec.tsx
@@ -137,7 +137,7 @@ describe('DetailsSubForm', () => {
       it('on edition, should display the EAN field', () => {
         renderDetailsSubForm({
           props: {
-            isEanSearchDisplayed: true,
+            isEanSearchDisplayed: false,
             isProductBased: true,
           },
           mode: OFFER_WIZARD_MODE.EDITION,

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsSubForm/DetailsSubForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsSubForm/DetailsSubForm.tsx
@@ -4,8 +4,6 @@ import useSWR from 'swr'
 import { api } from 'apiClient/api'
 import { GET_MUSIC_TYPES_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { showOptionsTree } from 'commons/core/Offers/categoriesSubTypes'
-import { OFFER_WIZARD_MODE } from 'commons/core/Offers/constants'
-import { useOfferWizardMode } from 'commons/hooks/useOfferWizardMode'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { DEFAULT_DETAILS_FORM_VALUES } from 'pages/IndividualOffer/IndividualOfferDetails/commons/constants'
 import { DetailsFormValues } from 'pages/IndividualOffer/IndividualOfferDetails/commons/types'
@@ -46,8 +44,6 @@ export const DetailsSubForm = ({
   isOfferCD,
   readOnlyFields,
 }: DetailsSubFormProps) => {
-  const mode = useOfferWizardMode()
-
   const {
     register,
     watch,
@@ -87,8 +83,7 @@ export const DetailsSubForm = ({
   )
 
   const displayEanField =
-    subcategoryConditionalFields.includes('ean') &&
-    (mode === OFFER_WIZARD_MODE.CREATION ? !isProductBased : true)
+    subcategoryConditionalFields.includes('ean') && !isEanSearchDisplayed
 
   return (
     <>

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/ImageUploaderOffer/ImageUploaderOffer.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/ImageUploaderOffer/ImageUploaderOffer.tsx
@@ -13,6 +13,7 @@ export interface ImageUploaderOfferProps {
   onImageDelete: () => void
   onImageDropOrSelected?: () => void
   hideActionButtons?: boolean
+  isDisabled?: boolean
 }
 
 export const ImageUploaderOffer = ({
@@ -21,6 +22,7 @@ export const ImageUploaderOffer = ({
   onImageDelete,
   onImageDropOrSelected,
   hideActionButtons,
+  isDisabled = false,
 }: ImageUploaderOfferProps) => (
   <FormLayout.Section title="Illustrez votre offre">
     <FormLayout.Row>
@@ -36,6 +38,7 @@ export const ImageUploaderOffer = ({
         mode={UploaderModeEnum.OFFER}
         onImageDropOrSelected={onImageDropOrSelected}
         hideActionButtons={hideActionButtons}
+        disabled={isDisabled}
       />
     </FormLayout.Row>
   </FormLayout.Section>

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/EanSearchCallout/EanSearchCallout.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/EanSearchCallout/EanSearchCallout.spec.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+
+import { EanSearchCallout } from './EanSearchCallout'
+
+const renderEanSearchCallout = (isDraftOffer = false) => {
+  render(<EanSearchCallout isDraftOffer={isDraftOffer} />)
+}
+
+const LABELS = {
+  calloutSuccess: /Les informations suivantes ont été synchronisées/,
+  calloutInfo: /Les informations de cette page ne sont pas modifiables/,
+}
+
+describe('EanSearchCallout', () => {
+  it('should display a callout with a success message when the offer is still a draft', () => {
+    renderEanSearchCallout(true)
+    const callout = screen.getByText(LABELS.calloutSuccess)
+    expect(callout).toBeInTheDocument()
+  })
+
+  it('should display a callout with an info message when the offer is not a draft', () => {
+    renderEanSearchCallout(false)
+    const callout = screen.getByText(LABELS.calloutInfo)
+    expect(callout).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/EanSearchCallout/EanSearchCallout.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/EanSearchCallout/EanSearchCallout.tsx
@@ -4,16 +4,14 @@ import { CalloutVariant } from 'ui-kit/Callout/types'
 import styles from './EanSearchCallout.module.scss'
 
 type EanSearchCalloutProps = {
-  isDirtyDraftOfferProductBased?: boolean
+  isDraftOffer: boolean
 }
 
-export const EanSearchCallout = ({
-  isDirtyDraftOfferProductBased = false,
-}: EanSearchCalloutProps) => {
-  const calloutVariant = isDirtyDraftOfferProductBased
+export const EanSearchCallout = ({ isDraftOffer }: EanSearchCalloutProps) => {
+  const calloutVariant = isDraftOffer
     ? CalloutVariant.SUCCESS
     : CalloutVariant.INFO
-  const calloutLabel = isDirtyDraftOfferProductBased
+  const calloutLabel = isDraftOffer
     ? 'Les informations suivantes ont été synchronisées à partir de l’EAN renseigné.'
     : 'Les informations de cette page ne sont pas modifiables car elles sont liées à l’EAN renseigné.'
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreen.spec.tsx
@@ -861,7 +861,7 @@ describe('IndividualOfferDetails', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('should let update an image even for provided offers', async () => {
+    it('should let update an image for synchronized offers', async () => {
       const mockHandleImageOnSubmit = vi.fn().mockResolvedValue(undefined)
       vi.spyOn(
         imageUploadModule,
@@ -894,6 +894,40 @@ describe('IndividualOfferDetails', () => {
       expect(api.patchDraftOffer).not.toHaveBeenCalledOnce()
       expect(mockHandleImageOnSubmit).toHaveBeenCalled()
     })
+
+    it('should not let update an image for product-based offers', async () => {
+      const mockHandleImageOnSubmit = vi.fn().mockResolvedValue(undefined)
+      vi.spyOn(
+        imageUploadModule,
+        'useIndividualOfferImageUpload'
+      ).mockReturnValue({
+        displayedImage: { url: 'my url', credit: null },
+        hasUpsertedImage: false,
+        onImageDelete: vi.fn(),
+        onImageUpload: vi.fn(),
+        handleEanImage: vi.fn(),
+        handleImageOnSubmit: mockHandleImageOnSubmit,
+      })
+
+      const context = individualOfferContextValuesFactory({
+        categories: MOCK_DATA.categories,
+        subCategories: MOCK_DATA.subCategories,
+        offer: getIndividualOfferFactory({
+          productId: 1,
+          subcategoryId: 'physicalBis' as SubcategoryIdEnum,
+        }),
+      })
+
+      renderDetailsScreen({
+        contextValue: context,
+        mode: OFFER_WIZARD_MODE.EDITION,
+      })
+
+      await userEvent.click(screen.getByText('Enregistrer les modifications'))
+
+      expect(mockHandleImageOnSubmit).not.toHaveBeenCalled()
+    })
+
     it('should display categories and subcategories as disabled', () => {
       const context = individualOfferContextValuesFactory({
         categories: MOCK_DATA.categories,


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

- [Front](?expand=1&template=template_front.md)
- [Back](?expand=1&template=template_back.md)
