### PR TITLE
(PC-36351)[PRO] feat: Removes <h1> and use 'mainHeading' Layout prop

### DIFF
--- a/pro/cypress/e2e/financialManagement.cy.ts
+++ b/pro/cypress/e2e/financialManagement.cy.ts
@@ -96,7 +96,7 @@ describe('Financial Management - messages, links to external help page, reimburs
           'We must be redirected on the homepage of the new offerer, who’s not onboarded',
       })
       cy.findByText('Bienvenue sur le pass Culture Pro !')
-      cy.findByText('À qui souhaitez-vous proposer votre première offre ?')
+      cy.findByText('Où souhaitez-vous diffuser votre première offre ?')
     })
   })
 

--- a/pro/cypress/support/helpers.ts
+++ b/pro/cypress/support/helpers.ts
@@ -143,8 +143,8 @@ export function logInAndSeeDidacticOnboarding(
 
     cy.findByText('Bienvenue sur le pass Culture Pro !')
     cy.findByText('Où souhaitez-vous diffuser votre première offre ?')
-    cy.findByText('Aux jeunes sur l’application mobile pass Culture')
-    cy.findByText('Aux enseignants sur la plateforme ADAGE')
+    cy.findByText('Sur l’application mobile à destination des jeunes')
+    cy.findByText('Sur ADAGE à destination des enseignants')
     cy.findAllByText('Commencer').should('have.length', 2)
   })
 }

--- a/pro/cypress/support/helpers.ts
+++ b/pro/cypress/support/helpers.ts
@@ -142,7 +142,7 @@ export function logInAndSeeDidacticOnboarding(
     cy.findAllByTestId('spinner').should('not.exist')
 
     cy.findByText('Bienvenue sur le pass Culture Pro !')
-    cy.findByText('À qui souhaitez-vous proposer votre première offre ?')
+    cy.findByText('Où souhaitez-vous diffuser votre première offre ?')
     cy.findByText('Aux jeunes sur l’application mobile pass Culture')
     cy.findByText('Aux enseignants sur la plateforme ADAGE')
     cy.findAllByText('Commencer').should('have.length', 2)

--- a/pro/eslint.config.mjs
+++ b/pro/eslint.config.mjs
@@ -1,12 +1,12 @@
-import { fixupPluginRules } from '@eslint/compat';
+import { fixupPluginRules } from '@eslint/compat'
 import eslint from '@eslint/js'
 
+import cypressPlugin from 'eslint-plugin-cypress/flat'
 import importPlugin from 'eslint-plugin-import'
 import reactPlugin from 'eslint-plugin-react'
 import reactHooksPlugin from 'eslint-plugin-react-hooks'
-import cypressPlugin from 'eslint-plugin-cypress/flat'
 
-import tseslint from 'typescript-eslint';
+import tseslint from 'typescript-eslint'
 
 import globals from 'globals'
 import path from 'node:path'
@@ -24,7 +24,7 @@ export default tseslint.config(
       ['import']: importPlugin,
       ['react']: reactPlugin,
       ['react-hooks']: fixupPluginRules(reactHooksPlugin),
-    }
+    },
   },
   // config with just ignores is the replacement for `.eslintignore`
   {
@@ -45,7 +45,7 @@ export default tseslint.config(
       '**/vite.config.ts',
       '.storybook/*',
       'src/**/*.gif',
-    ]
+    ],
   },
   // extends ...
   eslint.configs.recommended,
@@ -111,13 +111,28 @@ export default tseslint.config(
       '@typescript-eslint/no-unnecessary-condition': 'error',
       '@typescript-eslint/prefer-ts-expect-error': 'error',
       '@typescript-eslint/switch-exhaustiveness-check': 'error',
-      'eqeqeq': 'error',
-      'curly': ['error', 'all'],
+      eqeqeq: 'error',
+      curly: ['error', 'all'],
       'import/export': 'error',
       'import/no-default-export': 'error',
       'no-console': 'error',
       'require-await': 'error',
-      'react/forbid-elements': [2, { forbid: [{ element: "DevTool", message: "Don't forget to remove before commit" }], }],
+      'react/forbid-elements': [
+        2,
+        {
+          forbid: [
+            {
+              element: 'DevTool',
+              message: "Don't forget to remove before commit",
+            },
+            {
+              element: 'MainHeading',
+              message:
+                'Avoid the use of `<MainHeading>` inside a component. Rather use the `<Layout>` component with the `mainHeading` prop whenever possible',
+            },
+          ],
+        },
+      ],
       'react/no-unescaped-entities': [
         'error',
         {
@@ -182,5 +197,5 @@ export default tseslint.config(
     rules: {
       'import/no-default-export': 'off',
     },
-  },
-);
+  }
+)

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -109,6 +109,7 @@ export const Layout = ({
     areMainHeadingAndBackToNavLinkInChild || (mainHeading && isConnected)
 
   const mainHeadingWrapper = mainHeading ? (
+    // eslint-disable-next-line react/forbid-elements
     <MainHeading
       mainHeading={mainHeading}
       mainSubHeading={mainSubHeading}

--- a/pro/src/app/App/layout/Layout.tsx
+++ b/pro/src/app/App/layout/Layout.tsx
@@ -50,6 +50,44 @@ export interface LayoutProps {
   showFooter?: boolean
 }
 
+interface MainHeadingProps {
+  className?: string
+  mainHeading: React.ReactNode
+  mainSubHeading?: string
+  isConnected?: boolean
+}
+export const MainHeading = ({
+  className,
+  mainHeading,
+  mainSubHeading,
+  isConnected = true,
+}: MainHeadingProps): JSX.Element => {
+  return (
+    <div
+      className={cn(className, styles['main-heading-wrapper'], {
+        [styles['main-heading-wrapper-with-subtitle']]: mainSubHeading,
+      })}
+    >
+      <h1 className={styles['main-heading-title']}>
+        {mainHeading}
+        {mainSubHeading && (
+          <span className={styles['main-heading-subtitle']}>
+            {mainSubHeading}
+          </span>
+        )}
+      </h1>
+      {isConnected && (
+        <BackToNavLink
+          className={cn(styles['main-heading-back-to-nav-link'], {
+            [styles['main-heading-back-to-nav-link-with-subtitle']]:
+              mainSubHeading,
+          })}
+        />
+      )}
+    </div>
+  )
+}
+
 export const Layout = ({
   children,
   mainHeading,
@@ -71,28 +109,11 @@ export const Layout = ({
     areMainHeadingAndBackToNavLinkInChild || (mainHeading && isConnected)
 
   const mainHeadingWrapper = mainHeading ? (
-    <div
-      className={cn(styles['main-heading-wrapper'], {
-        [styles['main-heading-wrapper-with-subtitle']]: mainSubHeading,
-      })}
-    >
-      <h1 className={styles['main-heading-title']}>
-        {mainHeading}
-        {mainSubHeading && (
-          <span className={styles['main-heading-subtitle']}>
-            {mainSubHeading}
-          </span>
-        )}
-      </h1>
-      {isConnected && (
-        <BackToNavLink
-          className={cn(styles['main-heading-back-to-nav-link'], {
-            [styles['main-heading-back-to-nav-link-with-subtitle']]:
-              mainSubHeading,
-          })}
-        />
-      )}
-    </div>
+    <MainHeading
+      mainHeading={mainHeading}
+      mainSubHeading={mainSubHeading}
+      isConnected={isConnected}
+    />
   ) : null
 
   return (

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.module.scss
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.module.scss
@@ -52,3 +52,7 @@
   justify-content: center;
   margin-top: rem.torem(16px);
 }
+
+.button-getting-started {
+  width: 100%;
+}

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.spec.tsx
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.spec.tsx
@@ -32,7 +32,7 @@ describe('OnboardingOffersChoice Component', () => {
   it('renders the first card with correct title, description, and button', () => {
     // Check for the first card's title
     const firstCardTitle = screen.getByText(
-      'Aux jeunes sur l’application mobile pass Culture'
+      'Sur l’application mobile à destination des jeunes'
     )
     expect(firstCardTitle).toBeInTheDocument()
 
@@ -44,7 +44,7 @@ describe('OnboardingOffersChoice Component', () => {
   it('renders the second card with correct title, description, and button', () => {
     // Check for the second card's title
     const secondCardTitle = screen.getByText(
-      'Aux enseignants sur la plateforme ADAGE'
+      'Sur ADAGE à destination des enseignants'
     )
     expect(secondCardTitle).toBeInTheDocument()
 

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
@@ -42,7 +42,7 @@ export const OnboardingOffersChoice = () => {
     <div className={styles['card-container']}>
       <Card
         imageSrc={individuelle}
-        title="Aux jeunes sur l’application mobile pass Culture"
+        title="Sur l’application mobile à destination des jeunes"
         actions={
           <ButtonLink
             variant={ButtonVariant.PRIMARY}
@@ -58,12 +58,12 @@ export const OnboardingOffersChoice = () => {
         <strong className={styles['card-description-highlight']}>
           + de 4 millions de jeunes
         </strong>
-        .
+        inscrits sur l’application mobile pass Culture.
       </Card>
 
       <Card
         imageSrc={collective}
-        title="Aux enseignants sur la plateforme ADAGE"
+        title="Sur ADAGE à destination des enseignants"
         actions={
           <Dialog
             title=""
@@ -90,9 +90,9 @@ export const OnboardingOffersChoice = () => {
           </Dialog>
         }
       >
-        Vos offres seront visibles par{' '}
+        Vos offres seront visibles{' '}
         <strong className={styles['card-description-highlight']}>
-          tous les enseignants
+          par tous les enseignants
         </strong>{' '}
         des collèges et lycées publics et privés sous contrat.
       </Card>

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
@@ -48,6 +48,7 @@ export const OnboardingOffersChoice = () => {
             variant={ButtonVariant.PRIMARY}
             to="/onboarding/individuel"
             aria-label="Commencer la création d’offre sur l’application mobile"
+            className={styles['button-getting-started']}
           >
             Commencer
           </ButtonLink>
@@ -78,6 +79,7 @@ export const OnboardingOffersChoice = () => {
                   )
                   setShowModal(true)
                 }}
+                className={styles['button-getting-started']}
               >
                 Commencer
               </Button>

--- a/pro/src/components/ReSendEmailCallout/ReSendEmailCallout.spec.tsx
+++ b/pro/src/components/ReSendEmailCallout/ReSendEmailCallout.spec.tsx
@@ -21,7 +21,7 @@ describe('ReSendEmailCallout', () => {
   it('should render correctly', () => {
     renderComponent()
     expect(
-      screen.getByText(/Vous n’avez pas reçu d’email ?/)
+      screen.getByText(/Vous n’avez pas reçu notre email ?/)
     ).toBeInTheDocument()
     expect(screen.getByText('cliquez ici')).toBeEnabled()
   })

--- a/pro/src/components/ReSendEmailCallout/ReSendEmailCallout.spec.tsx
+++ b/pro/src/components/ReSendEmailCallout/ReSendEmailCallout.spec.tsx
@@ -21,7 +21,7 @@ describe('ReSendEmailCallout', () => {
   it('should render correctly', () => {
     renderComponent()
     expect(
-      screen.getByText(/Vous n’avez pas reçu notre email ?/)
+      screen.getByText(/Vous n’avez pas reçu d’email ?/)
     ).toBeInTheDocument()
     expect(screen.getByText('cliquez ici')).toBeEnabled()
   })

--- a/pro/src/components/ReSendEmailCallout/ReSendEmailCallout.tsx
+++ b/pro/src/components/ReSendEmailCallout/ReSendEmailCallout.tsx
@@ -30,7 +30,7 @@ export const ReSendEmailCallout = ({
   return (
     <Callout>
       <p className={styles['re-send-callout']}>
-        Vous n’avez pas reçu notre email ? <br /> Vérifiez vos spams
+        Vous n’avez pas reçu d’email ? <br /> Vérifiez vos spams
         {hideLink ? (
           '.'
         ) : (

--- a/pro/src/components/ReSendEmailCallout/ReSendEmailCallout.tsx
+++ b/pro/src/components/ReSendEmailCallout/ReSendEmailCallout.tsx
@@ -30,7 +30,7 @@ export const ReSendEmailCallout = ({
   return (
     <Callout>
       <p className={styles['re-send-callout']}>
-        Vous n’avez pas reçu d’email ? <br /> Vérifiez vos spams
+        Vous n’avez pas reçu notre email ? <br /> Vérifiez vos spams
         {hideLink ? (
           '.'
         ) : (

--- a/pro/src/components/SignupJourneyForm/Activity/Activity.module.scss
+++ b/pro/src/components/SignupJourneyForm/Activity/Activity.module.scss
@@ -10,7 +10,3 @@
 
   margin-bottom: rem.torem(12px);
 }
-
-.signup-offerer-authentication-form {
-  margin-bottom: rem.torem(16px);
-}

--- a/pro/src/components/SignupJourneyForm/Activity/Activity.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/Activity.tsx
@@ -115,6 +115,7 @@ export const Activity = (): JSX.Element => {
           onSubmit={methods.handleSubmit(onSubmit)}
           data-testid="signup-activity-form"
         >
+          {/* eslint-disable-next-line react/forbid-elements */}
           <MainHeading
             mainHeading="Votre structure"
             className={styles['main-heading-wrapper']}

--- a/pro/src/components/SignupJourneyForm/Activity/Activity.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/Activity.tsx
@@ -5,6 +5,7 @@ import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
 import { Target } from 'apiClient/v1'
+import { MainHeading } from 'app/App/layout/Layout'
 import { GET_VENUE_TYPES_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import {
   ActivityContext,
@@ -19,6 +20,7 @@ import { Spinner } from 'ui-kit/Spinner/Spinner'
 
 import { ActionBar } from '../ActionBar/ActionBar'
 
+import styles from './Activity.module.scss'
 import { ActivityForm, ActivityFormValues } from './ActivityForm'
 import { defaultActivityFormValues } from './constants'
 import { validationSchema } from './validationSchema'
@@ -113,6 +115,13 @@ export const Activity = (): JSX.Element => {
           onSubmit={methods.handleSubmit(onSubmit)}
           data-testid="signup-activity-form"
         >
+          <MainHeading
+            mainHeading="Votre structure"
+            className={styles['main-heading-wrapper']}
+          />
+          <h2 className={styles['subtitle']}>
+            Et enfin, définissez l’activité de votre structure
+          </h2>
           <FormLayout.MandatoryInfo />
           <ActivityForm venueTypes={venueTypes} />
           <ActionBar

--- a/pro/src/components/SignupJourneyForm/Activity/ActivityForm.module.scss
+++ b/pro/src/components/SignupJourneyForm/Activity/ActivityForm.module.scss
@@ -3,12 +3,6 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_size.scss" as size;
 
-.activity-form-wrapper {
-  @include fonts.title3;
-
-  margin-bottom: rem.torem(24px);
-}
-
 .delete-button {
   display: flex;
   align-content: center;

--- a/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -52,7 +52,6 @@ export const ActivityForm = ({
 
   return (
     <FormLayout.Section>
-      <h1 className={styles['activity-form-wrapper']}>Activité</h1>
       <FormLayout.Row mdSpaceAfter>
         <Select
           options={[

--- a/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
@@ -85,7 +85,6 @@ describe('screens:SignupJourney::ActivityForm', () => {
   it('should render activity form', async () => {
     renderActivityForm(initialValues, props, contextValue)
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
     expect(screen.getByLabelText('Activité principale *')).toHaveValue('')
     expect(screen.getAllByText('Site internet, réseau social')).toHaveLength(1)
     expect(
@@ -134,20 +133,16 @@ describe('screens:SignupJourney::ActivityForm', () => {
   it('should not navigate to the next step if activity form is not valid', async () => {
     renderActivityForm(initialValues, props, contextValue)
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
-
     await userEvent.click(
       screen.getByRole('button', { name: 'Étape suivante' })
     )
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
     expect(screen.queryByText('Validation screen')).not.toBeInTheDocument()
   })
 
   it('should add social url input on click add url button', async () => {
     renderActivityForm(initialValues, props, contextValue)
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
     expect(screen.getAllByText('Site internet, réseau social')).toHaveLength(1)
     await userEvent.click(screen.getByText('Ajouter un lien'))
     expect(screen.getAllByText('Site internet, réseau social')).toHaveLength(2)

--- a/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityScreen.spec.tsx
@@ -66,7 +66,12 @@ describe('screens:SignupJourney::Activity', () => {
 
     renderActivityScreen(contextValue)
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'Et enfin, définissez l’activité de votre structure',
+      })
+    ).toBeInTheDocument()
     expect(
       screen.getByText('Tous les champs suivis d’un * sont obligatoires.')
     ).toBeInTheDocument()
@@ -113,7 +118,12 @@ describe('screens:SignupJourney::Activity', () => {
 
     renderActivityScreen(contextValue)
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'Et enfin, définissez l’activité de votre structure',
+      })
+    ).toBeInTheDocument()
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Étape suivante' })
@@ -132,7 +142,12 @@ describe('screens:SignupJourney::Activity', () => {
 
     renderActivityScreen(contextValue)
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'Et enfin, définissez l’activité de votre structure',
+      })
+    ).toBeInTheDocument()
     expect(screen.getByLabelText('Au grand public')).toBeChecked()
     expect(screen.getByLabelText('À des groupes scolaires')).not.toBeChecked()
 
@@ -153,7 +168,12 @@ describe('screens:SignupJourney::Activity', () => {
 
     renderActivityScreen(contextValue)
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'Et enfin, définissez l’activité de votre structure',
+      })
+    ).toBeInTheDocument()
     expect(screen.getByLabelText('Au grand public')).not.toBeChecked()
     expect(screen.getByLabelText('À des groupes scolaires')).toBeChecked()
 
@@ -167,7 +187,12 @@ describe('screens:SignupJourney::Activity', () => {
   it('should display authentification screen on click previous step button', async () => {
     renderActivityScreen(contextValue)
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'Et enfin, définissez l’activité de votre structure',
+      })
+    ).toBeInTheDocument()
 
     await userEvent.click(
       screen.getByRole('button', { name: 'Étape précédente' })
@@ -179,7 +204,12 @@ describe('screens:SignupJourney::Activity', () => {
   it('should display error notification', async () => {
     renderActivityScreen(contextValue)
 
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'Et enfin, définissez l’activité de votre structure',
+      })
+    ).toBeInTheDocument()
 
     await userEvent.click(screen.getByText('Au grand public'))
     await userEvent.click(
@@ -191,7 +221,12 @@ describe('screens:SignupJourney::Activity', () => {
         'Une ou plusieurs erreurs sont présentes dans le formulaire'
       )
     ).toBeInTheDocument()
-    expect(await screen.findByText('Activité')).toBeInTheDocument()
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'Et enfin, définissez l’activité de votre structure',
+      })
+    ).toBeInTheDocument()
     expect(screen.queryByText('Validation screen')).not.toBeInTheDocument()
   })
 })

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect } from 'react'
 import { FormProvider, Resolver, useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router'
 
+import { MainHeading } from 'app/App/layout/Layout'
 import { useSignupJourneyContext } from 'commons/context/SignupJourneyContext/SignupJourneyContext'
 import { removeQuotes } from 'commons/utils/removeQuotes'
 import { FormLayout } from 'components/FormLayout/FormLayout'
@@ -74,6 +75,13 @@ export const OffererAuthentication = (): JSX.Element => {
           onSubmit={methods.handleSubmit(onSubmit)}
           data-testid="signup-offerer-authentication-form"
         >
+          <MainHeading
+            mainHeading="Votre structure"
+            className={styles['main-heading-wrapper']}
+          />
+          <h2 className={styles['subtitle']}>
+            Complétez les informations de votre structure
+          </h2>
           <FormLayout.MandatoryInfo />
           <OffererAuthenticationForm />
           <ActionBar

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
@@ -75,6 +75,7 @@ export const OffererAuthentication = (): JSX.Element => {
           onSubmit={methods.handleSubmit(onSubmit)}
           data-testid="signup-offerer-authentication-form"
         >
+          {/* eslint-disable-next-line react/forbid-elements */}
           <MainHeading
             mainHeading="Votre structure"
             className={styles['main-heading-wrapper']}

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.module.scss
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.module.scss
@@ -1,12 +1,6 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
 
-.title {
-  @include fonts.title3;
-
-  margin-bottom: rem.torem(24px);
-}
-
 .open-to-public-toggle {
   margin-top: rem.torem(16px);
 

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
@@ -45,7 +45,6 @@ export const OffererAuthenticationForm = (): JSX.Element => {
 
   return (
     <FormLayout.Section>
-      <h1 className={styles['title']}>Identification</h1>
       <FormLayout.Row mdSpaceAfter>
         <TextInput
           {...register('siret')}

--- a/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
@@ -138,7 +138,10 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
     expect(screen.queryByRole('button', { name: 'Retour' })).toBeInTheDocument()
 
     expect(
-      screen.getByRole('heading', { level: 1, name: 'Identification' })
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'Complétez les informations de votre structure',
+      })
     ).toBeInTheDocument()
 
     const siretField = screen.getByLabelText('Numéro de SIRET *')
@@ -159,7 +162,12 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
 
   it('should display activity screen on submit', async () => {
     renderOffererAuthenticationScreen(contextValue)
-    expect(await screen.findByText('Identification')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'Complétez les informations de votre structure',
+      })
+    ).toBeInTheDocument()
     await userEvent.click(
       screen.getByRole('button', { name: 'Étape suivante' })
     )
@@ -170,7 +178,12 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
 
   it('should display offerer screen on submit', async () => {
     renderOffererAuthenticationScreen(contextValue)
-    expect(await screen.findByText('Identification')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'Complétez les informations de votre structure',
+      })
+    ).toBeInTheDocument()
     await userEvent.click(screen.getByRole('button', { name: 'Retour' }))
     expect(screen.getByText('Offerer screen')).toBeInTheDocument()
   })

--- a/pro/src/components/SignupJourneyForm/Offerer/Offerer.module.scss
+++ b/pro/src/components/SignupJourneyForm/Offerer/Offerer.module.scss
@@ -6,7 +6,13 @@
   padding: rem.torem(24px);
 }
 
-.title {
+.main-heading {
+  &-wrapper {
+    margin-bottom: rem.torem(24px);
+  }
+}
+
+.subtitle {
   @include fonts.title3;
 }
 

--- a/pro/src/components/SignupJourneyForm/Offerer/Offerer.module.scss
+++ b/pro/src/components/SignupJourneyForm/Offerer/Offerer.module.scss
@@ -16,7 +16,7 @@
   @include fonts.title3;
 }
 
-.mandatory-info {
+.input-siret {
   margin-top: rem.torem(32px);
 }
 

--- a/pro/src/components/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/components/SignupJourneyForm/Offerer/Offerer.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router'
 import { api } from 'apiClient/api'
 import { isError } from 'apiClient/helpers'
 import { useAnalytics } from 'app/App/analytics/firebase'
+import { MainHeading } from 'app/App/layout/Layout'
 import { useSignupJourneyContext } from 'commons/context/SignupJourneyContext/SignupJourneyContext'
 import { Events } from 'commons/core/FirebaseEvents/constants'
 import {
@@ -177,9 +178,14 @@ export const Offerer = (): JSX.Element => {
           data-testid="signup-offerer-form"
         >
           <FormLayout.Section>
-            <h1 className={styles['title']}>
-              Renseignez le SIRET de votre structure
-            </h1>
+            <MainHeading
+              mainHeading="Votre structure"
+              className={styles['main-heading-wrapper']}
+            />
+            <h2 className={styles['subtitle']}>
+              Dites-nous pour quelle structure vous travaillez
+            </h2>
+
             <FormLayout.MandatoryInfo className={styles['mandatory-info']} />
             <FormLayout.Row>
               <TextInput

--- a/pro/src/components/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/components/SignupJourneyForm/Offerer/Offerer.tsx
@@ -186,7 +186,6 @@ export const Offerer = (): JSX.Element => {
               Dites-nous pour quelle structure vous travaillez
             </h2>
 
-            <FormLayout.MandatoryInfo className={styles['mandatory-info']} />
             <FormLayout.Row>
               <TextInput
                 label="Numéro de SIRET à 14 chiffres"

--- a/pro/src/components/SignupJourneyForm/Offerer/Offerer.tsx
+++ b/pro/src/components/SignupJourneyForm/Offerer/Offerer.tsx
@@ -178,6 +178,7 @@ export const Offerer = (): JSX.Element => {
           data-testid="signup-offerer-form"
         >
           <FormLayout.Section>
+            {/* eslint-disable-next-line react/forbid-elements */}
             <MainHeading
               mainHeading="Votre structure"
               className={styles['main-heading-wrapper']}

--- a/pro/src/components/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -159,7 +159,7 @@ describe('Offerer', () => {
     renderOffererScreen(contextValue)
 
     expect(
-      screen.getByText('Renseignez le SIRET de votre structure')
+      screen.getByText('Dites-nous pour quelle structure vous travaillez')
     ).toBeInTheDocument()
 
     await userEvent.type(
@@ -173,7 +173,7 @@ describe('Offerer', () => {
     expect(api.getSiretInfo).toHaveBeenCalled()
     expect(screen.queryByText('Authentication screen')).not.toBeInTheDocument()
     expect(
-      screen.getByText('Renseignez le SIRET de votre structure')
+      screen.getByText('Dites-nous pour quelle structure vous travaillez')
     ).toBeInTheDocument()
   })
 
@@ -181,7 +181,9 @@ describe('Offerer', () => {
     renderOffererScreen(contextValue)
 
     expect(
-      await screen.findByText('Renseignez le SIRET de votre structure')
+      await screen.findByText(
+        'Dites-nous pour quelle structure vous travaillez'
+      )
     ).toBeInTheDocument()
     await userEvent.type(
       screen.getByLabelText('Numéro de SIRET à 14 chiffres *'),
@@ -449,7 +451,9 @@ describe('Offerer', () => {
     renderOffererScreen(contextValue)
 
     expect(
-      await screen.findByText('Renseignez le SIRET de votre structure')
+      await screen.findByText(
+        'Dites-nous pour quelle structure vous travaillez'
+      )
     ).toBeInTheDocument()
 
     expect(

--- a/pro/src/components/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Offerer/__specs__/Offerer.spec.tsx
@@ -457,10 +457,6 @@ describe('Offerer', () => {
     ).toBeInTheDocument()
 
     expect(
-      screen.getByText('Tous les champs suivis d’un * sont obligatoires.')
-    ).toBeInTheDocument()
-
-    expect(
       screen.getByLabelText('Numéro de SIRET à 14 chiffres *')
     ).toHaveValue('')
   })

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.module.scss
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.module.scss
@@ -1,12 +1,6 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
 
-.title {
-  @include fonts.title3;
-
-  margin-bottom: 0;
-}
-
 .subtitle {
   @include fonts.title4;
 }

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
@@ -6,6 +6,7 @@ import useSWR from 'swr'
 import { api } from 'apiClient/api'
 import { SaveNewOnboardingDataQueryModel, Target } from 'apiClient/v1'
 import { useAnalytics } from 'app/App/analytics/firebase'
+import { MainHeading } from 'app/App/layout/Layout'
 import { GET_VENUE_TYPES_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { defaultActivityValues } from 'commons/context/SignupJourneyContext/constants'
 import { useSignupJourneyContext } from 'commons/context/SignupJourneyContext/SignupJourneyContext'
@@ -192,9 +193,12 @@ export const Validation = (): JSX.Element => {
   return (
     <div className={styles['validation-screen']}>
       <section>
-        <h1 className={styles['title']}>Validation</h1>
+        <MainHeading
+          mainHeading="Votre structure"
+          className={styles['main-heading-wrapper']}
+        />
         <div className={styles['validation-screen-subtitle']}>
-          <h2 className={styles['subtitle']}>Identification</h2>
+          <h2 className={styles['subtitle']}>Vos informations</h2>
           <ButtonLink
             to="/parcours-inscription/identification"
             onClick={() => {
@@ -225,7 +229,7 @@ export const Validation = (): JSX.Element => {
       </section>
       <section className={styles['validation-screen']}>
         <div className={styles['validation-screen-subtitle']}>
-          <h2 className={styles['subtitle']}>Activité</h2>
+          <h2 className={styles['subtitle']}>Votre activité</h2>
           <ButtonLink
             to="/parcours-inscription/activite"
             onClick={() => {

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
@@ -193,6 +193,7 @@ export const Validation = (): JSX.Element => {
   return (
     <div className={styles['validation-screen']}>
       <section>
+        {/* eslint-disable-next-line react/forbid-elements */}
         <MainHeading
           mainHeading="Votre structure"
           className={styles['main-heading-wrapper']}

--- a/pro/src/components/SignupJourneyStepper/SignupJourneyStepper.tsx
+++ b/pro/src/components/SignupJourneyStepper/SignupJourneyStepper.tsx
@@ -44,7 +44,7 @@ export const SignupJourneyStepper = () => {
   const signupJourneyBreadcrumbSteps: Step[] = [
     {
       id: SIGNUP_JOURNEY_STEP_IDS.AUTHENTICATION,
-      label: 'Identification',
+      label: 'Vos informations',
       url: '/parcours-inscription/identification',
       onClick: () =>
         logBreadcrumbClick(
@@ -54,7 +54,7 @@ export const SignupJourneyStepper = () => {
     },
     {
       id: SIGNUP_JOURNEY_STEP_IDS.ACTIVITY,
-      label: 'Activité',
+      label: 'Votre activité',
       url: isActivityStepDisabled
         ? undefined
         : '/parcours-inscription/activite',

--- a/pro/src/components/SignupJourneyStepper/__specs__/SignupJourneyStepper.spec.tsx
+++ b/pro/src/components/SignupJourneyStepper/__specs__/SignupJourneyStepper.spec.tsx
@@ -42,8 +42,8 @@ const renderSignupStepper = (
     { user: sharedCurrentUserFactory(), initialRouterEntries: [url] }
   )
 
-  const tabAuthentication = screen.queryByText('Identification')
-  const tabActivity = screen.queryByText('Activité')
+  const tabAuthentication = screen.queryByText('Vos informations')
+  const tabActivity = screen.queryByText('Votre activité')
   const tabValidation = screen.queryByText('Validation')
 
   return {

--- a/pro/src/components/SignupJourneyStepper/__specs__/SignupJourneyStepper.trackers.spec.tsx
+++ b/pro/src/components/SignupJourneyStepper/__specs__/SignupJourneyStepper.trackers.spec.tsx
@@ -48,8 +48,8 @@ const renderSignupJourneyStepper = (
     { user: sharedCurrentUserFactory(), initialRouterEntries: [url] }
   )
 
-  const tabAuthentication = screen.queryByText('Identification')
-  const tabActivity = screen.queryByText('Activité')
+  const tabAuthentication = screen.queryByText('Vos informations')
+  const tabActivity = screen.queryByText('Votre activité')
   const tabValidation = screen.queryByText('Validation')
 
   return {

--- a/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/pro/src/components/UserPasswordForm/UserPasswordForm.tsx
@@ -134,7 +134,7 @@ export const UserPasswordForm = ({
               <PasswordInput
                 {...register('newConfirmationPassword')}
                 error={errors.newConfirmationPassword?.message}
-                label="Confirmer votre nouveau mot de passe"
+                label="Confirmez votre nouveau mot de passe"
               />
             </div>
           </FormLayout>

--- a/pro/src/components/UserPasswordForm/__specs__/UserPasswordForm.spec.tsx
+++ b/pro/src/components/UserPasswordForm/__specs__/UserPasswordForm.spec.tsx
@@ -32,7 +32,7 @@ describe('components:UserPasswordForm', () => {
     expect(screen.getByLabelText(/Mot de passe actuel/)).toBeInTheDocument()
     expect(screen.getByLabelText(/Nouveau mot de passe/)).toBeInTheDocument()
     expect(
-      screen.getByLabelText(/Confirmer votre nouveau mot de passe/)
+      screen.getByLabelText(/Confirmez votre nouveau mot de passe/)
     ).toBeInTheDocument()
   })
 
@@ -48,7 +48,7 @@ describe('components:UserPasswordForm', () => {
       'MyNewSuper1Password,'
     )
     await userEvent.type(
-      screen.getByLabelText(/Confirmer votre nouveau mot de passe/),
+      screen.getByLabelText(/Confirmez votre nouveau mot de passe/),
       'MyNewSuper1Password,'
     )
     await userEvent.tab()
@@ -86,7 +86,7 @@ describe('components:UserPasswordForm', () => {
       'MyNewSuper1Password,'
     )
     await userEvent.type(
-      screen.getByLabelText(/Confirmer votre nouveau mot de passe/),
+      screen.getByLabelText(/Confirmez votre nouveau mot de passe/),
       'MyNewSuper1Password,'
     )
     await userEvent.tab()

--- a/pro/src/pages/LostPassword/LostPassword.module.scss
+++ b/pro/src/pages/LostPassword/LostPassword.module.scss
@@ -6,12 +6,6 @@
     margin-bottom: rem.torem(12px);
   }
 
-  &-title {
-    @include fonts.title1;
-
-    margin-bottom: rem.torem(16px);
-  }
-
   &-body {
     @include fonts.body;
 
@@ -26,12 +20,6 @@
 }
 
 .change-password-request-form {
-  .title {
-    @include fonts.title1;
-
-    margin-bottom: rem.torem(16px);
-  }
-
   .subtitle {
     @include fonts.body-xs;
 
@@ -58,10 +46,6 @@
 
   // remove when removing WIP_2025_SIGN_UP
   &-old {
-    .title {
-      margin-bottom: rem.torem(16px);
-    }
-
     .subtitle {
       @include fonts.title4;
 

--- a/pro/src/pages/LostPassword/LostPassword.tsx
+++ b/pro/src/pages/LostPassword/LostPassword.tsx
@@ -73,9 +73,6 @@ export const LostPassword = (): JSX.Element => {
 
   const successComponent = is2025SignUpEnabled ? (
     <section className={styles['change-password-request-success']}>
-      <h1 className={styles['change-password-request-success-title']}>
-        Vous allez recevoir un email
-      </h1>
       <p className={styles['change-password-request-success-body']}>
         Cliquez sur le lien envoyé par email à <b>{email}</b>
       </p>
@@ -90,8 +87,17 @@ export const LostPassword = (): JSX.Element => {
     />
   )
 
+  const mainHeading = email
+    ? is2025SignUpEnabled
+      ? 'Vous allez recevoir un email'
+      : ''
+    : 'Réinitialisez votre mot de passe'
+
   return (
-    <Layout layout={is2025SignUpEnabled ? 'sign-up' : 'logged-out'}>
+    <Layout
+      layout={is2025SignUpEnabled ? 'sign-up' : 'logged-out'}
+      mainHeading={mainHeading}
+    >
       {email ? (
         successComponent
       ) : (
@@ -100,7 +106,6 @@ export const LostPassword = (): JSX.Element => {
             [styles['change-password-request-form-old']]: !is2025SignUpEnabled,
           })}
         >
-          <h1 className={styles['title']}>Réinitialisez votre mot de passe</h1>
           <p className={styles['subtitle']}>
             {is2025SignUpEnabled
               ? 'Entrez votre email pour recevoir un lien de réinitialisation.'

--- a/pro/src/pages/OfferType/OfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux'
-import { useLocation, Navigate } from 'react-router'
+import { Navigate, useLocation } from 'react-router'
 
 import { Layout } from 'app/App/layout/Layout'
 import { useOfferer } from 'commons/hooks/swr/useOfferer'

--- a/pro/src/pages/Onboarding/OnboardingOfferIndividual/DraftOffers/DraftOffers.module.scss
+++ b/pro/src/pages/Onboarding/OnboardingOfferIndividual/DraftOffers/DraftOffers.module.scss
@@ -2,11 +2,10 @@
 @use "styles/mixins/_rem.scss" as rem;
 
 .title-drafts {
-  @include fonts.title2;
+  @include fonts.title3;
 
   margin-top: rem.torem(64px);
   margin-bottom: rem.torem(16px);
-  text-align: center;
 }
 
 .offer {

--- a/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.module.scss
+++ b/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.module.scss
@@ -13,14 +13,11 @@
 }
 
 .offers-title {
-  @include fonts.title3;
-
-  text-align: center;
-  margin-bottom: rem.torem(8px);
+  margin-bottom: rem.torem(16px);
 }
 
 .offers-subtitle {
-  @include fonts.title1;
+  @include fonts.title3;
 
   text-align: center;
   margin-bottom: rem.torem(32px);
@@ -36,7 +33,7 @@
   margin-bottom: 0;
 
   .offer-choice {
-    min-width: rem.torem(207px);
+    min-width: rem.torem(230px);
     flex: 1;
     margin-bottom: 0;
   }

--- a/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.module.scss
+++ b/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.module.scss
@@ -19,7 +19,6 @@
 .offers-subtitle {
   @include fonts.title3;
 
-  text-align: center;
   margin-bottom: rem.torem(32px);
 }
 

--- a/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.tsx
@@ -53,6 +53,7 @@ export const OnboardingOfferIndividual = (): JSX.Element => {
 
   return (
     <OnboardingLayout verticallyCentered={draftOffers.length <= 1}>
+      {/* eslint-disable-next-line react/forbid-elements */}
       <MainHeading
         mainHeading="Offre à destination des jeunes"
         className={styles['offers-title']}

--- a/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.tsx
@@ -3,9 +3,8 @@ import useSWR from 'swr'
 
 import { api } from 'apiClient/api'
 import { OfferStatus } from 'apiClient/v1/models/OfferStatus'
-import {
-  GET_OFFERS_QUERY_KEY,
-} from 'commons/config/swrQueryKeys'
+import { MainHeading } from 'app/App/layout/Layout'
+import { GET_OFFERS_QUERY_KEY } from 'commons/config/swrQueryKeys'
 import { useOfferer } from 'commons/hooks/swr/useOfferer'
 import { selectCurrentOffererId } from 'commons/store/offerer/selectors'
 import { FormLayout } from 'components/FormLayout/FormLayout'
@@ -24,7 +23,8 @@ export const MAX_DRAFT_TO_DISPLAY = 50
 export const OnboardingOfferIndividual = (): JSX.Element => {
   const selectedOffererId = useSelector(selectCurrentOffererId)
 
-  const { data: offerer, isLoading: isOffererLoading } = useOfferer(selectedOffererId)
+  const { data: offerer, isLoading: isOffererLoading } =
+    useOfferer(selectedOffererId)
 
   const offersQuery = useSWR(
     [GET_OFFERS_QUERY_KEY, { status: 'DRAFT' }],
@@ -53,7 +53,10 @@ export const OnboardingOfferIndividual = (): JSX.Element => {
 
   return (
     <OnboardingLayout verticallyCentered={draftOffers.length <= 1}>
-      <h1 className={styles['offers-title']}>Offre à destination des jeunes</h1>
+      <MainHeading
+        mainHeading="Offre à destination des jeunes"
+        className={styles['offers-title']}
+      />
       <h2 className={styles['offers-subtitle']}>
         Comment souhaitez-vous créer votre 1ère offre ?
       </h2>

--- a/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.module.scss
+++ b/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.module.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   gap: rem.torem(32px);
-  align-items: center;
+  align-items: flex-start;
   justify-content: flex-start;
 }
 
@@ -14,18 +14,13 @@
   display: flex;
   flex-direction: column;
   gap: rem.torem(8px);
-  align-items: center;
+  align-items: flex-start;
 }
 
-.onboarding-offer-header-title,
+.onboarding-offer-main-heading-wrapper {
+  margin-bottom: rem.torem(16px);
+}
+
 .onboarding-offer-header-subtitle {
-  text-align: center;
-}
-
-.onboarding-offer-header-title {
   @include fonts.title3;
-}
-
-.onboarding-offer-header-subtitle {
-  @include fonts.title1;
 }

--- a/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.spec.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.spec.tsx
@@ -22,7 +22,7 @@ describe('OnboardingOffersChoice Component', () => {
     ).toBeInTheDocument()
 
     expect(
-      screen.getByText('À qui souhaitez-vous proposer votre première offre ?')
+      screen.getByText('Où souhaitez-vous diffuser votre première offre ?')
     ).toBeInTheDocument()
 
     // Check that the first title is displayed

--- a/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.spec.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.spec.tsx
@@ -27,12 +27,12 @@ describe('OnboardingOffersChoice Component', () => {
 
     // Check that the first title is displayed
     expect(
-      screen.getByText('Aux jeunes sur l’application mobile pass Culture')
+      screen.getByText('Sur l’application mobile à destination des jeunes')
     ).toBeInTheDocument()
 
     // Check that the second title is displayed
     expect(
-      screen.getByText('Aux enseignants sur la plateforme ADAGE')
+      screen.getByText('Sur ADAGE à destination des enseignants')
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.tsx
@@ -10,6 +10,7 @@ export const OnboardingOffersTypeChoice = () => {
     <OnboardingLayout verticallyCentered stickyActionsAndFooter={false}>
       <div className={styles['onboarding-offer-container']}>
         <div className={styles['onboarding-offer-header']}>
+          {/* eslint-disable-next-line react/forbid-elements */}
           <MainHeading
             mainHeading="Bienvenue sur le pass Culture Pro !"
             className={styles['onboarding-offer-main-heading-wrapper']}

--- a/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.tsx
@@ -1,3 +1,4 @@
+import { MainHeading } from 'app/App/layout/Layout'
 import { OnboardingOffersChoice } from 'components/OnboardingOffersChoice/OnboardingOffersChoice'
 
 import { OnboardingLayout } from '../components/OnboardingLayout/OnboardingLayout'
@@ -9,11 +10,12 @@ export const OnboardingOffersTypeChoice = () => {
     <OnboardingLayout verticallyCentered stickyActionsAndFooter={false}>
       <div className={styles['onboarding-offer-container']}>
         <div className={styles['onboarding-offer-header']}>
-          <h1 className={styles['onboarding-offer-header-title']}>
-            Bienvenue sur le pass Culture Pro !
-          </h1>
+          <MainHeading
+            mainHeading="Bienvenue sur le pass Culture Pro !"
+            className={styles['onboarding-offer-main-heading-wrapper']}
+          />
           <h2 className={styles['onboarding-offer-header-subtitle']}>
-            À qui souhaitez-vous proposer votre première offre ?{' '}
+            Où souhaitez-vous diffuser votre première offre ?
           </h2>
         </div>
         <OnboardingOffersChoice />

--- a/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
@@ -56,7 +56,7 @@ export const ChangePasswordForm = ({
           <>
             <div className={styles['text-input']}>
               <PasswordInput
-                label="Confirmer votre nouveau mot de passe"
+                label="Confirmez votre nouveau mot de passe"
                 error={errors.newConfirmationPassword?.message}
                 {...register('newConfirmationPassword')}
               />

--- a/pro/src/pages/ResetPassword/ResetPassword.module.scss
+++ b/pro/src/pages/ResetPassword/ResetPassword.module.scss
@@ -2,12 +2,6 @@
 @use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_fonts.scss" as fonts;
 
-.change-password-title {
-  @include fonts.title1;
-
-  margin-bottom: rem.torem(16px);
-}
-
 .mandatory-info {
   @include fonts.body-xs;
 

--- a/pro/src/pages/ResetPassword/ResetPassword.spec.tsx
+++ b/pro/src/pages/ResetPassword/ResetPassword.spec.tsx
@@ -91,7 +91,7 @@ describe('ResetPassword', () => {
         'MyN3wP4$$w0rd'
       )
       await userEvent.type(
-        await screen.findByLabelText(/Confirmer votre nouveau mot de passe/),
+        await screen.findByLabelText(/Confirmez votre nouveau mot de passe/),
         'MyN3wP4$$w0rd'
       )
       await userEvent.click(screen.getByText('Confirmer'))

--- a/pro/src/pages/ResetPassword/ResetPassword.tsx
+++ b/pro/src/pages/ResetPassword/ResetPassword.tsx
@@ -1,7 +1,7 @@
 import { yupResolver } from '@hookform/resolvers/yup'
 import { useCallback, useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
-import { useNavigate, useParams, Params } from 'react-router'
+import { Params, useNavigate, useParams } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { Layout } from 'app/App/layout/Layout'
@@ -82,8 +82,16 @@ export const ResetPassword = (): JSX.Element => {
     return <Spinner />
   }
 
+  const mainHeading =
+    token && !passwordChanged && !isBadToken
+      ? 'Réinitialisez votre mot de passe'
+      : ''
+
   return (
-    <Layout layout={is2025SignUpEnabled ? 'sign-up' : 'logged-out'}>
+    <Layout
+      layout={is2025SignUpEnabled ? 'sign-up' : 'logged-out'}
+      mainHeading={mainHeading}
+    >
       <div>
         {passwordChanged && !isBadToken && (
           <Hero
@@ -103,9 +111,6 @@ export const ResetPassword = (): JSX.Element => {
         )}
         {token && !passwordChanged && !isBadToken && (
           <section>
-            <h1 className={styles['change-password-title']}>
-              Réinitialisez votre mot de passe
-            </h1>
             <p className={styles['mandatory-info']}>
               Veuillez définir votre nouveau mot de passe afin d’accéder à la
               plateforme.

--- a/pro/src/pages/Signup/SignUpValidation/SignUpValidation.tsx
+++ b/pro/src/pages/Signup/SignUpValidation/SignUpValidation.tsx
@@ -1,6 +1,6 @@
-import { useRef, useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { useParams, Navigate } from 'react-router'
+import { Navigate, useParams } from 'react-router'
 
 import { api } from 'apiClient/api'
 import { getError, isErrorAPIError } from 'apiClient/helpers'
@@ -33,7 +33,7 @@ export const SignupValidation = (): JSX.Element | null => {
             const user = await api.getProfile()
             const result = await dispatch(initializeUserThunk(user)).unwrap()
             if (result.success) {
-                setUrlToRedirect('/')
+              setUrlToRedirect('/')
             }
           } else {
             setUrlToRedirect('/connexion?accountValidation=true')

--- a/pro/src/pages/Signup/Signup.tsx
+++ b/pro/src/pages/Signup/Signup.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router'
+import { Outlet, useLocation } from 'react-router'
 
 import { Layout } from 'app/App/layout/Layout'
 import { useActiveFeature } from 'commons/hooks/useActiveFeature'
@@ -11,8 +11,20 @@ export const Signup = () => {
   )
   const is2025SignUpEnabled = useActiveFeature('WIP_2025_SIGN_UP')
 
+  const location = useLocation()
+
+  const mainHeadingsMap = new Map([
+    ['/inscription/compte/creation', 'Créez votre compte'],
+    ['/inscription/compte/confirmation', 'Validez votre adresse email'],
+  ])
+
+  const mainHeading = mainHeadingsMap.get(location.pathname)
+
   return (
-    <Layout layout={is2025SignUpEnabled ? 'sign-up' : 'logged-out'}>
+    <Layout
+      layout={is2025SignUpEnabled ? 'sign-up' : 'logged-out'}
+      mainHeading={mainHeading}
+    >
       {isProAccountCreationEnabled ? <Outlet /> : <SignupUnavailable />}
     </Layout>
   )

--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.module.scss
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.module.scss
@@ -8,12 +8,6 @@
     margin-bottom: rem.torem(12px);
   }
 
-  &-title {
-    @include fonts.title1;
-
-    margin-bottom: rem.torem(16px);
-  }
-
   &-body {
     @include fonts.body;
 
@@ -25,10 +19,6 @@
   display: flex;
   align-items: center;
 
-  .title {
-    @include fonts.title1;
-  }
-
   .confirmation-text {
     @include fonts.title4;
 
@@ -39,5 +29,3 @@
     margin-top: rem.torem(24px);
   }
 }
-
-

--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.spec.tsx
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.spec.tsx
@@ -28,10 +28,12 @@ describe('SignupConfirmation', () => {
   it('Should render correctly with new signup FF', () => {
     renderSignup(['WIP_2025_SIGN_UP'])
     expect(
-      screen.getByText('Cliquez sur le lien envoyé par email')
+      screen.getByText(
+        'Cliquez sur le lien que nous vous avons envoyé par email'
+      )
     ).toBeInTheDocument()
     expect(
-      screen.getByText(/Vous n’avez pas reçu d’email ?/)
+      screen.getByText(/Vous n’avez pas reçu notre email ?/)
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.spec.tsx
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.spec.tsx
@@ -28,9 +28,7 @@ describe('SignupConfirmation', () => {
   it('Should render correctly with new signup FF', () => {
     renderSignup(['WIP_2025_SIGN_UP'])
     expect(
-      screen.getByText(
-        'Cliquez sur le lien que nous vous avons envoyé par email'
-      )
+      screen.getByText('Cliquez sur le lien envoyé par email')
     ).toBeInTheDocument()
     expect(
       screen.getByText(/Vous n’avez pas reçu d’email ?/)

--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.spec.tsx
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.spec.tsx
@@ -33,7 +33,7 @@ describe('SignupConfirmation', () => {
       )
     ).toBeInTheDocument()
     expect(
-      screen.getByText(/Vous n’avez pas reçu notre email ?/)
+      screen.getByText(/Vous n’avez pas reçu d’email ?/)
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.tsx
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.tsx
@@ -16,11 +16,11 @@ export const SignupConfirmation = () => {
   return isNewSignupEnabled ? (
     <section className={styles['signup-confirmation']}>
       <p className={styles['signup-confirmation-body']}>
-        Cliquez sur le lien que nous vous avons envoyé par email
+        Cliquez sur le lien envoyé par email
         {location.state?.email && (
           <>
             {' '}
-            à <br />
+            à<br />
             <b>{location.state.email}</b>
           </>
         )}

--- a/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.tsx
+++ b/pro/src/pages/Signup/SignupConfirmation/SignupConfirmation.tsx
@@ -15,15 +15,13 @@ export const SignupConfirmation = () => {
 
   return isNewSignupEnabled ? (
     <section className={styles['signup-confirmation']}>
-      <h1 className={styles['signup-confirmation-title']}>
-        Validez votre adresse email
-      </h1>
       <p className={styles['signup-confirmation-body']}>
-        Cliquez sur le lien envoyé par email
+        Cliquez sur le lien que nous vous avons envoyé par email
         {location.state?.email && (
           <>
             {' '}
-            à <b>{location.state.email}</b>
+            à <br />
+            <b>{location.state.email}</b>
           </>
         )}
       </p>
@@ -32,9 +30,8 @@ export const SignupConfirmation = () => {
   ) : (
     <section className={styles['content']}>
       <div className={styles['hero-body']}>
-        <h1 className={styles['title']}>Validez votre adresse email</h1>
         <div className={styles['confirmation-text']}>
-          Votre compte est en cours de création.
+          Votre compte est en cours de création
         </div>
         <div className={styles['confirmation-text']}>
           Vous allez recevoir un lien de confirmation par email. Cliquez sur ce

--- a/pro/src/pages/Signup/SignupContainer/SignupContainer.module.scss
+++ b/pro/src/pages/Signup/SignupContainer/SignupContainer.module.scss
@@ -3,10 +3,6 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/variables/_forms.scss" as forms;
 
-.title {
-  @include fonts.title1;
-}
-
 .content {
   .siren-field {
     margin-bottom: rem.torem(16px);

--- a/pro/src/pages/Signup/SignupContainer/SignupContainer.tsx
+++ b/pro/src/pages/Signup/SignupContainer/SignupContainer.tsx
@@ -132,14 +132,7 @@ export const SignupContainer = (): JSX.Element => {
 
   return (
     <section className={styles['content']}>
-      {isNewSignupEnabled ? (
-        <h1 className={styles['title']}>Créez votre compte</h1>
-      ) : (
-        <>
-          <h1 className={styles['title']}>Créez votre compte</h1>
-          <OperatingProcedures />
-        </>
-      )}
+      {isNewSignupEnabled || <OperatingProcedures />}
 
       <div className={styles['mandatory']}>
         <MandatoryInfo areAllFieldsMandatory={true} />

--- a/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.tsx
+++ b/pro/src/pages/Signup/SignupContainer/__specs__/SignupContainer.spec.tsx
@@ -87,13 +87,7 @@ describe('Signup', () => {
       // when the user sees the form
       renderSignUp()
 
-      // then it should have a title
-      expect(
-        screen.getByRole('heading', {
-          name: /Créez votre compte/,
-        })
-      ).toBeInTheDocument()
-      // and an external link to the help center
+      // the it should have an external link to the help center
       expect(
         screen.getByRole('link', {
           name: /Consulter notre centre d’aide/,

--- a/pro/src/pages/Signup/__specs__/Signup.spec.tsx
+++ b/pro/src/pages/Signup/__specs__/Signup.spec.tsx
@@ -5,8 +5,8 @@ import { api } from 'apiClient/api'
 import { routesSignup } from 'app/AppRouter/subroutesSignupMap'
 import { getOffererNameFactory } from 'commons/utils/factories/individualApiFactories'
 import {
-  sharedCurrentUserFactory,
   currentOffererFactory,
+  sharedCurrentUserFactory,
 } from 'commons/utils/factories/storeFactories'
 import {
   renderWithProviders,
@@ -82,7 +82,7 @@ describe('src | components | pages | Signup', () => {
     })
 
     expect(
-      screen.getByText(/Votre compte est en cours de création./)
+      screen.getByText(/Votre compte est en cours de création/)
     ).toBeInTheDocument()
 
     expect(

--- a/pro/src/pages/SignupJourneyRoutes/__specs__/SignupJourneyRoutes.spec.tsx
+++ b/pro/src/pages/SignupJourneyRoutes/__specs__/SignupJourneyRoutes.spec.tsx
@@ -39,7 +39,10 @@ describe('SignupJourneyRoutes', () => {
     renderSignupJourneyRoutes()
     await waitFor(() => {
       expect(
-        screen.getByText('Renseignez le SIRET de votre structure')
+        screen.getByRole('heading', {
+          level: 2,
+          name: 'Dites-nous pour quelle structure vous travaillez',
+        })
       ).toBeInTheDocument()
     })
   })

--- a/pro/src/styles/mixins/_size.scss
+++ b/pro/src/styles/mixins/_size.scss
@@ -13,7 +13,7 @@ $action-bar-sticky-height: rem.torem(72px);
 $input-min-height: rem.torem(40px);
 $input-border-width: rem.torem(1px);
 $input-filter-variant-horizontal-padding: rem.torem(4px);
-$signup-content-width: rem.torem(488px);
+$signup-content-width: rem.torem(563px);
 $button-icon-size: rem.torem(20px);
 $header-nav-item-padding: rem.torem(16px);
 $logo-side-width: rem.torem(520px);


### PR DESCRIPTION
## 🎯 Related Ticket

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36351)

Uniformisation des titrages en utilisant au possible le  `mainHeading` du `<Layout>`

Dans certains cas où ce n'était pas possible de manipuler l'attribut du Layout de façon dynamique (sous-routes + composants de container imbriqués), il a été créé le sous-composant importable `<MainHeading>` pour une utilisation directement in-component. Ex :

```tsx
<MainHeading
   mainHeading="Titre principal"
   mainSubHeading="Titre secondaire"
   isConnected
/>
```

> [!WARNING]
> Ce composant n'est pas à privilégier et ne sert qu'à permettre de gérer les titres de façon uniforme lorsqu'on n'a pas accès au `<Layout>` depuis le composant.
> 
> **La best-practice reste d'utiliser l'attribut `mainHeading` du `<Layout>` quand c'est possible !**
> Raison pour laquelle ce composant `<MainHeading>` a été ajouté à la règle ESLint `react/forbid-element`

Aussi dans le scope de ce ticket : certains wordings ont été mis à jour, conformément avec le Design.

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

<!-- ## 🖼️ Before & After Images

If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
