### PR TITLE
(BSR)[API] fix: Do not create action history for destination venue if already permanent during regularization

### DIFF
--- a/api/src/pcapi/scripts/move_offer/move_batch_offer.py
+++ b/api/src/pcapi/scripts/move_offer/move_batch_offer.py
@@ -251,16 +251,17 @@ def _create_action_history(
             actionType=history_models.ActionType.VENUE_SOFT_DELETED,
         )
     )
-    db.session.add(
-        history_models.ActionHistory(
-            venueId=destination_venue_id,
-            actionType=history_models.ActionType.VENUE_REGULARIZATION,
-            extraData={
-                "origin_venue_id": origin_venue_id,
-                "modified_info": {"isPermanent": {"old_info": False, "new_info": True}},
-            },
+    if destination_venue_updated_to_permanent:
+        db.session.add(
+            history_models.ActionHistory(
+                venueId=destination_venue_id,
+                actionType=history_models.ActionType.VENUE_REGULARIZATION,
+                extraData={
+                    "origin_venue_id": origin_venue_id,
+                    "modified_info": {"isPermanent": {"old_info": False, "new_info": True}},
+                },
+            )
         )
-    )
 
 
 def _soft_delete_origin_venue(origin_venue: offerers_models.Venue) -> None:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

BSR

Fix de la création des actionHistory lors de la régularisation (commande move_batch_offer)

Avant la correction :
Création d'une actionHistory pour indiquer le passage en permanent de la venue de destination dans tous les cas : que la venue soit permanente ou non avant le lancement de la commande

Après correction :
Création de l'actionHistory seulement lorsque nécessaire

Un ticket est prévu pour supprimer les actionHistory inutiles créées lors du lancement de la commande par le passé : https://passculture.atlassian.net/browse/PC-37378

- [ ] Travail pair testé en environnement de preview
