### PR TITLE
(BSR)[API] chore: Rely on location info & factory and not obsolete Venue address in tests

### DIFF
--- a/api/tests/routes/adage/v1/confirm_prebooking_test.py
+++ b/api/tests/routes/adage/v1/confirm_prebooking_test.py
@@ -107,7 +107,7 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json == {
             **expected_serialized_prebooking(booking),
-            "address": "1 boulevard Poissonnière 75002 Paris",
+            "address": offer.offererAddress.address.fullAddress,
         }
 
     @time_machine.travel("2021-10-15 09:00:00")

--- a/api/tests/routes/adage/v1/get_educational_bookings_test.py
+++ b/api/tests/routes/adage/v1/get_educational_bookings_test.py
@@ -63,7 +63,10 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json == {
             "prebookings": [
-                {**expected_serialized_prebooking(booking), "address": "1 boulevard Poissonnière 75002 Paris"}
+                {
+                    **expected_serialized_prebooking(booking),
+                    "address": offer.offererAddress.address.fullAddress,
+                }
             ]
         }
 

--- a/api/tests/routes/adage/v1/get_educational_institution_test.py
+++ b/api/tests/routes/adage/v1/get_educational_institution_test.py
@@ -108,7 +108,10 @@ class Returns200Test:
             "credit": 0,
             "isFinal": False,
             "prebookings": [
-                {**expected_serialized_prebooking(booking), "address": "1 boulevard Poissonnière 75002 Paris"}
+                {
+                    **expected_serialized_prebooking(booking),
+                    "address": offer.offererAddress.address.fullAddress,
+                }
             ],
         }
 

--- a/api/tests/routes/adage/v1/get_prebookings_test.py
+++ b/api/tests/routes/adage/v1/get_prebookings_test.py
@@ -141,6 +141,9 @@ class Returns200Test:
         assert response.status_code == 200
         assert response.json == {
             "prebookings": [
-                {**expected_serialized_prebooking(booking), "address": "1 boulevard Poissonnière 75002 Paris"}
+                {
+                    **expected_serialized_prebooking(booking),
+                    "address": offer.offererAddress.address.fullAddress,
+                }
             ]
         }

--- a/api/tests/routes/adage/v1/refuse_prebookings_test.py
+++ b/api/tests/routes/adage/v1/refuse_prebookings_test.py
@@ -92,7 +92,7 @@ class Returns200Test:
         response = client.with_eac_token().post(f"/adage/v1/prebookings/{collective_booking.id}/refuse")
 
         assert response.status_code == 200
-        assert response.json["address"] == "1 boulevard Poissonnière 75002 Paris"
+        assert response.json["address"] == offer.offererAddress.address.fullAddress
 
     def test_refuse_collective_booking_when_pending(self, client):
         collective_booking = CollectiveBookingFactory(

--- a/api/tests/routes/adage_iframe/get_collective_offer_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_test.py
@@ -53,6 +53,7 @@ class CollectiveOfferTest:
                 "addressType": "offererVenue",
                 "otherAddress": "",
             },
+            collectiveOffer__venue=venue,
         )
         offer = stock.collectiveOffer
 
@@ -80,16 +81,19 @@ class CollectiveOfferTest:
             },
             "venue": {
                 "adageId": None,
-                "address": "1 boulevard Poissonnière",
-                "city": "Paris",
-                "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
+                "address": venue.offererAddress.address.street,
+                "city": venue.offererAddress.address.city,
+                "coordinates": {
+                    "latitude": float(venue.offererAddress.address.latitude),
+                    "longitude": float(venue.offererAddress.address.longitude),
+                },
                 "distance": None,
                 "id": offer.venue.id,
                 "imgUrl": None,
                 "managingOfferer": {"name": offer.venue.managingOfferer.name},
                 "name": offer.venue.name,
-                "postalCode": "75002",
-                "departmentCode": "75",
+                "postalCode": venue.offererAddress.address.postalCode,
+                "departmentCode": venue.offererAddress.address.departmentCode,
                 "publicName": offer.venue.publicName,
             },
             "audioDisabilityCompliant": False,
@@ -101,12 +105,12 @@ class CollectiveOfferTest:
             "contactPhone": offer.contactPhone,
             "offerVenue": {
                 "addressType": "offererVenue",
-                "address": "1 boulevard Poissonnière",
-                "city": "Paris",
+                "address": venue.offererAddress.address.street,
+                "city": venue.offererAddress.address.city,
                 "distance": None,
                 "name": venue.name,
                 "otherAddress": "",
-                "postalCode": "75002",
+                "postalCode": venue.offererAddress.address.postalCode,
                 "publicName": venue.publicName,
                 "venueId": venue.id,
             },

--- a/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution_test.py
@@ -82,16 +82,19 @@ class CollectiveOfferTest:
         venue = stocks[0].collectiveOffer.venue
         assert response_data[0]["venue"] == {
             "adageId": None,
-            "address": "1 boulevard Poissonnière",
-            "city": "Paris",
-            "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
+            "address": venue.offererAddress.address.street,
+            "city": venue.offererAddress.address.city,
+            "coordinates": {
+                "latitude": float(venue.offererAddress.address.latitude),
+                "longitude": float(venue.offererAddress.address.longitude),
+            },
             "distance": None,
             "id": venue.id,
             "imgUrl": None,
             "managingOfferer": {"name": venue.managingOfferer.name},
             "name": venue.name,
-            "postalCode": "75002",
-            "departmentCode": "75",
+            "postalCode": venue.offererAddress.address.postalCode,
+            "departmentCode": venue.offererAddress.address.departmentCode,
             "publicName": venue.publicName,
         }
 
@@ -101,16 +104,19 @@ class CollectiveOfferTest:
         venue = stocks[1].collectiveOffer.venue
         assert response_data[1]["venue"] == {
             "adageId": None,
-            "address": "1 boulevard Poissonnière",
-            "city": "Paris",
-            "coordinates": {"latitude": 48.87004, "longitude": 2.3785},
+            "address": venue.offererAddress.address.street,
+            "city": venue.offererAddress.address.city,
+            "coordinates": {
+                "latitude": float(venue.offererAddress.address.latitude),
+                "longitude": float(venue.offererAddress.address.longitude),
+            },
             "distance": None,
             "id": venue.id,
             "imgUrl": None,
             "managingOfferer": {"name": venue.managingOfferer.name},
             "name": venue.name,
-            "postalCode": "75002",
-            "departmentCode": "75",
+            "postalCode": venue.offererAddress.address.postalCode,
+            "departmentCode": venue.offererAddress.address.departmentCode,
             "publicName": venue.publicName,
         }
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Afin de pouvoir supprimer les données d'adresse de la Venue, nettoyage de tests qui utilisent l'adresse par défaut de la Venue au lieu de celle de l'OffererAddress

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
