### PR TITLE
(PC-37662)[PRO] fix: Do not use Object.hasOwn while it does not have …

### DIFF
--- a/pro/src/commons/utils/types.ts
+++ b/pro/src/commons/utils/types.ts
@@ -11,7 +11,8 @@ export const hasProperty = <T extends string>(
     return false
   }
 
-  return Boolean(Object.hasOwn(element, property))
+  // biome-ignore lint/suspicious/noPrototypeBuiltins: We cannot use hasOwn due to lack of support
+  return Boolean(element.hasOwnProperty(property))
 }
 
 export const hasProperties = <T extends string>(


### PR DESCRIPTION
…enough support.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37662)

Ne pas utiliser la method ES2022 JS `hasOwn` qui est pas encore supportée par tous les navigateurs [de notre baseline](https://www.notion.so/passcultureapp/Navigateurs-support-s-a0f14c1a6e8643f6b2ed69151d9f7ae0), et qui est remontée [en erreur dans sentry](https://pass-culture.sentry.io/issues/56914885/?project=4508818035638352&query=is%3Aunresolved&referrer=issue-stream).
