### PR TITLE
(PC-36979)[PRO] fix: restore sorting on stocks table

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventEdition/StocksEventEdition.tsx
@@ -696,7 +696,7 @@ export const StocksEventEdition = ({
                     const beginningDate = stock.beginningDate
 
                     return (
-                      <tr className={styles['table-row']} key={index}>
+                      <tr className={styles['table-row']} key={f.id}>
                         <td className={styles['data']}>
                           <DatePicker
                             label=""


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

- [Front](?expand=1&template=template_front.md)
- [Back](?expand=1&template=template_back.md)
