### PR TITLE
Pc 36183/bye bye future offer another try

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-ded99f0acd9e (pre) (head)
+7cbc7b9e7230 (pre) (head)
 4b97dba7262f (post) (head)

--- a/api/src/pcapi/alembic/versions/20240621T130747_2144f7e4df3c_add_future_offer_fk_constraint.py
+++ b/api/src/pcapi/alembic/versions/20240621T130747_2144f7e4df3c_add_future_offer_fk_constraint.py
@@ -14,7 +14,7 @@ depends_on: list[str] | None = None
 def upgrade() -> None:
     op.execute(
         """
-        ALTER TABLE "future_offer" ADD CONSTRAINT "future_offer_offerId" FOREIGN KEY("offerId") REFERENCES offer (id) on delete CASCADE NOT VALID;
+        ALTER TABLE IF EXISTS "future_offer" ADD CONSTRAINT "future_offer_offerId" FOREIGN KEY("offerId") REFERENCES offer (id) on delete CASCADE NOT VALID;
         """
     )
 

--- a/api/src/pcapi/alembic/versions/20250227T165242_b587bd63c5b6_add_future_offers_reminders_constraints.py
+++ b/api/src/pcapi/alembic/versions/20250227T165242_b587bd63c5b6_add_future_offers_reminders_constraints.py
@@ -11,6 +11,13 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
+def future_offer_exists() -> bool:
+    connection = op.get_bind()
+
+    res = connection.execute("SELECT to_regclass('future_offer')").all()[0][0]
+    return res is not None
+
+
 def upgrade() -> None:
     op.create_foreign_key(
         "future_offer_reminder_userId_fkey",
@@ -21,17 +28,21 @@ def upgrade() -> None:
         ondelete="CASCADE",
         postgresql_not_valid=True,
     )
-    op.create_foreign_key(
-        "future_offer_reminder_futureOfferId_fkey",
-        "future_offer_reminder",
-        "future_offer",
-        ["futureOfferId"],
-        ["id"],
-        ondelete="CASCADE",
-        postgresql_not_valid=True,
-    )
+    # future offer is removed in a more recent (pre) migration which
+    # will always be run before any post migration.
+    if future_offer_exists():
+        op.create_foreign_key(
+            "future_offer_reminder_futureOfferId_fkey",
+            "future_offer_reminder",
+            "future_offer",
+            ["futureOfferId"],
+            ["id"],
+            ondelete="CASCADE",
+            postgresql_not_valid=True,
+        )
 
 
 def downgrade() -> None:
     op.drop_constraint("future_offer_reminder_userId_fkey", "future_offer_reminder", type_="foreignkey")
-    op.drop_constraint("future_offer_reminder_futureOfferId_fkey", "future_offer_reminder", type_="foreignkey")
+    if future_offer_exists():
+        op.drop_constraint("future_offer_reminder_futureOfferId_fkey", "future_offer_reminder", type_="foreignkey")

--- a/api/src/pcapi/alembic/versions/20250227T165606_ea04f7c88f15_validate_future_offers_reminders_constraints.py
+++ b/api/src/pcapi/alembic/versions/20250227T165606_ea04f7c88f15_validate_future_offers_reminders_constraints.py
@@ -13,10 +13,22 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
+def future_offer_exists() -> bool:
+    connection = op.get_bind()
+    res = connection.execute("SELECT to_regclass('future_offer')").all()[0][0]
+    return res is not None
+
+
 def upgrade() -> None:
     op.execute("SET SESSION statement_timeout='300s'")
     op.execute("""ALTER TABLE future_offer_reminder VALIDATE CONSTRAINT "future_offer_reminder_userId_fkey" """)
-    op.execute("""ALTER TABLE future_offer_reminder VALIDATE CONSTRAINT "future_offer_reminder_futureOfferId_fkey" """)
+
+    # future offer is removed in a more recent (pre) migration which
+    # will always be run before any post migration.
+    if future_offer_exists():
+        op.execute(
+            """ALTER TABLE future_offer_reminder VALIDATE CONSTRAINT "future_offer_reminder_futureOfferId_fkey" """
+        )
     op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
 
 

--- a/api/src/pcapi/alembic/versions/20250605T150203_9b599c492622_remove_future_offer_reminder_table.py
+++ b/api/src/pcapi/alembic/versions/20250605T150203_9b599c492622_remove_future_offer_reminder_table.py
@@ -12,20 +12,44 @@ branch_labels: tuple[str] | None = None
 depends_on: list[str] | None = None
 
 
+def future_offer_exists() -> bool:
+    connection = op.get_bind()
+    res = connection.execute("SELECT to_regclass('future_offer')").all()[0][0]
+    return res is not None
+
+
 def upgrade() -> None:
     op.drop_table("future_offer_reminder")
 
 
 def downgrade() -> None:
-    op.create_table(
-        "future_offer_reminder",
-        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
-        sa.Column("userId", sa.BigInteger(), nullable=False),
-        sa.Column("futureOfferId", sa.BigInteger(), nullable=False),
-        sa.PrimaryKeyConstraint("id"),
-        sa.ForeignKeyConstraint(["userId"], ["user.id"], name="future_offer_reminder_userId_fkey", ondelete="CASCADE"),
-        sa.ForeignKeyConstraint(
-            ["futureOfferId"], ["future_offer.id"], name="future_offer_reminder_futureOfferId_fkey", ondelete="CASCADE"
-        ),
-        sa.UniqueConstraint("userId", "futureOfferId", name="unique_reminder_per_user_per_future_offer"),
-    )
+    if future_offer_exists():
+        op.create_table(
+            "future_offer_reminder",
+            sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+            sa.Column("userId", sa.BigInteger(), nullable=False),
+            sa.Column("futureOfferId", sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(
+                ["userId"], ["user.id"], name="future_offer_reminder_userId_fkey", ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(
+                ["futureOfferId"],
+                ["future_offer.id"],
+                name="future_offer_reminder_futureOfferId_fkey",
+                ondelete="CASCADE",
+            ),
+            sa.UniqueConstraint("userId", "futureOfferId", name="unique_reminder_per_user_per_future_offer"),
+        )
+    else:
+        op.create_table(
+            "future_offer_reminder",
+            sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+            sa.Column("userId", sa.BigInteger(), nullable=False),
+            sa.Column("futureOfferId", sa.BigInteger(), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+            sa.ForeignKeyConstraint(
+                ["userId"], ["user.id"], name="future_offer_reminder_userId_fkey", ondelete="CASCADE"
+            ),
+            sa.UniqueConstraint("userId", "futureOfferId", name="unique_reminder_per_user_per_future_offer"),
+        )

--- a/api/src/pcapi/alembic/versions/20250627T130249_7cbc7b9e7230_rm_future_offer.py
+++ b/api/src/pcapi/alembic/versions/20250627T130249_7cbc7b9e7230_rm_future_offer.py
@@ -1,0 +1,45 @@
+"""rm future_offer"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "7cbc7b9e7230"
+down_revision = "ded99f0acd9e"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_table("future_offer", if_exists=True)
+
+
+def downgrade() -> None:
+    op.create_table(
+        "future_offer",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("offerId", sa.BigInteger(), nullable=False),
+        sa.Column("publicationDate", sa.DateTime(), nullable=False),
+        sa.Column("isSoftDeleted", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        if_not_exists=True,
+    )
+    with op.get_context().autocommit_block():
+        op.create_index(
+            op.f("ix_future_offer_offerId"),
+            "future_offer",
+            ["offerId"],
+            unique=True,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            op.f("ix_future_offer_publicationDate"),
+            "future_offer",
+            ["publicationDate"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -583,23 +583,6 @@ class EventWeekDayOpeningHours(PcObject, Base, Model):
     )
 
 
-class FutureOffer(PcObject, Base, Model, SoftDeletableMixin):
-    __tablename__ = "future_offer"
-
-    offerId: int = sa.Column(
-        sa.BigInteger, sa.ForeignKey("offer.id", ondelete="CASCADE"), nullable=False, index=True, unique=True
-    )
-    publicationDate = sa.Column(sa.DateTime, index=True, nullable=False)
-
-    @hybrid_property
-    def isWaitingForPublication(self) -> bool:
-        return datetime.datetime.utcnow() < self.publicationDate
-
-    @isWaitingForPublication.expression  # type: ignore[no-redef]
-    def isWaitingForPublication(cls) -> bool:
-        return sa.func.now() < cls.publicationDate
-
-
 class HeadlineOffer(PcObject, Base, Model):
     __tablename__ = "headline_offer"
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -5181,7 +5181,6 @@ def assert_offers_have_been_completely_cleaned(offer_ids):
         assert db.session.query(finance_models.CustomReimbursementRule).filter_by(offerId=offer_id).count() == 0
         assert db.session.query(models.EventOpeningHours).filter_by(offerId=offer_id).count() == 0
         assert db.session.query(users_models.Favorite).filter_by(offerId=offer_id).count() == 0
-        assert db.session.query(models.FutureOffer).filter_by(offerId=offer_id).count() == 0
         assert db.session.query(models.HeadlineOffer).filter_by(offerId=offer_id).count() == 0
         assert db.session.query(models.Mediation).filter_by(offerId=offer_id).count() == 0
         assert db.session.query(chronicles_models.OfferChronicle).filter_by(offerId=offer_id).count() == 0


### PR DESCRIPTION
[Ticket Jira](https://passculture.atlassian.net/browse/PC-36183)

Suppression du modèle FutureOffer et de la table future_offer.
Toute la suppression de code liée à l'utilisation de FutureOffer a déjà été réalisée dans une précédente PR : https://github.com/pass-culture/pass-culture-main/pull/17980.