### PR TITLE
(PC-36855)[API] refactor: replace venue location with venue OA addres…

### DIFF
--- a/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
+++ b/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
@@ -98,7 +98,7 @@ def test_with_pricings(client):
     assert row["SIRET de la structure"] == venue1.siret
     assert row["IBAN"] == bank_account_1.iban
     assert row["Raison sociale de la structure"] == venue1.name
-    assert row["Adresse de l'offre"] == f"{venue1.street} {venue1.postalCode} {venue1.city}"
+    assert row["Adresse de l'offre"] == venue1.offererAddress.address.fullAddress
     assert row["SIRET de la structure"] == venue1.siret
     assert row["Nom de l'offre"] == offer.name
     assert row["N° de réservation (offre collective)"] == ""
@@ -193,7 +193,7 @@ def test_with_pricings_collective_use_case(client):
     assert row["SIRET de la structure"] == venue1.siret
     assert row["IBAN"] == bank_account_1.iban
     assert row["Raison sociale de la structure"] == venue1.name
-    assert row["Adresse de l'offre"] == f"{venue1.street} {venue1.postalCode} {venue1.city}"
+    assert row["Adresse de l'offre"] == venue1.offererAddress.address.fullAddress
     assert row["SIRET de la structure"] == venue1.siret
     assert row["Nom de l'offre"] == collective_offer.name
     assert row["N° de réservation (offre collective)"] == str(collective_booking.id)
@@ -201,7 +201,7 @@ def test_with_pricings_collective_use_case(client):
     assert row["Prénom (offre collective)"] == redactor.firstName
     assert row["Nom de l'établissement (offre collective)"] == institution.name
     assert row["Date de l'évènement (offre collective)"] == utc_datetime_to_department_timezone(
-        collective_booking.collectiveStock.startDatetime, venue1.departementCode
+        collective_booking.collectiveStock.startDatetime, venue1.offererAddress.address.departmentCode
     ).strftime("%d/%m/%Y %H:%M")
     assert row["Contremarque"] == ""
     assert row["Date de validation de la réservation"] == collective_booking.dateUsed.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
…s in finance and test  so only relevant addresses are used

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36855)

Changed SQL request for csv generztion so that we use address of venue OA instead of venue.street etc.
For individual offers, we try to return first offer OA, then venue OA, and then offerer OA
Added tests for pro route for both collective and individual offers to check we return ONLY relevant data (see https://passculture.atlassian.net/browse/PC-36841 for why these tests are now included

- [x] Travail pair testé en environnement de preview
