### PR TITLE
(PC-36796)[BO] feat: add new page for user profile refresh campaign management

### DIFF
--- a/api/.env.testauto
+++ b/api/.env.testauto
@@ -54,7 +54,6 @@ LOG_PLAIN_TEXT=0
 OBJECT_STORAGE_PROVIDER=local
 OBJECT_STORAGE_URL=http://localhost/storage
 PUSH_NOTIFICATION_BACKEND=pcapi.notifications.push.backends.testing.TestingBackend
-PROFILE_EXPIRY_DATETIME=2025-01-01
 REMOVE_LOGGER_HANDLER=1
 REPORT_OFFER_EMAIL_ADDRESS=report_offer@example.com
 SEARCH_BACKEND=pcapi.core.search.backends.testing.TestingBackend

--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-6418ef94834a (pre) (head)
+6488ec58e584 (pre) (head)
 48519dd044d4 (post) (head)

--- a/api/src/pcapi/alembic/versions/20250807T130314_6488ec58e584_user_profile_refresh_campaign.py
+++ b/api/src/pcapi/alembic/versions/20250807T130314_6488ec58e584_user_profile_refresh_campaign.py
@@ -1,0 +1,31 @@
+"""
+Add UserProfileRefreshCampaign table
+Used to store the date after which the user will be asked to update his profile information
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "6488ec58e584"
+down_revision = "6418ef94834a"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_profile_refresh_campaign",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("campaignDate", sa.DateTime(), nullable=False),
+        sa.Column("creationDate", sa.DateTime(), nullable=False),
+        sa.Column("isActive", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("updateDate", sa.DateTime(), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_profile_refresh_campaign", if_exists=True)

--- a/api/src/pcapi/core/permissions/models.py
+++ b/api/src/pcapi/core/permissions/models.py
@@ -39,6 +39,10 @@ class Permissions(enum.Enum):
     ANONYMIZE_PUBLIC_ACCOUNT = "anonymiser un compte grand public"
     READ_CHRONICLE = "visualiser les chroniques"
     MANAGE_CHRONICLE = "gérer les chroniques"
+    READ_USER_PROFILE_REFRESH_CAMPAIGN = (
+        "visualiser les campagnes de mise à jour des profils bénéficiaires/grand public"
+    )
+    MANAGE_USER_PROFILE_REFRESH_CAMPAIGN = "gérer les campagnes de mise à jour des profils bénéficiaires/grand public"
 
     SUSPEND_USER = "suspendre un compte jeune"
     UNSUSPEND_USER = "réactiver un compte jeune"

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -1272,3 +1272,8 @@ class UserTagCategoryFactory(BaseFactory):
 class UserTagCategoryMappingFactory(BaseFactory):
     class Meta:
         model = models.UserTagCategoryMapping
+
+
+class UserProfileRefreshCampaignFactory(BaseFactory):
+    class Meta:
+        model = models.UserProfileRefreshCampaign

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -1272,3 +1272,18 @@ class UserTagCategory(PcObject, Base, Model):
 
     def __str__(self) -> str:
         return self.label or self.name
+
+
+class UserProfileRefreshCampaign(PcObject, Base, Model):
+    """
+    Profile refresh campaign. Used to determine if the user's profile is expired or not:
+    If last time the user updated his profile (or it was updated for him through a support operator) is before
+    `campaignDate`'s value then his profile will be considered as expired.
+    """
+
+    __tablename__ = "user_profile_refresh_campaign"
+
+    campaignDate: datetime = sa.Column(sa.DateTime, nullable=False)
+    creationDate: datetime = sa.Column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    updateDate: datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now(), onupdate=sa.func.now())
+    isActive: bool = sa.Column(sa.Boolean, nullable=False, server_default=expression.true(), default=True)

--- a/api/src/pcapi/routes/backoffice/__init__.py
+++ b/api/src/pcapi/routes/backoffice/__init__.py
@@ -17,6 +17,7 @@ def install_routes(app: Flask) -> None:
     from .accounts import update_request_blueprint
     from .admin import blueprint as admin_blueprint
     from .admin import bo_users_blueprint
+    from .admin import user_profile_refresh_campaigns_blueprint
     from .bank_account import blueprint as bank_account_blueprint
     from .bookings import collective_bookings_blueprint
     from .bookings import individual_bookings_blueprint

--- a/api/src/pcapi/routes/backoffice/admin/forms.py
+++ b/api/src/pcapi/routes/backoffice/admin/forms.py
@@ -1,3 +1,4 @@
+import wtforms
 from flask_wtf import FlaskForm
 
 from pcapi import settings
@@ -41,3 +42,14 @@ class EditBOUserForm(utils.PCForm):
     first_name = fields.PCOptStringField("Prénom")
     last_name = fields.PCOptStringField("Nom")
     email = fields.PCEmailField("Email")
+
+
+class UserProfileRefreshCampaignForm(utils.PCForm):
+    campaign_date = fields.PCDateTimeField(
+        "Date de début de la campagne",
+        format="%Y-%m-%dT%H:%M",
+        validators=[
+            wtforms.validators.InputRequired("Information obligatoire"),
+        ],
+    )
+    is_active = fields.PCCheckboxField("Active")

--- a/api/src/pcapi/routes/backoffice/admin/user_profile_refresh_campaigns_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/user_profile_refresh_campaigns_blueprint.py
@@ -1,0 +1,109 @@
+from flask import flash
+from flask import redirect
+from flask import render_template
+from flask import request
+from flask import url_for
+from werkzeug.exceptions import NotFound
+
+from pcapi.core.permissions import models as perm_models
+from pcapi.core.users import models as users_models
+from pcapi.models import db
+from pcapi.routes.backoffice import utils
+from pcapi.routes.backoffice.admin import forms
+
+
+user_profile_refresh_campaigns_blueprint = utils.child_backoffice_blueprint(
+    "user_profile_refresh_campaigns",
+    __name__,
+    url_prefix="/admin/user-profile-refresh-campaigns",
+    permission=perm_models.Permissions.READ_USER_PROFILE_REFRESH_CAMPAIGN,
+)
+
+
+@user_profile_refresh_campaigns_blueprint.route("", methods=["GET"])
+def list_campaigns() -> utils.BackofficeResponse:
+    creation_form = forms.UserProfileRefreshCampaignForm()
+    campaigns = (
+        db.session.query(users_models.UserProfileRefreshCampaign)
+        .order_by(users_models.UserProfileRefreshCampaign.id)
+        .all()
+    )
+
+    return render_template(
+        "admin/user_profile_refresh_campaigns/list.html",
+        creation_form=creation_form,
+        rows=campaigns,
+    )
+
+
+@user_profile_refresh_campaigns_blueprint.route("/create", methods=["POST"])
+@utils.permission_required(perm_models.Permissions.MANAGE_USER_PROFILE_REFRESH_CAMPAIGN)
+def create_campaign() -> utils.BackofficeResponse:
+    form = forms.UserProfileRefreshCampaignForm()
+    if not form.validate():
+        flash(utils.build_form_error_msg(form), "warning")
+        return redirect(
+            request.referrer or url_for("backoffice_web.user_profile_refresh_campaigns.list_campaigns"),
+            code=303,
+        )
+
+    campaign = users_models.UserProfileRefreshCampaign(
+        campaignDate=form.campaign_date.data,
+        isActive=bool(form.is_active.data),
+    )
+    db.session.add(campaign)
+    db.session.flush()
+    flash("Campagne de mise à jour de données créée avec succès.", "success")
+
+    return redirect(url_for("backoffice_web.user_profile_refresh_campaigns.list_campaigns"), code=303)
+
+
+@user_profile_refresh_campaigns_blueprint.route("/<int:campaign_id>/edit_form", methods=["GET"])
+@utils.permission_required(perm_models.Permissions.MANAGE_USER_PROFILE_REFRESH_CAMPAIGN)
+def get_campaign_edit_form(campaign_id: int) -> utils.BackofficeResponse:
+    campaign = db.session.query(users_models.UserProfileRefreshCampaign).filter_by(id=campaign_id).one_or_none()
+    if not campaign:
+        raise NotFound()
+
+    form = forms.UserProfileRefreshCampaignForm()
+    form.is_active.data = campaign.isActive
+    form.campaign_date.data = campaign.campaignDate
+
+    return render_template(
+        "components/dynamic/modal_form.html",
+        target_id=f"#campaign-row-{campaign_id}",
+        form=form,
+        dst=url_for("backoffice_web.user_profile_refresh_campaigns.edit_campaign", campaign_id=campaign_id),
+        div_id=f"edit-campaign-modal-{campaign_id}",
+        title=f"Modification de la campagne #{campaign_id}",
+        button_text="Valider",
+        ajax_redirect=True,
+    )
+
+
+@user_profile_refresh_campaigns_blueprint.route("/<int:campaign_id>/edit", methods=["POST"])
+@utils.permission_required(perm_models.Permissions.MANAGE_USER_PROFILE_REFRESH_CAMPAIGN)
+def edit_campaign(campaign_id: int) -> utils.BackofficeResponse:
+    campaign = db.session.query(users_models.UserProfileRefreshCampaign).filter_by(id=campaign_id).one_or_none()
+    if not campaign:
+        raise NotFound()
+
+    form = forms.UserProfileRefreshCampaignForm()
+    if not form.validate():
+        flash(utils.build_form_error_msg(form), "warning")
+        return redirect(request.referrer, 400)
+
+    campaign.isActive = form.is_active.data
+    campaign.campaignDate = form.campaign_date.data
+    db.session.add(campaign)
+    db.session.flush()
+
+    flash("La campagne a été modifiée", "success")
+
+    campaigns = (
+        db.session.query(users_models.UserProfileRefreshCampaign)
+        .filter(users_models.UserProfileRefreshCampaign.id == campaign_id)
+        .all()
+    )
+
+    return render_template("admin/user_profile_refresh_campaigns/list_rows.html", rows=campaigns)

--- a/api/src/pcapi/routes/backoffice/menu.py
+++ b/api/src/pcapi/routes/backoffice/menu.py
@@ -264,6 +264,11 @@ MENU_SECTIONS = [
                 label="Liste des sous-catégories",
                 url_name="backoffice_web.get_subcategories",
             ),
+            MenuItem(
+                label="Campagnes de mise à jour de données",
+                url_name="backoffice_web.user_profile_refresh_campaigns.list_campaigns",
+                permissions=["READ_USER_PROFILE_REFRESH_CAMPAIGN"],
+            ),
         ],
     ),
     MenuSection(

--- a/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list.html
@@ -1,0 +1,49 @@
+{% extends "layouts/list.html" %}
+{% from "components/dynamic/modal.html" import build_dynamic_modal with context %}
+{% from "components/dynamic/modal.html" import build_static_htmx_modal with context %}
+{% set table_id = "campaign-table" %}
+{% set rows_count = rows|length %}
+{% set hide_search_block = True %}
+{% block title %}
+  Liste des campagnes
+{% endblock title %}
+{% block before_table %}
+  {% if has_permission("MANAGE_USER_PROFILE_REFRESH_CAMPAIGN") %}
+    <div class="d-flex flex-row justify-content-end">
+      <button class="btn btn-outline-primary lead fw-bold mt-2"
+              data-bs-toggle="modal"
+              data-bs-target="#create-campaign-modal"
+              type="button">Créer une nouvelle campagne</button>
+    </div>
+  {% endif %}
+{% endblock before_table %}
+{% block table_header %}
+  {% if has_permission("MANAGE_USER_PROFILE_REFRESH_CAMPAIGN") %}<th scope="col"></th>{% endif %}
+  <th scope="col">Id</th>
+  <th scope="col">Active</th>
+  <th scope="col">Date de début</th>
+  <th scope="col">Date de création</th>
+  <th scope="col">Date de mise à jour</th>
+{% endblock table_header %}
+{% block table_body %}
+  {% include "admin/user_profile_refresh_campaigns/list_rows.html" %}
+{% endblock table_body %}
+{% block after_table %}
+  {% set ajax_submit = False %}
+  {% set div_id = "create-campaign" %}
+  {% set form = creation_form %}
+  {% set title = "Création d'une nouvelle campagne" %}
+  {% set button_text = "Créer" %}
+  {% set dst = url_for("backoffice_web.user_profile_refresh_campaigns.create_campaign") %}
+  {% set ajax_submit = False %}
+  <div class="modal fade modal-{{ modal_size }}"
+       id="create-campaign-modal"
+       tabindex="-1"
+       aria-labelledby="create-campaign-label"
+       aria-hidden="false">
+    <div class="modal-dialog modal-dialog-centered">{% include "components/dynamic/modal_form.html" %}</div>
+  </div>
+  {% for campaign in rows %}
+    {{ build_dynamic_modal(url_for('backoffice_web.user_profile_refresh_campaigns.get_campaign_edit_form', campaign_id=campaign.id) , "edit-campaign-modal-" + campaign.id|string) }}
+  {% endfor %}
+{% endblock after_table %}

--- a/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list_rows.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list_rows.html
@@ -1,0 +1,28 @@
+{% for campaign in rows %}
+  <tr id="campaign-row-{{ campaign.id  }}">
+    {% if has_permission("MANAGE_USER_PROFILE_REFRESH_CAMPAIGN") %}
+      <td>
+        <div class="dropdown">
+          <button type="button"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                  class="btn p-0">
+            <i class="bi bi-three-dots-vertical"></i>
+          </button>
+          <ul class="dropdown-menu">
+            <li class="dropdown-item">
+              <a class="btn btn-sm d-block w-100 text-start px-3"
+                 data-bs-toggle="modal"
+                 data-bs-target="#edit-campaign-modal-{{ campaign.id }}">Modifier</a>
+            </li>
+          </ul>
+        </div>
+      </td>
+    {% endif %}
+    <td>{{ campaign.id }}</td>
+    <td>{{ campaign.isActive | format_bool_badge }}</td>
+    <td>{{ campaign.campaignDate }}</td>
+    <td>{{ campaign.creationDate }}</td>
+    <td>{{ campaign.updateDate }}</td>
+  </tr>
+{% endfor %}

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_role_permissions.py
@@ -15,6 +15,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.MANAGE_OFFERER_TAG,
         perm_models.Permissions.MANAGE_OFFERS_AND_VENUES_TAGS,
         perm_models.Permissions.ANONYMIZE_PUBLIC_ACCOUNT,
+        perm_models.Permissions.READ_USER_PROFILE_REFRESH_CAMPAIGN,
+        perm_models.Permissions.MANAGE_USER_PROFILE_REFRESH_CAMPAIGN,
     ],
     "codir_admin": [
         perm_models.Permissions.READ_INCIDENTS,
@@ -154,6 +156,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.READ_CHRONICLE,
         perm_models.Permissions.READ_SPECIAL_EVENTS,
         perm_models.Permissions.READ_TECH_PARTNERS,
+        perm_models.Permissions.READ_USER_PROFILE_REFRESH_CAMPAIGN,
     ],
     "qa": [
         perm_models.Permissions.READ_PERMISSIONS,
@@ -203,6 +206,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.CLOSE_OFFERER,
         perm_models.Permissions.READ_NON_PAYMENT_NOTICES,
         perm_models.Permissions.MANAGE_NON_PAYMENT_NOTICES,
+        perm_models.Permissions.READ_USER_PROFILE_REFRESH_CAMPAIGN,
+        perm_models.Permissions.MANAGE_USER_PROFILE_REFRESH_CAMPAIGN,
     ],
     "global_access": [
         perm_models.Permissions.READ_ADMIN_ACCOUNTS,
@@ -251,6 +256,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.CLOSE_OFFERER,
         perm_models.Permissions.READ_NON_PAYMENT_NOTICES,
         perm_models.Permissions.MANAGE_NON_PAYMENT_NOTICES,
+        perm_models.Permissions.READ_USER_PROFILE_REFRESH_CAMPAIGN,
+        perm_models.Permissions.MANAGE_USER_PROFILE_REFRESH_CAMPAIGN,
     ],
     "dpo": [
         perm_models.Permissions.ANONYMIZE_PUBLIC_ACCOUNT,

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -44,6 +44,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.PRO_FRAUD_ACTIONS,
         perm_models.Permissions.BENEFICIARY_FRAUD_ACTIONS,
         perm_models.Permissions.ANONYMIZE_PUBLIC_ACCOUNT,
+        perm_models.Permissions.READ_USER_PROFILE_REFRESH_CAMPAIGN,
+        perm_models.Permissions.MANAGE_USER_PROFILE_REFRESH_CAMPAIGN,
     ],
     "support_n1": [
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,
@@ -184,6 +186,7 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.READ_SPECIAL_EVENTS,
         perm_models.Permissions.READ_TAGS,
         perm_models.Permissions.READ_TECH_PARTNERS,
+        perm_models.Permissions.READ_USER_PROFILE_REFRESH_CAMPAIGN,
     ],
     "qa": [],
     "global_access": [
@@ -231,6 +234,8 @@ ROLE_PERMISSIONS: dict[str, list[perm_models.Permissions]] = {
         perm_models.Permissions.CLOSE_OFFERER,
         perm_models.Permissions.READ_NON_PAYMENT_NOTICES,
         perm_models.Permissions.MANAGE_NON_PAYMENT_NOTICES,
+        perm_models.Permissions.READ_USER_PROFILE_REFRESH_CAMPAIGN,
+        perm_models.Permissions.MANAGE_USER_PROFILE_REFRESH_CAMPAIGN,
     ],
     "dpo": [
         perm_models.Permissions.READ_PUBLIC_ACCOUNT,


### PR DESCRIPTION

<img width="1387" height="585" alt="Capture d’écran 2025-08-13 à 11 22 22" src="https://github.com/user-attachments/assets/3a16a19c-e4f5-4502-8e79-9f414c233320" />

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36796)

 - Add new page to manage user profile refresh campaigns
 - Use the next user profile refresh campaign's date in the calculation of `hasProfileExpired` field in the native `/me` endpoint
