### PR TITLE
(PC-36948)[PRO] fix: accueil link redirect to collective offer ith st…

### DIFF
--- a/pro/src/commons/core/Offers/hooks/__specs__/useQuerySearchFilters.spec.ts
+++ b/pro/src/commons/core/Offers/hooks/__specs__/useQuerySearchFilters.spec.ts
@@ -1,0 +1,56 @@
+import { renderHook } from '@testing-library/react'
+import * as reactRouter from 'react-router'
+
+import { useQueryCollectiveSearchFilters } from '../useQuerySearchFilters'
+
+vi.mock('react-router', async () => ({
+  ...(await vi.importActual('react-router')),
+  useLocation: vi.fn(),
+}))
+
+describe('useQueryCollectiveSearchFilters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return status as an array if status is a string in the URL', () => {
+    // @ts-expect-error
+    reactRouter.useLocation.mockReturnValue({
+      search: '?status=UNDER_REVIEW&page=2',
+    })
+
+    const { result } = renderHook(() => useQueryCollectiveSearchFilters())
+    expect(result.current.status).toEqual(['UNDER_REVIEW'])
+    expect(result.current.page).toBe(2)
+  })
+
+  it('should return status as an array if multiple status are present in the URL', () => {
+    // @ts-expect-error
+    reactRouter.useLocation.mockReturnValue({
+      search: '?status=active&status=en-attente',
+    })
+
+    const { result } = renderHook(() => useQueryCollectiveSearchFilters())
+    expect(result.current.status).toEqual(['PUBLISHED', 'UNDER_REVIEW'])
+  })
+
+  it('should return undefined for status if status is absent in the URL', () => {
+    // @ts-expect-error
+    reactRouter.useLocation.mockReturnValue({
+      search: '',
+    })
+
+    const { result } = renderHook(() => useQueryCollectiveSearchFilters())
+    expect(result.current.status).toBeUndefined()
+  })
+
+  it('should convert page to a number', () => {
+    // @ts-expect-error
+    reactRouter.useLocation.mockReturnValue({
+      search: '?page=3',
+    })
+
+    const { result } = renderHook(() => useQueryCollectiveSearchFilters())
+    expect(result.current.page).toBe(3)
+  })
+})

--- a/pro/src/commons/core/Offers/hooks/useQuerySearchFilters.ts
+++ b/pro/src/commons/core/Offers/hooks/useQuerySearchFilters.ts
@@ -14,12 +14,13 @@ export const useQuerySearchFilters = (): Partial<SearchFiltersParams> => {
     const urlParams = new URLSearchParams(search)
     const queryParams = parseUrlParams(urlParams)
 
-    const urlFilters: Partial<SearchFiltersParams> = translateQueryParamsToApiParams(
-      {
-        ...queryParams,
-      },
-      Audience.INDIVIDUAL
-    )
+    const urlFilters: Partial<SearchFiltersParams> =
+      translateQueryParamsToApiParams(
+        {
+          ...queryParams,
+        },
+        Audience.INDIVIDUAL
+      )
 
     // Convert page type to number
     urlFilters.page =
@@ -33,24 +34,30 @@ export const useQuerySearchFilters = (): Partial<SearchFiltersParams> => {
   return urlSearchFilters
 }
 
-export const useQueryCollectiveSearchFilters = (): Partial<CollectiveSearchFiltersParams> => {
-  const { search } = useLocation()
+export const useQueryCollectiveSearchFilters =
+  (): Partial<CollectiveSearchFiltersParams> => {
+    const { search } = useLocation()
 
-  const urlParams = new URLSearchParams(search)
-  const queryParams = parseUrlParams(urlParams)
+    const urlParams = new URLSearchParams(search)
+    const queryParams = parseUrlParams(urlParams)
 
-  const urlFilters: Partial<CollectiveSearchFiltersParams> = translateQueryParamsToApiParams(
-    {
-      ...queryParams,
-    },
-    Audience.COLLECTIVE
-  )
+    const urlFilters: Partial<CollectiveSearchFiltersParams> =
+      translateQueryParamsToApiParams(
+        {
+          ...queryParams,
+        },
+        Audience.COLLECTIVE
+      )
 
-  // Convert page type to number
-  urlFilters.page =
-    typeof urlFilters.page === 'string'
-      ? parseInt(urlFilters.page)
-      : urlFilters.page
+    // Convert page type to number
+    urlFilters.page =
+      typeof urlFilters.page === 'string'
+        ? parseInt(urlFilters.page)
+        : urlFilters.page
 
-  return urlFilters
-}
+    if (urlFilters.status && !Array.isArray(urlFilters.status)) {
+      urlFilters.status = [urlFilters.status]
+    }
+
+    return urlFilters
+  }

--- a/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
+++ b/pro/src/pages/CollectiveOffers/CollectiveOffers.tsx
@@ -5,9 +5,7 @@ import useSWR from 'swr'
 import { api } from 'apiClient/api'
 import { CollectiveOfferType } from 'apiClient/v1'
 import { Layout } from 'app/App/layout/Layout'
-import {
-  GET_VENUES_QUERY_KEY,
-} from 'commons/config/swrQueryKeys'
+import { GET_VENUES_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { DEFAULT_PAGE } from 'commons/core/Offers/constants'
 import { useDefaultCollectiveSearchFilters } from 'commons/core/Offers/hooks/useDefaultCollectiveSearchFilters'
 import { useQueryCollectiveSearchFilters } from 'commons/core/Offers/hooks/useQuerySearchFilters'
@@ -31,10 +29,10 @@ export const CollectiveOffers = (): JSX.Element => {
   const urlSearchFilters = useQueryCollectiveSearchFilters()
   const { storedFilters } = getStoredFilterConfig('collective')
   const finalSearchFilters = {
-    ...urlSearchFilters,
     ...(isToggleAndMemorizeFiltersEnabled
       ? (storedFilters as Partial<CollectiveSearchFiltersParams>)
       : {}),
+    ...urlSearchFilters,
   }
 
   const isNewOffersAndBookingsActive = useActiveFeature(
@@ -48,7 +46,11 @@ export const CollectiveOffers = (): JSX.Element => {
 
   const currentPageNumber = finalSearchFilters.page ?? DEFAULT_PAGE
 
-  const { data: offerer, isLoading: isOffererLoading, isValidating: isOffererValidating } = useOfferer(
+  const {
+    data: offerer,
+    isLoading: isOffererLoading,
+    isValidating: isOffererValidating,
+  } = useOfferer(
     offererId !== defaultCollectiveFilters.offererId ? offererId : null,
     true
   )
@@ -129,9 +131,9 @@ export const CollectiveOffers = (): JSX.Element => {
       {/* When the venues are cached for a given offerer, we still need to reset the Screen component.
       SWR isLoading is only true when the data is not cached, while isValidating is always set to true when the key is updated */}
       {isOffererLoading ||
-        isOffererValidating ||
-        isVenuesLoading ||
-        isVenuesValidating ? (
+      isOffererValidating ||
+      isVenuesLoading ||
+      isVenuesValidating ? (
         <Spinner />
       ) : (
         <CollectiveOffersScreen

--- a/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
+++ b/pro/src/pages/CollectiveOffers/__specs__/CollectiveOffers.spec.tsx
@@ -113,7 +113,7 @@ describe('route CollectiveOffers', () => {
             2,
             undefined,
             '1',
-            CollectiveOfferDisplayedStatus.EXPIRED,
+            [CollectiveOfferDisplayedStatus.EXPIRED],
             undefined,
             undefined,
             undefined,


### PR DESCRIPTION
…atus

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36948)

Les liens sur la page d'accueil redirigent vers la liste des offres collectives en préfiltrant avec un statut

Avant la migration on initialisé les valeurs du status avec formik, donc maintenant dans le MultiSelect on regarde si il y a un status dans les filtres