### PR TITLE
(BSR)[API] test: fix flakyness of test test_delete_stock_cancel_booki…

### DIFF
--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -58,6 +58,7 @@ from pcapi.models.offer_mixin import OfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.notifications.push import testing as push_testing
+from pcapi.repository.session_management import atomic
 from pcapi.utils.human_ids import humanize
 
 import tests
@@ -966,7 +967,8 @@ class DeleteStockTest:
         booking_id_3 = booking3.id
         booking_id_4 = booking4.id
 
-        api.delete_stock(stock)
+        with atomic():
+            api.delete_stock(stock)
 
         # cancellation can trigger more than one request to Batch
         assert len(push_testing.requests) >= 1


### PR DESCRIPTION
…ngs_and_send_emails

la fonction testée par le test n'est jamais apellée hors de @atomic donc il n'est pas utile de la tester sans ce décorateur
