### PR TITLE
(BSR)[API] fix: (deprecated) opening hours upsert: missing venue

### DIFF
--- a/api/src/pcapi/core/opening_hours/deprecated.py
+++ b/api/src/pcapi/core/opening_hours/deprecated.py
@@ -27,7 +27,7 @@ def get_venue_opening_hours_by_weekday(
     for opening_hours in venue.openingHours:
         if opening_hours.weekday == weekday:
             return opening_hours
-    return offerers_models.OpeningHours(weekday=weekday)
+    return offerers_models.OpeningHours(venue=venue, weekday=weekday)
 
 
 def upsert_venue_opening_hours(venue: offerers_models.Venue, opening_hours: MappedWeekdayOpeningHours) -> None:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-XXXXX)

Bug : lors de l'ajout d'horaires d'ouverture à un lieu sur le portail pro (le lieu n'en a pas et on en créé), le nouvel objet `OpeningHours` créé l'était sans lieu... ce que n'apprécie pas la base de données (logique).

Fix : ajouter le lieu.