### PR TITLE
Pc 36970 timetable venue openinghours

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/commons/__specs__/getTimetableDefaultOpeningHours.spec.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/commons/__specs__/getTimetableDefaultOpeningHours.spec.ts
@@ -1,0 +1,55 @@
+import type {
+  GetVenueResponseModel,
+  WeekdayOpeningHoursTimespans,
+} from '@/apiClient/v1'
+
+import { getTimetableDefaultOpeningHours } from '../getTimetableDefaultOpeningHours'
+
+const defaultOfferOpeningHours: WeekdayOpeningHoursTimespans = {
+  MONDAY: null,
+  TUESDAY: null,
+  WEDNESDAY: null,
+  THURSDAY: null,
+  FRIDAY: null,
+  SATURDAY: null,
+  SUNDAY: null,
+}
+
+const defaultVenueOpeningHours: GetVenueResponseModel['openingHours'] = {
+  MONDAY: null,
+  TUESDAY: null,
+  WEDNESDAY: null,
+  THURSDAY: null,
+  FRIDAY: null,
+  SATURDAY: null,
+  SUNDAY: null,
+}
+
+describe('getTimetableDefaultOpeningHours', () => {
+  it('should return the offer opening hours if they are not empty', () => {
+    expect(
+      getTimetableDefaultOpeningHours({
+        offerOpeningHours: {
+          ...defaultOfferOpeningHours,
+          MONDAY: [['10:10', '11:11']],
+        },
+        venueOpeningHours: {
+          ...defaultVenueOpeningHours,
+          MONDAY: [['17:12', '19:22']],
+        },
+      })
+    ).toEqual(expect.objectContaining({ MONDAY: [['10:10', '11:11']] }))
+  })
+
+  it('should return the venue opening hours if the offer opening hours are empty', () => {
+    expect(
+      getTimetableDefaultOpeningHours({
+        offerOpeningHours: defaultOfferOpeningHours,
+        venueOpeningHours: {
+          ...defaultVenueOpeningHours,
+          MONDAY: [['17:12', '19:22']],
+        },
+      })
+    ).toEqual(expect.objectContaining({ MONDAY: [['17:12', '19:22']] }))
+  })
+})

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/commons/getTimetableDefaultOpeningHours.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/commons/getTimetableDefaultOpeningHours.ts
@@ -1,0 +1,22 @@
+import type {
+  GetVenueResponseModel,
+  WeekdayOpeningHoursTimespans,
+} from '@/apiClient/v1'
+
+import { areOpeningHoursEmpty } from './areOpeningHoursEmpty'
+
+export function getTimetableDefaultOpeningHours({
+  offerOpeningHours,
+  venueOpeningHours,
+}: {
+  offerOpeningHours?: WeekdayOpeningHoursTimespans | null
+  venueOpeningHours?: GetVenueResponseModel['openingHours']
+}) {
+  const offerOpeningHoursEmpty = areOpeningHoursEmpty(offerOpeningHours)
+
+  const venueOpeningHoursEmpty = areOpeningHoursEmpty(venueOpeningHours)
+
+  return offerOpeningHoursEmpty && !venueOpeningHoursEmpty
+    ? venueOpeningHours
+    : offerOpeningHours
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/commons/getTimetableFormDefaultValues.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/commons/getTimetableFormDefaultValues.ts
@@ -5,25 +5,33 @@ import type {
 } from '@/apiClient/v1'
 
 import { areOpeningHoursEmpty } from './areOpeningHoursEmpty'
+import { getTimetableDefaultOpeningHours } from './getTimetableDefaultOpeningHours'
 import { HasDateEnum, type IndividualOfferTimetableFormValues } from './types'
 
 export function getTimetableFormDefaultValues({
   openingHours,
+  venueOpeningHours,
   stocks,
   offer,
   isOhoFFEnabled,
 }: {
   openingHours?: WeekdayOpeningHoursTimespans | null
+  venueOpeningHours?: WeekdayOpeningHoursTimespans | null
   stocks?: GetOfferStockResponseModel[]
   offer: GetIndividualOfferWithAddressResponseModel
   isOhoFFEnabled: boolean
 }) {
+  const prefilledOpeningHours = getTimetableDefaultOpeningHours({
+    offerOpeningHours: openingHours,
+    venueOpeningHours: venueOpeningHours,
+  })
+
   return {
     timetableType:
       !isOhoFFEnabled || areOpeningHoursEmpty(openingHours)
         ? 'calendar'
         : 'openingHours',
-    openingHours: openingHours,
+    openingHours: prefilledOpeningHours,
     hasStartDate: HasDateEnum.NO, //  TODO : retrieve the openingHours startDate when it exists on the model
     hasEndDate: HasDateEnum.NO, //  TODO : retrieve the openingHours endDate when it exists on the model
     startDate: null, //  TODO : retrieve the openingHours startDate when it exists on the model

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/IndividualOfferTimetableScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/IndividualOfferTimetableScreen.tsx
@@ -7,6 +7,7 @@ import { api } from '@/apiClient/api'
 import {
   type GetIndividualOfferWithAddressResponseModel,
   type GetOfferStockResponseModel,
+  type GetVenueResponseModel,
   SubcategoryIdEnum,
   type WeekdayOpeningHoursTimespans,
 } from '@/apiClient/v1'
@@ -37,6 +38,7 @@ export type IndividualOfferTimetableScreenProps = {
   mode: OFFER_WIZARD_MODE
   openingHours?: WeekdayOpeningHoursTimespans | null
   stocks: GetOfferStockResponseModel[]
+  venue?: GetVenueResponseModel
 }
 
 //  TODO : have this info on the subcategories in the back
@@ -53,6 +55,7 @@ export function IndividualOfferTimetableScreen({
   mode,
   openingHours,
   stocks,
+  venue,
 }: IndividualOfferTimetableScreenProps) {
   const isNewOfferCreationFlowFFEnabled = useActiveFeature(
     'WIP_ENABLE_NEW_OFFER_CREATION_FLOW'
@@ -68,6 +71,7 @@ export function IndividualOfferTimetableScreen({
   const form = useForm<IndividualOfferTimetableFormValues>({
     defaultValues: getTimetableFormDefaultValues({
       openingHours,
+      venueOpeningHours: venue?.openingHours,
       stocks,
       offer,
       isOhoFFEnabled,


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36970)

Pré-remplir les plages horaires de la `venue` dans la nouvelle interface de création d'offre individuelle sur plages horaires.

- Activer les FF `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` & `WIP_ENABLE_OHO`
- Aller sur l'étape Horaire de la création d'offre indiv sur une offre dont la sous-catégorie est isEvent (par ex "Visite")
