### PR TITLE
(PC-37327)[API] chore: Use open data API Entreprise whenever possible and delete redondant API Insee calls

### DIFF
--- a/api/src/pcapi/connectors/entreprise/api.py
+++ b/api/src/pcapi/connectors/entreprise/api.py
@@ -7,12 +7,12 @@ from .backends.base import get_backend
 PROTECTED_DATA_PLACEHOLDER = "[ND]"
 
 
-def get_siren_open_data(siren: str) -> models.SirenInfo:
+def get_siren_open_data(siren: str, with_address: bool = True) -> models.SirenInfo:
     """
     Get INSEE information about the requested SIREN.
     All returned data is public. If entity is "partially diffusible", name and address are replaced by placeholder value.
     """
-    return get_backend(settings.ENTREPRISE_BACKEND).get_siren_open_data(siren)
+    return get_backend(settings.ENTREPRISE_BACKEND).get_siren_open_data(siren, with_address=with_address)
 
 
 def get_siren(siren: str, with_address: bool = True, raise_if_non_public: bool = True) -> models.SirenInfo:

--- a/api/src/pcapi/connectors/entreprise/sirene.py
+++ b/api/src/pcapi/connectors/entreprise/sirene.py
@@ -1,14 +1,10 @@
 """
-Legacy functions which gets Sirene information using INSEE API directly, for public information only.
-Or the one configured in SIRENE_BACKEND.
-Not through API Entreprise. No protected data.
-Can be used to retrieve information for autocomplete features in PC Pro.
+Functions which gets Sirene information using INSEE API and not Entreprise API, or the one configured in SIRENE_BACKEND.
 """
 
 import datetime
 
 from pcapi import settings
-from pcapi.models import feature
 
 from . import models
 from .backends.base import get_backend
@@ -16,26 +12,12 @@ from .backends.base import get_backend
 
 def get_siren(siren: str, with_address: bool = True, raise_if_non_public: bool = True) -> models.SirenInfo:
     """Return information about the requested SIREN.
-
     Getting the address requires a second HTTP request to the Sirene
     API. Ask it only if needed.
     """
-    _check_feature_flag()
     return get_backend(settings.SIRENE_BACKEND).get_siren(
         siren, with_address=with_address, raise_if_non_public=raise_if_non_public
     )
-
-
-def get_siret(siret: str, raise_if_non_public: bool = True) -> models.SiretInfo:
-    """Return information about the requested SIRET."""
-    _check_feature_flag()
-    return get_backend(settings.SIRENE_BACKEND).get_siret(siret, raise_if_non_public)
-
-
-def siret_is_active(siret: str, raise_if_non_public: bool = True) -> bool:
-    """Return whether the requested SIRET is active."""
-    siret_info = get_siret(siret, raise_if_non_public)
-    return siret_info.active
 
 
 def get_siren_closed_at_date(date_closed: datetime.date) -> list[str]:
@@ -43,8 +25,3 @@ def get_siren_closed_at_date(date_closed: datetime.date) -> list[str]:
     Closure date may be the same day, in the past or in the future.
     """
     return get_backend(settings.SIRENE_BACKEND).get_siren_closed_at_date(date_closed)
-
-
-def _check_feature_flag() -> None:
-    if feature.FeatureToggle.DISABLE_ENTERPRISE_API.is_active():
-        raise feature.DisabledFeatureError("DISABLE_ENTERPRISE_API is activated")

--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -68,12 +68,9 @@ def check_offerer_siren_task(payload: CheckOffererSirenRequest) -> None:
 
     try:
         siren_info = sirene.get_siren(payload.siren, with_address=False, raise_if_non_public=False)
-    except entreprise_exceptions.SireneException:
-        try:
-            siren_info = entreprise_api.get_siren(payload.siren, with_address=False, raise_if_non_public=False)
-        except entreprise_exceptions.EntrepriseException as exc:
-            logger.info("Could not fetch info from Sirene API", extra={"siren": payload.siren, "exc": exc})
-            return
+    except entreprise_exceptions.EntrepriseException as exc:
+        logger.info("Could not fetch info from Sirene API", extra={"siren": payload.siren, "exc": exc})
+        return
 
     offerer = (
         db.session.query(offerers_models.Offerer)

--- a/api/src/pcapi/routes/backoffice/pro/forms.py
+++ b/api/src/pcapi/routes/backoffice/pro/forms.py
@@ -6,9 +6,9 @@ import urllib.parse
 import wtforms
 from flask_wtf import FlaskForm
 
+from pcapi.connectors.entreprise import api as entreprise_api
 from pcapi.connectors.entreprise import exceptions as sirene_exceptions
 from pcapi.connectors.entreprise import models as sirene_models
-from pcapi.connectors.entreprise import sirene
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers.repository import find_offerer_by_siren
 from pcapi.core.users import models as users_models
@@ -146,11 +146,11 @@ class CreateOffererForm(FlaskForm):
                 raise wtforms.validators.ValidationError(f"Une entité juridique existe déjà avec le SIREN {siren}")
 
             try:
-                siret_info = sirene.get_siret(siret.data, raise_if_non_public=False)
+                siret_info = entreprise_api.get_siret_open_data(siret.data)
             except sirene_exceptions.UnknownEntityException:
                 raise wtforms.validators.ValidationError(f"Le SIRET {siret.data} n'existe pas")
             except sirene_exceptions.ApiException:
-                raise wtforms.validators.ValidationError("Une erreur s'est produite lors de l'appel à l'API Sirene")
+                raise wtforms.validators.ValidationError("Une erreur s'est produite lors de l'appel à l'API Entreprise")
 
             if not siret_info.active:
                 raise wtforms.validators.ValidationError(f"L'établissement portant le SIRET {siret.data} est fermé")

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -10,7 +10,7 @@ from flask_login import login_required
 
 import pcapi.connectors.entreprise.exceptions as entreprise_exceptions
 from pcapi import settings
-from pcapi.connectors.entreprise import sirene
+from pcapi.connectors.entreprise import api as entreprise_api
 from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import exceptions
@@ -109,9 +109,8 @@ def edit_venue(venue_id: int, body: venues_serialize.EditVenueBodyModel) -> venu
     venue = get_or_404(Venue, venue_id)
 
     check_user_has_access_to_offerer(current_user, venue.managingOffererId)
-    has_siret_changed = bool(body.siret and body.siret != venue.siret)
     try:
-        if body.siret and not sirene.siret_is_active(body.siret, raise_if_non_public=has_siret_changed):
+        if body.siret and not entreprise_api.get_siret_open_data(body.siret).active:
             raise ApiErrors(errors={"siret": ["SIRET is no longer active"]})
     except entreprise_exceptions.UnknownEntityException:
         if settings.ENFORCE_SIRET_CHECK or not FeatureToggle.DISABLE_SIRET_CHECK.is_active():

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -926,25 +926,10 @@ class CreateOffererTest(PostEndpointHelper):
         assert new_offerer_action.userId == user.id
         assert new_offerer_action.authorUserId == legit_user.id
         assert new_offerer_action.comment == "Entité juridique créée depuis le backoffice"
-        assert new_offerer_action.extraData == {
-            "target": form_data["target"],
-            "venue_type_code": form_data["venue_type_code"],
-            "web_presence": form_data["web_presence"],
-            "ds_dossier_id": int(form_data["ds_id"]),
-            "sirene_info": {
-                "active": True,
-                "address": {"city": "CANNES", "insee_code": "06029", "postal_code": "[ND]", "street": "[ND]"},
-                "ape_code": "90.01Z",
-                "ape_label": "Arts du spectacle vivant",
-                "creation_date": f"{datetime.date.today().year}-01-01",
-                "closure_date": None,
-                "diffusible": False,
-                "head_office_siret": "90000000100017",
-                "legal_category_code": "1000",
-                "name": "[ND]",
-                "siren": "900000001",
-            },
-        }
+        assert new_offerer_action.extraData.get("target") == form_data["target"]
+        assert new_offerer_action.extraData.get("venue_type_code") == form_data["venue_type_code"]
+        assert new_offerer_action.extraData.get("web_presence") == form_data["web_presence"]
+        assert new_offerer_action.extraData.get("ds_dossier_id") == int(form_data["ds_id"])
 
         new_venue_action: history_models.ActionHistory = (
             db.session.query(history_models.ActionHistory)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

- Ne plus utiliser l'API Insee et migrer vers l'API Entreprise lorsque c'est possible
- Privilégier les routes Open Data aux routes exposant des données protégées
- Supprimer les appels redondants du connecteur API Insee


<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
