### PR TITLE
(BSR)[API] feat: add collectiveEmail for EAC venues in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
@@ -421,7 +421,7 @@ def create_venues(offerer_list: list[offerers_models.Offerer]) -> None:
 
 
 def create_venue(*, reimbursement: bool = False, **kwargs: typing.Any) -> offerers_models.Venue:
-    venue = offerers_factories.VenueFactory.create(**kwargs)
+    venue = offerers_factories.VenueFactory.create(**kwargs, collectiveEmail="email@exemple.com")
     if reimbursement:
         bank_account = finance_factories.BankAccountFactory.create(offerer=venue.managingOfferer)
         offerers_factories.VenueBankAccountLinkFactory.create(venue=venue, bankAccount=bank_account)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Ajout d'une valeur pour `collectiveEmail` sur les Venues EAC de la sandbox, pour pré-remplir les champs à la création d'une offre

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
