### PR TITLE
(PC-37538)[PRO] fix: improve indiv. offer creation summary page margins

### DIFF
--- a/pro/src/components/SummaryLayout/SummaryLayout.module.scss
+++ b/pro/src/components/SummaryLayout/SummaryLayout.module.scss
@@ -35,7 +35,7 @@
       display: flex;
       flex-direction: row;
       align-items: top;
-      margin: rem.torem(24px) 0;
+      margin-bottom: rem.torem(24px);
 
       &-edit-link {
         height: unset;
@@ -54,7 +54,7 @@
     &-title {
       @include fonts.title3;
 
-      margin-bottom: rem.torem(24px);
+      margin-bottom: rem.torem(8px);
     }
   }
 
@@ -69,7 +69,7 @@
   }
 
   &-row {
-    margin-bottom: rem.torem(16px);
+    margin-bottom: rem.torem(8px);
     max-width: 100%;
 
     &-title {

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/OfferSection/OfferSection.module.scss
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/OfferSection/OfferSection.module.scss
@@ -1,8 +1,0 @@
-@use "styles/mixins/_rem.scss" as rem;
-
-// Cancels the margin-top of the title when we show the event publication form
-// A cleaner way to do this would be to remove the margin-top from the summary title component
-// but it would require to change all pages using this component
-.cancel-title-margin {
-  margin-top: rem.torem(-32px);
-}

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/OfferSection/OfferSection.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/OfferSection/OfferSection.tsx
@@ -25,8 +25,6 @@ import { SummarySubSection } from '@/components/SummaryLayout/SummarySubSection'
 import { serializeOfferSectionData } from '@/pages/IndividualOfferSummary/commons/serializer'
 import { Spinner } from '@/ui-kit/Spinner/Spinner'
 
-import styles from './OfferSection.module.scss'
-
 interface OfferSummaryProps {
   offer: GetIndividualOfferWithAddressResponseModel
   conditionalFields: string[]
@@ -202,7 +200,6 @@ export const OfferSection = ({
           isOnboarding,
         })}
         aria-label="Modifier les détails de l’offre"
-        className={styles['cancel-title-margin']}
         shouldShowDivider
       >
         <SummarySubSection

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/StockSection/StockSection.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/StockSection/StockSection.tsx
@@ -100,7 +100,6 @@ export const StockSection = ({
       title={offer.isEvent ? 'Dates et capacités' : 'Stocks et prix'}
       editLink={editLink}
       aria-label="Modifier les stocks et prix"
-      shouldShowDivider
     >
       {stockWarningText && (
         <SummaryDescriptionList


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37538)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

- Modification des marges sur la page "Récapitulatif", correspondant à la dernière étape de création d'une offre individuelle.
