### PR TITLE
(PC-36734) [PRO] fix: Redirects to forgotten password page is token is missing in reset page

### DIFF
--- a/pro/src/pages/ResetPassword/ResetPassword.spec.tsx
+++ b/pro/src/pages/ResetPassword/ResetPassword.spec.tsx
@@ -4,7 +4,7 @@ import { userEvent } from '@testing-library/user-event'
 import { api } from 'apiClient/api'
 import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
-import { ResetPassword } from '../ResetPassword'
+import { ResetPassword } from './ResetPassword'
 
 vi.mock('commons/utils/recaptcha', () => ({
   initReCaptchaScript: vi.fn(() => ({ remove: vi.fn() })),

--- a/pro/src/pages/ResetPassword/ResetPassword.tsx
+++ b/pro/src/pages/ResetPassword/ResetPassword.tsx
@@ -35,14 +35,14 @@ export const ResetPassword = (): JSX.Element => {
   useRedirectLoggedUser()
 
   const invalidTokenHandler = useCallback(() => {
-    notify.error('Le lien a expiré. Veuillez recommencer.')
+    notify.error('Le lien a expiré ou est invalide. Veuillez recommencer.')
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     navigate('/demande-mot-de-passe')
   }, [navigate, notify])
 
   // If the FF WIP_2025_SIGN_UP is enabled, we check token validity on page load
   useEffect(() => {
-    if (token && is2025SignUpEnabled) {
+    if (is2025SignUpEnabled) {
       api.postCheckToken({ token }).then(() => {
         setIsLoading(false)
       }, invalidTokenHandler)

--- a/pro/src/pages/ResetPassword/__specs__/ResetPassword.spec.tsx
+++ b/pro/src/pages/ResetPassword/__specs__/ResetPassword.spec.tsx
@@ -96,6 +96,23 @@ describe('ResetPassword', () => {
       expect(mockUseNavigate).toHaveBeenCalledWith('/connexion')
     })
 
+    it('should immediately redirect to login page if token is missing', async () => {
+      const url = '/mot-de-passe-perdu'
+
+      vi.spyOn(api, 'postCheckToken').mockRejectedValue({
+        token: ['Ce champ est obligatoire'],
+      })
+
+      renderLostPassword(url, ['WIP_2025_SIGN_UP'])
+
+      await vi.waitFor(() => {
+        expect(mockUseNotification.error).toHaveBeenCalledWith(
+          'Le lien a expiré ou est invalide. Veuillez recommencer.'
+        )
+        expect(mockUseNavigate).toHaveBeenCalledWith('/demande-mot-de-passe')
+      })
+    })
+
     it('should immediately redirect to login page if token is invalid', async () => {
       const url = '/mot-de-passe-perdu?token=ABC'
 
@@ -107,7 +124,7 @@ describe('ResetPassword', () => {
 
       await vi.waitFor(() => {
         expect(mockUseNotification.error).toHaveBeenCalledWith(
-          'Le lien a expiré. Veuillez recommencer.'
+          'Le lien a expiré ou est invalide. Veuillez recommencer.'
         )
         expect(mockUseNavigate).toHaveBeenCalledWith('/demande-mot-de-passe')
       })


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36734)

> [!IMPORTANT]
> Nécessite le FF `WIP_2025_SIGN_UP` d'activé

- Modification de la condition pour gérer le cas du token manquant
- Ajout d'un test unitaire pour gérer le cas du token manquant
- Modification du message d'erreur dans la notification afin qu'il soit plus générique
- (refacto) Déplacement du fichier unique de tests à côté du composant (et suppression de `__specs__`)

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

Before | After
:---: | :---:
❌ Accès à `/mot-de-passe-perdu` sans `?token` ->  loading infini ![image](https://github.com/user-attachments/assets/e0e52a43-5331-46e5-9149-20800920e2e1) | ✅ Redirection vers `/demande-mot-de-passe` avec notification d'erreur ![image](https://github.com/user-attachments/assets/42716884-c8a6-4167-b34d-eeed889691aa)
