### PR TITLE
(PC-36382)[API] feat: pro:offers: CRUD opening hours routes

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-1c971d27bcb9 (pre) (head)
-3f4006677b43 (post) (head)
+82773754a29f (pre) (head)
+0bfe4eb50b49 (post) (head)

--- a/api/src/pcapi/alembic/versions/20250710T172534_82773754a29f_opening_hours_use_venue_or_offer.py
+++ b/api/src/pcapi/alembic/versions/20250710T172534_82773754a29f_opening_hours_use_venue_or_offer.py
@@ -1,0 +1,43 @@
+"""opening hours: use venue or offer"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "82773754a29f"
+down_revision = "1c971d27bcb9"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column("opening_hours", "venueId", existing_type=sa.BIGINT(), nullable=True)
+    op.add_column("opening_hours", sa.Column("offerId", sa.BigInteger(), nullable=True))
+    op.create_foreign_key(
+        "opening_hours_offerId_fkey",
+        "opening_hours",
+        "offer",
+        ["offerId"],
+        ["id"],
+        ondelete="CASCADE",
+        postgresql_not_valid=True,
+    )
+
+    op.execute(
+        """
+        ALTER TABLE "opening_hours"
+        ADD CONSTRAINT "opening_hours_uses_either_venue_or_offer"
+        CHECK (
+            ("venueId" IS NULL AND "offerId" IS NOT NULL)
+            OR ("venueId" IS NOT NULL AND "offerId" IS NULL)
+        )
+        NOT VALID
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("opening_hours_uses_either_venue_or_offer", "opening_hours")
+    op.drop_column("opening_hours", "offerId")

--- a/api/src/pcapi/alembic/versions/20250721T175641_c333f15058f1_opening_hours_add_offerid_index.py
+++ b/api/src/pcapi/alembic/versions/20250721T175641_c333f15058f1_opening_hours_add_offerid_index.py
@@ -1,0 +1,32 @@
+"""opening hours: add offerId index"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "c333f15058f1"
+down_revision = "3f4006677b43"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS "ix_opening_hours_offerId"
+            ON opening_hours ("offerId");
+            """
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            op.f("ix_opening_hours_offerId"), table_name="opening_hours", postgresql_concurrently=True, if_exists=True
+        )

--- a/api/src/pcapi/alembic/versions/20250722T152014_a927abb5583b_opening_hours_validate_offer_id_fkey.py
+++ b/api/src/pcapi/alembic/versions/20250722T152014_a927abb5583b_opening_hours_validate_offer_id_fkey.py
@@ -1,0 +1,23 @@
+"""opening hours: validate offer id fkey"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "a927abb5583b"
+down_revision = "c333f15058f1"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET SESSION statement_timeout='300s'")
+    op.execute("""ALTER TABLE opening_hours VALIDATE CONSTRAINT "opening_hours_offerId_fkey" """)
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/alembic/versions/20250722T152332_0bfe4eb50b49_opening_hours_validate_offer_xor_venue_constraint.py
+++ b/api/src/pcapi/alembic/versions/20250722T152332_0bfe4eb50b49_opening_hours_validate_offer_xor_venue_constraint.py
@@ -1,0 +1,23 @@
+"""opening hours: validate offer xor venue constraint"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "0bfe4eb50b49"
+down_revision = "a927abb5583b"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET SESSION statement_timeout='300s'")
+    op.execute("""ALTER TABLE opening_hours VALIDATE CONSTRAINT "opening_hours_uses_either_venue_or_offer" """)
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -182,7 +182,9 @@ class VenueFactory(BaseFactory):
                     timespan = timespan_str_to_numrange(OPENING_HOURS)
                 else:
                     timespan = None
-                opening_hours.append(OpeningHoursFactory.create(venue=self, weekday=weekday, timespan=timespan))
+                opening_hours.append(
+                    OpeningHoursFactory.create(venue=self, offer=None, weekday=weekday, timespan=timespan)
+                )
         return opening_hours
 
     @factory.post_generation
@@ -308,7 +310,11 @@ class OpeningHoursFactory(BaseFactory):
     class Meta:
         model = models.OpeningHours
 
+    # TODO(jbaudet::2025-07) make both optional and check that only one
+    # is set at a time
     venue = factory.SubFactory(VenueFactory)
+    offer: factory.SubFactory | None = None
+
     weekday = models.Weekday.MONDAY
     timespan = timespan_str_to_numrange(OPENING_HOURS)
 

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -52,6 +52,7 @@ if typing.TYPE_CHECKING:
     from pcapi.core.criteria.models import Criterion
     from pcapi.core.educational.models import CollectiveOffer
     from pcapi.core.educational.models import CollectiveOfferTemplate
+    from pcapi.core.offerers import models as offerers_models
     from pcapi.core.offerers.models import OffererAddress
     from pcapi.core.offerers.models import Venue
     from pcapi.core.reactions.models import Reaction
@@ -774,6 +775,10 @@ class Offer(PcObject, Base, Model, ValidationMixin, AccessibilityMixin):
     )
     headlineOffers: sa_orm.Mapped[list["HeadlineOffer"]] = sa_orm.relationship(
         "HeadlineOffer", back_populates="offer", uselist=True, cascade="all, delete-orphan", passive_deletes=True
+    )
+
+    openingHours: sa_orm.Mapped[list["offerers_models.OpeningHours"]] = sa_orm.relationship(
+        "OpeningHours", back_populates="offer", passive_deletes=True
     )
 
     sa.Index("idx_offer_trgm_name", name, postgresql_using="gin")

--- a/api/src/pcapi/core/offers/opening_hours/api.py
+++ b/api/src/pcapi/core/offers/opening_hours/api.py
@@ -1,0 +1,45 @@
+from datetime import time
+
+from psycopg2.extras import NumericRange
+
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offers import models
+from pcapi.core.offers import schemas
+from pcapi.models import db
+from pcapi.utils.date import timespan_str_to_numrange
+
+
+def _timespan_to_numeric_range(timespans: schemas.OpeningHoursTimespans) -> list[NumericRange]:
+    def _format_timespan(hours: schemas.OpeningHours) -> NumericRange:
+        to_time_objects = [time.fromisoformat(t) for t in hours]
+        ts = sorted(to_time_objects, key=lambda t: (t.hour, t.minute))
+
+        start = ts[0].hour * 60 + ts[0].minute
+        end = ts[1].hour * 60 + ts[1].minute
+        return NumericRange(start, end, "[]")
+
+    return [_format_timespan(ts) for ts in timespans if ts]
+
+
+def upsert_opening_hours(offer: models.Offer, opening_hours: schemas.WeekdayOpeningHoursTimespans | None) -> None:
+    """Upsert an offer's opening hours, erasing previous ones (if any)"""
+    db.session.query(offerers_models.OpeningHours).filter_by(offerId=offer.id).delete(synchronize_session="evaluate")
+
+    # for some obscure reason, inspecting offer's opening hours from
+    # a breakpoint can keep the deleted objects... which can be very
+    # confusing. This should not happen otherwise, but just in case
+    # it might be safer to keep this assert (even though it might be
+    # turned off).
+    assert not offer.openingHours
+
+    for raw_weekday, timespans in opening_hours or []:
+        if not timespans:
+            continue
+
+        numeric_ranges = timespan_str_to_numrange(timespans)
+
+        weekday = offerers_models.Weekday[raw_weekday]
+        oh = offerers_models.OpeningHours(offer=offer, weekday=weekday, timespan=numeric_ranges)
+        db.session.add(oh)
+
+    db.session.flush()

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -54,6 +54,7 @@ OFFER_LOAD_OPTIONS = typing.Iterable[
         "stock",
         "venue",
         "meta_data",
+        "openingHours",
     ]
 ]
 
@@ -952,6 +953,8 @@ def get_offer_by_id(offer_id: int, load_options: OFFER_LOAD_OPTIONS = ()) -> mod
                     get_pending_bookings_subquery(offer_id),
                 )
             )
+        if "openingHours" in load_options:
+            query = query.options(sa_orm.joinedload(models.Offer.openingHours))
 
         return query.one()
     except sa_orm.exc.NoResultFound:

--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -1,6 +1,8 @@
 import datetime
 import typing
 
+from pydantic.v1 import ConstrainedList
+from pydantic.v1 import ConstrainedStr
 from pydantic.v1 import EmailStr
 from pydantic.v1 import Field
 from pydantic.v1 import HttpUrl
@@ -183,3 +185,100 @@ class UpdateOffer(BaseModel):
         arbitrary_types_allowed = True
         alias_generator = serialization_utils.to_camel
         extra = "forbid"
+
+
+class Hour(ConstrainedStr):
+    """defines a time string that matches the HH:MM format"""
+
+    __args__ = (str,)
+    regex = r"^(([0-1][0-9])|(2[0-3])):[0-5][0-9]$"
+    strip_whitespace = True
+    strict = True
+
+
+class OpeningHours(ConstrainedList):
+    """defines start and end opening hours
+    eg. ["10:00", "18:00"] (from 10:00 to 18:00)
+    """
+
+    __args__ = (Hour,)
+    item_type = Hour
+    min_items = 2
+    max_items = 2
+    unique_items = True
+
+
+class OpeningHoursTimespans(ConstrainedList):
+    """defines a whole day's opening hours
+
+    eg. [["10:00", "13:00"], ["14:00", "18:00"]]
+    """
+
+    __args__ = (OpeningHours,)
+    item_type = OpeningHours
+    min_items = 1
+    max_items = 2
+    unique_items = True
+
+
+def validate_timespans(timespans: OpeningHoursTimespans | None) -> OpeningHoursTimespans | None:
+    """Check that timespans are well-formed (if any)
+
+    -> Each timespan is a (start, end) pair.
+    -> Check that start is always before end.
+    -> Check that there is no overlapping pair, eg. from 10:00 to
+    14:00 and from 13:00 to 17:00.
+    """
+
+    def unpack_opening_hours(oh: OpeningHours) -> tuple[datetime.time, datetime.time]:
+        start, end = oh
+        return datetime.time.fromisoformat(start), datetime.time.fromisoformat(end)
+
+    if timespans is None:
+        return None
+
+    # check that start and end pairs are well ordered
+    ranges = [unpack_opening_hours(ts) for ts in timespans]
+
+    for start, end in ranges:
+        if start >= end:
+            raise ValueError(f"opening hours start ({start}) cannot be after end ({end})")
+
+    # check that there is no overlapping (start, end) pair
+    ranges = sorted(ranges, key=lambda opening_hours: opening_hours[0])
+    previous_end = ranges[0][1]
+
+    for start, end in ranges[1:]:
+        if start < previous_end:
+            raise ValueError(f"overlapping opening hours: {start} <> {previous_end}")
+        previous_end = end
+
+    return timespans
+
+
+class WeekdayOpeningHoursTimespans(BaseModel):
+    MONDAY: OpeningHoursTimespans | None
+    TUESDAY: OpeningHoursTimespans | None
+    WEDNESDAY: OpeningHoursTimespans | None
+    THURSDAY: OpeningHoursTimespans | None
+    FRIDAY: OpeningHoursTimespans | None
+    SATURDAY: OpeningHoursTimespans | None
+    SUNDAY: OpeningHoursTimespans | None
+
+    _validate_monday = validator("MONDAY", allow_reuse=True)(validate_timespans)
+    _validate_tuesday = validator("TUESDAY", allow_reuse=True)(validate_timespans)
+    _validate_wednesday = validator("WEDNESDAY", allow_reuse=True)(validate_timespans)
+    _validate_thursday = validator("THURSDAY", allow_reuse=True)(validate_timespans)
+    _validate_friday = validator("FRIDAY", allow_reuse=True)(validate_timespans)
+    _validate_saturday = validator("SATURDAY", allow_reuse=True)(validate_timespans)
+    _validate_sunday = validator("SUNDAY", allow_reuse=True)(validate_timespans)
+
+    class Config:
+        extra = "forbid"
+
+
+class OfferOpeningHoursSchema(BaseModel):
+    openingHours: WeekdayOpeningHoursTimespans
+
+    class Config:
+        use_enum_values = True

--- a/api/tests/core/offers/opening_hours/test_api.py
+++ b/api/tests/core/offers/opening_hours/test_api.py
@@ -1,0 +1,105 @@
+import pytest
+
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offerers import models as offerers_models
+from pcapi.core.offers import factories
+from pcapi.core.offers import schemas
+from pcapi.core.offers.opening_hours import api
+from pcapi.models import db
+from pcapi.utils.date import timespan_str_to_numrange
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+@pytest.fixture(name="venue")
+def venue_fixture():
+    return offerers_factories.VenueFactory()
+
+
+@pytest.fixture(name="offer")
+def offer_fixture(venue):
+    return factories.ThingOfferFactory(venue=venue)
+
+
+def validate_timespans(fetched_timespans, expected_timespans):
+    """Check that timespans fetched from the DB matched the input timespans
+
+    fetched_timespans example: [NumericRange(600, 720), NumericRange(780, 1200)]
+    expected_timespans example: [["10:00", "12:00"], ["13:00", "20:00"]]
+    """
+    fetched_timespans = sorted(fetched_timespans, key=lambda ts: ts.lower)
+    expected_timespans = sorted(expected_timespans, key=lambda oh: oh[0])
+
+    assert fetched_timespans == timespan_str_to_numrange(expected_timespans)
+
+
+class UpsertOpeningHoursTest:
+    def test_create_one_weekday_with_one_timespan(self, offer):
+        opening_hours = schemas.WeekdayOpeningHoursTimespans(MONDAY=[["10:00", "18:00"]])
+        api.upsert_opening_hours(offer, opening_hours)
+
+        assert db.session.query(offerers_models.OpeningHours).count() == 1
+
+        oh = db.session.query(offerers_models.OpeningHours).first()
+        assert oh.weekday == offerers_models.Weekday.MONDAY
+
+        validate_timespans(oh.timespan, opening_hours.MONDAY)
+
+    def test_create_many_weekdays_with_some_timespans(self, offer):
+        opening_hours = schemas.WeekdayOpeningHoursTimespans(
+            MONDAY=[["10:00", "18:00"]],
+            WEDNESDAY=[["11:00", "12:30"], ["14:00", "19:00"]],
+            FRIDAY=[["12:00", "20:00"]],
+        )
+        api.upsert_opening_hours(offer, opening_hours)
+
+        filtered_opening_hours = {
+            weekday: timespans for weekday, timespans in opening_hours.dict().items() if timespans
+        }
+
+        found = db.session.query(offerers_models.OpeningHours).count()
+        expected = len(list(filtered_opening_hours.values()))
+        assert found == expected
+
+        weekdays = {oh.weekday.value for oh in db.session.query(offerers_models.OpeningHours)}
+        assert weekdays == set(filtered_opening_hours.keys())
+
+        for raw_weekday, timespans in filtered_opening_hours.items():
+            weekday = offerers_models.Weekday[raw_weekday]
+            oh = db.session.query(offerers_models.OpeningHours).filter_by(weekday=weekday).first()
+            validate_timespans(oh.timespan, timespans)
+
+    def test_create_one_weekday_with_opening_hours_erases_all_existing_ones(self, offer):
+        # should all be deleted
+        offerers_factories.OpeningHoursFactory(venue=None, offer=offer, weekday=offerers_models.Weekday.MONDAY)
+        offerers_factories.OpeningHoursFactory(venue=None, offer=offer, weekday=offerers_models.Weekday.SATURDAY)
+        offerers_factories.OpeningHoursFactory(venue=None, offer=offer, weekday=offerers_models.Weekday.SUNDAY)
+
+        opening_hours = schemas.WeekdayOpeningHoursTimespans(MONDAY=[["10:00", "18:00"]])
+        api.upsert_opening_hours(offer, opening_hours)
+
+        assert db.session.query(offerers_models.OpeningHours).count() == 1
+
+        oh = db.session.query(offerers_models.OpeningHours).first()
+        assert oh.weekday == offerers_models.Weekday.MONDAY
+        validate_timespans(oh.timespan, opening_hours.MONDAY)
+
+    def test_upsert_opening_hours_without_timespans_is_ok_but_creates_nothing(self, offer):
+        api.upsert_opening_hours(offer, schemas.WeekdayOpeningHoursTimespans(TUESDAY=None))
+        assert db.session.query(offerers_models.OpeningHours).count() == 0
+
+    def test_upsert_opening_hours_with_some_missing_timespans_is_ok(self, offer):
+        opening_hours = schemas.WeekdayOpeningHoursTimespans(MONDAY=[["10:00", "18:00"]], THURSDAY=None)
+        api.upsert_opening_hours(offer, opening_hours)
+
+        assert db.session.query(offerers_models.OpeningHours).count() == 1
+
+        oh = db.session.query(offerers_models.OpeningHours).first()
+        assert oh.weekday == offerers_models.Weekday.MONDAY
+
+        validate_timespans(oh.timespan, opening_hours.MONDAY)
+
+    def test_null_opening_hours_is_valid_but_creates_nothing(self, offer):
+        api.upsert_opening_hours(offer, None)
+        assert db.session.query(offerers_models.OpeningHours).count() == 0

--- a/api/tests/core/offers/test_schemas.py
+++ b/api/tests/core/offers/test_schemas.py
@@ -1,10 +1,11 @@
+from datetime import time
+
 import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.exceptions as offers_exceptions
 from pcapi.core.categories import subcategories
-from pcapi.core.offers.schemas import PatchDraftOfferBodyModel
-from pcapi.core.offers.schemas import PostDraftOfferBodyModel
+from pcapi.core.offers import schemas
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -13,7 +14,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class PostDraftOfferBodyModelTest:
     def test_post_draft_offer_body_model(self):
         venue = offerers_factories.VirtualVenueFactory()
-        _ = PostDraftOfferBodyModel(
+        _ = schemas.PostDraftOfferBodyModel(
             name="Name",
             subcategoryId=subcategories.ABO_PLATEFORME_VIDEO.id,
             venueId=venue.id,
@@ -25,15 +26,116 @@ class PostDraftOfferBodyModelTest:
 
 class PatchDraftOfferBodyModelTest:
     def test_patch_draft_offer_body_model(self):
-        _ = PatchDraftOfferBodyModel(
+        _ = schemas.PatchDraftOfferBodyModel(
             name="Name", description="description", extraData={"artist": "An-2"}, durationMinutes=12
         )
 
     def test_patch_offer_with_invalid_subcategory(self):
         with pytest.raises(offers_exceptions.OfferException) as error:
-            _ = PatchDraftOfferBodyModel(
+            _ = schemas.PatchDraftOfferBodyModel(
                 name="I solemnly swear that my intentions are evil",
                 subcategoryId="Misconduct fullfield",
             )
 
         assert error.value.errors["subcategory"] == ["La sous-catégorie de cette offre est inconnue"]
+
+
+class OfferOpeningHoursSchemaTest:
+    def test_empty_opening_hours_is_valid(self):
+        oh = schemas.OfferOpeningHoursSchema(openingHours={})
+        assert oh.openingHours.MONDAY is None
+        assert oh.openingHours.TUESDAY is None
+        assert oh.openingHours.WEDNESDAY is None
+        assert oh.openingHours.THURSDAY is None
+        assert oh.openingHours.FRIDAY is None
+        assert oh.openingHours.SATURDAY is None
+        assert oh.openingHours.SUNDAY is None
+
+    def test_many_days_with_some_timespans_or_not_is_ok(self):
+        oh = schemas.OfferOpeningHoursSchema(
+            openingHours={
+                "MONDAY": [["10:00", "13:00"], ["14:00", "17:00"]],
+                "FRIDAY": [["12:00", "19:00"]],
+                "SUNDAY": None,
+            }
+        )
+
+        assert oh.openingHours.MONDAY == [["10:00", "13:00"], ["14:00", "17:00"]]
+        assert oh.openingHours.FRIDAY == [["12:00", "19:00"]]
+
+    def test_none_opening_hours_is_not_ok(self):
+        with pytest.raises(ValueError, match="none is not an allowed value"):
+            schemas.OfferOpeningHoursSchema(openingHours=None)
+
+    @pytest.mark.parametrize(
+        "timespans, expected_error_message",
+        [
+            ([["10:00", "13:00", "19:00"]], "ensure this value has at most 2 items"),
+            ([["10:00"]], "ensure this value has at least 2 items"),
+            ([["10:00"]], "ensure this value has at least 2 items"),
+            ([[]], "ensure this value has at least 2 items"),
+            ([], "ensure this value has at least 1 items"),
+        ],
+    )
+    def test_invalid_opening_hour_timespans_is_not_ok(self, timespans, expected_error_message):
+        with pytest.raises(ValueError, match=expected_error_message):
+            schemas.OfferOpeningHoursSchema(openingHours={"MONDAY": timespans})
+
+    @pytest.mark.parametrize(
+        "timespans",
+        [
+            [["1:", "10:00"]],  # should be 01:00 (minutes missing)
+            [["1:00", "10:00"]],  # should be 01:00
+            [["29:00", "10:00"]],  # hour error
+            [["24:00", "10:00"]],  # hour error (should be 00:00)
+            [["12:99", "10:00"]],  # minutes error
+            [["1200", "10:00"]],  # missing time separator
+            [["12T01", "10:00"]],  # unexpected time separator
+            [["12 02", "10:00"]],  # another unexpected time separator
+            [["10:00:00:00:00", "18:00"]],  # not a valid iso time
+            [["10:00:00", "18:00"]],  # HH:MM expected, not HH:MM:SS
+        ],
+    )
+    def test_malformed_timespan_is_not_ok(self, timespans):
+        with pytest.raises(ValueError, match="string does not match regex"):
+            schemas.OfferOpeningHoursSchema(openingHours={"MONDAY": timespans})
+
+    @pytest.mark.parametrize(
+        "timespans",
+        [
+            [[time(10), "18:00"]],  # time objects are not valid (only str)
+            [[10 * 60, "18:00"]],  # int is not a valid data type
+        ],
+    )
+    def test_invalid_timespan_data_type_is_not_ok(self, timespans):
+        with pytest.raises(ValueError, match="str type expected"):
+            schemas.OfferOpeningHoursSchema(openingHours={"MONDAY": timespans})
+
+    def test_null_timespan_is_not_ok(self):
+        with pytest.raises(ValueError, match="none is not an allowed value"):
+            schemas.OfferOpeningHoursSchema(openingHours={"MONDAY": [[None, "18:00"]]})
+
+    @pytest.mark.parametrize(
+        "timespans",
+        [
+            [["10:00", "18:00"], ["12:00", "15:00"]],  # overlap: inside
+            [["10:00", "16:00"], ["12:00", "19:00"]],  # overlap: inside/outside
+        ],
+    )
+    def test_overlapping_timespans_is_not_ok(self, timespans):
+        with pytest.raises(ValueError, match="overlapping"):
+            schemas.OfferOpeningHoursSchema(openingHours={"MONDAY": timespans})
+
+    @pytest.mark.parametrize(
+        "weekday, expected_error_message",
+        [
+            ("MNDAY", "extra fields not permitted"),
+            ("monday", "extra fields not permitted"),
+            ("OOPS", "extra fields not permitted"),
+            (1, "keywords must be strings"),
+            (None, "keywords must be strings"),
+        ],
+    )
+    def test_unknown_weekday_is_not_valid(self, weekday, expected_error_message):
+        with pytest.raises(ValueError, match=expected_error_message):
+            schemas.OfferOpeningHoursSchema(openingHours={weekday: [["10:00", "18:00"]]})

--- a/api/tests/routes/pro/get_offer_opening_hours_test.py
+++ b/api/tests/routes/pro/get_offer_opening_hours_test.py
@@ -1,0 +1,117 @@
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offerers.models as offerers_models
+from pcapi.core.offers import factories
+from pcapi.core.testing import assert_num_queries
+from pcapi.utils.date import timespan_str_to_numrange
+
+
+def setup_auth_client_and_offer(client):
+    venue = offerers_factories.VenueFactory()
+    offer = factories.ThingOfferFactory(venue=venue)
+    user = offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com").user
+    auth_client = client.with_session_auth(user.email)
+    return auth_client, offer
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns401Test:
+    def test_unauthenticated_user_gets_an_error(self, client):
+        offer = factories.ThingOfferFactory()
+        url = f"/offers/{offer.id}/opening-hours"
+        response = client.get(url)
+        assert response.status_code == 401
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns403Test:
+    def test_authenticated_user_but_with_no_rights_on_offer_gets_an_error(self, client):
+        auth_client, _ = setup_auth_client_and_offer(client)
+        offer = factories.ThingOfferFactory()
+
+        url = f"/offers/{offer.id}/opening-hours"
+        response = auth_client.get(url)
+        assert response.status_code == 403
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns404Test:
+    def test_unknown_offer_returns_an_error(self, client):
+        auth_client, _ = setup_auth_client_and_offer(client)
+
+        url = "/offers/-1/opening-hours"
+        response = auth_client.get(url)
+        assert response.status_code == 404
+
+
+@pytest.mark.usefixtures("db_session")
+class Returns200Test:
+    def test_opening_hours_no_existing_hours_returns_empty_week(self, client):
+        auth_client, offer = setup_auth_client_and_offer(client)
+
+        url = f"/offers/{offer.id}/opening-hours"
+        response = auth_client.get(url)
+
+        assert response.status_code == 200
+        assert response.json == {"openingHours": {weekday.value: None for weekday in offerers_models.Weekday}}
+
+    def test_opening_hours_existings_are_returned_with_all_week_days(self, client):
+        auth_client, offer = setup_auth_client_and_offer(client)
+
+        opening_hours = timespan_str_to_numrange([("10:00", "12:00"), ("14:00", "18:00")])
+
+        offerers_factories.OpeningHoursFactory(
+            venue=None, offer=offer, weekday=offerers_models.Weekday.TUESDAY, timespan=opening_hours
+        )
+
+        offerers_factories.OpeningHoursFactory(
+            venue=None, offer=offer, weekday=offerers_models.Weekday.WEDNESDAY, timespan=opening_hours
+        )
+
+        url = f"/offers/{offer.id}/opening-hours"
+
+        # fetch user_session
+        # fetch user
+        # fetch offer with its venue
+        # check user has access to offer
+        with assert_num_queries(4):
+            response = auth_client.get(url)
+
+        assert response.status_code == 200
+        assert response.json == {
+            "openingHours": {
+                **{weekday.value: None for weekday in offerers_models.Weekday},
+                "TUESDAY": [["10:00", "12:00"], ["14:00", "18:00"]],
+                "WEDNESDAY": [["10:00", "12:00"], ["14:00", "18:00"]],
+            }
+        }
+
+    def test_opening_hours_every_weekday_has_opening_hours_set_and_all_are_returned(self, client):
+        auth_client, offer = setup_auth_client_and_offer(client)
+        opening_hours = timespan_str_to_numrange([("10:00", "12:00"), ("14:00", "18:00")])
+
+        for weekday in offerers_models.Weekday:
+            offerers_factories.OpeningHoursFactory(venue=None, offer=offer, weekday=weekday, timespan=opening_hours)
+
+        url = f"/offers/{offer.id}/opening-hours"
+
+        # fetch user_session
+        # fetch user
+        # fetch offer with its venue
+        # check user has access to offer
+        with assert_num_queries(4):
+            response = auth_client.get(url)
+
+        assert response.status_code == 200
+        assert response.json == {
+            "openingHours": {
+                "MONDAY": [["10:00", "12:00"], ["14:00", "18:00"]],
+                "TUESDAY": [["10:00", "12:00"], ["14:00", "18:00"]],
+                "WEDNESDAY": [["10:00", "12:00"], ["14:00", "18:00"]],
+                "THURSDAY": [["10:00", "12:00"], ["14:00", "18:00"]],
+                "FRIDAY": [["10:00", "12:00"], ["14:00", "18:00"]],
+                "SATURDAY": [["10:00", "12:00"], ["14:00", "18:00"]],
+                "SUNDAY": [["10:00", "12:00"], ["14:00", "18:00"]],
+            }
+        }

--- a/api/tests/routes/pro/patch_offer_opening_hours_test.py
+++ b/api/tests/routes/pro/patch_offer_opening_hours_test.py
@@ -1,0 +1,166 @@
+"""Check that one client can create an offer's opening hours
+
+This should only test some relatively basic behaviour:
+    * all more complex opening hours creation tests should be done
+    by the opening hours api test module
+    * all the complex input validation tests should be done by the model
+    test module
+
+-> Check that every part seems to work together, there is no need to
+go any further.
+"""
+
+import pytest
+
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offerers.models as offerers_models
+from pcapi.core.offers import factories
+from pcapi.core.testing import assert_num_queries
+from pcapi.models import db
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def setup_auth_client_and_offer(client):
+    venue = offerers_factories.VenueFactory()
+    offer = factories.ThingOfferFactory(venue=venue)
+    user = offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com").user
+    auth_client = client.with_session_auth(user.email)
+    return auth_client, offer
+
+
+class Returns200Test:
+    def test_create_simple_opening_hours_works(self, client):
+        auth_client, offer = setup_auth_client_and_offer(client)
+
+        data = {"openingHours": {"MONDAY": [["10:00", "18:00"]]}}
+        url = f"/offers/{offer.id}/opening-hours"
+
+        # fetch user_session
+        # fetch user
+        # fetch offer with its venue
+        # check user has access to offer
+        # delete offer's opening hours
+        # insert opening hours
+        # reload offer (with its opening hours)
+        with assert_num_queries(7):
+            response = auth_client.patch(url, json=data)
+
+        assert response.status_code == 200
+        assert response.json == {
+            "openingHours": {
+                **{weekday.value: None for weekday in offerers_models.Weekday},
+                **data["openingHours"],
+            }
+        }
+
+        db.session.refresh(offer)
+
+        assert offer.openingHours
+        assert len(offer.openingHours) == 1
+        assert offer.openingHours[0].weekday == offerers_models.Weekday.MONDAY
+
+        assert len(offer.openingHours[0].timespan) == 1
+        timespan = offer.openingHours[0].timespan[0]
+
+        assert timespan.lower == 10 * 60
+        assert timespan.upper == 18 * 60
+
+    @pytest.mark.parametrize("opening_hours", [{}, {"MONDAY": None, "TUESDAY": None}])
+    def test_empty_opening_hours_is_ok_and_creates_nothing(self, client, opening_hours):
+        auth_client, offer = setup_auth_client_and_offer(client)
+
+        data = {"openingHours": opening_hours}
+        url = f"/offers/{offer.id}/opening-hours"
+
+        # fetch user_session
+        # fetch user
+        # fetch offer with its venue
+        # check user has access to offer
+        # delete offer's existing opening hours
+        # reload offer (with its opening hours)
+        with assert_num_queries(6):
+            response = auth_client.patch(url, json=data)
+
+        assert response.status_code == 200
+        assert response.json == {"openingHours": {weekday.value: None for weekday in offerers_models.Weekday}}
+
+
+class Returns400Test:
+    def test_missing_opening_hours_returns_an_error(self, client):
+        auth_client, offer = setup_auth_client_and_offer(client)
+
+        url = f"/offers/{offer.id}/opening-hours"
+        response = auth_client.patch(url, json=None)
+
+        assert response.status_code == 400
+        assert not response.json
+
+    def test_too_many_opening_hours_for_one_day_returns_an_error(self, client):
+        auth_client, offer = setup_auth_client_and_offer(client)
+
+        data = {"openingHours": {"MONDAY": [["10:00", "18:00", "21:00"]]}}
+        url = f"/offers/{offer.id}/opening-hours"
+
+        response = auth_client.patch(url, json=data)
+        assert response.status_code == 400
+        assert response.json == {"openingHours.MONDAY.0": ["ensure this value has at most 2 items"]}
+
+    def test_starting_opening_hour_without_an_end_returns_an_error(self, client):
+        auth_client, offer = setup_auth_client_and_offer(client)
+
+        data = {"openingHours": {"MONDAY": [["10:00"]]}}
+        url = f"/offers/{offer.id}/opening-hours"
+
+        response = auth_client.patch(url, json=data)
+        assert response.status_code == 400
+        assert response.json == {"openingHours.MONDAY.0": ["ensure this value has at least 2 items"]}
+
+    def test_overlapping_timespans_returns_an_error(self, client):
+        auth_client, offer = setup_auth_client_and_offer(client)
+
+        data = {"openingHours": {"MONDAY": [["10:00", "18:00"], ["12:00", "19:00"]]}}
+        url = f"/offers/{offer.id}/opening-hours"
+
+        response = auth_client.patch(url, json=data)
+        assert response.status_code == 400
+        assert response.json == {"openingHours.MONDAY": ["overlapping opening hours: 12:00:00 <> 18:00:00"]}
+
+    def test_unknown_weekday_returns_an_error(self, client):
+        auth_client, offer = setup_auth_client_and_offer(client)
+
+        data = {"openingHours": {"OOPS": [["10:00", "18:00"]]}}
+        url = f"/offers/{offer.id}/opening-hours"
+
+        response = auth_client.patch(url, json=data)
+        assert response.status_code == 400
+        assert "openingHours.OOPS" in response.json
+
+
+class Returns401Test:
+    def test_unauthenticated_user_gets_an_error(self, client):
+        offer = factories.ThingOfferFactory()
+
+        url = f"/offers/{offer.id}/opening-hours"
+        response = client.patch(url, json={"openingHours": {"MONDAY": [["10:00", "18:00"]]}})
+        assert response.status_code == 401
+
+
+class Returns403Test:
+    def test_authenticated_user_but_with_no_rights_on_offer_gets_an_error(self, client):
+        auth_client, _ = setup_auth_client_and_offer(client)
+        offer = factories.ThingOfferFactory()
+
+        url = f"/offers/{offer.id}/opening-hours"
+        response = auth_client.patch(url, json={"openingHours": {"MONDAY": [["10:00", "18:00"]]}})
+        assert response.status_code == 403
+
+
+class Returns404Test:
+    def test_unknown_offer_returns_an_error(self, client):
+        auth_client, _ = setup_auth_client_and_offer(client)
+
+        url = "/offers/-1/opening-hours"
+        response = auth_client.patch(url, json={"openingHours": {"MONDAY": [["10:00", "18:00"]]}})
+        assert response.status_code == 404

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -196,6 +196,7 @@ export type { OffererStatsDataModel } from './models/OffererStatsDataModel';
 export type { OffererStatsResponseModel } from './models/OffererStatsResponseModel';
 export type { OffererViewsModel } from './models/OffererViewsModel';
 export type { OfferImage } from './models/OfferImage';
+export type { OfferOpeningHoursSchema } from './models/OfferOpeningHoursSchema';
 export { OfferStatus } from './models/OfferStatus';
 export type { OpeningHoursModel } from './models/OpeningHoursModel';
 export type { PatchAllOffersActiveStatusBodyModel } from './models/PatchAllOffersActiveStatusBodyModel';
@@ -267,6 +268,7 @@ export { VenueTypeCode } from './models/VenueTypeCode';
 export type { VenueTypeListResponseModel } from './models/VenueTypeListResponseModel';
 export type { VenueTypeResponseModel } from './models/VenueTypeResponseModel';
 export type { VisualDisabilityModel } from './models/VisualDisabilityModel';
+export type { WeekdayOpeningHoursTimespans } from './models/WeekdayOpeningHoursTimespans';
 export { WithdrawalTypeEnum } from './models/WithdrawalTypeEnum';
 
 export { DefaultService } from './services/DefaultService';

--- a/pro/src/apiClient/v1/models/OfferOpeningHoursSchema.ts
+++ b/pro/src/apiClient/v1/models/OfferOpeningHoursSchema.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { WeekdayOpeningHoursTimespans } from './WeekdayOpeningHoursTimespans';
+export type OfferOpeningHoursSchema = {
+  openingHours: WeekdayOpeningHoursTimespans;
+};
+

--- a/pro/src/apiClient/v1/models/WeekdayOpeningHoursTimespans.ts
+++ b/pro/src/apiClient/v1/models/WeekdayOpeningHoursTimespans.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type WeekdayOpeningHoursTimespans = {
+  FRIDAY?: Array<Array<string>> | null;
+  MONDAY?: Array<Array<string>> | null;
+  SATURDAY?: Array<Array<string>> | null;
+  SUNDAY?: Array<Array<string>> | null;
+  THURSDAY?: Array<Array<string>> | null;
+  TUESDAY?: Array<Array<string>> | null;
+  WEDNESDAY?: Array<Array<string>> | null;
+};
+

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -77,6 +77,7 @@ import type { LoginUserBodyModel } from '../models/LoginUserBodyModel';
 import type { NewPasswordBodyModel } from '../models/NewPasswordBodyModel';
 import type { OffererEligibilityResponseModel } from '../models/OffererEligibilityResponseModel';
 import type { OffererStatsResponseModel } from '../models/OffererStatsResponseModel';
+import type { OfferOpeningHoursSchema } from '../models/OfferOpeningHoursSchema';
 import type { OfferStatus } from '../models/OfferStatus';
 import type { PatchAllOffersActiveStatusBodyModel } from '../models/PatchAllOffersActiveStatusBodyModel';
 import type { PatchCollectiveOfferActiveStatusBodyModel } from '../models/PatchCollectiveOfferActiveStatusBodyModel';
@@ -1971,6 +1972,59 @@ export class DefaultService {
     return this.httpRequest.request({
       method: 'PATCH',
       url: '/offers/{offer_id}',
+      path: {
+        'offer_id': offerId,
+      },
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
+   * get_offer_opening_hours <GET>
+   * @param offerId
+   * @returns OfferOpeningHoursSchema OK
+   * @throws ApiError
+   */
+  public getOfferOpeningHours(
+    offerId: number,
+  ): CancelablePromise<OfferOpeningHoursSchema> {
+    return this.httpRequest.request({
+      method: 'GET',
+      url: '/offers/{offer_id}/opening-hours',
+      path: {
+        'offer_id': offerId,
+      },
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
+   * Create or update an offer's opening hours (erase existing if any)
+   * For each day of the week, there can be at most two pairs of timespans (opening hours start and end).
+   *
+   * Week days might have null/empty opening hours: in that case, no data will be inserted. This allows a more flexible way to send data.
+   *
+   * The output data will always contain every week day. If no opening hours has been set, the timespan data will be null.
+   *
+   * Note: since opening hours should always be erased before any new data is inserted, this route can also be used as a DELETE one.
+   * @param offerId
+   * @param requestBody
+   * @returns OfferOpeningHoursSchema OK
+   * @throws ApiError
+   */
+  public upsertOfferOpeningHours(
+    offerId: number,
+    requestBody?: OfferOpeningHoursSchema,
+  ): CancelablePromise<OfferOpeningHoursSchema> {
+    return this.httpRequest.request({
+      method: 'PATCH',
+      url: '/offers/{offer_id}/opening-hours',
       path: {
         'offer_id': offerId,
       },


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36382)

Ajout de routes concernant les horaires d'ouvertures d'une offre sur le portail pro, qui permettent les actions suivantes : 

- créer des horaires d'ouvertures ;
- modifier des horaires d'ouverture ;
- supprimer des horaires d'ouverture ;
- consulter les horaires d'ouverture existant.

Les trois premières sont réalisées par une seule et même route : la suppression revient à indiquer explicitement l'absence d'horaires d'ouverture pour chaque jour de la semaine. Etant donnée qu'on ne sauvegarde en base de données que les horaires d'ouvertures explicites, cette même route peut être utilisée pour réaliser les trois premières actions.

Dans tous les cas, l'objet de réponse contiendra les horaires d'ouverture de l'offre sur toute une semaine.

## Implémentation

Le ticket a commencé en partant des horaires d'ouverture sur les lieux (_venues_) mais l'approche finale est un peu différente dans le sens où elle est, à mon sens, plus strict au niveau de la validation (ce qui peut poser soucis). Notamment en ajoutant une contrainte en base 