### PR TITLE
(PC-37219)[PRO] fix: Dont display the date error message when there i…

### DIFF
--- a/pro/src/components/IndividualOfferLayout/OfferPublicationEdition/OfferPublicationEditionForm/OfferPublicationEditionForm.tsx
+++ b/pro/src/components/IndividualOfferLayout/OfferPublicationEdition/OfferPublicationEditionForm/OfferPublicationEditionForm.tsx
@@ -92,13 +92,18 @@ export function OfferPublicationEditionForm({
   const form = useForm<EventPublicationEditionFormValues>({
     defaultValues: getDefaultValuesFromOffer(offer, publicationHoursOptions),
     resolver: yupResolver(validationSchema),
+    mode: 'onBlur',
   })
 
   const isPaused = form.watch('isPaused')
 
   return (
     <FormProvider {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className={styles['form']}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className={styles['form']}
+        noValidate
+      >
         <ScrollToFirstHookFormErrorAfterSubmit />
         <MandatoryInfo />
         <div className={styles['form-content']}>
@@ -137,6 +142,10 @@ export function OfferPublicationEditionForm({
                       disabled={isPaused}
                       required
                       {...form.register('publicationDate')}
+                      onBlur={async (e) => {
+                        await form.register('publicationDate').onBlur(e)
+                        await form.trigger('publicationTime')
+                      }}
                       error={form.formState.errors.publicationDate?.message}
                     />
                     <Select
@@ -189,6 +198,10 @@ export function OfferPublicationEditionForm({
                       disabled={isPaused}
                       required
                       {...form.register('bookingAllowedDate')}
+                      onBlur={async (e) => {
+                        await form.register('bookingAllowedDate').onBlur(e)
+                        await form.trigger('bookingAllowedDate')
+                      }}
                       error={form.formState.errors.bookingAllowedDate?.message}
                     />
                     <Select

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/EventPublicationForm/__specs__/validationSchema.spec.ts
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/EventPublicationForm/__specs__/validationSchema.spec.ts
@@ -57,10 +57,10 @@ describe('EventPublicationForm validationSchema', () => {
         publicationDate: new Date().toISOString().split('T')[0],
         publicationTime: '00:00',
       },
-      expectedErrors: ['Veuillez indiquer une date dans le futur'],
+      expectedErrors: ['Veuillez indiquer une heure dans le futur'],
     },
     {
-      description: 'should not be able to make an aoofer bookable in the past',
+      description: 'should not be able to make an offer bookable in the past',
       formValues: {
         ...defaultValues,
         bookingAllowedMode: 'later',
@@ -70,15 +70,14 @@ describe('EventPublicationForm validationSchema', () => {
       expectedErrors: ['Veuillez indiquer une date dans le futur'],
     },
     {
-      description:
-        'should not be able to make an aoofer bookable earlier today',
+      description: 'should not be able to make an offer bookable earlier today',
       formValues: {
         ...defaultValues,
         bookingAllowedMode: 'later',
         bookingAllowedDate: new Date().toISOString().split('T')[0],
         bookingAllowedTime: '00:00',
       },
-      expectedErrors: ['Veuillez indiquer une date dans le futur'],
+      expectedErrors: ['Veuillez indiquer une heure dans le futur'],
     },
   ]
 

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
@@ -991,7 +991,7 @@ describe('Form', () => {
     ).not.toBeInTheDocument()
     expect(
       screen.queryByText(ERROR_MESSAGES.publicationDateMustBeInFuture)
-    ).toBeVisible()
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByText(ERROR_MESSAGES.publicationTimeIsRequired)
     ).toBeVisible()
@@ -1045,13 +1045,6 @@ describe('Form', () => {
       await screen.findByText(ERROR_MESSAGES.publicationDateMustBeInFuture)
     ).toBeVisible()
 
-    // await act(() =>
-    //   fireEvent.input(publicationDateInput, {
-    //     target: {
-    //       value: format(inOneMonth, 'yyyy-MM-dd'),
-    //     },
-    //   })
-    // )
     await userEvent.clear(publicationDateInput)
     await userEvent.type(publicationDateInput, format(inOneMonth, 'yyyy-MM-dd'))
 


### PR DESCRIPTION
…s no time and when  that date at 23:59 would be valid.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37219)

Activer le FF `WIP_REFACTO_FUTURE_OFFER`, se rendre sur la page d'une offre indiv publiée -> ouvrir le drawer de publication dans le futur via le bouton "Modifier" à côté du tag du statut.

Correctif :
- Ne pas invalider les champs de date de publication dans le futur/date de réservabilité lorsque l'horaire n'a pas encore été renseigné, et que la même date à 23h59 n'est pas dans le passé.
- Afficher un message d'erreur sur le champ "Horaire" quand la date est aujourd'hui et que l'heure est dans le passé
- Re-déclencher la validation de l'Horaire quand la date change et inversement

(en gros, si on met la date d'hier -> erreur, si on met la date d'aujourd'hui -> pas d'erreur tant qu'on n'a pas renseigné l'horaire)
