### PR TITLE
(PC-37613)[PRO] feat: delete prebooked cta when ff is active

### DIFF
--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveActionsCells/CollectiveActionsCells.spec.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveActionsCells/CollectiveActionsCells.spec.tsx
@@ -5,6 +5,7 @@ import createFetchMock from 'vitest-fetch-mock'
 
 import { api } from '@/apiClient/api'
 import {
+  CollectiveBookingStatus,
   CollectiveOfferAllowedAction,
   CollectiveOfferDisplayedStatus,
   CollectiveOfferTemplateAllowedAction,
@@ -615,5 +616,49 @@ describe('CollectiveActionsCells', () => {
       'Une erreur est survenue lors de l’archivage de l’offre',
       expect.any(Object)
     )
+  })
+
+  it('should not show action link to see pre-reservation when ff WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE is active', async () => {
+    renderCollectiveActionsCell(
+      {
+        offer: collectiveOfferFactory({
+          isShowcase: false,
+          booking: {
+            id: 1,
+            booking_status: CollectiveBookingStatus.PENDING,
+          },
+          displayedStatus: CollectiveOfferDisplayedStatus.PREBOOKED,
+        }),
+      },
+      ['WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE']
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Voir les actions' })
+    )
+
+    expect(screen.queryByText('Voir la préréservation')).not.toBeInTheDocument()
+  })
+
+  it('should not show action link to see reservation when ff WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE is active', async () => {
+    renderCollectiveActionsCell(
+      {
+        offer: collectiveOfferFactory({
+          isShowcase: false,
+          booking: {
+            id: 1,
+            booking_status: CollectiveBookingStatus.CONFIRMED,
+          },
+          displayedStatus: CollectiveOfferDisplayedStatus.BOOKED,
+        }),
+      },
+      ['WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE']
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Voir les actions' })
+    )
+
+    expect(screen.queryByText('Voir la réservation')).not.toBeInTheDocument()
   })
 })

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveActionsCells/CollectiveActionsCells.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveActionsCells/CollectiveActionsCells.tsx
@@ -329,14 +329,16 @@ export const CollectiveActionsCells = ({
       headers={`${rowId} ${getCellsDefinition().ACTIONS.id}`}
     >
       <div className={styles['actions-column-container']}>
-        {shouldDisplayBookingLink && offer.booking && (
-          <BookingLinkCell
-            bookingId={offer.booking.id}
-            bookingStatus={offer.booking.booking_status}
-            offerEventDate={offer.stocks[0].startDatetime}
-            offerId={offer.id}
-          />
-        )}
+        {shouldDisplayBookingLink &&
+          offer.booking &&
+          !isNewOffersAndBookingsActive && (
+            <BookingLinkCell
+              bookingId={offer.booking.id}
+              bookingStatus={offer.booking.booking_status}
+              offerEventDate={offer.stocks[0].startDatetime}
+              offerId={offer.id}
+            />
+          )}
         {!noActionsAllowed && (
           <DropdownMenuWrapper
             title="Voir les actions"
@@ -344,36 +346,38 @@ export const CollectiveActionsCells = ({
             triggerTooltip
             dropdownTriggerRef={dropdownTriggerRef}
           >
-            {shouldDisplayBookingLink && offer.booking && (
-              <>
-                <DropdownMenu.Item className={styles['menu-item']} asChild>
-                  <ButtonLink
-                    to={bookingLink}
-                    icon={fullNextIcon}
-                    onClick={() =>
-                      logEvent(
-                        CollectiveBookingsEvents.CLICKED_SEE_COLLECTIVE_BOOKING,
-                        {
-                          from: location.pathname,
-                          offerId: offer.id,
-                          offerType: 'collective',
-                          offererId: selectedOffererId?.toString(),
-                        }
-                      )
-                    }
-                  >
-                    Voir la{' '}
-                    {offer.booking.booking_status ===
-                    CollectiveBookingStatus.PENDING
-                      ? 'préréservation'
-                      : 'réservation'}
-                  </ButtonLink>
-                </DropdownMenu.Item>
-                <DropdownMenu.Separator
-                  className={cn(styles['separator'], styles['tablet-only'])}
-                />
-              </>
-            )}
+            {shouldDisplayBookingLink &&
+              offer.booking &&
+              !isNewOffersAndBookingsActive && (
+                <>
+                  <DropdownMenu.Item className={styles['menu-item']} asChild>
+                    <ButtonLink
+                      to={bookingLink}
+                      icon={fullNextIcon}
+                      onClick={() =>
+                        logEvent(
+                          CollectiveBookingsEvents.CLICKED_SEE_COLLECTIVE_BOOKING,
+                          {
+                            from: location.pathname,
+                            offerId: offer.id,
+                            offerType: 'collective',
+                            offererId: selectedOffererId?.toString(),
+                          }
+                        )
+                      }
+                    >
+                      Voir la{' '}
+                      {offer.booking.booking_status ===
+                      CollectiveBookingStatus.PENDING
+                        ? 'préréservation'
+                        : 'réservation'}
+                    </ButtonLink>
+                  </DropdownMenu.Item>
+                  <DropdownMenu.Separator
+                    className={cn(styles['separator'], styles['tablet-only'])}
+                  />
+                </>
+              )}
             {canDuplicateOffer && (
               <DropdownMenu.Item
                 className={styles['menu-item']}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37613)

Ne plus afficher les cta préreservation et reservation si le ff de split des pages est activé 