### PR TITLE
(BSR)[API] fix: avoid crash in error log

### DIFF
--- a/api/src/pcapi/connectors/typeform.py
+++ b/api/src/pcapi/connectors/typeform.py
@@ -189,7 +189,7 @@ class TypeformBackend(BaseBackend):
                 extra={
                     "url": url,
                     "status_code": response.status_code,
-                    "message": response.text,
+                    "text": response.text,
                 },
             )
             raise TypeformApiException(f"Error {response.status_code} response from Typeform API: {url}")


### PR DESCRIPTION
```
Traceback (most recent call last):
  ...
  File "/usr/src/app/src/pcapi/core/chronicles/api.py", line 45, in import_cine_club_chronicles
    for form in typeform.get_responses_generator(get_last_chronicle_date, form_id):
  File "/usr/src/app/src/pcapi/connectors/typeform.py", line 97, in get_responses_generator
    forms = get_responses(
            ^^^^^^^^^^^^^^
  File "/usr/src/app/src/pcapi/connectors/typeform.py", line 76, in get_responses
    return _get_backend().get_responses(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/src/pcapi/connectors/typeform.py", line 278, in get_responses
    data = self._get(path, params=params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/src/pcapi/connectors/typeform.py", line 187, in _get
    logger.error(
  File "/usr/local/lib/python3.11/logging/__init__.py", line 1518, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/usr/src/app/src/pcapi/core/logging.py", line 151, in _log
    return self.__original_log(
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/logging/__init__.py", line 1632, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/src/pcapi/core/logging.py", line 117, in makeRecord
    record = self.__original_makeRecord(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/logging/__init__.py", line 1606, in makeRecord
    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
KeyError: "Attempt to overwrite 'message' in LogRecord"
```