### PR TITLE
(PC-37608)[BO] feat: Update action history info for regularisation wh…

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/history/actions.html
@@ -42,9 +42,7 @@
             {% elif action.actionType.name == "VENUE_REGULARIZATION" %}
               {% set origin_venue_id = action.extraData.get('origin_venue_id') %}
               {% set destination_venue_id = action.extraData.get('destination_venue_id') %}
-              {% if origin_venue_id %}
-                Transfert des éléments du partenaire culturel {{ origin_venue_id }}.
-              {% elif destination_venue_id %}
+              {% if destination_venue_id %}
                 Tous les éléments ont été transférés vers le partenaire culturel
                 <a href="{{ url_for('backoffice_web.venue.get', venue_id=destination_venue_id) }}"
                    class="link-primary">{{ destination_venue_id }}</a>

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -2584,10 +2584,7 @@ class GetVenueHistoryTest(GetEndpointHelper):
         assert len(rows) == 1
 
         assert rows[0]["Type"] == "Régularisation des partenaires culturels"
-        assert (
-            rows[0]["Commentaire"]
-            == f"Transfert des éléments du partenaire culturel {venue.id}. Informations modifiées : Permanent : ajout de : Oui"
-        )
+        assert rows[0]["Commentaire"] == "Informations modifiées : Permanent : ajout de : Oui"
 
     def test_venue_history_without_fraud_permission(self, client, read_only_bo_user):
         venue = offerers_factories.VenueFactory()


### PR DESCRIPTION
…en destination venue is set to permanent

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37608)

Tout petit nettoyage. Les action history venant de la régul spécifiquement pour indiquer un passage de la venue de destination en permanent affichaient un message pas très compréhensible. Ce message est supprimé.

- [x] Travail pair testé en environnement de preview
