### PR TITLE
(PC-34844)[API][SENTRY] feat: remove autologin token from sentry logs

### DIFF
--- a/api/src/pcapi/core/token/__init__.py
+++ b/api/src/pcapi/core/token/__init__.py
@@ -477,10 +477,7 @@ def validate_passwordless_token(token: str) -> dict:
         results = pipeline.execute()
 
     if not results[0]:
-        logger.error(
-            "Token doesn’t exist or was already used. Token: %s",
-            token,
-        )
+        logger.error("Token doesn’t exist or was already used.")
         raise users_exceptions.InvalidToken
     redis_value = json.loads(results[0])
     # The below statement are purely defensive code.

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -832,7 +832,8 @@ def create_and_send_signup_email_confirmation(new_pro_user: models.User) -> None
         token = token_utils.create_passwordless_login_token(
             user_id=new_pro_user.id, ttl=constants.PASSWORDLESS_TOKEN_LIFE_TIME
         )
-        logger.info("Login Token: %s/inscription/compte/confirmation/%s", settings.PRO_URL, token)
+        if settings.IS_DEV or settings.IS_TESTING:
+            logger.info("Link for signup confirmation: %s/inscription/compte/confirmation/%s", settings.PRO_URL, token)
     else:
         token = token_utils.Token.create(
             token_utils.TokenType.SIGNUP_EMAIL_CONFIRMATION,

--- a/api/tests/utils/sentry_test.py
+++ b/api/tests/utils/sentry_test.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import patch
 
 import pytest
@@ -6,11 +7,15 @@ from pydantic.v1 import BaseModel
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.routes.apis import private_api
+from pcapi.utils.sentry import SCRUBBED_INFO_PLACEHOLDER
 from pcapi.utils.sentry import before_send
+from pcapi.utils.sentry import before_send_transaction
 from pcapi.utils.sentry import init_sentry_sdk
 
 
 original_before_send = before_send
+
+original_before_send_transaction = before_send_transaction
 
 
 def before_send_wrapper(*args, **kwargs):
@@ -28,6 +33,13 @@ def before_send_wrapper_with_custom_fingerprint(*args, **kwargs):
     event = original_before_send(*args, **kwargs)
     assert event["fingerprint"][0] == "{{ default }}"
     assert event["fingerprint"][1]
+
+
+def before_send_transaction_wrapper(*args, **kwargs):
+    """Wrapper around the `before_send_transaction` sentry hook to ensure
+    it behaves as we want given different exceptions.
+    """
+    original_before_send_transaction(*args, **kwargs)
 
 
 @private_api.route("/test/route", methods=["GET"])
@@ -93,3 +105,93 @@ def test_validation_erros_are_stamped_with_custom_fingerprint(mocked_before_send
     client.get("/test/route-with-validation-error/field_2")
 
     mocked_before_send.assert_called_once()
+
+
+@patch("pcapi.utils.sentry.before_send")
+@patch("uuid.uuid4", return_value=uuid.uuid4())
+@patch("pcapi.core.mails.transactional.send_signup_email_confirmation_to_pro")
+@pytest.mark.features(WIP_2025_AUTOLOGIN=True)
+@pytest.mark.settings(IS_DEV=False)
+@pytest.mark.usefixtures("db_session")
+@pytest.mark.usefixtures("rsa_keys")
+def test_remove_token_from_sentry_event_in_before_send(
+    mocked_send_signup_email,
+    mocked_uuid,
+    mocked_before_send,
+    rsa_keys,
+    client,
+    settings,
+):
+    mocked_before_send.side_effect = before_send_wrapper
+    init_sentry_sdk()
+
+    private_key_pem_file, public_key_pem_file = rsa_keys
+    settings.PASSWORDLESS_LOGIN_PRIVATE_KEY = private_key_pem_file
+    settings.PASSWORDLESS_LOGIN_PUBLIC_KEY = public_key_pem_file
+    user_data = {
+        "email": "pro@example.com",
+        "firstName": "Toto",
+        "lastName": "Pro",
+        "password": "__v4l1d_P455sw0rd__",
+        "contactOk": False,
+        "token": "token",
+        "phoneNumber": "0102030405",
+    }
+    client.post("/users/signup", json=user_data)
+
+    args, _ = mocked_send_signup_email.call_args
+    passwordless_login_token = args[1]
+
+    client.patch(f"/users/validate_signup/{passwordless_login_token}")
+
+    client.patch(f"/users/validate_signup/{passwordless_login_token}")
+    assert (
+        mocked_before_send.mock_calls[0]
+        .args[0]["request"]["url"]
+        .endswith("/users/validate_signup/" + SCRUBBED_INFO_PLACEHOLDER)
+    )
+
+
+@patch("pcapi.utils.sentry.before_send_transaction")
+@patch("uuid.uuid4", return_value=uuid.uuid4())
+@patch("pcapi.core.mails.transactional.send_signup_email_confirmation_to_pro")
+@pytest.mark.features(WIP_2025_AUTOLOGIN=True)
+@pytest.mark.settings(IS_DEV=False)
+@pytest.mark.usefixtures("db_session")
+@pytest.mark.usefixtures("rsa_keys")
+def test_remove_token_from_sentry_event_in_before_send_transaction(
+    mocked_send_signup_email,
+    mocked_uuid,
+    mocked_before_send_transaction,
+    rsa_keys,
+    client,
+    settings,
+):
+    mocked_before_send_transaction.side_effect = before_send_transaction_wrapper
+    init_sentry_sdk()
+
+    private_key_pem_file, public_key_pem_file = rsa_keys
+    settings.PASSWORDLESS_LOGIN_PRIVATE_KEY = private_key_pem_file
+    settings.PASSWORDLESS_LOGIN_PUBLIC_KEY = public_key_pem_file
+    user_data = {
+        "email": "pro@example.com",
+        "firstName": "Toto",
+        "lastName": "Pro",
+        "password": "__v4l1d_P455sw0rd__",
+        "contactOk": False,
+        "token": "token",
+        "phoneNumber": "0102030405",
+    }
+    client.post("/users/signup", json=user_data)
+
+    args, _ = mocked_send_signup_email.call_args
+    passwordless_login_token = args[1]
+
+    client.patch(f"/users/validate_signup/{passwordless_login_token}")
+
+    client.patch("/offers/123")
+    assert (
+        mocked_before_send_transaction.mock_calls[1]
+        .args[0]["request"]["url"]
+        .endswith("/users/validate_signup/" + SCRUBBED_INFO_PLACEHOLDER)
+    )


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-34844)

Ajout d'une fonction qui retire le token d'autologin de l'event et le remplace par [REDACTED] et appel de cette fonction dans le before send et le before send transaction de sentry

Test dans les 2 cas (pour le before send, qui s'enclenche quand une erreur survient sur la route ou le token est utilisé, et dans le before`_send_transaction qui concerne n'importe quelle erreur ou l -e parcours utilisateur comprend la route ou le token a ete utilisé)

nettoyage pour les endroits ou on log en clair le token

- [ ] Travail pair testé en environnement de preview
