### PR TITLE
Pc 36742 add chronicles count to offer route

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -809,6 +809,7 @@ class Offer(PcObject, Base, Model, ValidationMixin, AccessibilityMixin):
     isNonFreeOffer: sa_orm.Mapped["bool"] = sa_orm.query_expression()
     bookingsCount: sa_orm.Mapped["int"] = sa_orm.query_expression()
     hasPendingBookings: sa_orm.Mapped["bool"] = sa_orm.query_expression()
+    chroniclesCount: sa_orm.Mapped["int"] = sa_orm.query_expression()
     likesCount: sa_orm.Mapped["int"] = sa_orm.query_expression()
 
     @property

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -483,6 +483,16 @@ def get_base_query_for_offer_indexation() -> BaseQuery:
             )
         )
         .options(sa_orm.joinedload(offers_models.Offer.headlineOffers))
+        .options(
+            sa_orm.with_expression(
+                offers_models.Offer.chroniclesCount, offers_repository.get_offer_chronicles_count_subquery()
+            )
+        )
+        .options(
+            sa_orm.with_expression(
+                offers_models.Offer.likesCount, offers_repository.get_offer_reaction_count_subquery()
+            )
+        )
         .options(sa_orm.joinedload(offers_models.Offer.criteria).load_only(criteria_models.Criterion.id))
         .options(sa_orm.joinedload(offers_models.Offer.mediations).load_only(offers_models.Mediation.id))
         .options(

--- a/api/src/pcapi/core/search/serialization.py
+++ b/api/src/pcapi/core/search/serialization.py
@@ -241,7 +241,6 @@ class AlgoliaSerializationMixin:
         )
         headlines_count = offer.product.headlinesCount if offer.product and offer.product.headlinesCount else None
         likes_count = offer.product.likesCount if offer.product and offer.product.likesCount else offer.likesCount
-
         # If you update this dictionary, please check whether you need to
         # also update `core.offerers.api.VENUE_ALGOLIA_INDEXED_FIELDS`.
         object_to_index: dict[str, typing.Any] = {
@@ -250,7 +249,7 @@ class AlgoliaSerializationMixin:
             "offer": {
                 "allocineId": extra_data.get("allocineId"),
                 "artist": " ".join(extra_data_artists).strip() or None,
-                "chroniclesCount": chronicles_count,
+                "chroniclesCount": chronicles_count or None,
                 "bookMacroSection": macro_section,
                 "dateCreated": date_created,
                 "dates": sorted(dates),
@@ -260,7 +259,7 @@ class AlgoliaSerializationMixin:
                 "gtlCodeLevel2": gtl_code_2,
                 "gtlCodeLevel3": gtl_code_3,
                 "gtlCodeLevel4": gtl_code_4,
-                "headlinesCount": headlines_count,
+                "headlinesCount": headlines_count or None,
                 "indexedAt": datetime.datetime.utcnow().isoformat(),
                 "isDigital": offer.isDigital,
                 "isDuo": offer.isDuo,
@@ -271,7 +270,7 @@ class AlgoliaSerializationMixin:
                 "isThing": offer.isThing,
                 "last30DaysBookings": last_30_days_bookings,
                 "last30DaysBookingsRange": get_last_30_days_bookings_range(last_30_days_bookings),
-                "likes": likes_count,
+                "likes": likes_count or None,
                 "movieGenres": extra_data.get("genres"),
                 "musicType": music_type_labels,
                 "name": offer.name,

--- a/api/src/pcapi/core/search/serialization.py
+++ b/api/src/pcapi/core/search/serialization.py
@@ -236,9 +236,11 @@ class AlgoliaSerializationMixin:
             (headline_offer for headline_offer in offer.headlineOffers if headline_offer.isActive), None
         )
 
-        chronicles_count = offer.product.chroniclesCount if offer.product and offer.product.chroniclesCount else None
+        chronicles_count = (
+            offer.product.chroniclesCount if offer.product and offer.product.chroniclesCount else offer.chroniclesCount
+        )
         headlines_count = offer.product.headlinesCount if offer.product and offer.product.headlinesCount else None
-        likes_count = offer.product.likesCount if offer.product and offer.product.likesCount else None
+        likes_count = offer.product.likesCount if offer.product and offer.product.likesCount else offer.likesCount
 
         # If you update this dictionary, please check whether you need to
         # also update `core.offerers.api.VENUE_ALGOLIA_INDEXED_FIELDS`.

--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -20,6 +20,7 @@ from pcapi.core.categories.genres.show import SHOW_TYPES_LABEL_BY_CODE
 from pcapi.core.chronicles.api import get_offer_published_chronicles
 from pcapi.core.geography.models import Address
 from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offers import models
 from pcapi.core.offers import offer_metadata
 from pcapi.core.offers import repository as offers_repository
 from pcapi.core.offers.api import get_expense_domains
@@ -263,8 +264,9 @@ MAX_PREVIEW_CHRONICLES = 5
 
 class BaseOfferResponseGetterDict(GetterDict):
     def get(self, key: str, default: Any = None) -> Any:
-        offer = self._obj
-        product = offer.product
+        offer: models.Offer = self._obj
+        product: models.Product | None = offer.product
+
         if key == "reactions_count":
             if product:
                 likes = product.likesCount or 0
@@ -347,6 +349,9 @@ class BaseOfferResponseGetterDict(GetterDict):
             published_chronicles = get_offer_published_chronicles(offer)
             return published_chronicles[:MAX_PREVIEW_CHRONICLES]
 
+        if key == "chroniclesCount":
+            return product.chroniclesCount if product and product.chroniclesCount else offer.chroniclesCount
+
         if key == "publicationDate":
             return offer.bookingAllowedDatetime  # FIXME: to be removed when min app version stop using publicationDate
 
@@ -421,6 +426,7 @@ class BaseOfferResponse(ConfiguredBaseModel):
     address: OfferAddressResponse | None
     artists: list[OfferArtist]
     chronicles: list[ChroniclePreview]
+    chronicles_count: int | None
     description: str | None
     expense_domains: list[ExpenseDomain]
     externalTicketOfficeUrl: str | None

--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -631,6 +631,10 @@ def create_offers_interactions() -> None:
         name="Livre 1 headline 1 chronique 5 likes dans vos Librairies des interactions",
         subcategoryId=subcategories.LIVRE_PAPIER.id,
     )
+    product_with_mixed_chronicles = offers_factories.ProductFactory.create(
+        name="Livre avec chroniques mixtes",
+        subcategoryId=subcategories.LIVRE_PAPIER.id,
+    )
 
     offer_1_likes_headline = offers_factories.OfferFactory.create(
         product=product_1_likes_1_headline, venue=venue_with_headlined_and_liked_books_1
@@ -653,12 +657,27 @@ def create_offers_interactions() -> None:
         product=product_2_likes_2_headline_1_chronicle, venue=venue_with_headlined_and_liked_books_1
     )
 
+    offer_without_product_with_chronicles = offers_factories.OfferFactory.create(
+        name="Offre sans produit avec chroniques", venue=venue_with_headlined_and_liked_books_1
+    )
+
+    offer_without_product_with_likes = offers_factories.OfferFactory.create(
+        name="Offre sans produit avec likes", venue=venue_with_headlined_and_liked_books_1
+    )
+
+    offer_with_product_with_chronicles = offers_factories.OfferFactory.create(
+        product=product_with_mixed_chronicles, venue=venue_with_headlined_and_liked_books_1
+    )
+
     offers_factories.StockFactory.create(offer=offer_1_likes_headline)
     offers_factories.StockFactory.create(offer=offer_1_likes_no_headline)
     offers_factories.StockFactory.create(offer=offer_2_likes_headline_1)
     offers_factories.StockFactory.create(offer=offer_2_likes_headline_2)
     offers_factories.StockFactory.create(offer=offer_5_likes_headline)
     offers_factories.StockFactory.create(offer=offer_5_likes_no_headline)
+    offers_factories.StockFactory.create(offer=offer_without_product_with_chronicles)
+    offers_factories.StockFactory.create(offer=offer_without_product_with_likes)
+    offers_factories.StockFactory.create(offer=offer_with_product_with_chronicles)
 
     ReactionFactory.create_batch(1, offer=offer_1_likes_headline, reactionType=ReactionTypeEnum.LIKE)
     ReactionFactory.create_batch(1, offer=offer_1_likes_no_headline, reactionType=ReactionTypeEnum.LIKE)
@@ -666,9 +685,58 @@ def create_offers_interactions() -> None:
     ReactionFactory.create_batch(2, offer=offer_2_likes_headline_2, reactionType=ReactionTypeEnum.LIKE)
     ReactionFactory.create_batch(5, offer=offer_5_likes_headline, reactionType=ReactionTypeEnum.LIKE)
     ReactionFactory.create_batch(5, offer=offer_5_likes_no_headline, reactionType=ReactionTypeEnum.LIKE)
+    ReactionFactory.create_batch(5, offer=offer_without_product_with_likes, reactionType=ReactionTypeEnum.LIKE)
 
     chronicles_factories.ChronicleFactory.create(products=[product_2_likes_2_headline_1_chronicle])
     chronicles_factories.ChronicleFactory.create(products=[product_5_likes_1_headline_1_chronicle])
+    chronicles_factories.ChronicleFactory.create(
+        content="Chronique avec likes et chroniques",
+        products=[product_with_mixed_chronicles],
+        isActive=True,
+        isSocialMediaDiffusible=True,
+    )
+    chronicles_factories.ChronicleFactory.create(
+        content="Chronique avec likes et chroniques",
+        products=[product_with_mixed_chronicles],
+        isActive=True,
+        isSocialMediaDiffusible=False,
+    )
+    chronicles_factories.ChronicleFactory.create(
+        content="Chronique avec likes et chroniques",
+        products=[product_with_mixed_chronicles],
+        isActive=False,
+        isSocialMediaDiffusible=True,
+    )
+    chronicles_factories.ChronicleFactory.create(
+        content="Chronique avec likes et chroniques",
+        products=[product_with_mixed_chronicles],
+        isActive=False,
+        isSocialMediaDiffusible=False,
+    )
+    chronicles_factories.ChronicleFactory.create(
+        content="Chronique inactive et non diffusible",
+        offers=[offer_without_product_with_chronicles],
+        isActive=False,
+        isSocialMediaDiffusible=False,
+    )
+    chronicles_factories.ChronicleFactory.create(
+        content="Chronique inactive et diffusible",
+        offers=[offer_without_product_with_chronicles],
+        isActive=False,
+        isSocialMediaDiffusible=True,
+    )
+    chronicles_factories.ChronicleFactory.create(
+        content="Chronique active et non diffusible",
+        offers=[offer_without_product_with_chronicles],
+        isActive=True,
+        isSocialMediaDiffusible=False,
+    )
+    chronicles_factories.ChronicleFactory.create(
+        content="Chronique active et diffusible",
+        offers=[offer_without_product_with_chronicles],
+        isActive=True,
+        isSocialMediaDiffusible=True,
+    )
 
     offers_factories.HeadlineOfferFactory.create(offer=offer_1_likes_headline)
     offers_factories.HeadlineOfferFactory.create(offer=offer_2_likes_headline_1)

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -473,6 +473,16 @@ def test_filter_on_empty_artist():
     assert serialized["offer"]["artist"] == "Artiste1 Artiste2"
 
 
+def test_serialize_offer_chronicles_and_likes_count_when_0():
+    offer = offers_factories.OfferFactory()
+
+    offer = get_base_query_for_offer_indexation().filter(offers_models.Offer.id == offer.id).one()
+    serialized = algolia.AlgoliaBackend().serialize_offer(offer, 0)
+    assert "chroniclesCount" not in serialized["offer"]
+    assert "headlinesCount" not in serialized["offer"]
+    assert "likes" not in serialized["offer"]
+
+
 def test_serialize_product_likes_count():
     product = offers_factories.ProductFactory()
     offer = offers_factories.OfferFactory(product=product)

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -485,10 +485,30 @@ def test_serialize_product_likes_count():
     assert serialized["offer"]["likes"] == 1
 
 
-def test_serialize_product_chronicles_count():
+def test_serialize_offer_likes_count():
+    offer = offers_factories.OfferFactory()
+    reactions_factories.ReactionFactory(reactionType=ReactionTypeEnum.LIKE, offer=offer)
+    reactions_factories.ReactionFactory(reactionType=ReactionTypeEnum.DISLIKE, offer=offer)
+    reactions_factories.ReactionFactory(reactionType=ReactionTypeEnum.NO_REACTION, offer=offer)
+
+    offer = get_base_query_for_offer_indexation().filter(offers_models.Offer.id == offer.id).one()
+    serialized = algolia.AlgoliaBackend().serialize_offer(offer, 0)
+    assert serialized["offer"]["likes"] == 1
+
+
+def test_serialize_offer_chronicles_count():
+    offer = offers_factories.OfferFactory()
+    chronicles_factories.ChronicleFactory(offers=[offer])
+
+    offer = get_base_query_for_offer_indexation().filter(offers_models.Offer.id == offer.id).one()
+    serialized = algolia.AlgoliaBackend().serialize_offer(offer, 0)
+    assert serialized["offer"]["chroniclesCount"] == 1
+
+
+def test_serialize_offer_with_product_chronicles_count():
     product = offers_factories.ProductFactory()
     offer = offers_factories.OfferFactory(product=product)
-    chronicles_factories.ChronicleFactory.create(products=[product])
+    chronicles_factories.ChronicleFactory(products=[product])
 
     offer = get_base_query_for_offer_indexation().filter(offers_models.Offer.id == offer.id).one()
     serialized = algolia.AlgoliaBackend().serialize_offer(offer, 0)

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -2996,6 +2996,11 @@
                         "title": "Chronicles",
                         "type": "array"
                     },
+                    "chroniclesCount": {
+                        "nullable": true,
+                        "title": "Chroniclescount",
+                        "type": "integer"
+                    },
                     "description": {
                         "nullable": true,
                         "title": "Description",
@@ -3169,6 +3174,11 @@
                         },
                         "title": "Chronicles",
                         "type": "array"
+                    },
+                    "chroniclesCount": {
+                        "nullable": true,
+                        "title": "Chroniclescount",
+                        "type": "integer"
                     },
                     "description": {
                         "nullable": true,

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -1806,7 +1806,7 @@ class OffersV2Test:
     def test_anonymize_author_of_chronicles(self, client):
         product = offers_factories.ProductFactory()
         offer = offers_factories.OfferFactory(product=product)
-        chronicle = chronicles_factories.ChronicleFactory(
+        chronicles_factories.ChronicleFactory(
             products=[product],
             isActive=True,
             isSocialMediaDiffusible=True,
@@ -1888,6 +1888,82 @@ class OffersV2Test:
 
         assert response.status_code == 200
         assert response.json["venue"]["name"] == "Public name"
+
+    def test_get_offer_with_no_chronicles(self, client):
+        offer = offers_factories.OfferFactory()
+
+        offer_id = offer.id
+        response = client.get(f"/native/v2/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 0
+
+    def test_get_offer_with_chronicles(self, client):
+        offer = offers_factories.OfferFactory()
+        chronicles_factories.ChronicleFactory(offers=[offer])
+        chronicles_factories.ChronicleFactory(offers=[offer])
+
+        offer_id = offer.id
+        response = client.get(f"/native/v2/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 2
+
+    def test_get_offer_with_product_with_no_chronicles(self, client):
+        product = offers_factories.ProductFactory()
+        offer = offers_factories.OfferFactory(product=product)
+
+        offer_id = offer.id
+        response = client.get(f"/native/v2/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 0
+
+    def test_get_offer_with_product_with_chronicles(self, client):
+        product = offers_factories.ProductFactory()
+        offer = offers_factories.OfferFactory(product=product)
+        chronicles_factories.ChronicleFactory(products=[product], isActive=False, isSocialMediaDiffusible=False)
+        chronicles_factories.ChronicleFactory(products=[product])
+
+        offer_id = offer.id
+        response = client.get(f"/native/v2/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 2
+
+    def test_get_offer_with_chronicles_with_product_with_chronicles(self, client):
+        product = offers_factories.ProductFactory()
+        offer = offers_factories.OfferFactory(product=product)
+        chronicles_factories.ChronicleFactory(products=[product], isActive=False, isSocialMediaDiffusible=False)
+        chronicles_factories.ChronicleFactory(products=[product])
+        chronicles_factories.ChronicleFactory(offers=[offer])
+
+        offer_id = offer.id
+        response = client.get(f"/native/v2/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 2
+
+    def test_get_offer_with_unpublished_chronicles(self, client):
+        offer = offers_factories.OfferFactory()
+        chronicles_factories.ChronicleFactory(offers=[offer], isActive=False, isSocialMediaDiffusible=False)
+
+        offer_id = offer.id
+        response = client.get(f"/native/v2/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 1
+
+    def test_get_offer_with_product_with_unpublished_chronicles(self, client):
+        product = offers_factories.ProductFactory()
+        offer = offers_factories.OfferFactory(product=product)
+        chronicles_factories.ChronicleFactory(products=[product], isActive=False, isSocialMediaDiffusible=False)
+
+        offer_id = offer.id
+        response = client.get(f"/native/v2/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 1
 
 
 class OffersStocksV2Test:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36742)

- [x] Ajout de cas de tests à la sandbox
- [x] Pour la route `/offer/offer_id`, ajout du champ `chroniclesCount` qui contient le nombre total de chroniques liées au produit de l'offre, ou à l'offre en l'absence de produit.
- [x] Dans la sérialisation Algolia, calcul du champ `chroniclesCount` pour une offre qui n'a pas de produit
- [x] Dans la sérialisation Algolia, calcul du champ `likesCount` pour une offre qui n'a pas de produit

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

