### PR TITLE
(PC-36799)[API] feat: add bookingAllowedDateTime to agolia offer serialization

### DIFF
--- a/api/src/pcapi/core/search/serialization.py
+++ b/api/src/pcapi/core/search/serialization.py
@@ -276,8 +276,8 @@ class AlgoliaSerializationMixin:
                 "name": offer.name,
                 "nativeCategoryId": native_categories,
                 "prices": sorted(prices),
-                "publicationDate": (
-                    offer.publicationDate.timestamp() if offer.publicationDate and not offer.isReleased else None
+                "bookingAllowedDatetime": (
+                    offer.bookingAllowedDatetime.timestamp() if offer.bookingAllowedDatetime else None
                 ),
                 "rankingWeight": offer.rankingWeight,
                 "releaseDate": release_date,


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36799)

Partly reverts the modifications of PC-36900.
Reintroduces _tag `is_future` when serializing offers in algolia.
