### PR TITLE
(BSR)[API] script: adding test to script doesnt run CI

### DIFF
--- a/.github/workflows/dev_on_pull_request_workflow.yml
+++ b/.github/workflows/dev_on_pull_request_workflow.yml
@@ -38,6 +38,7 @@ jobs:
             api/**
             !api/documentation/**
             !api/src/pcapi/scripts/**/main.py
+            !api/src/pcapi/scripts/**/test_script.py
             !api/src/pcapi/scripts/**/main.sql
       - name: "Check api documentation folder changes"
         id: check-api-documentation-changes


### PR DESCRIPTION
QUand on ajoute un test à un script, on veut faire en sorte que la CI ne soit pas executée non plus