### PR TITLE
(PC-35385)[API] feat: "" for lat/long on venue update

### DIFF
--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -139,7 +139,7 @@ def edit_venue(venue_id: int, body: venues_serialize.EditVenueBodyModel) -> venu
     modifications = {
         field: value for field, value in update_venue_attrs.items() if venue.field_exists_and_has_changed(field, value)
     }
-    update_location_attrs = body.dict(include=location_fields, exclude_unset=True)
+    update_location_attrs = body.dict(include=location_fields, exclude_unset=True, exclude_none=True)
     location_modifications = {
         field: value
         for field, value in update_location_attrs.items()

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -320,8 +320,8 @@ class EditVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
     @validator("latitude", pre=True)
     @classmethod
     def check_and_format_latitude(cls, raw_latitude: typing.Any) -> Decimal | None:
-        if raw_latitude is None:
-            return raw_latitude
+        if raw_latitude is None or raw_latitude == "":
+            return None
         try:
             latitude = geography_utils.format_coordinate(raw_latitude)
         except ValueError:
@@ -333,8 +333,8 @@ class EditVenueBodyModel(BaseModel, AccessibilityComplianceMixin):
     @validator("longitude", pre=True)
     @classmethod
     def check_and_format_longitude(cls, raw_longitude: typing.Any) -> Decimal | None:
-        if raw_longitude is None:
-            return raw_longitude
+        if raw_longitude is None or raw_longitude == "":
+            return None
         try:
             longitude = geography_utils.format_coordinate(raw_longitude)
         except ValueError:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-35385)

Prise en compte de lat/long avec une string vide lors de la mise à jour de la venue.