### PR TITLE
Pc 37648 use ba status history in bo

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 aae08bded987 (pre) (head)
-cd92fbabf123 (post) (head)
+2b1434238dd9 (post) (head)

--- a/api/src/pcapi/alembic/versions/20250829T160610_2b1434238dd9_drop_datelaststatusupdated_in_bankaccount.py
+++ b/api/src/pcapi/alembic/versions/20250829T160610_2b1434238dd9_drop_datelaststatusupdated_in_bankaccount.py
@@ -1,0 +1,23 @@
+"""Drop dateLastStatusUpdate in BankAccount"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "2b1434238dd9"
+down_revision = "cd92fbabf123"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("bank_account", "dateLastStatusUpdate")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "bank_account", sa.Column("dateLastStatusUpdate", postgresql.TIMESTAMP(), autoincrement=False, nullable=True)
+    )

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -3759,7 +3759,6 @@ def mark_bank_account_without_continuation(ds_application_id: int) -> None:
         return
 
     bank_account.status = models.BankAccountApplicationStatus.WITHOUT_CONTINUATION
-    bank_account.dateLastStatusUpdate = now
     if bank_account.statusHistory:
         current_status_history = bank_account.statusHistory[0]
         current_status_history.timespan = db_utils.make_timerange(current_status_history.timespan.lower, now)

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -262,7 +262,6 @@ class BankAccount(PcObject, Base, Model, DeactivableMixin):
         sa.Enum(BankAccountApplicationStatus), nullable=False
     )
     dateCreated: datetime.datetime = sa.Column(sa.DateTime, nullable=False, server_default=sa.func.now())
-    dateLastStatusUpdate: datetime.datetime = sa.Column(sa.DateTime)
     venueLinks: sa_orm.Mapped[list["offerers_models.VenueBankAccountLink"]] = sa_orm.relationship(
         "VenueBankAccountLink", back_populates="bankAccount", passive_deletes=True
     )

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/bank_accounts.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/bank_accounts.html
@@ -12,13 +12,14 @@
     </tr>
   </thead>
   <tbody>
-    {% for bank_account in bank_accounts %}
+    {% for row in rows %}
+      {% set bank_account = row.BankAccount %}
       <tr>
         <th scope="row"></th>
         <td class="fw-bolder">{{ links.build_bank_account_name_to_details_link(bank_account, text_attr="id") }}</td>
         <td class="text-break">{{ build_connect_as_link(connect_as[bank_account.id], bank_account.label, "link-primary") }}</td>
         <td>{{ bank_account.status | format_dms_application_status_badge }}</td>
-        <td>{{ bank_account.dateLastStatusUpdate | format_date_time }}</td>
+        <td>{{ row.date_last_status_update | format_date_time }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -124,7 +124,6 @@ class BankAccountResponseModel(BaseModel):
     dsApplicationId: int | None
     status: finance_models.BankAccountApplicationStatus
     dateCreated: datetime.datetime
-    dateLastStatusUpdate: datetime.datetime | None
     linkedVenues: list[LinkedVenues]
 
     class Config:

--- a/api/tests/core/finance/test_ds.py
+++ b/api/tests/core/finance/test_ds.py
@@ -170,7 +170,9 @@ class MarkWithoutApplicationTooOldApplicationsTest:
 
         bank_account = db.session.query(BankAccount).filter_by(dsApplicationId=application_id).one()
         assert bank_account.status == BankAccountApplicationStatus.WITHOUT_CONTINUATION
-        assert bank_account.dateLastStatusUpdate.timestamp() == pytest.approx(datetime.datetime.utcnow().timestamp())
+        assert bank_account.statusHistory[0].timespan.lower.timestamp() == pytest.approx(
+            datetime.datetime.utcnow().timestamp()
+        )
 
     @patch("pcapi.connectors.dms.api.DMSGraphQLClient.archive_application")
     @patch("pcapi.connectors.dms.api.DMSGraphQLClient.mark_without_continuation")
@@ -223,7 +225,9 @@ class MarkWithoutApplicationTooOldApplicationsTest:
 
         bank_account = db.session.query(BankAccount).filter_by(dsApplicationId=application_id).one()
         assert bank_account.status == BankAccountApplicationStatus.WITHOUT_CONTINUATION
-        assert bank_account.dateLastStatusUpdate.timestamp() == pytest.approx(datetime.datetime.utcnow().timestamp())
+        assert bank_account.statusHistory[0].timespan.lower.timestamp() == pytest.approx(
+            datetime.datetime.utcnow().timestamp()
+        )
 
     @patch("pcapi.connectors.dms.api.DMSGraphQLClient.archive_application")
     @patch("pcapi.connectors.dms.api.DMSGraphQLClient.mark_without_continuation")
@@ -497,7 +501,6 @@ class MarkWithoutApplicationTooOldApplicationsTest:
 
         bank_account = db.session.query(BankAccount).filter_by(dsApplicationId=application_id).one()
         assert bank_account.status == BankAccountApplicationStatus.WITHOUT_CONTINUATION
-        assert bank_account.dateLastStatusUpdate.timestamp() == pytest.approx(datetime.datetime.utcnow().timestamp())
         assert bank_account.venueLinks
         assert len(bank_account.statusHistory) == 2
         for status_history in bank_account.statusHistory:

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -214,7 +214,6 @@ class Returns200Test:
             "bankAccount": {
                 "bic": bank_account_link.bankAccount.bic,
                 "dateCreated": format_into_utc_date(bank_account_link.bankAccount.dateCreated),
-                "dateLastStatusUpdate": bank_account_link.bankAccount.dateLastStatusUpdate,
                 "dsApplicationId": bank_account_link.bankAccount.dsApplicationId,
                 "id": bank_account_link.bankAccount.id,
                 "isActive": bank_account_link.bankAccount.isActive,

--- a/pro/src/apiClient/v1/models/BankAccountResponseModel.ts
+++ b/pro/src/apiClient/v1/models/BankAccountResponseModel.ts
@@ -7,7 +7,6 @@ import type { LinkedVenues } from './LinkedVenues';
 export type BankAccountResponseModel = {
   bic: string;
   dateCreated: string;
-  dateLastStatusUpdate?: string | null;
   dsApplicationId?: number | null;
   id: number;
   isActive: boolean;

--- a/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
+++ b/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
@@ -63,7 +63,6 @@ describe('ReimbursementBankAccount', () => {
       dsApplicationId: 6,
       status: BankAccountApplicationStatus.ACCEPTE,
       dateCreated: '2023-09-22T12:44:05.410448',
-      dateLastStatusUpdate: null,
       linkedVenues: [{ id: 315, commonName: 'Le Petit Rintintin' }],
     }
 
@@ -87,7 +86,7 @@ describe('ReimbursementBankAccount', () => {
     expect(screen.getByText(/en cours de validation/)).toBeInTheDocument()
     expect(screen.getByText('Voir le dossier')).toBeInTheDocument()
     expect(
-      screen.queryByText('Structure rattéchée à ce compte bancaire')
+      screen.queryByText('Structure rattachée à ce compte bancaire')
     ).not.toBeInTheDocument()
   })
 
@@ -102,7 +101,7 @@ describe('ReimbursementBankAccount', () => {
     expect(screen.getByText(/informations manquantes/)).toBeInTheDocument()
     expect(screen.getByText(/Compléter le dossier/)).toBeInTheDocument()
     expect(
-      screen.queryByText('Structure rattéchée à ce compte bancaire')
+      screen.queryByText('Structure rattachée à ce compte bancaire')
     ).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37648)

PR deux en un :
- utiliser la table BankAccountStatusHistory dans le BO, et pas la colonne dateLastStatusUpdate, qui n'est quasiment pas remplie
- supprimer cette colonne, qui ne sert ni dans le front ni dans le BO


- [ ] Travail pair testé en environnement de preview
