### PR TITLE
(PC-33233)[BO] feat: add 'postal code' field in user generator page

### DIFF
--- a/api/src/pcapi/core/users/generator.py
+++ b/api/src/pcapi/core/users/generator.py
@@ -34,6 +34,7 @@ class GenerateUserData:
     step: GeneratedSubscriptionStep = GeneratedSubscriptionStep.EMAIL_VALIDATION
     transition_17_18: bool = False
     date_created: datetime.datetime = datetime.datetime.utcnow()
+    postal_code: str | None = None
 
 
 def generate_user(user_data: GenerateUserData) -> users_models.User:
@@ -49,11 +50,14 @@ def generate_user(user_data: GenerateUserData) -> users_models.User:
         user_data.age = 18
 
     Factory = _get_user_factory(user_data)
+    # ensure that postal code is set only for ProfileCompletedUserFactory or a factory that is a descendant of it
+    factory_has_postal_code = users_factories.ProfileCompletedUserFactory in Factory.mro()
     return Factory.create(
         age=user_data.age,
         beneficiaryFraudChecks__type=user_data.id_provider.value,
         beneficiaryFraudChecks__dateCreated=user_data.date_created,
         dateCreated=user_data.date_created,
+        **({"postalCode": user_data.postal_code} if (user_data.postal_code and factory_has_postal_code) else {}),
     )
 
 

--- a/api/src/pcapi/routes/backoffice/dev/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/dev/blueprint.py
@@ -149,6 +149,7 @@ def generate_user() -> utils.BackofficeResponse:
             step=users_generator.GeneratedSubscriptionStep[form.step.data],
             transition_17_18=form.transition_17_18.data,
             date_created=datetime.datetime(raw_date_created.year, raw_date_created.month, raw_date_created.day),
+            postal_code=form.postal_code.data,
         )
         user = users_generator.generate_user(user_data=user_data)
     except users_exceptions.UserGenerationForbiddenException:

--- a/api/src/pcapi/routes/backoffice/dev/forms.py
+++ b/api/src/pcapi/routes/backoffice/dev/forms.py
@@ -64,6 +64,7 @@ class UserGeneratorForm(utils.PCForm):
         default=GeneratedSubscriptionStep.EMAIL_VALIDATION.name,
     )
     date_created = fields.PCDateField("Date de dépôt du dossier", default=datetime.date.today())
+    postal_code = fields.PCOptPostalCodeField("Code postal")
     transition_17_18 = fields.PCCheckboxField("Transition 17-18")
 
 

--- a/api/tests/routes/backoffice/dev_test.py
+++ b/api/tests/routes/backoffice/dev_test.py
@@ -155,6 +155,24 @@ class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermis
         )
         assert number_of_users_before == number_of_users_after
 
+    def test_user_set_postal_code(self, authenticated_client):
+        form = {"age": 18, "id_provider": "UBBLE", "step": "BENEFICIARY", "postal_code": "63170"}
+        response = self.post_to_endpoint(authenticated_client, form=form, follow_redirects=True)
+        assert response.status_code == 200
+        query_args = response.request.args.to_dict()
+        user_id = query_args["userId"]
+        user = db.session.query(users_models.User).get(user_id)
+        assert user.postalCode == "63170"
+
+    def test_user_postal_code_ignored_before_profile_completion(self, authenticated_client):
+        form = {"age": 18, "id_provider": "UBBLE", "step": "EMAIL_VALIDATION", "postal_code": "63170"}
+        response = self.post_to_endpoint(authenticated_client, form=form, follow_redirects=True)
+        assert response.status_code == 200
+        query_args = response.request.args.to_dict()
+        user_id = query_args["userId"]
+        user = db.session.query(users_models.User).get(user_id)
+        assert user.postalCode is None
+
 
 class UserDeletionPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermissionHelper):
     endpoint = "backoffice_web.dev.delete_user"


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-33233)

Add `postal_code` field to the form of user generator page

<img width="809" height="653" alt="Capture d’écran 2025-08-14 à 17 35 10" src="https://github.com/user-attachments/assets/e6d97c27-a6d7-4bb0-b9d8-c1a38ad19faa" />
