### PR TITLE
(BSR)[API] fix: make cine chronicles offers bookable

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_chronicles.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_chronicles.py
@@ -66,7 +66,7 @@ def create_industrial_chronicles() -> None:
             subcategoryId=subcategories.SEANCE_CINE.id,
         )
         products_with_allocine_id.append(product)
-        offers_factories.OfferFactory(product=product)
+        offers_factories.StockFactory(offer__product=product)
 
     logger.info("Creating 'BOOK' type chronicles with all fields")
     for user, product, i in zip(itertools.cycle(users), itertools.cycle(products_with_ean), range(30)):


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

- Utiliser la factory `StockFactory` au lieu de `OfferFactory` pour que l'offre créée soit réservable, et donc indexée sur Algolia