### PR TITLE
(PC-36728)[PRO] fix: Removes disabled attribute on LostPassword form

### DIFF
--- a/pro/src/pages/LostPassword/LostPassword.tsx
+++ b/pro/src/pages/LostPassword/LostPassword.tsx
@@ -52,7 +52,7 @@ export const LostPassword = (): JSX.Element => {
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { errors },
   } = hookForm
 
   const submitChangePasswordRequest = async (formValues: FormValues) => {
@@ -133,7 +133,6 @@ export const LostPassword = (): JSX.Element => {
                   type="submit"
                   className={styles['validation-button']}
                   variant={ButtonVariant.PRIMARY}
-                  disabled={!isValid}
                 >
                   {is2025SignUpEnabled ? 'Réinitialiser' : 'Valider'}
                 </Button>


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36728)

- Retrait de la prop `disabled` sur le submit du formulaire de mot de passe oublié (pour être cohérent avec les autres formulaires)
- Vérification de la bonne utilisation des design-tokens -> RAS

## 🖼️ Before & After Images

Before | After
:---: | :---:
![image](https://github.com/user-attachments/assets/95ef7d28-f755-4390-9851-b9248b2f4ba3) | ![image](https://github.com/user-attachments/assets/0091a552-4722-4ad8-8ad7-6cccca9b6d64)

