### PR TITLE
(PC-37510)[PRO] fix: Get the venue from page individual offer useful …

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.spec.tsx
@@ -90,46 +90,42 @@ describe('screens:IndividualOffer::UsefulInformation', () => {
     subCategories,
   })
 
+  const selectedVenue = {
+    ...venueListItemFactory({
+      id: 1,
+      publicName: 'Lieu Nom Public Pour Test',
+    }),
+    address: {
+      banId: '75101_9575_00003',
+      city: 'Paris',
+      id: 945,
+      id_oa: 1,
+      inseeCode: '75056',
+      isLinkedToVenue: false,
+      isManualEdition: false,
+      label: 'MINISTERE DE LA CULTURE',
+      latitude: 48.87171,
+      longitude: 2.30829,
+      postalCode: '75001',
+      street: '3 Rue de Valois',
+    },
+  }
+
   const offlineOfferProps: IndividualOfferInformationsScreenProps = {
     offer: getIndividualOfferFactory({
       id: 3,
       subcategoryId: 'OFFLINE_SUBCATEGORY' as SubcategoryIdEnum,
       venue: getOfferVenueFactory({ id: 1 }),
     }),
+    selectedVenue: selectedVenue,
   }
   const onlineOfferProps: IndividualOfferInformationsScreenProps = {
     offer: {
       ...offlineOfferProps.offer,
       subcategoryId: 'ONLINE_SUBCATEGORY' as SubcategoryIdEnum,
     },
+    selectedVenue: selectedVenue,
   }
-
-  beforeEach(() => {
-    vi.spyOn(api, 'getVenues').mockResolvedValue({
-      venues: [
-        {
-          ...venueListItemFactory({
-            id: 1,
-            publicName: 'Lieu Nom Public Pour Test',
-          }),
-          address: {
-            banId: '75101_9575_00003',
-            city: 'Paris',
-            id: 945,
-            id_oa: 1,
-            inseeCode: '75056',
-            isLinkedToVenue: false,
-            isManualEdition: false,
-            label: 'MINISTERE DE LA CULTURE',
-            latitude: 48.87171,
-            longitude: 2.30829,
-            postalCode: '75001',
-            street: '3 Rue de Valois',
-          },
-        },
-      ],
-    })
-  })
 
   it('should render the component', async () => {
     renderUsefulInformationScreen(offlineOfferProps, contextValue)
@@ -202,7 +198,7 @@ describe('screens:IndividualOffer::UsefulInformation', () => {
   it('should submit the form with correct payload', async () => {
     vi.spyOn(api, 'patchOffer').mockResolvedValue(
       getIndividualOfferFactory({
-        id: 12,
+        id: 3,
       })
     )
     renderUsefulInformationScreen(offlineOfferProps, contextValue)
@@ -225,7 +221,6 @@ describe('screens:IndividualOffer::UsefulInformation', () => {
     expect(api.patchOffer).toHaveBeenCalledWith(3, {
       address: {
         city: 'Paris',
-        isManualEdition: false,
         isVenueAddress: true,
         label: 'MINISTERE DE LA CULTURE',
         latitude: '48.87171',

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.tsx
@@ -2,15 +2,15 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useLocation, useNavigate } from 'react-router'
-import useSWR, { useSWRConfig } from 'swr'
+import { useSWRConfig } from 'swr'
 
 import { api } from '@/apiClient/api'
 import { isErrorAPIError } from '@/apiClient/helpers'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
-import {
-  GET_OFFER_QUERY_KEY,
-  GET_VENUES_QUERY_KEY,
-} from '@/commons/config/swrQueryKeys'
+import type {
+  GetIndividualOfferWithAddressResponseModel,
+  VenueListItemResponseModel,
+} from '@/apiClient/v1'
+import { GET_OFFER_QUERY_KEY } from '@/commons/config/swrQueryKeys'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import {
   INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
@@ -42,10 +42,12 @@ import { UsefulInformationForm } from './UsefulInformationForm/UsefulInformation
 
 export type IndividualOfferInformationsScreenProps = {
   offer: GetIndividualOfferWithAddressResponseModel
+  selectedVenue?: VenueListItemResponseModel
 }
 
 export const IndividualOfferInformationsScreen = ({
   offer,
+  selectedVenue,
 }: IndividualOfferInformationsScreenProps): JSX.Element => {
   const navigate = useNavigate()
   const { pathname } = useLocation()
@@ -75,17 +77,6 @@ export const IndividualOfferInformationsScreen = ({
     'WIP_ENABLE_NEW_OFFER_CREATION_FLOW'
   )
 
-  // Getting selected venue at step 1 (details) to infer address fields
-  const venuesQuery = useSWR(
-    [GET_VENUES_QUERY_KEY, offer.venue.managingOfferer.id],
-    ([, offererIdParam]) => api.getVenues(null, true, offererIdParam),
-    { fallbackData: { venues: [] } }
-  )
-
-  const selectedVenue = venuesQuery.data.venues.find(
-    (v) => v.id.toString() === offer.venue.id.toString()
-  )
-
   const offerSubCategory = subCategories.find(
     (s) => s.id === offer.subcategoryId
   )
@@ -107,6 +98,7 @@ export const IndividualOfferInformationsScreen = ({
     selectedVenue,
     offerSubcategory: offerSubCategory,
   })
+
   const form = useForm<UsefulInformationFormValues>({
     defaultValues: initialValues,
     mode: 'all',


### PR DESCRIPTION
…information so that the venue is already there on screen first render for useForm defaultValues.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37510)

Bug : A l'étape 2 (localisation) de création d'offre indiv, si on recharge la page (en création), le radio group de la loc n'est pas pré-rempli, donc submit le form ne fonctionne pas, et on n'a pas de message d'erreur.

Correction : le champ n'est pas rempli parce qu'au rechargement, on n'a pas encore l'offre au moment de récupérer la venue qui sert à remplir le radio groupe de la loc. Donc au premier render (celui qui initialise le state initial dans le useForm) la venue est `udefined`.
Pour corriger j'ai déplacé la récupération de la venue dans la page parente, pour s'assurer que la venue est toujours là au premier render du screen (comme c'est fait dans le première page (détail) du parcours).
