### PR TITLE
(BSR)[BO] fix: defer FF dependant string eval

### DIFF
--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -16,6 +16,7 @@ from markupsafe import Markup
 from markupsafe import escape
 
 import pcapi.core.categories.genres.music
+import pcapi.routes.backoffice.forms.utils as forms_utils
 from pcapi import settings
 from pcapi.connectors.dms.models import GraphQLApplicationStates
 from pcapi.core.bookings import models as bookings_models
@@ -688,9 +689,9 @@ def format_offer_status(status: offer_mixin.OfferStatus) -> str:
         case offer_mixin.OfferStatus.PUBLISHED:
             return "Publiée non réservable"
         case offer_mixin.OfferStatus.ACTIVE:
-            if FeatureToggle.WIP_REFACTO_FUTURE_OFFER.is_active():
-                return "Réservable"
-            return "Publiée"
+            return typing.cast(
+                str, forms_utils.LazyFFString(FeatureToggle.WIP_REFACTO_FUTURE_OFFER, "Réservable", "Publiée")
+            )
         case offer_mixin.OfferStatus.PENDING:
             return "En instruction"
         case offer_mixin.OfferStatus.EXPIRED:

--- a/api/src/pcapi/routes/backoffice/forms/utils.py
+++ b/api/src/pcapi/routes/backoffice/forms/utils.py
@@ -4,6 +4,7 @@ import typing
 
 from flask_wtf import FlaskForm
 
+from pcapi.models import feature
 from pcapi.utils import email as email_utils
 
 
@@ -29,3 +30,18 @@ def choices_from_enum(
 def is_slug(string: str) -> bool:
     pattern = r"^[a-z0-9\-]+$"
     return bool(re.match(pattern, string))
+
+
+class LazyFFString:
+    def __init__(self, feature_flag: feature.FeatureToggle, value_on: str, value_off: str) -> None:
+        self.feature_flag = feature_flag
+        self.value_off = value_off
+        self.value_on = value_on
+
+    def __str__(self) -> str:
+        if self.feature_flag.is_active():
+            return str(self.value_on)
+        return str(self.value_off)
+
+    def __repr__(self) -> str:
+        return self.__str__()


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Don't use FF dependant strings on the global scope - ie they are evaluated on import instead of on use.
This also fixes running BO tests from a fresh DB without the backoffice flag explicitly added to pytest

- [ ] Travail pair testé en environnement de preview
