### PR TITLE
(PC-37280)[PRO] test: attempt to fix connection page e2e test flakyness

### DIFF
--- a/pro/cypress/e2e/desk.cy.ts
+++ b/pro/cypress/e2e/desk.cy.ts
@@ -15,8 +15,36 @@ describe('Desk (Guichet) feature', { testIsolation: false }, () => {
   })
 
   it('I should see help information on desk page', () => {
+    // Attempt to ignore problematic 401 errors on connection page first load
+    // TODO (igabriele, 2025-07-31): The real solution is be to clean the 401 from connection page (see PC-37280)
+    // https://github.com/cypress-io/cypress/issues/27501#issuecomment-2272519301
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/users/current',
+        times: 2,
+      },
+      {
+        global: ['Authentification nécessaire'],
+      }
+    ).as('getCurrentUser')
+    cy.intercept(
+      {
+        method: 'GET',
+        url: '/offerers/names',
+        times: 2,
+      },
+      {
+        global: ['Authentification nécessaire'],
+      }
+    ).as('getOffererNames')
+
     cy.wrap(Cypress.session.clearAllSavedSessions())
+
     cy.visit('/connexion')
+    cy.wait('@getCurrentUser')
+    cy.wait('@getOffererNames')
+
     cy.sandboxCall(
       'GET',
       'http://localhost:5001/sandboxes/pro/create_pro_user_with_bookings',


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37280)

- Intercept useless 401 responses on connection page first load, hoping to fix this flakyness error:

<img width="1314" height="924" alt="image" src="https://github.com/user-attachments/assets/f2945415-b229-4e8a-896d-20b57f096125" />

- Ran CI 5 times without failure on the last commit:

<img width="379" height="448" alt="image" src="https://github.com/user-attachments/assets/32158ad9-c0ac-4337-a389-10513b287615" />