### PR TITLE
(PC-36975)[API] feat: Use Open Data API Entreprise routes in structure creation

### DIFF
--- a/api/src/pcapi/connectors/entreprise/api.py
+++ b/api/src/pcapi/connectors/entreprise/api.py
@@ -4,20 +4,41 @@ from . import models
 from .backends.base import get_backend
 
 
+PROTECTED_DATA_PLACEHOLDER = "[ND]"
+
+
+def get_siren_open_data(siren: str) -> models.SirenInfo:
+    """
+    Get INSEE information about the requested SIREN.
+    All returned data is public. If entity is "partially diffusible", name and address are replaced by placeholder value.
+    """
+    return get_backend(settings.ENTREPRISE_BACKEND).get_siren_open_data(siren)
+
+
 def get_siren(siren: str, with_address: bool = True, raise_if_non_public: bool = True) -> models.SirenInfo:
     """
     Get information from INSEE about the requested SIREN.
-    Returned data is public, except name and address when "non-diffusible"
+    Not all returned data is public. If entity is "partially diffusible", name and address are protected data.
+    Use get_siren_open_data instead unless access to protected data is strictly necessary.
     """
     return get_backend(settings.ENTREPRISE_BACKEND).get_siren(
         siren, with_address=with_address, raise_if_non_public=raise_if_non_public
     )
 
 
+def get_siret_open_data(siret: str) -> models.SiretInfo:
+    """
+    Get INSEE information about the requested SIRET.
+    All returned data is public. If entity is "partially diffusible", name and address are replaced by placeholder value.
+    """
+    return get_backend(settings.ENTREPRISE_BACKEND).get_siret_open_data(siret)
+
+
 def get_siret(siret: str, raise_if_non_public: bool = True) -> models.SiretInfo:
     """
     Get information from INSEE about the requested SIRET.
-    Returned data is public, except name and address when "non-diffusible"
+    Not all returned data is public. If entity is "partially diffusible", name and address are protected data.
+    Use get_siret_open_data instead unless access to protected data is strictly necessary.
     """
     return get_backend(settings.ENTREPRISE_BACKEND).get_siret(siret, raise_if_non_public=raise_if_non_public)
 

--- a/api/src/pcapi/connectors/entreprise/backends/base.py
+++ b/api/src/pcapi/connectors/entreprise/backends/base.py
@@ -11,7 +11,13 @@ def get_backend(module_path: str | None) -> "BaseBackend":
 
 
 class BaseBackend:
+    def get_siren_open_data(self, siren: str, with_address: bool = True) -> models.SirenInfo:
+        raise NotImplementedError()
+
     def get_siren(self, siren: str, with_address: bool = True, raise_if_non_public: bool = True) -> models.SirenInfo:
+        raise NotImplementedError()
+
+    def get_siret_open_data(self, siret: str) -> models.SiretInfo:
         raise NotImplementedError()
 
     def get_siret(self, siret: str, raise_if_non_public: bool = False) -> models.SiretInfo:

--- a/api/src/pcapi/routes/pro/sirene.py
+++ b/api/src/pcapi/routes/pro/sirene.py
@@ -1,6 +1,6 @@
 from flask_login import login_required
 
-from pcapi.connectors.entreprise import sirene
+from pcapi.core.offerers import api as offerers_api
 from pcapi.repository.session_management import atomic
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import sirene as sirene_serializers
@@ -17,7 +17,7 @@ from . import blueprint
     api=blueprint.pro_private_schema,
 )
 def get_siret_info(siret: str) -> sirene_serializers.SiretInfo:
-    info = sirene.get_siret(siret)
+    info = offerers_api.find_siret_info(siret)
     assert info.address  # helps mypy
     info_address_dict = info.address.dict()
     info_address_dict.pop("insee_code")

--- a/api/tests/routes/pro/sirene_test.py
+++ b/api/tests/routes/pro/sirene_test.py
@@ -38,7 +38,7 @@ class GetSiretTest:
         }
 
     @pytest.mark.usefixtures("db_session")
-    @mock.patch("pcapi.connectors.entreprise.sirene.get_siret", get_siret_raises)
+    @mock.patch("pcapi.connectors.entreprise.api.get_siret_open_data", get_siret_raises)
     def test_siret_error(self, client):
         pro = users_factories.ProFactory()
         siret = "12345678900001"


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36975)

When searching for SIRET and creating new Venue & Offerer, we should rely on Open Data API Entreprise routes, which send only public data that can be safely show in our pro frontend
- Add `get_siren_open_data` and `get_siret_open_data `in connector to call `.../diffusibles/` routes
- Replace usages in structure identification, structure creation, and manual structure creation in backoffice

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [x] Travail pair testé en environnement de preview
