### PR TITLE
(BSR)[PRO] fix: Click the right edit button in summary page during in…

### DIFF
--- a/pro/cypress/e2e/oaIndividualOffer.cy.ts
+++ b/pro/cypress/e2e/oaIndividualOffer.cy.ts
@@ -124,7 +124,7 @@ describe('Create individual offers with OA', () => {
     cy.findByText('Informations pratiques').click()
     cy.url().should('contain', '/pratiques')
     cy.contains('Adresse : 1 boulevard Poissonnière 75002 Paris')
-    cy.findByText('Modifier').click()
+    cy.findAllByText('Modifier').eq(1).click()
     cy.url().should('contain', '/edition/pratiques')
 
     cy.stepLog({ message: 'I update the OA' })
@@ -257,7 +257,7 @@ describe('Create individual offers with OA', () => {
     cy.findByText('Informations pratiques').click()
     cy.url().should('contain', '/pratiques')
     cy.contains('Adresse : 1 boulevard Poissonnière 75002 Paris')
-    cy.findByText('Modifier').click()
+    cy.findAllByText('Modifier').eq(1).click()
     cy.url().should('contain', '/edition/pratiques')
 
     cy.stepLog({ message: 'I update the OA' })


### PR DESCRIPTION
…dividual offer e2e test.

## 🎯 Related Ticket or 🔧 Changes Made
BSR

Depuis qu'on a activé le FF `WIP_REFACTO_FUTURE_OFFER` par défaut ([cf ce commit](https://github.com/pass-culture/pass-culture-main/commit/d5246c22d550cad33eb413a4536bac80b9b35c22)), la page de récap de l'offre indiv a 2 boutons "Modifier" (alors qu'il y en avait un seul avant). Le test `oaIndividualOffer` ne sait pas sur lequel cliquer si on lui dit pas explicitement.