### PR TITLE
(PC-36938)[PRO] fix: recap preview adage info price for offer bookable

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferInfoSection.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/AdageOfferInfoSection.tsx
@@ -144,7 +144,9 @@ export const AdageOfferInfoSection = ({
             {isOfferBookable ? 'Prix' : 'Information sur le prix'}
           </h3>
           {isOfferBookable && <p>{getBookableOfferStockPrice(offer)}</p>}
-          {offer.educationalPriceDetail}
+          {isOfferBookable
+            ? offer.stock.educationalPriceDetail
+            : offer.educationalPriceDetail}
         </div>
       )}
     </>

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferDetailsSection/__specs__/AdageOfferInfoSection.spec.tsx
@@ -90,6 +90,24 @@ describe('AdageOfferInfoSection', () => {
     expect(screen.getByText('The detail of the price')).toBeInTheDocument()
   })
 
+  it('should display the offer price details for a bookable offer', () => {
+    renderAdageOfferInfoSection({
+      offer: {
+        ...defaultCollectiveOffer,
+        educationalPriceDetail: 'The detail of the price',
+        stock: {
+          ...defaultCollectiveOffer.stock,
+          educationalPriceDetail: 'Price details for bookable offer',
+        },
+      },
+    })
+
+    expect(screen.getByRole('heading', { name: 'Prix' })).toBeInTheDocument()
+    expect(
+      screen.getByText('Price details for bookable offer')
+    ).toBeInTheDocument()
+  })
+
   it('should not display the price details section if the offer has no price details', () => {
     renderAdageOfferInfoSection({
       offer: {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36938)

Ajouter l'information sur le prix dans l'aperçu sur adage d'une offre
