### PR TITLE
(BSR)[PRO] fix: RadioButtonGroup - adds error icon + fix LabelTag description font

### DIFF
--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.module.scss
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.module.scss
@@ -35,6 +35,19 @@
 }
 
 .radio-button-group-description {
+  &.has-label {
+    &-span {
+      @include fonts.body-s;
+    }
+
+    &-h1,
+    &-h2,
+    &-h3,
+    &-h4 {
+      @include fonts.body;
+    }
+  }
+
   color: var(--color-text-subtle);
 }
 
@@ -42,6 +55,12 @@
   @include fonts.body-accent-s;
 
   color: var(--color-text-error);
+
+  &-icon {
+    color: var(--color-text-error);
+    margin-right: rem.torem(4px);
+    vertical-align: middle;
+  }
 }
 
 .radio-button-group-options {

--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.stories.tsx
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.stories.tsx
@@ -92,6 +92,7 @@ export const WithHeadingTag: StoryObj<typeof RadioButtonGroup> = {
   args: {
     name: 'radio-button-group',
     label: 'Radio Button Group with Heading Tag',
+    description: 'This is a description with heading tag.',
     labelTag: 'h2',
     options,
   },
@@ -101,6 +102,7 @@ export const WithSpanTag: StoryObj<typeof RadioButtonGroup> = {
   args: {
     name: 'radio-button-group',
     label: 'Radio Button Group with Span Tag',
+    description: 'This is a description with span tag.',
     labelTag: 'span',
     options,
   },

--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.tsx
@@ -4,9 +4,11 @@ import { ElementType, useId } from 'react'
 import {
   RadioButton,
   RadioButtonProps,
-  RadioButtonVariantProps,
   RadioButtonSizing,
+  RadioButtonVariantProps,
 } from 'design-system/RadioButton/RadioButton'
+import fullError from 'icons/full-error.svg'
+import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
 import styles from './RadioButtonGroup.module.scss'
 
@@ -109,14 +111,26 @@ export const RadioButtonGroup = ({
         {description && (
           <span
             id={descriptionId}
-            className={styles['radio-button-group-description']}
+            className={cn(styles['radio-button-group-description'], {
+              [styles[`has-label-${LabelTag}`]]: LabelTag,
+            })}
           >
             {description}
           </span>
         )}
         <div role="alert" id={errorId}>
           {error && (
-            <span className={styles['radio-button-group-error']}>{error}</span>
+            <>
+              <SvgIcon
+                src={fullError}
+                alt=""
+                width="16"
+                className={styles['radio-button-group-error-icon']}
+              />
+              <span className={styles['radio-button-group-error']}>
+                {error}
+              </span>
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## 🔧 Changes Made

Correctifs sur le composant `<RadioButtonGroup>` pour être conforme à la maquette Figma originale : https://www.figma.com/design/1rs8Bx3sqYGDBpskwSEMZW/branch/N8IuqNmW9JnUHvxWaROOrJ/Design-System-pass-Culture--WIP-?node-id=3716-9958&m=dev

Éléments corrigés :
- Oubli de l'icône sur les messages d'erreur
- Changement de la font de la description suivant le "LabelTag" choisi (span/h1/h2/h3/h4)

## 🖼️ Before & After Images

Before | After
:---: | :---:
<img width="285" height="228" alt="image" src="https://github.com/user-attachments/assets/a7d097d3-7eae-4fc8-b7d2-de0c50f33879" /> | <img width="289" height="226" alt="image" src="https://github.com/user-attachments/assets/816dd1cd-768f-4e54-b32b-3c787fc5a019" />
<img width="324" height="229" alt="image" src="https://github.com/user-attachments/assets/7f2ee002-44af-48ec-8b47-1f0c561a4019" /> | <img width="323" height="221" alt="image" src="https://github.com/user-attachments/assets/a54d33b8-704f-4098-8aec-90d002e37d5f" />
(label `body-accent` --> description `body` ❌ ) | (label `body-accent` --> description `body-s` ✅ )

