### PR TITLE
(PC-37381)[API] fix: delete old offers: handle rejected

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1334,7 +1334,9 @@ def get_unbookable_unbooked_old_offer_ids(
             AND offer.id < :max_id
             AND offer."dateUpdated" < now() - interval '1 year'
             -- offers without any bookable stock (either no stocks
-            -- at all, or no one with a quantity > 0)
+            -- at all, or no one with a quantity > 0) and whose
+            -- validation status is not REJECTED (rejected offers
+            -- cannot be booked).
             AND offer.id NOT IN (
                 SELECT
                     distinct(stock."offerId")
@@ -1348,7 +1350,7 @@ def get_unbookable_unbooked_old_offer_ids(
                     AND (
                         stock."bookingLimitDatetime" IS NULL
                         OR stock."bookingLimitDatetime" > now()
-                    )
+                    ) AND offer.validation != 'REJECTED'
             )
             -- offers without any linked booking
             -- (event cancelled ones)

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -2252,6 +2252,29 @@ class GetUnbookableUnbookedOldOfferIdsTest:
         ids = list(repository.get_unbookable_unbooked_old_offer_ids(0, offer.id + 1))
         assert ids == [offer.id]
 
+    def test_old_rejected_offer_with_bookable_stock_is_matched(self):
+        # If the offer has been rejected bookable stocks are meaningless
+        # as long as there is no booking
+        offer = factories.StockFactory(
+            quantity=10,
+            offer__dateCreated=self.a_year_ago,
+            offer__dateUpdated=self.a_year_ago,
+            offer__validation=offer_mixin.OfferValidationStatus.REJECTED,
+        ).offer
+
+        ids = list(repository.get_unbookable_unbooked_old_offer_ids(0, offer.id + 1))
+        assert ids == [offer.id]
+
+    def test_old_rejected_offer_with_bookable_stock_and_a_booking_is_ignored(self):
+        offer = bookings_factories.BookingFactory(
+            stock__quantity=10,
+            stock__offer__dateCreated=self.a_year_ago,
+            stock__offer__dateUpdated=self.a_year_ago,
+            stock__offer__validation=offer_mixin.OfferValidationStatus.REJECTED,
+        ).stock.offer
+
+        assert not list(repository.get_unbookable_unbooked_old_offer_ids(0, offer.id + 1))
+
     def test_get_old_offer_with_an_ongoing_stock_is_ignored(self):
         offer = factories.StockFactory(offer__dateCreated=self.a_year_ago, offer__dateUpdated=self.a_year_ago).offer
         assert not list(repository.get_unbookable_unbooked_old_offer_ids(0, offer.id + 1))


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37381)

La tâche de suppression des anciennes offres non réservées et non réservables ne prenait pas en compte le statut de l'offre pour déterminer si elle était réservable ou non. Cette PR vient corriger cela : une offre rejetée n'est pas réservable même si elle a au moins un stock qui l'est.

⚠️ cette modification ne concerne que la partie "non réservable" de la définition. Une offre rejetée avec des réservations ne peut pas, et ne doit pas, être supprimée.