### PR TITLE
(PC-36838)[PRO] feat: prepare post & patch routes for new offer creation flow

### DIFF
--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -29,6 +29,12 @@ class PostDraftOfferBodyModel(BaseModel):
     duration_minutes: int | None = None
     product_id: int | None
     video_url: HttpUrl | None
+    # These props become mandatory when `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` feature flag is enabled.
+    # They are optional here in order to not break the existing POST `/offers/drafts` route while both flows coexist.
+    audio_disability_compliant: bool | None
+    mental_disability_compliant: bool | None
+    motor_disability_compliant: bool | None
+    visual_disability_compliant: bool | None
 
     @validator("name", pre=True)
     def validate_name(cls, name: str, values: dict) -> str:
@@ -53,6 +59,12 @@ class PatchDraftOfferBodyModel(BaseModel):
     extra_data: dict[str, typing.Any] | None = None
     duration_minutes: int | None = None
     video_url: HttpUrl | None
+    # These props become mandatory when `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` feature flag is enabled.
+    # They are optional here in order to not break the existing POST `/offers/drafts` route while both flows coexist.
+    audio_disability_compliant: bool | None
+    mental_disability_compliant: bool | None
+    motor_disability_compliant: bool | None
+    visual_disability_compliant: bool | None
 
     @validator("name", pre=True)
     def validate_name(cls, name: str, values: dict) -> str:

--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -59,8 +59,6 @@ class PatchDraftOfferBodyModel(BaseModel):
     extra_data: dict[str, typing.Any] | None = None
     duration_minutes: int | None = None
     video_url: HttpUrl | None
-    # These props become mandatory when `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` feature flag is enabled.
-    # They are optional here in order to not break the existing POST `/offers/drafts` route while both flows coexist.
     audio_disability_compliant: bool | None
     mental_disability_compliant: bool | None
     motor_disability_compliant: bool | None

--- a/api/tests/routes/pro/patch_draft_offer_test.py
+++ b/api/tests/routes/pro/patch_draft_offer_test.py
@@ -377,7 +377,7 @@ class Returns200Test:
         assert response.json["address"]["label"] == venue.common_name if is_venue_address else "Librairie des mangas"
 
     @pytest.mark.features(WIP_ENABLE_NEW_OFFER_CREATION_FLOW=True)
-    def test_update_offer_draft_with_new_offer_creation_flow(self, client):
+    def test_update_offer_accepts_accessibility_fields(self, client):
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
         venue = offerers_factories.VirtualVenueFactory(managingOfferer=user_offerer.offerer)
         offer = offers_factories.OfferFactory(
@@ -489,7 +489,7 @@ class Returns400Test:
         assert response.json["global"] == ["Les extraData des offres avec produit ne sont pas modifiables"]
 
     @pytest.mark.features(WIP_ENABLE_NEW_OFFER_CREATION_FLOW=True)
-    def test_fail_when_body_has_null_disability_props_with_new_offer_creation_flow(self, client):
+    def test_fail_when_body_has_null_accessibility_fields(self, client):
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
         venue = offerers_factories.VirtualVenueFactory(managingOfferer=user_offerer.offerer)
         offer = offers_factories.OfferFactory(

--- a/api/tests/routes/pro/post_draft_offer_test.py
+++ b/api/tests/routes/pro/post_draft_offer_test.py
@@ -287,7 +287,7 @@ class Returns201Test:
         assert offer.visualDisabilityCompliant == True
 
     @pytest.mark.features(WIP_ENABLE_NEW_OFFER_CREATION_FLOW=True)
-    def test_create_offer_with_new_offer_creation_flow(self, client):
+    def test_create_offer_accepts_accessibility_fields(self, client):
         venue = offerers_factories.VenueFactory(
             audioDisabilityCompliant=False,
             mentalDisabilityCompliant=False,
@@ -440,7 +440,7 @@ class Returns400Test:
         assert response.json["subcategory"] == [msg]
 
     @pytest.mark.features(WIP_ENABLE_NEW_OFFER_CREATION_FLOW=True)
-    def test_fail_when_body_is_missing_disability_props_with_new_offer_creation_flow(self, client):
+    def test_fail_when_body_is_missing_accessibility_fields(self, client):
         venue = offerers_factories.VenueFactory()
         offerer = venue.managingOfferer
         offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")

--- a/pro/src/apiClient/v1/models/PatchDraftOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PatchDraftOfferBodyModel.ts
@@ -3,12 +3,16 @@
 /* tslint:disable */
 /* eslint-disable */
 export type PatchDraftOfferBodyModel = {
+  audioDisabilityCompliant?: boolean | null;
   description?: string | null;
   durationMinutes?: number | null;
   extraData?: Record<string, any> | null;
+  mentalDisabilityCompliant?: boolean | null;
+  motorDisabilityCompliant?: boolean | null;
   name?: string | null;
   subcategoryId?: string | null;
   url?: string | null;
   videoUrl?: string | null;
+  visualDisabilityCompliant?: boolean | null;
 };
 

--- a/pro/src/apiClient/v1/models/PostDraftOfferBodyModel.ts
+++ b/pro/src/apiClient/v1/models/PostDraftOfferBodyModel.ts
@@ -3,14 +3,18 @@
 /* tslint:disable */
 /* eslint-disable */
 export type PostDraftOfferBodyModel = {
+  audioDisabilityCompliant?: boolean | null;
   description?: string | null;
   durationMinutes?: number | null;
   extraData?: any;
+  mentalDisabilityCompliant?: boolean | null;
+  motorDisabilityCompliant?: boolean | null;
   name: string;
   productId?: number | null;
   subcategoryId: string;
   url?: string | null;
   venueId: number;
   videoUrl?: string | null;
+  visualDisabilityCompliant?: boolean | null;
 };
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36838)

### Changes

- Validate accessibility modes body props on POST et PATCH `/offers/draft[/<offer_id>]` when `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` FF is enabled.

### Usage

N/A.

- [ ] Travail pair testé en environnement de preview
