### PR TITLE
(PC-37361)[PRO] feat: Update publication radiogroup wording.

### DIFF
--- a/pro/src/components/IndividualOfferLayout/OfferPublicationEdition/OfferPublicationEditionForm/OfferPublicationEditionForm.tsx
+++ b/pro/src/components/IndividualOfferLayout/OfferPublicationEdition/OfferPublicationEditionForm/OfferPublicationEditionForm.tsx
@@ -122,7 +122,7 @@ export function OfferPublicationEditionForm({
           </div>
           <RadioButtonGroup
             className={styles['group']}
-            label="Quand votre offre doit-elle être publiée dans l’application ?"
+            label="Quand votre offre doit-elle être publiée&nbsp;?"
             name="publicationMode"
             variant="detailed"
             disabled={isPaused}
@@ -175,7 +175,7 @@ export function OfferPublicationEditionForm({
           />
           <RadioButtonGroup
             className={styles['group']}
-            label="Quand votre offre pourra être réservable ?"
+            label="Quand votre offre pourra être réservable&nbsp;?"
             name="bookingAllowedMode"
             variant="detailed"
             disabled={isPaused}

--- a/pro/src/components/IndividualOfferLayout/OfferPublicationEdition/OfferPublicationEditionForm/__specs__/OfferPublicationEditionForm.spec.tsx
+++ b/pro/src/components/IndividualOfferLayout/OfferPublicationEdition/OfferPublicationEditionForm/__specs__/OfferPublicationEditionForm.spec.tsx
@@ -32,7 +32,7 @@ describe('OfferPublicationEditionForm', () => {
 
     expect(
       screen.getAllByRole('radiogroup', {
-        name: 'Quand votre offre doit-elle être publiée dans l’application ?',
+        name: /Quand votre offre doit-elle être publiée/,
       })[0]
     ).toBeInTheDocument()
 

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/EventPublicationForm/EventPublicationForm.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/EventPublicationForm/EventPublicationForm.tsx
@@ -110,7 +110,7 @@ export const EventPublicationForm = () => {
             }
           >
             <RadioButtonGroup
-              label="Quand votre offre doit-elle être publiée dans l’application ?"
+              label="Quand votre offre doit-elle être publiée&nbsp;?"
               name="publicationMode"
               variant="detailed"
               options={[
@@ -161,7 +161,7 @@ export const EventPublicationForm = () => {
         {isNewPublicationDatetimeEnabled && (
           <FormLayout.Section>
             <RadioButtonGroup
-              label="Quand votre offre pourra être réservable ?"
+              label="Quand votre offre pourra être réservable&nbsp;?"
               name="bookingAllowedMode"
               variant="detailed"
               options={[


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37361)

Modification du nom du radio groupe de la publication dans le futur (sinon le "?" passe a la ligne).

Pour tester activer le FF `WIP_REFACTO_FUTURE_OFFER`, et créer un offre indiv. Le radio group se trouve a la dernière étape.

## 🖼️ Before & After Images

Before | After
:---: | :---:
![before](https://github.com/user-attachments/assets/7892b5bc-4123-4fbd-ab6a-92ed21a2019e) | ![after](https://github.com/user-attachments/assets/10b5b31c-184d-47d3-9cf3-2bdce9a37323)
