### PR TITLE
(BSR) ci: allow VS Code mypy extension activation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  "mypy-type-checker.cwd": "${workspaceFolder}/api",
+  "mypy-type-checker.importStrategy": "fromEnvironment",
+  "mypy-type-checker.preferDaemon": true,
+  "mypy-type-checker.reportingScope": "workspace",
   "python.formatting.provider": "black",
   "python.testing.cwd": "${workspaceFolder}/api",
   "python.testing.pytestEnabled": true,

--- a/api/bin/alembic_add_not_null_constraint.py
+++ b/api/bin/alembic_add_not_null_constraint.py
@@ -22,6 +22,7 @@ import pathlib
 import string
 import subprocess
 import sys
+from typing import Any
 
 import alembic.util as alembic_util
 
@@ -35,7 +36,7 @@ ALEMBIC_TEMPLATE = ALEMBIC_DIR / "script.py.mako"
 ALEMBIC_VERSION_DIR = ALEMBIC_DIR / "versions"
 
 
-def _get_alembic_version_filename_template():
+def _get_alembic_version_filename_template() -> str:
     parser = configparser.ConfigParser()
     with open(ALEMBIC_INI_FILE) as fp:
         parser.read_file(fp)
@@ -111,7 +112,7 @@ STEP_4 = {
 STEPS = (STEP_1, STEP_2, STEP_3, STEP_4)
 
 
-def main():
+def main() -> None:
     args = parse_args()
 
     bindings = {
@@ -164,7 +165,7 @@ def main():
         down_revision = rev_id
 
 
-def get_current_post_head():
+def get_current_post_head() -> str:
     command = "alembic show post@head"
     result = subprocess.run(
         command.split(" "),
@@ -192,7 +193,7 @@ def get_current_post_head():
     sys.exit(message)
 
 
-def fake_alembic_config_for_template():
+def fake_alembic_config_for_template() -> Any:
     # The template needs an Alembic config object to populate
     # `${config.cmd_opts.head.split("@")[0]}`. We know we want to
     # replace that by "post".
@@ -205,7 +206,7 @@ def fake_alembic_config_for_template():
     return Config()
 
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--table", required=True)
     parser.add_argument("--column", required=True)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -125,7 +125,6 @@ types-urllib3 = "^1.26.25.14"
 python_version = "3.11"
 mypy_path = "stubs/"
 disallow_untyped_defs = true
-follow_imports = "silent"
 # The following line solves the internal mypy (v>1.4) error due to
 # the usage of @declared_attr. See github issue here:
 # https://github.com/sqlalchemy/sqlalchemy/issues/10282


### PR DESCRIPTION
1. Ajout de quelques types pour que `cd api && mypy .` passe sans erreur.
2. Suppression de l'option `--follow-imports=silent` car à priori inutile sur la base de code actuelle + non recommandé par leur doc + non supporté par le daemon mypy.
3. Ajoute des settings par défaut pour que l'extension Mypy (Microsoft) fonctionne par défaut et de manière optimale.

## Notes

- L'ajout des settings lié au daemon est possiblement trop opinionated. Il y a un vrai gain à l'utiliser car il indexe arbres de fichiers et de types, les met en cache et permet du check incrémental via change diffs. Cela permet d'avoir type-checking sur le scope du workspace entier sans impact sur les perfs.
- À vérifier mais j'ai noté que de limiter le scope au seul fichier semblait ne pas toujours lier les types "lointains", d'où l'importance du point précédent.
- Je me suis permis un `Any` car je ne voyais pas comment typer un des retours du script Alembic (`Config`).
