### PR TITLE
(BSR) ci: fix Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dev_on_workflow_dependabot_auto_merge.yml
+++ b/.github/workflows/dev_on_workflow_dependabot_auto_merge.yml
@@ -1,5 +1,9 @@
 name: "3 [on_workflow] Dependabot auto-merge"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   workflow_call:
     secrets:
@@ -26,6 +30,7 @@ jobs:
           repositories: |
             pass-culture-main
           permission-contents: write
+          permission-pull-requests: write
       - name: "Dependabot metadata"
         id: "metadata"
         uses: dependabot/fetch-metadata@v2


### PR DESCRIPTION
This permission should allow Dependabot to approve then merge its PRs