### PR TITLE
(PC-36377)[API] feat: starting to replace isEvent to isTimestamped

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -152,6 +152,7 @@ def get_individual_bookings(user: users_models.User) -> list[models.Booking]:
                     sa_orm.joinedload(offers_models.Offer.offererAddress)
                     .load_only(offerers_models.OffererAddress.addressId, offerers_models.OffererAddress.label)
                     .joinedload(offerers_models.OffererAddress.address),
+                    sa_orm.selectinload(offers_models.Offer.openingHours).load_only(offerers_models.OpeningHours.id),
                 ),
                 sa_orm.joinedload(offers_models.Stock.priceCategory)
                 .joinedload(offers_models.PriceCategory.priceCategoryLabel)
@@ -614,7 +615,7 @@ def _cancel_bookings_from_stock(
         if booking.status in (models.BookingStatus.REIMBURSED, models.BookingStatus.CANCELLED):
             continue
 
-        cancel_even_if_used = stock.offer.isEvent
+        cancel_even_if_used = stock.offer.isTimestamped
         if booking.status == models.BookingStatus.USED and not cancel_even_if_used:
             continue
 
@@ -1215,7 +1216,7 @@ def is_voucher_displayed(offer: offers_models.Offer, isExternal: bool) -> bool:
     if offer.subcategoryId == SEANCE_CINE.id:
         return not isExternal
 
-    return not offer.isEvent
+    return not offer.isTimestamped
 
 
 def has_email_been_sent(stock: offers_models.Stock, withdrawal_delay: int | None) -> bool:

--- a/api/src/pcapi/core/bookings/factories.py
+++ b/api/src/pcapi/core/bookings/factories.py
@@ -111,6 +111,10 @@ class ReimbursedBookingFactory(BookingFactory):
     reimbursementDate = factory.LazyFunction(datetime.datetime.utcnow)
 
 
+class EventBookingFactory(BookingFactory):
+    stock = factory.SubFactory(offers_factories.EventStockFactory)
+
+
 class ExternalBookingFactory(BaseFactory):
     class Meta:
         model = models.ExternalBooking

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
@@ -25,7 +25,7 @@ def get_booking_cancellation_by_beneficiary_email_data(
     ):
         can_book_again = True
 
-    if offer.isEvent:
+    if offer.isTimestamped:
         if stock.beginningDatetime is None:
             raise ValueError("Can't convert None to local timezone")
         beginning_date_time_in_tz = utc_datetime_to_department_timezone(
@@ -43,7 +43,7 @@ def get_booking_cancellation_by_beneficiary_email_data(
             "EVENT_DATE": event_date,
             "EVENT_HOUR": event_hour,
             "IS_FREE_OFFER": is_free_offer,
-            "IS_EVENT": offer.isEvent,
+            "IS_EVENT": offer.isTimestamped,
             "IS_EXTERNAL": booking.isExternal,
             "OFFER_NAME": offer.name,
             "OFFER_PRICE": float(booking.total_amount),

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_to_pro.py
@@ -47,7 +47,7 @@ def get_booking_cancellation_by_beneficiary_to_pro_email_data(
                 else ""
             ),
             "EXTERNAL_BOOKING_INFORMATION": external_booking_information,
-            "IS_EVENT": booking.stock.offer.isEvent,
+            "IS_EVENT": booking.stock.offer.isTimestamped,
             "IS_EXTERNAL": booking.isExternal,
             "OFFER_NAME": booking.stock.offer.name,
             "PRICE": booking.stock.price if booking.stock.price > 0 else "Gratuit",

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
@@ -13,7 +13,7 @@ def get_booking_cancellation_by_pro_to_beneficiary_email_data(
 ) -> models.TransactionalEmailData:
     stock = booking.stock
     offer = stock.offer
-    if offer.isEvent:
+    if offer.isTimestamped:
         event_date = get_date_formatted_for_email(get_event_datetime(stock))
         event_hour = get_time_formatted_for_email(get_event_datetime(stock))
     else:
@@ -28,7 +28,7 @@ def get_booking_cancellation_by_pro_to_beneficiary_email_data(
             "BOOKING_CONTACT": offer.bookingContact,
             "EVENT_DATE": event_date,
             "EVENT_HOUR": event_hour,
-            "IS_EVENT": offer.isEvent,
+            "IS_EVENT": offer.isTimestamped,
             "IS_FREE_OFFER": is_free_offer,
             "IS_ONLINE": offer.isDigital,
             "IS_THING": not offer.isDigital and offer.isThing,

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_confirmation_by_pro.py
@@ -27,7 +27,7 @@ def get_booking_cancellation_confirmation_by_pro_email_data(
             "VENUE_NAME": offer.venue.common_name,
             "PRICE": offer_price,
             "FORMATTED_PRICE": format_price(stock.price, offer.venue),
-            "IS_EVENT": offer.isEvent,
+            "IS_EVENT": offer.isTimestamped,
             "IS_EXTERNAL": booking.isExternal,
             "EVENT_DATE": event_date,
             "EVENT_HOUR": event_hour,

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -49,7 +49,7 @@ def get_booking_confirmation_to_beneficiary_email_data(
 
     stock_price = f"{booking.total_amount} €" if stock.price > 0 else "Gratuit"
 
-    if offer.isEvent:
+    if offer.isTimestamped:
         if stock.beginningDatetime is None:
             raise ValueError("Can't convert None to local timezone")
         event_beginning_date_in_tz = utc_datetime_to_department_timezone(stock.beginningDatetime, department_code)
@@ -91,11 +91,11 @@ def get_booking_confirmation_to_beneficiary_email_data(
             ),
             "CODE_EXPIRATION_DATE": code_expiration_date,
             "VENUE_NAME": venue.common_name,
-            "ALL_BUT_NOT_VIRTUAL_THING": offer.isEvent or (not offer.isEvent and not offer.isDigital),
-            "ALL_THINGS_NOT_VIRTUAL_THING": not offer.isEvent and not offer.isDigital,
-            "IS_EVENT": offer.isEvent,
+            "ALL_BUT_NOT_VIRTUAL_THING": offer.isTimestamped or (not offer.isTimestamped and not offer.isDigital),
+            "ALL_THINGS_NOT_VIRTUAL_THING": not offer.isTimestamped and not offer.isDigital,
+            "IS_EVENT": offer.isTimestamped,
             "IS_EXTERNAL": booking.isExternal,
-            "IS_SINGLE_EVENT": offer.isEvent and booking.quantity == 1,
+            "IS_SINGLE_EVENT": offer.isTimestamped and booking.quantity == 1,
             "IS_DUO_EVENT": booking.quantity == 2,
             "CAN_EXPIRE": can_expire,
             "EXPIRATION_DELAY": expiration_delay,

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_postponed_by_pro_to_beneficiary.py
@@ -24,7 +24,7 @@ def get_booking_postponed_by_pro_to_beneficiary_email_data(
     stock = booking.stock
     offer = stock.offer
 
-    if offer.isEvent:
+    if offer.isTimestamped:
         event_date = get_date_formatted_for_email(get_event_datetime(stock)) if stock.beginningDatetime else ""
         event_hour = get_time_formatted_for_email(get_event_datetime(stock)) if stock.beginningDatetime else ""
     else:

--- a/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
@@ -51,7 +51,7 @@ def get_new_booking_to_pro_email_data(
         .one()
     )
 
-    if offer.isEvent:
+    if offer.isTimestamped:
         event_date = get_date_formatted_for_email(get_event_datetime(stock)) if stock.beginningDatetime else ""
         event_hour = get_time_formatted_for_email(get_event_datetime(stock)) if stock.beginningDatetime else ""
     else:
@@ -89,7 +89,7 @@ def get_new_booking_to_pro_email_data(
             "EVENT_DATE": event_date,
             "EVENT_HOUR": event_hour,
             "IS_BOOKING_AUTOVALIDATED": is_booking_autovalidated,
-            "IS_EVENT": offer.isEvent,
+            "IS_EVENT": offer.isTimestamped,
             "IS_THING": offer.isThing,
             "IS_DIGITAL": offer.isDigital,
             "IS_EXTERNAL": booking.isExternal,

--- a/api/src/pcapi/core/mails/transactional/pro/event_offer_postponed_confirmation_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/event_offer_postponed_confirmation_to_pro.py
@@ -22,7 +22,9 @@ def get_event_offer_postponed_confirmation_to_pro_email_data(
         params={
             "OFFER_NAME": stock.offer.name,
             "VENUE_NAME": stock.offer.venue.common_name,
-            "EVENT_DATE": get_date_formatted_for_email(get_event_datetime(stock)) if stock.offer.isEvent else None,
+            "EVENT_DATE": get_date_formatted_for_email(get_event_datetime(stock))
+            if stock.offer.isTimestamped
+            else None,
             "BOOKING_COUNT": booking_count,
             "OFFER_ADDRESS": stock.offer.fullAddress,
         },

--- a/api/src/pcapi/core/mails/transactional/pro/first_venue_approved_offer_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/first_venue_approved_offer_to_pro.py
@@ -43,7 +43,7 @@ def get_first_venue_approved_offer_email_data(offer: Offer) -> models.Transactio
         params={
             "OFFER_NAME": offer.name,
             "VENUE_NAME": offer.venue.common_name,
-            "IS_EVENT": offer.isEvent,
+            "IS_EVENT": offer.isTimestamped,
             "IS_THING": offer.isThing,
             "IS_DIGITAL": offer.isDigital,
             "WITHDRAWAL_PERIOD": (

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -310,13 +310,21 @@ class OpeningHoursFactory(BaseFactory):
     class Meta:
         model = models.OpeningHours
 
-    # TODO(jbaudet::2025-07) make both optional and check that only one
-    # is set at a time
-    venue = factory.SubFactory(VenueFactory)
+    venue: factory.SubFactory | None = None
     offer: factory.SubFactory | None = None
 
     weekday = models.Weekday.MONDAY
     timespan = timespan_str_to_numrange(OPENING_HOURS)
+
+
+class VenueOpeningHoursFactory(OpeningHoursFactory):
+    venue: factory.SubFactory | None = factory.SubFactory(VenueFactory)
+    offer: factory.SubFactory | None = None
+
+
+class OfferOpeningHoursFactory(OpeningHoursFactory):
+    venue: factory.SubFactory | None = None
+    offer: factory.SubFactory | None = factory.SubFactory("pcapi.core.offers.factories.OfferFactory")
 
 
 class UserOffererFactory(BaseFactory):

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -696,7 +696,7 @@ def remove_headline_offer(headline_offer: offers_models.HeadlineOffer) -> None:
 
 
 def _notify_pro_upon_stock_edit_for_event_offer(stock: models.Stock, bookings: list[bookings_models.Booking]) -> None:
-    if stock.offer.isEvent:
+    if stock.offer.isTimestamped:
         transactional_mails.send_event_offer_postponement_confirmation_email_to_pro(stock, len(bookings))
 
 
@@ -1912,7 +1912,7 @@ def get_stocks_stats(offer_id: int) -> StocksStats:
 
 
 def check_can_move_event_offer(offer: models.Offer) -> list[offerers_models.Venue]:
-    if not offer.isEvent:
+    if not offer.isTimestamped:
         raise exceptions.OfferIsNotEvent()
 
     count_past_stocks = (
@@ -2148,7 +2148,7 @@ def move_event_offer(
 def update_used_stock_price(
     stock: models.Stock, new_price: float | None = None, price_percent: decimal.Decimal | None = None
 ) -> None:
-    if not stock.offer.isEvent:
+    if not stock.offer.isTimestamped:
         raise ValueError("Only stocks associated with an event offer can be edited with used bookings")
     if (new_price is None) == (price_percent is None):
         raise ValueError("One of [new_price, price_percent] is mandatory")

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -1,6 +1,7 @@
 import datetime
 import decimal
 import random
+import time
 import typing
 import uuid
 
@@ -214,10 +215,12 @@ class OfferFactory(BaseFactory):
             and kwargs.get("validation") != models.OfferValidationStatus.DRAFT
             and "publicationDatetime" not in kwargs
         ):
-            kwargs["publicationDatetime"] = datetime.datetime.now() - datetime.timedelta(minutes=5)
+            utc_offset = time.localtime().tm_gmtoff // 3600
+            kwargs["publicationDatetime"] = datetime.datetime.now() - datetime.timedelta(minutes=5, hours=utc_offset)
 
         if kwargs.get("validation") != models.OfferValidationStatus.DRAFT and "finalizationDatetime" not in kwargs:
-            kwargs["finalizationDatetime"] = datetime.datetime.now()
+            utc_offset = time.localtime().tm_gmtoff // 3600
+            kwargs["finalizationDatetime"] = datetime.datetime.now() - datetime.timedelta(hours=utc_offset)
 
         product = kwargs.get("product")
         if product:

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -281,6 +281,20 @@ class EventOfferFactory(OfferFactory):
         lambda o: (o.product.subcategoryId if hasattr(o, "product") else subcategories.SEANCE_CINE.id)
     )
 
+    @classmethod
+    def _create(
+        cls,
+        model_class: type[models.Offer],
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> models.Offer:
+        offer = super()._create(model_class, *args, **kwargs)
+
+        if "openingHours" not in kwargs:
+            offerers_factories.OfferOpeningHoursFactory(offer=offer)
+
+        return offer
+
 
 class ThingOfferFactory(OfferFactory):
     subcategoryId = factory.LazyAttribute(
@@ -375,14 +389,14 @@ class StockFactory(BaseFactory):
     quantity = 1000
 
     beginningDatetime: factory.declarations.BaseDeclaration | None = factory.Maybe(
-        "offer.isEvent",
+        "offer.isTimestamped",
         factory.LazyFunction(
             lambda: datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
         ),
         None,
     )
     bookingLimitDatetime: factory.declarations.BaseDeclaration | None = factory.Maybe(
-        "stock.beginningDatetime and offer.isEvent",
+        "stock.beginningDatetime and offer.isTimestamped",
         factory.LazyAttribute(lambda stock: stock.beginningDatetime - datetime.timedelta(minutes=60)),
         None,
     )

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -922,6 +922,11 @@ class Offer(PcObject, Base, Model, ValidationMixin, AccessibilityMixin):
     def isPermanent(cls) -> BinaryExpression:
         return cls.subcategoryId.in_(subcategories.PERMANENT_SUBCATEGORIES)
 
+    @property
+    def isTimestamped(self) -> bool:
+        """A timestamped offer is an event with opening hours"""
+        return self.subcategory.is_event and self.openingHours is not None and len(self.openingHours) > 0
+
     @hybrid_property
     def isEvent(self) -> bool:
         return self.subcategory.is_event

--- a/api/src/pcapi/core/offers/offer_metadata.py
+++ b/api/src/pcapi/core/offers/offer_metadata.py
@@ -58,7 +58,7 @@ def _get_common_metadata_from_offer(offer: offers_models.Offer) -> Metadata:
                 "https://schema.org/InStock"
                 if offer.hasStocks
                 else "https://schema.org/SoldOut"
-                if offer.isEvent
+                if offer.isTimestamped
                 else "https://schema.org/OutOfStock"
             ),
         }
@@ -128,7 +128,7 @@ def get_metadata_from_offer(offer: offers_models.Offer) -> Metadata:
         "@context": "https://schema.org",
     }
 
-    if offer.isEvent:
+    if offer.isTimestamped:
         return context | _get_event_metadata_from_offer(offer)
 
     if offer.subcategory.id in book_subcategories:

--- a/api/src/pcapi/core/offers/tasks.py
+++ b/api/src/pcapi/core/offers/tasks.py
@@ -3,6 +3,7 @@ import logging
 
 import sqlalchemy as sa
 
+import pcapi.core.offers.repository as offers_repository
 from pcapi.core import search
 from pcapi.core.categories import subcategories
 from pcapi.core.finance import utils as finance_utils
@@ -131,7 +132,9 @@ def _get_existing_offers(
         db.session.query(
             sa.func.max(offers_models.Offer.id).label("max_id"),
         )
-        .filter(offers_models.Offer.isEvent == False)
+        # TODO(jbaudet): add full isEvent filter (subcategory + has
+        # opening hours) when public API is ready
+        .filter(sa.not_(offers_repository.has_event_subcategory_filter()))
         .filter(offers_models.Offer.venue == venue)
         .filter(offers_models.Offer.ean.in_(ean_to_create_or_update))
         .group_by(

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -550,6 +550,7 @@ def get_base_query_for_offer_indexation() -> sa_orm.Query:
                 )
             )
         )
+        .options(sa_orm.selectinload(offers_models.Offer.openingHours).load_only(offerers_models.OpeningHours.id))
     )
 
 

--- a/api/src/pcapi/core/search/serialization.py
+++ b/api/src/pcapi/core/search/serialization.py
@@ -126,7 +126,7 @@ class AlgoliaSerializationMixin:
         prices = {stock.price for stock in offer.searchableStocks}
         dates = set()
         times = set()
-        if offer.isEvent:
+        if offer.isTimestamped:
             dates = {stock.beginningDatetime.timestamp() for stock in offer.searchableStocks}  # type: ignore[union-attr]
             times = {
                 date_utils.get_time_in_seconds_from_datetime(stock.beginningDatetime)  # type: ignore[arg-type]
@@ -268,7 +268,7 @@ class AlgoliaSerializationMixin:
                 "isDigital": offer.isDigital,
                 "isDuo": offer.isDuo,
                 "isEducational": False,
-                "isEvent": offer.isEvent,
+                "isEvent": offer.isTimestamped,
                 "isForbiddenToUnderage": offer.is_forbidden_to_underage,
                 "isPermanent": offer.isPermanent,
                 "isThing": offer.isThing,

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -25,6 +25,7 @@ import pcapi.core.mails.transactional as transactional_mails
 import pcapi.core.offerers.api as offerers_api
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
+import pcapi.core.offers.repository as offers_repository
 import pcapi.core.subscription.phone_validation.exceptions as phone_validation_exceptions
 import pcapi.core.users.constants as users_constants
 import pcapi.core.users.repository as users_repository
@@ -518,7 +519,7 @@ def _cancel_bookings_of_user_on_requested_account_suspension(
         bookings_query = (
             bookings_query.join(bookings_models.Booking.stock)
             .join(offers_models.Stock.offer)
-            .filter(sa.func.not_(offers_models.Offer.isEvent))
+            .filter(sa.func.not_(offers_repository.has_event_subcategory_filter()))
         )
     else:
         return 0

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -38,6 +38,7 @@ from pcapi.core.offerers import repository as offerers_repository
 from pcapi.core.offers import api as offers_api
 from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.core.offers import models as offers_models
+from pcapi.core.offers import repository as offers_repository
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.providers import models as providers_models
 from pcapi.core.search import search_offer_ids
@@ -474,7 +475,7 @@ def _get_offers_by_ids(
             sa.case(
                 (
                     sa.or_(
-                        sa.not_(offers_models.Offer.isEvent),
+                        sa.not_(offers_repository.has_event_subcategory_filter()),
                         sa.func.max(offers_models.Stock.beginningDatetime).cast(sa.Date).is_(None),
                     ),
                     sa.cast(postgresql.array([]), postgresql.ARRAY(sa.Date)),
@@ -1208,6 +1209,7 @@ def get_offer_details(offer_id: int) -> utils.BackofficeResponse:
             .load_only(offerers_models.OffererAddress.label)
             .joinedload(offerers_models.OffererAddress.address),
             sa_orm.joinedload(offers_models.Offer.compliance),
+            sa_orm.joinedload(offers_models.Offer.openingHours).load_only(offerers_models.OpeningHours.id),
         )
     )
     offer = offer_query.one_or_none()

--- a/api/src/pcapi/routes/backoffice/templates/offer/details.html
+++ b/api/src/pcapi/routes/backoffice/templates/offer/details.html
@@ -222,7 +222,7 @@
             <th>Stock restant</th>
             {% if show_price_category %}<th>Tarif</th>{% endif %}
             <th>Prix</th>
-            {% if offer.isEvent %}
+            {% if offer.isTimestamped %}
               <th>Date / Heure</th>
               <th>Fin des réservations</th>
             {% endif %}
@@ -273,7 +273,7 @@
                   {{ stock.price | format_amount(target=offer.venue) }}
                 {% endif %}
               </td>
-              {% if offer.isEvent %}
+              {% if offer.isTimestamped %}
                 <td>{{ stock.beginningDatetime | format_date_time }}</td>
                 <td>{{ stock.bookingLimitDatetime | format_date_time }}</td>
               {% endif %}

--- a/api/src/pcapi/routes/native/v2/serialization/bookings.py
+++ b/api/src/pcapi/routes/native/v2/serialization/bookings.py
@@ -233,7 +233,7 @@ class BookingResponseGetterDict(GetterDict):
                 withdrawal=withdrawal,
             )
 
-        if offer.isEvent and booking.isExternal:
+        if offer.isTimestamped and booking.isExternal:
             booking_visible = is_external_event_booking_visible(offer=offer, stock=stock)
             return TicketResponse(
                 activation_code=None,

--- a/api/src/pcapi/routes/serialization/bookings.py
+++ b/api/src/pcapi/routes/serialization/bookings.py
@@ -77,7 +77,7 @@ def get_booking_response(booking: Booking) -> GetBookingResponse:
         offerId=booking.stock.offer.id,
         publicOfferId=humanize(booking.stock.offer.id),  # type: ignore[arg-type]
         offerName=booking.stock.offer.name,
-        offerType=BookingOfferType.EVENEMENT if booking.stock.offer.isEvent else BookingOfferType.EVENEMENT,
+        offerType=BookingOfferType.EVENEMENT if booking.stock.offer.isTimestamped else BookingOfferType.EVENEMENT,
         phoneNumber=booking.user.phoneNumber,
         price=booking.amount,
         priceCategoryLabel=booking.priceCategoryLabel,

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -267,6 +267,15 @@ class ListOffersOfferResponseModel(BaseModel):
         orm_mode = True
         getter_dict = ListOffersOfferResponseModelsGetterDict
 
+    @classmethod
+    def from_orm(cls, offer: offers_models.Offer) -> "ListOffersOfferResponseModel":
+        # TODO(jbaudet): remove this dirty trick when isEvent has been
+        # fully migrated and either isTimestamped has been renamed to
+        # isEvent or isEvent has been removed in favor of isTimestamped
+        res = super().from_orm(offer)
+        res.isEvent = offer.isTimestamped
+        return res
+
 
 class ListOffersResponseModel(BaseModel):
     __root__: list[ListOffersOfferResponseModel]

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -2269,22 +2269,24 @@ class PopBarcodesFromQueueAndCancelWastedExternalBookingTest:
 
 
 @pytest.mark.parametrize(
-    "is_digital,is_external,subcategory_id,expected",
+    "is_digital,is_external,subcategory,expected",
     (
-        (True, False, subcategories.LIVESTREAM_MUSIQUE.id, False),
-        (True, True, subcategories.LIVESTREAM_MUSIQUE.id, False),
-        (False, False, subcategories.SEANCE_CINE.id, True),
-        (False, True, subcategories.SEANCE_CINE.id, False),
-        (False, False, subcategories.CONCERT.id, False),
-        (False, True, subcategories.CONCERT.id, False),
-        (False, False, subcategories.ATELIER_PRATIQUE_ART.id, False),
-        (False, True, subcategories.ATELIER_PRATIQUE_ART.id, False),
-        (False, False, subcategories.LIVRE_PAPIER.id, True),
+        (True, False, subcategories.LIVESTREAM_MUSIQUE, False),
+        (True, True, subcategories.LIVESTREAM_MUSIQUE, False),
+        (False, False, subcategories.SEANCE_CINE, True),
+        (False, True, subcategories.SEANCE_CINE, False),
+        (False, False, subcategories.CONCERT, False),
+        (False, True, subcategories.CONCERT, False),
+        (False, False, subcategories.ATELIER_PRATIQUE_ART, False),
+        (False, True, subcategories.ATELIER_PRATIQUE_ART, False),
+        (False, False, subcategories.LIVRE_PAPIER, True),
     ),
 )
 @pytest.mark.usefixtures("clean_database")
-def test_voucher_is_displayed(is_digital, is_external, subcategory_id, expected):
-    offer = offers_factories.OfferFactory(subcategoryId=subcategory_id)
+def test_voucher_is_displayed(is_digital, is_external, subcategory, expected):
+    factory = offers_factories.EventOfferFactory if subcategory.is_event else offers_factories.OfferFactory
+    offer = factory(subcategoryId=subcategory.id)
+
     if is_digital:
         offer.url = "example.com"
 

--- a/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
@@ -36,7 +36,9 @@ def make_booking(**kwargs):
         stock__offer__venue__departementCode="75",
     )
     attributes.update(kwargs)
-    return bookings_factories.BookingFactory(**attributes)
+    booking = bookings_factories.BookingFactory(**attributes)
+    offerers_factories.OfferOpeningHoursFactory(offer=booking.stock.offer)
+    return booking
 
 
 def get_expected_base_email_data(booking, **overrides):
@@ -355,6 +357,7 @@ class OffererBookingRecapTest:
         # Preload available data - calling functions should do that
         _ = booking.stock.offer.venue.offererAddress.address
         _ = booking.user
+        _ = booking.stock.offer.openingHours
         # 1 - SELECT venue with bank account
         # 0 - SELECT feature (already cached by BeneficiaryGrant18Factory.beneficiaryImports)
         # 1 - SELECT external booking (might be preloaded ?)
@@ -383,6 +386,7 @@ class OffererBookingRecapTest:
         # Preload available data - calling functions should do that
         _ = booking.stock.offer.venue.offererAddress.address
         _ = booking.user
+        _ = booking.stock.offer.openingHours
         # 1 - SELECT venue with bank account
         # 0 - SELECT feature (already cached by BeneficiaryGrant18Factory.beneficiaryImports)
         # 1 - SELECT external booking (might be preloaded ?)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -4473,7 +4473,7 @@ class UpdateUsedStockPriceTest:
             api.update_used_stock_price(booking.stock, new_price=booking.stock.price - 1)
 
     def test_update_used_stock_price_should_delete_pricings_on_used_event(self):
-        offer = factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
+        offer = factories.EventOfferFactory(subcategoryId=subcategories.CONFERENCE.id)
         venue = offer.venue
         stock_to_edit = factories.StockFactory(
             offer=offer,
@@ -4535,7 +4535,7 @@ class UpdateUsedStockPriceTest:
         assert db.session.query(finance_models.Pricing).filter_by(id=later_pricing_id).count() == 0
 
     def test_update_used_stock_price_should_update_confirmed_events(self):
-        stock_to_edit = factories.StockFactory(
+        stock_to_edit = factories.EventStockFactory(
             offer__subcategoryId=subcategories.CONFERENCE.id,
             price=decimal.Decimal("123.45"),
         )

--- a/api/tests/core/offers/test_offer_metadata.py
+++ b/api/tests/core/offers/test_offer_metadata.py
@@ -118,14 +118,14 @@ class OfferMetadataTest:
             assert metadata["@type"] == "Event"
 
         def should_describe_an_event_for_a_concert(self):
-            offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONCERT.id)
+            offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.CONCERT.id)
 
             metadata = get_metadata_from_offer(offer)
 
             assert metadata["@type"] == "Event"
 
         def should_describe_an_event_for_a_festival(self):
-            offer = offers_factories.OfferFactory(subcategoryId=subcategories.FESTIVAL_MUSIQUE.id)
+            offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.FESTIVAL_MUSIQUE.id)
 
             metadata = get_metadata_from_offer(offer)
 

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -47,7 +47,8 @@ class GetCappedOffersForFiltersTest:
         # 1 to get user
         # 1 to get user_offerer
         # 1 to get offers
-        with assert_num_queries(3):
+        # 1 to get offers' opening hours
+        with assert_num_queries(4):
             offers = repository.get_capped_offers_for_filters(
                 user_id=user_offerer.user.id,
                 user_is_admin=user_offerer.user.has_admin_role,

--- a/api/tests/core/opening_hours/test_api.py
+++ b/api/tests/core/opening_hours/test_api.py
@@ -72,9 +72,9 @@ class UpsertOpeningHoursTest:
 
     def test_create_one_weekday_with_opening_hours_erases_all_existing_ones(self, offer):
         # should all be deleted
-        offerers_factories.OpeningHoursFactory(venue=None, offer=offer, weekday=offerers_models.Weekday.MONDAY)
-        offerers_factories.OpeningHoursFactory(venue=None, offer=offer, weekday=offerers_models.Weekday.SATURDAY)
-        offerers_factories.OpeningHoursFactory(venue=None, offer=offer, weekday=offerers_models.Weekday.SUNDAY)
+        offerers_factories.OfferOpeningHoursFactory(offer=offer, weekday=offerers_models.Weekday.MONDAY)
+        offerers_factories.OfferOpeningHoursFactory(offer=offer, weekday=offerers_models.Weekday.SATURDAY)
+        offerers_factories.OfferOpeningHoursFactory(offer=offer, weekday=offerers_models.Weekday.SUNDAY)
 
         opening_hours = schemas.WeekdayOpeningHoursTimespans(MONDAY=[["10:00", "18:00"]])
         api.upsert_opening_hours(offer, opening_hours=opening_hours)

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -206,7 +206,7 @@ class ReindexOfferIdsTest:
         num_queries = 1  # base query for indexation
         num_queries += 1  # FF
         num_queries += 1  # last30DaysBookings
-
+        num_queries += 1  # fetch opening hours (to find if offer is an event)
         num_queries += 1  # venues from offers
         with assert_num_queries(num_queries):
             with assert_no_duplicated_queries():

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -301,7 +301,7 @@ def test_index_last_30_days_bookings(app, bookings_count, expected_range):
 
 
 def test_serialize_offer_event():
-    offer = offers_factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
+    offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
     dt1 = datetime.datetime(2032, 1, 4, 12, 15)
     offers_factories.EventStockFactory(offer=offer, beginningDatetime=dt1)
     dt2 = datetime.datetime(2032, 1, 1, 16, 30)
@@ -598,14 +598,14 @@ def test_serialize_future_offer():
     booking_allowed_dt = publication_date + datetime.timedelta(days=30)
     beginning_date = datetime.datetime(2032, 1, 4, 12, 15)
 
-    offer_1 = offers_factories.OfferFactory(
+    offer = offers_factories.EventOfferFactory(
         subcategoryId=subcategories.FESTIVAL_MUSIQUE.id,
         publicationDatetime=publication_date,
         bookingAllowedDatetime=booking_allowed_dt,
     )
-    offers_factories.EventStockFactory(offer=offer_1, price=10, beginningDatetime=beginning_date)
+    offers_factories.EventStockFactory(offer=offer, price=10, beginningDatetime=beginning_date)
 
-    serialized = algolia.AlgoliaBackend().serialize_offer(offer_1, 0)
+    serialized = algolia.AlgoliaBackend().serialize_offer(offer, 0)
     assert serialized["offer"]["prices"] == [decimal.Decimal("10.00")]
     assert serialized["offer"]["dates"] == [beginning_date.timestamp()]
     assert serialized["offer"]["times"] == [12 * 60 * 60 + 15 * 60]

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -149,8 +149,9 @@ class CancelBeneficiaryBookingsOnSuspendAccountTest:
         """
         in_the_past = datetime.datetime.utcnow() - relativedelta(seconds=1)
         further_in_the_past = datetime.datetime.utcnow() - relativedelta(days=3)
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
         booking_event = bookings_factories.BookingFactory(
-            stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
+            stock__offer=offer,
             status=BookingStatus.CONFIRMED,
             dateCreated=further_in_the_past,
             cancellationLimitDate=in_the_past,

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -2723,7 +2723,7 @@ class EditOfferStockTest(PostEndpointHelper):
     needed_permission = perm_models.Permissions.MANAGE_OFFERS
 
     def test_offer_stock_edit_used_booking(self, authenticated_client):
-        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.CONFERENCE.id)
         venue = offer.venue
         stock_to_edit = offers_factories.StockFactory(
             offer=offer,
@@ -2788,7 +2788,7 @@ class EditOfferStockTest(PostEndpointHelper):
         assert db.session.query(finance_models.Pricing).filter_by(id=later_pricing_id).count() == 0
 
     def test_offer_stock_edit_with_french_decimal(self, authenticated_client):
-        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.CONFERENCE.id)
         stock_to_edit = offers_factories.StockFactory(
             offer=offer,
             price=decimal.Decimal("123.45"),
@@ -2811,7 +2811,7 @@ class EditOfferStockTest(PostEndpointHelper):
         assert booking_to_edit.amount == decimal.Decimal("50.1")
 
     def test_offer_stock_edit_confirmed_booking(self, authenticated_client):
-        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.CONFERENCE.id)
         stock_to_edit = offers_factories.StockFactory(
             offer=offer,
             price=decimal.Decimal("123.45"),
@@ -2834,7 +2834,7 @@ class EditOfferStockTest(PostEndpointHelper):
         assert booking_to_edit.amount == decimal.Decimal("50.1")
 
     def test_offer_stock_edit_confirmed_booking_percent(self, authenticated_client):
-        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.CONFERENCE.id)
         stock_to_edit = offers_factories.StockFactory(
             offer=offer,
             price=decimal.Decimal("123.45"),
@@ -3076,7 +3076,7 @@ class EditOfferStockTest(PostEndpointHelper):
         assert event.booking.stock.price == decimal.Decimal("123.45")
 
     def test_edit_stock_withprice_higher_than_booking(self, authenticated_client):
-        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.CONFERENCE.id)
         venue = offer.venue
         event = finance_factories.FinanceEventFactory(
             booking__amount=decimal.Decimal("5.00"),
@@ -3489,8 +3489,8 @@ class GetOfferDetailsTest(GetEndpointHelper):
     endpoint_kwargs = {"offer_id": 1}
     needed_permission = perm_models.Permissions.READ_OFFERS
 
-    # session + user + offer with joined data
-    expected_num_queries = 3
+    # session + user + offer with joined data + opening hours
+    expected_num_queries = 4
     expected_num_queries_with_ff = 4
 
     def test_get_detail_offer(self, authenticated_client):
@@ -3785,7 +3785,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert descriptions["Date de la dernière validation"] == format_date(validation_date, "%d/%m/%Y à %Hh%M")
 
     def test_get_offer_details_with_one_expired_stock(self, legit_user, authenticated_client):
-        offer = offers_factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
 
         expired_stock = offers_factories.EventStockFactory(
             offer=offer, beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(hours=1), price=6.66
@@ -3809,7 +3809,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert stocks_rows[0]["Date / Heure"] == format_date(expired_stock.beginningDatetime, "%d/%m/%Y à %Hh%M")
 
     def test_get_offer_details_with_two_expired_stocks(self, legit_user, authenticated_client):
-        offer = offers_factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
 
         expired_stock_1 = offers_factories.EventStockFactory(
             offer=offer,
@@ -3867,7 +3867,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         venue_factory,
         expected_price,
     ):
-        offer = offers_factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id, venue=venue_factory())
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id, venue=venue_factory())
         stock = offers_factories.EventStockFactory(offer=offer, quantity=quantity, dnBookedQuantity=booked_quantity)
 
         query_count = self.expected_num_queries_with_ff

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -66,7 +66,7 @@ class OffersTest:
             "releaseDate": "2020-01-01",
             "certificate": "Interdit au moins de 18 ans",
         }
-        offer = offers_factories.OfferFactory(
+        offer = offers_factories.EventOfferFactory(
             subcategoryId=subcategories.SEANCE_CINE.id,
             isDuo=True,
             description="desk cryption",
@@ -128,6 +128,7 @@ class OffersTest:
         nb_queries += 1  # select stocks
         nb_queries += 1  # select mediations
         nb_queries += 1  # select chronicles
+        nb_queries += 1  # select opening hours
         with assert_num_queries(nb_queries):
             with assert_no_duplicated_queries():
                 response = client.get(f"/native/v1/offer/{offer_id}")
@@ -280,10 +281,11 @@ class OffersTest:
         offer_id = offer.id
         # 1. select offer
         # 2. select stocks
-        # 3. select mediations
-        # 4. select chronicles
-        # 5. select artists
-        with assert_num_queries(5):
+        # 3. select opening hours
+        # 4. select mediations
+        # 5. select chronicles
+        # 6. select artists
+        with assert_num_queries(6):
             with assert_no_duplicated_queries():
                 response = client.get(f"/native/v1/offer/{offer_id}")
                 assert response.status_code == 200
@@ -299,6 +301,7 @@ class OffersTest:
         offer_id = offer.id
         nb_queries = 1  # select offer
         nb_queries += 1  # select stocks
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select mediations
         nb_queries += 1  # select chronicles
         with assert_num_queries(nb_queries):
@@ -313,6 +316,7 @@ class OffersTest:
         offer_id = offer.id
         nb_queries = 1  # select offer
         nb_queries += 1  # select stocks
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select mediations
         nb_queries += 1  # select chronicles
         with assert_num_queries(nb_queries):
@@ -349,7 +353,7 @@ class OffersTest:
     ):
         provider = get_provider_by_local_class(provider_class)
         product = offers_factories.ProductFactory(thumbCount=1, subcategoryId=subcategories.SEANCE_CINE.id)
-        offer = offers_factories.OfferFactory(
+        offer = offers_factories.EventOfferFactory(
             product=product,
             venue__isPermanent=True,
             subcategoryId=subcategories.SEANCE_CINE.id,
@@ -361,17 +365,18 @@ class OffersTest:
         setattr(features, ff_name, ff_value)
 
         # 1. select offer
-        # 2. select product with artists
-        # 3. select stocks
-        # 4. select mediations
-        # 5. check cinema venue_provider exists
-        # 6. check offer is from current cinema provider
-        # 7. select active cinema provider
-        # 8. update offer
-        # 9. select chronicles
-        # 10. selecte features
-        # 11. reload offer
-        with assert_num_queries(11):
+        # 1. select offer's opening hours
+        # 3. select product with artists
+        # 4. select stocks
+        # 5. select mediations
+        # 6. check cinema venue_provider exists
+        # 7. check offer is from current cinema provider
+        # 8. select active cinema provider
+        # 9. update offer
+        # 10. select chronicles
+        # 11. selecte features
+        # 12. reload offer
+        with assert_num_queries(12):
             with assert_no_duplicated_queries():
                 response = client.get(f"/native/v1/offer/{offer_id}")
                 assert response.status_code == 200
@@ -384,6 +389,7 @@ class OffersTest:
 
         nb_queries = 1  # select offer
         nb_queries += 1  # select stocks
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select mediations
         nb_queries += 1  # select activation_code
         nb_queries += 1  # select chronicles
@@ -400,6 +406,7 @@ class OffersTest:
 
         nb_queries = 1  # select offer
         nb_queries += 1  # select stocks
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select mediations
         nb_queries += 1  # select activation_code
         nb_queries += 1  # select chronicles
@@ -416,6 +423,7 @@ class OffersTest:
 
         nb_queries = 1  # select offer
         nb_queries += 1  # select stocks
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select mediations
         nb_queries += 1  # select activation_code
         nb_queries += 1  # select chronicles
@@ -434,6 +442,7 @@ class OffersTest:
 
         nb_queries = 1  # select offer
         nb_queries += 1  # select stocks
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select mediations
         nb_queries += 1  # select chronicles
         with assert_num_queries(nb_queries):
@@ -480,7 +489,7 @@ class OffersTest:
         providers_factories.CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
 
         offer_id_at_provider = f"{movie_id}%{venue_provider.venue.siret}"
-        offer = offers_factories.OfferFactory(
+        offer = offers_factories.EventOfferFactory(
             subcategoryId=subcategories.SEANCE_CINE.id,
             idAtProvider=offer_id_at_provider,
             lastProviderId=venue_provider.providerId,
@@ -493,6 +502,7 @@ class OffersTest:
         offer_id = offer.id
 
         nb_queries = 1  # select offer
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select stocks
         nb_queries += 1  # select mediations
         nb_queries += 1  # check cinema venue_provider exists
@@ -548,6 +558,7 @@ class OffersTest:
 
         offer_id = offer.id
         nb_queries = 1  # select offer
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select stocks
         nb_queries += 1  # select mediations
         nb_queries += 1  # select EXISTS venue_provider
@@ -588,7 +599,7 @@ class OffersTest:
             cinemaProviderPivot=cinema_provider_pivot, cinemaUrl="https://cgr-cinema-0.example.com/web_service"
         )
         offer_id_at_provider = f"{allocine_movie_id}%{venue_provider.venueId}%CGR"
-        offer = offers_factories.OfferFactory(
+        offer = offers_factories.EventOfferFactory(
             subcategoryId=subcategories.SEANCE_CINE.id,
             idAtProvider=offer_id_at_provider,
             lastProviderId=venue_provider.providerId,
@@ -603,6 +614,7 @@ class OffersTest:
 
         offer_id = offer.id
         nb_queries = 1  # select offer
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select stocks
         nb_queries += 1  # select mediations
         nb_queries += 1  # select EXISTS venue_provider
@@ -630,7 +642,7 @@ class OffersTest:
             idAtProvider=venue_provider.venueIdAtOfferProvider,
         )
         providers_factories.CDSCinemaDetailsFactory(cinemaProviderPivot=cinema_provider_pivot)
-        offer = offers_factories.OfferFactory(
+        offer = offers_factories.EventOfferFactory(
             subcategoryId=subcategories.SEANCE_CINE.id,
             idAtProvider="toto",
             lastProviderId=venue_provider.providerId,
@@ -640,6 +652,7 @@ class OffersTest:
 
         offer_id = offer.id
         nb_query = 1  # select offer
+        nb_query += 1  # select opening hours
         nb_query += 1  # select stocks
         nb_query += 1  # select mediations
         nb_query += 1  # check cinema venue_provider exists
@@ -660,6 +673,7 @@ class OffersTest:
         offer_id = offer.id
         nb_query = 1  # select offer
         nb_query += 1  # select stocks
+        nb_query += 1  # select opening hours
         nb_query += 1  # select mediations
         nb_query += 1  # select chronicles
         with assert_num_queries(nb_query):
@@ -677,6 +691,7 @@ class OffersTest:
         offer_id = offer.id
         nb_query = 1  # select offer
         nb_query += 1  # select stocks
+        nb_query += 1  # select opening hours
         nb_query += 1  # select mediations
         nb_query += 1  # select chronicles
         with assert_num_queries(nb_query):
@@ -695,6 +710,7 @@ class OffersTest:
         offer_id = offer.id
         nb_query = 1  # select offer
         nb_query += 1  # select stocks
+        nb_query += 1  # select opening hours
         nb_query += 1  # select mediations
         nb_query += 1  # select chronicles
         with assert_num_queries(nb_query):
@@ -718,10 +734,11 @@ class OffersTest:
         offer_id = offer.id
         # 1. select offer
         # 2. select stocks
-        # 3. select mediations
-        # 4. select chronicles
-        # 5. select products and artists
-        with assert_num_queries(5):
+        # 3. select opening hours
+        # 4. select mediations
+        # 5. select chronicles
+        # 6. select products and artists
+        with assert_num_queries(6):
             response = client.get(f"/native/v1/offer/{offer_id}")
 
         assert response.status_code == 200
@@ -745,10 +762,11 @@ class OffersTest:
         offer_id = offer.id
         # 1. select offer
         # 2. select stocks
-        # 3. select mediations
-        # 4. select chronicles
-        # 5. select artists
-        with assert_num_queries(5):
+        # 3. select opening hours
+        # 4. select mediations
+        # 5. select chronicles
+        # 6. select artists
+        with assert_num_queries(6):
             response = client.get(f"/native/v1/offer/{offer_id}")
 
         assert response.status_code == 200
@@ -767,10 +785,11 @@ class OffersTest:
         offer_id = offer.id
         # 1. select offer
         # 2. select stocks
-        # 3. select mediations
-        # 4. select chronicles
-        # 5. select artists
-        with assert_num_queries(5):
+        # 3. select opening hours
+        # 4. select mediations
+        # 5. select chronicles
+        # 6. select artists
+        with assert_num_queries(6):
             response = client.get(f"/native/v1/offer/{offer_id}")
 
         assert response.status_code == 200
@@ -791,10 +810,11 @@ class OffersTest:
         offer_id = offer.id
         # 1. select offer
         # 2. select stocks
-        # 3. select mediations
-        # 4. select chronicles
-        # 5. select artists
-        with assert_num_queries(5):
+        # 3. select opening hours
+        # 4. select mediations
+        # 5. select chronicles
+        # 6. select artists
+        with assert_num_queries(6):
             response = client.get(f"/native/v1/offer/{offer_id}")
 
         assert response.status_code == 200
@@ -806,6 +826,7 @@ class OffersTest:
 
 class OffersV2Test:
     base_num_queries = 1  # select offer with joins
+    base_num_queries += 1  # select opening hours
     base_num_queries += 1  # select mediations (selectinload)
     base_num_queries += 1  # select stocks (selectinload)
     base_num_queries += 1  # select chronicles (selectinload)
@@ -839,7 +860,7 @@ class OffersV2Test:
             "releaseDate": "2020-01-01",
             "certificate": "Interdit aux moins de 18 ans",
         }
-        offer = offers_factories.OfferFactory(
+        offer = offers_factories.EventOfferFactory(
             subcategoryId=subcategories.SEANCE_CINE.id,
             isDuo=True,
             description="desk cryption",
@@ -2017,7 +2038,7 @@ class OffersStocksV2Test:
             "releaseDate": "2020-01-01",
             "certificate": "Déconseillé -12 ans",
         }
-        offer = offers_factories.OfferFactory(
+        offer = offers_factories.EventOfferFactory(
             subcategoryId=subcategories.SEANCE_CINE.id,
             name="l'offre du siècle",
             ean=ean,
@@ -2072,6 +2093,7 @@ class OffersStocksV2Test:
 
         nb_queries = 1  # select offer
         nb_queries += 1  # select stocks
+        nb_queries += 1  # select opening hours
         nb_queries += 1  # select mediations
         nb_queries += 1  # select chronicles
         with assert_num_queries(nb_queries):

--- a/api/tests/routes/native/v2/bookings_test.py
+++ b/api/tests/routes/native/v2/bookings_test.py
@@ -88,8 +88,8 @@ class GetBookingsTest:
         )
 
         client = client.with_token(self.identifier)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(3):
+            # select user, booking, opening hours
             response = client.get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -200,8 +200,8 @@ class GetBookingsTest:
         )
 
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(3):
+            # select user, booking, opening hours
             response = client.get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -216,8 +216,8 @@ class GetBookingsTest:
         ReactionFactory(user=ongoing_booking.user, offer=stock.offer)
 
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(3):
+            # select user, booking, opening hours
             response = client.get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -232,15 +232,15 @@ class GetBookingsTest:
         )
         ReactionFactory(reactionType=ReactionTypeEnum.LIKE, user=ongoing_booking.user, product=stock.offer.product)
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(3):
-            # select user, booking, offer
+        with assert_num_queries(4):
+            # select user, booking, offer, opening hours
             response = client.get("/native/v2/bookings")
 
         assert response.status_code == 200
         assert response.json["ongoingBookings"][0]["userReaction"] == "LIKE"
 
     def test_get_bookings_returns_enable_pop_up_reaction(self, client):
-        offer = offers_factories.OfferFactory(
+        offer = offers_factories.EventOfferFactory(
             subcategoryId=subcategories.SEANCE_CINE.id,
         )
         booking = booking_factories.UsedBookingFactory(
@@ -248,8 +248,8 @@ class GetBookingsTest:
             dateUsed=datetime.utcnow() - timedelta(seconds=60 * 24 * 3600),
         )
         client = client.with_token(booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking, offer
+        with assert_num_queries(3):
+            # select user, booking, opening hours
             response = client.get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -263,8 +263,8 @@ class GetBookingsTest:
         )
         booking_factories.BookingFactory(stock=stock, user=ongoing_booking.user, status=BookingStatus.CANCELLED)
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(3):
+            # select user, booking, opening hours
             response = client.get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -289,8 +289,8 @@ class GetBookingsTest:
         )
 
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(3):
+            # select user, booking, opening hours
             response = client.get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -306,8 +306,8 @@ class GetBookingsTest:
         )
 
         test_client = client.with_token(user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(3):
+            # select user, booking, opening hours
             response = test_client.get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -324,7 +324,7 @@ class GetBookingsTest:
         offer = offers_factories.OfferFactory(venue=venue, offererAddress=None)
         booking_factories.BookingFactory(stock__offer=offer, user=user)
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -346,7 +346,7 @@ class GetBookingsTest:
         )
         booking_factories.BookingFactory(stock__offer=offer, user=user)
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -360,7 +360,7 @@ class GetBookingsTest:
         booking_factories.BookingFactory(user=user)
 
         client = client.with_token(user.email)
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.get("/native/v2/bookings")
 
         assert response.status_code == 200
@@ -410,7 +410,7 @@ class GetBookingTicketTest:
             stock__offer__withdrawalDelay=60 * 30,
         )
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
             assert response.status_code == 200
 
@@ -427,7 +427,7 @@ class GetBookingTicketTest:
             stock__offer__withdrawalType=offer_models.WithdrawalTypeEnum.NO_TICKET,
         )
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
             assert response.status_code == 200
 
@@ -454,7 +454,7 @@ class GetBookingTicketTest:
             stock__beginningDatetime=beginningDatetime,
         )
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
             assert response.status_code == 200
 
@@ -473,7 +473,7 @@ class GetBookingTicketTest:
             activationCode=digital_stock.activationCodes[0],
         )
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
             assert response.status_code == 200
 
@@ -497,7 +497,7 @@ class GetBookingTicketTest:
             stock=digital_stock,
         )
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
             assert response.status_code == 200
 
@@ -516,7 +516,7 @@ class GetBookingTicketTest:
             stock__offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
         )
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
             assert response.status_code == 200
 
@@ -553,13 +553,13 @@ class GetBookingTicketTest:
     )
     def test_get_internal_event_ticket(self, client, subcategory, withdrawal_type, voucher, display):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
-        booking = booking_factories.BookingFactory(
+        booking = booking_factories.EventBookingFactory(
             user=user,
             stock__offer__subcategoryId=subcategory,
             stock__offer__withdrawalType=withdrawal_type,
         )
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
             assert response.status_code == 200
 
@@ -568,18 +568,16 @@ class GetBookingTicketTest:
             assert ticket["voucher"] == {"data": f"PASSCULTURE:v3;TOKEN:{booking.token}"}
         else:
             assert ticket["voucher"] == None
-        assert ticket["token"] == {
-            "data": booking.token,
-        }
+
+        assert ticket["token"] == {"data": booking.token}
         assert ticket["display"] == display
 
     @pytest.mark.features(ENABLE_CDS_IMPLEMENTATION=True)
     def test_get_external_event_ticket_visible(self, client):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
-
         provider = providers_api.get_provider_by_local_class("CDSStocks")
         beginningDatetime = datetime.utcnow() + timedelta(days=1)
-        booking = booking_factories.BookingFactory(
+        booking = booking_factories.EventBookingFactory(
             user=user,
             stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
             stock__offer__withdrawalType=offer_models.WithdrawalTypeEnum.IN_APP,
@@ -591,7 +589,7 @@ class GetBookingTicketTest:
         ExternalBookingFactory(booking=booking, barcode="111111111", seat="A_1")
         ExternalBookingFactory(booking=booking, barcode="111111112", seat="A_2")
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
             assert response.status_code == 200
 
@@ -612,7 +610,7 @@ class GetBookingTicketTest:
 
         provider = providers_api.get_provider_by_local_class("CDSStocks")
         beginningDatetime = datetime.utcnow() + timedelta(days=2, seconds=200)
-        booking = booking_factories.BookingFactory(
+        booking = booking_factories.EventBookingFactory(
             user=user,
             stock__offer__subcategoryId=subcategories.CONFERENCE.id,
             stock__offer__withdrawalType=offer_models.WithdrawalTypeEnum.IN_APP,
@@ -624,7 +622,7 @@ class GetBookingTicketTest:
         ExternalBookingFactory(booking=booking, barcode="111111111", seat="A_1")
         ExternalBookingFactory(booking=booking, barcode="111111112", seat="A_2")
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(3):  # user + booking + opening hours
             response = client.with_token(self.identifier).get("/native/v2/bookings")
             assert response.status_code == 200
 

--- a/api/tests/routes/pro/get_offer_opening_hours_test.py
+++ b/api/tests/routes/pro/get_offer_opening_hours_test.py
@@ -61,12 +61,12 @@ class Returns200Test:
 
         opening_hours = timespan_str_to_numrange([("10:00", "12:00"), ("14:00", "18:00")])
 
-        offerers_factories.OpeningHoursFactory(
-            venue=None, offer=offer, weekday=offerers_models.Weekday.TUESDAY, timespan=opening_hours
+        offerers_factories.OfferOpeningHoursFactory(
+            offer=offer, weekday=offerers_models.Weekday.TUESDAY, timespan=opening_hours
         )
 
-        offerers_factories.OpeningHoursFactory(
-            venue=None, offer=offer, weekday=offerers_models.Weekday.WEDNESDAY, timespan=opening_hours
+        offerers_factories.OfferOpeningHoursFactory(
+            offer=offer, weekday=offerers_models.Weekday.WEDNESDAY, timespan=opening_hours
         )
 
         url = f"/offers/{offer.id}/opening-hours"
@@ -92,7 +92,7 @@ class Returns200Test:
         opening_hours = timespan_str_to_numrange([("10:00", "12:00"), ("14:00", "18:00")])
 
         for weekday in offerers_models.Weekday:
-            offerers_factories.OpeningHoursFactory(venue=None, offer=offer, weekday=weekday, timespan=opening_hours)
+            offerers_factories.OfferOpeningHoursFactory(offer=offer, weekday=weekday, timespan=opening_hours)
 
         url = f"/offers/{offer.id}/opening-hours"
 

--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class Returns200Test:
     number_of_queries = testing.AUTHENTICATION_QUERIES
     number_of_queries += 1  # search offers
+    number_of_queries += 1  # fetch their opening hours (if any) to figure out if they are events
     number_of_queries += 1  # FF WIP_REFACTO_FUTURE_OFFER
 
     def should_filter_by_venue_when_user_is_not_admin_and_request_specific_venue_with_rights_on_it(self, client):
@@ -49,8 +50,8 @@ class Returns200Test:
 
         venue_id = venue.id
         authenticated_client = client.with_session_auth(email=pro.email)
-        # -2 due to mocking
-        with testing.assert_num_queries(self.number_of_queries - 2):
+        # -3 due to mocking
+        with testing.assert_num_queries(self.number_of_queries - 3):
             response = authenticated_client.get(f"/offers?venueId={venue_id}")
             assert response.status_code == 200
         mocked_get_capped_offers.assert_called_once_with(
@@ -75,8 +76,8 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
 
         authenticated_client = client.with_session_auth(email=pro.email)
-        # -2 due to mocking
-        with testing.assert_num_queries(self.number_of_queries - 2):
+        # -3 due to mocking
+        with testing.assert_num_queries(self.number_of_queries - 3):
             response = authenticated_client.get("/offers?status=ACTIVE")
             assert response.status_code == 200
 
@@ -104,8 +105,8 @@ class Returns200Test:
 
         offerer_id = offerer.id
         authenticated_client = client.with_session_auth(email=pro.email)
-        # -2 due to mocking
-        with testing.assert_num_queries(self.number_of_queries - 2):
+        # -3 due to mocking
+        with testing.assert_num_queries(self.number_of_queries - 3):
             response = authenticated_client.get(f"/offers?offererId={offerer_id}")
             assert response.status_code == 200
 
@@ -131,8 +132,8 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
 
         authenticated_client = client.with_session_auth(email=pro.email)
-        # -2 due to mocking
-        with testing.assert_num_queries(self.number_of_queries - 2):
+        # -3 due to mocking
+        with testing.assert_num_queries(self.number_of_queries - 3):
             response = authenticated_client.get("/offers?creationMode=imported")
             assert response.status_code == 200
 
@@ -158,8 +159,8 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
 
         authenticated_client = client.with_session_auth(email=pro.email)
-        # -2 due to mocking
-        with testing.assert_num_queries(self.number_of_queries - 2):
+        # -3 due to mocking
+        with testing.assert_num_queries(self.number_of_queries - 3):
             response = authenticated_client.get("/offers?periodBeginningDate=2020-10-11")
             assert response.status_code == 200
 
@@ -231,8 +232,8 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
 
         authenticated_client = client.with_session_auth(email=pro.email)
-        # -2 due to mocking
-        with testing.assert_num_queries(self.number_of_queries - 2):
+        # -3 due to mocking
+        with testing.assert_num_queries(self.number_of_queries - 3):
             response = authenticated_client.get("/offers?periodEndingDate=2020-10-11")
             assert response.status_code == 200
 
@@ -258,8 +259,8 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
 
         authenticated_client = client.with_session_auth(email=pro.email)
-        # -2 due to mocking
-        with testing.assert_num_queries(self.number_of_queries - 2):
+        # -3 due to mocking
+        with testing.assert_num_queries(self.number_of_queries - 3):
             response = authenticated_client.get("/offers?categoryId=LIVRE")
             assert response.status_code == 200
 
@@ -825,7 +826,10 @@ class Returns200Test:
 
         venue_id = venue.id
         authenticated_client = client.with_session_auth(email=pro.email)
-        with testing.assert_num_queries(self.number_of_queries - 1):  # -1 sur FF WIP_REFACTO_FUTURE_OFFER
+
+        # -1 because of WIP_REFACTO_FUTURE_OFFER (?)
+        # -1 because opening hours are not loaded since there are no offers to load
+        with testing.assert_num_queries(self.number_of_queries - 2):
             response = authenticated_client.get(f"/offers?venueId={venue_id}")
             assert response.status_code == 200
 
@@ -840,7 +844,10 @@ class Returns200Test:
 
         venue_id = offerer.id
         authenticated_client = client.with_session_auth(email=pro.email)
-        with testing.assert_num_queries(self.number_of_queries - 1):  # -1 sur FF WIP_REFACTO_FUTURE_OFFER
+
+        # -1 because of WIP_REFACTO_FUTURE_OFFER (?)
+        # -1 because opening hours are not loaded since there are no offers to load
+        with testing.assert_num_queries(self.number_of_queries - 2):
             response = authenticated_client.get(f"/offers?venueId={venue_id}")
             assert response.status_code == 200
 

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -604,7 +604,7 @@ class Returns200Test:
         venue = offerers_factories.VenueFactory(
             name="L'encre et la plume", managingOfferer=user_offerer.offerer, venueTypeCode=VenueTypeCode.LIBRARY
         )
-        offerers_factories.OpeningHoursFactory(
+        offerers_factories.VenueOpeningHoursFactory(
             venue=venue,
             weekday=Weekday.SATURDAY,
             timespan=timespan_str_to_numrange([("14:00", "19:00"), ("10:00", "13:00")]),

--- a/api/tests/routes/pro/patch_venue_test.py
+++ b/api/tests/routes/pro/patch_venue_test.py
@@ -689,7 +689,7 @@ class Returns200Test:
             managingOfferer=user_offerer.offerer,
             contact=None,
         )
-        offerers_factories.OpeningHoursFactory(
+        offerers_factories.VenueOpeningHoursFactory(
             venue=venue,
             weekday=offerers_models.Weekday("TUESDAY"),
             timespan=timespan_str_to_numrange([("10:00", "13:00")]),


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36377)

Objectif : créer une nouvelle méthode `Offer.isTimestamped()` qui doit servir à remplacer `Offer.isEvent` le temps que l'API publique puisse migrer vers la nouvelle définition d'un événement.

Pourquoi ? Parce qu'on veut préciser la définition de ce qu'est un événement : une offre qui a des horaires d'ouvertures précis (et dont la sous-catégorie doit être de type événementiel, en toute logique). Ceci est lié au fait que les offres peuvent maintenant avoir des horaires d'ouverture, comme les lieux.

Le but de cette PR est donc d'adapter le code à cette évolution de la définition. Et la nouvelle méthode permet de laisser intacte toute l'API publique.

### Pourquoi laisser l'API publique en dehors ?

Si on appliquait le même changement pour tout le monde, alors un utilisateur qui utiliserait la route pour créer un événement, créerait une offre en base de donnée qui ne serait pas considérée comme un événement... puisqu'elle n'aurait pas d'horaires d'ouverture puisque la création ne permet pas de les renseigner. Il ne pourrait donc pas ensuite la modifier, etc. à moins d'utiliser les routes des produits (ce qui risque de générer de la confusion).

Il faudra donc adapter l'interface (voir une partie du fonctionnement de l'API publique) pour éviter ce genre de problème.