### PR TITLE
(PC-37450) [journée backend] suppression des anciennes offres non réservées et non réservations : quelques améliorations

### DIFF
--- a/api/src/pcapi/core/offers/commands.py
+++ b/api/src/pcapi/core/offers/commands.py
@@ -39,7 +39,7 @@ def set_upper_timespan_of_inactive_headline_offers() -> None:
 
 
 @blueprint.cli.command("delete_unbookable_unbooked_old_offers")
-@click.argument("min_offer_id", required=False, type=int, default=0)
+@click.argument("min_offer_id", required=False, type=int, default=None)
 @click.argument("max_offer_id", required=False, type=int, default=None)
 @click.argument("query_batch_size", required=False, type=int, default=5_000)
 @click.argument("filter_batch_size", required=False, type=int, default=2_500)

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1306,7 +1306,7 @@ def offer_has_timestamped_stocks(offer_id: int) -> bool:
 
 
 def get_unbookable_unbooked_old_offer_ids(
-    min_id: int = 0, max_id: int | None = None, batch_size: int = 5_000
+    min_id: int, max_id: int, batch_size: int = 5_000
 ) -> typing.Generator[int, None, None]:
     """Find unbookable unbooked old offer ids.
 
@@ -1379,9 +1379,6 @@ def get_unbookable_unbooked_old_offer_ids(
 
                 if idx == 0:
                     raise
-
-    if max_id is None:
-        max_id = db.session.query(models.Offer).order_by(models.Offer.id.desc()).first().id
 
     while min_id < max_id:
         try:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket JIRA](https://passculture.atlassian.net/browse/PC-37450)

Améliorer la tâche de suppression des anciennes offres non réservables et non réservées : au lieu de scanner toute la table des offres progressivement, n'avancer que par 10% au maximum et enregistrer le dernier id d'offre supprimé pour savoir d'où commencer la prochaine fois. Cela permettra de lancer plus de petites tâches, plus régulièrement : par exemple, une tous les jours pendant 10 jours au lieu d'une toutes les une ou deux semaines.