### PR TITLE
(PC-36381)[PRO] feat: Create the new practical info individual page.

### DIFF
--- a/pro/src/app/AppRouter/subroutesIndividualOfferWizardMap.tsx
+++ b/pro/src/app/AppRouter/subroutesIndividualOfferWizardMap.tsx
@@ -130,6 +130,30 @@ export const routesIndividualOfferWizard: RouteConfig[] = [
     path: '/offre/individuelle/:offerId/stocks',
     title: 'Stocks et prix - Consulter une offre individuelle',
   },
+  {
+    lazy: () =>
+      import(
+        '@/pages/IndividualOffer/IndividualOfferPracticalInfos/IndividualOfferPracticalInfos'
+      ),
+    path: '/offre/individuelle/:offerId/creation/informations_pratiques',
+    title: 'Informations pratiques - Créer une offre individuelle',
+  },
+  {
+    lazy: () =>
+      import(
+        '@/pages/IndividualOffer/IndividualOfferPracticalInfos/IndividualOfferPracticalInfos'
+      ),
+    path: '/offre/individuelle/:offerId/edition/informations_pratiques',
+    title: 'Informations pratiques - Modifier une offre individuelle',
+  },
+  {
+    lazy: () =>
+      import(
+        '@/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/IndividualOfferSummaryPracticalInfos'
+      ),
+    path: '/offre/individuelle/:offerId/informations_pratiques',
+    title: 'Informations pratiques - Consulter une offre individuelle',
+  },
   // Booking summary page
   {
     lazy: () =>
@@ -220,6 +244,15 @@ export const routesOnboardingIndividualOfferWizard: RouteConfig[] = [
     path: '/onboarding/offre/individuelle/:offerId/creation/tarifs',
     featureName: 'WIP_ENABLE_PRO_DIDACTIC_ONBOARDING',
     title: 'Tarifs - Créer une offre individuelle - Onboarding',
+  },
+  {
+    lazy: () =>
+      import(
+        '@/pages/IndividualOffer/IndividualOfferPracticalInfos/IndividualOfferPracticalInfos'
+      ),
+    path: '/onboarding/offre/individuelle/:offerId/creation/informations_pratiques',
+    title: 'Informations pratiques - Créer une offre individuelle - Onboarding',
+    featureName: 'WIP_ENABLE_PRO_DIDACTIC_ONBOARDING',
   },
   {
     lazy: () => import('@/pages/IndividualOfferWizard/Stocks/Stocks'),

--- a/pro/src/commons/core/Offers/constants.ts
+++ b/pro/src/commons/core/Offers/constants.ts
@@ -49,6 +49,7 @@ export enum INDIVIDUAL_OFFER_WIZARD_STEP_IDS {
   MEDIA = 'media',
   TARIFS = 'tarifs',
   STOCKS = 'stocks',
+  PRACTICAL_INFOS = 'informations_pratiques',
   SUMMARY = 'recapitulatif',
   CONFIRMATION = 'confirmation',
   BOOKINGS = 'reservations',

--- a/pro/src/commons/core/Offers/utils/getIndividualOfferUrl.ts
+++ b/pro/src/commons/core/Offers/utils/getIndividualOfferUrl.ts
@@ -38,6 +38,14 @@ const routes = {
     [OFFER_WIZARD_MODE.EDITION]: `/offre/individuelle/:offerId/edition/tarifs`,
     [OFFER_WIZARD_MODE.READ_ONLY]: `/offre/individuelle/:offerId/tarifs`,
   },
+  [INDIVIDUAL_OFFER_WIZARD_STEP_IDS.PRACTICAL_INFOS]: {
+    [OFFER_WIZARD_MODE.CREATION]:
+      '/offre/individuelle/:offerId/creation/informations_pratiques',
+    [OFFER_WIZARD_MODE.EDITION]:
+      '/offre/individuelle/:offerId/edition/informations_pratiques',
+    [OFFER_WIZARD_MODE.READ_ONLY]:
+      '/offre/individuelle/:offerId/informations_pratiques',
+  },
   [INDIVIDUAL_OFFER_WIZARD_STEP_IDS.SUMMARY]: {
     [OFFER_WIZARD_MODE.CREATION]: `/offre/individuelle/:offerId/creation/recapitulatif`,
     [OFFER_WIZARD_MODE.EDITION]: ``,

--- a/pro/src/components/FormLayout/FormLayout.module.scss
+++ b/pro/src/components/FormLayout/FormLayout.module.scss
@@ -55,7 +55,6 @@ $info-box-margin-left: rem.torem(24px);
       }
 
       &-content {
-        white-space: pre-line;
         margin-top: rem.torem(8px);
       }
     }

--- a/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarActionsBar/StocksCalendarActionsBar.tsx
+++ b/pro/src/components/IndividualOffer/StocksEventCreation/StocksCalendar/StocksCalendarActionsBar/StocksCalendarActionsBar.tsx
@@ -7,6 +7,7 @@ import {
   OFFER_WIZARD_MODE,
 } from '@/commons/core/Offers/constants'
 import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
+import { useActiveFeature } from '@/commons/hooks/useActiveFeature'
 import { useNotification } from '@/commons/hooks/useNotification'
 import { pluralize } from '@/commons/utils/pluralize'
 import { ActionsBarSticky } from '@/components/ActionsBarSticky/ActionsBarSticky'
@@ -38,6 +39,10 @@ export function StocksCalendarActionsBar({
   const navigate = useNavigate()
   const { pathname } = useLocation()
   const isOnboarding = pathname.indexOf('onboarding') !== -1
+
+  const isNewOfferCreationFlowFeatureActive = useActiveFeature(
+    'WIP_ENABLE_NEW_OFFER_CREATION_FLOW'
+  )
 
   function handlePreviousStep() {
     if (mode === OFFER_WIZARD_MODE.EDITION) {
@@ -75,7 +80,9 @@ export function StocksCalendarActionsBar({
     navigate(
       getIndividualOfferUrl({
         offerId: offerId,
-        step: INDIVIDUAL_OFFER_WIZARD_STEP_IDS.SUMMARY,
+        step: isNewOfferCreationFlowFeatureActive
+          ? INDIVIDUAL_OFFER_WIZARD_STEP_IDS.PRACTICAL_INFOS
+          : INDIVIDUAL_OFFER_WIZARD_STEP_IDS.SUMMARY,
         mode,
         isOnboarding,
       })

--- a/pro/src/components/IndividualOfferLayout/IndividualOfferNavigation/utils/getSteps.tsx
+++ b/pro/src/components/IndividualOfferLayout/IndividualOfferNavigation/utils/getSteps.tsx
@@ -89,6 +89,11 @@ export const getSteps = ({
         significativeProperty: 'priceCategories',
       })
     }
+    steps.push({
+      id: INDIVIDUAL_OFFER_WIZARD_STEP_IDS.PRACTICAL_INFOS,
+      label: 'Informations pratiques',
+      significativeProperty: null,
+    })
   } else {
     // This part will disappear once the FF is enabled in production.
     if (isEvent) {

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/UsefulInformationForm/UsefulInformationForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/UsefulInformationForm/UsefulInformationForm.tsx
@@ -38,6 +38,19 @@ export interface UsefulInformationFormProps {
   hasPublishedOfferWithSameEan?: boolean
 }
 
+export function getFirstWithdrawalTypeEnumValue(value: string) {
+  switch (value) {
+    case WithdrawalTypeEnum.BY_EMAIL:
+      return ticketSentDateOptions[0].value
+
+    case WithdrawalTypeEnum.ON_SITE:
+      return ticketWithdrawalHourOptions[0].value
+
+    default:
+      return null
+  }
+}
+
 export const UsefulInformationForm = ({
   conditionalFields,
   selectedVenue,
@@ -88,19 +101,6 @@ export const UsefulInformationForm = ({
     offerSubCategory?.reimbursementRule === REIMBURSEMENT_RULES.NOT_REIMBURSED
   const displayWithdrawalReminder =
     !offerSubCategory?.isEvent && !isOfferSubcategoryOnline
-
-  const getFirstWithdrawalTypeEnumValue = (value: string) => {
-    switch (value) {
-      case WithdrawalTypeEnum.BY_EMAIL:
-        return ticketSentDateOptions[0].value
-
-      case WithdrawalTypeEnum.ON_SITE:
-        return ticketWithdrawalHourOptions[0].value
-
-      default:
-        return undefined
-    }
-  }
 
   if (!selectedVenue) {
     return <Spinner />
@@ -159,7 +159,7 @@ export const UsefulInformationForm = ({
                   )
                   setValue(
                     'withdrawalDelay',
-                    getFirstWithdrawalTypeEnumValue(e.target.value)
+                    getFirstWithdrawalTypeEnumValue(e.target.value) || undefined
                   )
                 }}
               />

--- a/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/IndividualOfferLocationScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/IndividualOfferLocationScreen.tsx
@@ -143,6 +143,7 @@ export const IndividualOfferLocationScreen = ({
               updateOffer(formValues, shouldSendMail)
             )()
           }
+          refToFocusOnClose={saveEditionChangesButtonRef}
         />
       )}
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/UpdateWarningDialog/UpdateWarningDialog.module.scss
+++ b/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/UpdateWarningDialog/UpdateWarningDialog.module.scss
@@ -4,4 +4,5 @@
   display: flex;
   gap: rem.torem(32px);
   flex-direction: column;
+  text-align: left;
 }

--- a/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/UpdateWarningDialog/UpdateWarningDialog.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/UpdateWarningDialog/UpdateWarningDialog.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 
 import { ConfirmDialog } from '@/components/ConfirmDialog/ConfirmDialog'
 import { FormLayout } from '@/components/FormLayout/FormLayout'
@@ -11,13 +11,15 @@ import styles from './UpdateWarningDialog.module.scss'
 interface UpdateWarningDialogProps {
   onCancel: () => void
   onConfirm: (shouldSendMail: boolean) => void
+  refToFocusOnClose?: React.RefObject<HTMLButtonElement>
+  message?: string
 }
 export const UpdateWarningDialog = ({
   onCancel,
   onConfirm,
+  refToFocusOnClose,
+  message,
 }: UpdateWarningDialogProps): JSX.Element => {
-  const saveEditionChangesButtonRef = useRef<HTMLButtonElement>(null)
-
   const [shouldSendMail, setShouldSendMail] = useState(true)
 
   return (
@@ -28,10 +30,10 @@ export const UpdateWarningDialog = ({
       onConfirm={() => onConfirm(shouldSendMail)}
       open
       title="Les changements vont s’appliquer à l’ensemble des réservations en cours associées"
-      refToFocusOnClose={saveEditionChangesButtonRef}
+      refToFocusOnClose={refToFocusOnClose}
     >
       <div className={styles['update-oa-wrapper']}>
-        <div>Vous avez modifié la localisation.</div>
+        <div>{message ?? 'Vous avez modifié la localisation.'}</div>
 
         <Callout variant={CalloutVariant.WARNING}>
           Si vous souhaitez que les réservations en cours conservent les données

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/IndividualOfferPracticalInfos.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/IndividualOfferPracticalInfos.spec.tsx
@@ -1,0 +1,56 @@
+import { screen } from '@testing-library/react'
+
+import { api } from '@/apiClient/api'
+import { IndividualOfferContextProvider } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
+import { getIndividualOfferFactory } from '@/commons/utils/factories/individualApiFactories'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { Component as IndividualOfferPracticalInfos } from './IndividualOfferPracticalInfos'
+
+const offer = getIndividualOfferFactory()
+
+vi.mock('react-router', async () => ({
+  ...(await vi.importActual('react-router')),
+  useParams: () => ({
+    offerId: offer.id,
+  }),
+}))
+
+const renderIndividualOfferMedia = () => {
+  return renderWithProviders(
+    <IndividualOfferContextProvider>
+      <IndividualOfferPracticalInfos />
+    </IndividualOfferContextProvider>,
+    { storeOverrides: { user: { currentUser: sharedCurrentUserFactory() } } }
+  )
+}
+
+describe('IndividialOfferPracticalInfos', () => {
+  it('should render a spinner until offer is fetched', () => {
+    renderIndividualOfferMedia()
+
+    const spinner = screen.getByTestId('spinner')
+    expect(spinner).toBeInTheDocument()
+  })
+
+  it('should display the page once the offer is fetched', async () => {
+    vi.spyOn(api, 'getOffer').mockResolvedValue(offer)
+    vi.spyOn(api, 'getCategories').mockResolvedValue({
+      categories: [],
+      subcategories: [],
+    })
+    vi.spyOn(api, 'getStocks').mockResolvedValue({
+      stocks: [],
+      hasStocks: false,
+      stockCount: 0,
+    })
+
+    renderIndividualOfferMedia()
+
+    const heading = await screen.findByRole('heading', {
+      name: 'Informations pratiques',
+    })
+    expect(heading).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/IndividualOfferPracticalInfos.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/IndividualOfferPracticalInfos.tsx
@@ -1,0 +1,43 @@
+import useSWR from 'swr'
+
+import { api } from '@/apiClient/api'
+import { GET_STOCKS_QUERY_KEY } from '@/commons/config/swrQueryKeys'
+import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
+import { useOfferWizardMode } from '@/commons/hooks/useOfferWizardMode'
+import { IndividualOfferLayout } from '@/components/IndividualOfferLayout/IndividualOfferLayout'
+import { getTitle } from '@/components/IndividualOfferLayout/utils/getTitle'
+import { Spinner } from '@/ui-kit/Spinner/Spinner'
+
+import { IndividualOfferPracticalInfosScreen } from './components/IndividualOfferPracticalInfosScreen'
+
+const IndividualOfferPracticalInfos = (): JSX.Element | null => {
+  const mode = useOfferWizardMode()
+  const { offer, hasPublishedOfferWithSameEan } = useIndividualOfferContext()
+
+  const getStocksQuery = useSWR(
+    offer?.id ? [GET_STOCKS_QUERY_KEY, offer.id] : null,
+    ([, offerId]) => api.getStocks(offerId)
+  )
+
+  if (!offer || !getStocksQuery.data) {
+    return <Spinner />
+  }
+
+  return (
+    <IndividualOfferLayout
+      offer={offer}
+      title={getTitle(mode)}
+      mode={mode}
+      venueHasPublishedOfferWithSameEan={hasPublishedOfferWithSameEan}
+    >
+      <IndividualOfferPracticalInfosScreen
+        offer={offer}
+        stocks={getStocksQuery.data.stocks}
+      />
+    </IndividualOfferLayout>
+  )
+}
+
+// Below exports are used by react-router
+// ts-unused-exports:disable-next-line
+export const Component = IndividualOfferPracticalInfos

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/getInitialValuesFromOffer.spec.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/getInitialValuesFromOffer.spec.ts
@@ -1,0 +1,61 @@
+import { WithdrawalTypeEnum } from '@/apiClient/v1'
+import {
+  getIndividualOfferFactory,
+  subcategoryFactory,
+} from '@/commons/utils/factories/individualApiFactories'
+import { MOCKED_SUBCATEGORY } from '@/pages/IndividualOffer/commons/__mocks__/constants'
+
+import { getInitialValuesFromOffer } from '../getInitialValuesFromOffer'
+
+describe('getInitialValuesFromOffer', () => {
+  const offer = getIndividualOfferFactory({
+    bookingAllowedDatetime: '2070-03-23T15:08:33Z',
+    bookingContact: 'bookingContact@example.co',
+    bookingEmail: 'bookingEmail@example.co',
+    externalTicketOfficeUrl: 'http://url.co',
+    withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+    withdrawalDelay: 10,
+    withdrawalDetails: 'Withdrawal details',
+  })
+
+  it('should get the default values from an offer with a withdrawable sub category', () => {
+    const withdrawableSubCategory = MOCKED_SUBCATEGORY.WIDTHDRAWABLE
+
+    expect(getInitialValuesFromOffer(offer, withdrawableSubCategory)).toEqual(
+      expect.objectContaining({
+        bookingAllowedMode: 'later',
+        bookingContact: 'bookingContact@example.co',
+        bookingEmail: 'bookingEmail@example.co',
+        externalTicketOfficeUrl: 'http://url.co',
+        withdrawalType: 'by_email',
+        withdrawalDelay: '10',
+        receiveNotificationEmails: true,
+        withdrawalDetails: 'Withdrawal details',
+      })
+    )
+  })
+
+  it('should get the default values from an offer with a non withdrawable sub category', () => {
+    const nonWithdrawableSubCategory = subcategoryFactory({
+      canBeWithdrawable: false,
+    })
+
+    expect(
+      getInitialValuesFromOffer(
+        {
+          ...offer,
+          bookingEmail: undefined,
+          bookingAllowedDatetime: undefined,
+          withdrawalType: null,
+        },
+        nonWithdrawableSubCategory
+      )
+    ).toEqual(
+      expect.objectContaining({
+        bookingAllowedMode: 'now',
+        withdrawalType: null,
+        receiveNotificationEmails: false,
+      })
+    )
+  })
+})

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/getPatchOfferBody.spec.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/getPatchOfferBody.spec.ts
@@ -1,0 +1,33 @@
+import { WithdrawalTypeEnum } from '@/apiClient/v1'
+
+import { getPatchOfferBody } from '../getPatchOfferBody'
+import type { IndividualOfferPracticalInfosFormValues } from '../types'
+
+describe('getPatchOfferBody', () => {
+  it('should create the patch body from the form values', () => {
+    const formValues: IndividualOfferPracticalInfosFormValues = {
+      bookingAllowedMode: 'later',
+      bookingAllowedDate: '2050-12-12',
+      bookingAllowedTime: '12:12',
+      bookingContact: 'bookingContact@example.co',
+      receiveNotificationEmails: true,
+      bookingEmail: 'bookingEmail@example.co',
+      externalTicketOfficeUrl: 'http://url.co',
+      withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+      withdrawalDelay: '10',
+      withdrawalDetails: 'Withdrawal details',
+    }
+
+    expect(getPatchOfferBody(formValues, '56', false)).toEqual(
+      expect.objectContaining({
+        bookingAllowedDatetime: expect.stringContaining('T'),
+        bookingContact: 'bookingContact@example.co',
+        bookingEmail: 'bookingEmail@example.co',
+        externalTicketOfficeUrl: 'http://url.co',
+        withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+        withdrawalDelay: 10,
+        withdrawalDetails: 'Withdrawal details',
+      })
+    )
+  })
+})

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/validationSchema.spec.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/validationSchema.spec.ts
@@ -1,0 +1,91 @@
+import { WithdrawalTypeEnum } from '@/apiClient/v1'
+import { getYupValidationSchemaErrors } from '@/commons/utils/yupValidationTestHelpers'
+
+import type { IndividualOfferPracticalInfosFormValues } from '../types'
+import { getValidationSchema } from '../validationSchema'
+
+describe('validationSchema', () => {
+  const defaultFormValues: IndividualOfferPracticalInfosFormValues = {
+    bookingAllowedMode: 'now',
+    withdrawalType: null,
+    bookingContact: null,
+    bookingEmail: null,
+    externalTicketOfficeUrl: null,
+    withdrawalDetails: null,
+    withdrawalDelay: null,
+    receiveNotificationEmails: false,
+  }
+
+  const cases: {
+    description: string
+    formValues: Partial<IndividualOfferPracticalInfosFormValues>
+    expectedErrors: string[]
+    canBeWithdrawable?: boolean
+  }[] = [
+    {
+      description: 'valid for default form values',
+      formValues: defaultFormValues,
+      expectedErrors: [],
+    },
+    {
+      description: 'invalid for missing booking limit date or time',
+      formValues: { ...defaultFormValues, bookingAllowedMode: 'later' },
+      expectedErrors: [
+        'Veuillez sélectionner une date de réservabilité',
+        'Veuillez sélectionner une heure de réservabilité',
+      ],
+    },
+    {
+      description: 'invalid for missing withdrawal informations',
+      formValues: defaultFormValues,
+      expectedErrors: [
+        'Veuillez sélectionner une méthode de distribution',
+        'Veuillez renseigner une adresse email',
+      ],
+      canBeWithdrawable: true,
+    },
+    {
+      description: 'invalid for missing withdrawal delay',
+      formValues: {
+        ...defaultFormValues,
+        withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+        bookingContact: 'test@test.co',
+      },
+      expectedErrors: [
+        'Vous devez choisir l’une des options de délai de retrait',
+      ],
+      canBeWithdrawable: true,
+    },
+    {
+      description: 'invalid for a pass culture withdrawal email',
+      formValues: {
+        ...defaultFormValues,
+        withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+        withdrawalDelay: '10',
+        bookingContact: 'test@passculture.app',
+      },
+      expectedErrors: ['Ce mail doit vous appartenir'],
+      canBeWithdrawable: true,
+    },
+    {
+      description: 'invalid for a missing notification email',
+      formValues: {
+        ...defaultFormValues,
+        receiveNotificationEmails: true,
+      },
+      expectedErrors: ['Veuillez renseigner une adresse email'],
+    },
+  ]
+
+  cases.forEach(
+    ({ description, formValues, expectedErrors, canBeWithdrawable }) => {
+      it(`should validate the form for case: ${description}`, async () => {
+        const errors = await getYupValidationSchemaErrors(
+          getValidationSchema(canBeWithdrawable),
+          formValues
+        )
+        expect(errors).toEqual(expectedErrors)
+      })
+    }
+  )
+})

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/getInitialValuesFromOffer.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/getInitialValuesFromOffer.ts
@@ -1,0 +1,46 @@
+import { format, isAfter } from 'date-fns'
+
+import {
+  type GetIndividualOfferWithAddressResponseModel,
+  type SubcategoryResponseModel,
+  WithdrawalTypeEnum,
+} from '@/apiClient/v1'
+import { FORMAT_HH_mm, formatShortDateForInput } from '@/commons/utils/date'
+import { getLocalDepartementDateTimeFromUtc } from '@/commons/utils/timezone'
+
+import type { IndividualOfferPracticalInfosFormValues } from './types'
+
+export function getInitialValuesFromOffer(
+  offer: GetIndividualOfferWithAddressResponseModel,
+  offerSubcategory?: SubcategoryResponseModel
+): IndividualOfferPracticalInfosFormValues {
+  return {
+    bookingAllowedMode:
+      offer.bookingAllowedDatetime &&
+      isAfter(offer.bookingAllowedDatetime, new Date())
+        ? 'later'
+        : 'now',
+    bookingAllowedDate: offer.bookingAllowedDatetime
+      ? formatShortDateForInput(
+          getLocalDepartementDateTimeFromUtc(offer.bookingAllowedDatetime)
+        )
+      : undefined,
+    bookingAllowedTime: offer.bookingAllowedDatetime
+      ? format(
+          getLocalDepartementDateTimeFromUtc(offer.bookingAllowedDatetime),
+          FORMAT_HH_mm
+        )
+      : undefined,
+    withdrawalDetails: offer.withdrawalDetails ?? null,
+    withdrawalDelay: offer.withdrawalDelay?.toString() ?? null,
+    withdrawalType:
+      offer.withdrawalType ??
+      (offerSubcategory?.canBeWithdrawable
+        ? WithdrawalTypeEnum.NO_TICKET
+        : null),
+    bookingEmail: offer.bookingEmail ?? null,
+    bookingContact: offer.bookingContact ?? null,
+    receiveNotificationEmails: Boolean(offer.bookingEmail),
+    externalTicketOfficeUrl: offer.externalTicketOfficeUrl ?? null,
+  }
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/getPatchOfferBody.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/getPatchOfferBody.ts
@@ -1,0 +1,46 @@
+import { WithdrawalTypeEnum } from '@/apiClient/v1'
+import { serializeDateTimeToUTCFromLocalDepartment } from '@/commons/utils/timezone'
+
+import type { IndividualOfferPracticalInfosFormValues } from './types'
+
+export function getPatchOfferBody(
+  formValues: IndividualOfferPracticalInfosFormValues,
+  departmentCode: string,
+  shouldSendMail: boolean
+) {
+  const withdrawalDelayNullishValue =
+    formValues.withdrawalType === WithdrawalTypeEnum.NO_TICKET
+      ? null
+      : undefined
+  const withdrawalDelay =
+    formValues.withdrawalDelay === undefined
+      ? withdrawalDelayNullishValue
+      : Number(formValues.withdrawalDelay)
+
+  const formattedBookabilityDate =
+    formValues.bookingAllowedDate && formValues.bookingAllowedTime
+      ? serializeDateTimeToUTCFromLocalDepartment(
+          formValues.bookingAllowedDate,
+          formValues.bookingAllowedTime,
+          departmentCode
+        )
+      : undefined
+
+  return {
+    bookingContact: formValues.bookingContact,
+    bookingEmail: !formValues.receiveNotificationEmails
+      ? null
+      : formValues.bookingEmail,
+    externalTicketOfficeUrl: !formValues.externalTicketOfficeUrl
+      ? null
+      : formValues.externalTicketOfficeUrl,
+    shouldSendMail: shouldSendMail,
+    withdrawalDelay,
+    withdrawalDetails: formValues.withdrawalDetails ?? undefined,
+    withdrawalType: formValues.withdrawalType,
+    bookingAllowedDatetime:
+      formValues.bookingAllowedMode === 'later'
+        ? formattedBookabilityDate
+        : null,
+  }
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/types.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/types.ts
@@ -1,0 +1,14 @@
+import type { WithdrawalTypeEnum } from '@/apiClient/v1'
+
+export type IndividualOfferPracticalInfosFormValues = {
+  bookingAllowedMode: 'now' | 'later'
+  bookingAllowedDate?: string
+  bookingAllowedTime?: string
+  withdrawalType: WithdrawalTypeEnum | null
+  withdrawalDelay: string | null
+  withdrawalDetails: string | null
+  bookingContact: string | null
+  externalTicketOfficeUrl: string | null
+  receiveNotificationEmails: boolean
+  bookingEmail: string | null
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/validationSchema.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/validationSchema.ts
@@ -1,0 +1,68 @@
+import * as yup from 'yup'
+
+import { WithdrawalTypeEnum } from '@/apiClient/v1'
+import { emailSchema } from '@/commons/utils/isValidEmail'
+import { nonEmptyStringOrNull } from '@/commons/utils/yup/nonEmptyStringOrNull'
+import {
+  bookingAllowedDateValidationSchema,
+  bookingAllowedTimeValidationSchema,
+} from '@/pages/IndividualOfferSummary/IndividualOfferSummary/components/EventPublicationForm/validationSchema'
+
+import type { IndividualOfferPracticalInfosFormValues } from './types'
+
+export function getValidationSchema(canBeWithdrawable?: boolean) {
+  return yup.object<IndividualOfferPracticalInfosFormValues>().shape({
+    bookingAllowedMode: yup.string<'now' | 'later'>().required(),
+    bookingAllowedDate: yup.string().when('bookingAllowedMode', {
+      is: 'later',
+      then: (schema) => bookingAllowedDateValidationSchema(schema),
+    }),
+    bookingAllowedTime: yup.string().when('bookingAllowedMode', {
+      is: 'later',
+      then: (schema) => bookingAllowedTimeValidationSchema(schema),
+    }),
+    withdrawalType: nonEmptyStringOrNull()
+      .oneOf(Object.values(WithdrawalTypeEnum))
+      .when([], {
+        is: () => canBeWithdrawable,
+        then: (schema) =>
+          schema.nonNullable(
+            'Veuillez sélectionner une méthode de distribution'
+          ),
+      }),
+    withdrawalDelay: nonEmptyStringOrNull().when('withdrawalType', {
+      is: (type: WithdrawalTypeEnum) =>
+        [WithdrawalTypeEnum.BY_EMAIL, WithdrawalTypeEnum.ON_SITE].includes(
+          type
+        ),
+      then: (schema) =>
+        schema.nonNullable(
+          'Vous devez choisir l’une des options de délai de retrait'
+        ),
+    }),
+    withdrawalDetails: nonEmptyStringOrNull(),
+    bookingContact: nonEmptyStringOrNull().when([], {
+      is: () => canBeWithdrawable,
+      then: (schema) =>
+        schema
+          .nonNullable('Veuillez renseigner une adresse email')
+          .test(emailSchema)
+          .test({
+            name: 'organisationEmailNotPassCulture',
+            message: 'Ce mail doit vous appartenir',
+            test: (value) => !value.toLowerCase().endsWith('@passculture.app'),
+          }),
+    }),
+    externalTicketOfficeUrl: nonEmptyStringOrNull().url(
+      'Veuillez renseigner une URL valide. Ex : https://exemple.com'
+    ),
+    receiveNotificationEmails: yup.boolean().required(),
+    bookingEmail: nonEmptyStringOrNull().when('receiveNotificationEmails', {
+      is: (receiveNotificationEmails: boolean) => receiveNotificationEmails,
+      then: (schema) =>
+        schema
+          .nonNullable('Veuillez renseigner une adresse email')
+          .test(emailSchema),
+    }),
+  })
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.module.scss
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.module.scss
@@ -1,0 +1,5 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.email-row {
+  margin-top: rem.torem(16px);
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.spec.tsx
@@ -1,0 +1,111 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormProvider, useForm } from 'react-hook-form'
+
+import { SubcategoryIdEnum, WithdrawalTypeEnum } from '@/apiClient/v1'
+import { IndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
+import {
+  getIndividualOfferFactory,
+  individualOfferContextValuesFactory,
+} from '@/commons/utils/factories/individualApiFactories'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+import { MOCKED_SUBCATEGORY } from '@/pages/IndividualOffer/commons/__mocks__/constants'
+
+import type { IndividualOfferPracticalInfosFormValues } from '../../commons/types'
+import {
+  IndividualOfferPracticalInfosForm,
+  type IndividualOfferPracticalInfosFormProps,
+} from './IndividualOfferPracticalInfosForm'
+
+function renderIndividualOfferPracticalInfosForm(
+  props?: Partial<IndividualOfferPracticalInfosFormProps>
+) {
+  function IndividualOfferPracticalInfosFormWrapper() {
+    const form = useForm<IndividualOfferPracticalInfosFormValues>({
+      defaultValues: {
+        bookingAllowedMode: 'now',
+        withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+      },
+    })
+    return (
+      <IndividualOfferContext.Provider
+        value={individualOfferContextValuesFactory({
+          categories: [],
+          subCategories: [],
+        })}
+      >
+        <FormProvider {...form}>
+          <IndividualOfferPracticalInfosForm
+            offer={getIndividualOfferFactory()}
+            stocks={[]}
+            subCategory={MOCKED_SUBCATEGORY.WIDTHDRAWABLE_OFFLINE}
+            {...props}
+          />
+        </FormProvider>
+      </IndividualOfferContext.Provider>
+    )
+  }
+  renderWithProviders(<IndividualOfferPracticalInfosFormWrapper />, {
+    user: sharedCurrentUserFactory(),
+  })
+}
+
+describe('IndividualOfferPracticalInfosForm', () => {
+  it('should show the warning booking callout if the offer is not an event', () => {
+    renderIndividualOfferPracticalInfosForm({
+      offer: getIndividualOfferFactory({ isEvent: false }),
+    })
+
+    expect(
+      screen.getByText(/La validation de la contremarque est obligatoire/)
+    ).toBeInTheDocument()
+  })
+
+  it('should show the withdrawal block if the sub category is withdrawable', () => {
+    renderIndividualOfferPracticalInfosForm({
+      offer: getIndividualOfferFactory({
+        subcategoryId: SubcategoryIdEnum.FESTIVAL_CINE,
+      }),
+    })
+
+    expect(
+      screen.getByRole('radiogroup', {
+        name: /Précisez la façon dont vous distribuerez les billets/,
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('should show a warning callout if the offer is physical and offline', () => {
+    renderIndividualOfferPracticalInfosForm({
+      offer: getIndividualOfferFactory({
+        subcategoryId: SubcategoryIdEnum.FESTIVAL_CINE,
+        isEvent: false,
+      }),
+    })
+
+    expect(
+      screen.getByText(/La livraison d’article est interdite/)
+    ).toBeInTheDocument()
+  })
+
+  it('should show the notification email field if the notification checkbox is checked', async () => {
+    renderIndividualOfferPracticalInfosForm()
+
+    const notificationCheckbox = screen.getByRole('checkbox', {
+      name: 'Être notifié par email des réservations',
+    })
+
+    expect(notificationCheckbox).not.toBeChecked()
+
+    expect(
+      screen.queryByLabelText('Email auquel envoyer les notifications')
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(notificationCheckbox)
+
+    expect(
+      screen.getByLabelText('Email auquel envoyer les notifications *')
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.tsx
@@ -1,0 +1,160 @@
+import { useFormContext } from 'react-hook-form'
+
+import type {
+  GetIndividualOfferWithAddressResponseModel,
+  GetOfferStockResponseModel,
+  SubcategoryResponseModel,
+} from '@/apiClient/v1'
+import { REIMBURSEMENT_RULES } from '@/commons/core/Finances/constants'
+import { CATEGORY_STATUS } from '@/commons/core/Offers/constants'
+import { isOfferDisabled } from '@/commons/core/Offers/utils/isOfferDisabled'
+import { useCurrentUser } from '@/commons/hooks/useCurrentUser'
+import { FormLayout } from '@/components/FormLayout/FormLayout'
+import { Checkbox } from '@/design-system/Checkbox/Checkbox'
+import { Callout } from '@/ui-kit/Callout/Callout'
+import { CalloutVariant } from '@/ui-kit/Callout/types'
+import { TextArea } from '@/ui-kit/form/TextArea/TextArea'
+import { TextInput } from '@/ui-kit/form/TextInput/TextInput'
+
+import type { IndividualOfferPracticalInfosFormValues } from '../../commons/types'
+import styles from './IndividualOfferPracticalInfosForm.module.scss'
+import { IndividualOfferPracticalInfosFormPublication } from './IndividualOfferPracticalInfosFormPublication/IndividualOfferPracticalInfosFormPublication'
+import { IndividualOfferPracticalInfosFormWithdrawal } from './IndividualOfferPracticalInfosFormWithdrawal/IndividualOfferPracticalInfosFormWithdrawal'
+
+export type IndividualOfferPracticalInfosFormProps = {
+  offer: GetIndividualOfferWithAddressResponseModel
+  subCategory?: SubcategoryResponseModel
+  stocks: GetOfferStockResponseModel[]
+}
+
+export function IndividualOfferPracticalInfosForm({
+  offer,
+  subCategory,
+  stocks,
+}: IndividualOfferPracticalInfosFormProps) {
+  const form = useFormContext<IndividualOfferPracticalInfosFormValues>()
+
+  const {
+    currentUser: { email },
+  } = useCurrentUser()
+
+  const receiveNotificationEmails = form.watch('receiveNotificationEmails')
+  const bookingEmail = form.watch('bookingEmail')
+
+  const isFormDisabled = isOfferDisabled(offer.status)
+
+  const hasNonFreeStock = stocks.some((s) => Boolean(s.price))
+
+  const offerWillBeReimbursed =
+    (subCategory?.reimbursementRule === REIMBURSEMENT_RULES.STANDARD ||
+      subCategory?.reimbursementRule === REIMBURSEMENT_RULES.BOOK) &&
+    hasNonFreeStock
+
+  const isPhysicalAndOffline =
+    !subCategory?.isEvent &&
+    subCategory?.onlineOfflinePlatform === CATEGORY_STATUS.OFFLINE
+
+  return (
+    <FormLayout fullWidthActions>
+      <FormLayout.Section title="Informations pratiques">
+        <IndividualOfferPracticalInfosFormPublication
+          isFormDisabled={isFormDisabled}
+        />
+        {subCategory?.canBeWithdrawable ? (
+          <IndividualOfferPracticalInfosFormWithdrawal
+            isFormDisabled={isFormDisabled}
+          />
+        ) : null}
+        {!offer?.isEvent && (
+          <FormLayout.Row mdSpaceAfter>
+            <Callout variant={CalloutVariant.WARNING}>
+              La validation de la contremarque est obligatoire
+              {offerWillBeReimbursed
+                ? ' pour que votre structure soit remboursée'
+                : ''}
+              , sinon la réservation sera automatiquement annulée et remise en
+              vente.
+            </Callout>
+          </FormLayout.Row>
+        )}
+        <FormLayout.Row mdSpaceAfter>
+          <TextArea
+            {...form.register('withdrawalDetails')}
+            label="Informations complémentaires"
+            maxLength={500}
+            disabled={isFormDisabled}
+            description="Ces informations seront communiquées aux jeunes après leur réservation."
+          />
+        </FormLayout.Row>
+      </FormLayout.Section>
+      {isPhysicalAndOffline && (
+        <FormLayout.Section>
+          <FormLayout.Row mdSpaceAfter>
+            <Callout
+              variant={CalloutVariant.WARNING}
+              links={[
+                {
+                  label: 'Consulter les conditions Générales d’Utilisation',
+                  href: 'https://pass.culture.fr/cgu-professionnels',
+                  isExternal: true,
+                },
+              ]}
+            >
+              La livraison d’article est interdite. Pour plus d’informations,
+              veuillez consulter nos CGU.
+            </Callout>
+          </FormLayout.Row>
+        </FormLayout.Section>
+      )}
+      <FormLayout.Section
+        title="Lien de réservation externe en l’absence de crédit"
+        description="S’ils ne disposent pas ou plus de crédit, les utilisateurs de
+          l’application seront redirigés sur ce lien pour pouvoir néanmoins
+          profiter de votre offre."
+      >
+        <FormLayout.Row mdSpaceAfter>
+          <TextInput
+            {...form.register('externalTicketOfficeUrl')}
+            label="URL de votre site ou billetterie"
+            type="text"
+            disabled={isFormDisabled}
+            description="Format : https://exemple.com"
+            error={form.formState.errors.externalTicketOfficeUrl?.message}
+          />
+        </FormLayout.Row>
+      </FormLayout.Section>
+      <FormLayout.Section title="Notifications">
+        <FormLayout.Row mdSpaceAfter>
+          <Checkbox
+            label="Être notifié par email des réservations"
+            checked={Boolean(receiveNotificationEmails)}
+            disabled={isFormDisabled}
+            onChange={(e) => {
+              if (e.target.checked && !bookingEmail) {
+                form.setValue(
+                  'bookingEmail',
+                  offer?.venue.bookingEmail ?? email
+                )
+              }
+
+              form.setValue('receiveNotificationEmails', e.target.checked)
+            }}
+          />
+        </FormLayout.Row>
+        {receiveNotificationEmails && (
+          <FormLayout.Row className={styles['email-row']} mdSpaceAfter>
+            <TextInput
+              {...form.register('bookingEmail')}
+              label="Email auquel envoyer les notifications"
+              maxLength={90}
+              disabled={isFormDisabled}
+              description="Format : email@exemple.com"
+              required
+              error={form.formState.errors.bookingEmail?.message}
+            />
+          </FormLayout.Row>
+        )}
+      </FormLayout.Section>
+    </FormLayout>
+  )
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosFormPublication/IndividualOfferPracticalInfosFormPublication.module.scss
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosFormPublication/IndividualOfferPracticalInfosFormPublication.module.scss
@@ -1,0 +1,14 @@
+@use 'styles/mixins/_rem.scss' as rem;
+
+.date-picker {
+  width: rem.torem(180px);
+}
+
+.time-picker {
+  width: rem.torem(110px);
+}
+
+.inputs-row {
+  display: flex;
+  gap: rem.torem(24px);
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosFormPublication/IndividualOfferPracticalInfosFormPublication.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosFormPublication/IndividualOfferPracticalInfosFormPublication.tsx
@@ -1,0 +1,71 @@
+import { useFormContext } from 'react-hook-form'
+
+import { FormLayout } from '@/components/FormLayout/FormLayout'
+import { RadioButtonGroup } from '@/design-system/RadioButtonGroup/RadioButtonGroup'
+import { getPublicationHoursOptions } from '@/pages/IndividualOfferSummary/IndividualOfferSummary/components/EventPublicationForm/EventPublicationForm'
+import { DatePicker } from '@/ui-kit/form/DatePicker/DatePicker'
+import { Select } from '@/ui-kit/form/Select/Select'
+
+import type { IndividualOfferPracticalInfosFormValues } from '../../../commons/types'
+import styles from './IndividualOfferPracticalInfosFormPublication.module.scss'
+
+export function IndividualOfferPracticalInfosFormPublication({
+  isFormDisabled,
+}: {
+  isFormDisabled: boolean
+}) {
+  const form = useFormContext<IndividualOfferPracticalInfosFormValues>()
+
+  return (
+    <FormLayout.Row mdSpaceAfter>
+      <RadioButtonGroup
+        label="Quand votre offre pourra-t-elle être réservable&nbsp;?"
+        variant="detailed"
+        disabled={isFormDisabled}
+        options={[
+          { label: 'Rendre réservable dès la publication', value: 'now' },
+          {
+            label: 'Rendre réservable plus tard',
+            value: 'later',
+            collapsed: form.watch('bookingAllowedMode') === 'later' && (
+              <div className={styles['inputs-row']}>
+                <DatePicker
+                  label="Date"
+                  disabled={isFormDisabled}
+                  className={styles['date-picker']}
+                  minDate={new Date()}
+                  required
+                  {...form.register('bookingAllowedDate')}
+                  onBlur={async (e) => {
+                    await form.register('bookingAllowedDate').onBlur(e)
+                    await form.trigger('bookingAllowedDate')
+                  }}
+                  error={form.formState.errors.bookingAllowedDate?.message}
+                />
+                <Select
+                  label="Heure"
+                  disabled={isFormDisabled}
+                  options={getPublicationHoursOptions()}
+                  defaultOption={{ label: 'HH:MM', value: '' }}
+                  className={styles['time-picker']}
+                  required
+                  {...form.register('bookingAllowedTime')}
+                  error={form.formState.errors.bookingAllowedTime?.message}
+                />
+              </div>
+            ),
+          },
+        ]}
+        checkedOption={form.watch('bookingAllowedMode')}
+        onChange={(event) => {
+          form.setValue(
+            'bookingAllowedMode',
+            event.target
+              .value as IndividualOfferPracticalInfosFormValues['bookingAllowedMode']
+          )
+        }}
+        name="bookingAllowedMode"
+      />
+    </FormLayout.Row>
+  )
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosFormWithdrawal/IndividualOfferPracticalInfosFormWithdrawal.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosFormWithdrawal/IndividualOfferPracticalInfosFormWithdrawal.spec.tsx
@@ -1,0 +1,80 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FormProvider, useForm } from 'react-hook-form'
+
+import { WithdrawalTypeEnum } from '@/apiClient/v1'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import type { IndividualOfferPracticalInfosFormValues } from '../../../commons/types'
+import {
+  IndividualOfferPracticalInfosFormWithdrawal,
+  type IndividualOfferPracticalInfosFormWithdrawalProps,
+} from './IndividualOfferPracticalInfosFormWithdrawal'
+
+function renderIndividualOfferPracticalInfosFormWithdrawal(
+  props?: Partial<IndividualOfferPracticalInfosFormWithdrawalProps>
+) {
+  function IndividualOfferPracticalInfosFormWithdrawalWrapper() {
+    const form = useForm<IndividualOfferPracticalInfosFormValues>({
+      defaultValues: {
+        bookingAllowedMode: 'now',
+        withdrawalType: WithdrawalTypeEnum.NO_TICKET,
+      },
+    })
+    return (
+      <FormProvider {...form}>
+        <IndividualOfferPracticalInfosFormWithdrawal
+          isFormDisabled={false}
+          {...props}
+        />
+      </FormProvider>
+    )
+  }
+  renderWithProviders(<IndividualOfferPracticalInfosFormWithdrawalWrapper />)
+}
+
+describe('IndividualOfferPracticalInfosFormWithdrawal', () => {
+  it('should display the withdrawal delay selects based on the selected withdrawal type', async () => {
+    renderIndividualOfferPracticalInfosFormWithdrawal()
+
+    const withdrawalGroup = screen.getByRole('radiogroup', {
+      name: /Précisez la façon dont vous distribuerez les billets/,
+    })
+
+    expect(withdrawalGroup).toBeInTheDocument()
+    expect(
+      screen.queryByRole('combobox', {
+        name: 'Date d’envoi - avant le début de l’évènement',
+      })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('combobox', {
+        name: 'Heure de retrait - avant le début de l’évènement',
+      })
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole('radio', {
+        name: 'Les billets seront envoyés par email',
+      })
+    )
+
+    expect(
+      screen.getByRole('combobox', {
+        name: 'Date d’envoi - avant le début de l’évènement',
+      })
+    ).toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole('radio', {
+        name: 'Retrait sur place (guichet, comptoir...)',
+      })
+    )
+
+    expect(
+      screen.getByRole('combobox', {
+        name: 'Heure de retrait - avant le début de l’évènement',
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosFormWithdrawal/IndividualOfferPracticalInfosFormWithdrawal.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosFormWithdrawal/IndividualOfferPracticalInfosFormWithdrawal.tsx
@@ -1,0 +1,108 @@
+import { useFormContext } from 'react-hook-form'
+
+import { WithdrawalTypeEnum } from '@/apiClient/v1'
+import { FormLayout } from '@/components/FormLayout/FormLayout'
+import { RadioButtonGroup } from '@/design-system/RadioButtonGroup/RadioButtonGroup'
+import {
+  ticketSentDateOptions,
+  ticketWithdrawalHourOptions,
+} from '@/pages/IndividualOffer/IndividualOfferInformations/commons/constants'
+import { getFirstWithdrawalTypeEnumValue } from '@/pages/IndividualOffer/IndividualOfferInformations/components/UsefulInformationForm/UsefulInformationForm'
+import { Select } from '@/ui-kit/form/Select/Select'
+import { TextInput } from '@/ui-kit/form/TextInput/TextInput'
+
+import type { IndividualOfferPracticalInfosFormValues } from '../../../commons/types'
+
+export type IndividualOfferPracticalInfosFormWithdrawalProps = {
+  isFormDisabled: boolean
+}
+
+export function IndividualOfferPracticalInfosFormWithdrawal({
+  isFormDisabled,
+}: IndividualOfferPracticalInfosFormWithdrawalProps) {
+  const form = useFormContext<IndividualOfferPracticalInfosFormValues>()
+
+  const withdrawalType = form.watch('withdrawalType')
+
+  const ticketWithdrawalTypeRadios = [
+    {
+      label: 'Aucun billet n’est nécessaire',
+      value: WithdrawalTypeEnum.NO_TICKET,
+    },
+    {
+      label: 'Les billets seront envoyés par email',
+      value: WithdrawalTypeEnum.BY_EMAIL,
+      collapsed: (
+        <Select
+          disabled={isFormDisabled}
+          {...form.register('withdrawalDelay')}
+          label="Date d’envoi - avant le début de l’évènement"
+          options={ticketSentDateOptions}
+          error={form.formState.errors.withdrawalDelay?.message}
+        />
+      ),
+    },
+    {
+      label: 'Retrait sur place (guichet, comptoir...)',
+      value: WithdrawalTypeEnum.ON_SITE,
+      collapsed: (
+        <Select
+          {...form.register('withdrawalDelay')}
+          disabled={isFormDisabled}
+          label="Heure de retrait - avant le début de l’évènement"
+          options={ticketWithdrawalHourOptions}
+        />
+      ),
+    },
+  ]
+
+  const providedTicketWithdrawalTypeRadios = [
+    ...ticketWithdrawalTypeRadios,
+    {
+      label: 'Les billets seront affichés dans l’application',
+      value: WithdrawalTypeEnum.IN_APP,
+    },
+  ]
+
+  return (
+    <>
+      <FormLayout.Row mdSpaceAfter>
+        <RadioButtonGroup
+          variant="detailed"
+          name="withdrawalType"
+          disabled={isFormDisabled}
+          checkedOption={withdrawalType || undefined}
+          error={form.formState.errors.withdrawalType?.message}
+          options={
+            withdrawalType === WithdrawalTypeEnum.IN_APP
+              ? providedTicketWithdrawalTypeRadios
+              : ticketWithdrawalTypeRadios
+          }
+          label="Précisez la façon dont vous distribuerez les billets&nbsp;:"
+          onChange={(e) => {
+            form.setValue(
+              'withdrawalType',
+              e.target.value as WithdrawalTypeEnum,
+              { shouldDirty: true }
+            )
+            form.setValue(
+              'withdrawalDelay',
+              getFirstWithdrawalTypeEnumValue(e.target.value)
+            )
+          }}
+        />
+      </FormLayout.Row>
+      <FormLayout.Row mdSpaceAfter>
+        <TextInput
+          {...form.register('bookingContact')}
+          label="Email de contact communiqué aux bénéficiaires"
+          maxLength={90}
+          disabled={isFormDisabled}
+          description="Format : email@exemple.com"
+          error={form.formState.errors.bookingContact?.message}
+          required
+        />
+      </FormLayout.Row>
+    </>
+  )
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosScreen.spec.tsx
@@ -1,0 +1,174 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { api } from '@/apiClient/api'
+import { SubcategoryIdEnum, WithdrawalTypeEnum } from '@/apiClient/v1'
+import { IndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
+import { OFFER_WIZARD_MODE } from '@/commons/core/Offers/constants'
+import * as useOfferWizardMode from '@/commons/hooks/useOfferWizardMode'
+import {
+  getIndividualOfferFactory,
+  individualOfferContextValuesFactory,
+  subcategoryFactory,
+} from '@/commons/utils/factories/individualApiFactories'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import {
+  IndividualOfferPracticalInfosScreen,
+  type IndividualOfferPracticalInfosScreenProps,
+} from './IndividualOfferPracticalInfosScreen'
+
+vi.mock('@/commons/hooks/useOfferWizardMode', () => ({
+  useOfferWizardMode: vi.fn(() => OFFER_WIZARD_MODE.CREATION),
+}))
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router', async () => {
+  return {
+    ...(await vi.importActual('react-router')),
+    useNavigate: () => mockNavigate,
+    default: vi.fn(),
+  }
+})
+
+Element.prototype.scrollIntoView = vi.fn()
+
+const LABELS = {
+  heading: 'Informations pratiques',
+  saveButton: 'Enregistrer et continuer',
+}
+
+function renderIndividualOfferPracticalInfosScreen(
+  props?: Partial<IndividualOfferPracticalInfosScreenProps>,
+  features?: string[]
+) {
+  renderWithProviders(
+    <IndividualOfferContext.Provider
+      value={individualOfferContextValuesFactory({
+        categories: [],
+        subCategories: [
+          subcategoryFactory({
+            id: SubcategoryIdEnum.CONCERT,
+            canBeWithdrawable: true,
+          }),
+        ],
+      })}
+    >
+      <IndividualOfferPracticalInfosScreen
+        offer={getIndividualOfferFactory()}
+        stocks={[]}
+        {...props}
+      />
+    </IndividualOfferContext.Provider>,
+    {
+      user: sharedCurrentUserFactory(),
+      features,
+    }
+  )
+}
+
+describe('IndividualOfferPracticalInfosScreen', () => {
+  it('should show the form action bar in creation mode', async () => {
+    renderIndividualOfferPracticalInfosScreen()
+
+    await waitFor(() => {
+      screen.getByRole('heading', { name: LABELS.heading })
+    })
+
+    expect(
+      screen.getByRole('button', { name: LABELS.saveButton })
+    ).toBeInTheDocument()
+  })
+
+  it('should open the warning dialog when submitting the form on an offer with active booking if the withdrawal info were modified', async () => {
+    renderIndividualOfferPracticalInfosScreen({
+      offer: getIndividualOfferFactory({
+        withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+        withdrawalDelay: 10,
+        withdrawalDetails: 'test',
+        bookingAllowedDatetime: null,
+        hasPendingBookings: true,
+        subcategoryId: SubcategoryIdEnum.CONCERT,
+        bookingContact: 'test@test.co',
+      }),
+    })
+
+    await waitFor(() => {
+      screen.getByRole('heading', { name: LABELS.heading })
+    })
+
+    await userEvent.click(
+      screen.getByRole('radio', {
+        name: 'Retrait sur place (guichet, comptoir...)',
+      })
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: LABELS.saveButton })
+    )
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Les changements vont s’appliquer à l’ensemble des réservations en cours associées',
+      })
+    ).toBeInTheDocument()
+  })
+
+  it('should update the offer when submitting the form', async () => {
+    renderIndividualOfferPracticalInfosScreen()
+
+    const updateSpy = vi
+      .spyOn(api, 'patchOffer')
+      .mockResolvedValue(getIndividualOfferFactory())
+
+    await waitFor(() => {
+      screen.getByRole('heading', { name: LABELS.heading })
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: LABELS.saveButton })
+    )
+
+    expect(updateSpy).toHaveBeenCalled()
+  })
+
+  it('should navigate to the stocks page whern clicking previous while on creation mode', async () => {
+    renderIndividualOfferPracticalInfosScreen({}, [
+      'WIP_ENABLE_NEW_OFFER_CREATION_FLOW',
+    ])
+
+    await waitFor(() => {
+      screen.getByRole('heading', { name: LABELS.heading })
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retour' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.stringContaining('/creation/stocks')
+    )
+  })
+
+  it('should navigate to the practical info summary page whern clicking cancel while on edition mode', async () => {
+    vi.spyOn(useOfferWizardMode, 'useOfferWizardMode').mockImplementation(
+      () => OFFER_WIZARD_MODE.EDITION
+    )
+
+    renderIndividualOfferPracticalInfosScreen({}, [
+      'WIP_ENABLE_NEW_OFFER_CREATION_FLOW',
+    ])
+
+    await waitFor(() => {
+      screen.getByRole('heading', { name: LABELS.heading })
+    })
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Annuler et quitter' })
+    )
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.stringContaining('/informations_pratiques')
+    )
+  })
+})

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosScreen.tsx
@@ -1,0 +1,195 @@
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useRef, useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { useLocation, useNavigate } from 'react-router'
+import { mutate } from 'swr'
+
+import { api } from '@/apiClient/api'
+import type {
+  GetIndividualOfferWithAddressResponseModel,
+  GetOfferStockResponseModel,
+} from '@/apiClient/v1'
+import { GET_OFFER_QUERY_KEY } from '@/commons/config/swrQueryKeys'
+import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
+import {
+  INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
+  OFFER_WIZARD_MODE,
+} from '@/commons/core/Offers/constants'
+import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
+import { isOfferDisabled } from '@/commons/core/Offers/utils/isOfferDisabled'
+import { SENT_DATA_ERROR_MESSAGE } from '@/commons/core/shared/constants'
+import { useNotification } from '@/commons/hooks/useNotification'
+import { useOfferWizardMode } from '@/commons/hooks/useOfferWizardMode'
+import { getDepartmentCode } from '@/commons/utils/getDepartmentCode'
+import { RouteLeavingGuardIndividualOffer } from '@/components/RouteLeavingGuardIndividualOffer/RouteLeavingGuardIndividualOffer'
+import { ScrollToFirstHookFormErrorAfterSubmit } from '@/components/ScrollToFirstErrorAfterSubmit/ScrollToFirstErrorAfterSubmit'
+import { ActionBar } from '@/pages/IndividualOffer/components/ActionBar/ActionBar'
+
+import { UpdateWarningDialog } from '../../IndividualOfferLocation/components/UpdateWarningDialog/UpdateWarningDialog'
+import { getInitialValuesFromOffer } from '../commons/getInitialValuesFromOffer'
+import { getPatchOfferBody } from '../commons/getPatchOfferBody'
+import type { IndividualOfferPracticalInfosFormValues } from '../commons/types'
+import { getValidationSchema } from '../commons/validationSchema'
+import { IndividualOfferPracticalInfosForm } from './IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm'
+
+export type IndividualOfferPracticalInfosScreenProps = {
+  offer: GetIndividualOfferWithAddressResponseModel
+  stocks: GetOfferStockResponseModel[]
+}
+
+export const IndividualOfferPracticalInfosScreen = ({
+  offer,
+  stocks,
+}: IndividualOfferPracticalInfosScreenProps): JSX.Element => {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const isOnboarding = pathname.indexOf('onboarding') !== -1
+  const mode = useOfferWizardMode()
+
+  const notify = useNotification()
+
+  const { subCategories } = useIndividualOfferContext()
+
+  const subCategory = subCategories.find(
+    (cat) => cat.id === offer?.subcategoryId
+  )
+
+  const [isUpdateWarningDialogOpen, setIsUpdateWarningDialogOpen] =
+    useState(false)
+
+  const saveEditionChangesButtonRef = useRef<HTMLButtonElement>(null)
+
+  const form = useForm<IndividualOfferPracticalInfosFormValues>({
+    defaultValues: getInitialValuesFromOffer(offer, subCategory),
+    resolver: yupResolver<
+      IndividualOfferPracticalInfosFormValues,
+      unknown,
+      unknown
+    >(getValidationSchema(subCategory?.canBeWithdrawable)),
+    mode: 'onBlur',
+  })
+
+  const handlePreviousStep = async () => {
+    if (mode === OFFER_WIZARD_MODE.CREATION) {
+      await navigate(
+        getIndividualOfferUrl({
+          offerId: offer.id,
+          step: offer.isEvent
+            ? INDIVIDUAL_OFFER_WIZARD_STEP_IDS.STOCKS
+            : INDIVIDUAL_OFFER_WIZARD_STEP_IDS.TARIFS,
+          mode: OFFER_WIZARD_MODE.CREATION,
+          isOnboarding,
+        })
+      )
+    } else {
+      await navigate(
+        getIndividualOfferUrl({
+          offerId: offer.id,
+          step: INDIVIDUAL_OFFER_WIZARD_STEP_IDS.PRACTICAL_INFOS,
+          mode: OFFER_WIZARD_MODE.READ_ONLY,
+          isOnboarding,
+        })
+      )
+    }
+  }
+
+  async function onSubmit(formValues: IndividualOfferPracticalInfosFormValues) {
+    const shouldOpenWarningDialog =
+      offer.hasPendingBookings &&
+      (
+        [
+          'withdrawalDetails',
+          'withdrawalDelay',
+          'withdrawalType',
+        ] as (keyof IndividualOfferPracticalInfosFormValues)[]
+      ).some((field) => {
+        return form.watch(field) !== form.formState.defaultValues?.[field]
+      })
+
+    if (shouldOpenWarningDialog) {
+      setIsUpdateWarningDialogOpen(true)
+    } else {
+      await onContinue(formValues, false)
+    }
+  }
+
+  async function onContinue(
+    formValues: IndividualOfferPracticalInfosFormValues,
+    shouldSendMail: boolean
+  ) {
+    try {
+      const requestBody = getPatchOfferBody(
+        formValues,
+        getDepartmentCode(offer),
+        shouldSendMail
+      )
+
+      const response = await api.patchOffer(offer.id, requestBody)
+
+      const receivedOfferId = response.id
+      await mutate([GET_OFFER_QUERY_KEY, receivedOfferId])
+
+      const nextStep =
+        mode === OFFER_WIZARD_MODE.EDITION
+          ? INDIVIDUAL_OFFER_WIZARD_STEP_IDS.PRACTICAL_INFOS
+          : INDIVIDUAL_OFFER_WIZARD_STEP_IDS.SUMMARY
+
+      navigate(
+        getIndividualOfferUrl({
+          offerId: receivedOfferId,
+          step: nextStep,
+          mode:
+            mode === OFFER_WIZARD_MODE.EDITION
+              ? OFFER_WIZARD_MODE.READ_ONLY
+              : mode,
+          isOnboarding,
+        })
+      )
+    } catch {
+      notify.error(SENT_DATA_ERROR_MESSAGE)
+      return
+    }
+  }
+
+  return (
+    <>
+      {isUpdateWarningDialogOpen && (
+        <UpdateWarningDialog
+          onCancel={() => setIsUpdateWarningDialogOpen(false)}
+          onConfirm={(shouldSendMail) => {
+            form.handleSubmit((formValues) =>
+              onContinue(formValues, shouldSendMail)
+            )()
+            setIsUpdateWarningDialogOpen(false)
+          }}
+          refToFocusOnClose={saveEditionChangesButtonRef}
+          message="Vous avez modifié les modalités de retrait."
+        />
+      )}
+      <FormProvider {...form}>
+        <form
+          onSubmit={form.handleSubmit((values) => onSubmit(values))}
+          noValidate
+        >
+          <ScrollToFirstHookFormErrorAfterSubmit />
+          <IndividualOfferPracticalInfosForm
+            offer={offer}
+            subCategory={subCategory}
+            stocks={stocks}
+          />
+          <ActionBar
+            onClickPrevious={handlePreviousStep}
+            step={INDIVIDUAL_OFFER_WIZARD_STEP_IDS.PRACTICAL_INFOS}
+            isDisabled={
+              form.formState.isSubmitting || isOfferDisabled(offer.status)
+            }
+            saveEditionChangesButtonRef={saveEditionChangesButtonRef}
+          />
+          <RouteLeavingGuardIndividualOffer
+            when={form.formState.isDirty && !form.formState.isSubmitting}
+          />
+        </form>
+      </FormProvider>
+    </>
+  )
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/hooks/__specs__/useSaveOfferPriceTable.spec.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/hooks/__specs__/useSaveOfferPriceTable.spec.ts
@@ -139,7 +139,7 @@ describe('useSaveOfferPriceTable', () => {
     expect(saveNonEventOfferPriceTable).toHaveBeenCalled()
     expect(useNavigateMock).toHaveBeenCalledWith(
       expect.stringMatching(
-        `/offre/individuelle/${offer.id}/creation/recapitulatif$`
+        `/offre/individuelle/${offer.id}/creation/informations_pratiques$`
       )
     )
   })

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/hooks/useSaveOfferPriceTable.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/hooks/useSaveOfferPriceTable.ts
@@ -42,7 +42,7 @@ export const useSaveOfferPriceTable = ({
           ? INDIVIDUAL_OFFER_WIZARD_STEP_IDS.TARIFS
           : offer.isEvent
             ? INDIVIDUAL_OFFER_WIZARD_STEP_IDS.STOCKS
-            : INDIVIDUAL_OFFER_WIZARD_STEP_IDS.SUMMARY,
+            : INDIVIDUAL_OFFER_WIZARD_STEP_IDS.PRACTICAL_INFOS,
       mode:
         mode === OFFER_WIZARD_MODE.EDITION ? OFFER_WIZARD_MODE.READ_ONLY : mode,
       isOnboarding,

--- a/pro/src/pages/IndividualOffer/commons/__mocks__/constants.ts
+++ b/pro/src/pages/IndividualOffer/commons/__mocks__/constants.ts
@@ -71,6 +71,12 @@ export const MOCKED_SUBCATEGORY = {
     categoryId: MOCKED_CATEGORY.A.id,
     canBeWithdrawable: true,
   }),
+  WIDTHDRAWABLE_OFFLINE: typedSubcategoryFactory({
+    id: SubcategoryIdEnum.FESTIVAL_CINE,
+    categoryId: MOCKED_CATEGORY.A.id,
+    canBeWithdrawable: true,
+    onlineOfflinePlatform: CATEGORY_STATUS.OFFLINE,
+  }),
 } satisfies Record<string, SubcategoryResponseModelWithId>
 
 export const MOCKED_SUBCATEGORIES = Object.values(MOCKED_SUBCATEGORY)

--- a/pro/src/pages/IndividualOffer/components/ActionBar/ActionBar.tsx
+++ b/pro/src/pages/IndividualOffer/components/ActionBar/ActionBar.tsx
@@ -149,6 +149,7 @@ export const ActionBar = ({
               iconPosition={IconPositionEnum.RIGHT}
               disabled={isDisabled}
               onClick={onClickNext}
+              ref={saveEditionChangesButtonRef}
             >
               Enregistrer et continuer
             </Button>

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/IndividualOfferSummaryScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/IndividualOfferSummaryScreen.tsx
@@ -57,6 +57,9 @@ export const IndividualOfferSummaryScreen = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const currentOfferer = useSelector(selectCurrentOfferer)
   const isMediaPageEnabled = useActiveFeature('WIP_ADD_VIDEO')
+  const isNewOfferCreationFlowFeatureActive = useActiveFeature(
+    'WIP_ENABLE_NEW_OFFER_CREATION_FLOW'
+  )
 
   const onPublish = async (values: EventPublicationFormValues) => {
     // Edition mode offers are already published
@@ -157,7 +160,9 @@ export const IndividualOfferSummaryScreen = () => {
     navigate(
       getIndividualOfferUrl({
         offerId: offer.id,
-        step: INDIVIDUAL_OFFER_WIZARD_STEP_IDS.STOCKS,
+        step: isNewOfferCreationFlowFeatureActive
+          ? INDIVIDUAL_OFFER_WIZARD_STEP_IDS.PRACTICAL_INFOS
+          : INDIVIDUAL_OFFER_WIZARD_STEP_IDS.STOCKS,
         mode,
         isOnboarding,
       })

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/IndividualOfferSummaryPracticalInfos.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/IndividualOfferSummaryPracticalInfos.spec.tsx
@@ -1,0 +1,40 @@
+import { screen } from '@testing-library/react'
+
+import {
+  IndividualOfferContext,
+  type IndividualOfferContextValues,
+} from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
+import { individualOfferContextValuesFactory } from '@/commons/utils/factories/individualApiFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { Component as IndividualOfferSummaryPracticalInfos } from './IndividualOfferSummaryPracticalInfos'
+
+const renderIndividualOfferSummaryPracticalInfos = (
+  context?: Partial<IndividualOfferContextValues>
+) => {
+  const contextValue = individualOfferContextValuesFactory()
+
+  renderWithProviders(
+    <IndividualOfferContext.Provider value={{ ...contextValue, ...context }}>
+      <IndividualOfferSummaryPracticalInfos />
+    </IndividualOfferContext.Provider>
+  )
+}
+
+describe('IndividualOfferSummaryPracticalInfos', () => {
+  it('should render a spinner if there is no offer', () => {
+    renderIndividualOfferSummaryPracticalInfos({ offer: null })
+
+    expect(screen.getByText('Chargement en cours')).toBeInTheDocument()
+  })
+
+  it('should render a practical info section', () => {
+    renderIndividualOfferSummaryPracticalInfos()
+
+    expect(
+      screen.getByRole('heading', {
+        name: 'Informations pratiques',
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/IndividualOfferSummaryPracticalInfos.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/IndividualOfferSummaryPracticalInfos.tsx
@@ -1,0 +1,33 @@
+/* istanbul ignore file */
+
+import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
+import { INDIVIDUAL_OFFER_WIZARD_STEP_IDS } from '@/commons/core/Offers/constants'
+import { useOfferWizardMode } from '@/commons/hooks/useOfferWizardMode'
+import { IndividualOfferLayout } from '@/components/IndividualOfferLayout/IndividualOfferLayout'
+import { ActionBar } from '@/pages/IndividualOffer/components/ActionBar/ActionBar'
+import { Spinner } from '@/ui-kit/Spinner/Spinner'
+
+import { IndividualOfferSummaryPracticalInfosScreen } from './components/IndividualOfferSummaryPracticalInfosScreen'
+
+const IndividualOfferSummaryPracticalInfos = (): JSX.Element | null => {
+  const mode = useOfferWizardMode()
+  const { offer } = useIndividualOfferContext()
+
+  if (offer === null) {
+    return <Spinner />
+  }
+
+  return (
+    <IndividualOfferLayout title="Récapitulatif" offer={offer} mode={mode}>
+      <IndividualOfferSummaryPracticalInfosScreen offer={offer} />
+      <ActionBar
+        step={INDIVIDUAL_OFFER_WIZARD_STEP_IDS.SUMMARY}
+        isDisabled={false}
+      />
+    </IndividualOfferLayout>
+  )
+}
+
+// Below exports are used by react-router
+// ts-unused-exports:disable-next-line
+export const Component = IndividualOfferSummaryPracticalInfos

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/components/IndividualOfferSummaryPracticalInfosScreen.module.scss
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/components/IndividualOfferSummaryPracticalInfosScreen.module.scss
@@ -1,0 +1,5 @@
+@use 'styles/mixins/_rem.scss' as rem;
+
+.withdrawal-block {
+    margin-bottom: rem.torem(24px);
+}

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/components/IndividualOfferSummaryPracticalInfosScreen.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/components/IndividualOfferSummaryPracticalInfosScreen.spec.tsx
@@ -1,0 +1,47 @@
+import { screen } from '@testing-library/react'
+
+import { WithdrawalTypeEnum } from '@/apiClient/v1'
+import { getIndividualOfferFactory } from '@/commons/utils/factories/individualApiFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import {
+  IndividualOfferSummaryPracticalInfosScreen,
+  type IndividualOfferSummaryPracticalInfosScreenProps,
+} from './IndividualOfferSummaryPracticalInfosScreen'
+
+const defaultProps = { offer: getIndividualOfferFactory() }
+
+function renderIndividualOfferSummaryPracticalInfosScreen(
+  props?: Partial<IndividualOfferSummaryPracticalInfosScreenProps>
+) {
+  renderWithProviders(
+    <IndividualOfferSummaryPracticalInfosScreen {...defaultProps} {...props} />
+  )
+}
+
+describe('IndividualOfferSummaryPracticalInfosScreen', () => {
+  it('should render the practical information summary sections', () => {
+    renderIndividualOfferSummaryPracticalInfosScreen()
+
+    screen.getByRole('heading', { name: 'Informations pratiques' })
+    screen.getByRole('heading', { name: 'Notification des réservations' })
+  })
+
+  it('should render the offer description infos', () => {
+    renderIndividualOfferSummaryPracticalInfosScreen({
+      offer: getIndividualOfferFactory({
+        withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+        withdrawalDelay: 10,
+        withdrawalDetails: 'Details for the withdrawal',
+        bookingContact: 'test@contact.co',
+        bookingEmail: 'test2@contact.co',
+      }),
+    })
+
+    screen.getByText('Details for the withdrawal')
+    screen.getByText(/Précisez la façon dont vous distribuerez les billets/)
+    screen.getByText(/Heure de retrait/)
+    screen.getByText('test@contact.co')
+    screen.getByText('test2@contact.co')
+  })
+})

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/components/IndividualOfferSummaryPracticalInfosScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/components/IndividualOfferSummaryPracticalInfosScreen.tsx
@@ -1,0 +1,90 @@
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import {
+  INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
+  OFFER_WITHDRAWAL_TYPE_LABELS,
+  OFFER_WIZARD_MODE,
+} from '@/commons/core/Offers/constants'
+import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
+import { getDelayToFrenchText } from '@/commons/utils/date'
+import { SummaryContent } from '@/components/SummaryLayout/SummaryContent'
+import {
+  type Description,
+  SummaryDescriptionList,
+} from '@/components/SummaryLayout/SummaryDescriptionList'
+import { SummaryLayout } from '@/components/SummaryLayout/SummaryLayout'
+import { SummarySection } from '@/components/SummaryLayout/SummarySection'
+import { SummarySubSection } from '@/components/SummaryLayout/SummarySubSection'
+
+import styles from './IndividualOfferSummaryPracticalInfosScreen.module.scss'
+
+export type IndividualOfferSummaryPracticalInfosScreenProps = {
+  offer: GetIndividualOfferWithAddressResponseModel
+}
+
+export function IndividualOfferSummaryPracticalInfosScreen({
+  offer,
+}: IndividualOfferSummaryPracticalInfosScreenProps) {
+  const practicalInfoDescriptions: Description[] = []
+
+  if (offer.withdrawalType) {
+    practicalInfoDescriptions.push({
+      title: 'Précisez la façon dont vous distribuerez les billets',
+      text: OFFER_WITHDRAWAL_TYPE_LABELS[offer.withdrawalType],
+    })
+  }
+  if (offer.withdrawalDelay) {
+    practicalInfoDescriptions.push({
+      title: 'Heure de retrait',
+      text: `${getDelayToFrenchText(offer.withdrawalDelay)} avant le début de l’évènement`,
+    })
+  }
+  practicalInfoDescriptions.push({
+    title: 'Informations complémentaires',
+    text: offer.withdrawalDetails || ' - ',
+  })
+  if (offer.bookingContact) {
+    practicalInfoDescriptions.push({
+      title: 'Email de contact',
+      text: offer.bookingContact || ' - ',
+    })
+  }
+  return (
+    <SummaryLayout>
+      <SummaryContent>
+        <SummarySection
+          title="Informations pratiques"
+          editLink={getIndividualOfferUrl({
+            offerId: offer.id,
+            step: INDIVIDUAL_OFFER_WIZARD_STEP_IDS.PRACTICAL_INFOS,
+            mode: OFFER_WIZARD_MODE.EDITION,
+          })}
+          aria-label="Modifier les détails de l’offre"
+        >
+          <div className={styles['withdrawal-block']}>
+            <SummaryDescriptionList descriptions={practicalInfoDescriptions} />
+          </div>
+          <SummarySubSection title="Lien de réservation externe en l’absence de crédit">
+            <SummaryDescriptionList
+              descriptions={[
+                {
+                  title: 'URL de votre site ou billetterie',
+                  text: offer.externalTicketOfficeUrl || ' - ',
+                },
+              ]}
+            />
+          </SummarySubSection>
+          <SummarySubSection title="Notification des réservations">
+            <SummaryDescriptionList
+              descriptions={[
+                {
+                  title: 'Email auquel envoyer les notifications',
+                  text: offer.bookingEmail || ' - ',
+                },
+              ]}
+            />
+          </SummarySubSection>
+        </SummarySection>
+      </SummaryContent>
+    </SummaryLayout>
+  )
+}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-36381)

Création de la nouvelle étape 5 du parcours de création d'offre individuelle "Informations pratiques" (l'étape 2 étant maintenant "Localisation").
Cette nouvelle étape regroupe les infos de retrait, les notification de réservations, et la date limite de réservabilité.

Pour tester, activer `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` et créer une offre individuelle.
