### PR TITLE
(PC-36998)[API] feat: create indexes for likes

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 185416119576 (pre) (head)
-7bd20bc60b52 (post) (head)
+280eae6d44f0 (post) (head)

--- a/api/src/pcapi/alembic/versions/20250711T155058_9954d7d01119_add_partial_index_on_reaction_like.py
+++ b/api/src/pcapi/alembic/versions/20250711T155058_9954d7d01119_add_partial_index_on_reaction_like.py
@@ -1,0 +1,53 @@
+"""Add partial indexes on table "reaction" """
+
+import sqlalchemy as sa
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "9954d7d01119"
+down_revision = "7bd20bc60b52"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_reaction_offer_like",
+            "reaction",
+            ["offerId"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+            postgresql_where=sa.text('"reactionType" = \'LIKE\' AND "offerId" IS NOT NULL'),
+        )
+        op.create_index(
+            "ix_reaction_product_like",
+            "reaction",
+            ["productId"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+            postgresql_where=sa.text('"reactionType" = \'LIKE\' AND "productId" IS NOT NULL'),
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_reaction_offer_like",
+            table_name="reaction",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.drop_index(
+            "ix_reaction_product_like",
+            table_name="reaction",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/api/src/pcapi/alembic/versions/20250715T140500_280eae6d44f0_remove_reaction_naive_indexes.py
+++ b/api/src/pcapi/alembic/versions/20250715T140500_280eae6d44f0_remove_reaction_naive_indexes.py
@@ -1,0 +1,37 @@
+"""Remove indexes "ix_reaction_offerId" and "ix_reaction_productId" in table "reaction" """
+
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "280eae6d44f0"
+down_revision = "9954d7d01119"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index("ix_reaction_offerId", table_name="reaction", postgresql_concurrently=True, if_exists=True)
+        op.drop_index("ix_reaction_productId", table_name="reaction", postgresql_concurrently=True, if_exists=True)
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_reaction_offerId",
+            "reaction",
+            ["offerId"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+        op.create_index(
+            "ix_reaction_productId",
+            "reaction",
+            ["productId"],
+            unique=False,
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )

--- a/api/src/pcapi/core/reactions/models.py
+++ b/api/src/pcapi/core/reactions/models.py
@@ -24,9 +24,9 @@ class Reaction(PcObject, Base, Model):
     reactionType = sa.Column(MagicEnum(ReactionTypeEnum), nullable=False)
     userId: int = sa.Column(sa.BigInteger, sa.ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True)
     user: sa_orm.Mapped["User"] = sa_orm.relationship("User", back_populates="reactions")
-    offerId = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id", ondelete="CASCADE"), nullable=True, index=True)
+    offerId = sa.Column(sa.BigInteger, sa.ForeignKey("offer.id", ondelete="CASCADE"), nullable=True)
     offer: sa_orm.Mapped["Offer"] = sa_orm.relationship("Offer", back_populates="reactions")
-    productId = sa.Column(sa.BigInteger, sa.ForeignKey("product.id", ondelete="CASCADE"), nullable=True, index=True)
+    productId = sa.Column(sa.BigInteger, sa.ForeignKey("product.id", ondelete="CASCADE"), nullable=True)
     product: sa_orm.Mapped["Product"] = sa_orm.relationship("Product", back_populates="reactions")
 
     __table_args__ = (
@@ -39,6 +39,16 @@ class Reaction(PcObject, Base, Model):
             )
         ),
         sa.Index("reaction_offer_product_user_unique_constraint", "userId", "offerId", "productId", unique=True),
+        sa.Index(
+            "ix_reaction_offer_like",
+            "offerId",
+            postgresql_where=sa.text('"reactionType" = \'LIKE\' AND "offerId" IS NOT NULL'),
+        ),
+        sa.Index(
+            "ix_reaction_product_like",
+            "productId",
+            postgresql_where=sa.text('"reactionType" = \'LIKE\' AND "productId" IS NOT NULL'),
+        ),
     )
 
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36998)

Création de 2 index partiels pour optimiser les query sur les likes : 
- 1 sur les offres
- 1 sur les produits

Le but est que les requêtes qui comptent le nombre de like pour une offre ou un produit ne fassent qu'un "Index Only Scan"