### PR TITLE
(PC-36479)[PRO] feat: add reimbursed banner to collective timeline

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/BookableOfferTimeline/BookableOfferTimeline.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/BookableOfferTimeline/BookableOfferTimeline.spec.tsx
@@ -402,29 +402,55 @@ describe('BookableOfferTimeline - step type rendering', () => {
         )
       ).toBeInTheDocument()
     })
-  })
 
-  it('should render a banner when current step is under review', () => {
-    renderWithProviders(
-      <BookableOfferTimeline
-        offer={getCollectiveOfferFactory({
-          history: {
-            past: [
-              {
-                status: CollectiveOfferDisplayedStatus.UNDER_REVIEW,
-              },
-            ],
-            future: [CollectiveOfferDisplayedStatus.BOOKED],
-          },
-        })}
-      />
-    )
-
-    expect(
-      screen.getByText(
-        /Votre offre est en cours d'instruction par notre équipe chargée du contrôle de conformité. Ce contrôle peut prendre jusqu'à 72 heures. Vous serez notifié par mail lors de sa validation ou de son refus./
+    it('should render a banner when current step is under review', () => {
+      renderWithProviders(
+        <BookableOfferTimeline
+          offer={getCollectiveOfferFactory({
+            history: {
+              past: [
+                {
+                  status: CollectiveOfferDisplayedStatus.UNDER_REVIEW,
+                },
+              ],
+              future: [CollectiveOfferDisplayedStatus.BOOKED],
+            },
+          })}
+        />
       )
-    ).toBeInTheDocument()
+
+      expect(
+        screen.getByText(
+          /Votre offre est en cours d'instruction par notre équipe chargée du contrôle de conformité. Ce contrôle peut prendre jusqu'à 72 heures. Vous serez notifié par mail lors de sa validation ou de son refus./
+        )
+      ).toBeInTheDocument()
+    })
+
+    it('should render a banner when current step is reimbursed', () => {
+      renderWithProviders(
+        <BookableOfferTimeline
+          offer={getCollectiveOfferFactory({
+            history: {
+              past: [
+                {
+                  status: CollectiveOfferDisplayedStatus.REIMBURSED,
+                },
+              ],
+              future: [],
+            },
+          })}
+        />
+      )
+
+      expect(
+        screen.getByText(/Votre offre a été remboursée./)
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('link', {
+          name: /Consulter les remboursements/,
+        })
+      ).toHaveAttribute('href', '/remboursements')
+    })
   })
 
   it('should render a banner when current step is archived', () => {

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/BookableOfferTimeline/BookableOfferTimeline.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/BookableOfferTimeline/BookableOfferTimeline.tsx
@@ -9,6 +9,7 @@ import { ArchivedBanner } from './banners/ArchivedBanner'
 import { BookingWaitingBanner } from './banners/BookingWaitingBanner'
 import { CancelledBanner } from './banners/CancelledBanner'
 import { DraftBanner } from './banners/DraftBanner'
+import { ReimbursedBanner } from './banners/ReimbursedBanner'
 import { RejectedBanner } from './banners/RejectedBanner'
 import { UnderReviewBanner } from './banners/UnderReviewBanner'
 import styles from './BookableOfferTimeline.module.scss'
@@ -168,10 +169,15 @@ export const BookableOfferTimeline = ({ offer }: BookableOfferTimeline) => {
       return {
         type: TimelineStepType.SUCCESS,
         content: (
-          <StatusWithDate
-            status={statusLabel}
-            date={datetime ? `Le ${getDateToFrenchText(datetime)}` : undefined}
-          />
+          <>
+            <StatusWithDate
+              status={statusLabel}
+              date={
+                datetime ? `Le ${getDateToFrenchText(datetime)}` : undefined
+              }
+            />
+            {isCurrentStep && <ReimbursedBanner />}
+          </>
         ),
       }
     }

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/BookableOfferTimeline/banners/ReimbursedBanner.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/BookableOfferTimeline/banners/ReimbursedBanner.tsx
@@ -1,0 +1,26 @@
+import fullNextIcon from 'icons/full-next.svg'
+import { Callout } from 'ui-kit/Callout/Callout'
+import { CalloutVariant } from 'ui-kit/Callout/types'
+
+import styles from '../BookableOfferTimeline.module.scss'
+
+export const ReimbursedBanner = () => {
+  return (
+    <Callout
+      className={styles['callout']}
+      variant={CalloutVariant.INFO}
+      links={[
+        {
+          label: 'Consulter les remboursements',
+          href: '/remboursements',
+          icon: {
+            src: fullNextIcon,
+            alt: 'Consulter les remboursements',
+          },
+        },
+      ]}
+    >
+      Votre offre a été remboursée.
+    </Callout>
+  )
+}

--- a/pro/src/ui-kit/Timeline/Timeline.module.scss
+++ b/pro/src/ui-kit/Timeline/Timeline.module.scss
@@ -108,6 +108,7 @@ $vertical-offset-icon-from-step: calc(
 .step-content {
   margin-left: rem.torem(16px);
   margin-bottom: rem.torem(32px);
+  width: 100%;
 }
 
 .step-content-last {


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

https://passculture.atlassian.net/browse/PC-36479

<img width="754" height="283" alt="image" src="https://github.com/user-attachments/assets/cac895a3-2eff-4caa-8c20-7ad684cccb29" />
