### PR TITLE
(PC-37572)[PRO] feat: Add RadioButtonGroup horizontal fill will descr…

### DIFF
--- a/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.module.scss
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.module.scss
@@ -8,23 +8,19 @@
   margin-bottom: rem.torem(32px);
 }
 
-.legend,
-.legend-without-margin {
+.legend {
   @include fonts.title4;
 
   display: flex;
   align-items: center;
   gap: rem.torem(10px);
+  margin-bottom: rem.torem(16px);
 
   &-icon {
     width: rem.torem(20px);
     height: rem.torem(20px);
     color: var(--color-icon-brand-primary);
   }
-}
-
-.legend {
-  margin-bottom: rem.torem(16px);
 }
 
 .radio-group {
@@ -94,9 +90,7 @@
 }
 
 .booking-date-limit-text {
-  margin-top: calc(
-    (size.$input-min-height - var(--typography-body-line-height)) / 2
-  );
+  margin-top: calc((size.$input-min-height - var(--typography-body-line-height)) / 2);
 }
 
 @media (min-width: size.$tablet) {

--- a/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/RecurrenceForm.tsx
@@ -323,7 +323,6 @@ export const RecurrenceForm = ({
 
           <div className={styles['recurrence-section']}>
             <RadioButtonGroup
-              labelClassName={styles['legend-without-margin']}
               label="Cet évènement aura lieu"
               labelTag="h2"
               display="horizontal"

--- a/pro/src/components/IndividualOfferLayout/OfferPublicationEdition/OfferPublicationEditionForm/OfferPublicationEditionForm.tsx
+++ b/pro/src/components/IndividualOfferLayout/OfferPublicationEdition/OfferPublicationEditionForm/OfferPublicationEditionForm.tsx
@@ -120,117 +120,125 @@ export function OfferPublicationEditionForm({
               }}
             />
           </div>
-          <RadioButtonGroup
-            className={styles['group']}
-            label="Quand votre offre doit-elle être publiée&nbsp;?"
-            name="publicationMode"
-            variant="detailed"
-            disabled={isPaused}
-            options={[
-              { label: 'Publier maintenant', value: 'now' },
-              {
-                label: 'Publier plus tard',
-                description:
-                  'L’offre restera secrète pour le public jusqu’à sa publication.',
-                value: 'later',
-                collapsed: (
-                  <div className={styles['inputs-row']}>
-                    <DatePicker
-                      label="Date"
-                      minDate={new Date()}
-                      className={styles['date-picker']}
-                      disabled={isPaused}
-                      required
-                      {...form.register('publicationDate')}
-                      onBlur={async (e) => {
-                        await form.register('publicationDate').onBlur(e)
-                        await form.trigger('publicationTime')
-                      }}
-                      error={form.formState.errors.publicationDate?.message}
-                    />
-                    <Select
-                      label="Heure"
-                      options={publicationHoursOptions}
-                      defaultOption={{ label: 'HH:MM', value: '' }}
-                      className={styles['time-picker']}
-                      disabled={isPaused}
-                      required
-                      {...form.register('publicationTime')}
-                      error={form.formState.errors.publicationTime?.message}
-                    />
-                  </div>
-                ),
-              },
-            ]}
-            checkedOption={
-              isPaused ? undefined : form.watch('publicationMode') || undefined
-            }
-            onChange={(event) => {
-              form.setValue(
-                'publicationMode',
-                event.target
-                  .value as EventPublicationFormValues['publicationMode']
-              )
-            }}
-          />
-          <RadioButtonGroup
-            className={styles['group']}
-            label="Quand votre offre pourra-t-elle être réservable&nbsp;?"
-            name="bookingAllowedMode"
-            variant="detailed"
-            disabled={isPaused}
-            options={[
-              {
-                label: 'Rendre réservable dès la publication',
-                value: 'now',
-              },
-              {
-                label: 'Rendre réservable plus tard',
-                description:
-                  'En activant cette option, vous permettez au public de visualiser l’entièreté de votre offre, de la mettre en favori et pouvoir la suivre mais sans qu’elle puisse être réservable.',
-                value: 'later',
-                collapsed: form.watch('bookingAllowedMode') === 'later' && (
-                  <div className={styles['inputs-row']}>
-                    <DatePicker
-                      label="Date"
-                      className={styles['date-picker']}
-                      minDate={new Date()}
-                      disabled={isPaused}
-                      required
-                      {...form.register('bookingAllowedDate')}
-                      onBlur={async (e) => {
-                        await form.register('bookingAllowedDate').onBlur(e)
-                        await form.trigger('bookingAllowedDate')
-                      }}
-                      error={form.formState.errors.bookingAllowedDate?.message}
-                    />
-                    <Select
-                      label="Heure"
-                      options={publicationHoursOptions}
-                      defaultOption={{ label: 'HH:MM', value: '' }}
-                      className={styles['time-picker']}
-                      disabled={isPaused}
-                      required
-                      {...form.register('bookingAllowedTime')}
-                      error={form.formState.errors.bookingAllowedTime?.message}
-                    />
-                  </div>
-                ),
-              },
-            ]}
-            checkedOption={
-              isPaused
-                ? undefined
-                : form.watch('bookingAllowedMode') || undefined
-            }
-            onChange={(event) => {
-              form.setValue(
-                'bookingAllowedMode',
-                event.target
-                  .value as EventPublicationFormValues['bookingAllowedMode']
-              )
-            }}
-          />
+          <div className={styles['group']}>
+            <RadioButtonGroup
+              label="Quand votre offre doit-elle être publiée&nbsp;?"
+              name="publicationMode"
+              variant="detailed"
+              disabled={isPaused}
+              options={[
+                { label: 'Publier maintenant', value: 'now' },
+                {
+                  label: 'Publier plus tard',
+                  description:
+                    'L’offre restera secrète pour le public jusqu’à sa publication.',
+                  value: 'later',
+                  collapsed: (
+                    <div className={styles['inputs-row']}>
+                      <DatePicker
+                        label="Date"
+                        minDate={new Date()}
+                        className={styles['date-picker']}
+                        disabled={isPaused}
+                        required
+                        {...form.register('publicationDate')}
+                        onBlur={async (e) => {
+                          await form.register('publicationDate').onBlur(e)
+                          await form.trigger('publicationTime')
+                        }}
+                        error={form.formState.errors.publicationDate?.message}
+                      />
+                      <Select
+                        label="Heure"
+                        options={publicationHoursOptions}
+                        defaultOption={{ label: 'HH:MM', value: '' }}
+                        className={styles['time-picker']}
+                        disabled={isPaused}
+                        required
+                        {...form.register('publicationTime')}
+                        error={form.formState.errors.publicationTime?.message}
+                      />
+                    </div>
+                  ),
+                },
+              ]}
+              checkedOption={
+                isPaused
+                  ? undefined
+                  : form.watch('publicationMode') || undefined
+              }
+              onChange={(event) => {
+                form.setValue(
+                  'publicationMode',
+                  event.target
+                    .value as EventPublicationFormValues['publicationMode']
+                )
+              }}
+            />
+          </div>
+          <div className={styles['group']}>
+            <RadioButtonGroup
+              label="Quand votre offre pourra-t-elle être réservable&nbsp;?"
+              name="bookingAllowedMode"
+              variant="detailed"
+              disabled={isPaused}
+              options={[
+                {
+                  label: 'Rendre réservable dès la publication',
+                  value: 'now',
+                },
+                {
+                  label: 'Rendre réservable plus tard',
+                  description:
+                    'En activant cette option, vous permettez au public de visualiser l’entièreté de votre offre, de la mettre en favori et pouvoir la suivre mais sans qu’elle puisse être réservable.',
+                  value: 'later',
+                  collapsed: form.watch('bookingAllowedMode') === 'later' && (
+                    <div className={styles['inputs-row']}>
+                      <DatePicker
+                        label="Date"
+                        className={styles['date-picker']}
+                        minDate={new Date()}
+                        disabled={isPaused}
+                        required
+                        {...form.register('bookingAllowedDate')}
+                        onBlur={async (e) => {
+                          await form.register('bookingAllowedDate').onBlur(e)
+                          await form.trigger('bookingAllowedDate')
+                        }}
+                        error={
+                          form.formState.errors.bookingAllowedDate?.message
+                        }
+                      />
+                      <Select
+                        label="Heure"
+                        options={publicationHoursOptions}
+                        defaultOption={{ label: 'HH:MM', value: '' }}
+                        className={styles['time-picker']}
+                        disabled={isPaused}
+                        required
+                        {...form.register('bookingAllowedTime')}
+                        error={
+                          form.formState.errors.bookingAllowedTime?.message
+                        }
+                      />
+                    </div>
+                  ),
+                },
+              ]}
+              checkedOption={
+                isPaused
+                  ? undefined
+                  : form.watch('bookingAllowedMode') || undefined
+              }
+              onChange={(event) => {
+                form.setValue(
+                  'bookingAllowedMode',
+                  event.target
+                    .value as EventPublicationFormValues['bookingAllowedMode']
+                )
+              }}
+            />
+          </div>
         </div>
         <DialogBuilder.Footer>
           <div className={styles['actions']}>

--- a/pro/src/components/OpenToPublicToggle/OpenToPublicToggle.tsx
+++ b/pro/src/components/OpenToPublicToggle/OpenToPublicToggle.tsx
@@ -1,7 +1,6 @@
 import { RadioButtonGroup } from '@/design-system/RadioButtonGroup/RadioButtonGroup'
 
 export interface OpenToPublicToggleProps {
-  className?: string
   radioDescriptions?: {
     yes?: string
     no?: string
@@ -18,7 +17,6 @@ const DEFAULT_RADIO_DESCRIPTIONS: OpenToPublicToggleProps['radioDescriptions'] =
   }
 
 export const OpenToPublicToggle = ({
-  className,
   radioDescriptions = {},
   onChange,
   isOpenToPublic,
@@ -39,7 +37,6 @@ export const OpenToPublicToggle = ({
   return (
     <RadioButtonGroup
       name="isOpenToPublic"
-      className={className}
       label="Accueillez-vous du public dans votre structure ?"
       {...(showDescription ? { description } : {})}
       variant="detailed"

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthenticationForm.tsx
@@ -111,9 +111,8 @@ export const OffererAuthenticationForm = (): JSX.Element => {
           error={errors.publicName?.message}
         />
       </FormLayout.Row>
-      <FormLayout.Row mdSpaceAfter>
+      <FormLayout.Row mdSpaceAfter className={styles['open-to-public-toggle']}>
         <OpenToPublicToggle
-          className={styles['open-to-public-toggle']}
           onChange={(e) => {
             if (isPartiallyDiffusableSignupEnabled && !offerer?.isDiffusible) {
               if (e.target.value === 'true') {

--- a/pro/src/design-system/RadioButton/RadioButton.tsx
+++ b/pro/src/design-system/RadioButton/RadioButton.tsx
@@ -24,8 +24,6 @@ type RadioButtonBaseProps = {
   disabled?: boolean
   /** If the radio is in an error state */
   hasError?: boolean
-  /** Custom CSS class for the radio button */
-  className?: string
   /** Event handler for change */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   /** Event handler for blur */
@@ -65,7 +63,6 @@ export const RadioButton = forwardRef(
       onChange,
       onBlur,
       name,
-      className,
     }: RadioButtonProps,
     ref: ForwardedRef<HTMLInputElement>
   ): JSX.Element => {
@@ -76,18 +73,14 @@ export const RadioButton = forwardRef(
     return (
       <>
         <div
-          className={cn(
-            styles['radio-button'],
-            {
-              [styles['sizing-fill']]: sizing === 'fill',
-              [styles['variant-detailed']]: isVariantDetailed,
-              [styles['is-collapsed']]: collapsed && checked,
-              [styles['is-checked']]: checked,
-              [styles['is-disabled']]: disabled,
-              [styles['has-error']]: hasError,
-            },
-            className
-          )}
+          className={cn(styles['radio-button'], {
+            [styles['sizing-fill']]: sizing === 'fill',
+            [styles['variant-detailed']]: isVariantDetailed,
+            [styles['is-collapsed']]: collapsed && checked,
+            [styles['is-checked']]: checked,
+            [styles['is-disabled']]: disabled,
+            [styles['has-error']]: hasError,
+          })}
         >
           <label htmlFor={id} className={styles['radio-button-label']}>
             <div className={styles['radio-button-left']}>

--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.module.scss
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.module.scss
@@ -9,7 +9,6 @@
 .radio-button-group-header {
   display: flex;
   flex-direction: column;
-  gap: rem.torem(4px);
 }
 
 .radio-button-group-label {
@@ -36,11 +35,13 @@
 
 .radio-button-group-description {
   color: var(--color-text-subtle);
+  margin-top: rem.torem(4px);
 }
 
 .radio-button-group-error {
   @include fonts.body-accent-s;
 
+  margin-top: rem.torem(4px);
   display: flex;
   align-items: center;
   gap: rem.torem(4px);
@@ -56,28 +57,25 @@
 
 .radio-button-group-options {
   display: flex;
+  flex-wrap: wrap;
   margin-top: rem.torem(8px);
-}
-
-.display-vertical {
-  flex-direction: column;
-  gap: rem.torem(24px);
-
-  &.variant-detailed {
-    gap: rem.torem(8px);
-  }
-}
-
-.display-horizontal {
-  flex-flow: row wrap;
   gap: rem.torem(16px);
+  width: 100%;
 
-  & > * {
-    flex: 1 1 auto;
-    width: auto !important;
+  &.display-horizontal.sizing-fill .radio-button-group-option {
+    flex-grow: 1;
+    flex-basis: 0;
   }
 
-  &.sizing-hug > * {
-    max-width: fit-content;
+  &.display-vertical {
+    gap: rem.torem(24px);
+
+    .radio-button-group-option {
+      width: 100%;
+    }
+
+    &.variant-detailed {
+      gap: rem.torem(8px);
+    }
   }
 }

--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.spec.tsx
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.spec.tsx
@@ -151,35 +151,6 @@ describe('<RadioButtonGroup />', () => {
     expect(selectedRadio).toBeChecked()
   })
 
-  it('should render an error message when less than 2 options are provided', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => vi.fn())
-    await waitFor(() =>
-      expect(() =>
-        render(
-          <RadioButtonGroup
-            name="radio-button-group"
-            label="Radio Button Group with Insufficient Options"
-            options={[options[0]]}
-          />
-        )
-      ).toThrow('RadioButtonGroup requires at least two options.')
-    )
-    vi.restoreAllMocks()
-  })
-
-  it('should not render an error when less than 2 options are provided but allowSingleOrNoneOption prop is passed', () => {
-    const { container } = render(
-      <RadioButtonGroup
-        name="radio-button-group"
-        label="Radio Button Group with Insufficient Options & allowSingleOrNoneOption"
-        options={[options[0]]}
-        allowSingleOrNoneOption
-      />
-    )
-
-    expect(container).toBeInTheDocument()
-  })
-
   it('should render an error message when options have duplicate values', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => vi.fn())
     await waitFor(() =>

--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.stories.tsx
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.stories.tsx
@@ -23,7 +23,7 @@ const options = [
   {
     label: 'Option 2',
     name: 'group1',
-    description: 'Description 2',
+    description: 'Description 2 that is a little longer...',
     value: '2',
   },
   {
@@ -60,6 +60,16 @@ export const Detailed: StoryObj<typeof RadioButtonGroup> = {
     name: 'radio-button-group',
     label: 'Detailed Radio Button Group',
     variant: 'detailed',
+    options,
+  },
+}
+
+export const DetailedHugged: StoryObj<typeof RadioButtonGroup> = {
+  args: {
+    name: 'radio-button-group',
+    label: 'Detailed Radio Button Group',
+    variant: 'detailed',
+    sizing: 'hug',
     options,
   },
 }

--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.tsx
@@ -50,10 +50,6 @@ export type RadioButtonGroupProps<
   display?: 'horizontal' | 'vertical'
   /** Selected option, required if the group is non-controlled */
   checkedOption?: string
-  /** Custom CSS class for the radio button group */
-  className?: string
-  /** Custom CSS class for the label */
-  labelClassName?: string
   /** If the radio button group is disabled, making all options unselectable */
   disabled?: D
   /** Event handler for change */
@@ -64,8 +60,6 @@ export type RadioButtonGroupProps<
   required?: boolean
   /** Whether the required asterisk is displayed or not */
   asterisk?: boolean
-  /** Allow options to be an array with none, or a single element - exception case: CollectiveOfferSelectionDuplication */
-  allowSingleOrNoneOption?: boolean
 }
 
 export const RadioButtonGroup = ({
@@ -80,14 +74,11 @@ export const RadioButtonGroup = ({
   display = 'vertical',
   disabled = false,
   checkedOption,
-  className,
-  labelClassName,
   asset,
   onChange,
   onBlur,
   required,
   asterisk = true,
-  allowSingleOrNoneOption,
 }: RadioButtonGroupProps<
   string,
   RadioButtonVariantProps,
@@ -100,10 +91,6 @@ export const RadioButtonGroup = ({
   const errorId = useId()
   const descriptionId = useId()
   const describedBy = `${error ? errorId : ''}${description ? ` ${descriptionId}` : ''}`
-
-  if (!allowSingleOrNoneOption && options.length < 2) {
-    throw new Error('RadioButtonGroup requires at least two options.')
-  }
 
   // Ensure all options have distinct values, which is natural
   // for radio buttons but also a requirement since they are used as unique keys.
@@ -119,29 +106,28 @@ export const RadioButtonGroup = ({
       aria-describedby={describedBy}
       aria-required={required}
       aria-invalid={!!error}
-      className={cn(styles['radio-button-group'], className)}
+      className={styles['radio-button-group']}
       data-testid={`wrapper-${name}`}
     >
       <div className={styles['radio-button-group-header']}>
         <LabelTag
           id={labelId}
-          className={cn(
-            styles[`radio-button-group-label-${LabelTag}`],
-            labelClassName
-          )}
+          className={cn(styles[`radio-button-group-label-${LabelTag}`])}
         >
           {label}
           {required && asterisk ? ' *' : ''}
         </LabelTag>
-        <span
-          id={descriptionId}
-          className={styles['radio-button-group-description']}
-          // Description might change based on selection,
-          // so an aria-live is needed to announce changes.
-          aria-live="polite"
-        >
-          {description}
-        </span>
+        {description && (
+          <span
+            id={descriptionId}
+            className={styles['radio-button-group-description']}
+            // Description might change based on selection,
+            // so an aria-live is needed to announce changes.
+            aria-live="polite"
+          >
+            {description}
+          </span>
+        )}
         <div role="alert" id={errorId}>
           {error && (
             <span className={styles['radio-button-group-error']}>
@@ -164,21 +150,25 @@ export const RadioButtonGroup = ({
         )}
       >
         {options.map((optionProps) => (
-          <RadioButton
+          <div
+            className={styles['radio-button-group-option']}
             key={optionProps.value}
-            {...optionProps}
-            name={name}
-            variant={variant}
-            sizing={sizing}
-            disabled={disabled}
-            hasError={!!error}
-            onChange={onChange}
-            onBlur={onBlur}
-            asset={asset}
-            {...(onChange && {
-              checked: checkedOption === optionProps.value,
-            })}
-          />
+          >
+            <RadioButton
+              {...optionProps}
+              name={name}
+              variant={variant}
+              sizing={sizing}
+              disabled={disabled}
+              hasError={!!error}
+              onChange={onChange}
+              onBlur={onBlur}
+              asset={asset}
+              {...(onChange && {
+                checked: checkedOption === optionProps.value,
+              })}
+            />
+          </div>
         ))}
       </div>
     </div>

--- a/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.tsx
+++ b/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.tsx
@@ -214,7 +214,6 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
                       e.target.value
                     )
                   }}
-                  allowSingleOrNoneOption
                 />
                 {offers && offers.length < 1 && (
                   <div className={styles['search-no-results']}>

--- a/pro/src/pages/OfferType/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType/CollectiveOfferType/CollectiveOfferType.tsx
@@ -40,77 +40,83 @@ export const CollectiveOfferType = ({ offerer }: CollectiveOfferTypeProps) => {
   return (
     <>
       {offerer?.isValidated && offerer.allowedOnAdage && (
-        <RadioButtonGroup
-          variant="detailed"
-          name="collectiveOfferSubtype"
-          className={styles['container']}
-          label="Quel est le type de l’offre ?"
-          labelTag="h2"
-          onChange={(e) =>
-            setValue('offer.collectiveOfferSubtype', e.target.value)
-          }
-          checkedOption={getValues('offer.collectiveOfferSubtype')}
-          options={[
-            {
-              label: 'Une offre réservable',
-              value: COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE,
-              description:
-                'Cette offre a une date et un prix. Elle doit être associée à un établissement scolaire avec lequel vous avez préalablement échangé.',
-              asset: {
-                variant: 'icon',
-                src: strokeBookedIcon,
+        <div className={styles['container']}>
+          <RadioButtonGroup
+            variant="detailed"
+            name="collectiveOfferSubtype"
+            label="Quel est le type de l’offre ?"
+            labelTag="h2"
+            onChange={(e) =>
+              setValue('offer.collectiveOfferSubtype', e.target.value)
+            }
+            checkedOption={getValues('offer.collectiveOfferSubtype')}
+            options={[
+              {
+                label: 'Une offre réservable',
+                value: COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE,
+                description:
+                  'Cette offre a une date et un prix. Elle doit être associée à un établissement scolaire avec lequel vous avez préalablement échangé.',
+                asset: {
+                  variant: 'icon',
+                  src: strokeBookedIcon,
+                },
               },
-            },
-            {
-              label: 'Une offre vitrine',
-              value: COLLECTIVE_OFFER_SUBTYPE.TEMPLATE,
-              description:
-                'Cette offre n’est pas réservable. Elle permet aux enseignants de vous contacter pour co-construire une offre adaptée. Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.',
-              asset: {
-                variant: 'icon',
-                src: strokeTemplateOfferIcon,
+              {
+                label: 'Une offre vitrine',
+                value: COLLECTIVE_OFFER_SUBTYPE.TEMPLATE,
+                description:
+                  'Cette offre n’est pas réservable. Elle permet aux enseignants de vous contacter pour co-construire une offre adaptée. Vous pourrez facilement la dupliquer pour chaque enseignant intéressé.',
+                asset: {
+                  variant: 'icon',
+                  src: strokeTemplateOfferIcon,
+                },
               },
-            },
-          ]}
-        />
+            ]}
+          />
+        </div>
       )}
 
       {offerer?.allowedOnAdage &&
         getValues('offer.collectiveOfferSubtype') ===
           COLLECTIVE_OFFER_SUBTYPE.COLLECTIVE && (
-          <RadioButtonGroup
-            variant="detailed"
-            name="collectiveOfferSubtypeDuplicate"
-            className={styles['container']}
-            label="Créer une nouvelle offre ou dupliquer une offre ?"
-            labelTag="h2"
-            onChange={(e) =>
-              setValue('offer.collectiveOfferSubtypeDuplicate', e.target.value)
-            }
-            checkedOption={getValues('offer.collectiveOfferSubtypeDuplicate')}
-            options={[
-              {
-                label: 'Créer une nouvelle offre',
-                value: COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.NEW_OFFER,
-                description:
-                  'Créer une nouvelle offre réservable en partant d’un formulaire vierge.',
-                asset: {
-                  variant: 'icon',
-                  src: strokeNewOfferIcon,
+          <div className={styles['container']}>
+            <RadioButtonGroup
+              variant="detailed"
+              name="collectiveOfferSubtypeDuplicate"
+              label="Créer une nouvelle offre ou dupliquer une offre ?"
+              labelTag="h2"
+              sizing="fill"
+              onChange={(e) =>
+                setValue(
+                  'offer.collectiveOfferSubtypeDuplicate',
+                  e.target.value
+                )
+              }
+              checkedOption={getValues('offer.collectiveOfferSubtypeDuplicate')}
+              options={[
+                {
+                  label: 'Créer une nouvelle offre',
+                  value: COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.NEW_OFFER,
+                  description:
+                    'Créer une nouvelle offre réservable en partant d’un formulaire vierge.',
+                  asset: {
+                    variant: 'icon',
+                    src: strokeNewOfferIcon,
+                  },
                 },
-              },
-              {
-                label: 'Dupliquer les informations d’une offre vitrine',
-                value: COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.DUPLICATE,
-                description:
-                  'Créer une offre réservable en dupliquant les informations d’une offre vitrine existante.',
-                asset: {
-                  variant: 'icon',
-                  src: strokeDuplicateOfferIcon,
+                {
+                  label: 'Dupliquer les informations d’une offre vitrine',
+                  value: COLLECTIVE_OFFER_SUBTYPE_DUPLICATE.DUPLICATE,
+                  description:
+                    'Créer une offre réservable en dupliquant les informations d’une offre vitrine existante.',
+                  asset: {
+                    variant: 'icon',
+                    src: strokeDuplicateOfferIcon,
+                  },
                 },
-              },
-            ]}
-          />
+              ]}
+            />
+          </div>
         )}
 
       {getValues('offer.offerType') === OFFER_TYPES.EDUCATIONAL &&

--- a/pro/src/pages/OfferType/OfferType/IndividualOfferType/IndividualOfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType/IndividualOfferType/IndividualOfferType.tsx
@@ -17,55 +17,62 @@ export const IndividualOfferType = () => {
   const isOnboarding = location.pathname.includes('onboarding')
 
   return (
-    <RadioButtonGroup
-      variant="detailed"
-      name="individualOfferSubtype"
+    <div
       className={cn(styles['container'], {
         [styles['container-onboarding']]: isOnboarding,
       })}
-      label="Votre offre est"
-      labelTag="h2"
-      onChange={(e) => setValue('offer.individualOfferSubtype', e.target.value)}
-      checkedOption={getValues('offer.individualOfferSubtype')}
-      options={[
-        {
-          label: 'Un bien physique',
-          value: INDIVIDUAL_OFFER_SUBTYPE.PHYSICAL_GOOD,
-          description:
-            'Livre, instrument de musique, abonnement, cartes et pass…',
-          asset: {
-            variant: 'icon',
-            src: thingStrokeIcon,
+    >
+      <RadioButtonGroup
+        variant="detailed"
+        name="individualOfferSubtype"
+        label="Votre offre est"
+        display="vertical"
+        sizing="fill"
+        labelTag="h2"
+        onChange={(e) =>
+          setValue('offer.individualOfferSubtype', e.target.value)
+        }
+        checkedOption={getValues('offer.individualOfferSubtype')}
+        options={[
+          {
+            label: 'Un bien physique',
+            value: INDIVIDUAL_OFFER_SUBTYPE.PHYSICAL_GOOD,
+            description:
+              'Livre, instrument de musique, abonnement, cartes et pass…',
+            asset: {
+              variant: 'icon',
+              src: thingStrokeIcon,
+            },
           },
-        },
-        {
-          label: 'Un bien numérique',
-          value: INDIVIDUAL_OFFER_SUBTYPE.VIRTUAL_GOOD,
-          description: 'Ebook, jeu vidéo, abonnement streaming...',
-          asset: {
-            variant: 'icon',
-            src: strokeVirtualThingIcon,
+          {
+            label: 'Un bien numérique',
+            value: INDIVIDUAL_OFFER_SUBTYPE.VIRTUAL_GOOD,
+            description: 'Ebook, jeu vidéo, abonnement streaming...',
+            asset: {
+              variant: 'icon',
+              src: strokeVirtualThingIcon,
+            },
           },
-        },
-        {
-          label: 'Un évènement physique daté',
-          value: INDIVIDUAL_OFFER_SUBTYPE.PHYSICAL_EVENT,
-          description: 'Concert, représentation, conférence, ateliers...',
-          asset: {
-            variant: 'icon',
-            src: strokeDateIcon,
+          {
+            label: 'Un évènement physique daté',
+            value: INDIVIDUAL_OFFER_SUBTYPE.PHYSICAL_EVENT,
+            description: 'Concert, représentation, conférence, ateliers...',
+            asset: {
+              variant: 'icon',
+              src: strokeDateIcon,
+            },
           },
-        },
-        {
-          label: 'Un évènement numérique daté',
-          value: INDIVIDUAL_OFFER_SUBTYPE.VIRTUAL_EVENT,
-          description: 'Livestream, cours en ligne, conférence en ligne...',
-          asset: {
-            variant: 'icon',
-            src: strokeVirtualEventIcon,
+          {
+            label: 'Un évènement numérique daté',
+            value: INDIVIDUAL_OFFER_SUBTYPE.VIRTUAL_EVENT,
+            description: 'Livestream, cours en ligne, conférence en ligne...',
+            asset: {
+              variant: 'icon',
+              src: strokeVirtualEventIcon,
+            },
           },
-        },
-      ]}
-    />
+        ]}
+      />
+    </div>
   )
 }

--- a/pro/src/pages/OfferType/OfferType/OfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType/OfferType.tsx
@@ -187,6 +187,7 @@ export const OfferTypeScreen = ({ collectiveOnly }: OfferTypeScreenProps) => {
                     },
                   ]}
                   display="horizontal"
+                  sizing="hug"
                 />
               )}
 


### PR DESCRIPTION
…iption.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37572)

Dans le cadre d'une nouvelle fonctionnalité sur Rétention, on a besoin d'un RadioButtonGroup horizontal en "fill" (càd qui prend toute la largeur dispo) avec une longue description qui passe à la ligne, ce qui est aujourd'hui impossible dans l'implémentation mais possible dans le design ([cf la maquette](https://www.figma.com/design/N8IuqNmW9JnUHvxWaROOrJ/RadioButtonGroup?node-id=3747-30444&t=buAMPPEbgpm63wpn-4)).

Autres changements apportés au composant :
- Suppression des props de class par cohérence avec les autres composants du Design System et pour empêcher de modifier le composant lui-même
- Suppression de la condition de nombre de radio buttons dans le groupe (Je suis d'accord avec ce conseil design mais je ne le vois pas en tant que règles de gestions dans le ticket JIRA du composant. Comme malgré ça le design a encore un cas où un radio groupe peut avoir 1 seul radio button, je propose de n'appliquer ce genre de règle dans le code que lorsqu'ils l'appliqueront en design)
- Ajustement de la marge entre le label et le radio group losque'il n'y a pas de description (vu en revue design avec Marion, mais l'exemple n'existe pas dans la maquette Figma -> maquette a ajuster)

## 🖼️ Before & After Images

Before | After
:---: | :---:
![before](https://github.com/user-attachments/assets/7581a95c-1fba-46af-b8be-2cbeec157888) | ![after](https://github.com/user-attachments/assets/61ed4bfc-ad8d-4cf5-85a7-c5df350c75f0)
