### PR TITLE
(BSR)[API] feat: apply `@atomic` to public API providers endpoints

### DIFF
--- a/api/src/pcapi/core/providers/api.py
+++ b/api/src/pcapi/core/providers/api.py
@@ -298,7 +298,7 @@ def update_provider_external_urls(
     if cancel_external_url != UNCHANGED:
         provider.cancelExternalUrl = cancel_external_url
 
-    repository.save(provider)
+    db.session.flush()
 
     return provider
 
@@ -350,13 +350,15 @@ def update_venue_provider_external_urls(
     )
 
     if is_deletion:
-        repository.delete(venue_provider_external_urls)
+        db.session.delete(venue_provider_external_urls)
+        db.session.flush()
         return
 
     if is_creation:
         venue_provider_external_urls = providers_models.VenueProviderExternalUrls(
             venueProvider=venue_provider,
         )
+        db.session.add(venue_provider_external_urls)
 
     # Update
     if notification_external_url != UNCHANGED:
@@ -368,7 +370,7 @@ def update_venue_provider_external_urls(
     if cancel_external_url != UNCHANGED:
         venue_provider_external_urls.cancelExternalUrl = cancel_external_url
 
-    repository.save(venue_provider_external_urls)
+    db.session.flush()
 
     return
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/providers.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/providers.py
@@ -2,6 +2,7 @@ from pcapi.core.providers import api as providers_api
 from pcapi.core.providers import exceptions as providers_exceptions
 from pcapi.core.providers import repository as providers_repository
 from pcapi.models import api_errors
+from pcapi.repository.session_management import atomic
 from pcapi.routes.public import blueprints
 from pcapi.routes.public import spectree_schemas
 from pcapi.routes.public.documentation_constants import http_responses
@@ -15,6 +16,7 @@ from pcapi.validation.routes.users_authentifications import provider_api_key_req
 
 
 @blueprints.public_api.route("/public/providers/v1/provider", methods=["GET"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
@@ -38,6 +40,7 @@ def get_provider() -> providers_serialization.ProviderResponse:
 
 
 @blueprints.public_api.route("/public/providers/v1/provider", methods=["PATCH"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
@@ -75,6 +78,7 @@ def update_provider(body: providers_serialization.ProviderUpdate) -> providers_s
 
 
 @blueprints.public_api.route("/public/providers/v1/venues/<int:venue_id>", methods=["PATCH"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     on_success_status=204,

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -576,6 +576,7 @@ class UpdateVenueProviderExternalUrlsTest:
         api.update_venue_provider_external_urls(
             venue_provider, booking_external_url=None, cancel_external_url=None, notification_external_url=None
         )
+        db.session.refresh(venue_provider)
 
         # Should have deleted `venue_provider_external_urls`
         assert venue_provider.externalUrls == None
@@ -597,6 +598,7 @@ class UpdateVenueProviderExternalUrlsTest:
             booking_external_url=None,
             cancel_external_url=None,
         )
+        db.session.refresh(venue_provider)
 
         # Should have deleted `venue_provider_external_urls`
         assert venue_provider.externalUrls == None
@@ -618,6 +620,7 @@ class UpdateVenueProviderExternalUrlsTest:
             venue_provider,
             notification_external_url=None,
         )
+        db.session.refresh(venue_provider)
 
         # Should have deleted `venue_provider_external_urls`
         assert venue_provider.externalUrls == None


### PR DESCRIPTION
Endpoints:

 - GET `/public/providers/v1/provider` -> testé manuellement ✅ 
 - PATCH `/public/providers/v1/provider` -> testé manuellement ✅ 
 - PATCH `/public/providers/v1/venues/<int:venue_id>` -> testé manuellement ✅ 

Please go to the `Preview` tab and select the appropriate sub-template:

- [Front](?expand=1&template=template_front.md)
- [Back](?expand=1&template=template_back.md)
