### PR TITLE
(PC-37632)[PRO] fix: add missing url to display media page in the context of onboarding indiv. offer creation

### DIFF
--- a/pro/src/app/AppRouter/subroutesIndividualOfferWizardMap.tsx
+++ b/pro/src/app/AppRouter/subroutesIndividualOfferWizardMap.tsx
@@ -202,6 +202,14 @@ export const routesOnboardingIndividualOfferWizard: RouteConfig[] = [
   },
   {
     lazy: () =>
+      import(
+        '@/pages/IndividualOffer/IndividualOfferMedia/IndividualOfferMedia'
+      ),
+    path: '/onboarding/offre/individuelle/:offerId/creation/media',
+    title: 'Image et vidéo - Créer une offre individuelle - Onboarding',
+  },
+  {
+    lazy: () =>
       import('@/pages/IndividualOfferWizard/PriceCategories/PriceCategories'),
     path: '/onboarding/offre/individuelle/:offerId/creation/tarifs',
     featureName: 'WIP_ENABLE_PRO_DIDACTIC_ONBOARDING',


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37632)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

- Déclare une url manquante pour afficher la page media / "Image & Vidéo", étape du process de création d'offre indiv. dans un contexte d'onboarding.
