### PR TITLE
(PC-37556)[PRO] fix: avoid loading original image url within modal if not opened

### DIFF
--- a/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.spec.tsx
+++ b/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.spec.tsx
@@ -12,7 +12,7 @@ import {
 } from './ImageDragAndDropUploader'
 
 vi.mock('react-avatar-editor', () => {
-  const MockAvatarEditor = forwardRef((props, ref) => {
+  const MockAvatarEditor = forwardRef((_props, ref) => {
     if (ref && typeof ref === 'object' && 'current' in ref) {
       ref.current = {
         getImage: vi.fn(() => ({ toDataURL: vi.fn(() => 'my img') })),

--- a/pro/src/components/ImageUploader/ImageUploader.spec.tsx
+++ b/pro/src/components/ImageUploader/ImageUploader.spec.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders } from '@/commons/utils/renderWithProviders'
 import { ImageUploader, type ImageUploaderProps } from './ImageUploader'
 
 vi.mock('react-avatar-editor', () => {
-  const MockAvatarEditor = forwardRef((props, ref) => {
+  const MockAvatarEditor = forwardRef((_props, ref) => {
     if (ref && typeof ref === 'object' && 'current' in ref) {
       ref.current = {
         getImage: vi.fn(() => ({ toDataURL: vi.fn(() => 'my img') })),

--- a/pro/src/components/ImageUploader/components/ButtonImageEdit/ButtonImageEdit.tsx
+++ b/pro/src/components/ImageUploader/components/ButtonImageEdit/ButtonImageEdit.tsx
@@ -86,10 +86,8 @@ export const ButtonImageEdit = ({
             type="button"
             disabled={disableForm}
           >
-            <>
-              <SvgIcon src={fullMoreIcon} alt="" className={style['icon']} />
-              <span className={style['label']}>Ajouter une image</span>
-            </>
+            <SvgIcon src={fullMoreIcon} alt="" className={style['icon']} />
+            <span className={style['label']}>Ajouter une image</span>
           </button>
         )
       }

--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
@@ -50,6 +50,19 @@ describe('ModalImageUpsertOrEdit', () => {
     expect(screen.getByRole('button', { name: 'Importer' })).toBeInTheDocument()
   })
 
+  it('should render a spinner until the image is loaded', async () => {
+    const mockImageUrl = 'http://example.com/image.jpg'
+    renderModalImageCrop({
+      initialValues: {
+        croppedImageUrl: mockImageUrl,
+        originalImageUrl: mockImageUrl,
+      },
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('spinner-img-load')).toBeInTheDocument()
+    })
+  })
+
   describe('when an image is loaded', () => {
     it('should render an image editor & a preview with the loaded image', async () => {
       vi.spyOn(imageUtils, 'getImageBitmap').mockResolvedValue({

--- a/pro/src/components/ModalImageUpsertOrEdit/components/ImageEditor/ImageEditor.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/components/ImageEditor/ImageEditor.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useId, useState } from 'react'
 import AvatarEditor, { type Position } from 'react-avatar-editor'
 import { useDebouncedCallback } from 'use-debounce'
 
@@ -60,6 +60,7 @@ export const ImageEditor = forwardRef<AvatarEditor, ImageEditorProps>(
     },
     ref
   ) => {
+    const imageDisableDescriptionId = useId()
     const [position, setPosition] = useState<Position>(initialPosition)
     const [windowWidth, setWindowWidth] = useState(window.innerWidth)
 
@@ -177,7 +178,7 @@ export const ImageEditor = forwardRef<AvatarEditor, ImageEditorProps>(
                 debouncedOnSearch()
               }}
               disabled={isScaleDisabled}
-              aria-describedby="image-editor-scale-disabled"
+              aria-describedby={imageDisableDescriptionId}
               label="Niveau de zoom de l'image"
               hideLabel
             />
@@ -186,7 +187,7 @@ export const ImageEditor = forwardRef<AvatarEditor, ImageEditorProps>(
         </div>
         {isScaleDisabled && (
           <span
-            id="image-editor-scale-disabled"
+            id={imageDisableDescriptionId}
             className={style['image-editor-scale-disabled']}
           >
             L’image est trop petite pour utiliser le zoom.


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37556)

- Micro-optimisation pour éviter de GET l'image originale d'une venue ou d'une offre si la modale n'est pas ouverte (et puisqu'elle est toujours rendue). C'est ce qui faisait afficher des toaster d'erreur énigmatiques pour l'user quand il y avait un problème sur celle-ci (voir broken url / buckets non correspondants) alors que l'image croppée (généralement affichée) ne semblait pas avoir eu de problème à être chargée.
- Quelques biome/eslint fixes.