### PR TITLE
(PC-37072)[BO] fix: correctly redirect to native app after dev user creation

### DIFF
--- a/api/tests/routes/backoffice/dev_test.py
+++ b/api/tests/routes/backoffice/dev_test.py
@@ -33,7 +33,15 @@ class UserGenerationGetRouteTest(GetEndpointWithoutPermissionHelper):
 
     def test_contains_link_to_app_if_token_and_names(self, authenticated_client):
         generated_user = users_factories.ProfileCompletedUserFactory()
-        response = authenticated_client.get(url_for(self.endpoint, userId=generated_user.id, accessToken="0"))
+        response = authenticated_client.get(
+            url_for(
+                self.endpoint,
+                userId=generated_user.id,
+                accessToken="0",
+                email=generated_user.email,
+                expirationTimestamp=123,
+            )
+        )
 
         assert response.status_code == 200
         assert (
@@ -43,7 +51,15 @@ class UserGenerationGetRouteTest(GetEndpointWithoutPermissionHelper):
 
     def test_contains_link_to_app_if_token_and_no_names(self, authenticated_client):
         generated_user = users_factories.BaseUserFactory()
-        response = authenticated_client.get(url_for(self.endpoint, userId=generated_user.id, accessToken="0"))
+        response = authenticated_client.get(
+            url_for(
+                self.endpoint,
+                userId=generated_user.id,
+                accessToken="0",
+                email=generated_user.email,
+                expirationTimestamp=123,
+            )
+        )
 
         assert response.status_code == 200
         assert f"Aller sur l'app en tant que User {generated_user.id}" in html_parser.content_as_text(response.data)


### PR DESCRIPTION
Fix "redirect to native app" feature as some fields were missing in the query params.
 
Add `expiration_timestamp` and `email` fields to `token` field as a follow up to the query params validation in the native app (cf. https://github.com/pass-culture/pass-culture-app-native/commit/f1b8032275cea2f99e6034a2e492e629afa12a29#diff-58b2648f00e9ae305c167ef3212a5bd208b91d43ffca03e05d45b40fa44462eeR28-R30)  