### PR TITLE
(PC-37229)[API] fix: sort artist product bookings with `nulls_last`

### DIFF
--- a/api/src/pcapi/core/artist/api.py
+++ b/api/src/pcapi/core/artist/api.py
@@ -20,7 +20,7 @@ def get_artist_image_url(artist: Artist) -> str | None:
                 )
             )
             .filter(ProductMediation.imageType.in_([ImageType.POSTER, ImageType.RECTO]))
-            .order_by(Product.last_30_days_booking.desc(), Product.id.desc())
+            .order_by(Product.last_30_days_booking.desc().nulls_last(), Product.id.desc())
             .first()
         )
 

--- a/api/tests/core/artist/test_api.py
+++ b/api/tests/core/artist/test_api.py
@@ -27,9 +27,13 @@ class GetArtistImageUrlTest:
 
     def test_get_image_from_most_popular_product(self):
         artist = artist_factories.ArtistFactory(image=None)
-        least_popular_product_mediation = offers_factories.ProductMediationFactory(product__last_30_days_booking=1)
+        least_popular_product_mediation = offers_factories.ProductMediationFactory(product__last_30_days_booking=None)
         artist_factories.ArtistProductLinkFactory(
             artist_id=artist.id, product_id=least_popular_product_mediation.product.id
+        )
+        medium_popular_product_mediation = offers_factories.ProductMediationFactory(product__last_30_days_booking=1)
+        artist_factories.ArtistProductLinkFactory(
+            artist_id=artist.id, product_id=medium_popular_product_mediation.product.id
         )
         most_popular_product_mediation = offers_factories.ProductMediationFactory(product__last_30_days_booking=2)
         artist_factories.ArtistProductLinkFactory(


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37229)

