### PR TITLE
(BSR)[API] style: Remove BaseQuery class

### DIFF
--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -42,7 +42,7 @@ from pcapi.models import db
 from pcapi.models import feature
 from pcapi.models import offer_mixin
 from pcapi.models import validation_status_mixin
-from pcapi.models.pc_object import BaseQuery
+from pcapi.models.utils import get_or_404
 from pcapi.repository.session_management import is_managed_transaction
 from pcapi.repository.session_management import on_commit
 from pcapi.routes.adage_iframe.serialization.offers import PostCollectiveRequestBodyModel
@@ -456,7 +456,8 @@ def get_venue_and_check_access_for_offer_creation(
     if offer_data.template_id is not None:
         template = educational_repository.get_collective_offer_template_by_id(offer_data.template_id)
         rest.check_user_has_access_to_offerer(user, offerer_id=template.venue.managingOffererId)
-    venue: offerers_models.Venue = db.session.query(offerers_models.Venue).get_or_404(offer_data.venue_id)
+    venue: offerers_models.Venue = get_or_404(offerers_models.Venue, offer_data.venue_id)
+
     rest.check_user_has_access_to_offerer(user, offerer_id=venue.managingOffererId)
     if not offerers_api.can_offerer_create_educational_offer(venue.managingOffererId):
         raise exceptions.CulturalPartnerNotFoundException("No venue has been found for the selected siren")
@@ -1152,7 +1153,7 @@ def archive_collective_offers_template(
     )
 
 
-def batch_update_collective_offers(query: BaseQuery, update_fields: dict) -> None:
+def batch_update_collective_offers(query: sa_orm.Query, update_fields: dict) -> None:
     allowed_validation_status = {offers_models.OfferValidationStatus.APPROVED}
     if "dateArchived" in update_fields:
         allowed_validation_status.update(
@@ -1183,7 +1184,7 @@ def batch_update_collective_offers(query: BaseQuery, update_fields: dict) -> Non
             db.session.commit()
 
 
-def batch_update_collective_offers_template(query: BaseQuery, update_fields: dict) -> None:
+def batch_update_collective_offers_template(query: sa_orm.Query, update_fields: dict) -> None:
     allowed_validation_status = {offers_models.OfferValidationStatus.APPROVED}
     if "dateArchived" in update_fields:
         allowed_validation_status.update(

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -23,7 +23,6 @@ from pcapi.core.providers import models as providers_models
 from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.models import offer_mixin
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository import repository
 from pcapi.utils.clean_accents import clean_accents
 
@@ -440,7 +439,7 @@ def get_paginated_collective_bookings_for_educational_year(
     return query.all()
 
 
-def get_expired_or_archived_collective_offers_template() -> BaseQuery:
+def get_expired_or_archived_collective_offers_template() -> sa_orm.Query:
     """Return a query of collective offer templates that are either expired (end date has passed)
     or archived.
     """
@@ -456,7 +455,7 @@ def get_expired_or_archived_collective_offers_template() -> BaseQuery:
     )
 
 
-def find_expiring_collective_bookings_query() -> BaseQuery:
+def find_expiring_collective_bookings_query() -> sa_orm.Query:
     today_at_midnight = datetime.combine(date.today(), time(0, 0))
 
     return db.session.query(educational_models.CollectiveBooking).filter(
@@ -550,7 +549,7 @@ def get_collective_offers_by_filters(
     period_beginning_date: date | None = None,
     period_ending_date: date | None = None,
     formats: list[EacFormat] | None = None,
-) -> BaseQuery:
+) -> sa_orm.Query:
     query = db.session.query(educational_models.CollectiveOffer)
 
     if not user_is_admin:
@@ -646,7 +645,7 @@ def get_collective_offers_template_by_filters(
     period_beginning_date: date | None = None,
     period_ending_date: date | None = None,
     formats: list[EacFormat] | None = None,
-) -> BaseQuery:
+) -> sa_orm.Query:
     query = db.session.query(educational_models.CollectiveOfferTemplate)
 
     if period_beginning_date is not None or period_ending_date is not None:
@@ -696,20 +695,20 @@ def get_collective_offers_template_by_filters(
 
 
 def _filter_collective_offers_by_statuses(
-    query: BaseQuery,
+    query: sa_orm.Query,
     statuses: list[educational_models.CollectiveOfferDisplayedStatus] | None,
-) -> BaseQuery:
+) -> sa_orm.Query:
     """
     Filter a SQLAlchemy query for CollectiveOffers based on a list of statuses.
 
     This function modifies the input query to filter CollectiveOffers based on their CollectiveOfferDisplayedStatus.
 
     Args:
-      query (BaseQuery): The initial query to be filtered.
+      query (sa_orm.Query): The initial query to be filtered.
       statuses (list[CollectiveOfferDisplayedStatus]): A list of status strings to filter by.
 
     Returns:
-      BaseQuery: The modified query with applied filters.
+      sa_orm.Query: The modified query with applied filters.
     """
     on_collective_offer_filters: list = []
     on_booking_status_filter: list = []
@@ -880,8 +879,8 @@ def _filter_collective_offers_by_statuses(
 
 
 def add_last_booking_status_to_collective_offer_query(
-    query: BaseQuery,
-) -> typing.Tuple[typing.Any, BaseQuery]:
+    query: sa_orm.Query,
+) -> typing.Tuple[typing.Any, sa_orm.Query]:
     last_booking_query = (
         db.session.query(educational_models.CollectiveBooking)
         .with_entities(
@@ -1023,7 +1022,7 @@ def _get_filtered_collective_bookings_query(
     venue_id: int | None = None,
     *,
     extra_joins: tuple[tuple[typing.Any, ...], ...] = (),
-) -> BaseQuery:
+) -> sa_orm.Query:
     collective_bookings_query = (
         db.session.query(educational_models.CollectiveBooking)
         .join(educational_models.CollectiveBooking.offerer)
@@ -1215,7 +1214,7 @@ def get_filtered_collective_booking_report(
     status_filter: educational_models.CollectiveBookingStatusFilter | None,
     event_date: datetime | None = None,
     venue_id: int | None = None,
-) -> BaseQuery:
+) -> sa_orm.Query:
     with_entities: tuple[typing.Any, ...] = (
         offerers_models.Venue.common_name.label("venueName"),  # type: ignore[attr-defined]
         offerers_models.Offerer.postalCode.label("offererPostalCode"),
@@ -1461,7 +1460,7 @@ def get_collective_offer_by_id_for_adage(offer_id: int) -> educational_models.Co
     return query.filter(educational_models.CollectiveOffer.id == offer_id).populate_existing().one()
 
 
-def _get_collective_offer_template_by_id_for_adage_base_query() -> BaseQuery:
+def _get_collective_offer_template_by_id_for_adage_base_query() -> sa_orm.Query:
     return (
         db.session.query(educational_models.CollectiveOfferTemplate)
         .filter(
@@ -1491,7 +1490,7 @@ def get_collective_offer_template_by_id_for_adage(offer_id: int) -> educational_
     return query.filter(educational_models.CollectiveOfferTemplate.id == offer_id).populate_existing().one()
 
 
-def get_collective_offer_templates_by_ids_for_adage(offer_ids: typing.Collection[int]) -> BaseQuery:
+def get_collective_offer_templates_by_ids_for_adage(offer_ids: typing.Collection[int]) -> sa_orm.Query:
     query = _get_collective_offer_template_by_id_for_adage_base_query()
     # Filter out the archived offers
     query = query.filter(educational_models.CollectiveOfferTemplate.isArchived == False)
@@ -1504,7 +1503,7 @@ def get_collective_offer_templates_by_ids_for_adage(offer_ids: typing.Collection
     return query.filter(educational_models.CollectiveOfferTemplate.id.in_(offer_ids)).populate_existing()
 
 
-def get_query_for_collective_offers_by_ids_for_user(user: User, ids: typing.Iterable[int]) -> BaseQuery:
+def get_query_for_collective_offers_by_ids_for_user(user: User, ids: typing.Iterable[int]) -> sa_orm.Query:
     query = db.session.query(educational_models.CollectiveOffer)
 
     if not user.has_admin_role:
@@ -1522,7 +1521,7 @@ def get_query_for_collective_offers_by_ids_for_user(user: User, ids: typing.Iter
     return query
 
 
-def get_query_for_collective_offers_template_by_ids_for_user(user: User, ids: typing.Iterable[int]) -> BaseQuery:
+def get_query_for_collective_offers_template_by_ids_for_user(user: User, ids: typing.Iterable[int]) -> sa_orm.Query:
     query = db.session.query(educational_models.CollectiveOfferTemplate)
     if not user.has_admin_role:
         query = query.join(offerers_models.Venue, educational_models.CollectiveOfferTemplate.venue)
@@ -1738,7 +1737,7 @@ def get_all_offer_template_by_redactor_id(redactor_id: int) -> list[educational_
     )
 
 
-def get_venue_base_query() -> BaseQuery:
+def get_venue_base_query() -> sa_orm.Query:
     return (
         db.session.query(offerers_models.Venue)
         .filter(

--- a/api/src/pcapi/core/external/automations/user.py
+++ b/api/src/pcapi/core/external/automations/user.py
@@ -14,7 +14,6 @@ from pcapi.core.external.attributes import api as attributes_api
 from pcapi.core.external.sendinblue import add_contacts_to_list
 from pcapi.core.users.models import User
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 
 
 YIELD_COUNT_PER_DB_QUERY = 1000
@@ -23,7 +22,7 @@ YIELD_COUNT_PER_DB_QUERY = 1000
 DAYS_IN_18_YEARS = 365 * 14 + 366 * 4
 
 
-def get_young_users_emails_query() -> BaseQuery:
+def get_young_users_emails_query() -> sa_orm.Query:
     return (
         db.session.query(User.email)
         .yield_per(YIELD_COUNT_PER_DB_QUERY)

--- a/api/src/pcapi/core/finance/backend/base.py
+++ b/api/src/pcapi/core/finance/backend/base.py
@@ -2,13 +2,13 @@ import calendar
 import datetime
 
 import sqlalchemy as sa
+import sqlalchemy.orm as sa_orm
 import sqlalchemy.sql.functions as sa_func
 
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.educational import models as educational_models
 from pcapi.core.finance import models as finance_models
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 
 
 INVOICE_LINE_INDIV_DICT = {
@@ -145,7 +145,7 @@ class BaseFinanceBackend:
 
         return indiv_data + indiv_incident_data + collective_data + collective_incident_data
 
-    def _get_indiv_data(self, invoice_id: int, query: BaseQuery) -> list[dict]:
+    def _get_indiv_data(self, invoice_id: int, query: sa_orm.Query) -> list[dict]:
         res = []
         data = (
             query.join(bookings_models.Booking.deposit)
@@ -181,7 +181,7 @@ class BaseFinanceBackend:
             )
         return res
 
-    def _get_collective_data(self, invoice_id: int, query: BaseQuery) -> list[dict]:
+    def _get_collective_data(self, invoice_id: int, query: sa_orm.Query) -> list[dict]:
         res = []
         data = (
             query.join(educational_models.CollectiveBooking.collectiveStock)

--- a/api/src/pcapi/core/finance/repository.py
+++ b/api/src/pcapi/core/finance/repository.py
@@ -16,7 +16,6 @@ import pcapi.utils.date as date_utils
 import pcapi.utils.db as db_utils
 from pcapi.core.geography import models as geography_models
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 
 from . import models
 from . import utils
@@ -340,7 +339,7 @@ def _get_sent_pricings_for_individual_bookings(
     ).all()
 
 
-def _get_reimbursement_details_from_invoices_base_query(invoice_ids: list[int]) -> BaseQuery:
+def _get_reimbursement_details_from_invoices_base_query(invoice_ids: list[int]) -> sa_orm.Query:
     return (
         db.session.query(models.Invoice)
         .filter(
@@ -367,7 +366,7 @@ def _get_reimbursement_details_from_invoices_base_query(invoice_ids: list[int]) 
     )
 
 
-def _get_collective_booking_reimbursement_data(query: BaseQuery) -> list[tuple]:
+def _get_collective_booking_reimbursement_data(query: sa_orm.Query) -> list[tuple]:
     return (
         query.join(models.Pricing.event)
         .join(educational_models.CollectiveStock, educational_models.CollectiveBooking.collectiveStock)
@@ -437,7 +436,7 @@ def _get_collective_reimbursement_details_from_invoices(invoice_ids: list[int]) 
     return collective_details
 
 
-def _get_individual_booking_reimbursement_data(query: BaseQuery) -> list[tuple]:
+def _get_individual_booking_reimbursement_data(query: sa_orm.Query) -> list[tuple]:
     columns = [
         bookings_models.Booking.token.label("booking_token"),
         _truncate_milliseconds(bookings_models.Booking.dateUsed).label("booking_used_date"),

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -69,7 +69,6 @@ from pcapi.models import feature
 from pcapi.models import offer_mixin
 from pcapi.models import pc_object
 from pcapi.models.feature import FeatureToggle
-from pcapi.models.pc_object import BaseQuery
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.repository import repository
 from pcapi.repository import transaction
@@ -1828,7 +1827,7 @@ def get_venue_by_id(venue_id: int) -> offerers_models.Venue:
     return offerers_repository.get_venue_by_id(venue_id)
 
 
-def search_offerer(search_query: str, departments: typing.Iterable[str] = ()) -> BaseQuery:
+def search_offerer(search_query: str, departments: typing.Iterable[str] = ()) -> sa_orm.Query:
     offerers = db.session.query(models.Offerer)
 
     search_query = search_query.strip()
@@ -1858,11 +1857,11 @@ def search_offerer(search_query: str, departments: typing.Iterable[str] = ()) ->
     return offerers
 
 
-def get_offerer_base_query(offerer_id: int) -> BaseQuery:
+def get_offerer_base_query(offerer_id: int) -> sa_orm.Query:
     return db.session.query(models.Offerer).filter(models.Offerer.id == offerer_id)
 
 
-def search_venue(search_query: str, departments: typing.Iterable[str] = ()) -> BaseQuery:
+def search_venue(search_query: str, departments: typing.Iterable[str] = ()) -> sa_orm.Query:
     venues = (
         db.session.query(models.Venue)
         .outerjoin(models.VenueContact)
@@ -1938,15 +1937,15 @@ def search_venue(search_query: str, departments: typing.Iterable[str] = ()) -> B
     return venues
 
 
-def get_venue_base_query(venue_id: int) -> BaseQuery:
+def get_venue_base_query(venue_id: int) -> sa_orm.Query:
     return db.session.query(models.Venue).outerjoin(offerers_models.VenueContact).filter(models.Venue.id == venue_id)
 
 
-def get_bank_account_base_query(bank_account_id: int) -> BaseQuery:
+def get_bank_account_base_query(bank_account_id: int) -> sa_orm.Query:
     return finance_models.BankAccount.filter(finance_models.BankAccount.id == bank_account_id)
 
 
-def search_bank_account(search_query: str, *_: typing.Any) -> BaseQuery:
+def search_bank_account(search_query: str, *_: typing.Any) -> sa_orm.Query:
     bank_accounts_query = db.session.query(finance_models.BankAccount).options(
         sa_orm.joinedload(finance_models.BankAccount.offerer)
     )

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -13,7 +13,6 @@ from pcapi.core.finance import models as finance_models
 from pcapi.core.geography import models as geography_models
 from pcapi.models import db
 from pcapi.models import offer_mixin
-from pcapi.models.pc_object import BaseQuery
 
 from . import exceptions
 from . import models
@@ -232,7 +231,7 @@ def find_virtual_venue_by_offerer_id(offerer_id: int) -> models.Venue | None:
 
 def find_venues_of_offerers_with_no_offer_and_at_least_one_physical_venue_and_validated_x_days_ago(
     days: int,
-) -> BaseQuery:
+) -> sa_orm.Query:
     validated_x_days_ago_with_physical_venue_offerers_ids_subquery = (
         sa.select(models.Offerer.id)
         .join(models.Venue, models.Offerer.id == models.Venue.managingOffererId)
@@ -1027,7 +1026,7 @@ def get_revenues_per_year(
     }
 
 
-def get_offerer_addresses(offerer_id: int, only_with_offers: bool = False) -> BaseQuery:
+def get_offerer_addresses(offerer_id: int, only_with_offers: bool = False) -> sa_orm.Query:
     query = (
         db.session.query(models.OffererAddress)
         .filter(models.OffererAddress.offererId == offerer_id)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -71,7 +71,6 @@ from pcapi.models import offer_mixin
 from pcapi.models import pc_object
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.offer_mixin import OfferValidationType
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository import repository
 from pcapi.repository import transaction
 from pcapi.repository.session_management import atomic
@@ -516,7 +515,7 @@ def update_offer(
 
 
 def batch_update_offers(
-    query: BaseQuery,
+    query: sa_orm.Query,
     update_fields: dict | None = None,
     activate: bool | None = None,
     send_email_notification: bool = False,
@@ -1699,7 +1698,7 @@ def fetch_or_update_product_with_titelive_data(titelive_product: models.Product)
     return product
 
 
-def batch_delete_draft_offers(query: BaseQuery) -> None:
+def batch_delete_draft_offers(query: sa_orm.Query) -> None:
     offer_ids = [id_ for (id_,) in query.with_entities(models.Offer.id)]
     filters = (models.Offer.validation == models.OfferValidationStatus.DRAFT, models.Offer.id.in_(offer_ids))
     db.session.query(models.Mediation).filter(models.Mediation.offerId == models.Offer.id).filter(*filters).delete(

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -39,7 +39,6 @@ from pcapi.models.has_thumb_mixin import HasThumbMixin
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import ValidationMixin
-from pcapi.models.pc_object import BaseQuery
 from pcapi.models.pc_object import PcObject
 from pcapi.models.soft_deletable_mixin import SoftDeletableMixin
 from pcapi.utils import db as db_utils
@@ -438,7 +437,7 @@ class Stock(PcObject, Base, Model, SoftDeletableMixin):
         )
 
     @classmethod
-    def queryNotSoftDeleted(cls) -> BaseQuery:
+    def queryNotSoftDeleted(cls) -> sa_orm.Query:
         return db.session.query(Stock).filter_by(isSoftDeleted=False)
 
     @staticmethod

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -10,7 +10,6 @@ import pcapi.core.offers.models as offers_models
 from pcapi.core.categories import subcategories
 from pcapi.core.offerers.models import Venue
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 
 from . import constants
 from . import models
@@ -53,7 +52,7 @@ def get_provider_by_name(name: str) -> models.Provider:
     return db.session.query(models.Provider).filter_by(name=name).one()
 
 
-def get_available_providers(venue: Venue) -> BaseQuery:
+def get_available_providers(venue: Venue) -> sa_orm.Query:
     from pcapi.local_providers import AllocineStocks
 
     query = (
@@ -101,7 +100,7 @@ def get_cds_cinema_details(cinema_id: str) -> models.CDSCinemaDetails:
     return cinema_details
 
 
-def get_cinema_venue_provider_query(venue_id: int) -> BaseQuery:
+def get_cinema_venue_provider_query(venue_id: int) -> sa_orm.Query:
     return db.session.query(models.VenueProvider).filter(
         models.VenueProvider.venueId == venue_id,
         models.VenueProvider.isFromCinemaProvider,
@@ -197,7 +196,7 @@ def is_cinema_external_ticket_applicable(offer: offers_models.Offer) -> bool:
     )
 
 
-def get_providers_venues(provider_id: int) -> BaseQuery:
+def get_providers_venues(provider_id: int) -> sa_orm.Query:
     return (
         db.session.query(Venue)
         .join(models.VenueProvider)
@@ -209,7 +208,7 @@ def get_providers_venues(provider_id: int) -> BaseQuery:
 
 def _get_future_provider_events_requiring_a_ticketing_system_query(
     provider: models.Provider,
-) -> BaseQuery:
+) -> sa_orm.Query:
     # base query
     events_query = (
         db.session.query(offers_models.Offer)

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -5,7 +5,7 @@ import typing
 from collections import abc
 
 import sqlalchemy as sa
-from sqlalchemy import orm as sa_orm
+import sqlalchemy.orm as sa_orm
 
 from pcapi import settings
 from pcapi.connectors.big_query import queries as big_query_queries
@@ -21,7 +21,6 @@ from pcapi.core.offers import repository as offers_repository
 from pcapi.core.search.backends import base
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository.session_management import atomic
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.utils import requests
@@ -458,7 +457,7 @@ def get_base_query_for_collective_template_offer_indexation() -> (
     )
 
 
-def get_base_query_for_offer_indexation() -> BaseQuery:
+def get_base_query_for_offer_indexation() -> sa_orm.Query:
     return (
         # We are only interested in bookable stocks, which means that
         # we can exclude past stocks (which are numerous for recurrent

--- a/api/src/pcapi/core/users/email/repository.py
+++ b/api/src/pcapi/core/users/email/repository.py
@@ -1,14 +1,15 @@
 from datetime import datetime
 
+import sqlalchemy.orm as sa_orm
+
 from pcapi.core.users import constants
 from pcapi.core.users.models import EmailHistoryEventTypeEnum
 from pcapi.core.users.models import User
 from pcapi.core.users.models import UserEmailHistory
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 
 
-def _query_ordered_email_update_entry(user: User) -> BaseQuery:
+def _query_ordered_email_update_entry(user: User) -> sa_orm.Query:
     latest_entries = (
         db.session.query(UserEmailHistory).filter_by(user=user).order_by(UserEmailHistory.creationDate.desc())
     )

--- a/api/src/pcapi/core/users/repository.py
+++ b/api/src/pcapi/core/users/repository.py
@@ -12,7 +12,6 @@ from sqlalchemy.sql.functions import func
 import pcapi.core.offerers.models as offerers_models
 import pcapi.utils.email as email_utils
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 from pcapi.utils import crypto
 
 from . import exceptions
@@ -63,7 +62,7 @@ def get_user_with_credentials(identifier: str, password: str, allow_inactive: bo
     return typing.cast(models.User, user)
 
 
-def _find_user_by_email_query(email: str) -> BaseQuery:
+def _find_user_by_email_query(email: str) -> sa_orm.Query:
     return db.session.query(models.User).filter(func.lower(models.User.email) == email_utils.sanitize_email(email))
 
 
@@ -71,7 +70,7 @@ def find_user_by_email(email: str) -> models.User | None:
     return _find_user_by_email_query(email).one_or_none()
 
 
-def find_pro_or_non_attached_pro_user_by_email_query(email: str) -> BaseQuery:
+def find_pro_or_non_attached_pro_user_by_email_query(email: str) -> sa_orm.Query:
     return _find_user_by_email_query(email).filter(models.User.has_any_pro_role)
 
 

--- a/api/src/pcapi/models/pc_object.py
+++ b/api/src/pcapi/models/pc_object.py
@@ -6,7 +6,6 @@ from pprint import pprint
 import sqlalchemy as sa
 import sqlalchemy.exc as sa_exc
 import sqlalchemy.orm as sa_orm
-from werkzeug.exceptions import NotFound
 
 
 logger = logging.getLogger(__name__)
@@ -17,31 +16,12 @@ NOT_FOUND_KEY_ERROR_CODE = "23503"
 OBLIGATORY_FIELD_ERROR_CODE = "23502"
 
 
-class BaseQuery(sa_orm.Query):
-    def get(self, obj_id: int) -> typing.Any:
-        return self.filter_by(id=obj_id).one_or_none()
-
-    def get_or_404(self, obj_id: int) -> typing.Any:
-        obj = self.filter_by(id=obj_id).one_or_none()
-        if not obj:
-            raise NotFound()
-        return obj
-
-    def first_or_404(self) -> typing.Any:
-        obj = self.first()
-        if not obj:
-            raise NotFound()
-        return obj
-
-
 class DeletedRecordException(Exception):
     pass
 
 
 class PcObject:
-    query_class = BaseQuery
-
-    id: sa_orm.Mapped[int] = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)  # type: ignore[assignment]
+    id: sa_orm.Mapped[int] = sa.Column(sa.BigInteger, primary_key=True, autoincrement=True)  # type: ignore
 
     def __init__(self, **kwargs: typing.Any) -> None:
         from_dict = kwargs.pop("from_dict", None)

--- a/api/src/pcapi/models/utils.py
+++ b/api/src/pcapi/models/utils.py
@@ -1,0 +1,28 @@
+import typing
+
+import sqlalchemy.orm as sa_orm
+from werkzeug.exceptions import NotFound
+
+from pcapi import models
+from pcapi.models import db
+
+
+T = typing.TypeVar("T", bound=models.Model)
+
+
+def get_or_404_from_query(query: "sa_orm.Query[T]", obj_id: int | str) -> T:
+    obj = query.filter_by(id=obj_id).one_or_none()
+    if not obj:
+        raise NotFound()
+    return obj
+
+
+def get_or_404(model: typing.Type[T], obj_id: int | str) -> T:
+    return get_or_404_from_query(db.session.query(model), obj_id)
+
+
+def first_or_404(query: "sa_orm.Query[T]") -> T:
+    obj = query.first()
+    if not obj:
+        raise NotFound()
+    return obj

--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -53,7 +53,6 @@ from pcapi.models import db
 from pcapi.models.beneficiary_import import BeneficiaryImport
 from pcapi.models.beneficiary_import_status import BeneficiaryImportStatus
 from pcapi.models.feature import DisabledFeatureError
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository.session_management import atomic
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.routes.backoffice import search_utils
@@ -74,7 +73,7 @@ public_accounts_blueprint = utils.child_backoffice_blueprint(
 )
 
 
-def _load_suspension_info(query: BaseQuery) -> BaseQuery:
+def _load_suspension_info(query: sa_orm.Query) -> sa_orm.Query:
     # Partial joined load with ActionHistory avoids N+1 query to show suspension reason, but the number of fetched rows
     # would be greater than the number of results when a single user has several suspension actions.
     # So these expressions use a subquery so that result count is accurate, and the redirection well forced when a
@@ -91,7 +90,7 @@ def _load_suspension_info(query: BaseQuery) -> BaseQuery:
     )
 
 
-def _load_current_deposit_data(query: BaseQuery, join_needed: bool = True) -> BaseQuery:
+def _load_current_deposit_data(query: sa_orm.Query, join_needed: bool = True) -> sa_orm.Query:
     # partial joined load with Deposit and Recredit to avoid N+1, show the version of the current
     # deposit and not mess with the pagination as a beneficiary cannot have multiple deposits active
     # at the same time

--- a/api/src/pcapi/routes/backoffice/accounts/update_request_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/update_request_blueprint.py
@@ -36,7 +36,6 @@ from pcapi.core.users import ds as users_ds
 from pcapi.core.users import models as users_models
 from pcapi.core.users.email import update as email_update
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.routes.backoffice import autocomplete
 from pcapi.routes.backoffice import search_utils
@@ -60,7 +59,7 @@ account_update_blueprint = utils.child_backoffice_blueprint(
 )
 
 
-def _get_filtered_account_update_requests(form: account_forms.AccountUpdateRequestSearchForm) -> BaseQuery:
+def _get_filtered_account_update_requests(form: account_forms.AccountUpdateRequestSearchForm) -> sa_orm.Query:
     aliased_instructor = sa_orm.aliased(users_models.User)
 
     query = (

--- a/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/bo_users_blueprint.py
@@ -19,7 +19,6 @@ from pcapi.core.users import exceptions as users_exceptions
 from pcapi.core.users import models as users_models
 from pcapi.core.users.email import update as email_update
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository import repository
 from pcapi.routes.backoffice import search_utils
 from pcapi.routes.backoffice import utils
@@ -38,7 +37,7 @@ bo_users_blueprint = utils.child_backoffice_blueprint(
 )
 
 
-def _get_bo_user_query(user_id: int) -> BaseQuery:
+def _get_bo_user_query(user_id: int) -> sa_orm.Query:
     return db.session.query(users_models.User).filter_by(id=user_id).join(users_models.User.backoffice_profile)
 
 

--- a/api/src/pcapi/routes/backoffice/bookings/helpers.py
+++ b/api/src/pcapi/routes/backoffice/bookings/helpers.py
@@ -2,6 +2,7 @@ import datetime
 import typing
 
 import sqlalchemy as sa
+import sqlalchemy.orm as sa_orm
 
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.categories import subcategories
@@ -9,7 +10,6 @@ from pcapi.core.educational import models as educational_models
 from pcapi.core.finance import models as finance_models
 from pcapi.core.offers import models as offers_models
 from pcapi.core.users import models as users_models
-from pcapi.models.pc_object import BaseQuery
 from pcapi.routes.backoffice.bookings.forms import BaseBookingListForm
 from pcapi.routes.backoffice.bookings.forms import BookingStatus
 from pcapi.utils import date as date_utils
@@ -19,7 +19,7 @@ from pcapi.utils import string as string_utils
 
 def get_bookings(
     *,
-    base_query: BaseQuery,
+    base_query: sa_orm.Query,
     form: BaseBookingListForm,
     stock_class: type[educational_models.CollectiveStock | offers_models.Stock],
     booking_class: type[educational_models.CollectiveBooking | bookings_models.Booking],

--- a/api/src/pcapi/routes/backoffice/chronicles/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/chronicles/blueprint.py
@@ -19,6 +19,7 @@ from pcapi.core.history import models as history_models
 from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.models import db
+from pcapi.models.utils import get_or_404
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.routes.backoffice import search_utils
 from pcapi.routes.backoffice import utils
@@ -192,7 +193,7 @@ def details(chronicle_id: int) -> utils.BackofficeResponse:
 @chronicles_blueprint.route("/<int:chronicle_id>/update-content", methods=["GET"])
 @permission_required(perm_models.Permissions.MANAGE_CHRONICLE)
 def get_update_chronicle_content_form(chronicle_id: int) -> utils.BackofficeResponse:
-    chronicle = db.session.query(chronicles_models.Chronicle).get_or_404(chronicle_id)
+    chronicle = get_or_404(chronicles_models.Chronicle, chronicle_id)
     form = forms.UpdateContentForm(content=chronicle.content)
 
     return render_template(
@@ -216,7 +217,7 @@ def update_chronicle_content(chronicle_id: int) -> utils.BackofficeResponse:
             url_for("backoffice_web.chronicles.details", chronicle_id=chronicle_id, active_tab="content"), code=303
         )
 
-    chronicle = db.session.query(chronicles_models.Chronicle).get_or_404(chronicle_id)
+    chronicle = get_or_404(chronicles_models.Chronicle, chronicle_id)
     chronicle.content = form.content.data
     db.session.add(chronicle)
     db.session.flush()
@@ -235,7 +236,7 @@ def update_chronicle_content(chronicle_id: int) -> utils.BackofficeResponse:
 @chronicles_blueprint.route("/<int:chronicle_id>/publish", methods=["POST"])
 @permission_required(perm_models.Permissions.MANAGE_CHRONICLE)
 def publish_chronicle(chronicle_id: int) -> utils.BackofficeResponse:
-    chronicle = db.session.query(chronicles_models.Chronicle).get_or_404(chronicle_id)
+    chronicle = get_or_404(chronicles_models.Chronicle, chronicle_id)
     chronicle.isActive = True
     db.session.add(chronicle)
     db.session.flush()
@@ -251,7 +252,7 @@ def publish_chronicle(chronicle_id: int) -> utils.BackofficeResponse:
 @chronicles_blueprint.route("/<int:chronicle_id>/unpublish", methods=["POST"])
 @permission_required(perm_models.Permissions.MANAGE_CHRONICLE)
 def unpublish_chronicle(chronicle_id: int) -> utils.BackofficeResponse:
-    chronicle = db.session.query(chronicles_models.Chronicle).get_or_404(chronicle_id)
+    chronicle = get_or_404(chronicles_models.Chronicle, chronicle_id)
     chronicle.isActive = False
     db.session.add(chronicle)
     db.session.flush()
@@ -267,7 +268,7 @@ def unpublish_chronicle(chronicle_id: int) -> utils.BackofficeResponse:
 @chronicles_blueprint.route("/<int:chronicle_id>/attach-product", methods=["POST"])
 @permission_required(perm_models.Permissions.MANAGE_CHRONICLE)
 def attach_product(chronicle_id: int) -> utils.BackofficeResponse:
-    selected_chronicle = db.session.query(chronicles_models.Chronicle).get_or_404(chronicle_id)
+    selected_chronicle = get_or_404(chronicles_models.Chronicle, chronicle_id)
 
     form = (
         forms.AttachBookProductForm()
@@ -343,7 +344,7 @@ def attach_product(chronicle_id: int) -> utils.BackofficeResponse:
 @chronicles_blueprint.route("/<int:chronicle_id>/detach-product/<int:product_id>", methods=["POST"])
 @permission_required(perm_models.Permissions.MANAGE_CHRONICLE)
 def detach_product(chronicle_id: int, product_id: int) -> utils.BackofficeResponse:
-    selected_chronicle = db.session.query(chronicles_models.Chronicle).get_or_404(chronicle_id)
+    selected_chronicle = get_or_404(chronicles_models.Chronicle, chronicle_id)
     chronicles_subquery = (
         db.session.query(chronicles_models.Chronicle)
         .filter(
@@ -388,7 +389,7 @@ def comment_chronicle(chronicle_id: int) -> utils.BackofficeResponse:
             url_for("backoffice_web.chronicles.details", chronicle_id=chronicle_id, active_tab="history"), code=303
         )
 
-    chronicle = db.session.query(chronicles_models.Chronicle).get_or_404(chronicle_id)
+    chronicle = get_or_404(chronicles_models.Chronicle, chronicle_id)
 
     history_api.add_action(
         history_models.ActionType.COMMENT, author=current_user, chronicle=chronicle, comment=form.comment.data

--- a/api/src/pcapi/routes/backoffice/chronicles/forms.py
+++ b/api/src/pcapi/routes/backoffice/chronicles/forms.py
@@ -66,7 +66,7 @@ class GetChronicleSearchForm(forms_utils.PCForm):
 
 
 class UpdateContentForm(forms_utils.PCForm):
-    def __init__(self, *args: typing.Any, content: str = "", **kwargs: typing.Any) -> None:
+    def __init__(self, *args: typing.Any, content: str | None = "", **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
         if content:
             self.content.data = content

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -33,7 +33,6 @@ from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models import feature
 from pcapi.models import offer_mixin
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository.session_management import atomic
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.routes.backoffice import utils
@@ -246,7 +245,7 @@ JOIN_DICT: dict[str, list[dict[str, typing.Any]]] = {
 }
 
 
-def _get_collective_offer_ids_query(form: forms.GetCollectiveOfferAdvancedSearchForm) -> BaseQuery:
+def _get_collective_offer_ids_query(form: forms.GetCollectiveOfferAdvancedSearchForm) -> sa_orm.Query:
     base_query, _, _, warnings = utils.generate_search_query(
         query=db.session.query(educational_models.CollectiveOffer.id),
         search_parameters=form.search.data,

--- a/api/src/pcapi/routes/backoffice/fraud/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/fraud/blueprint.py
@@ -19,7 +19,6 @@ from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
 from pcapi.core.users.api import suspend_account
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.routes.backoffice import utils
 
@@ -71,7 +70,7 @@ def list_blacklisted_domain_names() -> utils.BackofficeResponse:
     return render_domain_names_list()
 
 
-def _filter_non_pro_by_domain_name_query(domain_name: str) -> BaseQuery:
+def _filter_non_pro_by_domain_name_query(domain_name: str) -> sa_orm.Query:
     return db.session.query(users_models.User).filter(
         sa.not_(users_models.User.isActive.is_(False)),
         sa.not_(users_models.User.has_pro_role),

--- a/api/src/pcapi/routes/backoffice/non_payment_notices/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/non_payment_notices/blueprint.py
@@ -17,6 +17,7 @@ from pcapi.core.history import models as history_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.models import db
+from pcapi.models.utils import get_or_404
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.routes.backoffice import autocomplete
 from pcapi.routes.backoffice import utils
@@ -219,7 +220,7 @@ def create_non_payment_notice() -> utils.BackofficeResponse:
 @non_payment_notices_blueprint.route("/<int:notice_id>/edit", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.MANAGE_NON_PAYMENT_NOTICES)
 def get_edit_form(notice_id: int) -> utils.BackofficeResponse:
-    notice: offerers_models.NonPaymentNotice = db.session.query(offerers_models.NonPaymentNotice).get_or_404(notice_id)
+    notice: offerers_models.NonPaymentNotice = get_or_404(offerers_models.NonPaymentNotice, notice_id)
 
     form = forms.EditNonPaymentNoticeForm(
         date_received=notice.dateReceived,
@@ -251,7 +252,7 @@ def get_edit_form(notice_id: int) -> utils.BackofficeResponse:
 @non_payment_notices_blueprint.route("/<int:notice_id>/edit", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_NON_PAYMENT_NOTICES)
 def edit(notice_id: int) -> utils.BackofficeResponse:
-    notice: offerers_models.NonPaymentNotice = db.session.query(offerers_models.NonPaymentNotice).get_or_404(notice_id)
+    notice: offerers_models.NonPaymentNotice = get_or_404(offerers_models.NonPaymentNotice, notice_id)
 
     form = forms.EditNonPaymentNoticeForm()
     return _create_or_update_non_payment_notice(form, notice)

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -38,6 +38,7 @@ from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.feature import FeatureToggle
+from pcapi.models.utils import get_or_404
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.repository.session_management import on_commit
 from pcapi.routes.backoffice.bookings import forms as bookings_forms
@@ -417,7 +418,7 @@ def get_revenue_details(offerer_id: int) -> utils.BackofficeResponse:
 @offerer_blueprint.route("/api-keys", methods=["POST"])
 @utils.permission_required(perm_models.Permissions.MANAGE_TECH_PARTNERS)
 def generate_api_key(offerer_id: int) -> utils.BackofficeResponse:
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
     if offerer.isRejected or offerer.isClosed:
         raise BadRequest()  # No need for a user-friendly message since button is not available
     try:
@@ -1341,7 +1342,7 @@ def update_individual_subscription(offerer_id: int) -> utils.BackofficeResponse:
 @offerer_blueprint.route("/api-entreprise", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.READ_PRO_ENTREPRISE_INFO)
 def get_entreprise_info(offerer_id: int) -> utils.BackofficeResponse:
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
 
     if not siren_utils.is_valid_siren(offerer.siren):
         mark_transaction_as_invalid()
@@ -1377,7 +1378,7 @@ def get_entreprise_info(offerer_id: int) -> utils.BackofficeResponse:
 @offerer_blueprint.route("/api-entreprise/rcs", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.READ_PRO_ENTREPRISE_INFO)
 def get_entreprise_rcs_info(offerer_id: int) -> utils.BackofficeResponse:
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
 
     if not siren_utils.is_valid_siren(offerer.siren):
         raise NotFound()
@@ -1396,7 +1397,7 @@ def get_entreprise_rcs_info(offerer_id: int) -> utils.BackofficeResponse:
 @offerer_blueprint.route("/api-entreprise/urssaf", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.READ_PRO_SENSITIVE_INFO)
 def get_entreprise_urssaf_info(offerer_id: int) -> utils.BackofficeResponse:
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
 
     if not siren_utils.is_valid_siren(offerer.siren):
         raise NotFound()
@@ -1423,7 +1424,7 @@ def get_entreprise_urssaf_info(offerer_id: int) -> utils.BackofficeResponse:
 @offerer_blueprint.route("/api-entreprise/dgfip", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.READ_PRO_SENSITIVE_INFO)
 def get_entreprise_dgfip_info(offerer_id: int) -> utils.BackofficeResponse:
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
 
     if not siren_utils.is_valid_siren(offerer.siren):
         raise NotFound()
@@ -1450,7 +1451,7 @@ def get_entreprise_dgfip_info(offerer_id: int) -> utils.BackofficeResponse:
 @offerer_blueprint.route("/close", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.CLOSE_OFFERER)
 def get_close_offerer_form(offerer_id: int) -> utils.BackofficeResponse:
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
 
     form = offerer_forms.OffererClosureForm()
     info = None

--- a/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_blueprint.py
@@ -22,7 +22,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
+from pcapi.models.utils import get_or_404
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.routes.backoffice import autocomplete
@@ -78,7 +78,7 @@ def list_offerers_to_validate() -> utils.BackofficeResponse:
         to_datetime=date_utils.date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time()),
     )
 
-    sorted_offerers: BaseQuery = offerers.order_by(
+    sorted_offerers: sa_orm.Query = offerers.order_by(
         getattr(getattr(offerers_models.Offerer, form.sort.data), form.order.data)()
     )
 
@@ -154,7 +154,7 @@ def _get_validation_action_information(offerer_ids: typing.Collection[int]) -> s
 @validation_blueprint.route("/offerer/<int:offerer_id>/validate", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.VALIDATE_OFFERER)
 def get_validate_offerer_form(offerer_id: int) -> utils.BackofficeResponse:
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
     information = _get_validation_action_information([offerer_id])
 
     return render_template(
@@ -203,7 +203,7 @@ def validate_offerer(offerer_id: int) -> utils.BackofficeResponse:
 @validation_blueprint.route("/offerer/<int:offerer_id>/reject", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.VALIDATE_OFFERER)
 def get_reject_offerer_form(offerer_id: int) -> utils.BackofficeResponse:
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
     information = _get_validation_action_information([offerer_id])
 
     return render_template(
@@ -529,7 +529,7 @@ def list_offerers_attachments_to_validate() -> utils.BackofficeResponse:
         to_datetime=date_utils.date_to_localized_datetime(form.to_date.data, datetime.datetime.max.time()),
     )
 
-    sorted_users_offerers: BaseQuery = users_offerers.order_by(  # type: ignore[assignment]
+    sorted_users_offerers: sa_orm.Query = users_offerers.order_by(
         getattr(getattr(offerers_models.UserOfferer, form.sort.data), form.order.data)()
     )
 

--- a/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
+++ b/api/src/pcapi/routes/backoffice/offerers/validation_repository.py
@@ -16,7 +16,6 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
-from pcapi.models.pc_object import BaseQuery
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.utils import email as email_utils
 from pcapi.utils import siren as siren_utils
@@ -189,7 +188,7 @@ def list_offerers_to_be_validated(
     dms_adage_status: list[GraphQLApplicationStates] | None = None,
     from_datetime: datetime | None = None,
     to_datetime: datetime | None = None,
-) -> BaseQuery:
+) -> sa_orm.Query:
     # Fetch only the single last comment to avoid loading the full history (joinedload would fetch 1 row per action)
     # This replaces lookup for last comment in offerer.action_history after joining with all actions
     last_comment_subquery = (

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -45,7 +45,6 @@ from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.offer_mixin import OfferValidationType
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository import repository
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.repository.session_management import on_commit
@@ -342,7 +341,7 @@ def _get_offer_ids_algolia(form: forms.GetOfferAlgoliaSearchForm) -> list[int]:
     return ids
 
 
-def _get_offer_ids_query(form: forms.GetOfferAdvancedSearchForm) -> BaseQuery:
+def _get_offer_ids_query(form: forms.GetOfferAdvancedSearchForm) -> sa_orm.Query:
     query, _, _, warnings = utils.generate_search_query(
         query=db.session.query(offers_models.Offer),
         search_parameters=form.search.data,
@@ -360,7 +359,7 @@ def _get_offer_ids_query(form: forms.GetOfferAdvancedSearchForm) -> BaseQuery:
 
 
 def _get_offers_by_ids(
-    offer_ids: list[int] | BaseQuery, *, sort: str | None = None, order: str | None = None
+    offer_ids: list[int] | sa_orm.Query, *, sort: str | None = None, order: str | None = None
 ) -> list[offers_models.Offer]:
     if utils.has_current_user_permission(perm_models.Permissions.PRO_FRAUD_ACTIONS):
         # Those columns are not shown to fraud pro users

--- a/api/src/pcapi/routes/backoffice/pro/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro/blueprint.py
@@ -1,6 +1,7 @@
 import typing
 from functools import partial
 
+import sqlalchemy.orm as sa_orm
 from flask import flash
 from flask import redirect
 from flask import render_template
@@ -26,7 +27,6 @@ from pcapi.core.token.serialization import ConnectAsInternalModel
 from pcapi.core.users import api as users_api
 from pcapi.core.users import models as users_models
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.routes.backoffice import search_utils
 from pcapi.routes.backoffice import utils
@@ -51,8 +51,8 @@ class Context:
     and venues. Each one has its own context to handle its specificities
     """
 
-    fetch_rows_func: typing.Callable[[str, list[str]], BaseQuery]
-    get_item_base_query: typing.Callable[[int], BaseQuery]
+    fetch_rows_func: typing.Callable[[str, list[str]], sa_orm.Query]
+    get_item_base_query: typing.Callable[[int], sa_orm.Query]
     endpoint: str
     row_id_name: str
 
@@ -289,7 +289,7 @@ def create_offerer() -> utils.BackofficeResponse:
     return redirect(url_for("backoffice_web.offerer.get", offerer_id=user_offerer.offererId), code=303)
 
 
-def _get_connect_as_base_query() -> BaseQuery:
+def _get_connect_as_base_query() -> sa_orm.Query:
     """Returns all user_id to be used as a subquery."""
     return (
         db.session.query(users_models.User)
@@ -304,7 +304,7 @@ def _get_connect_as_base_query() -> BaseQuery:
     )
 
 
-def _get_best_user_id_for_connect_as(query: BaseQuery) -> int | None:
+def _get_best_user_id_for_connect_as(query: sa_orm.Query) -> int | None:
     """Partial workaround to fix connect as when a user as multiple offerers.
 
     The workaround is to try to always select a user with only one offerer when we can

--- a/api/src/pcapi/routes/backoffice/search_utils.py
+++ b/api/src/pcapi/routes/backoffice/search_utils.py
@@ -4,11 +4,11 @@ import re
 import typing
 
 import sqlalchemy as sa
+import sqlalchemy.orm as sa_orm
 from werkzeug.exceptions import NotFound
 
 from pcapi.core.finance import models as finance_models
 from pcapi.core.users import models as users_models
-from pcapi.models.pc_object import BaseQuery
 from pcapi.models.pc_object import PcObject
 from pcapi.routes.backoffice.forms import search as search_forms
 
@@ -46,7 +46,7 @@ def pagination_links(partial_func: UrlForPartial, current_page: int, pages_total
     return [(page, partial_func(page=page)) for page in range(start_page, end_page + 1)]
 
 
-def paginate(query: BaseQuery, page: int = 1, per_page: int = 20) -> PaginatedQuery:
+def paginate(query: sa_orm.Query, page: int = 1, per_page: int = 20) -> PaginatedQuery:
     if page < 1:
         raise NotFound()
 
@@ -73,7 +73,7 @@ def split_terms(search_query: str) -> list[str]:
     return re.split(r"[,;\s]+", search_query)
 
 
-def apply_filter_on_beneficiary_status(query: BaseQuery, account_search_filters: list[str]) -> BaseQuery:
+def apply_filter_on_beneficiary_status(query: sa_orm.Query, account_search_filters: list[str]) -> sa_orm.Query:
     query = query.outerjoin(
         finance_models.Deposit,
         sa.and_(

--- a/api/src/pcapi/routes/backoffice/utils.py
+++ b/api/src/pcapi/routes/backoffice/utils.py
@@ -7,6 +7,7 @@ import typing
 from collections import defaultdict
 from functools import wraps
 
+import sqlalchemy.orm as sa_orm
 from flask import Blueprint
 from flask import Response as FlaskResponse
 from flask import flash
@@ -27,7 +28,6 @@ from pcapi.core.permissions import models as perm_models
 from pcapi.models import db
 from pcapi.models import feature
 from pcapi.models.api_errors import ApiErrors
-from pcapi.models.pc_object import BaseQuery
 from pcapi.utils import date as date_utils
 from pcapi.utils.regions import get_all_regions
 
@@ -263,14 +263,14 @@ def get_regions_choices() -> list[tuple]:
 
 
 def generate_search_query(
-    query: BaseQuery,
+    query: sa_orm.Query,
     *,
     search_parameters: typing.Iterable[dict[str, typing.Any]],
     fields_definition: dict[str, dict[str, typing.Any]],
     joins_definition: dict[str, list[dict[str, typing.Any]]],
     subqueries_definition: dict[str, dict[str, typing.Any]],
     _ignore_subquery_joins: bool = False,
-) -> tuple[BaseQuery, set[str], set[str], set[str]]:
+) -> tuple[sa_orm.Query, set[str], set[str], set[str]]:
     """
     Generate a search query from a list of dict (from a ListField of FormFields).
 
@@ -346,11 +346,11 @@ def generate_search_query(
 
 
 def _manage_joins(
-    query: BaseQuery,
+    query: sa_orm.Query,
     joins: set,
     joins_definition: dict[str, list[dict[str, typing.Any]]],
     join_type: str = "inner_join",
-) -> tuple[BaseQuery, set[str]]:
+) -> tuple[sa_orm.Query, set[str]]:
     join_log = set()
     join_containers = sorted((joins_definition[join] for join in joins), key=len, reverse=True)
     for join_container in join_containers:

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -42,6 +42,7 @@ from pcapi.core.providers import models as providers_models
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.feature import FeatureToggle
+from pcapi.models.utils import get_or_404
 from pcapi.repository.session_management import mark_transaction_as_invalid
 from pcapi.repository.session_management import on_commit
 from pcapi.routes.backoffice import autocomplete
@@ -587,7 +588,7 @@ def get_history(venue_id: int) -> utils.BackofficeResponse:
 @venue_blueprint.route("/<int:venue_id>/protected-info", methods=["GET"])
 @utils.permission_required(perm_models.Permissions.READ_PRO_ENTREPRISE_INFO)
 def get_entreprise_info(venue_id: int) -> utils.BackofficeResponse:
-    venue = db.session.query(offerers_models.Venue).get_or_404(venue_id)
+    venue = get_or_404(offerers_models.Venue, venue_id)
 
     if not venue.siret:
         raise NotFound()

--- a/api/src/pcapi/routes/native/v1/bookings.py
+++ b/api/src/pcapi/routes/native/v1/bookings.py
@@ -11,6 +11,7 @@ from pcapi.core.providers.exceptions import InactiveProvider
 from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
+from pcapi.models.utils import first_or_404
 from pcapi.repository import repository
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.routes.native.v1.serialization.bookings import BookOfferRequest
@@ -122,7 +123,7 @@ def get_bookings(user: User) -> BookingsResponse:
 @spectree_serialize(api=blueprint.api, on_success_status=204, on_error_statuses=[400, 404])
 @authenticated_and_active_user_required
 def cancel_booking(user: User, booking_id: int) -> None:
-    booking = db.session.query(Booking).filter(Booking.id == booking_id, Booking.userId == user.id).first_or_404()
+    booking = first_or_404(db.session.query(Booking).filter(Booking.id == booking_id, Booking.userId == user.id))
     try:
         bookings_api.cancel_booking_by_beneficiary(user, booking)
     except bookings_exceptions.BookingIsCancelled:
@@ -150,6 +151,6 @@ def cancel_booking(user: User, booking_id: int) -> None:
 @spectree_serialize(api=blueprint.api, on_success_status=204, on_error_statuses=[400])
 @authenticated_and_active_user_required
 def flag_booking_as_used(user: User, booking_id: int, body: BookingDisplayStatusRequest) -> None:
-    booking = db.session.query(Booking).filter(Booking.userId == user.id, Booking.id == booking_id).first_or_404()
+    booking = first_or_404(db.session.query(Booking).filter(Booking.userId == user.id, Booking.id == booking_id))
     booking.displayAsEnded = body.ended
     repository.save(booking)

--- a/api/src/pcapi/routes/native/v1/favorites.py
+++ b/api/src/pcapi/routes/native/v1/favorites.py
@@ -21,6 +21,7 @@ from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ResourceNotFoundError
+from pcapi.models.utils import first_or_404
 from pcapi.repository import transaction
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
@@ -219,5 +220,5 @@ def create_favorite(user: User, body: serializers.FavoriteRequest) -> serializer
 @authenticated_and_active_user_required
 def delete_favorite(user: User, favorite_id: int) -> None:
     with transaction():
-        favorite = db.session.query(Favorite).filter_by(id=favorite_id, user=user).first_or_404()
+        favorite = first_or_404(db.session.query(Favorite).filter_by(id=favorite_id, user=user))
         db.session.delete(favorite)

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -22,6 +22,7 @@ from pcapi.core.offerers import repository
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ResourceNotFoundError
+from pcapi.models.utils import get_or_404
 from pcapi.repository.session_management import atomic
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import headline_offer_serialize
@@ -107,7 +108,7 @@ def get_offerer(offerer_id: int) -> offerers_serialize.GetOffererResponseModel:
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
 def invite_member(offerer_id: int, body: offerers_serialize.InviteMemberQueryModel) -> None:
     check_user_has_access_to_offerer(current_user, offerer_id)
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
     try:
         api.invite_member(offerer, body.email, current_user)
     except offerers_exceptions.EmailAlreadyInvitedException:
@@ -122,7 +123,7 @@ def invite_member(offerer_id: int, body: offerers_serialize.InviteMemberQueryMod
 @spectree_serialize(on_success_status=204, api=blueprint.pro_private_schema)
 def invite_member_again(offerer_id: int, body: offerers_serialize.InviteMemberQueryModel) -> None:
     check_user_has_access_to_offerer(current_user, offerer_id)
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
     try:
         api.invite_member_again(offerer, body.email)
     except offerers_exceptions.InviteAgainImpossibleException:
@@ -135,7 +136,7 @@ def invite_member_again(offerer_id: int, body: offerers_serialize.InviteMemberQu
 @spectree_serialize(response_model=offerers_serialize.GetOffererMembersResponseModel, api=blueprint.pro_private_schema)
 def get_offerer_members(offerer_id: int) -> offerers_serialize.GetOffererMembersResponseModel:
     check_user_has_access_to_offerer(current_user, offerer_id)
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
     members = api.get_offerer_members(offerer)
     return offerers_serialize.GetOffererMembersResponseModel(
         members=[
@@ -178,7 +179,7 @@ def create_offerer(body: offerers_serialize.CreateOffererQueryModel) -> offerers
 def get_offerer_stats_dashboard_url(
     offerer_id: int,
 ) -> offerers_serialize.OffererStatsResponseModel:
-    offerer = db.session.query(offerers_models.Offerer).get_or_404(offerer_id)
+    offerer = get_or_404(offerers_models.Offerer, offerer_id)
     check_user_has_access_to_offerer(current_user, offerer.id)
     url = api.get_metabase_stats_iframe_url(offerer, venues=offerer.managedVenues)
     return offerers_serialize.OffererStatsResponseModel(dashboardUrl=url)

--- a/api/src/pcapi/routes/pro/providers.py
+++ b/api/src/pcapi/routes/pro/providers.py
@@ -2,7 +2,7 @@ from flask_login import login_required
 
 import pcapi.core.providers.repository as providers_repository
 from pcapi.core.offerers.models import Venue
-from pcapi.models import db
+from pcapi.models.utils import get_or_404
 from pcapi.repository.session_management import atomic
 from pcapi.routes.serialization.providers_serialize import ListProviderResponse
 from pcapi.routes.serialization.providers_serialize import ProviderResponse
@@ -21,6 +21,6 @@ from . import blueprint
     api=blueprint.pro_private_schema,
 )
 def get_providers_by_venue(venue_id: int) -> ListProviderResponse:
-    venue = db.session.query(Venue).get_or_404(venue_id)
+    venue = get_or_404(Venue, venue_id)
     providers = providers_repository.get_available_providers(venue)
     return ListProviderResponse(__root__=[ProviderResponse.from_orm(provider) for provider in providers])

--- a/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_bookings_serialize.py
@@ -6,6 +6,7 @@ from enum import Enum
 from io import BytesIO
 from io import StringIO
 
+import sqlalchemy.orm as sa_orm
 import xlsxwriter
 from pydantic.v1 import root_validator
 
@@ -15,7 +16,6 @@ from pcapi.core.educational import models
 from pcapi.core.educational import repository
 from pcapi.core.finance.models import BankAccountApplicationStatus
 from pcapi.models.api_errors import ApiErrors
-from pcapi.models.pc_object import BaseQuery
 from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization.collective_offers_serialize import CollectiveOfferOfferVenueResponseModel
 from pcapi.routes.serialization.educational_institutions import EducationalInstitutionResponseModel
@@ -344,7 +344,7 @@ COLLECTIVE_BOOKING_EXPORT_HEADER = [
 ]
 
 
-def serialize_collective_booking_csv_report(query: BaseQuery) -> str:
+def serialize_collective_booking_csv_report(query: sa_orm.Query) -> str:
     output = StringIO()
     writer = csv.writer(output, dialect=csv.excel, delimiter=";", quoting=csv.QUOTE_NONNUMERIC)
     writer.writerow(COLLECTIVE_BOOKING_EXPORT_HEADER)
@@ -374,7 +374,7 @@ def serialize_collective_booking_csv_report(query: BaseQuery) -> str:
     return output.getvalue()
 
 
-def serialize_collective_booking_excel_report(query: BaseQuery) -> bytes:
+def serialize_collective_booking_excel_report(query: sa_orm.Query) -> bytes:
     output = BytesIO()
     workbook = xlsxwriter.Workbook(output)
 

--- a/api/src/pcapi/scripts/booking/handle_expired_bookings.py
+++ b/api/src/pcapi/scripts/booking/handle_expired_bookings.py
@@ -3,6 +3,8 @@ import logging
 from itertools import groupby
 from operator import attrgetter
 
+from sqlalchemy import orm as sa_orm
+
 import pcapi.core.bookings.repository as bookings_repository
 import pcapi.core.educational.repository as educational_repository
 import pcapi.core.mails.transactional as transactional_mails
@@ -15,7 +17,6 @@ from pcapi.core.educational.models import CollectiveBookingCancellationReasons
 from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.users.models import User
 from pcapi.models import db
-from pcapi.models.pc_object import BaseQuery
 
 
 logger = logging.getLogger(__name__)
@@ -59,7 +60,7 @@ def cancel_expired_individual_bookings(batch_size: int = 500) -> None:
     logger.info("[cancel_expired_individual_bookings] End")
 
 
-def cancel_expired_bookings(query: BaseQuery, batch_size: int = 500) -> None:
+def cancel_expired_bookings(query: sa_orm.Query, batch_size: int = 500) -> None:
     updated_total = 0
     expiring_booking_ids = [b[0] for b in query.with_entities(Booking.id).all()]
 

--- a/api/tests/models/pc_object_test.py
+++ b/api/tests/models/pc_object_test.py
@@ -1,15 +1,10 @@
 from datetime import datetime
 
-import pytest
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
-from werkzeug.exceptions import NotFound
 
-from pcapi.core.users import factories as users_factories
-from pcapi.core.users import models as users_models
 from pcapi.models import Base
 from pcapi.models import Model
-from pcapi.models import db
 from pcapi.models.pc_object import PcObject
 
 
@@ -33,22 +28,3 @@ time_interval = TimeInterval()
 time_interval.start = datetime(2018, 1, 1, 10, 20, 30, 111000)
 time_interval.end = datetime(2018, 2, 2, 5, 15, 25, 222000)
 now = datetime.utcnow()
-
-
-class FirstOr404Test:
-    def test_first_or_404_should_return_first_object_when_found(self, db_session):
-        obj_1 = users_factories.UserFactory(firstName="Alice")
-        obj_2 = users_factories.UserFactory(firstName="Alice")
-        obj_3 = users_factories.UserFactory(firstName="Bob")
-        db.session.add_all([obj_1, obj_2, obj_3])
-
-        first_object = db.session.query(users_models.User).filter(users_models.User.firstName == "Alice").first_or_404()
-
-        assert first_object in (obj_1, obj_2)
-
-    def test_first_or_404_should_raise_exception_when_not_found(self, db_session):
-        obj = users_factories.UserFactory(firstName="Alice")
-        db.session.add(obj)
-
-        with pytest.raises(NotFound):
-            db.session.query(users_models.User).filter(users_models.User.firstName == "Bob").first_or_404()

--- a/api/tests/models/utils_test.py
+++ b/api/tests/models/utils_test.py
@@ -1,0 +1,26 @@
+import pytest
+from werkzeug.exceptions import NotFound
+
+from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
+from pcapi.models import db
+from pcapi.models.utils import first_or_404
+
+
+class FirstOr404Test:
+    def test_first_or_404_should_return_first_object_when_found(self, db_session):
+        obj_1 = users_factories.UserFactory(firstName="Alice")
+        obj_2 = users_factories.UserFactory(firstName="Alice")
+        obj_3 = users_factories.UserFactory(firstName="Bob")
+        db.session.add_all([obj_1, obj_2, obj_3])
+
+        first_object = first_or_404(db.session.query(users_models.User).filter(users_models.User.firstName == "Alice"))
+
+        assert first_object in (obj_1, obj_2)
+
+    def test_first_or_404_should_raise_exception_when_not_found(self, db_session):
+        obj = users_factories.UserFactory(firstName="Alice")
+        db.session.add(obj)
+
+        with pytest.raises(NotFound):
+            first_or_404(db.session.query(users_models.User).filter(users_models.User.firstName == "Bob"))

--- a/api/tests/routes/backoffice/titelive_test.py
+++ b/api/tests/routes/backoffice/titelive_test.py
@@ -15,6 +15,7 @@ from pcapi.core.permissions import models as perm_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationType
+from pcapi.models.utils import get_or_404
 from pcapi.routes.backoffice.filters import format_titelive_id_lectorat
 
 from ...connectors.titelive import fixtures
@@ -235,13 +236,13 @@ class AddProductWhitelistTest(PostEndpointHelper):
         mock_whitelist_product.assert_called_with(self.endpoint_kwargs["ean"])
 
         for offer in offers_to_restore:
-            offer = db.session.query(offers_models.Offer).get_or_404(offer.id)
+            offer = get_or_404(offers_models.Offer, offer.id)
             assert offer.validation == offers_models.OfferValidationStatus.APPROVED
             assert offer.lastValidationDate.strftime("%d/%m/%Y") == datetime.date.today().strftime("%d/%m/%Y")
             assert offer.lastValidationType == OfferValidationType.MANUAL
 
         for offer in offers_not_to_restore:
-            offer = db.session.query(offers_models.Offer).get_or_404(offer.id)
+            offer = get_or_404(offers_models.Offer, offer.id)
             assert not offer.validation == offers_models.OfferValidationStatus.APPROVED
             assert offer.lastValidationDate.strftime("%d/%m/%Y") == (
                 datetime.date.today() - datetime.timedelta(days=2)
@@ -366,7 +367,7 @@ class AddProductWhitelistTest(PostEndpointHelper):
 
         self.post_to_endpoint(authenticated_client, form=self.form_data, **self.endpoint_kwargs)
 
-        offer = db.session.query(offers_models.Offer).get_or_404(offer.id)
+        offer = get_or_404(offers_models.Offer, offer.id)
         assert offer.validation == offers_models.OfferValidationStatus.APPROVED
         assert offer.lastValidationDate.strftime("%d/%m/%Y") == datetime.date.today().strftime("%d/%m/%Y")
         assert offer.lastValidationType == OfferValidationType.MANUAL


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-XXXXX)

The issue : `get_or_404` is very hard to type correctly when it is provided by the query. In order to ease the transition to `flask-sqlalchemy` and avoid typing issue, we decided to remove `BaseQuery` and provide easy utility type for `get_or_404` and `first_or_404`

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
