### PR TITLE
(PC-35943)[API] feat: create celery task for creating and updating ean offer

### DIFF
--- a/api/src/pcapi/celery_tasks/celery_worker.py
+++ b/api/src/pcapi/celery_tasks/celery_worker.py
@@ -1,3 +1,4 @@
+from pcapi.core.offers import tasks  # noqa: F401
 from pcapi.flask_app import app as flask_app
 
 

--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -4,6 +4,7 @@ import typing
 from pydantic.v1 import EmailStr
 from pydantic.v1 import Field
 from pydantic.v1 import HttpUrl
+from pydantic.v1 import StrictInt
 from pydantic.v1 import root_validator
 from pydantic.v1 import validator
 
@@ -11,6 +12,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers import schemas as offerers_schemas
 from pcapi.core.offers import models as offers_models
 from pcapi.core.opening_hours import schemas as opening_hours_schemas
+from pcapi.routes.public.individual_offers.v1 import serialization as individual_offers_v1_serialization
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization import utils as serialization_utils
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
@@ -203,3 +205,19 @@ class OfferOpeningHoursSchema(BaseModel):
 
     class Config:
         use_enum_values = True
+
+
+class SerializedProductsStocks(typing.TypedDict):
+    quantity: StrictInt | individual_offers_v1_serialization.UNLIMITED_LITERAL | None
+    price: int
+    booking_limit_datetime: datetime.datetime | None
+    publication_datetime: datetime.datetime | None
+    booking_allowed_datetime: datetime.datetime | None
+
+
+class CreateOrUpdateEANOffersRequest(BaseModel):
+    serialized_products_stocks: dict[str, SerializedProductsStocks]
+    venue_id: int
+    provider_id: int
+    address_id: int | None
+    address_label: str | None

--- a/api/src/pcapi/core/offers/tasks.py
+++ b/api/src/pcapi/core/offers/tasks.py
@@ -3,6 +3,7 @@ import logging
 
 import sqlalchemy as sa
 
+from pcapi.celery_tasks.tasks import celery_async_task
 from pcapi.core import search
 from pcapi.core.categories import subcategories
 from pcapi.core.finance import utils as finance_utils
@@ -11,6 +12,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import api as offers_api
 from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.core.offers import models as offers_models
+from pcapi.core.offers import schemas as offers_schemas
 from pcapi.core.providers import models as providers_models
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationType
@@ -148,7 +150,39 @@ def _get_existing_offers(
     )
 
 
+@celery_async_task(
+    name="tasks.offers.default.create_or_update_ean_offers",
+    autoretry_for=(),
+    model=offers_schemas.CreateOrUpdateEANOffersRequest,
+)
+def create_or_update_ean_offers_celery(payload: offers_schemas.CreateOrUpdateEANOffersRequest) -> None:
+    create_or_update_ean_offers(
+        serialized_products_stocks=payload.serialized_products_stocks,
+        venue_id=payload.venue_id,
+        provider_id=payload.provider_id,
+        address_id=payload.address_id,
+        address_label=payload.address_label,
+    )
+
+
 @job(worker.low_queue)
+def create_or_update_ean_offers_rq(
+    *,
+    serialized_products_stocks: dict,
+    venue_id: int,
+    provider_id: int,
+    address_id: int | None = None,
+    address_label: str | None = None,
+) -> None:
+    create_or_update_ean_offers(
+        serialized_products_stocks=serialized_products_stocks,
+        venue_id=venue_id,
+        provider_id=provider_id,
+        address_id=address_id,
+        address_label=address_label,
+    )
+
+
 def create_or_update_ean_offers(
     *,
     serialized_products_stocks: dict,
@@ -217,6 +251,7 @@ def create_or_update_ean_offers(
                             "exc": exc.__class__.__name__,
                         },
                     )
+
             db.session.bulk_save_objects(created_offers)
 
             reloaded_offers = _get_existing_offers(ean_list_to_create, venue)

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -221,6 +221,7 @@ finance_utils.install_template_filters(app)
 app.config.from_mapping(
     CELERY=dict(
         broker_url=settings.REDIS_URL,
+        result_backend=settings.REDIS_URL,
         task_acks_late=True,
         task_reject_on_worker_lost=True,
         task_serializer="json",
@@ -231,6 +232,8 @@ app.config.from_mapping(
         task_routes={
             "tasks.mails.default.*": {"queue": "celery.external_calls.default"},
             "tasks.mails.priority.*": {"queue": "celery.external_calls.priority"},
+            "tasks.offers.default.*": {"queue": "celery.internal_calls.default"},
+            "tasks.offers.priority.*": {"queue": "celery.internal_calls.priority"},
         },
         task_ignore_result=True,
     ),

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -122,6 +122,9 @@ class FeatureToggle(enum.Enum):
     WIP_ASYNCHRONOUS_CELERY_MAILS = (
         "Activer le backend de tâches asynchrones Celery pour les tâches liées à l'envoi de mails"
     )
+    WIP_ASYNCHRONOUS_CELERY_CREATE_UPDATE_EAN_OFFERS = (
+        "Activer le backend de tâches asynchrones Celery pour les tâches liées à la mise à jour d'offres EAN"
+    )
     WIP_COLLAPSED_MEMORIZED_FILTERS = "Activer la fonction de masquage et de mémorisation des filtres en sessionStorage"
     WIP_DISABLE_CANCEL_BOOKING_NOTIFICATION = (
         "Désactiver la notification push Batch pour l'annulation d'une réservation"
@@ -221,6 +224,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_2025_SIGN_UP_PARTIALLY_DIFFUSIBLE,
     FeatureToggle.WIP_ADD_VIDEO,
     FeatureToggle.WIP_ASYNCHRONOUS_CELERY_MAILS,
+    FeatureToggle.WIP_ASYNCHRONOUS_CELERY_CREATE_UPDATE_EAN_OFFERS,
     FeatureToggle.WIP_DISABLE_CANCEL_BOOKING_NOTIFICATION,
     FeatureToggle.WIP_DISABLE_NOTIFY_USERS_BOOKINGS_NOT_RETRIEVED,
     FeatureToggle.WIP_DISABLE_SEND_NOTIFICATIONS_FAVORITES_NOT_BOOKED,

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -22,6 +22,7 @@ from pcapi.core.providers.constants import TITELIVE_MUSIC_GENRES_BY_GTL_ID
 from pcapi.core.providers.constants import TITELIVE_MUSIC_TYPES
 from pcapi.models import api_errors
 from pcapi.models import db
+from pcapi.models.feature import FeatureToggle
 from pcapi.routes.public import blueprints
 from pcapi.routes.public import spectree_schemas
 from pcapi.routes.public import utils as public_utils
@@ -326,13 +327,23 @@ def post_product_offer_by_ean(body: products_serializers.ProductsOfferByEanCreat
 
     chunk_size = settings.PUBLIC_API_EAN_PRODUCTS_BATCH_SIZE
     for products in chunks_utils.get_chunks(body.products, chunk_size=chunk_size):
-        offers_tasks.create_or_update_ean_offers.delay(
-            serialized_products_stocks=_serialize_products_from_body(products),
-            venue_id=venue.id,
-            provider_id=current_api_key.provider.id,
-            address_id=address_id,
-            address_label=address_label,
-        )
+        if FeatureToggle.WIP_ASYNCHRONOUS_CELERY_CREATE_UPDATE_EAN_OFFERS.is_active():
+            payload = offers_schemas.CreateOrUpdateEANOffersRequest(
+                serialized_products_stocks=_serialize_products_from_body(products),
+                venue_id=venue.id,
+                provider_id=current_api_key.provider.id,
+                address_id=address_id,
+                address_label=address_label,
+            )
+            offers_tasks.create_or_update_ean_offers_celery.delay(payload.dict())
+        else:
+            offers_tasks.create_or_update_ean_offers_rq.delay(
+                serialized_products_stocks=_serialize_products_from_body(products),
+                venue_id=venue.id,
+                provider_id=current_api_key.provider.id,
+                address_id=address_id,
+                address_label=address_label,
+            )
 
 
 def _serialize_products_from_body(

--- a/api/start-celery-worker.sh
+++ b/api/start-celery-worker.sh
@@ -6,4 +6,6 @@ until psql $DATABASE_URL -c '\q'; do
   sleep 1
 done
 
-celery -A pcapi.celery_tasks.celery_worker worker -Q "celery.external_calls.priority,celery.external_calls.default" --loglevel=DEBUG
+celery -A pcapi.celery_tasks.celery_worker worker \
+  -Q "celery.external_calls.priority,celedy.internal_calls.priority,celery.internal_calls.default,celery.external_calls.default" \
+  --loglevel=DEBUG

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -123,10 +123,26 @@ def build_main_app():
     # pytest_flask_sqlalchemy.
     app.teardown_request_funcs[None].remove(remove_db_session)
 
+    from pcapi import settings as pcapi_settings
+
     app.config.from_mapping(
         CELERY=dict(
-            # For testing, tasks are run locally
+            broker_url=pcapi_settings.REDIS_URL,
+            result_backend=pcapi_settings.REDIS_URL,
+            task_acks_late=True,
             task_always_eager=True,
+            task_reject_on_worker_lost=True,
+            task_serializer="json",
+            result_serializer="json",
+            accept_content=["json"],
+            # We must prefix celery queues with "celery." to easily monitor
+            # their length using the redis prometheus exporter
+            task_routes={
+                "tasks.mails.default.*": {"queue": "celery.external_calls.default"},
+                "tasks.mails.priority.*": {"queue": "celery.external_calls.priority"},
+                "tasks.offers.default.*": {"queue": "celery.internal_calls.default"},
+                "tasks.offers.priority.*": {"queue": "celery.internal_calls.priority"},
+            },
         ),
     )
 

--- a/api/tests/routes/public/individual_offers/v1/products/post_product_by_ean_celery_test.py
+++ b/api/tests/routes/public/individual_offers/v1/products/post_product_by_ean_celery_test.py
@@ -15,6 +15,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.providers import factories as providers_factories
+from pcapi.core.providers import models as providers_models
 from pcapi.models import db
 from pcapi.utils import date as date_utils
 
@@ -22,7 +23,7 @@ from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
 
 
 @pytest.mark.usefixtures("db_session")
-@pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_CREATE_UPDATE_EAN_OFFERS=False)
+@pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_CREATE_UPDATE_EAN_OFFERS=True)
 class PostProductByEanTest(PublicAPIVenueEndpointHelper):
     endpoint_url = "/public/offers/v1/products/ean"
     endpoint_method = "post"
@@ -62,7 +63,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         response = self.make_request(plain_api_key, json_body=payload)
         assert response.status_code == 404
 
-    @mock.patch("pcapi.core.offers.tasks.create_or_update_ean_offers_rq.delay")
+    @mock.patch("pcapi.core.offers.tasks.create_or_update_ean_offers_celery.delay")
     def test_create_or_update_offer_is_asynchronous(self, mock_delay):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         venue = venue_provider.venue
@@ -154,6 +155,10 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         assert response.status_code == 204
 
         created_offer = db.session.query(offers_models.Offer).one()
+        venue = created_offer.venue
+        product = created_offer.product
+        venue_provider = venue.venueProviders[0]
+
         assert created_offer.bookingEmail == venue.bookingEmail
         assert created_offer._description is None
         assert created_offer.description == product.description
@@ -321,6 +326,8 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         response = self.make_request(plain_api_key, json_body=payload)
 
         assert response.status_code == 204
+        offer = db.session.query(offers_models.Offer).one()
+        stock = offer.stocks[0]
         assert stock.quantity == 5
         assert stock.price == decimal.Decimal("12.34")
 
@@ -340,6 +347,8 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
 
         response = self.make_request(plain_api_key, json_body=payload)
         assert response.status_code == 204
+        offer = db.session.query(offers_models.Offer).one()
+        venue_provider = db.session.query(providers_models.VenueProvider).one()
         assert offer.lastProvider == venue_provider.provider
         assert offer.isActive == True
 
@@ -374,15 +383,14 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         assert stock.price == decimal.Decimal("12.34")
 
     def test_update_multiple_stocks_with_one_rejected(self, caplog):
+        book_ean = "1234527890123"
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         venue = venue_provider.venue
 
         cd_product = offers_factories.ThingProductFactory(
             subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id, ean="1234567890123"
         )
-        book_product = offers_factories.ThingProductFactory(
-            subcategoryId=subcategories.LIVRE_PAPIER.id, ean="1234527890123"
-        )
+        book_product = offers_factories.ThingProductFactory(subcategoryId=subcategories.LIVRE_PAPIER.id, ean=book_ean)
 
         cd_offer = offers_factories.ThingOfferFactory(product=cd_product, venue=venue)
         book_offer = offers_factories.ThingOfferFactory(
@@ -392,7 +400,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         )
 
         cd_stock = offers_factories.ThingStockFactory(offer=cd_offer, quantity=10, price=100)
+        cd_stock_id = cd_stock.id
         book_stock = offers_factories.ThingStockFactory(offer=book_offer, quantity=10, price=100)
+        book_stock_id = book_stock.id
 
         in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
@@ -419,6 +429,12 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         }
         with caplog.at_level(logging.INFO):
             response = self.make_request(plain_api_key, json_body=payload)
+
+        cd_stock = db.session.query(offers_models.Stock).filter_by(id=cd_stock_id).one()
+        book_stock = db.session.query(offers_models.Stock).filter_by(id=book_stock_id).one()
+        book_product = db.session.query(offers_models.Product).filter_by(ean=book_ean).one()
+        venue = db.session.query(offerers_models.Venue).one()
+        venue_provider = db.session.query(providers_models.VenueProvider).one()
 
         log = next(record for record in caplog.records if "Error while creating offer by ean" == record.message)
 
@@ -636,19 +652,21 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
             ean="1234567890123",
             lastProviderId=product_provider.id,
         )
+        ean = product.ean
+        venue_id = venue_provider.venue.id
 
         self.make_request(
             plain_api_key,
             json_body={
-                "products": [{"ean": product.ean, "stock": {"price": 1234, "quantity": 3}}],
-                "location": {"type": "physical", "venueId": venue_provider.venue.id},
+                "products": [{"ean": ean, "stock": {"price": 1234, "quantity": 3}}],
+                "location": {"type": "physical", "venueId": venue_id},
             },
         )
         self.make_request(
             plain_api_key,
             json_body={
-                "products": [{"ean": product.ean, "stock": {"price": 7890, "quantity": 3}}],
-                "location": {"type": "physical", "venueId": venue_provider.venue.id},
+                "products": [{"ean": ean, "stock": {"price": 7890, "quantity": 3}}],
+                "location": {"type": "physical", "venueId": venue_id},
             },
         )
 
@@ -665,6 +683,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
             offerer=venue_provider.venue.managingOfferer,
             label="My beautiful address no one knows about",
         )
+        offerer_address_id = offerer_address.id
         ean, _ = self._get_base_product()
 
         payload = {
@@ -680,10 +699,12 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
 
         assert response.status_code == 204
         created_offer = db.session.query(offers_models.Offer).one()
+        offerer_address = db.session.query(offerers_models.OffererAddress).filter_by(id=offerer_address_id).one()
         assert created_offer.offererAddress == offerer_address
 
     def test_with_custom_address_should_create_offerer_address(self):
         address = geography_factories.AddressFactory()
+        address_id = address.id
         ean, _ = self._get_base_product()
         plain_api_key, venue_provider = self.setup_active_venue_provider()
 
@@ -703,7 +724,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         offerer_address = (
             db.session.query(offerers_models.OffererAddress)
             .filter(
-                offerers_models.OffererAddress.addressId == address.id,
+                offerers_models.OffererAddress.addressId == address_id,
                 offerers_models.OffererAddress.label == "My beautiful address no one knows about",
             )
             .one()
@@ -735,19 +756,23 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
             isActive=False,
         )
         address = geography_factories.AddressFactory()
+        address_id = address.id
         payload = {
             "location": {"type": "address", "venueId": venue_provider.venue.id, "addressId": address.id},
             "products": [{"ean": product.ean, "stock": {"price": 1234, "quantity": 0}}],
         }
         response = self.make_request(plain_api_key, json_body=payload)
 
+        offer = db.session.query(offers_models.Offer).one()
+        offerer_address = offer.offererAddress
         assert response.status_code == 204
-        assert offer.offererAddress.addressId == address.id
+        assert offerer_address.addressId == address_id
         assert offer.isActive == True
 
     def test_create_and_update_offer(self):
         product_provider = providers_factories.ProviderFactory()
         plain_api_key, venue_provider = self.setup_active_venue_provider()
+        venue_id = venue_provider.venue.id
         ean_to_update = "1234567890123"
         ean_to_create = "1234567897123"
         offers_factories.ProductFactory(
@@ -765,7 +790,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
             plain_api_key,
             json_body={
                 "products": [{"ean": ean_to_update, "stock": {"price": 234, "quantity": 12}}],
-                "location": {"type": "physical", "venueId": venue_provider.venue.id},
+                "location": {"type": "physical", "venueId": venue_id},
             },
         )
         self.make_request(
@@ -775,7 +800,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
                     {"ean": ean_to_update, "stock": {"price": 1234, "quantity": 3}},
                     {"ean": ean_to_create, "stock": {"price": 9876, "quantity": 22}},
                 ],
-                "location": {"type": "physical", "venueId": venue_provider.venue.id},
+                "location": {"type": "physical", "venueId": venue_id},
             },
         )
 
@@ -873,8 +898,8 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
 
         assert response.status_code == 204
 
-        created_product = db.session.query(offers_models.Offer).one()
-        created_stock = created_product.stocks[0]
+        created_offer = db.session.query(offers_models.Offer).one()
+        created_stock = created_offer.stocks[0]
 
         assert created_stock.price == 0
 
@@ -891,6 +916,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
             quantity=10,
             price=100,
         )
+        stock_id = stock.id
 
         payload = {
             "location": {
@@ -904,6 +930,6 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
 
         assert response.status_code == 204
 
-        updated_stock = db.session.get(offers_models.Stock, stock.id)
+        updated_stock = db.session.get(offers_models.Stock, stock_id)
         assert updated_stock.price == 0
         assert updated_stock.quantity == 3

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -33,7 +33,7 @@ services:
       target: api-flask
     working_dir: /usr/src/app
     container_name: pc-api
-    command: [ "./start-api-when-database-is-ready.sh" ]
+    command: ["./start-api-when-database-is-ready.sh"]
     volumes:
       - ./api:/usr/src/app
     env_file:
@@ -57,7 +57,7 @@ services:
       target: api-flask
     working_dir: /usr/src/app
     container_name: pc-backoffice
-    command: [ "./start-backoffice-when-api-is-ready.sh" ]
+    command: ["./start-backoffice-when-api-is-ready.sh"]
     volumes:
       - ./api:/usr/src/app
     env_file:
@@ -81,7 +81,7 @@ services:
       target: api-flask
     working_dir: /usr/src/app
     container_name: pc-celery-worker
-    command: [ "./start-celery-worker.sh" ]
+    command: ["./start-celery-worker.sh"]
     volumes:
       - ./api:/usr/src/app
     env_file:
@@ -92,6 +92,7 @@ services:
     depends_on:
       - postgres
       - redis
+      - postgres-test
     ports:
       - 10003:10003 # debugger port
 


### PR DESCRIPTION
# But de la PR

Création de la tâche create_or_update_ean_offers en mode celery, l'ancienne fonction a été renommé pour faire apparaître explicitement le fait qu'elle passe par rq.
Désormais le call au endpoint choisira l'une ou l'autre des implémentation selon si le feature flag est set ou non.

On a pu faire un test en local avec @mgeoffray-pass pour s'assurer que c'était ok avec rq mais aussi avec celery.
 
Pour les tests j'ai repris ceux existants pour rq, mais il a fallu les modifier pour recharger les objets sql alchemy avec de vraies requêtes en base car à partir du moment ou on a fait une requête via celery les objets rattachés à la sessions sql alchemy sont invalidés