### PR TITLE
(BSR)[API] perf: delete count() arg to allow index only scan

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -779,7 +779,7 @@ def get_pending_bookings_subquery(offer_id: int) -> sa.sql.selectable.Exists:
 
 def get_offer_chronicles_count_subquery() -> sa.sql.selectable.ScalarSelect:
     return (
-        sa.select(sa.func.count(chronicles_models.OfferChronicle.id))
+        sa.select(sa.func.count())
         .select_from(chronicles_models.OfferChronicle)
         .where(chronicles_models.OfferChronicle.offerId == models.Offer.id)
         .correlate(models.Offer)
@@ -789,7 +789,7 @@ def get_offer_chronicles_count_subquery() -> sa.sql.selectable.ScalarSelect:
 
 def get_offer_reaction_count_subquery() -> sa.sql.selectable.ScalarSelect:
     return (
-        sa.select(sa.func.count(reactions_models.Reaction.id))
+        sa.select(sa.func.count())
         .select_from(reactions_models.Reaction)
         .where(reactions_models.Reaction.offerId == models.Offer.id)
         .where(reactions_models.Reaction.reactionType == reactions_models.ReactionTypeEnum.LIKE)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

En faisant un `count()` sur l'`id` du modèle, postgres doit récupérer cette valeur et fait donc un Index Scan au lieu d'un Index Only Scan

Sur la query qui est faite pour l'indexation des offres (dans `get_base_query_for_offer_indexation`), pour 1 seule offre en staging, on passe de :
````
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| QUERY PLAN                                                                                                                                                                                                                                   >
|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| Nested Loop Left Join  (cost=6.01..199.91 rows=2 width=2982)
...

|   SubPlan 1                                                                                                                                                                                                                                  >
|     ->  Aggregate  (cost=7.31..7.32 rows=1 width=8)                                                                                                                                                                                          >
|           ->  Index Scan using "ix_offer_chronicle_offerId" on offer_chronicle  (cost=0.15..7.29 rows=8 width=8)                                                                                                                             >
|                 Index Cond: ("offerId" = offer.id)                                                                                                                                                                                           >
|   SubPlan 2                                                                                                                                                                                                                                  >
|     ->  Aggregate  (cost=10.46..10.47 rows=1 width=8)                                                                                                                                                                                        >
|           ->  Index Scan using ix_reaction_offer_like on reaction  (cost=0.29..10.44 rows=9 width=8)                                                                                                                                         >
|                 Index Cond: ("offerId" = offer.id)                                                                                                                                                                                           >
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
EXPLAIN 65
Time: 0.165s
````

à
````
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| QUERY PLAN                                                                                                                                                                                                                                   >
|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| Nested Loop Left Join  (cost=6.01..185.93 rows=2 width=2982)
...

|   SubPlan 1                                                                                                                                                                                                                                  >
|     ->  Aggregate  (cost=7.31..7.32 rows=1 width=8)                                                                                                                                                                                          >
|           ->  Index Only Scan using "ix_offer_chronicle_offerId" on offer_chronicle  (cost=0.15..7.29 rows=8 width=0)                                                                                                                        >
|                 Index Cond: ("offerId" = offer.id)                                                                                                                                                                                           >
|   SubPlan 2                                                                                                                                                                                                                                  >
|     ->  Aggregate  (cost=3.47..3.48 rows=1 width=8)                                                                                                                                                                                          >
|           ->  Index Only Scan using ix_reaction_offer_like on reaction  (cost=0.29..3.45 rows=9 width=0)                                                                                                                                     >
|                 Index Cond: ("offerId" = offer.id)                                                                                                                                                                                           >
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
EXPLAIN 65
Time: 0.139s
````

Le gain est "substantiel"
