### PR TITLE
(PC-37571)[PRO] feat: add from_banner query param in view_page logged event to register from_banner=banner_video when indiv. offer creation is initiated

### DIFF
--- a/pro/src/app/App/hook/useLogNavigation.ts
+++ b/pro/src/app/App/hook/useLogNavigation.ts
@@ -1,33 +1,38 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useLocation, useParams } from 'react-router'
 
 import { useAnalytics } from '@/app/App/analytics/firebase'
 import { Events } from '@/commons/core/FirebaseEvents/constants'
+import { usePrevious } from '@/commons/hooks/usePrevious'
+import { isEqual } from '@/commons/utils/isEqual'
 import { parseUrlParams } from '@/commons/utils/parseUrlParams'
 
 export const useLogNavigation = (): void => {
   const location = useLocation()
+  const previousLocation = usePrevious(location)
   const params = useParams()
   const { logEvent } = useAnalytics()
-  const [previousPage, setPreviousPage] = useState<string>()
 
   useEffect(() => {
-    const urlSearchParams = new URLSearchParams(location.search)
-    const queryParams = parseUrlParams(urlSearchParams)
+    if (
+      previousLocation === undefined ||
+      !isEqual(location, previousLocation)
+    ) {
+      const urlSearchParams = new URLSearchParams(location.search)
+      const queryParams = parseUrlParams(urlSearchParams)
 
-    const urlParams = { ...params }
+      const urlParams = { ...params }
 
-    // useParams exposes a * key with the end of the path
-    // when the end was not explicitely specified in the path
-    // we do not want to log it
-    delete urlParams['*']
-    logEvent(Events.PAGE_VIEW, {
-      ...urlParams,
-      ...queryParams,
-      from: previousPage,
-    })
-    setPreviousPage(location.pathname)
+      // useParams exposes a * key with the end of the path
+      // when the end was not explicitely specified in the path
+      // we do not want to log it
+      delete urlParams['*']
 
-    return
-  }, [location, logEvent])
+      logEvent(Events.PAGE_VIEW, {
+        ...urlParams,
+        ...queryParams,
+        from: previousLocation?.pathname,
+      })
+    }
+  }, [location, previousLocation, params, logEvent])
 }

--- a/pro/src/pages/IndividualOffers/IndividualOffers.spec.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffers.spec.tsx
@@ -960,7 +960,10 @@ describe('IndividualOffers', () => {
 
     expect(
       screen.getByRole('link', { name: 'Créer une offre' })
-    ).toHaveAttribute('href', '/offre/individuelle/creation/details')
+    ).toHaveAttribute(
+      'href',
+      '/offre/individuelle/creation/details?from_banner=banner_video'
+    )
   })
 
   it('should have a create offer button that redirects to the offer type selection when the FF WIP_ENABLE_NEW_OFFER_CREATION_FLOW is disabled', async () => {
@@ -968,6 +971,6 @@ describe('IndividualOffers', () => {
 
     expect(
       screen.getByRole('link', { name: 'Créer une offre' })
-    ).toHaveAttribute('href', '/offre/creation')
+    ).toHaveAttribute('href', '/offre/creation?from_banner=banner_video')
   })
 })

--- a/pro/src/pages/IndividualOffers/IndividualOffers.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffers.tsx
@@ -115,6 +115,8 @@ export const IndividualOffers = (): JSX.Element => {
   })
 
   const offers = offersQuery.error ? [] : offersQuery.data || []
+  // This is for tracking purposes, check useLogNavigation for more details.
+  const bannerVideoQueryParam = '?from_banner=banner_video'
 
   return (
     <HeadlineOfferContextProvider>
@@ -132,7 +134,6 @@ export const IndividualOffers = (): JSX.Element => {
                       className={styles['banner-img']}
                       alt=""
                       src={videoBannerPng}
-                      role="presentation"
                     />
                   }
                   cta={
@@ -145,8 +146,8 @@ export const IndividualOffers = (): JSX.Element => {
                               step: INDIVIDUAL_OFFER_WIZARD_STEP_IDS.DETAILS,
                               mode: OFFER_WIZARD_MODE.CREATION,
                               isOnboarding: false,
-                            })
-                          : '/offre/creation'
+                            }) + bannerVideoQueryParam
+                          : `/offre/creation${bannerVideoQueryParam}`
                       }
                     >
                       Créer une offre


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37571)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

- Ajout d'un query param à logger lorsque la création d'offre indiv. est initiée depuis la bannière GTM vidéo.
- Réécriture du useLogNavigation pour corriger les exhaustive deps sur le useEffect.
- Suppression d'un role="presentation" inutile.

