### PR TITLE
(BSR)[PRO] chore: Attempt to enhance e2e tests and CI

### DIFF
--- a/.github/workflows/dev_on_push_workflow_main.yml
+++ b/.github/workflows/dev_on_push_workflow_main.yml
@@ -164,12 +164,11 @@ jobs:
       GCP_EHP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       GCP_EHP_SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
 
-  test-pro-e2e:
-    name: "Pro E2E Tests"
+  test-pro-e2e-parallel:
+    name: "Pro E2E Tests (Parallel)"
     needs: [pcapi-init-job, build-pcapi-tests]
     uses: ./.github/workflows/dev_on_workflow_tests_pro_e2e.yml
-    if: |
-      always() &&
+    if: always() &&
       !cancelled() &&
       needs.pcapi-init-job.outputs.api-changed == 'true' ||
       needs.pcapi-init-job.outputs.pro-changed == 'true'

--- a/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
+++ b/.github/workflows/dev_on_workflow_tests_pro_e2e.yml
@@ -69,6 +69,19 @@ jobs:
           if-no-files-found: error
           path: pro/build
 
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+
+      - name: Cache Poetry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pypoetry
+          key: poetry-${{ hashFiles('**/poetry.lock') }}
+
   setup:
     name: Setup E2E 🔧
     runs-on: ubuntu-24.04
@@ -89,11 +102,18 @@ jobs:
     needs: [setup, install]
     strategy:
       # don't fail the entire matrix on failure
-      fail-fast: false
+      fail-fast: true
+      max-parallel: 4
       matrix:
         #chunk: ${{ fromJson(needs.setup.outputs['test-chunks']) }}
-        # Manually setting tests to have them have (aproximatively) the same duration
-        chunk: ["cypress/e2e/desk.cy.ts,cypress/e2e/signupJourneyCreateOfferer.cy.ts,cypress/e2e/adageConfirmation.cy.ts", "cypress/e2e/editDigitalIndividualOffer.cy.ts,cypress/e2e/searchCollectiveOffer.cy.ts,cypress/e2e/navigation.cy.ts,cypress/e2e/createIndividualOffer.cy.ts", "cypress/e2e/oaIndividualOffer.cy.ts,cypress/e2e/didacticOnboarding.cy.ts,cypress/e2e/createAccount.cy.ts,cypress/e2e/cookieBanner.cy.ts,cypress/e2e/collaborator.cy.ts", "cypress/e2e/searchIndividualOffer.cy.ts,cypress/e2e/collectiveBooking.cy.ts,cypress/e2e/createCollectiveOffer.cy.ts,cypress/e2e/adage.cy.ts,cypress/e2e/financialManagement.cy.ts"]
+        # Manually setting tests to have them have (approximatively) the same duration
+        chunk: [
+          'cypress/e2e/desk.cy.ts,cypress/e2e/signupJourneyCreateOfferer.cy.ts,cypress/e2e/adageConfirmation.cy.ts',
+          'cypress/e2e/editDigitalIndividualOffer.cy.ts,cypress/e2e/searchCollectiveOffer.cy.ts,cypress/e2e/navigation.cy.ts,cypress/e2e/createIndividualOffer.cy.ts',
+          'cypress/e2e/oaIndividualOffer.cy.ts,cypress/e2e/didacticOnboarding.cy.ts,cypress/e2e/createAccount.cy.ts,cypress/e2e/cookieBanner.cy.ts,cypress/e2e/collaborator.cy.ts',
+          'cypress/e2e/searchIndividualOffer.cy.ts,cypress/e2e/collectiveBooking.cy.ts,cypress/e2e/createCollectiveOffer.cy.ts,cypress/e2e/adage.cy.ts,cypress/e2e/financialManagement.cy.ts',
+          'cypress/e2e/oaCollectiveOffer.cy.ts'
+        ]
 
     steps:
       - name: Checkout
@@ -212,7 +232,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           wait-on: "http://localhost:5001/health/api,http://localhost:5001/health/database"
-          wait-on-timeout: 600
+          wait-on-timeout: 120 # 2 minutes is enough for API/DB to be ready
           working-directory: pro
           browser: chrome
           config-file: cypress/cypress.config.ts
@@ -223,7 +243,7 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ steps.secrets.outputs.CYPRESS_CLOUD_RECORD_KEY }}
           CYPRESS_PROJECT_ID: ${{ steps.secrets.outputs.CYPRESS_CLOUD_PROJECT_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEBUG: 'cypress:server:socket-base,cypress:server:socket-e2e'
+          #DEBUG: 'cypress:server:socket-base,cypress:server:socket-e2e'
           # see https://github.com/cypress-io/github-action/issues/1408#issuecomment-2744425883
           NODE_OPTIONS: "--no-experimental-require-module --no-experimental-detect-module"
 
@@ -232,7 +252,6 @@ jobs:
         run: |
           mkdir -p cypress/videos/${{ github.ref }}/${{ github.sha }} && \
           mv cypress/videos/*.mp4 cypress/videos/${{ github.ref }}/${{ github.sha }}/
-
       - name: "Archive E2E results"
         if: always() && failure() && github.ref != 'refs/heads/master' # useless on master bc Cypress Cloud
         uses: google-github-actions/upload-cloud-storage@v2

--- a/pro/cypress/cypress.config.ts
+++ b/pro/cypress/cypress.config.ts
@@ -1,7 +1,5 @@
-import fs from 'fs'
-
-// import { allureCypress } from 'allure-cypress/reporter'
 import { defineConfig } from 'cypress'
+import fs from 'fs'
 import cypressFailFast = require('cypress-fail-fast/plugin')
 
 // ts-unused-exports:disable-next-line

--- a/pro/cypress/e2e/oaCollectiveOffer.cy.ts
+++ b/pro/cypress/e2e/oaCollectiveOffer.cy.ts
@@ -99,7 +99,6 @@ describe('Create collective offers with OA', () => {
       data.institution
     )
     cy.get('#list-institution').findByText(new RegExp(data.institution)).click()
-    cy.findByLabelText('Nom de l’établissement scolaire ou code UAI *').click()
     cy.findByText('Enregistrer et continuer').click()
   }
 

--- a/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.tsx
+++ b/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.tsx
@@ -28,6 +28,7 @@ import { RadioGroup } from 'ui-kit/form/RadioGroup/RadioGroup'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
+import { useEffect } from 'react'
 import styles from './CollectiveOfferSelectionDuplication.module.scss'
 import { SkeletonLoader } from './CollectiveOfferSelectionLoaderSkeleton'
 
@@ -101,9 +102,13 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
     )
   )
 
-  const templateOfferForm = useForm<SelectionFormValues>({
-    defaultValues: { templateOfferId: String(offers?.[0]?.id) },
-  })
+  const templateOfferForm = useForm<SelectionFormValues>()
+
+  useEffect(() => {
+    if (!isLoading && offers && offers.length > 0) {
+      templateOfferForm.setValue('templateOfferId', String(offers[0].id))
+    }
+  }, [offers, isLoading, templateOfferForm])
 
   const { handleSubmit: handleSubmitSelection } = templateOfferForm
 


### PR DESCRIPTION
Remise d'ordre et amélioration des tests e2e, qui devraient améliorer un peu la vitesse d'exécution.

_Commits un peu désordonnés en raison de divers essais sur certaines parties (ex: retrait de recording vidéo, mais finalement non …)_

- Mise en cache des layers Docker et Poetry (pour éviter de re-build à chaque job)
- Remise de `fail-fast` à `true`
- ~~Parallèlisation automatique des tests e2e~~ -> Remise en manuel (en attendant mieux) avec prise en compte du nouveau `oaCollectiveOffer.cy.ts`
- Désactivation des logs verbose
- Correction d'un test e2e en échec (`oaCollectiveOffer.cy.ts`) sur la part collective (`CollectiveOfferSelectionDuplication.tsx`)