### PR TITLE
(PC-37599)[API] feat: check event for no_ticket booking v2 route

### DIFF
--- a/api/src/pcapi/routes/native/v2/serialization/bookings.py
+++ b/api/src/pcapi/routes/native/v2/serialization/bookings.py
@@ -201,7 +201,7 @@ class BookingResponseGetterDict(GetterDict):
             delay=offer.withdrawalDelay,
         )
 
-        if offer.withdrawalType == WithdrawalTypeEnum.NO_TICKET:
+        if offer.withdrawalType == WithdrawalTypeEnum.NO_TICKET and offer.isEvent:
             return TicketResponse(
                 activation_code=None,
                 external_booking=None,

--- a/api/tests/routes/native/v2/bookings_test.py
+++ b/api/tests/routes/native/v2/bookings_test.py
@@ -434,6 +434,25 @@ class GetBookingTicketTest:
         ticket = response.json["ongoingBookings"][0]["ticket"]
         assert ticket["display"] == "no_ticket"
 
+    def test_get_booking_not_event_no_ticket(self, client):
+        user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
+        booking = booking_factories.BookingFactory(
+            user=user,
+            stock__offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
+            stock__offer__withdrawalType=offer_models.WithdrawalTypeEnum.NO_TICKET,
+        )
+
+        with assert_num_queries(2):  # user + booking
+            response = client.with_token(self.identifier).get("/native/v2/bookings")
+            assert response.status_code == 200
+
+        ticket = response.json["ongoingBookings"][0]["ticket"]
+        assert ticket["token"] == {
+            "data": booking.token,
+        }
+        assert ticket["voucher"] == {"data": f"PASSCULTURE:v3;TOKEN:{booking.token}"}
+        assert ticket["display"] == "voucher"
+
     @pytest.mark.parametrize(
         "withdrawal_delay,delta,display",
         [


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37599)

## Rationale
Some offers in production are not events but still have a withdrawalType at "no_ticket". Rendering of booking ticket is broken in native app due to this mismatch.
Add a protection in the bookings V2 serializer to prevent non event offers to fall in no_ticket case.

- [ ] Travail pair testé en environnement de preview
