### PR TITLE
(PC-37504)[PRO] fix: fix venue name, price, preview button display on collective offer

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.spec.tsx
@@ -98,9 +98,23 @@ describe('BookableOfferSummary', () => {
     expect(screen.getByText('Test Offer')).toBeInTheDocument()
   })
 
-  it('should render the venue name', () => {
+  it('should render the venue public name', () => {
     renderBookableOfferSummary(props)
     expect(screen.getByText('Proposé par Test Venue')).toBeInTheDocument()
+  })
+
+  it('should render the venue default name when venue has no public name', () => {
+    const testProps = {
+      offer: getCollectiveOfferFactory({
+        venue: getCollectiveOfferVenueFactory({
+          publicName: null,
+          name: 'Venue 1',
+          departementCode: '75',
+        }),
+      }),
+    }
+    renderBookableOfferSummary(testProps)
+    expect(screen.getByText('Proposé par Venue 1')).toBeInTheDocument()
   })
 
   it('should render the number of participants', () => {
@@ -129,6 +143,24 @@ describe('BookableOfferSummary', () => {
   it('should render the price', () => {
     renderBookableOfferSummary(props)
     expect(screen.getByText('1000 euros')).toBeInTheDocument()
+  })
+
+  it('should render "0 euro" price when offer is free', () => {
+    const testProps = {
+      offer: getCollectiveOfferFactory({
+        collectiveStock: {
+          id: 1,
+          isBooked: false,
+          isCancellable: true,
+          numberOfTickets: 50,
+          price: 0,
+          bookingLimitDatetime: null,
+        },
+      }),
+    }
+
+    renderBookableOfferSummary(testProps)
+    expect(screen.getByText('0 euro')).toBeInTheDocument()
   })
 
   it('should render the booking limit date', () => {
@@ -217,6 +249,18 @@ describe('BookableOfferSummary', () => {
     renderBookableOfferSummary(testProps)
     const previewButton = screen.getByText('Aperçu')
     expect(previewButton).toBeInTheDocument()
+  })
+
+  it('should not render the "Aperçu" action for a draft offer', () => {
+    const testProps = {
+      offer: getCollectiveOfferFactory({
+        displayedStatus: CollectiveOfferDisplayedStatus.DRAFT,
+      }),
+    }
+
+    renderBookableOfferSummary(testProps)
+    const previewButton = screen.queryByText('Aperçu')
+    expect(previewButton).not.toBeInTheDocument()
   })
 
   it('should render the "Dupliquer" action if duplication is allowed', () => {

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.tsx
@@ -235,7 +235,10 @@ export const BookableOfferSummary = ({ offer }: BookableOfferSummaryProps) => {
           <dl className={styles['detail-list']}>
             <DetailItem>n°{offer.id}</DetailItem>
             <DetailItem alt={offer.venue.publicName ?? ''} src={strokeHomeIcon}>
-              Proposé par {offer.venue.publicName}
+              Proposé par{' '}
+              {offer.venue.publicName
+                ? offer.venue.publicName
+                : offer.venue.name}
             </DetailItem>
             <DetailItem alt={'Date de l’offre'} src={strokeCalendarIcon}>
               {formatDateRangeWithTime()}
@@ -254,8 +257,9 @@ export const BookableOfferSummary = ({ offer }: BookableOfferSummaryProps) => {
                 : DEFAULT_RECAP_VALUE}
             </DetailItem>
             <DetailItem alt="Prix de l’offre" src={strokeEuroIcon}>
-              {offer.collectiveStock?.price
-                ? `${offer.collectiveStock.price} euros`
+              {offer.collectiveStock?.price ||
+              offer.collectiveStock?.price === 0
+                ? `${offer.collectiveStock.price} ${pluralizeString('euro', offer.collectiveStock.price)}`
                 : DEFAULT_RECAP_VALUE}
             </DetailItem>
             <DetailItem alt="Adresse de l’offre" src={strokeLocationIcon}>
@@ -287,15 +291,18 @@ export const BookableOfferSummary = ({ offer }: BookableOfferSummaryProps) => {
                 </li>
               )}
 
-              <li>
-                <ButtonLink
-                  to={`/offre/${offer.id}/collectif/apercu`}
-                  icon={fullShowIcon}
-                  ref={adagePreviewButtonRef}
-                >
-                  Aperçu
-                </ButtonLink>
-              </li>
+              {offer.displayedStatus !==
+                CollectiveOfferDisplayedStatus.DRAFT && (
+                <li>
+                  <ButtonLink
+                    to={`/offre/${offer.id}/collectif/apercu`}
+                    icon={fullShowIcon}
+                    ref={adagePreviewButtonRef}
+                  >
+                    Aperçu
+                  </ButtonLink>
+                </li>
+              )}
 
               {canDuplicateOffer && (
                 <li>


### PR DESCRIPTION
https://passculture.atlassian.net/browse/PC-37504

- correction du bouton aperçu qui ne doit pas apparaître sur les offres brouillon
- si la venue organisatrice n'a pas de nom public, afficher sa raison sociale
- si l'offre est gratuite, afficher "0 euro" et non "-"
