### PR TITLE
(BSR)[PRO] fix: restore ImagePreviewStories.module.scss (for now) to fix ImagePreview story import

### DIFF
--- a/pro/src/components/ModalImageUpsertOrEdit/components/ImagePreview/stories/ImagePreview.stories.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/components/ImagePreview/stories/ImagePreview.stories.tsx
@@ -2,7 +2,7 @@ import type { StoryObj } from '@storybook/react'
 
 import { ImagePreview, ImagePreviewScreenProps } from '../ImagePreview'
 import { ImagePreviewsWrapper } from '../ImagePreviewsWrapper'
-import style from './HomeScreenShell.module.scss'
+import style from './ImagePreviewStories.module.scss'
 import offerHomeShell from './offer-home-shell.png'
 import offerPreview from './offer-preview.jpg'
 import offerShell from './offer-shell.png'

--- a/pro/src/components/ModalImageUpsertOrEdit/components/ImagePreview/stories/ImagePreviewStories.module.scss
+++ b/pro/src/components/ModalImageUpsertOrEdit/components/ImagePreview/stories/ImagePreviewStories.module.scss
@@ -1,0 +1,37 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.home-screen-shell {
+  position: absolute;
+  width: rem.torem(92px);
+}
+
+.preview-on-home-screen {
+  background-color: var(--color-background-default);
+  left: rem.torem(5.88px);
+  position: absolute;
+  top: rem.torem(86.75px);
+  width: rem.torem(35.8px);
+}
+
+.offer-screen-shell {
+  top: rem.torem(50px);
+  position: absolute;
+  width: rem.torem(92px);
+}
+
+.blurred-preview-on-offer-screen {
+  background-color: var(--color-background-default);
+  filter: blur(2px);
+  position: absolute;
+  top: rem.torem(1px);
+  width: 92px;
+  overflow: hidden;
+}
+
+.preview-on-offer-screen {
+  background-color: var(--color-background-default);
+  left: rem.torem(16.15px);
+  position: absolute;
+  top: rem.torem(29.44px);
+  width: rem.torem(58.88px);
+}


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

- [Front](?expand=1&template=template_front.md)
- [Back](?expand=1&template=template_back.md)
- [DS](?expand=1&template=template_DS.md)
