### PR TITLE
(PC-36377)[API] feat: update Offer.isEvent's definition

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -126,6 +126,24 @@ def get_individual_bookings(user: users_models.User) -> list[models.Booking]:
                     offers_models.Offer._extraData,
                 )
                 .options(
+                    # The booking's stock's offers' stocks are needed to
+                    # figure out whether the offer is an event or not
+                    # (-> the offer has at least one timestamped stock)
+                    sa_orm.selectinload(offers_models.Offer.stocks)
+                    .load_only(
+                        offers_models.Stock.id,
+                        offers_models.Stock.beginningDatetime,
+                        offers_models.Stock.price,
+                        offers_models.Stock.features,
+                        offers_models.Stock.offerId,
+                    )
+                    # TODO(jbaudet): why is this joinedload needed?
+                    # Which fields could be loaded and which can be
+                    # ignored? I still have no clue. Feel free to
+                    # fix this, I gave up.
+                    .joinedload(offers_models.Stock.offer)
+                )
+                .options(
                     sa_orm.joinedload(offers_models.Offer.product)
                     .load_only(
                         offers_models.Product.id,

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -1106,10 +1106,10 @@ def find_individual_bookings_event_happening_tomorrow_query() -> list[models.Boo
         .join(offers_models.Offer.venue)
         .outerjoin(models.Booking.activationCode)
         .outerjoin(offers_models.Offer.criteria)
+        .filter(offers_models.Offer.hasEventSubcategory)
         .filter(
             offers_models.Stock.beginningDatetime >= tomorrow_min, offers_models.Stock.beginningDatetime <= tomorrow_max
         )
-        .filter(offers_models.Offer.isEvent)
         .filter(sa.not_(offers_models.Offer.isDigital))
         .filter(models.Booking.status != models.BookingStatus.CANCELLED)
         .options(sa_orm.contains_eager(models.Booking.user))

--- a/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
+++ b/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
@@ -89,9 +89,11 @@ def _get_online_bookings_happening_soon() -> sa_orm.query.Query:
             booking_models.Booking.status == booking_models.BookingStatus.CONFIRMED,
             Stock.beginningDatetime >= in_30_minutes,
             Stock.beginningDatetime < in_1_hour,
-            Offer.isEvent,
             Offer.isDigital,
         )
+        # event -> has event subcategory and a timestamped stock
+        .filter(Offer.hasEventSubcategory)
+        .filter(Stock.beginningDatetime != None)
     )
 
     return bookings_query

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -225,7 +225,6 @@ def _get_future_provider_events_requiring_a_ticketing_system_query(
     # Events linked to the provider & requiring a ticketing system
     events_query = events_query.filter(
         offers_models.Offer.lastProvider == provider,
-        offers_models.Offer.isEvent,
         offers_models.Offer.withdrawalType == offers_models.WithdrawalTypeEnum.IN_APP,
     )
 
@@ -233,6 +232,9 @@ def _get_future_provider_events_requiring_a_ticketing_system_query(
     events_query = events_query.filter(
         offers_models.Stock.beginningDatetime >= datetime.datetime.utcnow(),
     )
+
+    # event -> has event subcategory and a timestamped stock (already checked)
+    events_query = events_query.filter(offers_models.Offer.hasEventSubcategory)
 
     return events_query
 

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -518,7 +518,7 @@ def _cancel_bookings_of_user_on_requested_account_suspension(
         bookings_query = (
             bookings_query.join(bookings_models.Booking.stock)
             .join(offers_models.Stock.offer)
-            .filter(sa.func.not_(offers_models.Offer.isEvent))
+            .filter(sa.not_(offers_models.Offer.hasEventSubcategory))
         )
     else:
         return 0

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -83,6 +83,9 @@ class FeatureToggle(enum.Enum):
     ENABLE_NATIVE_CULTURAL_SURVEY = (
         "Active le Questionnaire des pratiques initiales natif (non TypeForm) sur l'app native et décli web"
     )
+    WIP_NEW_OFFER_IS_EVENT_DEFINITION = (
+        "Active la nouvelle définition de Offer.isEvent (qui colle davantage à la réalité)"
+    )
     ENABLE_OFFERS_AUTO_CLEANUP = "Active la suppression automatique des offres obsolètes"
     ENABLE_PHONE_VALIDATION = "Active la validation du numéro de téléphone"
     ENABLE_PRO_ACCOUNT_CREATION = "Permettre l'inscription des comptes professionels"

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -191,7 +191,9 @@ def get_event(event_id: int) -> events_serializers.EventOfferResponse:
     """
     offer: offers_models.Offer | None = (
         utils.retrieve_offer_relations_query(utils.retrieve_offer_query(event_id))
-        .filter(offers_models.Offer.isEvent)
+        # event -> has event subcategory and a timestamped stock
+        .filter(offers_models.Offer.hasEventSubcategory)
+        .filter(offers_models.Stock.beginningDatetime != None)
         .one_or_none()
     )
     if not offer:
@@ -260,7 +262,9 @@ def edit_event(event_id: int, body: events_serializers.EventOfferEdition) -> eve
     """
     offer: offers_models.Offer | None = (
         utils.retrieve_offer_relations_query(utils.retrieve_offer_query(event_id))
-        .filter(offers_models.Offer.isEvent)
+        # event -> has event subcategory and a timestamped stock
+        .filter(offers_models.Offer.hasEventSubcategory)
+        .filter(offers_models.Stock.beginningDatetime != None)
         .one_or_none()
     )
 
@@ -352,7 +356,13 @@ def post_event_price_categories(
 
     Batch create price categories for given event.
     """
-    offer = utils.retrieve_offer_query(event_id).filter(offers_models.Offer.isEvent).one_or_none()
+    offer = (
+        utils.retrieve_offer_query(event_id)
+        # event -> has event subcategory and a timestamped stock
+        .filter(offers_models.Offer.hasEventSubcategory)
+        .filter(offers_models.Stock.beginningDatetime != None)
+        .one_or_none()
+    )
     if not offer:
         raise api_errors.ApiErrors({"event_id": ["The event could not be found"]}, status_code=404)
 
@@ -419,7 +429,13 @@ def get_event_price_categories(
 
     Get existing price categories for given event
     """
-    offer = utils.retrieve_offer_query(event_id).filter(offers_models.Offer.isEvent).one_or_none()
+    offer = (
+        utils.retrieve_offer_query(event_id)
+        # event -> has event subcategory and a timestamped stock
+        .filter(offers_models.Offer.hasEventSubcategory)
+        .filter(offers_models.Stock.beginningDatetime != None)
+        .one_or_none()
+    )
 
     if not offer:
         raise api_errors.ApiErrors({"event_id": ["The event could not be found"]}, status_code=404)
@@ -525,7 +541,9 @@ def post_event_stocks(
     offer = (
         utils.retrieve_offer_query(event_id)
         .options(sa_orm.joinedload(offers_models.Offer.priceCategories))
-        .filter(offers_models.Offer.isEvent)
+        # event -> has event subcategory and a timestamped stock
+        .filter(offers_models.Offer.hasEventSubcategory)
+        .filter(offers_models.Stock.beginningDatetime != None)
         .one_or_none()
     )
 
@@ -603,7 +621,13 @@ def get_event_stocks(
 
     Return all stocks for given event. Results are paginated (by default there are `50` date per page).
     """
-    offer = utils.retrieve_offer_query(event_id).filter(offers_models.Offer.isEvent).one_or_none()
+    offer = (
+        utils.retrieve_offer_query(event_id)
+        # event -> has event subcategory and a timestamped stock
+        .filter(offers_models.Offer.hasEventSubcategory)
+        .filter(offers_models.Stock.beginningDatetime != None)
+        .one_or_none()
+    )
     if not offer:
         raise api_errors.ApiErrors({"event_id": ["The event could not be found"]}, status_code=404)
 
@@ -665,7 +689,9 @@ def delete_event_stock(event_id: int, stock_id: int) -> None:
     """
     offer = (
         utils.retrieve_offer_query(event_id)
-        .filter(offers_models.Offer.isEvent)
+        # event -> has event subcategory and a timestamped stock
+        .filter(offers_models.Offer.hasEventSubcategory)
+        .filter(offers_models.Stock.beginningDatetime != None)
         .options(sa_orm.joinedload(offers_models.Offer.stocks))
         .one_or_none()
     )
@@ -709,7 +735,9 @@ def patch_event_stock(
     """
     offer: offers_models.Offer | None = (
         utils.retrieve_offer_relations_query(utils.retrieve_offer_query(event_id))
-        .filter(offers_models.Offer.isEvent)
+        # event -> has event subcategory and a timestamped stock
+        .filter(offers_models.Offer.hasEventSubcategory)
+        .filter(offers_models.Stock.beginningDatetime != None)
         .one_or_none()
     )
     if not offer:

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -374,7 +374,7 @@ def get_product(product_id: int) -> serialization.ProductOfferResponse:
     """
     offer: offers_models.Offer | None = (
         utils.retrieve_offer_relations_query(utils.retrieve_offer_query(product_id))
-        .filter(sa.not_(offers_models.Offer.isEvent))
+        .filter(sa.not_(offers_models.Offer.hasEventSubcategory))
         .one_or_none()
     )
     if not offer:
@@ -409,7 +409,7 @@ def get_product_by_ean(
     utils.check_venue_id_is_tied_to_api_key(query.venueId)
     offers: list[offers_models.Offer] | None = (
         utils.retrieve_offer_relations_query(_retrieve_offer_by_eans_query(query.eans, query.venueId))  # type: ignore[arg-type]
-        .filter(sa.not_(offers_models.Offer.isEvent))
+        .filter(sa.not_(offers_models.Offer.hasEventSubcategory))
         .all()
     )
 
@@ -582,7 +582,7 @@ def edit_product(body: products_serializers.ProductOfferEdition) -> serializatio
     query = utils.retrieve_offer_query(body.offer_id)
     query = utils.retrieve_offer_relations_query(query)
     query = utils.load_venue_and_provider_query(query)
-    query = query.filter(sa.not_(offers_models.Offer.isEvent))
+    query = query.filter(sa.not_(offers_models.Offer.hasEventSubcategory))
 
     offer = query.one_or_none()
 

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1579,7 +1579,7 @@ class CancelByOffererTest:
     def test_cancel_all_bookings_from_stock_dont_call_external_api(self, mock_cancel_event_ticket):
         public_api_provider = providers_factories.PublicApiProviderFactory()
         event_offer = offers_factories.EventOfferFactory(lastProvider=public_api_provider)
-        stock = offers_factories.StockFactory(dnBookedQuantity=1, offer=event_offer)
+        stock = offers_factories.EventStockFactory(dnBookedQuantity=1, offer=event_offer)
         booking = bookings_factories.BookingFactory(stock=stock, status=models.BookingStatus.USED)
         bookings_factories.ExternalBookingFactory(bookingId=booking.id)
 
@@ -2269,22 +2269,26 @@ class PopBarcodesFromQueueAndCancelWastedExternalBookingTest:
 
 
 @pytest.mark.parametrize(
-    "is_digital,is_external,subcategory_id,expected",
+    "is_digital,is_external,subcategory,expected",
     (
-        (True, False, subcategories.LIVESTREAM_MUSIQUE.id, False),
-        (True, True, subcategories.LIVESTREAM_MUSIQUE.id, False),
-        (False, False, subcategories.SEANCE_CINE.id, True),
-        (False, True, subcategories.SEANCE_CINE.id, False),
-        (False, False, subcategories.CONCERT.id, False),
-        (False, True, subcategories.CONCERT.id, False),
-        (False, False, subcategories.ATELIER_PRATIQUE_ART.id, False),
-        (False, True, subcategories.ATELIER_PRATIQUE_ART.id, False),
-        (False, False, subcategories.LIVRE_PAPIER.id, True),
+        (True, False, subcategories.LIVESTREAM_MUSIQUE, False),
+        (True, True, subcategories.LIVESTREAM_MUSIQUE, False),
+        (False, False, subcategories.SEANCE_CINE, True),
+        (False, True, subcategories.SEANCE_CINE, False),
+        (False, False, subcategories.CONCERT, False),
+        (False, True, subcategories.CONCERT, False),
+        (False, False, subcategories.ATELIER_PRATIQUE_ART, False),
+        (False, True, subcategories.ATELIER_PRATIQUE_ART, False),
+        (False, False, subcategories.LIVRE_PAPIER, True),
     ),
 )
 @pytest.mark.usefixtures("clean_database")
-def test_voucher_is_displayed(is_digital, is_external, subcategory_id, expected):
-    offer = offers_factories.OfferFactory(subcategoryId=subcategory_id)
+def test_voucher_is_displayed(is_digital, is_external, subcategory, expected):
+    if subcategory.is_event:
+        offer = offers_factories.EventStockFactory(offer__subcategoryId=subcategory.id).offer
+    else:
+        offer = offers_factories.OfferFactory(subcategoryId=subcategory.id)
+
     if is_digital:
         offer.url = "example.com"
 

--- a/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
+++ b/api/tests/core/mails/transactional/bookings/new_booking_to_pro_test.py
@@ -353,6 +353,7 @@ class OffererBookingRecapTest:
         offerers_factories.VenueBankAccountLinkFactory(venue=venue)
         booking = make_booking(stock__offer__venue=venue)
         # Preload available data - calling functions should do that
+        _ = booking.stock.offer.stocks
         _ = booking.stock.offer.venue.offererAddress.address
         _ = booking.user
         # 1 - SELECT venue with bank account
@@ -381,6 +382,7 @@ class OffererBookingRecapTest:
         )
         booking = make_booking(stock__offer__venue=venue)
         # Preload available data - calling functions should do that
+        _ = booking.stock.offer.stocks
         _ = booking.stock.offer.venue.offererAddress.address
         _ = booking.user
         # 1 - SELECT venue with bank account

--- a/api/tests/core/mails/transactional/pro/first_venue_approved_offer_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/first_venue_approved_offer_to_pro_test.py
@@ -72,7 +72,8 @@ class SendinblueSendFirstVenueOfferEmailTest:
 
         # offer
         # venue
-        with assert_num_queries(2):
+        # FF
+        with assert_num_queries(3):
             new_offer_validation_email = get_first_venue_approved_offer_email_data(offer)
 
         assert new_offer_validation_email.template == TransactionalEmail.FIRST_VENUE_APPROVED_OFFER_TO_PRO.value

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -4473,9 +4473,9 @@ class UpdateUsedStockPriceTest:
             api.update_used_stock_price(booking.stock, new_price=booking.stock.price - 1)
 
     def test_update_used_stock_price_should_delete_pricings_on_used_event(self):
-        offer = factories.OfferFactory(subcategoryId=subcategories.CONFERENCE.id)
+        offer = factories.EventOfferFactory(subcategoryId=subcategories.CONFERENCE.id)
         venue = offer.venue
-        stock_to_edit = factories.StockFactory(
+        stock_to_edit = factories.EventStockFactory(
             offer=offer,
             price=decimal.Decimal("123.45"),
         )
@@ -4535,7 +4535,7 @@ class UpdateUsedStockPriceTest:
         assert db.session.query(finance_models.Pricing).filter_by(id=later_pricing_id).count() == 0
 
     def test_update_used_stock_price_should_update_confirmed_events(self):
-        stock_to_edit = factories.StockFactory(
+        stock_to_edit = factories.EventStockFactory(
             offer__subcategoryId=subcategories.CONFERENCE.id,
             price=decimal.Decimal("123.45"),
         )

--- a/api/tests/core/offers/test_offer_metadata.py
+++ b/api/tests/core/offers/test_offer_metadata.py
@@ -111,21 +111,21 @@ class OfferMetadataTest:
 
     class GivenAnEventTest:
         def should_describe_an_event(self):
-            offer = offers_factories.EventOfferFactory()
+            offer = offers_factories.EventStockFactory().offer
 
             metadata = get_metadata_from_offer(offer)
 
             assert metadata["@type"] == "Event"
 
         def should_describe_an_event_for_a_concert(self):
-            offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONCERT.id)
+            offer = offers_factories.EventStockFactory(offer__subcategoryId=subcategories.CONCERT.id).offer
 
             metadata = get_metadata_from_offer(offer)
 
             assert metadata["@type"] == "Event"
 
         def should_describe_an_event_for_a_festival(self):
-            offer = offers_factories.OfferFactory(subcategoryId=subcategories.FESTIVAL_MUSIQUE.id)
+            offer = offers_factories.EventStockFactory(offer__subcategoryId=subcategories.FESTIVAL_MUSIQUE.id).offer
 
             metadata = get_metadata_from_offer(offer)
 
@@ -148,15 +148,15 @@ class OfferMetadataTest:
             assert metadata["startDate"] == "2023-05-03T12:39"
 
         def should_have_a_location_when_event_is_physical(self):
-            offer = offers_factories.EventOfferFactory(
-                venue__name="Le Poney qui tousse",
-                venue__offererAddress__address__street="Rue du Poney qui tousse",
-                venue__offererAddress__address__postalCode="75001",
-                venue__offererAddress__address__city="Boulgourville",
-                venue__offererAddress__address__latitude="47.097456",
-                venue__offererAddress__address__longitude="-1.270040",
-                url=None,
-            )
+            offer = offers_factories.EventStockFactory(
+                offer__venue__name="Le Poney qui tousse",
+                offer__venue__offererAddress__address__street="Rue du Poney qui tousse",
+                offer__venue__offererAddress__address__postalCode="75001",
+                offer__venue__offererAddress__address__city="Boulgourville",
+                offer__venue__offererAddress__address__latitude="47.097456",
+                offer__venue__offererAddress__address__longitude="-1.270040",
+                offer__url=None,
+            ).offer
 
             metadata = get_metadata_from_offer(offer)
 
@@ -177,37 +177,34 @@ class OfferMetadataTest:
             }
 
         def should_not_have_a_location_when_event_is_digital(self):
-            offer = offers_factories.EventOfferFactory(url="https://digital-offer.com")
+            offer = offers_factories.EventStockFactory(offer__url="https://digital-offer.com").offer
 
             metadata = get_metadata_from_offer(offer)
 
             assert "location" not in metadata
 
         def should_have_an_url(self):
-            offer = offers_factories.EventOfferFactory(id=72180399)
-
-            offers_factories.StockFactory(offer=offer)
-
+            offer = offers_factories.EventStockFactory(offer__id=72180399).offer
             metadata = get_metadata_from_offer(offer)
 
             assert metadata["offers"]["url"] == "https://webapp-v2.example.com/offre/72180399"
 
         def should_have_online_event_attendance_mode(self):
-            offer = offers_factories.EventOfferFactory(url="https://passculture.app/offre/72180399")
+            offer = offers_factories.EventStockFactory(offer__url="https://passculture.app/offre/72180399").offer
 
             metadata = get_metadata_from_offer(offer)
 
             assert metadata["eventAttendanceMode"] == "OnlineEventAttendanceMode"
 
         def should_have_offline_event_attendance_mode(self):
-            offer = offers_factories.EventOfferFactory()
+            offer = offers_factories.EventStockFactory().offer
 
             metadata = get_metadata_from_offer(offer)
 
             assert metadata["eventAttendanceMode"] == "OfflineEventAttendanceMode"
 
         def should_have_valid_from_date(self):
-            offer = offers_factories.EventOfferFactory(extraData={"releaseDate": "2000-01-01"})
+            offer = offers_factories.EventStockFactory(offer__extraData={"releaseDate": "2000-01-01"}).offer
 
             metadata = get_metadata_from_offer(offer)
 
@@ -215,7 +212,7 @@ class OfferMetadataTest:
 
         def should_be_sold_out_when_offer_has_no_active_stocks(self):
             offer = offers_factories.EventOfferFactory()
-            offers_factories.StockFactory(offer=offer, isSoftDeleted=True)
+            offers_factories.EventStockFactory(offer=offer, isSoftDeleted=True)
 
             metadata = get_metadata_from_offer(offer)
 
@@ -240,7 +237,7 @@ class OfferMetadataTest:
             offer_address = offerers_factories.OffererAddressFactory(
                 address=address, label="Le grand poney qui respire"
             )
-            offer = offers_factories.EventOfferFactory(venue=venue, offererAddress=offer_address)
+            offer = offers_factories.EventStockFactory(offer__venue=venue, offer__offererAddress=offer_address).offer
 
             metadata = get_metadata_from_offer(offer)
 

--- a/api/tests/core/providers/test_api.py
+++ b/api/tests/core/providers/test_api.py
@@ -205,9 +205,11 @@ class UpdateProviderExternalUrlsTest:
         previous_cancel_url = provider.cancelExternalUrl
         venue = offerers_factories.VenueFactory()
         providers_factories.VenueProviderFactory(provider=provider, venue=venue)
-        event_offer = offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
+        event_offer = offers_factories.EventStockFactory(
+            offer__lastProvider=provider,
+            offer__venue=venue,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+        ).offer
         offers_factories.StockFactory(offer=event_offer)
 
         with pytest.raises(exceptions.ProviderException) as e:
@@ -355,12 +357,11 @@ class UpdateVenueProviderExternalUrlsTest:
         )
         previous_booking_url = venue_provider_external_urls.bookingExternalUrl
         previous_cancel_url = venue_provider_external_urls.cancelExternalUrl
-        event_offer = offers_factories.EventOfferFactory(
-            lastProvider=provider_without_ticketing_urls,
-            venue=venue,
-            withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
-        )
-        offers_factories.StockFactory(offer=event_offer)
+        event_offer = offers_factories.EventStockFactory(
+            offer__lastProvider=provider_without_ticketing_urls,
+            offer__venue=venue,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+        ).offer
 
         with pytest.raises(exceptions.ProviderException) as e:
             api.update_venue_provider_external_urls(venue_provider, booking_external_url=None, cancel_external_url=None)

--- a/api/tests/core/providers/test_repository.py
+++ b/api/tests/core/providers/test_repository.py
@@ -89,19 +89,18 @@ class GetFutureEventsRequiringTicketingSystemTest:
         venue = offerers_factories.VenueFactory()
         factories.VenueProviderFactory(provider=provider, venue=venue)
 
-        expected_event_offer = offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
-        # event not linked to ticketing
-        offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL
-        )
-        # event with no stock
-        offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
+        expected_event_offer = offers_factories.EventStockFactory(
+            offer__lastProvider=provider,
+            offer__venue=venue,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+        ).offer
 
-        offers_factories.StockFactory(offer=expected_event_offer)
+        # event not linked to ticketing
+        offers_factories.EventStockFactory(
+            offer__lastProvider=provider,
+            offer__venue=venue,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
+        )
 
         future_events = repository.get_future_events_requiring_ticketing_system(provider)
 
@@ -144,33 +143,33 @@ class GetFutureEventsRequiringTicketingSystemTest:
         venue_2 = offerers_factories.VenueFactory()
         factories.VenueProviderFactory(provider=provider, venue=venue)
 
-        expected_event_offer = offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
+        expected_event_offer = offers_factories.EventStockFactory(
+            offer__lastProvider=provider,
+            offer__venue=venue,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+        ).offer
 
         # event with old stock
-        event_with_old_sock = offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
+        one_day_ago = datetime.utcnow() - timedelta(days=1)
+        offers_factories.EventStockFactory(
+            offer__lastProvider=provider,
+            offer__venue=venue,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+            beginningDatetime=one_day_ago,
+        ).offer
         # event not linked to ticketing
-        not_linked_to_ticketing_event_offer = offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL
-        )
-        # event with no stock
-        offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
+        offers_factories.EventStockFactory(
+            offer__lastProvider=provider,
+            offer__venue=venue,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
+        ).offer
 
         # event linked to other venue
-        linked_to_other_venue_offer = offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue_2, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
-
-        offers_factories.StockFactory(offer=expected_event_offer)
-        offers_factories.StockFactory(offer=not_linked_to_ticketing_event_offer)
-        offers_factories.StockFactory(offer=linked_to_other_venue_offer)
-        one_day_ago = datetime.utcnow() - timedelta(days=1)
-        offers_factories.StockFactory(offer=event_with_old_sock, beginningDatetime=one_day_ago)
+        offers_factories.EventStockFactory(
+            offer__lastProvider=provider,
+            offer__venue=venue_2,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+        ).offer
 
         future_events = repository.get_future_events_requiring_ticketing_system(provider, venue)
 

--- a/api/tests/core/providers/test_validation.py
+++ b/api/tests/core/providers/test_validation.py
@@ -29,10 +29,11 @@ class CheckTicketingUrlsCanBeUnsetTest:
         provider = factories.PublicApiProviderFactory()
         venue = offerers_factories.VenueFactory()
         factories.VenueProviderFactory(provider=provider, venue=venue)
-        event_offer = offers_factories.EventOfferFactory(
-            lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
-        )
-        offers_factories.StockFactory(offer=event_offer)
+        event_offer = offers_factories.EventStockFactory(
+            offer__lastProvider=provider,
+            offer__venue=venue,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+        ).offer
 
         with pytest.raises(exceptions.ProviderException) as e:
             validation.check_ticketing_urls_can_be_unset(provider)
@@ -57,12 +58,11 @@ class CheckTicketingUrlsCanBeUnsetTest:
         provider_without_ticketing_urls = factories.ProviderFactory()
         venue = offerers_factories.VenueFactory()
         factories.VenueProviderFactory(provider=provider_without_ticketing_urls, venue=venue)
-        event_offer = offers_factories.EventOfferFactory(
-            lastProvider=provider_without_ticketing_urls,
-            venue=venue,
-            withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
-        )
-        offers_factories.StockFactory(offer=event_offer)
+        event_offer = offers_factories.EventStockFactory(
+            offer__lastProvider=provider_without_ticketing_urls,
+            offer__venue=venue,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+        ).offer
 
         with pytest.raises(exceptions.ProviderException) as e:
             validation.check_ticketing_urls_can_be_unset(provider=provider_without_ticketing_urls, venue=venue)

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -204,10 +204,9 @@ class ReindexOfferIdsTest:
             app.redis_client.hset(redis_queues.REDIS_HASHMAP_INDEXED_OFFERS_NAME, offer_id, "")
 
         num_queries = 1  # base query for indexation
-        num_queries += 1  # FF
         num_queries += 1  # last30DaysBookings
-
         num_queries += 1  # venues from offers
+
         with assert_num_queries(num_queries):
             with assert_no_duplicated_queries():
                 search.reindex_offer_ids(offer_ids)

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -150,7 +150,7 @@ class CancelBeneficiaryBookingsOnSuspendAccountTest:
         in_the_past = datetime.datetime.utcnow() - relativedelta(seconds=1)
         further_in_the_past = datetime.datetime.utcnow() - relativedelta(days=3)
         booking_event = bookings_factories.BookingFactory(
-            stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
+            stock=offers_factories.EventStockFactory(offer__subcategoryId=subcategories.SEANCE_CINE.id),
             status=BookingStatus.CONFIRMED,
             dateCreated=further_in_the_past,
             cancellationLimitDate=in_the_past,

--- a/api/tests/routes/backoffice/users_test.py
+++ b/api/tests/routes/backoffice/users_test.py
@@ -8,6 +8,7 @@ from pcapi.core.bookings import models as bookings_models
 from pcapi.core.categories import subcategories
 from pcapi.core.history import models as history_models
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offers import factories as offers_factories
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import constants as users_constants
@@ -114,9 +115,9 @@ class SuspendUserTest(PostEndpointHelper):
         confirmed_booking = bookings_factories.BookingFactory(user=user)
         used_booking = bookings_factories.UsedBookingFactory(user=user)
         reimbursed_booking = bookings_factories.ReimbursedBookingFactory(user=user)
+
         event_booking = bookings_factories.BookingFactory(
-            user=user,
-            stock__offer__subcategoryId=subcategories.CINE_PLEIN_AIR.id,
+            user=user, stock=offers_factories.EventStockFactory(offer__subcategoryId=subcategories.CINE_PLEIN_AIR.id)
         )
 
         response = self.post_to_endpoint(

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -759,6 +759,11 @@ class PostBookingTest:
 class GetBookingsTest:
     identifier = "pascal.ture@example.com"
 
+    nb_queries = 1  # select user
+    nb_queries += 1  # select booking
+    nb_queries += 1  # select booking's stock's offer with its stocks
+    # -> is the offer an event?
+
     def test_get_bookings(self, client):
         OFFER_URL = "https://demo.pass/some/path?token={token}&email={email}&offerId={offerId}"
         user = users_factories.BeneficiaryFactory(email=self.identifier, age=18)
@@ -822,8 +827,7 @@ class GetBookingsTest:
         )
 
         client = client.with_token(self.identifier)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(self.nb_queries):
             response = client.get("/native/v1/bookings")
 
         assert response.status_code == 200
@@ -928,8 +932,7 @@ class GetBookingsTest:
         )
 
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(self.nb_queries):
             response = client.get("/native/v1/bookings")
 
         assert response.status_code == 200
@@ -944,8 +947,7 @@ class GetBookingsTest:
         ReactionFactory(user=ongoing_booking.user, offer=stock.offer)
 
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(self.nb_queries):
             response = client.get("/native/v1/bookings")
 
         assert response.status_code == 200
@@ -960,24 +962,22 @@ class GetBookingsTest:
         )
         ReactionFactory(reactionType=ReactionTypeEnum.LIKE, user=ongoing_booking.user, product=stock.offer.product)
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(3):
-            # select user, booking, offer
+        with assert_num_queries(self.nb_queries):
             response = client.get("/native/v1/bookings")
 
         assert response.status_code == 200
         assert response.json["ongoing_bookings"][0]["userReaction"] == "LIKE"
 
     def test_get_bookings_returns_enable_pop_up_reaction(self, client):
-        offer = offers_factories.OfferFactory(
-            subcategoryId=subcategories.SEANCE_CINE.id,
-        )
+        offer = offers_factories.EventStockFactory(
+            offer__subcategoryId=subcategories.SEANCE_CINE.id,
+        ).offer
         booking = booking_factories.UsedBookingFactory(
             stock__offer=offer,
             dateUsed=datetime.utcnow() - timedelta(seconds=60 * 24 * 3600),
         )
         client = client.with_token(booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking, offer
+        with assert_num_queries(self.nb_queries):
             response = client.get("/native/v1/bookings")
 
         assert response.status_code == 200
@@ -991,8 +991,7 @@ class GetBookingsTest:
         )
         booking_factories.BookingFactory(stock=stock, user=ongoing_booking.user, status=BookingStatus.CANCELLED)
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(self.nb_queries):
             response = client.get("/native/v1/bookings")
 
         assert response.status_code == 200
@@ -1017,8 +1016,7 @@ class GetBookingsTest:
         )
 
         client = client.with_token(ongoing_booking.user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(self.nb_queries):
             response = client.get("/native/v1/bookings")
 
         assert response.status_code == 200
@@ -1034,8 +1032,7 @@ class GetBookingsTest:
         )
 
         test_client = client.with_token(user.email)
-        with assert_num_queries(2):
-            # select user, booking
+        with assert_num_queries(self.nb_queries):
             response = test_client.get("/native/v1/bookings")
 
         assert response.status_code == 200
@@ -1052,7 +1049,7 @@ class GetBookingsTest:
             stock__offer__withdrawalDelay=60 * 30,
         )
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(self.nb_queries):
             response = client.with_token(self.identifier).get("/native/v1/bookings")
             assert response.status_code == 200
 
@@ -1076,7 +1073,7 @@ class GetBookingsTest:
         ExternalBookingFactory(booking=booking, barcode="111111111", seat="A_1")
         ExternalBookingFactory(booking=booking, barcode="111111112", seat="A_2")
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(self.nb_queries):
             response = client.with_token(self.identifier).get("/native/v1/bookings")
             assert response.status_code == 200
 
@@ -1098,7 +1095,7 @@ class GetBookingsTest:
         offer = offers_factories.OfferFactory(venue=venue, offererAddress=None)
         booking_factories.BookingFactory(stock__offer=offer, user=user)
 
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(self.nb_queries):
             response = client.with_token(self.identifier).get("/native/v1/bookings")
 
         assert response.status_code == 200
@@ -1110,7 +1107,7 @@ class GetBookingsTest:
         booking_factories.BookingFactory(user=user)
 
         client = client.with_token(user.email)
-        with assert_num_queries(2):  # user + booking
+        with assert_num_queries(self.nb_queries):
             response = client.get("/native/v1/bookings")
 
         assert response.status_code == 200
@@ -1363,7 +1360,10 @@ class ToggleBookingVisibilityTest:
         )
 
         client = client.with_token(self.identifier)
-        with assert_num_queries(2):  # user + booking
+        # 1. select user
+        # 2. select booking
+        # 3. select booking's stock's offer with its stocks (check if offer is an event)
+        with assert_num_queries(3):
             response = client.get("/native/v1/bookings")
             assert response.status_code == 200
 

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -48,6 +48,7 @@ class OffersTest:
     nb_queries = 1  # select offer
     nb_queries += 1  # select stocks
     nb_queries += 1  # select opening hours
+    nb_queries += 1  # select features (including WIP_NEW_OFFER_IS_EVENT_DEFINITION)
     nb_queries += 1  # select mediations
     nb_queries += 1  # select chronicles
 
@@ -359,25 +360,12 @@ class OffersTest:
         offer_id = offer.id
         setattr(features, ff_name, ff_value)
 
-        # 1. select offer
-        # 2. select product with artists
-        # 3. select stocks
-        # 4. select mediations
-        # 5. check cinema venue_provider exists
-        # 6. check offer is from current cinema provider
-        # 7. select active cinema provider
-        # 8. update offer
-        # 9. select chronicles
-        # 10. selecte features
-        # 11. reload offer
-
         nb_queries = self.nb_queries
         nb_queries += 1  # product with artists
         nb_queries += 1  # check cinema venue_provider exists
         nb_queries += 1  # check offer is from current cinema provider
         nb_queries += 1  # select active cinema provider
         nb_queries += 1  # update offer
-        nb_queries += 1  # select features
         nb_queries += 1  # reload offer
         with assert_num_queries(nb_queries):
             with assert_no_duplicated_queries():
@@ -412,7 +400,7 @@ class OffersTest:
         stock = offers_factories.StockWithActivationCodesFactory(activationCodes__expirationDate=datetime(2000, 1, 1))
         offer_id = stock.offer.id
 
-        with assert_num_queries(self.nb_queries + 1):  # activation_code
+        with assert_num_queries(self.nb_queries + 1):  # activation code
             with assert_no_duplicated_queries():
                 response = client.get(f"/native/v1/offer/{offer_id}")
                 assert response.status_code == 200
@@ -485,7 +473,6 @@ class OffersTest:
         nb_queries += 1  # check cinema venue_provider exists
         nb_queries += 1  # select active cinema provider
         nb_queries += 1  # select cinema_provider_pivot
-        nb_queries += 1  # select feature
         nb_queries += 1  # update stock
         with assert_num_queries(nb_queries):
             response = client.get(f"/native/v1/offer/{offer_id}")
@@ -538,7 +525,6 @@ class OffersTest:
         nb_queries += 1  # select EXISTS venue_provider
         nb_queries += 1  # select EXISTS provider
         nb_queries += 1  # select cinema_provider_pivot
-        nb_queries += 1  # select feature
         nb_queries += 1  # select EXISTS provider
         nb_queries += 1  # select boost_cinema_details
         nb_queries += 1  # update stock
@@ -591,7 +577,6 @@ class OffersTest:
         nb_queries += 1  # select EXISTS venue_provider
         nb_queries += 1  # select EXISTS provider
         nb_queries += 1  # select cinema_provider_pivot
-        nb_queries += 1  # select feature
         nb_queries += 1  # select EXISTS provider
         nb_queries += 1  # select cgr_cinema_details
         nb_queries += 1  # update stock
@@ -627,7 +612,6 @@ class OffersTest:
         nb_query += 1  # check cinema venue_provider exists
         nb_query += 1  # select active cinema provider
         nb_query += 1  # update offer
-        nb_query += 1  # select feature
 
         with assert_num_queries(nb_query):
             response = client.get(f"/native/v1/offer/{offer_id}")
@@ -2031,6 +2015,7 @@ class OffersStocksV2Test:
         payload = {"offer_ids": [offer.id]}
 
         nb_queries = 1  # select offer
+        nb_queries += 1  # select WIP_NEW_OFFER_IS_EVENT_DEFINITION FF
         nb_queries += 1  # select stocks
         nb_queries += 1  # select opening hours
         nb_queries += 1  # select mediations

--- a/api/tests/routes/pro/get_booking_by_token_v2_test.py
+++ b/api/tests/routes/pro/get_booking_by_token_v2_test.py
@@ -48,7 +48,7 @@ class Returns200Test:
 
         client = client.with_session_auth(pro.email)
         booking_token = booking.token
-        with testing.assert_num_queries(self.num_queries):
+        with testing.assert_num_queries(self.num_queries + 1):  # select WIP_NEW_OFFER_IS_EVENT_DEFINITION FF
             response = client.get(f"/bookings/token/{booking_token}")
             assert response.status_code == 200
 
@@ -87,7 +87,7 @@ class Returns200Test:
         pro_user = user_offerer.user
 
         client = client.with_session_auth(pro_user.email)
-        with testing.assert_num_queries(self.num_queries):
+        with testing.assert_num_queries(self.num_queries + 1):  # select WIP_NEW_OFFER_IS_EVENT_DEFINITION FF
             response = client.get(f"/bookings/token/{booking_token}")
             assert response.status_code == 200
 

--- a/api/tests/routes/public/individual_offers/v1/events/get_price_categories_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/get_price_categories_test.py
@@ -15,11 +15,12 @@ class PostPriceCategoriesTest(PublicAPIVenueEndpointHelper):
     endpoint_method = "get"
     default_path_params = {"event_id": 1}
 
-    def setup_base_resource(self, venue=None, provider=None) -> offers_models.Offer:
-        return offers_factories.EventOfferFactory(
-            venue=venue or self.setup_venue(),
-            lastProvider=provider,
-        )
+    def setup_base_resource(self, venue=None, provider=None, **kwargs) -> offers_models.Offer:
+        return offers_factories.EventStockFactory(
+            offer__venue=venue or self.setup_venue(),
+            offer__lastProvider=provider,
+            **kwargs,
+        ).offer
 
     def test_should_raise_404_because_has_no_access_to_venue(self, client: TestClient):
         plain_api_key, _ = self.setup_provider()
@@ -35,7 +36,9 @@ class PostPriceCategoriesTest(PublicAPIVenueEndpointHelper):
 
     def test_should_return_price_categories(self, client: TestClient):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
-        event = self.setup_base_resource(venue=venue_provider.venue, provider=venue_provider.provider)
+        event = self.setup_base_resource(
+            venue=venue_provider.venue, provider=venue_provider.provider, priceCategory=None
+        )
         price_category_1 = offers_factories.PriceCategoryFactory(
             offer=event,
             priceCategoryLabel=offers_factories.PriceCategoryLabelFactory(

--- a/api/tests/routes/public/individual_offers/v1/events/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/patch_event_test.py
@@ -51,10 +51,14 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
             shared_data["publicationDatetime"] = publication_datetime
 
         if digital:
-            return offers_factories.DigitalOfferFactory(**shared_data, subcategoryId="LIVESTREAM_MUSIQUE")
-        return offers_factories.EventOfferFactory(
-            **shared_data, subcategoryId="CONCERT", extraData={"gtl_id": "02000000"}
-        )
+            return offers_factories.EventStockFactory(
+                offer=offers_factories.DigitalOfferFactory(**shared_data, subcategoryId="LIVESTREAM_MUSIQUE")
+            ).offer
+        return offers_factories.EventStockFactory(
+            offer=offers_factories.EventOfferFactory(
+                **shared_data, subcategoryId="CONCERT", extraData={"gtl_id": "02000000"}
+            )
+        ).offer
 
     def test_should_raise_404_because_has_no_access_to_venue(self):
         plain_api_key, _ = self.setup_provider()
@@ -81,12 +85,12 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
     @pytest.mark.features(WIP_REFACTO_FUTURE_OFFER=True)
     def test_activate_offer_default_publication_datetime(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=True)
-        offer = offers_factories.EventOfferFactory(
-            venue=venue_provider.venue,
-            lastProvider=venue_provider.provider,
-            publicationDatetime=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1),
-            isActive=False,
-        )
+        offer = offers_factories.EventStockFactory(
+            offer__venue=venue_provider.venue,
+            offer__lastProvider=venue_provider.provider,
+            offer__publicationDatetime=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1),
+            offer__isActive=False,
+        ).offer
 
         now = datetime.datetime.now(datetime.timezone.utc)
         with time_machine.travel(now, tick=False):
@@ -98,17 +102,17 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
 
     def test_sets_field_to_none_and_leaves_other_unchanged(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
-        offer = offers_factories.EventOfferFactory(
-            subcategoryId="CONCERT",
-            venue=venue_provider.venue,
-            withdrawalDetails="Des conditions de retrait sur la sellette",
-            withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
-            withdrawalDelay=86400,
-            bookingContact="contact@example.com",
-            bookingEmail="notify@example.com",
-            lastProvider=venue_provider.provider,
-            extraData={"gtl_id": "03000000"},
-        )
+        offer = offers_factories.EventStockFactory(
+            offer__subcategoryId="CONCERT",
+            offer__venue=venue_provider.venue,
+            offer__withdrawalDetails="Des conditions de retrait sur la sellette",
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
+            offer__withdrawalDelay=86400,
+            offer__bookingContact="contact@example.com",
+            offer__bookingEmail="notify@example.com",
+            offer__lastProvider=venue_provider.provider,
+            offer__extraData={"gtl_id": "03000000"},
+        ).offer
 
         response = self.make_request(plain_api_key, {"offer_id": offer.id}, json_body={"itemCollectionDetails": None})
 
@@ -121,14 +125,14 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
 
     def test_sets_accessibility_partially(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
-        offer = offers_factories.EventOfferFactory(
-            venue=venue_provider.venue,
-            audioDisabilityCompliant=True,
-            mentalDisabilityCompliant=True,
-            motorDisabilityCompliant=True,
-            visualDisabilityCompliant=True,
-            lastProvider=venue_provider.provider,
-        )
+        offer = offers_factories.EventStockFactory(
+            offer__venue=venue_provider.venue,
+            offer__audioDisabilityCompliant=True,
+            offer__mentalDisabilityCompliant=True,
+            offer__motorDisabilityCompliant=True,
+            offer__visualDisabilityCompliant=True,
+            offer__lastProvider=venue_provider.provider,
+        ).offer
 
         response = self.make_request(
             plain_api_key,
@@ -150,20 +154,20 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
 
     def test_update_extra_data_partially(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
-        offer = offers_factories.EventOfferFactory(
-            venue=venue_provider.venue,
-            subcategoryId="FESTIVAL_ART_VISUEL",
-            extraData={
+        offer = offers_factories.EventStockFactory(
+            offer__venue=venue_provider.venue,
+            offer__subcategoryId="FESTIVAL_ART_VISUEL",
+            offer__extraData={
                 "author": "Maurice",
                 "stageDirector": "Robert",
                 "performer": "Pink Pâtisserie",
             },
-            lastProvider=venue_provider.provider,
-            withdrawalDelay=86400,
-            withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
-            bookingContact="contact@example.com",
-            bookingEmail="notify@example.com",
-        )
+            offer__lastProvider=venue_provider.provider,
+            offer__withdrawalDelay=86400,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
+            offer__bookingContact="contact@example.com",
+            offer__bookingEmail="notify@example.com",
+        ).offer
 
         response = self.make_request(
             plain_api_key,
@@ -192,20 +196,20 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
 
     def test_should_update_extra_data_even_if_extra_data_has_an_empty_stage_director(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
-        offer = offers_factories.EventOfferFactory(
-            venue=venue_provider.venue,
-            subcategoryId="FESTIVAL_ART_VISUEL",
-            extraData={
+        offer = offers_factories.EventStockFactory(
+            offer__venue=venue_provider.venue,
+            offer__subcategoryId="FESTIVAL_ART_VISUEL",
+            offer__extraData={
                 "author": "Maurice",
                 "stageDirector": "",  # faulty stageDirector
                 "performer": "Pink Pâtisserie",
             },
-            lastProvider=venue_provider.provider,
-            withdrawalDelay=86400,
-            withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
-            bookingContact="contact@example.com",
-            bookingEmail="notify@example.com",
-        )
+            offer__lastProvider=venue_provider.provider,
+            offer__withdrawalDelay=86400,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.BY_EMAIL,
+            offer__bookingContact="contact@example.com",
+            offer__bookingEmail="notify@example.com",
+        ).offer
 
         response = self.make_request(
             plain_api_key,
@@ -234,20 +238,20 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
 
     def test_patch_all_fields(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=True)
-        offer = offers_factories.EventOfferFactory(
-            venue=venue_provider.venue,
-            bookingContact="contact@example.com",
-            bookingEmail="notify@passq.com",
-            subcategoryId="CONCERT",
-            durationMinutes=20,
-            isDuo=False,
-            lastProvider=venue_provider.provider,
-            withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
-            withdrawalDelay=86400,
-            withdrawalDetails="Around there",
-            description="A description",
-            extraData={"gtl_id": "02000000"},
-        )
+        offer = offers_factories.EventStockFactory(
+            offer__venue=venue_provider.venue,
+            offer__bookingContact="contact@example.com",
+            offer__bookingEmail="notify@passq.com",
+            offer__subcategoryId="CONCERT",
+            offer__durationMinutes=20,
+            offer__isDuo=False,
+            offer__lastProvider=venue_provider.provider,
+            offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+            offer__withdrawalDelay=86400,
+            offer__withdrawalDetails="Around there",
+            offer__description="A description",
+            offer__extraData={"gtl_id": "02000000"},
+        ).offer
 
         new_name = offer.name + "_updated"
         response = self.make_request(
@@ -358,12 +362,12 @@ class PatchEventTest(PublicAPIVenueEndpointHelper):
 
     def test_update_with_non_nullable_fields_does_not_update_them(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=True)
-        offer = offers_factories.EventOfferFactory(
-            venue=venue_provider.venue,
-            lastProvider=venue_provider.provider,
-            publicationDatetime=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        offer = offers_factories.EventStockFactory(
+            offer__venue=venue_provider.venue,
+            offer__lastProvider=venue_provider.provider,
+            offer__publicationDatetime=datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
             - datetime.timedelta(days=1),
-        )
+        ).offer
 
         response = self.make_request(plain_api_key, {"offer_id": offer.id}, json_body={"isActive": None})
         assert response.status_code == 200

--- a/api/tests/routes/public/individual_offers/v1/events/post_price_categories_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/post_price_categories_test.py
@@ -16,7 +16,10 @@ class PostPriceCategoriesTest(PublicAPIVenueEndpointHelper):
     default_path_params = {"event_id": 1}
 
     def setup_base_resource(self, venue=None, provider=None) -> offers_models.Offer:
-        return offers_factories.EventOfferFactory(venue=venue or self.setup_venue(), lastProvider=provider)
+        return offers_factories.EventStockFactory(
+            priceCategory=None,
+            offer=offers_factories.EventOfferFactory(venue=venue or self.setup_venue(), lastProvider=provider),
+        ).offer
 
     @staticmethod
     def _get_base_payload() -> dict:

--- a/api/tests/routes/public/individual_offers/v1/providers/patch_provider_test.py
+++ b/api/tests/routes/public/individual_offers/v1/providers/patch_provider_test.py
@@ -110,7 +110,7 @@ class PatchProviderTest(PublicAPIEndpointBaseHelper):
         event_offer = offers_factories.EventOfferFactory(
             lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
         )
-        offers_factories.StockFactory(offer=event_offer)
+        offers_factories.EventStockFactory(offer=event_offer)
 
         response = self.make_request(plain_api_key, json_body={"cancelUrl": None, "bookingUrl": None})
 

--- a/api/tests/routes/public/individual_offers/v1/providers/patch_venue_provider_external_urls_test.py
+++ b/api/tests/routes/public/individual_offers/v1/providers/patch_venue_provider_external_urls_test.py
@@ -139,7 +139,7 @@ class PatchVenueProviderExternalUrlsTest(PublicAPIVenueEndpointHelper):
             venue=venue_provider.venue,
             withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
         )
-        offers_factories.StockFactory(offer=event_offer)
+        offers_factories.EventStockFactory(offer=event_offer)
         previous_booking_url = venue_provider_external_urls.bookingExternalUrl
         previous_cancel_url = venue_provider_external_urls.cancelExternalUrl
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36377)

But : mettre à jour la définition de `Offer.isEvent`. Cela permet de correspondre davantage à la réalité : dans la pratique, les événements doivent de fait avoir un stock avec une date de début. Cela ne devrait pas avoir d'impact, mais étant donné que cela est sensible, le changement est placé sous un _FF_.