### PR TITLE
(BSR)[API] fix: make /ean public route asynchronous again

### DIFF
--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -323,7 +323,7 @@ def post_product_offer_by_ean(body: products_serializers.ProductsOfferByEanCreat
         address_label = body.location.address_label
 
     serialized_products_stocks = _serialize_products_from_body(body.products)
-    offers_tasks.create_or_update_ean_offers(
+    offers_tasks.create_or_update_ean_offers.delay(
         serialized_products_stocks=serialized_products_stocks,
         venue_id=venue.id,
         provider_id=current_api_key.provider.id,


### PR DESCRIPTION
The regression happened here : https://github.com/pass-culture/pass-culture-main/commit/9057b5294119a4d28a47d3f635a9f0502cbae8e6#diff-71490f5793d9fba5a23611e7221cab71f869f3154846b1a3b612e5af739329acL11-L312 (search "delay")