### PR TITLE
(PC-37537)[PRO] fix: handle empty cat & subCat id on change in offer details

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/Subcategories/Subcategories.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/Subcategories/Subcategories.tsx
@@ -71,6 +71,16 @@ export function Subcategories({
     clearErrors(['categoryId', 'subcategoryId'])
 
     const nextCategoryId = event.target.value
+    if (nextCategoryId === DEFAULT_DETAILS_FORM_VALUES.categoryId) {
+      resetField('subcategoryId')
+      setValue(
+        'subcategoryConditionalFields',
+        DEFAULT_DETAILS_FORM_VALUES.subcategoryConditionalFields
+      )
+
+      return
+    }
+
     const options = buildSubcategoryOptions(
       filteredSubcategories,
       nextCategoryId
@@ -91,6 +101,14 @@ export function Subcategories({
 
   const handleSubcategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const nextSubcategoryId = event.target.value
+    if (nextSubcategoryId === DEFAULT_DETAILS_FORM_VALUES.subcategoryId) {
+      setValue(
+        'subcategoryConditionalFields',
+        DEFAULT_DETAILS_FORM_VALUES.subcategoryConditionalFields
+      )
+
+      return
+    }
 
     handleSubcategoryUpdate(nextSubcategoryId)
   }


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37537)

### Bug

Lors de la création d'une offre individuelle, changer la catégorie ou la sous-catégorie à celle par défaut (= "Choisir une...") après avoir sélectionné une catégorie et/ou une sous-catégorie throw une erreur car ce n'est pas géré par le code. 

Cela n'a pas d'impact UI ou UX pour l'utilisateur·ice.