### PR TITLE
(PC-37076)[PRO] feat: add Frontend unexpected error handling

### DIFF
--- a/pro/package.json
+++ b/pro/package.json
@@ -123,6 +123,7 @@
     "vitest": "^3.1.4",
     "vitest-axe": "^0.1.0",
     "vitest-canvas-mock": "^0.3.3",
+    "vitest-fail-on-console": "0.8.0",
     "vitest-fetch-mock": "^0.4.5"
   },
   "resolutions": {

--- a/pro/src/Root.tsx
+++ b/pro/src/Root.tsx
@@ -2,7 +2,7 @@ import { Provider } from 'react-redux'
 
 import { AppRouter } from '@/app/AppRouter/AppRouter'
 import { StoreProvider } from '@/commons/store/StoreProvider/StoreProvider'
-import { createStore } from '@/commons/store/store'
+import { rootStore } from '@/commons/store/store'
 import { PageTitleAnnouncer } from '@/components/PageTitleAnnouncer/PageTitleAnnouncer'
 
 interface RootProps {
@@ -10,10 +10,8 @@ interface RootProps {
 }
 
 export const Root = ({ isAdageIframe }: RootProps): JSX.Element => {
-  const { store } = createStore()
-
   return (
-    <Provider store={store}>
+    <Provider store={rootStore}>
       <StoreProvider isAdageIframe={isAdageIframe}>
         <AppRouter />
         <PageTitleAnnouncer />

--- a/pro/src/commons/errors/FrontendError.ts
+++ b/pro/src/commons/errors/FrontendError.ts
@@ -1,0 +1,7 @@
+export class FrontendError extends Error {
+  public readonly name = 'FrontendError'
+
+  constructor(internalMessage: string) {
+    super(internalMessage)
+  }
+}

--- a/pro/src/commons/errors/__specs__/assertOrFrontendError.spec.ts
+++ b/pro/src/commons/errors/__specs__/assertOrFrontendError.spec.ts
@@ -1,0 +1,99 @@
+import type { Mock } from 'vitest'
+
+import { assertOrFrontendError } from '../assertOrFrontendError'
+import { FrontendError } from '../FrontendError'
+import { handleUnexpectedError } from '../handleUnexpectedError'
+
+vitest.mock('../handleUnexpectedError', () => ({
+  handleUnexpectedError: vitest.fn(),
+}))
+
+const mockedHandleUnexpectedError = handleUnexpectedError as Mock
+
+describe('assertOrFrontendError', () => {
+  beforeEach(() => {
+    mockedHandleUnexpectedError.mockClear()
+  })
+
+  // This test is a placeholder to check that TS type-checking correctly infers types after a call to `assertOrFrontendError()`.
+  // If it was not, this code couldn't compile.
+  it('should respect TypeScript type-checking', () => {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+
+    const items = [
+      { id: 1, name: 'Item 1' },
+      { id: 2, name: 'Item 2' },
+    ]
+
+    const foundItem = items.find((item) => item.id === 1)
+    // @ts-expect-error `'foundItem' is possibly 'undefined'.`
+    const _impossibleExtraction = foundItem.id
+    assertOrFrontendError(foundItem, 'This should not fail')
+    // @ts-expect-no-error
+    const _extraction = foundItem.id
+
+    const mixedArray = [1, 'two', true]
+    const firstMixedArrayItem = mixedArray[0]
+    // @ts-expect-error `The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.`
+    const _impossibleCalculation = firstMixedArrayItem / 2
+    assertOrFrontendError(
+      typeof firstMixedArrayItem === 'number',
+      'This should not fail'
+    )
+    // @ts-expect-no-error
+    const _calculation = firstMixedArrayItem / 2
+
+    expect(handleUnexpectedError).not.toHaveBeenCalled()
+
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  })
+
+  it('should NOT call handleUnexpectedError() when condition is truthy', () => {
+    expect(() =>
+      assertOrFrontendError(true, 'This should not fail')
+    ).not.toThrow()
+    expect(() =>
+      assertOrFrontendError({}, 'This should not fail')
+    ).not.toThrow()
+    expect(() =>
+      assertOrFrontendError([], 'This should not fail')
+    ).not.toThrow()
+
+    expect(() =>
+      assertOrFrontendError('abc', 'This should not fail')
+    ).not.toThrow()
+    expect(() =>
+      assertOrFrontendError(123, 'This should not fail')
+    ).not.toThrow()
+
+    expect(handleUnexpectedError).not.toHaveBeenCalled()
+  })
+
+  it('should call handleUnexpectedError() when condition is falsy', () => {
+    expect(() => assertOrFrontendError(false, 'This should fail')).toThrow()
+    expect(() => assertOrFrontendError(null, 'This should fail')).toThrow()
+    expect(() => assertOrFrontendError(undefined, 'This should fail')).toThrow()
+
+    expect(() => assertOrFrontendError(0, 'This should not fail')).toThrow()
+    expect(() => assertOrFrontendError('', 'This should not fail')).toThrow()
+
+    expect(handleUnexpectedError).toHaveBeenCalledTimes(5)
+  })
+
+  it('should call handleUnexpectedError() and throw an error', () => {
+    const condition = false
+    const errorInternalMessage = 'The condition was not met'
+
+    const call = () => assertOrFrontendError(condition, errorInternalMessage)
+
+    expect(call).toThrow(FrontendError)
+    expect(call).toThrow(errorInternalMessage)
+
+    expect(handleUnexpectedError).toHaveBeenCalledTimes(2)
+
+    const firstCallArgs = mockedHandleUnexpectedError.mock.calls[0]
+    const errorInstance = firstCallArgs[0]
+
+    expect(errorInstance.message).toBe(errorInternalMessage)
+  })
+})

--- a/pro/src/commons/errors/__specs__/handleUnexpectedError.spec.ts
+++ b/pro/src/commons/errors/__specs__/handleUnexpectedError.spec.ts
@@ -1,0 +1,100 @@
+import { closeNotification } from 'commons/store/notifications/reducer'
+import { rootStore } from 'commons/store/store'
+
+import { FrontendError } from '../FrontendError'
+import { handleUnexpectedError } from '../handleUnexpectedError'
+import type { FrontendErrorOptions } from '../types'
+
+describe('handleUnexpectedError', () => {
+  const mockedSentry = vi.hoisted(() => {
+    const setExtrasMock = vi.fn()
+    const captureException = vi.fn()
+    const withScopeMock = vi.fn((cb) => cb({ setExtras: setExtrasMock }))
+
+    return { setExtrasMock, captureException, withScopeMock }
+  })
+  vi.mock('@sentry/browser', () => ({
+    withScope: mockedSentry.withScopeMock,
+    captureException: mockedSentry.captureException,
+  }))
+
+  const error = new FrontendError('An internal error message.')
+
+  afterEach(() => {
+    rootStore.dispatch(closeNotification())
+    vi.clearAllMocks()
+  })
+
+  it('dispatches a notification, logs to Sentry & console when not silent', () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(vi.fn())
+
+    const err = new FrontendError('Boom!')
+
+    handleUnexpectedError(err)
+
+    const state = rootStore.getState()
+    expect(state.notification.notification).toStrictEqual({
+      text: 'Une erreur est survenue de notre côté. Veuillez réessayer plus tard.',
+      type: 'error',
+      duration: expect.any(Number),
+    })
+
+    expect(mockedSentry.captureException).toHaveBeenCalledWith(err)
+    expect(mockedSentry.setExtrasMock).not.toHaveBeenCalled()
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(err)
+  })
+
+  it('does NOT dispatch a notification when isSilent is true', () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(vi.fn())
+
+    const options: FrontendErrorOptions = {
+      isSilent: true,
+    }
+
+    handleUnexpectedError(error, options)
+
+    const state = rootStore.getState()
+    expect(state.notification.notification).toBeNull()
+
+    expect(mockedSentry.captureException).toHaveBeenCalledOnce()
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(error)
+  })
+
+  it('forwards extras to Sentry scope when provided', () => {
+    vi.spyOn(console, 'error').mockImplementation(vi.fn())
+
+    const options: FrontendErrorOptions = {
+      extras: {
+        foo: 'bar',
+        id: 7,
+      },
+    }
+
+    handleUnexpectedError(error, options)
+
+    expect(mockedSentry.setExtrasMock).toHaveBeenCalledWith(options.extras)
+  })
+
+  it('honours a custom userMessage', () => {
+    vi.spyOn(console, 'error').mockImplementation(vi.fn())
+
+    const options: FrontendErrorOptions = {
+      userMessage: 'Houston, we have a problem…',
+    }
+
+    handleUnexpectedError(error, options)
+
+    const state = rootStore.getState()
+    expect(state.notification.notification).toStrictEqual({
+      text: options.userMessage,
+      type: 'error',
+      duration: expect.any(Number),
+    })
+  })
+})

--- a/pro/src/commons/errors/assertOrFrontendError.ts
+++ b/pro/src/commons/errors/assertOrFrontendError.ts
@@ -1,0 +1,30 @@
+import { FrontendError } from './FrontendError'
+import { handleUnexpectedError } from './handleUnexpectedError'
+import type { FrontendErrorOptions } from './types'
+
+/**
+ * Asserts that a condition is true in a TypeScript-friendly way,
+ * throwing a gracefully handled error if the condition is false.
+ *
+ * @example
+ * ```ts
+ * const foundItem = items.find((item) => item.id === selectedItemId)
+ * assertOrFrontendError(foundItem, `selectedItemId = ${selectedItemId} doesn't exist in items.`)
+ * // `foundItem` is now guaranteed to be defined and TS understands it.
+ * ```
+ */
+export function assertOrFrontendError(
+  condition: any,
+  errorInternalMessage: string,
+  errorOptions?: FrontendErrorOptions
+): asserts condition {
+  if (condition) {
+    return
+  }
+
+  const error = new FrontendError(errorInternalMessage)
+
+  handleUnexpectedError(error, errorOptions)
+
+  throw error
+}

--- a/pro/src/commons/errors/handleUnexpectedError.ts
+++ b/pro/src/commons/errors/handleUnexpectedError.ts
@@ -1,0 +1,54 @@
+import { captureException, withScope } from '@sentry/browser'
+
+import { NOTIFICATION_SHOW_DURATION } from 'commons/core/Notification/constants'
+import { NotificationTypeEnum } from 'commons/hooks/useNotification'
+import { showNotification } from 'commons/store/notifications/reducer'
+import { rootStore } from 'commons/store/store'
+
+import { FrontendError } from './FrontendError'
+import { FrontendErrorOptions } from './types'
+
+const DEFAULT_OPTIONS: FrontendErrorOptions = {
+  isSilent: false,
+  userMessage:
+    'Une erreur est survenue de notre côté. Veuillez réessayer plus tard.',
+}
+
+/**
+ * Gracefully handles an unexpected error (= "that should never happen") by:
+ * - Notifying the user (unless `isSilent` is true)
+ * - Logging it to Sentry
+ * - Logging it to the console
+ *
+ * Can be used anywhere, inluding outside of the Redux context.
+ */
+export function handleUnexpectedError(
+  error: FrontendError,
+  options: FrontendErrorOptions = {}
+): void {
+  const { extras, isSilent, userMessage } = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  }
+
+  if (!isSilent && typeof userMessage === 'string') {
+    rootStore.dispatch(
+      showNotification({
+        text: userMessage,
+        type: NotificationTypeEnum.ERROR,
+        duration: NOTIFICATION_SHOW_DURATION,
+      })
+    )
+  }
+
+  withScope((scope) => {
+    if (extras) {
+      scope.setExtras(extras)
+    }
+
+    captureException(error)
+  })
+
+  // eslint-disable-next-line no-console
+  console.error(error)
+}

--- a/pro/src/commons/errors/handleUnexpectedError.ts
+++ b/pro/src/commons/errors/handleUnexpectedError.ts
@@ -1,5 +1,4 @@
 import { captureException, withScope } from '@sentry/browser'
-
 import { NOTIFICATION_SHOW_DURATION } from 'commons/core/Notification/constants'
 import { NotificationTypeEnum } from 'commons/hooks/useNotification'
 import { showNotification } from 'commons/store/notifications/reducer'

--- a/pro/src/commons/errors/types.ts
+++ b/pro/src/commons/errors/types.ts
@@ -12,7 +12,7 @@ export type FrontendErrorOptions = Partial<{
    */
   isSilent: boolean
   /**
-   * End-user message to display when `shouldNotifyUser` is true.
+   * End-user message to display (unless `isSilent` is set to `true`).
    * @default "Une erreur est survenue de notre côté. Veuillez réessayer plus tard."
    */
   userMessage: string

--- a/pro/src/commons/errors/types.ts
+++ b/pro/src/commons/errors/types.ts
@@ -1,0 +1,19 @@
+import type { Context } from '@sentry/browser'
+import type { Extras } from '@sentry/core/build/types/types-hoist/extra.d.ts'
+
+export type FrontendErrorOptions = Partial<{
+  /** Sentry context to attach to the error. */
+  context: Context
+  /** Additional Sentry extras to attach to the error. */
+  extras: Extras
+  /**
+   * Whether to notify the user about the error.
+   * @default false
+   */
+  isSilent: boolean
+  /**
+   * End-user message to display when `shouldNotifyUser` is true.
+   * @default "Une erreur est survenue de notre côté. Veuillez réessayer plus tard."
+   */
+  userMessage: string
+}>

--- a/pro/src/commons/hooks/useCurrentUser.ts
+++ b/pro/src/commons/hooks/useCurrentUser.ts
@@ -4,6 +4,8 @@ import { SharedCurrentUserResponseModel } from '@/apiClient/v1'
 import { selectCurrentOffererId } from '@/commons/store/offerer/selectors'
 import { selectCurrentUser } from '@/commons/store/user/selectors'
 
+import { assertOrFrontendError } from '../errors/assertOrFrontendError'
+
 interface UseCurrentUserReturn {
   currentUser: SharedCurrentUserResponseModel
   selectedOffererId: number | null
@@ -13,11 +15,10 @@ export const useCurrentUser = (): UseCurrentUserReturn => {
   const currentUser = useSelector(selectCurrentUser)
   const selectedOffererId = useSelector(selectCurrentOffererId)
 
-  if (!currentUser) {
-    throw new Error(
-      'useCurrentUser should only be used on authenticated pages. Use useSelector(selectCurrentUser) otherwise.'
-    )
-  }
+  assertOrFrontendError(
+    currentUser,
+    '`useCurrentUser()` should only be used on authenticated pages. Use `useSelector(selectCurrentUser)` otherwise.'
+  )
 
   return {
     currentUser,

--- a/pro/src/commons/store/store.ts
+++ b/pro/src/commons/store/store.ts
@@ -18,4 +18,7 @@ export const createStore = (initialState = {}) => {
   return { store }
 }
 
+// We expose the store so that it can be used outside of the Redux context
+export const { store: rootStore } = createStore()
+
 export type AppDispatch = ReturnType<typeof createStore>['store']['dispatch']

--- a/pro/src/commons/utils/__specs__/yupValidationTestHelpers.spec.ts
+++ b/pro/src/commons/utils/__specs__/yupValidationTestHelpers.spec.ts
@@ -18,6 +18,8 @@ describe('getNthParentFormValues', () => {
   })
 
   it('should throw errors if context is invalid', () => {
+    vi.spyOn(console, 'error').mockImplementation(vi.fn())
+
     const context = {
       from: [
         { child: 0 },
@@ -28,10 +30,12 @@ describe('getNthParentFormValues', () => {
 
     expect(() =>
       getNthParentFormValues(context as unknown as yup.TestContext<unknown>, 1)
-    ).toThrowError('TestContext is not valid')
+    ).toThrowError('Missing or invalid "from" attribute in `testContext`.')
   })
 
   it('should throw error if parent is invalid', () => {
+    vi.spyOn(console, 'error').mockImplementation(vi.fn())
+
     const context = {
       from: [
         { value: { child: 0 } },
@@ -42,6 +46,8 @@ describe('getNthParentFormValues', () => {
 
     expect(() =>
       getNthParentFormValues(context as unknown as yup.TestContext<unknown>, 10)
-    ).toThrowError('Parent depth is not valid')
+    ).toThrowError(
+      "Parent depth (10) can't be greater than the number of available parents (3)."
+    )
   })
 })

--- a/pro/src/commons/utils/renderWithProviders.tsx
+++ b/pro/src/commons/utils/renderWithProviders.tsx
@@ -36,25 +36,6 @@ export type RenderComponentFunction<
     ExtraParams
 ) => void
 
-interface RenderComponentFunctionParams<
-  ComponentProps extends Record<string, any> | void = void,
-  ContextValues extends Record<string, any> | void = void,
-> {
-  contextValue?: ContextValues
-  options?: RenderWithProvidersOptions
-  path?: string
-  props?: Partial<ComponentProps>
-}
-/**
- * Common Template-Type for integration tests render functions utilizing `renderWithProviders()`.
- */
-export type RenderComponentFunction<
-  ComponentProps extends Record<string, any> | void = void,
-  ContextValues extends Record<string, any> | void = void,
-> = (
-  params: RenderComponentFunctionParams<ComponentProps, ContextValues>
-) => void
-
 export type RenderWithProvidersOptions = {
   storeOverrides?: DeepPartial<RootState>
   initialRouterEntries?: string[]

--- a/pro/src/commons/utils/renderWithProviders.tsx
+++ b/pro/src/commons/utils/renderWithProviders.tsx
@@ -37,9 +37,7 @@ export type RenderComponentFunction<
 ) => void
 
 interface RenderComponentFunctionParams<
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   ComponentProps extends Record<string, any> | void = void,
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   ContextValues extends Record<string, any> | void = void,
 > {
   contextValue?: ContextValues
@@ -51,10 +49,8 @@ interface RenderComponentFunctionParams<
  * Common Template-Type for integration tests render functions utilizing `renderWithProviders()`.
  */
 export type RenderComponentFunction<
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  ComponentProps extends Record<string, any> = {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  ContextValues extends Record<string, any> = {},
+  ComponentProps extends Record<string, any> | void = void,
+  ContextValues extends Record<string, any> | void = void,
 > = (
   params: RenderComponentFunctionParams<ComponentProps, ContextValues>
 ) => void

--- a/pro/src/commons/utils/renderWithProviders.tsx
+++ b/pro/src/commons/utils/renderWithProviders.tsx
@@ -36,6 +36,29 @@ export type RenderComponentFunction<
     ExtraParams
 ) => void
 
+interface RenderComponentFunctionParams<
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  ComponentProps extends Record<string, any> | void = void,
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  ContextValues extends Record<string, any> | void = void,
+> {
+  contextValue?: ContextValues
+  options?: RenderWithProvidersOptions
+  path?: string
+  props?: Partial<ComponentProps>
+}
+/**
+ * Common Template-Type for integration tests render functions utilizing `renderWithProviders()`.
+ */
+export type RenderComponentFunction<
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  ComponentProps extends Record<string, any> = {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  ContextValues extends Record<string, any> = {},
+> = (
+  params: RenderComponentFunctionParams<ComponentProps, ContextValues>
+) => void
+
 export type RenderWithProvidersOptions = {
   storeOverrides?: DeepPartial<RootState>
   initialRouterEntries?: string[]

--- a/pro/src/commons/utils/yupValidationTestHelpers.ts
+++ b/pro/src/commons/utils/yupValidationTestHelpers.ts
@@ -1,6 +1,6 @@
 import * as yup from 'yup'
 
-import { assertOrFrontendError } from 'commons/errors/assertOrFrontendError'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 
 import { hasProperty } from './types'
 

--- a/pro/src/commons/utils/yupValidationTestHelpers.ts
+++ b/pro/src/commons/utils/yupValidationTestHelpers.ts
@@ -1,5 +1,7 @@
 import * as yup from 'yup'
 
+import { assertOrFrontendError } from 'commons/errors/assertOrFrontendError'
+
 import { hasProperty } from './types'
 
 export const getYupValidationSchemaErrors = async <T extends yup.AnyObject>(
@@ -18,7 +20,7 @@ export const getYupValidationSchemaErrors = async <T extends yup.AnyObject>(
   return []
 }
 
-const hasFromAttribute = (
+const hasValidFromAttribute = (
   element: unknown
 ): element is { from: { value: unknown }[] } =>
   hasProperty(element, 'from') &&
@@ -31,14 +33,15 @@ export const getNthParentFormValues = (
   testContext: yup.TestContext<unknown>,
   parentDepth: number
 ): unknown => {
-  if (!hasFromAttribute(testContext)) {
-    throw new Error('TestContext is not valid')
-  }
+  assertOrFrontendError(
+    hasValidFromAttribute(testContext),
+    'Missing or invalid "from" attribute in `testContext`.'
+  )
   const allParentValues = testContext.from
-
-  if (allParentValues.length < parentDepth) {
-    throw new Error('Parent depth is not valid')
-  }
+  assertOrFrontendError(
+    parentDepth <= allParentValues.length,
+    `Parent depth (${parentDepth}) can't be greater than the number of available parents (${allParentValues.length}).`
+  )
 
   return allParentValues[parentDepth].value
 }

--- a/pro/src/pages/Accessibility/AccessibilityLayout.tsx
+++ b/pro/src/pages/Accessibility/AccessibilityLayout.tsx
@@ -1,11 +1,14 @@
+import { useSelector } from 'react-redux'
+
 import { Layout, LayoutProps } from '@/app/App/layout/Layout'
 import { useCurrentUser } from '@/commons/hooks/useCurrentUser'
+import { selectCurrentUser } from '@/commons/store/user/selectors'
 import fullBackIcon from '@/icons/full-back.svg'
 import { ButtonLink } from '@/ui-kit/Button/ButtonLink'
 
 import styles from './AccessibilityLayout.module.scss'
 
-interface AccessibilityLayoutProps extends LayoutProps {
+export interface AccessibilityLayoutProps extends LayoutProps {
   showBackToSignInButton?: boolean
 }
 
@@ -14,14 +17,8 @@ export const AccessibilityLayout = ({
   showBackToSignInButton,
   mainHeading,
 }: AccessibilityLayoutProps) => {
-  let isUserConnected = false
-  try {
-    // biome-ignore lint/correctness/useHookAtTopLevel: Will be fixed by https://github.com/pass-culture/pass-culture-main/pull/18427.
-    const user = useCurrentUser()
-    isUserConnected = Boolean(user)
-  } catch {
-    isUserConnected = false
-  }
+  const user = useSelector(selectCurrentUser)
+  const isUserConnected = !!user
 
   return isUserConnected ? (
     <Layout mainHeading={mainHeading} layout="basic">

--- a/pro/src/pages/Accessibility/__specs__/Accessibility.spec.tsx
+++ b/pro/src/pages/Accessibility/__specs__/Accessibility.spec.tsx
@@ -1,12 +1,20 @@
 import { screen } from '@testing-library/react'
 
-import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+import {
+  RenderComponentFunction,
+  renderWithProviders,
+} from '@/commons/utils/renderWithProviders'
 
 import { AccessibilityMenu } from '../AccessibilityMenu'
 
+const renderAccessibilityMenu: RenderComponentFunction = () => {
+  renderWithProviders(<AccessibilityMenu />)
+}
+
 describe('Statement of Accessibility page', () => {
   it('should display Accessibility information message', () => {
-    renderWithProviders(<AccessibilityMenu />)
+    renderAccessibilityMenu({})
+
     expect(screen.getByText('Informations d’accessibilité')).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Accessibility/__specs__/AccessibilityLayout.spec.tsx
+++ b/pro/src/pages/Accessibility/__specs__/AccessibilityLayout.spec.tsx
@@ -4,21 +4,36 @@ import {
   currentOffererFactory,
   sharedCurrentUserFactory,
 } from '@/commons/utils/factories/storeFactories'
-import { renderWithProviders } from '@/commons/utils/renderWithProviders'
-import { AccessibilityLayout } from '@/pages/Accessibility/AccessibilityLayout'
+import {
+  type RenderComponentFunction,
+  renderWithProviders,
+} from '@/commons/utils/renderWithProviders'
+
+import {
+  AccessibilityLayout,
+  type AccessibilityLayoutProps,
+} from '../AccessibilityLayout'
+
+const renderAccessibilityLayout: RenderComponentFunction<
+  AccessibilityLayoutProps
+> = ({ options = {}, props = {} }) => {
+  renderWithProviders(
+    <AccessibilityLayout {...props}>Children</AccessibilityLayout>,
+    options
+  )
+}
 
 describe('Accessibility layout', () => {
   it('should handle connected users', () => {
-    const user = sharedCurrentUserFactory()
-    renderWithProviders(<AccessibilityLayout>Children</AccessibilityLayout>, {
-      user,
-      storeOverrides: {
-        user: {
-          currentUser: user,
+    renderAccessibilityLayout({
+      options: {
+        storeOverrides: {
+          offerer: currentOffererFactory(),
+          user: { currentUser: sharedCurrentUserFactory() },
         },
-        offerer: currentOffererFactory(),
       },
     })
+
     expect(screen.queryByTestId('logged-out-section')).not.toBeInTheDocument()
 
     expect(
@@ -27,11 +42,8 @@ describe('Accessibility layout', () => {
   })
 
   it('should handle not connected with back button', () => {
-    renderWithProviders(
-      <AccessibilityLayout showBackToSignInButton={true}>
-        Children
-      </AccessibilityLayout>
-    )
+    renderAccessibilityLayout({ props: { showBackToSignInButton: true } })
+
     expect(screen.getByTestId('logged-out-section')).toBeInTheDocument()
     expect(
       screen.getByText('Retour à la page de connexion')
@@ -39,7 +51,8 @@ describe('Accessibility layout', () => {
   })
 
   it('should handle not connected', () => {
-    renderWithProviders(<AccessibilityLayout>Children</AccessibilityLayout>)
+    renderAccessibilityLayout({})
+
     expect(screen.getByTestId('logged-out-section')).toBeInTheDocument()
     expect(
       screen.queryByText('Retour à la page de connexion')

--- a/pro/src/pages/AdageIframe/app/hooks/useAdageUser.ts
+++ b/pro/src/pages/AdageIframe/app/hooks/useAdageUser.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 
-import { assertOrFrontendError } from 'commons/errors/assertOrFrontendError'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 
 import { AdageUserContext } from '../providers/AdageUserContext'
 

--- a/pro/src/pages/AdageIframe/app/hooks/useAdageUser.ts
+++ b/pro/src/pages/AdageIframe/app/hooks/useAdageUser.ts
@@ -1,5 +1,7 @@
 import { useContext } from 'react'
 
+import { assertOrFrontendError } from 'commons/errors/assertOrFrontendError'
+
 import { AdageUserContext } from '../providers/AdageUserContext'
 
 export const useAdageUser = () => {
@@ -10,12 +12,10 @@ export const useAdageUser = () => {
     institutionOfferCount,
     setInstitutionOfferCount,
   } = useContext(AdageUserContext)
-  /* istanbul ignore next: this is a safety check, shouldn't be possible to hit */
-  if (!adageUser) {
-    throw new Error(
-      'useAdageUser must be used within an AdageUserContextProvider'
-    )
-  }
+  assertOrFrontendError(
+    adageUser,
+    '`useAdageUser` must be used within an `AdageUserContextProvider`.'
+  )
 
   return {
     adageUser,

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/useCollectiveOfferFromParams.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/useCollectiveOfferFromParams.tsx
@@ -13,6 +13,7 @@ import {
   GET_COLLECTIVE_OFFER_TEMPLATE_QUERY_KEY,
 } from '@/commons/config/swrQueryKeys'
 import { extractOfferIdAndOfferTypeFromRouteParams } from '@/commons/core/OfferEducational/utils/extractOfferIdAndOfferTypeFromRouteParams'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { useOfferer } from '@/commons/hooks/swr/useOfferer'
 import { Spinner } from '@/ui-kit/Spinner/Spinner'
 
@@ -65,14 +66,16 @@ export const useCollectiveOfferFromParams = (
   const { data: offerer } = useOfferer(offererId)
 
   if (offerIdFromParams === undefined) {
-    if (isOfferMandatory) {
-      throw new Error('useOffer hook called on a page without offerId')
-    } else {
-      return {
-        offer: undefined,
-        isTemplate: pathNameIncludesTemplate,
-        offerer: undefined,
-      }
+    assertOrFrontendError(
+      !isOfferMandatory,
+      // TODO (igabriele, 2025-07-31): This error message is obscure, we should clarify it.
+      'useOffer hook called on a page without offerId.'
+    )
+
+    return {
+      offer: undefined,
+      isTemplate: pathNameIncludesTemplate,
+      offerer: undefined,
     }
   }
 

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferStock/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferStock/CollectiveOfferStockCreation/CollectiveOfferStockCreation.tsx
@@ -24,6 +24,7 @@ import { createStockDataPayload } from '@/commons/core/OfferEducational/utils/cr
 import { extractInitialStockValues } from '@/commons/core/OfferEducational/utils/extractInitialStockValues'
 import { hasStatusCodeAndErrorsCode } from '@/commons/core/OfferEducational/utils/hasStatusCode'
 import { FORM_ERROR_MESSAGE } from '@/commons/core/shared/constants'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { useNotification } from '@/commons/hooks/useNotification'
 import { queryParamsFromOfferer } from '@/commons/utils/queryParamsFromOfferer'
 import { CollectiveOfferLayout } from '@/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferLayout'
@@ -63,11 +64,10 @@ export const CollectiveOfferStockCreation = ({
     ([, id]) => api.getCollectiveOfferRequest(Number(id))
   )
 
-  if (isCollectiveOfferTemplate(offer)) {
-    throw new Error(
-      'Impossible de mettre à jour les stocks d’une offre vitrine.'
-    )
-  }
+  assertOrFrontendError(
+    !isCollectiveOfferTemplate(offer),
+    '`offer` shoud not be a (collective offer) template.'
+  )
 
   const initialValues = extractInitialStockValues(
     offer,

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferStock/CollectiveOfferStockEdition/CollectiveOfferStockEdition.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferStock/CollectiveOfferStockEdition/CollectiveOfferStockEdition.tsx
@@ -17,6 +17,7 @@ import {
   FORM_ERROR_MESSAGE,
   PATCH_SUCCESS_MESSAGE,
 } from '@/commons/core/shared/constants'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { useNotification } from '@/commons/hooks/useNotification'
 import { isCollectiveStockEditable } from '@/commons/utils/isActionAllowedOnCollectiveOffer'
 import { CollectiveOfferLayout } from '@/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferLayout'
@@ -35,9 +36,10 @@ export const CollectiveOfferStockEdition = ({
   const navigate = useNavigate()
   const { mutate } = useSWRConfig()
 
-  if (isCollectiveOfferTemplate(offer)) {
-    throw new Error('Impossible de mettre à jour le stock d’une offre vitrine.')
-  }
+  assertOrFrontendError(
+    !isCollectiveOfferTemplate(offer),
+    '`offer` shoud not be a (collective offer) template.'
+  )
 
   const initialValues = extractInitialStockValues(offer)
 

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferCreationVisibility.tsx
@@ -11,6 +11,7 @@ import {
   Mode,
 } from '@/commons/core/OfferEducational/types'
 import { extractInitialVisibilityValues } from '@/commons/core/OfferEducational/utils/extractInitialVisibilityValues'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { queryParamsFromOfferer } from '@/commons/utils/queryParamsFromOfferer'
 import {
   MandatoryCollectiveOfferFromParamsProps,
@@ -52,11 +53,10 @@ export const CollectiveOfferVisibility = ({
     navigate(`/offre/${offerId}/collectif/creation/recapitulatif`)
   }
 
-  if (isCollectiveOfferTemplate(offer)) {
-    throw new Error(
-      'Impossible de mettre à jour la visibilité d’une offre vitrine.'
-    )
-  }
+  assertOrFrontendError(
+    !isCollectiveOfferTemplate(offer),
+    '`offer` shoud not be a (collective offer) template.'
+  )
 
   const initialValues = extractInitialVisibilityValues(offer.institution)
 

--- a/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferEditionVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/CollectiveOfferEditionVisibility.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/commons/core/OfferEducational/types'
 import { computeURLCollectiveOfferId } from '@/commons/core/OfferEducational/utils/computeURLCollectiveOfferId'
 import { extractInitialVisibilityValues } from '@/commons/core/OfferEducational/utils/extractInitialVisibilityValues'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { useNotification } from '@/commons/hooks/useNotification'
 import { isCollectiveInstitutionEditable } from '@/commons/utils/isActionAllowedOnCollectiveOffer'
 import {
@@ -38,11 +39,10 @@ export const CollectiveOfferEditionVisibility = ({
     { fallbackData: [] }
   )
 
-  if (isCollectiveOfferTemplate(offer)) {
-    throw new Error(
-      'Impossible de mettre à jour la visibilité d’une offre vitrine.'
-    )
-  }
+  assertOrFrontendError(
+    !isCollectiveOfferTemplate(offer),
+    '`offer` shoud not be a (collective offer) template.'
+  )
 
   const onSuccess = async ({
     message,

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/commons/utils.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/commons/utils.ts
@@ -12,6 +12,7 @@ import { showOptionsTree } from '@/commons/core/Offers/categoriesSubTypes'
 import { isOfferSynchronized } from '@/commons/core/Offers/utils/typology'
 import { AccessibilityFormValues } from '@/commons/core/shared/types'
 import { SelectOption } from '@/commons/custom_types/form'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { getAccessibilityInfoFromVenue } from '@/commons/utils/getAccessibilityInfoFromVenue'
 import { Option } from '@/pages/AdageIframe/app/types'
 
@@ -143,10 +144,7 @@ export function getInitialValuesFromOffer({
     (subcategory: SubcategoryResponseModel) =>
       subcategory.id === offer.subcategoryId
   )
-
-  if (subcategory === undefined) {
-    throw Error('La categorie de l’offre est introuvable')
-  }
+  assertOrFrontendError(subcategory, 'La categorie de l’offre est introuvable.')
 
   const ean = offer.extraData?.ean ?? DEFAULT_DETAILS_FORM_VALUES.ean
   const maybeAccessibility = isNewOfferCreationFlowFeatureActive

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux'
 
 import { api } from '@/apiClient/api'
 import { getError, isErrorAPIError } from '@/apiClient/helpers'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { selectCurrentOffererId } from '@/commons/store/offerer/selectors'
 import { FormLayout } from '@/components/FormLayout/FormLayout'
 import fullCloseIcon from '@/icons/full-close.svg'
@@ -93,9 +94,10 @@ export const DetailsEanSearch = ({
   const onSearch = async (data: EanSearchForm) => {
     if (data.eanSearch) {
       try {
-        if (!selectedOffererId) {
-          throw new Error('Offerer should have already been selected')
-        }
+        assertOrFrontendError(
+          selectedOffererId,
+          'Offerer should have already been selected.'
+        )
 
         const product = await api.getProductByEan(
           data.eanSearch,

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsForm.tsx
@@ -108,10 +108,7 @@ export const DetailsForm = ({
     }
 
     const venue = venues.find((venue) => venue.id === Number(venueId))
-    if (!venue) {
-      // TODO (igabriele, 2025-07-16): Handle that more gracefully once we have agreed on how to handle it.
-      throw new Error(`Venue with id ${venueId} not found in venues.`)
-    }
+    assert(venue, `Venue with id ${venueId} not found in venues.`)
 
     const { accessibility } = getAccessibilityInfoFromVenue(venue)
     setValue('accessibility', accessibility)

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreen.tsx
@@ -22,6 +22,8 @@ import {
 import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
 import { isOfferDisabled } from '@/commons/core/Offers/utils/isOfferDisabled'
 import { isOfferSynchronized } from '@/commons/core/Offers/utils/typology'
+import { FrontendError } from '@/commons/errors/FrontendError'
+import { handleUnexpectedError } from '@/commons/errors/handleUnexpectedError'
 import { useActiveFeature } from '@/commons/hooks/useActiveFeature'
 import { useOfferWizardMode } from '@/commons/hooks/useOfferWizardMode'
 import { FormLayout } from '@/components/FormLayout/FormLayout'
@@ -264,9 +266,10 @@ export const IndividualOfferDetailsScreen = ({
     const subCategory = subCategories.find(
       (subCategory) => subCategory.id === subcategoryId
     )
-
     if (!subCategory) {
-      throw new Error('Unknown or missing subcategoryId')
+      return handleUnexpectedError(
+        new FrontendError('Unknown or missing subcategoryId')
+      )
     }
 
     const { categoryId, conditionalFields: subcategoryConditionalFields } =

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreenNext.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreenNext.tsx
@@ -20,6 +20,8 @@ import {
 import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
 import { isOfferDisabled } from '@/commons/core/Offers/utils/isOfferDisabled'
 import { isOfferSynchronized } from '@/commons/core/Offers/utils/typology'
+import { FrontendError } from '@/commons/errors/FrontendError'
+import { handleUnexpectedError } from '@/commons/errors/handleUnexpectedError'
 import { useActiveFeature } from '@/commons/hooks/useActiveFeature'
 import { useOfferWizardMode } from '@/commons/hooks/useOfferWizardMode'
 import { FormLayout } from '@/components/FormLayout/FormLayout'
@@ -234,15 +236,14 @@ export const IndividualOfferDetailsScreenNext = ({
       images,
     } = product
 
-    const subCategory = subCategories.find(
-      (subCategory) => subCategory.id === subcategoryId
-    )
-
-    if (!subCategory) {
-      throw new Error('Unknown or missing subcategoryId')
+    const subcategory = subCategories.find((s) => s.id === subcategoryId)
+    if (!subcategory) {
+      return handleUnexpectedError(
+        new FrontendError('Unknown or missing `subcategoryId`.')
+      )
     }
 
-    const { categoryId, conditionalFields } = subCategory
+    const { categoryId, conditionalFields } = subcategory
 
     const imageUrl = images.recto
     if (imageUrl) {

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryBookings/components/DownloadBookingsModal/DownloadBookingModal.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryBookings/components/DownloadBookingsModal/DownloadBookingModal.spec.tsx
@@ -16,6 +16,7 @@ const render = (priceCategoryAndScheduleCountByDate: EventDatesInfos) => {
   renderWithProviders(
     <Dialog.Root defaultOpen>
       <Dialog.Content aria-describedby={undefined}>
+        <Dialog.Title>Title</Dialog.Title>
         <DownloadBookingsModal
           offerId={MOCK_OFFER_ID}
           priceCategoryAndScheduleCountByDate={

--- a/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/pages/Offerers/Offerer/VenueV1/VenueEdition/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -1,6 +1,7 @@
 import { DMSApplicationForEAC, DMSApplicationstatus } from '@/apiClient/v1'
 import { useAnalytics } from '@/app/App/analytics/firebase'
 import { Events } from '@/commons/core/FirebaseEvents/constants'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { getDateToFrenchText } from '@/commons/utils/date'
 import { ButtonLink } from '@/ui-kit/Button/ButtonLink'
 import { ButtonVariant } from '@/ui-kit/Button/types'
@@ -350,6 +351,6 @@ export const CollectiveDmsTimeline = ({
       return droppedByDms
     /* istanbul ignore next: we dont want to test this case in unit test */
     default:
-      throw new Error('Invalid dms status')
+      assertOrFrontendError(false, 'Invalid dms status.')
   }
 }

--- a/pro/src/pages/VenueSettings/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx
+++ b/pro/src/pages/VenueSettings/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx
@@ -20,6 +20,7 @@ const renderCinemaProviderForm = async (
   renderWithProviders(
     <Dialog.Root defaultOpen>
       <Dialog.Content aria-describedby={undefined}>
+        <Dialog.Title>Title</Dialog.Title>
         <GenericCinemaProviderForm {...props} />
       </Dialog.Content>
     </Dialog.Root>

--- a/pro/src/vitest.setup.ts
+++ b/pro/src/vitest.setup.ts
@@ -2,6 +2,7 @@ import 'regenerator-runtime/runtime'
 import { expect, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import * as matchers from 'vitest-axe/matchers'
+import failOnConsole from 'vitest-fail-on-console'
 import createFetchMock from 'vitest-fetch-mock'
 import 'vitest-canvas-mock'
 
@@ -36,114 +37,6 @@ class ResizeObserver {
 
 window.ResizeObserver = ResizeObserver
 
-/* BELOW WE HANDLE WARNINGS AND ERRORS THROWN INSIDE THE TESTS */
-
-// DO NOT ADD ERRORS TO THIS LIST!
-// We should remove it progressively
-const acceptableErrors = [
-  // This is added because `orejim` uses React 17 internally.
-  // We'll wait for the library update to remove this.
-  {
-    error:
-      "Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot",
-    files: [''],
-  },
-  {
-    error:
-      '⚠️ React Router Future Flag Warning: React Router will begin wrapping state updates in `React.startTransition` in v7. You can use the `v7_startTransition` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_starttransition.',
-    files: [''],
-  },
-  {
-    error:
-      '⚠️ React Router Future Flag Warning: Relative route resolution within Splat routes is changing in v7. You can use the `v7_relativeSplatPath` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_relativesplatpath.',
-    files: [''],
-  },
-  {
-    error:
-      '⚠️ React Router Future Flag Warning: The persistence behavior of fetchers is changing in v7. You can use the `v7_fetcherPersist` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_fetcherpersist.',
-    files: [''],
-  },
-  {
-    error:
-      '⚠️ React Router Future Flag Warning: Casing of `formMethod` fields is being normalized to uppercase in v7. You can use the `v7_normalizeFormMethod` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_normalizeformmethod.',
-    files: [''],
-  },
-  {
-    error:
-      '⚠️ React Router Future Flag Warning: `RouterProvider` hydration behavior is changing in v7. You can use the `v7_partialHydration` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_partialhydration.',
-    files: [''],
-  },
-  {
-    error:
-      '⚠️ React Router Future Flag Warning: The revalidation behavior after 4xx/5xx `action` responses is changing in v7. You can use the `v7_skipActionErrorRevalidation` future flag to opt-in early. For more information, see https://reactrouter.com/v6/upgrading/future#v7_skipactionerrorrevalidation.',
-    files: [''],
-  },
-  // Radix-ui updates wants us to use `DialogTitle` that always adds a `h2`
-  // RGAA requires the title to be a `h1`
-  // All our dilogs have titles
-  {
-    error:
-      '`DialogContent` requires a `DialogTitle` for the component to be accessible for screen reader users.',
-    files: [''],
-  },
-]
-
-const findErrorSourceFile = (...data: any[]) => {
-  let fileMatching: string | null = null
-  for (let i = 0; i < data.length; i++) {
-    const item = data[i]
-    if (!(typeof item === 'string')) {
-      return false
-    }
-
-    const isSourceFileRegexp = new RegExp('pro/src')
-    const lines = item.split('\n')
-    for (let j = 0; j < lines.length; j++) {
-      if (isSourceFileRegexp.test(lines[j])) {
-        fileMatching = lines[j]
-        break
-      }
-    }
-    if (fileMatching !== null) {
-      break
-    }
-  }
-
-  const extractFilenameRegexp = new RegExp('pro/src/(.*):.*:')
-  return fileMatching?.match(extractFilenameRegexp)?.[1]
-}
-
-const isErrorInAllowList = (...data: any[]) => {
-  const cleanedError = data[0].split('\n')[0]
-  // When this message happens, it is always because there is another console.error that is more relevant
-  if (cleanedError.includes('The above error occurred in')) {
-    return true
-  }
-
-  const errorSourceFile = findErrorSourceFile(...data)
-
-  return acceptableErrors.some(
-    (possibleError) =>
-      possibleError.error === cleanedError &&
-      possibleError.files.includes(errorSourceFile || '')
-  )
-}
-
-// Flag console.warn and console.error as failed tests
-const originalWarn = global.console.warn
-global.console.warn = (message, ...args) => {
-  originalWarn(`Already caught: ${message}`, ...args)
-
-  if (!isErrorInAllowList(message, ...args)) {
-    throw message
-  }
-}
-
-const originalError = global.console.error
-global.console.error = (message, ...args) => {
-  originalError(`Already caught: ${message}`, ...args)
-
-  if (!isErrorInAllowList(message, ...args)) {
-    throw message
-  }
-}
+// Fail on console errors and warnings
+// https://github.com/thomasbrodusch/vitest-fail-on-console#readme
+failOnConsole()

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -2957,7 +2957,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.0.1:
+chalk@^5.0.1, chalk@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.4.1.tgz#1b48bf0963ec158dce2aacf69c093ae2dd2092d8"
   integrity sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==
@@ -6752,6 +6752,13 @@ vitest-canvas-mock@^0.3.3:
   integrity sha512-3P968tYBpqYyzzOaVtqnmYjqbe13576/fkjbDEJSfQAkHtC5/UjuRHOhFEN/ZV5HVZIkaROBUWgazDKJ+Ibw+Q==
   dependencies:
     jest-canvas-mock "~2.5.2"
+
+vitest-fail-on-console@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/vitest-fail-on-console/-/vitest-fail-on-console-0.8.0.tgz#632a973c2deadef47cdb0fd36f67975b75b640ef"
+  integrity sha512-RvUaTyX/0/CYq+US/6UzXOWtKZF8ewrYEnobEZFh2FW9OCuw9dZzecKlskKS0dDpaMuPfBP9xqJ2rp5XxpJeMQ==
+  dependencies:
+    chalk "^5.4.1"
 
 vitest-fetch-mock@^0.4.5:
   version "0.4.5"


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37076)

## Pourquoi ?

Parce qu’une erreur improbable mais possible pour laquelle on a besoin de faire une condition de type checking doit à la fois :

- Être catchée ou handlée le plus tôt possible (scope le plus proche).
- Être logguée dans Sentry.
- Afficher un message à l’utilisateur·ice, à minima générique, pour l’avertir que son action n’a pas fonctionné et que l’erreur “est de notre faute” (pas de la sienne).

Ce genre d’erreur devient généralement un bug high prio quand elle arrive.

## Example de cas

```tsx
export function Example({ myItems }: { myItems: MyItem[] }) {
  const myItemsAsOptions = toOptions(myItems)

  const updateMyItem = (event: ChangeEvent<HTMLSelectElement>) => {
    const myItemId = event.target.value
    const myItem = myItems.find(({ id }) => id === myItemId)
    if (!myItem) {
      // Voici le genre d'erreur "qui ne devrait jamais arriver",
      // mais peut, et nécessite un traitement normalisé.
    }

    // ...
  }

  return <Select options={myItemsAsOptions} onChange={updateMyItem} />
}
```

## Proposition actuelle

> [!NOTE]  
> Quelque soit la version choisie, on peut :
> - Customiser le message d'erreur affichée à l'utilisateur·ice.
> - Choisir d'afficher ou non le message à l'utilisateur·ice.
> - Customiser le contexte et les extras envoyés à Sentry.

### Version avec Soft Return

```ts
  const updateMyItem = (event: ChangeEvent<HTMLSelectElement>) => {
    const myItemId = event.target.value
    const myItem = myItems.find(({ id }) => id === myItemId)
    if (!myItem) {
      return handleUnexpectedError(new FrontendError(`myItemId = ${myItemId} doesn't exist in myItems.`))
    }
  }
```

### Version avec Hard Throw

> [!WARNING]   
> Dans un monde idéal, utiliser cette écriture suppose qu'on se trouve au sein de composants dont les errors boundaries sont parfaitement gérées, y compris en terme d'UX. Si la condition est falsy, une `FrontendError` est thrown et devrait être catchée proprement par le composant parent.

```ts
  const updateMyItem = (event: ChangeEvent<HTMLSelectElement>) => {
    const myItemId = event.target.value
    const myItem = myItems.find(({ id }) => id === myItemId)
    assertOrFrontendError(myItem, `myItemId = ${myItemId} doesn't exist in myItems.`)
    // TS infère bien à partir d'ici que `myItem` est défini.
  }
```