### PR TITLE
(PC-37692)[API] fix: raise InvalidFormatException in case of invalid SIREN or SIRET

### DIFF
--- a/api/tests/connectors/api_entreprise_test.py
+++ b/api/tests/connectors/api_entreprise_test.py
@@ -15,7 +15,7 @@ from . import api_entreprise_test_data
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siren_without_address():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}",
@@ -24,7 +24,7 @@ def test_get_siren_without_address():
         siren_info = api.get_siren(siren, with_address=False)
         assert siren_info.siren == siren
         assert siren_info.name == "LE PETIT RINTINTIN"
-        assert siren_info.head_office_siret == "12345678900012"
+        assert siren_info.head_office_siret == "12345678200012"
         assert siren_info.ape_code == "4761Z"
         assert siren_info.ape_label == "Commerce de détail de livres en magasin spécialisé"
         assert siren_info.legal_category_code == "5710"
@@ -37,7 +37,7 @@ def test_get_siren_without_address():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siren_with_address():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}/siege_social",
@@ -46,7 +46,7 @@ def test_get_siren_with_address():
         siren_info = api.get_siren(siren)
         assert siren_info.siren == siren
         assert siren_info.name == "LE PETIT RINTINTIN"
-        assert siren_info.head_office_siret == "12345678900012"
+        assert siren_info.head_office_siret == "12345678200012"
         assert siren_info.ape_code == "4761Z"
         assert siren_info.ape_label == "Commerce de détail de livres en magasin spécialisé"
         assert siren_info.legal_category_code == "5710"
@@ -65,7 +65,7 @@ def test_get_siren_with_address():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siren_of_entreprise_individuelle():
-    siren = "111222333"
+    siren = "111222337"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}/siege_social",
@@ -74,7 +74,7 @@ def test_get_siren_of_entreprise_individuelle():
         siren_info = api.get_siren(siren)
         assert siren_info.siren == siren
         assert siren_info.name == "MARIE SKLODOWSKA CURIE"
-        assert siren_info.head_office_siret == "11122233300022"
+        assert siren_info.head_office_siret == "11122233700022"
         assert siren_info.ape_code == "7219Z"
         assert siren_info.ape_label == "Recherche-développement en autres sciences physiques et naturelles"
         assert siren_info.legal_category_code == "1000"
@@ -89,7 +89,7 @@ def test_get_siren_of_entreprise_individuelle():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siren_with_non_public_data():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}",
@@ -101,7 +101,7 @@ def test_get_siren_with_non_public_data():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siren_with_non_public_data_do_not_raise():
-    siren = "987654321"
+    siren = "987654324"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}/siege_social",
@@ -110,7 +110,7 @@ def test_get_siren_with_non_public_data_do_not_raise():
         siren_info = api.get_siren(siren, raise_if_non_public=False)
         assert siren_info.siren == siren
         assert siren_info.name == "GEORGE DUPIN SAND"
-        assert siren_info.head_office_siret == "98765432100016"
+        assert siren_info.head_office_siret == "98765432400019"
         assert siren_info.ape_code == "9003B"
         assert siren_info.ape_label == "Autre création artistique"
         assert siren_info.legal_category_code == "1000"
@@ -125,7 +125,7 @@ def test_get_siren_with_non_public_data_do_not_raise():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siren_of_inactive_company():
-    siren = "777899888"
+    siren = "777899881"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}",
@@ -134,7 +134,7 @@ def test_get_siren_of_inactive_company():
         siren_info = api.get_siren(siren, with_address=False)
         assert siren_info.siren == siren
         assert siren_info.name == "LE RIDEAU FERME"
-        assert siren_info.head_office_siret == "77789988800021"
+        assert siren_info.head_office_siret == "77789988100021"
         assert siren_info.ape_code == "9001Z"
         assert siren_info.ape_label == "Arts du spectacle vivant"
         assert siren_info.legal_category_code == "5499"
@@ -161,7 +161,7 @@ def test_get_siren_without_ape():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siren_without_creation_date():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}",
@@ -175,7 +175,7 @@ def test_get_siren_without_creation_date():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siren_invalid_parameter():
-    siren = "111111111"
+    siren = "111111118"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}/siege_social",
@@ -193,6 +193,19 @@ def test_get_siren_pass_culture():
     with pytest.raises(exceptions.EntrepriseException) as error:
         api.get_siren(siren)
     assert str(error.value) == "Pass Culture"
+
+
+@pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
+def test_get_invalid_siren():
+    siren = "111111111"
+
+    with pytest.raises(exceptions.InvalidFormatException) as error:
+        api.get_siren(siren)
+    assert str(error.value) == "SIREN invalide"
+
+    with pytest.raises(exceptions.InvalidFormatException) as error:
+        api.get_siren_open_data(siren)
+    assert str(error.value) == "SIREN invalide"
 
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
@@ -216,7 +229,7 @@ def test_get_siren_reached_rate_limit():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siret():
-    siret = "12345678900017"
+    siret = "12345678200010"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/{siret}",
@@ -241,7 +254,7 @@ def test_get_siret():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siret_of_entreprise_individuelle():
-    siret = "12345678900045"
+    siret = "12345678200044"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/{siret}",
@@ -262,7 +275,7 @@ def test_get_siret_of_entreprise_individuelle():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siret_with_non_public_data():
-    siret = "12345678900017"
+    siret = "12345678200010"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/{siret}",
@@ -274,7 +287,7 @@ def test_get_siret_with_non_public_data():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siret_with_non_public_data_do_not_raise():
-    siret = "12345678900017"
+    siret = "12345678200010"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/{siret}",
@@ -295,7 +308,7 @@ def test_get_siret_with_non_public_data_do_not_raise():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_siret_of_inactive_company():
-    siret = "77789988800021"
+    siret = "77789988100026"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/{siret}",
@@ -312,6 +325,27 @@ def test_get_siret_of_inactive_company():
         assert siret_info.legal_category_code == "5499"
         assert siret_info.active is False
         assert siret_info.diffusible is True
+
+
+@pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
+def test_get_siret_pass_culture():
+    siren = settings.PASS_CULTURE_SIRET
+    with pytest.raises(exceptions.EntrepriseException) as error:
+        api.get_siret(siren)
+    assert str(error.value) == "Pass Culture"
+
+
+@pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
+def test_get_invalid_siret():
+    siret = "11111111822222"
+
+    with pytest.raises(exceptions.InvalidFormatException) as error:
+        api.get_siret(siret)
+    assert str(error.value) == "SIRET invalide"
+
+    with pytest.raises(exceptions.InvalidFormatException) as error:
+        api.get_siret_open_data(siret)
+    assert str(error.value) == "SIRET invalide"
 
 
 @pytest.mark.parametrize(
@@ -332,7 +366,7 @@ def test_get_siret_of_inactive_company():
 )
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_error_handling(status_code, expected_exception):
-    siret = "invalid"
+    siret = "11111111800019"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/{siret}",
@@ -344,7 +378,7 @@ def test_error_handling(status_code, expected_exception):
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_error_handling_on_non_json_response():
-    siret = "anything"
+    siret = "11111111800019"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/{siret}",
@@ -357,7 +391,7 @@ def test_error_handling_on_non_json_response():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_rcs_registered():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/infogreffe/rcs/unites_legales/{siren}/extrait_kbis",
@@ -380,7 +414,7 @@ def test_get_rcs_registered():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_rcs_deregistered():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/infogreffe/rcs/unites_legales/{siren}/extrait_kbis",
@@ -403,7 +437,7 @@ def test_get_rcs_deregistered():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_rcs_not_registered():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v3/infogreffe/rcs/unites_legales/{siren}/extrait_kbis",
@@ -416,7 +450,7 @@ def test_get_rcs_not_registered():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_urssaf_ok():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v4/urssaf/unites_legales/{siren}/attestation_vigilance",
@@ -437,7 +471,7 @@ def test_get_urssaf_ok():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_urssaf_refused():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v4/urssaf/unites_legales/{siren}/attestation_vigilance",
@@ -457,7 +491,7 @@ def test_get_urssaf_refused():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_urssaf_not_found():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v4/urssaf/unites_legales/{siren}/attestation_vigilance",
@@ -471,7 +505,7 @@ def test_get_urssaf_not_found():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_dgfip_ok():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v4/dgfip/unites_legales/{siren}/attestation_fiscale",
@@ -483,7 +517,7 @@ def test_get_dgfip_ok():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_dgfip_entreprise_individuelle():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v4/dgfip/unites_legales/{siren}/attestation_fiscale",
@@ -501,7 +535,7 @@ def test_get_dgfip_entreprise_individuelle():
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_dgfip_inactive_company():
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock.get(
             f"https://entreprise.api.gouv.fr/v4/dgfip/unites_legales/{siren}/attestation_fiscale",
@@ -521,7 +555,7 @@ def test_get_dgfip_inactive_company():
 @unittest.mock.patch("flask.current_app.redis_client.set")
 @unittest.mock.patch("flask.current_app.redis_client.ttl", return_value=-1)
 def test_check_rate_limit_ok(mock_redis_client_ttl, mock_redis_client_set, mock_sleep, caplog):
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock_request = mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}",
@@ -547,7 +581,7 @@ def test_check_rate_limit_ok(mock_redis_client_ttl, mock_redis_client_set, mock_
 @pytest.mark.parametrize("seconds", [15, 0])
 @unittest.mock.patch("flask.current_app.redis_client.set")
 def test_check_rate_limit_near_limit(mock_redis_client_set, seconds, caplog):
-    siren = "123456789"
+    siren = "123456782"
     reset_timestamp = int(time.time()) + seconds
     with requests_mock.Mocker() as mock:
         mock_request = mock.get(
@@ -581,7 +615,7 @@ def test_check_rate_limit_near_limit(mock_redis_client_set, seconds, caplog):
 @unittest.mock.patch("flask.current_app.redis_client.set")
 @unittest.mock.patch("flask.current_app.redis_client.ttl", side_effect=[20, -1])
 def test_rate_limit_locked(mock_redis_client_ttl, mock_redis_client_set, mock_sleep):
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock_request = mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}",
@@ -605,7 +639,7 @@ def test_rate_limit_locked(mock_redis_client_ttl, mock_redis_client_set, mock_sl
 @unittest.mock.patch("flask.current_app.redis_client.set")
 @unittest.mock.patch("flask.current_app.redis_client.ttl", return_value=20)
 def test_rate_limit_locked_over_timeout(mock_redis_client_ttl, mock_redis_client_set, mock_sleep):
-    siren = "123456789"
+    siren = "123456782"
     with requests_mock.Mocker() as mock:
         mock_request = mock.get(
             f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/{siren}",

--- a/api/tests/connectors/api_entreprise_test_data.py
+++ b/api/tests/connectors/api_entreprise_test_data.py
@@ -1,8 +1,8 @@
 RESPONSE_SIREN_COMPANY = {
     "data": {
-        "siren": "123456789",
+        "siren": "123456782",
         "rna": None,
-        "siret_siege_social": "12345678900012",
+        "siret_siege_social": "12345678200012",
         "categorie_entreprise": "PME",
         "type": "personne_morale",
         "personne_morale_attributs": {"raison_sociale": "LE PETIT RINTINTIN", "sigle": None},
@@ -38,15 +38,15 @@ RESPONSE_SIREN_COMPANY = {
         "date_creation": 1563832800,
     },
     "links": {
-        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/12345678900012",
-        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/12345678900012/adresse",
+        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/12345678200012",
+        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/12345678200012/adresse",
     },
     "meta": {"date_derniere_mise_a_jour": 1701298800, "redirect_from_siren": None},
 }
 
 RESPONSE_SIRET_COMPANY = {
     "data": {
-        "siret": "12345678900012",
+        "siret": "12345678200012",
         "siege_social": True,
         "etat_administratif": "A",
         "date_fermeture": None,
@@ -61,9 +61,9 @@ RESPONSE_SIRET_COMPANY = {
         "status_diffusion": "diffusible",
         "date_creation": 1677625200,
         "unite_legale": {
-            "siren": "123456789",
+            "siren": "123456782",
             "rna": None,
-            "siret_siege_social": "12345678900012",
+            "siret_siege_social": "12345678200012",
             "type": "personne_morale",
             "personne_morale_attributs": {"raison_sociale": "LE PETIT RINTINTIN", "sigle": None},
             "personne_physique_attributs": {
@@ -124,15 +124,15 @@ RESPONSE_SIRET_COMPANY = {
             },
         },
     },
-    "links": {"unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/123456789"},
+    "links": {"unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/123456782"},
     "meta": {"date_derniere_mise_a_jour": 1683151200, "redirect_from_siret": None},
 }
 
 RESPONSE_SIREN_ENTREPRISE_INDIVIDUELLE = {
     "data": {
-        "siren": "111222333",
+        "siren": "111222337",
         "rna": None,
-        "siret_siege_social": "11122233300022",
+        "siret_siege_social": "11122233700022",
         "categorie_entreprise": "PME",
         "type": "personne_physique",
         "personne_morale_attributs": {"raison_sociale": None, "sigle": None},
@@ -162,15 +162,15 @@ RESPONSE_SIREN_ENTREPRISE_INDIVIDUELLE = {
         "date_creation": 1704063600,
     },
     "links": {
-        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/11122233300022",
-        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/11122233300022/adresse",
+        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/11122233700022",
+        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/11122233700022/adresse",
     },
     "meta": {"date_derniere_mise_a_jour": 1704063600, "redirect_from_siren": None},
 }
 
 RESPONSE_SIRET_ENTREPRISE_INDIVIDUELLE = {
     "data": {
-        "siret": "11122233300022",
+        "siret": "11122233700022",
         "siege_social": True,
         "etat_administratif": "A",
         "date_fermeture": None,
@@ -185,9 +185,9 @@ RESPONSE_SIRET_ENTREPRISE_INDIVIDUELLE = {
         "status_diffusion": "diffusible",
         "date_creation": 1704063600,
         "unite_legale": {
-            "siren": "111222333",
+            "siren": "111222337",
             "rna": None,
-            "siret_siege_social": "11122233300022",
+            "siret_siege_social": "11122233700022",
             "type": "personne_physique",
             "personne_morale_attributs": {"raison_sociale": None, "sigle": None},
             "personne_physique_attributs": {
@@ -242,15 +242,15 @@ RESPONSE_SIRET_ENTREPRISE_INDIVIDUELLE = {
             },
         },
     },
-    "links": {"unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/111222333"},
+    "links": {"unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/111222337"},
     "meta": {"date_derniere_mise_a_jour": 1704063600, "redirect_from_siret": None},
 }
 
 RESPONSE_SIREN_COMPANY_WITH_NON_PUBLIC_DATA = {
     "data": {
-        "siren": "987654321",
+        "siren": "987654324",
         "rna": None,
-        "siret_siege_social": "98765432100016",
+        "siret_siege_social": "98765432400019",
         "categorie_entreprise": "PME",
         "type": "personne_physique",
         "personne_morale_attributs": {"raison_sociale": None, "sigle": None},
@@ -280,8 +280,8 @@ RESPONSE_SIREN_COMPANY_WITH_NON_PUBLIC_DATA = {
         "date_creation": 1617228000,
     },
     "links": {
-        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/98765432100016",
-        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/98765432100016/adresse",
+        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/98765432400019",
+        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/98765432400019/adresse",
     },
     "meta": {"date_derniere_mise_a_jour": 1618178400, "redirect_from_siren": None},
 }
@@ -289,7 +289,7 @@ RESPONSE_SIREN_COMPANY_WITH_NON_PUBLIC_DATA = {
 
 RESPONSE_SIRET_COMPANY_WITH_NON_PUBLIC_DATA = {
     "data": {
-        "siret": "98765432100016",
+        "siret": "98765432400019",
         "siege_social": True,
         "etat_administratif": "A",
         "date_fermeture": None,
@@ -304,9 +304,9 @@ RESPONSE_SIRET_COMPANY_WITH_NON_PUBLIC_DATA = {
         "status_diffusion": "partiellement_diffusible",
         "date_creation": 1618178400,
         "unite_legale": {
-            "siren": "987654321",
+            "siren": "987654324",
             "rna": None,
-            "siret_siege_social": "98765432100016",
+            "siret_siege_social": "98765432400019",
             "type": "personne_physique",
             "personne_morale_attributs": {"raison_sociale": None, "sigle": None},
             "personne_physique_attributs": {
@@ -368,9 +368,9 @@ RESPONSE_SIRET_COMPANY_WITH_NON_PUBLIC_DATA = {
 
 RESPONSE_SIREN_INACTIVE_COMPANY = {
     "data": {
-        "siren": "777899888",
+        "siren": "777899881",
         "rna": None,
-        "siret_siege_social": "77789988800021",
+        "siret_siege_social": "77789988100021",
         "categorie_entreprise": None,
         "type": "personne_morale",
         "personne_morale_attributs": {"raison_sociale": "LE RIDEAU FERME", "sigle": None},
@@ -405,15 +405,15 @@ RESPONSE_SIREN_INACTIVE_COMPANY = {
         "date_creation": 1262300400,
     },
     "links": {
-        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/77789988800021",
-        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/77789988800021/adresse",
+        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/77789988100021",
+        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/77789988100021/adresse",
     },
     "meta": {"date_derniere_mise_a_jour": 1618178400, "redirect_from_siren": None},
 }
 
 RESPONSE_SIRET_INACTIVE_COMPANY = {
     "data": {
-        "siret": "77789988800021",
+        "siret": "77789988100021",
         "siege_social": True,
         "etat_administratif": "F",
         "date_fermeture": 1703977200,
@@ -430,9 +430,9 @@ RESPONSE_SIRET_INACTIVE_COMPANY = {
         "status_diffusion": "diffusible",
         "date_creation": 1262300400,
         "unite_legale": {
-            "siren": "777899888",
+            "siren": "777899881",
             "rna": None,
-            "siret_siege_social": "77789988800021",
+            "siret_siege_social": "77789988100021",
             "type": "personne_morale",
             "personne_morale_attributs": {"raison_sociale": "LE RIDEAU FERME", "sigle": None},
             "personne_physique_attributs": {
@@ -492,7 +492,7 @@ RESPONSE_SIRET_INACTIVE_COMPANY = {
             },
         },
     },
-    "links": {"unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/777899888"},
+    "links": {"unite_legale": "https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/777899881"},
     "meta": {"date_derniere_mise_a_jour": 1618178400, "redirect_from_siret": None},
 }
 
@@ -547,9 +547,9 @@ RESPONSE_SIREN_WITHOUT_APE = {
 
 RESPONSE_SIREN_WITHOUT_CREATION_DATE = {
     "data": {
-        "siren": "123456789",
+        "siren": "123456782",
         "rna": "W123000045",
-        "siret_siege_social": "12345678900012",
+        "siret_siege_social": "12345678200012",
         "categorie_entreprise": "PME",
         "type": "personne_morale",
         "personne_morale_attributs": {"raison_sociale": "PAS DE DATE DE CREATION", "sigle": None},
@@ -585,8 +585,8 @@ RESPONSE_SIREN_WITHOUT_CREATION_DATE = {
         "date_creation": None,
     },
     "links": {
-        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/12345678900012",
-        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/12345678900012/adresse",
+        "siege_social": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/12345678200012",
+        "siege_social_adresse": "https://entreprise.api.gouv.fr/v3/insee/sirene/etablissements/12345678200012/adresse",
     },
     "meta": {"date_derniere_mise_a_jour": 1711062000, "redirect_from_siren": None},
 }
@@ -609,7 +609,7 @@ RESPONSE_SIREN_ERROR_429 = {"errors": ["Vous avez effectué trop de requêtes"]}
 
 RESPONSE_RCS_REGISTERED_COMPANY = {
     "data": {
-        "siren": "123456789",
+        "siren": "123456782",
         "date_extrait": "15 JANVIER 2024",
         "date_radiation": None,
         "date_immatriculation": "2024-01-01",
@@ -632,7 +632,7 @@ RESPONSE_RCS_REGISTERED_COMPANY = {
                 "type": "personne_physique",
                 "raison_sociale": "AUDIT EXEMPLE - SOCIETE PAR ACTIONS SIMPLIFIEE",
                 "fonction": "COMMISSAIRE AUX COMPTES TITULAIRE",
-                "numero_identification": "123456789",
+                "numero_identification": "123456782",
             },
         ],
         "observations": [],
@@ -676,7 +676,7 @@ RESPONSE_RCS_REGISTERED_COMPANY = {
 
 RESPONSE_RCS_DEREGISTERED_COMPANY = {
     "data": {
-        "siren": "123456789",
+        "siren": "123456782",
         "date_extrait": "15 FEVRIER 2024",
         "date_radiation": "2024-02-05",
         "date_immatriculation": "2024-01-01",

--- a/api/tests/routes/pro/post_offerer_test.py
+++ b/api/tests/routes/pro/post_offerer_test.py
@@ -251,7 +251,7 @@ def test_create_offerer_action_is_logged(client):
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_with_inactive_siren(requests_mock, client):
-    siren = "123456789"
+    siren = "777899881"
     requests_mock.get(
         f"https://entreprise.api.gouv.fr/v3/insee/sirene/unites_legales/diffusibles/{siren}/siege_social",
         json=api_entreprise_test_data.RESPONSE_SIRET_INACTIVE_COMPANY,

--- a/api/tests/routes/pro/post_save_new_onboarding_data_test.py
+++ b/api/tests/routes/pro/post_save_new_onboarding_data_test.py
@@ -258,7 +258,7 @@ class Returns400Test:
 
     @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
     def test_inactive_siret(self, requests_mock, client):
-        siret = "77789988800021"
+        siret = "77789988100026"
         REQUEST_BODY["siret"] = siret
 
         requests_mock.get(


### PR DESCRIPTION
When the SIREN/SIRET was invalid, an InvalidFormatException was raised so that the error message is properly displayed in PC Pro. Now API Entreprise is called, but a generic error is reported in our alerts. We should handle this invalid SIREN/SIRET the same way ; best before calling API.

https://pass-culture.sentry.io/issues/51070177/

Ticket Jira : https://passculture.atlassian.net/browse/PC-37692