### PR TITLE
(PC-37496)[PRO] fix: Reset the form when the offer id changes in the …

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreenNext.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreenNext.tsx
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup'
+import { useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useLocation, useNavigate } from 'react-router'
 import { useSWRConfig } from 'swr'
@@ -89,23 +90,32 @@ export const IndividualOfferDetailsScreenNext = ({
   const availableVenues = filterAvailableVenues(venues)
   const availableVenuesAsOptions = getVenuesAsOptions(availableVenues)
 
-  const initialValues = isNewOfferDraft
-    ? getInitialValuesFromVenues(
-        availableVenues,
-        isNewOfferCreationFlowFeatureActive
-      )
-    : getInitialValuesFromOffer({
-        offer: initialOffer,
-        subcategories: subCategories,
-        isNewOfferCreationFlowFeatureActive,
-      })
+  const getInitialValues = () => {
+    return isNewOfferDraft
+      ? getInitialValuesFromVenues(
+          availableVenues,
+          isNewOfferCreationFlowFeatureActive
+        )
+      : getInitialValuesFromOffer({
+          offer: initialOffer,
+          subcategories: subCategories,
+          isNewOfferCreationFlowFeatureActive,
+        })
+  }
+
   const form = useForm<DetailsFormValues>({
-    defaultValues: initialValues,
+    defaultValues: getInitialValues(),
     resolver: yupResolver<DetailsFormValues>(
       getValidationSchemaForNewOfferCreationFlow()
     ),
     mode: 'onBlur',
   })
+
+  useEffect(() => {
+    //  If we go from an offer edition details page to the offer creation,
+    // the offerId is then null but the page remains the same so the form would not be reset
+    form.reset(getInitialValues())
+  }, [initialOffer?.id, form.reset])
 
   const hasSelectedProduct = !!form.watch('productId')
   const selectedSubcategoryId = form.watch('subcategoryId')


### PR DESCRIPTION
…details page in case a user creates a new offer from sidebar while on step 1.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37496)

Avec le FF `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` activé, on peut accéder à la création d'offre indiv direct à l'étape 1 depuis la sidebar. Donc si on ets déjà su l'étape 1 en création/édition d'une offre, et qu'on clique sur "Créer une offre indiv" dans la sidebar, il n'y a pas de redirection et le formulaire n'est pas reset.

Pour corriger j'ai ajouté un useEffect qui reset le form si l'offerId change, c'est un peu brutal mais je vois pas d'autre solution ? 🤔 