### PR TITLE
(PC-33065)[API] feat: add preformatted prices/credits for caledonian …

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
@@ -4,6 +4,7 @@ from pcapi.core import mails
 from pcapi.core.bookings.models import Booking
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.mails.transactional.utils import format_price
 from pcapi.core.offers.utils import offer_app_link
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
@@ -47,6 +48,7 @@ def get_booking_cancellation_by_beneficiary_email_data(
             "IS_EXTERNAL": booking.isExternal,
             "OFFER_NAME": offer.name,
             "OFFER_PRICE": float(booking.total_amount),
+            "FORMATTED_OFFER_PRICE": format_price(booking.total_amount, beneficiary),
             "USER_FIRST_NAME": beneficiary.firstName,
             "CAN_BOOK_AGAIN": can_book_again,
             "OFFER_LINK": offer_app_link(offer),

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
@@ -2,6 +2,7 @@ from pcapi.core import mails
 from pcapi.core.bookings.models import Booking
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.mails.transactional.utils import format_price
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.mailing import get_event_datetime
@@ -13,6 +14,7 @@ def get_booking_cancellation_by_pro_to_beneficiary_email_data(
 ) -> models.TransactionalEmailData:
     stock = booking.stock
     offer = stock.offer
+    beneficiary = booking.user
     if offer.isEvent:
         event_date = get_date_formatted_for_email(get_event_datetime(stock))
         event_hour = get_time_formatted_for_email(get_event_datetime(stock))
@@ -35,6 +37,7 @@ def get_booking_cancellation_by_pro_to_beneficiary_email_data(
             "IS_EXTERNAL": booking.isExternal,
             "OFFER_NAME": offer.name,
             "OFFER_PRICE": booking.total_amount,
+            "FORMATTED_OFFER_PRICE": format_price(booking.total_amount, beneficiary),
             "OFFERER_NAME": offer.venue.managingOfferer.name,
             "REASON": booking.cancellationReason.value if booking.cancellationReason else None,
             "REJECTED": rejected_by_fraud_action,

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -6,6 +6,7 @@ from pcapi.core.categories import subcategories
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.bookings import common as bookings_common
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.mails.transactional.utils import format_price
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.date import utc_datetime_to_department_timezone
@@ -81,6 +82,7 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "EVENT_DATE": formatted_event_beginning_date,
             "EVENT_HOUR": formatted_event_beginning_time,
             "OFFER_PRICE": stock_price,
+            "FORMATTED_OFFER_PRICE": format_price(booking.total_amount, beneficiary),
             "OFFER_PRICE_CATEGORY": booking.priceCategoryLabel,
             "OFFER_TAGS": ",".join([criterion.name for criterion in offer.criteria]),
             "OFFER_TOKEN": bookings_common.get_booking_token(booking),

--- a/api/src/pcapi/core/mails/transactional/users/accepted_as_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/users/accepted_as_beneficiary.py
@@ -4,6 +4,7 @@ from pcapi.core import mails
 from pcapi.core.finance.conf import get_credit_amount_per_age_and_eligibility
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.mails.transactional.utils import format_price
 from pcapi.core.users.eligibility_api import get_pre_decree_or_current_eligibility
 from pcapi.core.users.models import EligibilityType
 from pcapi.core.users.models import User
@@ -20,9 +21,13 @@ def get_accepted_as_beneficiary_email_v3_data(user: User) -> models.Transactiona
     amount_to_display = get_credit_amount_per_age_and_eligibility(user.age, eligibility_to_activate)
     if amount_to_display is None:
         amount_to_display = user.deposit.amount
+    credit = int(amount_to_display)
     return models.TransactionalEmailData(
         template=TransactionalEmail.ACCEPTED_AS_BENEFICIARY_V3.value,
-        params={"CREDIT": int(amount_to_display)},
+        params={
+            "CREDIT": credit,
+            "FORMATTED_CREDIT": format_price(credit, user, replace_free_amount=False),
+        },
     )
 
 

--- a/api/src/pcapi/core/mails/transactional/users/birthday_to_newly_eligible_user.py
+++ b/api/src/pcapi/core/mails/transactional/users/birthday_to_newly_eligible_user.py
@@ -1,17 +1,22 @@
 from pcapi.core import mails
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.mails.transactional.utils import format_price
 from pcapi.core.users import models as users_models
 
 
 def send_birthday_age_18_email_to_newly_eligible_user_v3(user: users_models.User) -> None:
     from pcapi.core.users.api import get_domains_credit
 
-    remaining_amount = get_domains_credit(user)
+    remaining_credit = get_domains_credit(user)
+    remaining_amount = remaining_credit.all.remaining if remaining_credit is not None else None
     data = models.TransactionalEmailData(
         template=TransactionalEmail.BIRTHDAY_AGE_18_TO_NEWLY_ELIGIBLE_USER_V3.value,
         params={
-            "CREDIT": remaining_amount.all.remaining if remaining_amount else None,
+            "CREDIT": remaining_amount,
+            "FORMATTED_CREDIT": format_price(remaining_amount, user, replace_free_amount=False)
+            if remaining_amount
+            else None,
             "DEPOSITS_COUNT": len(user.deposits),
         },
     )

--- a/api/src/pcapi/core/mails/transactional/users/recredit_to_underage_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/users/recredit_to_underage_beneficiary.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from pcapi.core import mails
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.core.mails.transactional.utils import format_price
 from pcapi.core.users import models as users_models
 
 
@@ -11,12 +12,17 @@ def get_recredit_to_underage_beneficiary_email_data(
     recredit_amount: Decimal,
     domains_credit: users_models.DomainsCredit | None,
 ) -> models.TransactionalEmailData:
+    assert domains_credit
+    remaining_credit = domains_credit.all.remaining
+    assert remaining_credit is not None
     return models.TransactionalEmailData(
         template=TransactionalEmail.RECREDIT_TO_UNDERAGE_BENEFICIARY.value,
         params={
             "FIRSTNAME": user.firstName,
             "NEW_CREDIT": recredit_amount,
-            "CREDIT": int(domains_credit.all.remaining),  # type: ignore[union-attr]
+            "FORMATTED_NEW_CREDIT": format_price(recredit_amount, user, replace_free_amount=False),
+            "CREDIT": int(remaining_credit),
+            "FORMATTED_CREDIT": format_price(remaining_credit, user, replace_free_amount=False),
         },
     )
 

--- a/api/src/pcapi/core/mails/transactional/utils.py
+++ b/api/src/pcapi/core/mails/transactional/utils.py
@@ -8,9 +8,10 @@ from pcapi.core.users import models as users_models
 def format_price(
     amount_in_euros: int | float | Decimal,
     target: users_models.User | offerers_models.Offerer | offerers_models.Venue | None,
+    replace_free_amount: bool = True,
 ) -> str:
     # format for transactional emails
-    if not amount_in_euros:
+    if not amount_in_euros and replace_free_amount:
         return "Gratuit"
 
     if target and target.is_caledonian:

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_test.py
@@ -73,6 +73,7 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
             "IS_FREE_OFFER": False,
             "OFFER_NAME": "Test thing name",
             "OFFER_PRICE": 10.20,
+            "FORMATTED_OFFER_PRICE": "10,20 €",
             "USER_FIRST_NAME": "Fabien",
             "OFFER_LINK": "https://webapp-v2.example.com/offre/123456",
         }
@@ -103,6 +104,7 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
             "IS_FREE_OFFER": False,
             "OFFER_NAME": "Test event name",
             "OFFER_PRICE": 10.20,
+            "FORMATTED_OFFER_PRICE": "10,20 €",
             "USER_FIRST_NAME": "Fabien",
             "OFFER_LINK": "https://webapp-v2.example.com/offre/123456",
         }
@@ -126,3 +128,15 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
 
         # Then
         assert email_data.params["OFFER_PRICE"] == 20.00
+        assert email_data.params["FORMATTED_OFFER_PRICE"] == "20 €"
+
+    def test_should_return_the_formatted_price_in_xpf(self):
+        # Given
+        booking = booking_factories.CancelledBookingFactory(quantity=2, stock__price=10, user__postalCode="98818")
+
+        # When
+        email_data = get_booking_cancellation_by_beneficiary_email_data(booking)
+
+        # Then
+        assert email_data.params["OFFER_PRICE"] == 20.00
+        assert email_data.params["FORMATTED_OFFER_PRICE"] == "2385 F"

--- a/api/tests/core/mails/transactional/users/accepted_as_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/users/accepted_as_beneficiary_test.py
@@ -18,4 +18,15 @@ class GetAcceptedAsBeneficiaryEmailSendinblueTest:
 
         # Then
         assert email.template == TransactionalEmail.ACCEPTED_AS_BENEFICIARY_V3.value
-        assert email.params == {"CREDIT": 150}
+        assert email.params == {"CREDIT": 150, "FORMATTED_CREDIT": "150 €"}
+
+    def test_return_correct_email_metadata_for_caledonian_user(self):
+        # Given
+        user = users_factories.BeneficiaryFactory(deposit__amount=42, postalCode="98818")
+
+        # When
+        email = get_accepted_as_beneficiary_email_v3_data(user)
+
+        # Then
+        assert email.template == TransactionalEmail.ACCEPTED_AS_BENEFICIARY_V3.value
+        assert email.params == {"CREDIT": 150, "FORMATTED_CREDIT": "17900 F"}

--- a/api/tests/core/mails/transactional/users/birthday_to_newly_eligible_user_test.py
+++ b/api/tests/core/mails/transactional/users/birthday_to_newly_eligible_user_test.py
@@ -33,7 +33,7 @@ class SendinblueSendNewlyEligibleUserEmailTest:
         send_birthday_age_18_email_to_newly_eligible_user_v3(user)
 
         assert len(mails_testing.outbox) == 1
-        assert mails_testing.outbox[0]["params"] == {"CREDIT": None, "DEPOSITS_COUNT": 0}
+        assert mails_testing.outbox[0]["params"] == {"FORMATTED_CREDIT": None, "CREDIT": None, "DEPOSITS_COUNT": 0}
         assert (
             mails_testing.outbox[0]["template"]
             == TransactionalEmail.BIRTHDAY_AGE_18_TO_NEWLY_ELIGIBLE_USER_V3.value.__dict__


### PR DESCRIPTION
Add the following parameters to notification and mail templates:

Mails:
 - `BOOKING_CANCELLATION_BY_PRO_TO_BENEFICIARY`:  `FORMATTED_OFFER_PRICE`
 - `BOOKING_CANCELLATION_BY_BENEFICIARY`:  `FORMATTED_OFFER_PRICE`
 - `BOOKING_CONFIRMATION_BY_BENEFICIARY`  `FORMATTED_OFFER_PRICE`
 - `ACCEPTED_AS_BENEFICIARY_V3`:  `FORMATTED_CREDIT`
 - `BIRTHDAY_AGE_18_TO_NEWLY_ELIGIBLE_USER_V3`:  `FORMATTED_CREDIT`
 - `RECREDIT`:  `FORMATTED_NEW_CREDIT`, `FORMATTED_CREDIT`
 - `RECREDIT_TO_UNDERAGE_BENEFICIARY`:  `FORMATTED_NEW_CREDIT`, `FORMATTED_CREDIT`


Notifications:
 - `BatchEvent.RECREDITED_ACCOUNT`:  `formatted_deposit_amount`
 - `BatchEvent.RECREDIT_ACCOUNT_CANCELLATION`:  `formatted_credit`, `formatted_offer_price`

