### PR TITLE
(BSR)[API] fix: use backend injection for cultural survey

### DIFF
--- a/api/src/pcapi/core/object_storage/__init__.py
+++ b/api/src/pcapi/core/object_storage/__init__.py
@@ -1,80 +1,73 @@
 from pcapi import settings
+from pcapi.core.object_storage.backends.base import BaseBackend
+from pcapi.core.object_storage.backends.gcp import GCPAlternateBackend
+from pcapi.core.object_storage.backends.gcp import GCPBackend
+from pcapi.core.object_storage.backends.local import LocalBackend
 from pcapi.utils.module_loading import import_string
 
 
 GCP = "GCP"
 GCP_ALTERNATE = "GCP_ALTERNATE"
 LOCAL_FILE_STORAGE = "local"
-BACKENDS_MAPPING = {
-    GCP: "pcapi.core.object_storage.backends.gcp.GCPBackend",
-    GCP_ALTERNATE: "pcapi.core.object_storage.backends.gcp.GCPAlternateBackend",
-    LOCAL_FILE_STORAGE: "pcapi.core.object_storage.backends.local.LocalBackend",
-}
+BACKENDS_MAPPING = {GCP: GCPBackend, GCP_ALTERNATE: GCPAlternateBackend, LOCAL_FILE_STORAGE: LocalBackend}
 
 
-class FileNotFound(Exception):
-    pass
-
-
-def _check_backends_module_paths() -> None:
-    """When the app starts, this checks if the module paths are correct"""
-    for path in BACKENDS_MAPPING.values():
-        import_string(path)
-
-
-_check_backends_module_paths()
-
-
-def _get_backends() -> set:
+def check_backend_setting() -> None:
+    """When the app starts, check that the env variable is correct."""
     providers = (settings.OBJECT_STORAGE_PROVIDER or "").split(",")
     providers = [p.strip() for p in providers]
     if not providers:
         raise RuntimeError("The OBJECT_STORAGE_PROVIDER env var must be defined")
-    return {BACKENDS_MAPPING[p] for p in providers}
+
+    for provider in providers:
+        if provider not in BACKENDS_MAPPING:
+            available_backends = ", ".join(str(short_name) for short_name in BACKENDS_MAPPING)
+            raise RuntimeError(f'Unknown storage provider ("{providers}"). Accepted values are: {available_backends}')
 
 
-def _check_backend_setting() -> None:
-    """When the app starts, check that the env variable is correct."""
-    try:
-        _get_backends()
-    except KeyError as exc:
-        value = exc.args[0]
-        available_backends = ", ".join(str(short_name) for short_name in BACKENDS_MAPPING)
-        raise RuntimeError(f'Unknown storage provider ("{value}"). Accepted values are: {available_backends}')
+check_backend_setting()
 
 
-_check_backend_setting()
+def _get_backends(bucket: str, project_id: str | None) -> set[BaseBackend]:
+    providers = (settings.OBJECT_STORAGE_PROVIDER or "").split(",")
+    providers = [p.strip() for p in providers]
+    if not providers:
+        raise RuntimeError("The OBJECT_STORAGE_PROVIDER env var must be defined")
+
+    backends: set[BaseBackend] = set()
+    for provider in providers:
+        ObjectStorageBackend = BACKENDS_MAPPING[provider]
+        backends.add(ObjectStorageBackend(project_id, bucket))
+
+    return backends
 
 
-def store_public_object(folder: str, object_id: str, blob: bytes, content_type: str, *, bucket: str = "") -> None:
-    for backend_path in _get_backends():
-        backend = import_string(backend_path)
-        backend(bucket_name=bucket).store_public_object(folder, object_id, blob, content_type)
+def store_public_object(
+    folder: str, object_id: str, blob: bytes, content_type: str, *, bucket: str = "", project_id: str | None = None
+) -> None:
+    for backend in _get_backends(bucket, project_id):
+        backend.store_public_object(folder, object_id, blob, content_type)
 
 
-def get_public_object(folder: str, object_id: str, *, bucket: str = "") -> list[bytes]:
+def get_public_object(folder: str, object_id: str, *, bucket: str = "", project_id: str | None = None) -> list[bytes]:
     files = []
-    for backend_path in _get_backends():
-        backend = import_string(backend_path)
-        files.append(backend(bucket_name=bucket).get_public_object(folder, object_id))
+    for backend in _get_backends(bucket, project_id):
+        files.append(backend.get_public_object(folder, object_id))
     return files
 
 
-def delete_public_object(folder: str, object_id: str, *, bucket: str = "") -> None:
-    for backend_path in _get_backends():
-        backend = import_string(backend_path)
-        backend(bucket_name=bucket).delete_public_object(folder, object_id)
+def delete_public_object(folder: str, object_id: str, *, bucket: str = "", project_id: str | None = None) -> None:
+    for backend in _get_backends(bucket, project_id):
+        backend.delete_public_object(folder, object_id)
 
 
-def delete_public_object_recursively(storage_path: str, bucket: str = "") -> None:
-    for backend_path in _get_backends():
-        backend = import_string(backend_path)
-        backend(bucket_name=bucket).delete_public_object_recursively(storage_path)
+def delete_public_object_recursively(storage_path: str, bucket: str = "", project_id: str | None = None) -> None:
+    for backend in _get_backends(bucket, project_id):
+        backend.delete_public_object_recursively(storage_path)
 
 
-def list_files(folder: str, *, bucket: str = "", max_results: int = 1000) -> list[str]:
+def list_files(folder: str, *, bucket: str = "", max_results: int = 1000, project_id: str | None = None) -> list[str]:
     files = []
-    for backend_path in _get_backends():
-        backend = import_string(backend_path)
-        files.extend(backend(bucket_name=bucket).list_files(folder, max_results=max_results))
+    for backend in _get_backends(bucket, project_id):
+        files.extend(backend.list_files(folder, max_results=max_results))
     return files

--- a/api/src/pcapi/core/object_storage/backends/base.py
+++ b/api/src/pcapi/core/object_storage/backends/base.py
@@ -1,3 +1,7 @@
+class FileNotFound(Exception):
+    pass
+
+
 class BaseBackend:
     def __init__(
         self,

--- a/api/src/pcapi/core/object_storage/backends/gcp.py
+++ b/api/src/pcapi/core/object_storage/backends/gcp.py
@@ -8,8 +8,8 @@ from google.oauth2.service_account import Credentials
 
 from pcapi import settings
 
-from .. import FileNotFound
 from .base import BaseBackend
+from .base import FileNotFound
 
 
 logger = logging.getLogger(__name__)

--- a/api/src/pcapi/core/object_storage/backends/local.py
+++ b/api/src/pcapi/core/object_storage/backends/local.py
@@ -5,8 +5,8 @@ from itertools import chain
 
 from pcapi import settings
 
-from .. import FileNotFound
 from .base import BaseBackend
+from .base import FileNotFound
 
 
 logger = logging.getLogger(__name__)

--- a/api/src/pcapi/routes/backoffice/gdpr_user_extract/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/gdpr_user_extract/blueprint.py
@@ -94,7 +94,7 @@ def download_gdpr_extract(extract_id: int) -> utils.BackofficeResponse:
             object_id=f"{extract.id}.zip",
             bucket=settings.GCP_GDPR_EXTRACT_BUCKET,
         )
-    except object_storage.FileNotFound:
+    except object_storage.backends.base.FileNotFound:
         flash("L'extraction demandée existe mais aucune archive ne lui est associée", "warning")
         return redirect(
             url_for("backoffice_web.gdpr_extract.list_gdpr_user_data_extract"),

--- a/api/tests/core/object_storage/object_storage_test.py
+++ b/api/tests/core/object_storage/object_storage_test.py
@@ -6,9 +6,7 @@ from google.cloud.exceptions import NotFound
 
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
-from pcapi.core.object_storage import BACKENDS_MAPPING
-from pcapi.core.object_storage import _check_backend_setting
-from pcapi.core.object_storage import _check_backends_module_paths
+from pcapi.core.object_storage import check_backend_setting
 from pcapi.core.object_storage import delete_public_object
 from pcapi.core.object_storage import store_public_object
 
@@ -39,28 +37,16 @@ class CheckBackendSettingTest:
     @pytest.mark.settings(OBJECT_STORAGE_PROVIDER="")
     def test_empty_setting(self):
         with pytest.raises(RuntimeError):
-            _check_backend_setting()
+            check_backend_setting()
 
     @pytest.mark.settings(OBJECT_STORAGE_PROVIDER="local, GCP")
     def test_correct_multi_values(self):
-        _check_backend_setting()
+        check_backend_setting()
 
     @pytest.mark.settings(OBJECT_STORAGE_PROVIDER="AWS")
     def test_unknown_backend(self):
         with pytest.raises(RuntimeError):
-            _check_backend_setting()
-
-
-class CheckBackendsModulePathsTest:
-    @pytest.fixture()
-    def wrong_backend_path(self):
-        BACKENDS_MAPPING["some_backend"] = "pcapi.some_dir.SomeBackend"
-        yield BACKENDS_MAPPING
-        BACKENDS_MAPPING.pop("some_backend")
-
-    def test_wrong_path(self, wrong_backend_path):
-        with pytest.raises(ModuleNotFoundError):
-            _check_backends_module_paths()
+            check_backend_setting()
 
 
 class DeletePublicObjectTest:

--- a/api/tests/tasks/cultural_survey_task_test.py
+++ b/api/tests/tasks/cultural_survey_task_test.py
@@ -1,13 +1,14 @@
 from datetime import datetime
 from unittest.mock import patch
 
+from pcapi import settings
 from pcapi.tasks.cloud_task import AUTHORIZATION_HEADER_KEY
 from pcapi.tasks.cloud_task import AUTHORIZATION_HEADER_VALUE
 
 
 class CulturalSurveyAnswerTest:
-    @patch("pcapi.core.object_storage.backends.gcp.GCPBackend.store_public_object")
-    def test_cultural_survey_task(self, store_public_object, client, db_session):
+    @patch("pcapi.tasks.cultural_survey_tasks.store_public_object")
+    def test_cultural_survey_task(self, store_public_object_mock, client, db_session):
         submit_time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
         submit_time_short = datetime.utcnow().strftime("%Y%m%d")
         data = {
@@ -28,9 +29,11 @@ class CulturalSurveyAnswerTest:
         answers_bytes = f'{{"user_id": 1, "submitted_at": "{submit_time}", "answers": [{{"question_id": "SORTIES", "answer_ids": ["FESTIVAL"]}}, {{"question_id": "FESTIVALS", "answer_ids": ["FESTIVAL_MUSIQUE"]}}]}}'.encode()
 
         assert response.status_code == 204
-        store_public_object.assert_called_once_with(
+        store_public_object_mock.assert_called_once_with(
             folder=f"QPI_exports/qpi_answers_{submit_time_short}",
             object_id="user_id_1.jsonl",
             blob=answers_bytes,
             content_type="application/json",
+            bucket=settings.GCP_DATA_BUCKET_NAME,
+            project_id=settings.GCP_DATA_PROJECT_ID,
         )


### PR DESCRIPTION
using dependency injection allows the local object storage backend to be used, making the beneficiary activation flow possible in local development environment without having gcp credentials.
