### PR TITLE
(BSR)[API] feat: add docker system prune -f before rebuilding the doc…

### DIFF
--- a/infra/pc_scripts/start_backend.sh
+++ b/infra/pc_scripts/start_backend.sh
@@ -15,17 +15,18 @@ function build_backend {
     concat_command
     move
     concat_command
+    if  [[ $SLOW == true ]];then
+        RUN="$RUN docker system prune -f &&"
+    fi
     if  [[ $FAST != true ]];then
-        RUN="$RUN docker compose -f '$ROOT_PATH/docker-compose-backend.yml' build"
+        RUN="$RUN docker system prune -f && docker compose -f '$ROOT_PATH/docker-compose-backend.yml' build"
     fi
 }
 
 function build_proxy_backend {
-    concat_command
-    move
-    concat_command
+    build_backend
     if  [[ $FAST != true ]];then
-        RUN="$RUN docker compose -f '$ROOT_PATH/docker-compose-backend.yml' build --build-arg=\"network_mode=proxy\""
+        RUN="$RUN  --build-arg=\"network_mode=proxy\""
     fi
 }
 

--- a/pc
+++ b/pc
@@ -255,6 +255,7 @@ elif [[ "$CMD" == "start-proxy-backend" ]]; then
 
 # Start API server with database and nginx server (without building the images)
 elif [[ "$CMD" == "up-backend" ]]; then
+  FAST=true
   source "$INFRA_SCRIPTS_PATH"/start_backend.sh
   start_backend
 


### PR DESCRIPTION
…ker compose

Maj de pc pour prune avant la recréation des dockers.

L'ancienne façon de faire (sans prune) reconstruisait les docker utilisant de plus en plus d'espace et docker avait tendance a quand même réutiliser certains artefact ce qui mene a des bugs.

Au passage: je fait aussi une legere factorisation entre start et start-proxy
