### PR TITLE
(BSR)[API] feat: apply `@atomic` to public API bookings endpoints 

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -727,7 +727,7 @@ def mark_as_used(booking: models.Booking, validation_author_type: models.Booking
     finance_api.add_event(finance_models.FinanceEventMotive.BOOKING_USED, booking=booking)
     achievements_api.unlock_achievement(booking)
 
-    repository.save(booking)
+    db.session.flush()
 
     logger.info(
         "Booking was marked as used",
@@ -847,7 +847,8 @@ def mark_as_unused(booking: models.Booking) -> None:
         booking=booking,
     )
     booking.mark_as_unused_set_confirmed()
-    repository.save(booking)
+
+    db.session.flush()
 
     logger.info(
         "Booking was marked as unused",

--- a/api/src/pcapi/routes/public/booking_token/v2/endpoints.py
+++ b/api/src/pcapi/routes/public/booking_token/v2/endpoints.py
@@ -8,6 +8,7 @@ from pcapi.core.bookings import repository as bookings_repository
 from pcapi.core.bookings import validation as bookings_validation
 from pcapi.models import api_errors
 from pcapi.models.api_errors import ForbiddenError
+from pcapi.repository.session_management import atomic
 from pcapi.routes.public import spectree_schemas
 from pcapi.routes.public.booking_token import blueprint
 from pcapi.routes.public.documentation_constants import tags
@@ -81,6 +82,7 @@ def get_booking_by_token_v2(token: str) -> serialization.GetBookingResponse:
 
 
 @blueprint.deprecated_booking_token_blueprint.route("/bookings/use/token/<token>", methods=["PATCH"])
+@atomic()
 @spectree_serialize(
     api=spectree_schemas.deprecated_public_api_schema,
     tags=[tags.DEPRECATED_BOOKING_TOKEN],
@@ -164,6 +166,7 @@ def patch_cancel_booking_by_token(token: str) -> None:
 
 
 @blueprint.deprecated_booking_token_blueprint.route("/bookings/keep/token/<token>", methods=["PATCH"])
+@atomic()
 @spectree_serialize(
     api=spectree_schemas.deprecated_public_api_schema,
     tags=[tags.DEPRECATED_BOOKING_TOKEN],

--- a/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
@@ -14,6 +14,7 @@ from pcapi.core.providers import models as providers_models
 from pcapi.core.users import models as users_models
 from pcapi.models import api_errors
 from pcapi.models import db
+from pcapi.repository.session_management import atomic
 from pcapi.routes.public import blueprints
 from pcapi.routes.public import spectree_schemas
 from pcapi.routes.public.documentation_constants import http_responses
@@ -105,6 +106,7 @@ def _get_paginated_and_filtered_bookings(
 
 
 @blueprints.public_api.route("/public/bookings/v1/bookings", methods=["GET"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
@@ -165,6 +167,7 @@ def _get_booking_by_token(token: str) -> booking_models.Booking | None:
 
 
 @blueprints.public_api.route("/public/bookings/v1/token/<string:token>", methods=["GET"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
@@ -207,6 +210,7 @@ def get_booking_by_token(token: str) -> serialization.GetBookingResponse:
 
 
 @blueprints.public_api.route("/public/bookings/v1/use/token/<token>", methods=["PATCH"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     on_success_status=204,
@@ -254,6 +258,7 @@ def validate_booking_by_token(token: str) -> None:
 
 
 @blueprints.public_api.route("/public/bookings/v1/keep/token/<token>", methods=["PATCH"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     on_success_status=204,
@@ -301,6 +306,7 @@ def cancel_booking_validation_by_token(token: str) -> None:
 
 
 @blueprints.public_api.route("/public/bookings/v1/cancel/token/<token>", methods=["PATCH"])
+@atomic()
 @provider_api_key_required
 @spectree_serialize(
     on_success_status=204,

--- a/api/tests/routes/public/individual_offers/v1/get_booking_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_booking_test.py
@@ -104,6 +104,7 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
         token = booking.token
         num_queries = 1  # select api_key
         num_queries += 1  # select booking
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(token=token))
             assert response.status_code == 404
@@ -114,6 +115,7 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
         token = booking.token
         num_queries = 1  # select api_key
         num_queries += 1  # select booking
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(token=token))
             assert response.status_code == 404
@@ -226,6 +228,7 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
         num_queries = 1  # select api_key
         num_queries += 1  # select booking
         num_queries += 1  # check pricing exists
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(token=booking_token))
             assert response.status_code == 403
@@ -250,6 +253,7 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
 
         num_queries = 1  # select api_key
         num_queries += 1  # select booking
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(token=booking_token))
             assert response.status_code == 403
@@ -272,6 +276,7 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
         num_queries = 1  # select api_key
         num_queries += 1  # select booking
         num_queries += 1  # check pricing exists
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(token=booking_token))
             assert response.status_code == 403
@@ -288,6 +293,7 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
         num_queries = 1  # select api_key
         num_queries += 1  # select booking
         num_queries += 1  # check pricing exists
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(token=booking_token))
             assert response.status_code == 410
@@ -304,6 +310,7 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
         num_queries = 1  # select api_key
         num_queries += 1  # select booking
         num_queries += 1  # check pricing exists
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url.format(token=booking_token))
             assert response.status_code == 410

--- a/api/tests/routes/public/individual_offers/v1/get_bookings_test.py
+++ b/api/tests/routes/public/individual_offers/v1/get_bookings_test.py
@@ -34,6 +34,7 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
         offer_id = offer.id
         num_queries = 1  # select api_key, offerer and provider
         num_queries += 1  # select offer
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url, params={"offer_id": offer_id})
             assert response.status_code == 404
@@ -45,6 +46,7 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
         offer_id = offer.id
         num_queries = 1  # select api_key, offerer and provider
         num_queries += 1  # select offer
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url, params={"offer_id": offer_id})
             assert response.status_code == 404
@@ -61,6 +63,7 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
         product_offer_id = product_offer.id
         num_queries = 1  # select api_key, offerer and provider
         num_queries += 1  # select offer
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(
                 self.endpoint_url, params={"offer_id": product_offer_id + 1}
@@ -871,6 +874,7 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
         bookings_factories.UsedBookingFactory(stock=product_stock)
 
         num_queries = 1  # select api_key, offerer and provider
+        num_queries += 1  # rollback atomic
         with testing.assert_num_queries(num_queries):
             response = client.with_explicit_token(plain_api_key).get(self.endpoint_url)
 


### PR DESCRIPTION
Endpoints:

 - GET `/public/bookings/v1/bookings` -> testé manuellement ✅ 
 - GET `/public/bookings/v1/token/<string:token>`  -> testé manuellement ✅ 
 - PATCH `/public/bookings/v1/use/token/<token>`  -> testé manuellement ✅ 
 - PATCH `/public/bookings/v1/keep/token/<token>`  -> testé manuellement ✅ 
 - PATCH `/public/bookings/v1/cancel/token/<token>` -> (à tester sur testing)

