### PR TITLE
(PC-36754)[PRO] fix: Allow collective duration above 23:59.

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/__specs__/validationSchema.spec.ts
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/__specs__/validationSchema.spec.ts
@@ -239,6 +239,14 @@ describe('validationSchema OfferEducational', () => {
         expectedErrors: ['Veuillez renseigner au moins un département'],
         isCollectiveOaActive: true,
       },
+      {
+        description: 'valid when duration is greater than 23:59',
+        formValues: {
+          ...defaultValues,
+          duration: '70:00',
+        },
+        expectedErrors: [],
+      },
     ]
 
     cases.forEach(

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/validationSchema.ts
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/validationSchema.ts
@@ -55,7 +55,7 @@ export function getOfferEducationalValidationSchema(
     duration: yup
       .string()
       .matches(
-        /^(([01]?[0-9]|2[0-3]):[0-5][0-9])?$/,
+        /^$|([0-9]{1,2}:[0-5][0-9])/,
         'Veuillez entrer une durée sous la forme HH:MM (ex: 1:30 pour 1h30)'
       ),
     offererId: yup


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36754)

On doit pouvoir entrer une durée sur le form d'offre collective, mais la regex qui vérifie le format HH:mm n'autorise pas à avoir une durée > 23:59, alors que ça doit être possible.

Je remets la regex d'avant migration rhf (a la différence qu'il faut autoriser à avoir une valeur vide aussi dans la regex).