### PR TITLE
(PC-37065)[API] feat: add generic logs to some public api routes

### DIFF
--- a/api/src/pcapi/core/logging.py
+++ b/api/src/pcapi/core/logging.py
@@ -197,6 +197,8 @@ class JsonFormatter(logging.Formatter):
         impersonator_id = get_logged_impersonator_id() if user_id else None
 
         json_record = {
+            # TODO(jbaudet): remove those two public api key/values since
+            # there is no need to log those outside of an public API call
             "api_key_offerer_id": get_api_key_offerer_id(),
             "api_key_provider_id": get_api_key_provider_id(),
             "logging.googleapis.com/trace": get_or_set_correlation_id(),

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -125,7 +125,7 @@ def setup_sentry_before_request() -> None:
         )
     sentry_sdk.set_tag("correlation-id", get_or_set_correlation_id())
     g.request_start = time.perf_counter()
-    g.log_request_details_extra = {}
+    g.public_api_log_request_details_extra = {}
 
 
 @app.after_request
@@ -157,11 +157,11 @@ def log_request_details(response: flask.wrappers.Response) -> flask.wrappers.Res
         extra["duration"] = duration
 
     try:
-        extra.update(g.log_request_details_extra)
+        extra.update(g.public_api_log_request_details_extra)
     except AttributeError:
-        logger.warning("g.log_request_details_extra was not available in log_request_details", exc_info=True)
+        logger.warning("g.public_api_log_request_details_extra was not available in log_request_details", exc_info=True)
     except Exception:
-        logger.warning("g.log_request_details_extra does not seem to contain a valid dict", exc_info=True)
+        logger.warning("g.public_api_log_request_details_extra does not seem to contain a valid dict", exc_info=True)
 
     logger.info("HTTP request at %s", request.path, extra=extra)
 

--- a/api/src/pcapi/routes/public/utils.py
+++ b/api/src/pcapi/routes/public/utils.py
@@ -1,5 +1,9 @@
 import base64
 import binascii
+import inspect
+import typing
+
+from flask import g
 
 from pcapi.core.geography import models as geography_models
 from pcapi.models import api_errors
@@ -26,3 +30,46 @@ def get_bytes_from_base64_string(base64_string: str) -> bytes:
         return base64.b64decode(base64_string.encode("utf-8"))
     except binascii.Error as error:
         raise InvalidBase64Exception() from error
+
+
+def setup_public_api_log_extra(route: typing.Callable) -> None:
+    """Setup `public_api_log_request_details_extra` base data
+
+    Add information shared by all public API routes: module, function
+    name, api key information; with a `technical_message_id` needed by
+    data import tools.
+
+    All these will be added to the base logger under the `extra` key.
+    Note that this data can and should be updated (with new keys and
+    values) through the whole request's lifecycle. To add any data from
+    a controller, for example, call `public_api_add_log_extra`.
+
+    Warning:
+        edit the `technical_message_id`'s value with great caution
+    """
+    if not hasattr(g, "public_api_log_request_details_extra"):
+        g.public_api_log_request_details_extra = {}
+
+    raw_module = inspect.getmodule(route)
+    module = raw_module.__name__.split(".")[-1] if raw_module is not None else ""
+
+    if hasattr(g, "current_api_key") and g.current_api_key is not None:
+        g.public_api_log_request_details_extra["technical_message_id"] = "public_api.call"
+        g.public_api_log_request_details_extra["public_api"] = {
+            "api_key": g.current_api_key.id,
+            "provider_id": g.current_api_key.providerId,
+            "module": module,
+            "function": route.__name__,
+        }
+
+
+def public_api_add_log_extra(**kwargs: typing.Any) -> None:
+    """Entry point for any `public_api_log_request_details_extra` update
+
+    Ensure that every new data update is added at the right place,
+    inside the same base object.
+    """
+    if not hasattr(g, "public_api_log_request_details_extra"):
+        # should not be used, but lets be cautious
+        g.public_api_log_request_details_extra = {"public_api": {}}
+    g.public_api_log_request_details_extra["public_api"].update(kwargs)

--- a/api/tests/routes/public/helpers.py
+++ b/api/tests/routes/public/helpers.py
@@ -109,7 +109,7 @@ class PublicAPIEndpointBaseHelper:
         env = "test"
         prefix_id = str(uuid.uuid1())
 
-        offerers_factories.ApiKeyFactory(
+        self._api_key = offerers_factories.ApiKeyFactory(
             offerer=offerer, provider=provider, secret=secret, prefix="%s_%s" % (env, prefix_id)
         )
         plain_api_key = "%s_%s_%s" % (env, prefix_id, secret)

--- a/api/tests/routes/public/individual_offers/v1/utils.py
+++ b/api/tests/routes/public/individual_offers/v1/utils.py
@@ -1,0 +1,27 @@
+import typing
+from datetime import datetime
+
+
+KwargBaseTypes = bool | int | float | str | datetime
+KwargInput = KwargBaseTypes | typing.Collection[KwargBaseTypes]
+
+
+def assert_public_api_data_logs_have_been_recorded(caplog, api_key, **kwargs: KwargInput) -> None:
+    """Assert that the expected information have been logged
+
+    All expected information should be passed to `kwargs` except the two
+    authenticated related fields: `api_key` and `provider_id` that are
+    checked using the `api_key` input.
+    """
+    log_record = next(
+        record
+        for record in caplog.records
+        if hasattr(record, "technical_message_id") and record.technical_message_id == "public_api.call"
+    )
+
+    public_api_extra_data = log_record.public_api
+    assert public_api_extra_data == {
+        "api_key": api_key.id,
+        "provider_id": api_key.providerId,
+        **kwargs,
+    }


### PR DESCRIPTION
[Ticket Jira](https://passculture.atlassian.net/browse/PC-37065)

# Ajout de logs (pour la _data_) concernant l'utilisation de routes de l'API publique : POC

Objectif : ajouter quelques informations qui nous permettraient de produire des tableaux de bords de l'utilisation de l'API publique. L'objectif n'est (pour l'instant) pas d'avoir une vue détaillée de son utilisation avec par exemple une copie des toutes les données (non sensible) en entrée : inutile de remplir les logs, vu le trafic.

Cette PR a pour objectif de proposer des outils simples sur les routes des offres produits (certaines données communes remonteront de fait dans toutes les routes mais c'est secondaire) et de voir ensuite comment les améliorer. 