### PR TITLE
(BSR)[BO] perf: Optimize SQL queries on Product.extraData[allocineId]…

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -1153,7 +1153,7 @@ def add_criteria_to_offers(
         ean = ean.replace("-", "").replace(" ", "")
         product_query = product_query.filter(models.Product.ean == ean)
     elif allocineId:
-        product_query = product_query.filter(models.Product.extraData["allocineId"].cast(sa.Integer) == allocineId)
+        product_query = product_query.filter(models.Product.extraData["allocineId"] == str(allocineId))
     elif visa:
         product_query = product_query.filter(models.Product.extraData["visa"].astext == visa)
 

--- a/api/src/pcapi/routes/backoffice/chronicles/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/chronicles/blueprint.py
@@ -70,7 +70,7 @@ def list_chronicles() -> utils.BackofficeResponse:
         q_filters.append(
             sa.or_(
                 offers_models.Product.ean == product_identifier,
-                offers_models.Product.extraData["allocineId"].astext == product_identifier,
+                offers_models.Product.extraData["allocineId"] == product_identifier,
                 offers_models.Product.extraData["visa"].astext == product_identifier,
             )
         )
@@ -281,7 +281,7 @@ def attach_product(chronicle_id: int) -> utils.BackofficeResponse:
         case chronicles_models.ChronicleProductIdentifierType.ALLOCINE_ID:
             products = (
                 db.session.query(offers_models.Product)
-                .filter(offers_models.Product.extraData["allocineId"].astext == form.product_identifier.data)
+                .filter(offers_models.Product.extraData["allocineId"] == form.product_identifier.data)
                 .all()
             )
         case chronicles_models.ChronicleProductIdentifierType.EAN:

--- a/api/src/pcapi/routes/backoffice/products/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/products/blueprint.py
@@ -529,12 +529,11 @@ def search_product() -> utils.BackofficeResponse:
     product = None
     FILTER_MAP = {
         forms.ProductFilterTypeEnum.VISA: offers_models.Product.extraData["visa"].astext,
-        forms.ProductFilterTypeEnum.ALLOCINE_ID: offers_models.Product.extraData["allocineId"].astext,
+        forms.ProductFilterTypeEnum.ALLOCINE_ID: offers_models.Product.extraData["allocineId"],
     }
     if result_type in FILTER_MAP:
         field_to_filter = FILTER_MAP[result_type]
         product = db.session.query(offers_models.Product).filter(field_to_filter == search_query).one_or_none()
-
     elif result_type == forms.ProductFilterTypeEnum.EAN:
         ean = search_query
         product = db.session.query(offers_models.Product).filter_by(ean=ean).one_or_none()

--- a/api/tests/core/chronicles/test_api.py
+++ b/api/tests/core/chronicles/test_api.py
@@ -808,7 +808,7 @@ class SaveCineClubChronicleTest:
         assert not chronicle.isSocialMediaDiffusible
 
     def test_save_cine_club_chronicle_link_to_product(self):
-        product = offers_factories.ProductFactory(extraData={"allocineId": "1000013191"})
+        product = offers_factories.ProductFactory(extraData={"allocineId": 1000013191})
         form = typeform.TypeformResponse(
             response_id=random_string(),
             date_submitted=datetime.datetime(2024, 10, 24),

--- a/api/tests/routes/backoffice/chronicles_test.py
+++ b/api/tests/routes/backoffice/chronicles_test.py
@@ -73,7 +73,7 @@ class ListChroniclesTest(GetEndpointHelper):
         assert rows[0]["ID"] == str(chronicle_with_product.id)
 
     def test_search_by_allocine_id(self, authenticated_client):
-        allocine_id = "1000013191"
+        allocine_id = 1000013191
         product = offers_factories.ProductFactory(extraData={"allocineId": allocine_id})
         chronicle_with_product = chronicles_factories.ChronicleFactory(products=[product])
         chronicles_factories.ChronicleFactory()
@@ -231,7 +231,7 @@ class GetChronicleDetailsTest(GetEndpointHelper):
     ):
         products = [
             offers_factories.ProductFactory(ean="1235467890123"),
-            offers_factories.ProductFactory(extraData={"allocineId": "1000013191"}),
+            offers_factories.ProductFactory(extraData={"allocineId": 1000013191}),
             offers_factories.ProductFactory(extraData={"visa": "1000013192"}),
             offers_factories.ProductFactory(),
         ]
@@ -473,7 +473,7 @@ class AttachProductTest(PostEndpointHelper):
         if product_identifier_type == chronicles_models.ChronicleProductIdentifierType.EAN:
             product = offers_factories.ProductFactory(ean=product_identifier)
         elif product_identifier_type == chronicles_models.ChronicleProductIdentifierType.ALLOCINE_ID:
-            product = offers_factories.ProductFactory(extraData={"allocineId": product_identifier})
+            product = offers_factories.ProductFactory(extraData={"allocineId": int(product_identifier)})
         else:
             product = offers_factories.ProductFactory(extraData={"visa": product_identifier})
         chronicle = chronicles_factories.ChronicleFactory(
@@ -522,7 +522,7 @@ class AttachProductTest(PostEndpointHelper):
         if product_identifier_type == chronicles_models.ChronicleProductIdentifierType.EAN:
             product = offers_factories.ProductFactory(ean=product_identifier)
         elif product_identifier_type == chronicles_models.ChronicleProductIdentifierType.ALLOCINE_ID:
-            product = offers_factories.ProductFactory(extraData={"allocineId": product_identifier})
+            product = offers_factories.ProductFactory(extraData={"allocineId": int(product_identifier)})
         else:
             product = offers_factories.ProductFactory(extraData={"visa": product_identifier})
 

--- a/api/tests/routes/backoffice/search_product_test.py
+++ b/api/tests/routes/backoffice/search_product_test.py
@@ -206,7 +206,7 @@ class SearchProductTest(search_helpers.SearchHelper, GetEndpointHelper):
     def test_search_by_allocine_id_existing_product(self, authenticated_client):
         product = offers_factories.ProductFactory.create(
             description="Une offre pour tester",
-            extraData={"allocineId": "123456"},
+            extraData={"allocineId": 123456},
         )
 
         with assert_num_queries(self.expected_num_queries):


### PR DESCRIPTION
… to leverage index usage

## 🎯 Related Ticket or 🔧 Changes Made

```py
import time

from pcapi.core.offers import models
from pcapi.models import db
from sqlalchemy import Integer
from sqlalchemy import cast
from sqlalchemy import select
from sqlalchemy.ext.compiler import compiles
from sqlalchemy.sql.expression import ClauseElement
from sqlalchemy.sql.expression import Executable


# Version avec allocine_id en string (accès JSON direct)
def get_movie_product_by_allocine_id_str(allocine_id: str) -> models.Product | None:
    return db.session.query(models.Product).filter(
        models.Product.extraData["allocineId"] == allocine_id
    ).one_or_none()

# Version avec allocine_id en string via .astext
def get_movie_product_by_allocine_id_astext(allocine_id: str) -> models.Product | None:
    return db.session.query(models.Product).filter(
        models.Product.extraData["allocineId"].astext == allocine_id
    ).one_or_none()

# Version avec allocine_id casté en int
def get_movie_product_by_allocine_id_int(allocine_id: int) -> models.Product | None:
    return db.session.query(models.Product).filter(
        cast(models.Product.extraData["allocineId"], Integer) == allocine_id
    ).one_or_none()

def benchmark_allocine_queries(allocine_id: int, iterations: int = 10):
    total_time_str = 0
    total_time_astext = 0
    total_time_int = 0
    result_str = None
    result_astext = None
    result_int = None

    for _ in range(iterations):
        # Version string (JSON direct)
        start = time.perf_counter()
        result_str = get_movie_product_by_allocine_id_str(str(allocine_id))
        total_time_str += time.perf_counter() - start

        # Version string avec astext
        start = time.perf_counter()
        result_astext = get_movie_product_by_allocine_id_astext(str(allocine_id))
        total_time_astext += time.perf_counter() - start

        # Version int (cast)
        start = time.perf_counter()
        result_int = get_movie_product_by_allocine_id_int(allocine_id)
        total_time_int += time.perf_counter() - start

    print(f"String version average time:   {total_time_str / iterations:.6f} seconds")
    print(f"ASTEXT version average time:   {total_time_astext / iterations:.6f} seconds")
    print(f"Int cast version average time: {total_time_int / iterations:.6f} seconds")
    print("\n")

    if result_str != result_astext:
        print("⚠️  Warning: Results differ between string and astext versions!")

    if result_str != result_int:
        print("⚠️  Warning: Results differ between string and int cast versions!")

    return {
        "string_avg_time": total_time_str / iterations,
        "astext_avg_time": total_time_astext / iterations,
        "int_avg_time": total_time_int / iterations,
        "result_str": result_str,
        "result_astext": result_astext,
        "result_int": result_int,
    }


class explain(Executable, ClauseElement):
    inherit_cache = False

    def __init__(self, stmt, analyze=False):
        self.statement = stmt
        self.analyze = analyze

@compiles(explain, "postgresql")
def pg_explain(element, compiler, **kw):
    text = "EXPLAIN "
    if element.analyze:
        text += "ANALYZE "
    text += compiler.process(element.statement, **kw)
    return text

# Comparison function using db.session.execute
def compare_explain_allocine_queries(allocine_id: int, analyze: bool = False):
    stmt_astext = select(models.Product).where(
        models.Product.extraData["allocineId"] == str(allocine_id)
    )

    # Query using allocineId as a string (via JSON->text comparison)
    stmt_str = select(models.Product).where(
        models.Product.extraData["allocineId"].astext == str(allocine_id)
    )

    # Query using allocineId cast to integer
    stmt_int = select(models.Product).where(
        cast(models.Product.extraData["allocineId"], Integer) == allocine_id
    )

    print("=== EXPLAIN: version with astext ===")
    result_str = db.session.execute(explain(stmt_astext, analyze=analyze)).fetchall()
    for row in result_str:
        print(row[0])

    print("\n=== EXPLAIN: version with string ===")
    result_str = db.session.execute(explain(stmt_str, analyze=analyze)).fetchall()
    for row in result_str:
        print(row[0])

    print("\n=== EXPLAIN: version with cast to int ===")
    result_int = db.session.execute(explain(stmt_int, analyze=analyze)).fetchall()
    for row in result_int:
        print(row[0])
```

resultats:
```
staging❯ compare_explain_allocine_queries(302772)
=== EXPLAIN: version with astext ===
Index Scan using "product_allocineId_idx" on product  (cost=0.29..2.30 rows=1 width=1046)
  Index Cond: (("jsonData" -> 'allocineId'::text) = '302772'::jsonb)

=== EXPLAIN: version with string ===
Gather  (cost=1000.00..737413.54 rows=21577 width=1046)
  Workers Planned: 2
  ->  Parallel Seq Scan on product  (cost=0.00..734255.84 rows=8990 width=1046)
        Filter: (("jsonData" ->> 'allocineId'::text) = '302772'::text)

=== EXPLAIN: version with cast to int ===
Gather  (cost=1000.00..741908.68 rows=21577 width=1046)
  Workers Planned: 2
  ->  Parallel Seq Scan on product  (cost=0.00..738750.98 rows=8990 width=1046)
        Filter: ((("jsonData" -> 'allocineId'::text))::integer = 302772)

staging❯ benchmark_allocine_queries(302772, 1)
String version average time:   0.017734 seconds
ASTEXT version average time:   23.685127 seconds
Int cast version average time: 2.082210 seconds

{'string_avg_time': 0.01773417799267918,
 'astext_avg_time': 23.68512704304885,
 'int_avg_time': 2.082209725980647,
 'result_str': <Product #6220882>,
 'result_astext': <Product #6220882>,
 'result_int': <Product #6220882>}
```