### PR TITLE
(PC-36966)[PRO] fix: rewrite cancel/save venue settings links to return to appropriate vue (partnerPage, address, collective)

### DIFF
--- a/pro/src/app/AppRouter/routesMap.tsx
+++ b/pro/src/app/AppRouter/routesMap.tsx
@@ -124,28 +124,37 @@ export const routes: RouteConfig[] = [
   },
   {
     lazy: () => import('pages/VenueEdition/VenueEdition'),
-    path: '/structures/:offererId/lieux/:venueId/page-partenaire/edition',
-    title: 'Gérer ma page sur l’application',
+    path: '/structures/:offererId/lieux/:venueId/collectif',
+    title: 'Gérer ma page sur ADAGE',
+    children: [
+      {
+        lazy: () => import('pages/VenueEdition/VenueEdition'),
+        path: '*',
+        title: 'Gérer ma page sur ADAGE',
+      },
+    ],
   },
   {
     lazy: () => import('pages/VenueEdition/VenueEdition'),
     path: '/structures/:offererId/lieux/:venueId',
     title: 'Gérer ma page adresse',
+    children: [
+      {
+        lazy: () => import('pages/VenueEdition/VenueEdition'),
+        path: '*',
+        title: 'Gérer ma page adresse',
+      },
+    ],
   },
   {
-    lazy: () => import('pages/VenueEdition/VenueEdition'),
-    path: '/structures/:offererId/lieux/:venueId/edition',
-    title: 'Gérer ma page adresse',
+    lazy: () => import('pages/VenueSettings/VenueSettings'),
+    path: '/structures/:offererId/lieux/:venueId/page-partenaire/parametres',
+    title: 'Paramètres généraux',
   },
   {
-    lazy: () => import('pages/VenueEdition/VenueEdition'),
-    path: '/structures/:offererId/lieux/:venueId/collectif',
-    title: 'Gérer ma page sur ADAGE',
-  },
-  {
-    lazy: () => import('pages/VenueEdition/VenueEdition'),
-    path: '/structures/:offererId/lieux/:venueId/collectif/edition',
-    title: 'Gérer ma page sur ADAGE',
+    lazy: () => import('pages/VenueSettings/VenueSettings'),
+    path: '/structures/:offererId/lieux/:venueId/collectif/parametres',
+    title: 'Paramètres généraux',
   },
   {
     lazy: () => import('pages/VenueSettings/VenueSettings'),

--- a/pro/src/commons/utils/__specs__/getVenuePagePathToNavigateTo.spec.ts
+++ b/pro/src/commons/utils/__specs__/getVenuePagePathToNavigateTo.spec.ts
@@ -1,0 +1,19 @@
+import { getVenuePagePathToNavigateTo } from '../getVenuePagePathToNavigateTo'
+
+describe('getVenuePagePathToNavigateTo', () => {
+  it('should preserve the base path as context to differentiate address / adage / partner pages and append subPath', () => {
+    const offererId = '123'
+    const venueId = '456'
+    const subPath = '/parametres'
+    const originalPath = `/structures/${offererId}/lieux/${venueId}/page-partenaire`
+    const expectedPath = `${originalPath}${subPath}`
+
+    Object.defineProperty(window, 'location', {
+      value: { pathname: originalPath },
+    })
+
+    expect(getVenuePagePathToNavigateTo(offererId, venueId, subPath)).toBe(
+      expectedPath
+    )
+  })
+})

--- a/pro/src/commons/utils/getVenuePagePathToNavigateTo.ts
+++ b/pro/src/commons/utils/getVenuePagePathToNavigateTo.ts
@@ -1,7 +1,7 @@
-export const getPathToNavigateTo = (
+export const getVenuePagePathToNavigateTo = (
   offererId: string | number,
   venueId: string | number,
-  isEdition = false
+  subPath: '' | '/edition' | '/parametres' = ''
 ) => {
   const basePath = `/structures/${offererId}/lieux/${venueId}`
   const context = location.pathname.includes('collectif')
@@ -10,5 +10,5 @@ export const getPathToNavigateTo = (
       ? '/page-partenaire'
       : ''
 
-  return `${basePath}${context}${isEdition ? '/edition' : ''}`
+  return `${basePath}${context}${subPath}`
 }

--- a/pro/src/pages/VenueEdition/VenueEdition.tsx
+++ b/pro/src/pages/VenueEdition/VenueEdition.tsx
@@ -13,6 +13,7 @@ import { SelectOption } from 'commons/custom_types/form'
 import { useOfferer } from 'commons/hooks/swr/useOfferer'
 import { setSelectedPartnerPageId } from 'commons/store/nav/reducer'
 import { selectCurrentOffererId } from 'commons/store/offerer/selectors'
+import { getVenuePagePathToNavigateTo } from 'commons/utils/getVenuePagePathToNavigateTo'
 import { setSavedPartnerPageVenueId } from 'commons/utils/savedPartnerPageVenueId'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { CollectiveDataEdition } from 'pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDataEdition/CollectiveDataEdition'
@@ -21,7 +22,6 @@ import { FieldLayout } from 'ui-kit/form/shared/FieldLayout/FieldLayout'
 import { NavLinkItem, NavLinkItems } from 'ui-kit/NavLinkItems/NavLinkItems'
 import { Spinner } from 'ui-kit/Spinner/Spinner'
 
-import { getPathToNavigateTo } from './context'
 import styles from './VenueEdition.module.scss'
 import { VenueEditionFormScreen } from './VenueEditionFormScreen'
 import { VenueEditionHeader } from './VenueEditionHeader'
@@ -93,7 +93,7 @@ export const VenueEdition = (): JSX.Element | null => {
           const fallbackVenueId = filteredVenues[0]?.id.toString()
 
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          navigate(getPathToNavigateTo(offerer.id, fallbackVenueId))
+          navigate(getVenuePagePathToNavigateTo(offerer.id, fallbackVenueId))
           dispatch(setSelectedPartnerPageId(fallbackVenueId))
         } else {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -174,7 +174,7 @@ export const VenueEdition = (): JSX.Element | null => {
                         dispatch(setSelectedPartnerPageId(venueId))
                       }
 
-                      const path = getPathToNavigateTo(
+                      const path = getVenuePagePathToNavigateTo(
                         offererId as string,
                         venueId
                       )

--- a/pro/src/pages/VenueEdition/VenueEditionForm.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionForm.tsx
@@ -12,6 +12,7 @@ import { Events } from 'commons/core/FirebaseEvents/constants'
 import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useNotification } from 'commons/hooks/useNotification'
 import { getFormattedAddress } from 'commons/utils/getFormattedAddress'
+import { getVenuePagePathToNavigateTo } from 'commons/utils/getVenuePagePathToNavigateTo'
 import { FormLayout } from 'components/FormLayout/FormLayout'
 import { MandatoryInfo } from 'components/FormLayout/FormLayoutMandatoryInfo'
 import { OpenToPublicToggle } from 'components/OpenToPublicToggle/OpenToPublicToggle'
@@ -22,7 +23,6 @@ import { TextArea } from 'ui-kit/form/TextArea/TextArea'
 import { TextInput } from 'ui-kit/form/TextInput/TextInput'
 
 import { AccessibilityForm } from './AccessibilityForm/AccessibilityForm'
-import { getPathToNavigateTo } from './context'
 import { OpeningHoursForm } from './OpeningHoursForm/OpeningHoursForm'
 import { RouteLeavingGuardVenueEdition } from './RouteLeavingGuardVenueEdition'
 import { serializeEditVenueBodyModel } from './serializers'
@@ -97,7 +97,10 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
 
       await mutate([GET_VENUE_QUERY_KEY, String(venue.id)])
 
-      const path = getPathToNavigateTo(venue.managingOfferer.id, venue.id)
+      const path = getVenuePagePathToNavigateTo(
+        venue.managingOfferer.id,
+        venue.id
+      )
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       navigate(path)
 

--- a/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionHeader.tsx
@@ -16,6 +16,7 @@ import { useActiveFeature } from 'commons/hooks/useActiveFeature'
 import { useNotification } from 'commons/hooks/useNotification'
 import { selectCurrentOffererId } from 'commons/store/offerer/selectors'
 import { WEBAPP_URL } from 'commons/utils/config'
+import { getVenuePagePathToNavigateTo } from 'commons/utils/getVenuePagePathToNavigateTo'
 import {
   UploadImageValues,
   UploaderModeEnum,
@@ -161,7 +162,11 @@ export const VenueEditionHeader = ({
           <ButtonLink
             variant={ButtonVariant.TERNARY}
             icon={fullParametersIcon}
-            to={`/structures/${venue.managingOfferer.id}/lieux/${venue.id}/parametres`}
+            to={getVenuePagePathToNavigateTo(
+              venue.managingOfferer.id,
+              venue.id,
+              '/parametres'
+            )}
           >
             Paramètres généraux
           </ButtonLink>

--- a/pro/src/pages/VenueEdition/VenueEditionReadOnly.tsx
+++ b/pro/src/pages/VenueEdition/VenueEditionReadOnly.tsx
@@ -1,34 +1,44 @@
 import { GetVenueResponseModel } from 'apiClient/v1'
 import { useActiveFeature } from 'commons/hooks/useActiveFeature'
+import { getVenuePagePathToNavigateTo } from 'commons/utils/getVenuePagePathToNavigateTo'
 import { SummaryDescriptionList } from 'components/SummaryLayout/SummaryDescriptionList'
 import { SummarySection } from 'components/SummaryLayout/SummarySection'
 import { SummarySubSection } from 'components/SummaryLayout/SummarySubSection'
 import { OpeningHoursReadOnly } from 'pages/VenueEdition/OpeningHoursReadOnly/OpeningHoursReadOnly'
 
 import { AccessibilityReadOnly } from './AccessibilityReadOnly/AccessibilityReadOnly'
-import { getPathToNavigateTo } from './context'
 
 interface VenueEditionReadOnlyProps {
   venue: GetVenueResponseModel
 }
 
+const PublicWelcomeSection = ({
+  isOpenToPublicEnabled,
+  children,
+}: {
+  isOpenToPublicEnabled: boolean
+  children: React.ReactNode | React.ReactNode[]
+}): JSX.Element => {
+  return isOpenToPublicEnabled ? (
+    <SummarySubSection title="Accueil du public" shouldShowDivider={false}>
+      {children}
+    </SummarySubSection>
+  ) : (
+    <>{children}</>
+  )
+}
+
 export const VenueEditionReadOnly = ({ venue }: VenueEditionReadOnlyProps) => {
   const isOpenToPublicEnabled = useActiveFeature('WIP_IS_OPEN_TO_PUBLIC')
-
-  const PublicWelcomeSection = ({ children }: { children: React.ReactNode | React.ReactNode[] }): JSX.Element => {
-    return isOpenToPublicEnabled ?
-      <SummarySubSection
-        title="Accueil du public"
-        shouldShowDivider={false}
-      >
-        {children}
-      </SummarySubSection> : <>{children}</>
-  }
 
   return (
     <SummarySection
       title="Vos informations pour le grand public"
-      editLink={getPathToNavigateTo(venue.managingOfferer.id, venue.id, true)}
+      editLink={getVenuePagePathToNavigateTo(
+        venue.managingOfferer.id,
+        venue.id,
+        '/edition'
+      )}
     >
       <SummarySubSection
         title="À propos de votre activité"
@@ -43,21 +53,23 @@ export const VenueEditionReadOnly = ({ venue }: VenueEditionReadOnlyProps) => {
           ]}
         />
       </SummarySubSection>
-      <PublicWelcomeSection>
-        {isOpenToPublicEnabled && !venue.isOpenToPublic && <span>
-          Accueil du public dans la structure : Non
-        </span>}
-        {(!isOpenToPublicEnabled || venue.isOpenToPublic) && <>
-          <OpeningHoursReadOnly
-            isOpenToPublicEnabled={isOpenToPublicEnabled}
-            openingHours={venue.openingHours}
-            address={venue.address}
-          />
-          <AccessibilityReadOnly
-            isOpenToPublicEnabled={isOpenToPublicEnabled}
-            venue={venue}
-          />
-        </>}
+      <PublicWelcomeSection isOpenToPublicEnabled={isOpenToPublicEnabled}>
+        {isOpenToPublicEnabled && !venue.isOpenToPublic && (
+          <span>Accueil du public dans la structure : Non</span>
+        )}
+        {(!isOpenToPublicEnabled || venue.isOpenToPublic) && (
+          <>
+            <OpeningHoursReadOnly
+              isOpenToPublicEnabled={isOpenToPublicEnabled}
+              openingHours={venue.openingHours}
+              address={venue.address}
+            />
+            <AccessibilityReadOnly
+              isOpenToPublicEnabled={isOpenToPublicEnabled}
+              venue={venue}
+            />
+          </>
+        )}
       </PublicWelcomeSection>
       <SummarySubSection
         title="Informations de contact"

--- a/pro/src/pages/VenueEdition/VenueFormActionBar/VenueFormActionBar.tsx
+++ b/pro/src/pages/VenueEdition/VenueFormActionBar/VenueFormActionBar.tsx
@@ -1,9 +1,8 @@
 import { GetVenueResponseModel } from 'apiClient/v1'
+import { getVenuePagePathToNavigateTo } from 'commons/utils/getVenuePagePathToNavigateTo'
 import { Button } from 'ui-kit/Button/Button'
 import { ButtonLink } from 'ui-kit/Button/ButtonLink'
 import { ButtonVariant } from 'ui-kit/Button/types'
-
-import { getPathToNavigateTo } from '../context'
 
 import styles from './VenueFormActionBar.module.scss'
 
@@ -22,7 +21,7 @@ export const VenueFormActionBar = ({
     <div className={styles['action-bar']}>
       <ButtonLink
         variant={ButtonVariant.SECONDARY}
-        to={getPathToNavigateTo(
+        to={getVenuePagePathToNavigateTo(
           venue?.managingOfferer.id as number,
           venue?.id as number
         )}

--- a/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
+++ b/pro/src/pages/VenueEdition/__specs__/VenueEditionHeader.spec.tsx
@@ -172,4 +172,22 @@ describe('VenueEditionHeader', () => {
 
     expect(screen.queryByText('Visualiser votre page')).not.toBeInTheDocument()
   })
+
+  it('should display a "Paramètres généraux" link', () => {
+    renderPartnerPages({
+      venue: {
+        ...defaultGetVenue,
+      },
+    })
+
+    const link = screen.getByRole('link', {
+      name: 'Paramètres généraux',
+    })
+
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute(
+      'href',
+      `/structures/${defaultGetOffererResponseModel.id}/lieux/${defaultGetVenue.id}/parametres`
+    )
+  })
 })

--- a/pro/src/pages/VenueSettings/VenueSettingsScreen.tsx
+++ b/pro/src/pages/VenueSettings/VenueSettingsScreen.tsx
@@ -16,6 +16,7 @@ import { useAnalytics } from 'app/App/analytics/firebase'
 import { GET_VENUE_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { Events } from 'commons/core/FirebaseEvents/constants'
 import { useNotification } from 'commons/hooks/useNotification'
+import { getVenuePagePathToNavigateTo } from 'commons/utils/getVenuePagePathToNavigateTo'
 import { MandatoryInfo } from 'components/FormLayout/FormLayoutMandatoryInfo'
 import { generateSiretValidationSchema } from 'pages/VenueSettings/SiretOrCommentFields/validationSchema'
 
@@ -70,7 +71,7 @@ export const VenueSettingsScreen = ({
       await mutate([GET_VENUE_QUERY_KEY, String(venue.id)])
 
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      navigate(`/structures/${venue.managingOfferer.id}/lieux/${venue.id}`)
+      navigate(getVenuePagePathToNavigateTo(venue.managingOfferer.id, venue.id))
 
       logEvent(Events.CLICKED_SAVE_VENUE, {
         from: location.pathname,


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36966)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## Side Notes
Le QualityGate fail sur `routesMap.tsx` : https://sonarcloud.io/component_measures?metric=new_duplicated_lines_density&selected=pass-culture_pass-culture-main%3Asrc%2Fapp%2FAppRouter%2FroutesMap.tsx&pullRequest=18374&id=pass-culture_pass-culture-main, pour des histoires de duplication.
Je ne comprends pas trop pourquoi, je dirais que ce n'est pas grave et que c'est à ignorer.