### PR TITLE
(BSR)[PRO] fix: Import Multiselect from /form instead of /ui-kit.

### DIFF
--- a/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffersScreen/TemplateOffersSearchFilters/TemplateOffersSearchFilters.tsx
+++ b/pro/src/pages/TemplateCollectiveOffers/TemplateCollectiveOffersScreen/TemplateOffersSearchFilters/TemplateOffersSearchFilters.tsx
@@ -13,10 +13,10 @@ import type { CollectiveSearchFiltersParams } from '@/commons/core/Offers/types'
 import type { SelectOption } from '@/commons/custom_types/form'
 import { FormLayout } from '@/components/FormLayout/FormLayout'
 import { OffersTableSearch } from '@/components/OffersTable/OffersTableSearch/OffersTableSearch'
+import { MultiSelect } from '@/ui-kit/form/MultiSelect/MultiSelect'
 import { PeriodSelector } from '@/ui-kit/form/PeriodSelector/PeriodSelector'
 import { Select } from '@/ui-kit/form/Select/Select'
 import { FieldLayout } from '@/ui-kit/form/shared/FieldLayout/FieldLayout'
-import { MultiSelect } from '@/ui-kit/MultiSelect/MultiSelect'
 
 import styles from '../TemplateCollectiveOffersScreen.module.scss'
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

J'ai bougé le composant `Multiselect` dans [ce commit](https://github.com/pass-culture/pass-culture-main/commit/2c0d660896fad2b6d98bfc2720a0aa846330489f) et entre temps un des imports a bougé.