### PR TITLE
(BSR)[API] chore: Rely on location info & factory and not obsolete Venue address in tests

### DIFF
--- a/api/src/pcapi/core/geography/factories.py
+++ b/api/src/pcapi/core/geography/factories.py
@@ -48,3 +48,14 @@ class ManualAddressFactory(AddressFactory):
     banId = None
     inseeCode = None
     isManualEdition = True
+
+
+class CaledonianAddressFactory(AddressFactory):
+    street: str | factory.declarations.BaseDeclaration | None = factory.Sequence(
+        "{} Avenue James Cook".format
+    )  # sequence avoids UniqueViolation (street+inseeCode)
+    postalCode: str = "98800"
+    city: str = "Nouméa"
+    latitude: float | None = -22.26355
+    longitude: float | None = 166.4146
+    banId: str = "98818_w65mkd"

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -199,18 +199,20 @@ def _get_department_code(postal_code: str | None) -> str | None:
 
 class CaledonianVenueFactory(VenueFactory):
     name = factory.Sequence("Partenaire culturel calédonien {}".format)
-    latitude: float | None = -22.26355
-    longitude: float | None = 166.4146
     managingOfferer = factory.SubFactory(CaledonianOffererFactory)
-    street = factory.LazyAttribute(lambda o: None if o.isVirtual else "Avenue James Cook")
-    banId = factory.LazyAttribute(lambda o: None if o.isVirtual else "98818_w65mkd")
-    postalCode = factory.LazyAttribute(lambda o: None if o.isVirtual else "98800")
-    city = factory.LazyAttribute(lambda o: None if o.isVirtual else "Nouméa")
     siret = factory.LazyAttributeSequence(
         lambda o, n: siren_utils.ridet_to_siret(f"{siren_utils.siren_to_rid7(o.managingOfferer.siren)}{n % 100:03}")
     )
     venueTypeCode = models.VenueTypeCode.BOOKSTORE
     adageId = None
+
+    offererAddress: factory.declarations.BaseDeclaration | None = factory.SubFactory(
+        "pcapi.core.offerers.factories.OffererAddressOfVenueFactory",
+        address=factory.SubFactory(
+            "pcapi.core.geography.factories.CaledonianAddressFactory",
+        ),
+        offerer=factory.SelfAttribute("..managingOfferer"),
+    )
 
 
 class CollectiveVenueFactory(VenueFactory):


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Afin de pouvoir supprimer les données d'adresse de la Venue, nettoyage de tests qui utilisent l'adresse par défaut de la Venue au lieu de celle de l'OffererAddress

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
