### PR TITLE
(BSR)[API] feat: add option to sandbox command to skip steps

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/utils/helpers.py
+++ b/api/src/pcapi/sandboxes/scripts/utils/helpers.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import typing
+from contextlib import contextmanager
 from functools import wraps
 
 from pcapi.core.users import models as users_models
@@ -20,9 +21,50 @@ def get_pro_user_helper(user: users_models.User) -> dict:
     return {"email": user.email}
 
 
+class StepsSkip:
+    def __init__(self, steps_to_skip: list[str]) -> None:
+        self.steps_to_skip = steps_to_skip
+
+
+STEPS_SKIP = StepsSkip(steps_to_skip=[])
+
+
+@contextmanager
+def skip_steps(steps: typing.Iterable[str] | None) -> typing.Iterator[None]:
+    """
+    This context manager allows to skip calls of functions decorated with log_func_duration
+
+    Example:
+
+    @log_func_duration
+    def my_step():
+        ...
+
+    def sandbox():
+        ...
+        my_step()
+        ...
+
+    with skip_steps(steps=["my_step"]):
+        sandbox() # my_step will not be called here
+    """
+
+    try:
+        if steps:
+            STEPS_SKIP.steps_to_skip = list(steps)
+        yield
+
+    finally:
+        STEPS_SKIP.steps_to_skip = []
+
+
 def log_func_duration(func: typing.Callable) -> typing.Callable:
     @wraps(func)
     def wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        if func.__name__ in STEPS_SKIP.steps_to_skip:
+            logger.info("Skipped %s", func.__name__)
+            return
+
         start_time = time.time()
         result = func(*args, **kwargs)
         logger.info("Executed %s in %.2fs", func.__name__, time.time() - start_time)

--- a/api/src/pcapi/scripts/sandbox.py
+++ b/api/src/pcapi/scripts/sandbox.py
@@ -12,10 +12,11 @@ blueprint = Blueprint(__name__, __name__)
 @click.option("-n", "--name", help="Sandbox name", default="classic")
 @click.option("-c", "--clean", help="Clean database first", default="true")
 @click.option("-cb", "--clean-bucket", help="Clean mediation bucket", default="false")
-def sandbox(name: str, clean: str, clean_bucket: str) -> None:
+@click.option("-sts", "--step-to-skip", help="Name of function to skip. Can provide multiple values", multiple=True)
+def sandbox(name: str, clean: str, clean_bucket: str, step_to_skip: tuple[str]) -> None:
     if settings.CAN_RUN_SANDBOX:
         with_clean = clean == "true"
         with_clean_bucket = clean_bucket == "true"
-        save_sandbox(name, with_clean, with_clean_bucket)
+        save_sandbox(name, with_clean, with_clean_bucket, step_to_skip)
     else:
         print("Sandbox is disabled on this environment")

--- a/api/tests/sandboxes/scripts/test_utils.py
+++ b/api/tests/sandboxes/scripts/test_utils.py
@@ -1,0 +1,81 @@
+from unittest import mock
+
+import pytest
+
+from pcapi.sandboxes.scripts.utils import helpers
+
+
+def test_skip_steps_without_decorator_without_manager():
+    func = mock.MagicMock()
+
+    def my_step():
+        func()
+
+    assert helpers.STEPS_SKIP.steps_to_skip == []
+    my_step()
+
+    func.assert_called_once()
+    assert helpers.STEPS_SKIP.steps_to_skip == []
+
+
+@pytest.mark.parametrize("to_skip", (None, [], ["something_else"], ["my_step"]))
+def test_skip_steps_without_decorator_with_manager(to_skip):
+    func = mock.MagicMock()
+
+    def my_step():
+        func()
+
+    assert helpers.STEPS_SKIP.steps_to_skip == []
+    with helpers.skip_steps(steps=to_skip):
+        assert helpers.STEPS_SKIP.steps_to_skip == ([] if to_skip is None else to_skip)
+        my_step()
+
+    func.assert_called_once()
+    assert helpers.STEPS_SKIP.steps_to_skip == []
+
+
+def test_skip_steps_with_decorator_without_manager():
+    func = mock.MagicMock()
+
+    @helpers.log_func_duration
+    def my_step():
+        func()
+
+    assert helpers.STEPS_SKIP.steps_to_skip == []
+    my_step()
+
+    func.assert_called_once()
+    assert helpers.STEPS_SKIP.steps_to_skip == []
+
+
+@pytest.mark.parametrize("to_skip", (None, [], ["something_else"]))
+def test_skip_steps_with_decorator_with_manager_not_skipped(to_skip):
+    func = mock.MagicMock()
+
+    @helpers.log_func_duration
+    def my_step():
+        func()
+
+    assert helpers.STEPS_SKIP.steps_to_skip == []
+    with helpers.skip_steps(steps=to_skip):
+        assert helpers.STEPS_SKIP.steps_to_skip == ([] if to_skip is None else to_skip)
+        my_step()
+
+    func.assert_called_once()
+    assert helpers.STEPS_SKIP.steps_to_skip == []
+
+
+def test_skip_steps_with_decorator_with_manager_skipped():
+    func = mock.MagicMock()
+
+    @helpers.log_func_duration
+    def my_step():
+        func()
+
+    assert helpers.STEPS_SKIP.steps_to_skip == []
+    with helpers.skip_steps(steps=["my_step"]):
+        assert helpers.STEPS_SKIP.steps_to_skip == ["my_step"]
+        my_step()
+
+    func.assert_not_called()
+    assert helpers.STEPS_SKIP.steps_to_skip == []


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Ajout d'une option pour skip des étapes de la sandbox

Usage : `flask sandbox -n industrial --step-to-skip build_many_extra_invoices`

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
