### PR TITLE
(BSR)[BO] fix: avoid double 'published' filters

### DIFF
--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -665,7 +665,7 @@ def format_offer_status(status: offer_mixin.OfferStatus) -> str:
         case offer_mixin.OfferStatus.SCHEDULED:
             return "Programmée"
         case offer_mixin.OfferStatus.PUBLISHED:
-            return "Publiée"
+            return "Publiée non réservable"
         case offer_mixin.CollectiveOfferStatus.ACTIVE:
             return "Publiée"
         case offer_mixin.OfferStatus.ACTIVE:


### PR DESCRIPTION
Avant:
![image](https://github.com/user-attachments/assets/20722db4-8cf8-484a-8cf2-79d980612f57)

Après 
![image](https://github.com/user-attachments/assets/64ac7804-dc13-4172-8be1-1e041fd7c0a7)
