### PR TITLE
(PC-36870)[API] script: Remove -lieu administratif- from venues public name

### DIFF
--- a/api/src/pcapi/scripts/update_venue_public_name/main.py
+++ b/api/src/pcapi/scripts/update_venue_public_name/main.py
@@ -22,38 +22,11 @@ logger = logging.getLogger(__name__)
 
 def main() -> None:
     venues_to_update_1 = db.session.query(offerers_models.Venue).filter(
-        func.lower(offerers_models.Venue.publicName).like("%(lieu administratif)%")
+        func.lower(offerers_models.Venue.publicName).like("%lieu administratif%")
     )
-    insensitive_1 = re.compile(re.escape("(lieu administratif)"), re.IGNORECASE)
+    insensitive_1 = re.compile(re.escape("lieu administratif"), re.IGNORECASE)
     for venue in venues_to_update_1.all():
         venue.publicName = insensitive_1.sub("", venue.publicName).strip()
-        logger.info("Update publicName for venue %d", venue.id)
-        db.session.add(venue)
-
-    venues_to_update_2 = db.session.query(offerers_models.Venue).filter(
-        func.lower(offerers_models.Venue.publicName).like("%/ lieu administratif%")
-    )
-    insensitive_2 = re.compile(re.escape("/ lieu administratif"), re.IGNORECASE)
-    for venue in venues_to_update_2.all():
-        venue.publicName = insensitive_2.sub("", venue.publicName).strip()
-        logger.info("Update publicName for venue %d", venue.id)
-        db.session.add(venue)
-
-    venues_to_update_3 = db.session.query(offerers_models.Venue).filter(
-        func.lower(offerers_models.Venue.publicName).like("% - lieu administratif%")
-    )
-    insensitive_3 = re.compile(re.escape(" - lieu administratif"), re.IGNORECASE)
-    for venue in venues_to_update_3.all():
-        venue.publicName = insensitive_3.sub("", venue.publicName).strip()
-        logger.info("Update publicName for venue %d", venue.id)
-        db.session.add(venue)
-
-    venues_to_update_4 = db.session.query(offerers_models.Venue).filter(
-        func.lower(offerers_models.Venue.publicName).like("%-lieu administratif%")
-    )
-    insensitive_4 = re.compile(re.escape("-lieu administratif"), re.IGNORECASE)
-    for venue in venues_to_update_4.all():
-        venue.publicName = insensitive_4.sub("", venue.publicName).strip()
         logger.info("Update publicName for venue %d", venue.id)
         db.session.add(venue)
 

--- a/api/src/pcapi/scripts/update_venue_public_name/main.py
+++ b/api/src/pcapi/scripts/update_venue_public_name/main.py
@@ -1,0 +1,57 @@
+"""
+Job console documentation here: https://www.notion.so/passcultureapp/Documentation-Job-Console-769beeacd5a146de9c97b6f8ee544276
+Assumed path to the script (copy-paste in github actions):
+
+https://github.com/pass-culture/pass-culture-main/blob/pcharlet/pc-36870-script-update-venue-public-name/api/src/pcapi/scripts/update_venue_public_name/main.py
+
+"""
+
+import argparse
+import logging
+import re
+
+from sqlalchemy import func
+
+from pcapi.app import app
+from pcapi.core.offerers import models as offerers_models
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    venues_to_update_hyphen_prefix = db.session.query(offerers_models.Venue).filter(
+        func.lower(offerers_models.Venue.publicName).like("%lieu administratif - %")
+    )
+    insensitive_hyphen_prefix = re.compile(re.escape("lieu administratif - "), re.IGNORECASE)
+    for venue in venues_to_update_hyphen_prefix.all():
+        venue.publicName = insensitive_hyphen_prefix.sub("", venue.publicName).strip()
+        logger.info("Update publicName for venue %d", venue.id)
+        db.session.add(venue)
+
+    venues_to_update_hyphen_suffix = db.session.query(offerers_models.Venue).filter(
+        func.lower(offerers_models.Venue.publicName).like("% - lieu administratif%")
+    )
+    insensitive_hyphen_suffix = re.compile(re.escape(" - lieu administratif"), re.IGNORECASE)
+    for venue in venues_to_update_hyphen_suffix.all():
+        venue.publicName = insensitive_hyphen_suffix.sub("", venue.publicName).strip()
+        logger.info("Update publicName for venue %d", venue.id)
+        db.session.add(venue)
+
+
+if __name__ == "__main__":
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--not-dry", action="store_true")
+    args = parser.parse_args()
+
+    main()
+
+    if args.not_dry:
+        logger.info("Finished")
+        db.session.commit()
+    else:
+        logger.info("Finished dry run, rollback")
+        db.session.rollback()

--- a/api/src/pcapi/scripts/update_venue_public_name/main.py
+++ b/api/src/pcapi/scripts/update_venue_public_name/main.py
@@ -21,21 +21,39 @@ logger = logging.getLogger(__name__)
 
 
 def main() -> None:
-    venues_to_update_hyphen_prefix = db.session.query(offerers_models.Venue).filter(
-        func.lower(offerers_models.Venue.publicName).like("%lieu administratif - %")
+    venues_to_update_1 = db.session.query(offerers_models.Venue).filter(
+        func.lower(offerers_models.Venue.publicName).like("%(lieu administratif)%")
     )
-    insensitive_hyphen_prefix = re.compile(re.escape("lieu administratif - "), re.IGNORECASE)
-    for venue in venues_to_update_hyphen_prefix.all():
-        venue.publicName = insensitive_hyphen_prefix.sub("", venue.publicName).strip()
+    insensitive_1 = re.compile(re.escape("(lieu administratif)"), re.IGNORECASE)
+    for venue in venues_to_update_1.all():
+        venue.publicName = insensitive_1.sub("", venue.publicName).strip()
         logger.info("Update publicName for venue %d", venue.id)
         db.session.add(venue)
 
-    venues_to_update_hyphen_suffix = db.session.query(offerers_models.Venue).filter(
+    venues_to_update_2 = db.session.query(offerers_models.Venue).filter(
+        func.lower(offerers_models.Venue.publicName).like("%/ lieu administratif%")
+    )
+    insensitive_2 = re.compile(re.escape("/ lieu administratif"), re.IGNORECASE)
+    for venue in venues_to_update_2.all():
+        venue.publicName = insensitive_2.sub("", venue.publicName).strip()
+        logger.info("Update publicName for venue %d", venue.id)
+        db.session.add(venue)
+
+    venues_to_update_3 = db.session.query(offerers_models.Venue).filter(
         func.lower(offerers_models.Venue.publicName).like("% - lieu administratif%")
     )
-    insensitive_hyphen_suffix = re.compile(re.escape(" - lieu administratif"), re.IGNORECASE)
-    for venue in venues_to_update_hyphen_suffix.all():
-        venue.publicName = insensitive_hyphen_suffix.sub("", venue.publicName).strip()
+    insensitive_3 = re.compile(re.escape(" - lieu administratif"), re.IGNORECASE)
+    for venue in venues_to_update_3.all():
+        venue.publicName = insensitive_3.sub("", venue.publicName).strip()
+        logger.info("Update publicName for venue %d", venue.id)
+        db.session.add(venue)
+
+    venues_to_update_4 = db.session.query(offerers_models.Venue).filter(
+        func.lower(offerers_models.Venue.publicName).like("%-lieu administratif%")
+    )
+    insensitive_4 = re.compile(re.escape("-lieu administratif"), re.IGNORECASE)
+    for venue in venues_to_update_4.all():
+        venue.publicName = insensitive_4.sub("", venue.publicName).strip()
         logger.info("Update publicName for venue %d", venue.id)
         db.session.add(venue)
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

DO NOT MERGE

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36870)

Script permettant de supprmer la chaine de caractère "lieu administratif" (case insensitive) des noms publiques des venues.

Gère les cas suivant :
- ` - lieu amdinistratif` [FAIT]
- `lieu amdinistratif - ` [FAIT]
- `(lieu administratif)` [FAIT]
- `/ lieu administratif` [FAIT]
- `lieu administratif`

- [x] Travail pair testé en environnement de preview
