### PR TITLE
(PC-36369)[PRO] feat: remove offer subtype selection from new offer creation flow

### DIFF
--- a/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.tsx
+++ b/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router'
@@ -28,7 +29,6 @@ import { RadioGroup } from 'ui-kit/form/RadioGroup/RadioGroup'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
-import { useEffect } from 'react'
 import styles from './CollectiveOfferSelectionDuplication.module.scss'
 import { SkeletonLoader } from './CollectiveOfferSelectionLoaderSkeleton'
 

--- a/pro/src/pages/OfferType/OfferType/OfferType.spec.tsx
+++ b/pro/src/pages/OfferType/OfferType/OfferType.spec.tsx
@@ -1,0 +1,28 @@
+import { screen } from '@testing-library/react'
+
+import { renderWithProviders } from 'commons/utils/renderWithProviders'
+
+import { OfferTypeScreen } from './OfferType'
+
+const renderOfferTypeScreen = (isNewOfferCreationFlowFeatureActive: boolean) => {
+  renderWithProviders(
+    <OfferTypeScreen />,
+    {
+      features: isNewOfferCreationFlowFeatureActive ? ['WIP_ENABLE_NEW_OFFER_CREATION_FLOW']: []
+    }
+  )
+}
+
+describe('OfferType', () => {
+  it('should display the offer subtype options', () => {
+    renderOfferTypeScreen(false)
+
+    expect(screen.getByTestId('wrapper-individualOfferSubtype')).toBeInTheDocument()
+  })
+
+  it('should NOT display the offer subtype options', () => {
+    renderOfferTypeScreen(true)
+
+    expect(screen.queryByTestId('wrapper-individualOfferSubtype')).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/OfferType/OfferType/OfferType.spec.tsx
+++ b/pro/src/pages/OfferType/OfferType/OfferType.spec.tsx
@@ -4,7 +4,11 @@ import { renderWithProviders } from 'commons/utils/renderWithProviders'
 
 import { OfferTypeScreen } from './OfferType'
 
-const renderOfferTypeScreen = (isNewOfferCreationFlowFeatureActive: boolean) => {
+const renderOfferTypeScreen = ({
+  isNewOfferCreationFlowFeatureActive
+}: {
+  isNewOfferCreationFlowFeatureActive?: boolean
+} = {}) => {
   renderWithProviders(
     <OfferTypeScreen />,
     {
@@ -15,13 +19,13 @@ const renderOfferTypeScreen = (isNewOfferCreationFlowFeatureActive: boolean) => 
 
 describe('OfferType', () => {
   it('should display the offer subtype options', () => {
-    renderOfferTypeScreen(false)
+    renderOfferTypeScreen()
 
     expect(screen.getByTestId('wrapper-individualOfferSubtype')).toBeInTheDocument()
   })
 
   it('should NOT display the offer subtype options', () => {
-    renderOfferTypeScreen(true)
+    renderOfferTypeScreen({isNewOfferCreationFlowFeatureActive: true})
 
     expect(screen.queryByTestId('wrapper-individualOfferSubtype')).not.toBeInTheDocument()
   })

--- a/pro/src/pages/OfferType/OfferType/OfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType/OfferType.tsx
@@ -15,6 +15,7 @@ import {
 import { getIndividualOfferUrl } from 'commons/core/Offers/utils/getIndividualOfferUrl'
 import { serializeApiCollectiveFilters } from 'commons/core/Offers/utils/serializer'
 import { useOfferer } from 'commons/hooks/swr/useOfferer'
+import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useNotification } from 'commons/hooks/useNotification'
 import { selectCurrentOffererId } from 'commons/store/offerer/selectors'
 import { FormLayout } from 'components/FormLayout/FormLayout'
@@ -34,6 +35,7 @@ export const OfferTypeScreen = () => {
   const queryParams = new URLSearchParams(location.search)
   const queryOffererId = useSelector(selectCurrentOffererId)?.toString()
   const queryVenueId = queryParams.get('lieu')
+  const isNewOfferCreationFlowFeatureActive = useActiveFeature('WIP_ENABLE_NEW_OFFER_CREATION_FLOW')
 
   const notify = useNotification()
 
@@ -63,7 +65,9 @@ export const OfferTypeScreen = () => {
   const onSubmit = async ({ offer }: OfferTypeFormValues) => {
     if (offer.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO) {
       const params = new URLSearchParams(location.search)
-      params.append('offer-type', offer.individualOfferSubtype)
+      if (!isNewOfferCreationFlowFeatureActive) {
+        params.append('offer-type', offer.individualOfferSubtype)
+      }
 
       return navigate({
         pathname: getIndividualOfferUrl({
@@ -174,7 +178,7 @@ export const OfferTypeScreen = () => {
                 />
               )}
 
-              {offer.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO && (
+              {!isNewOfferCreationFlowFeatureActive && offer.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO && (
                 <IndividualOfferType />
               )}
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36369)

### Changes

- Hide offer subtype selection when creating a new individual offer with `WIP_ENABLE_NEW_OFFER_CREATION_FLOW ` feature flag.

### Usage

1. Enable the `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` feature flag
2. Try creating a new individual offer
3. You won't see "Votre offre est ..." with the subtype selection anymore

## 🖼️ Before & After Images

Before | After
:---: | :---:
<img width="555" alt="image" src="https://github.com/user-attachments/assets/5c2b5f68-2511-4dc4-8345-4eb74d0ff5ba" /> | <img width="895" alt="image" src="https://github.com/user-attachments/assets/ed598546-a12a-4b97-9919-ab19b478f497" />
