### PR TITLE
(PC-37693)[API] fix: KeyError: 'token', when Titelive returns error 500

### DIFF
--- a/api/src/pcapi/connectors/titelive.py
+++ b/api/src/pcapi/connectors/titelive.py
@@ -57,7 +57,7 @@ def get_jwt_token() -> str:
                         "response_text": response.text,
                     },
                 )
-                raise requests.ExternalAPIException(True, {"status_code": response.status_code})
+            raise requests.ExternalAPIException(True, {"status_code": response.status_code})
 
         return response.json()["token"]
 

--- a/api/tests/connectors/titelive/titelive_test.py
+++ b/api/tests/connectors/titelive/titelive_test.py
@@ -10,6 +10,7 @@ from pcapi.connectors import titelive
 from pcapi.connectors.titelive import GtlIdError
 from pcapi.core.categories import subcategories
 from pcapi.utils import date as date_utils
+from pcapi.utils.requests import ExternalAPIException
 
 from tests.connectors.titelive import fixtures
 
@@ -31,6 +32,15 @@ class TiteliveTest:
         self._configure_mock(requests_mock)
 
         assert titelive.get_jwt_token() == "XYZ"
+
+    def test_get_jwt_token_error_500(self, requests_mock):
+        requests_mock.post(
+            f"{settings.TITELIVE_EPAGINE_API_AUTH_URL}/login/test@example.com/token",
+            status_code=500,
+        )
+
+        with pytest.raises(ExternalAPIException):
+            titelive.get_jwt_token()
 
     def test_get_by_ean13(self, requests_mock):
         ean = "9782070455379"


### PR DESCRIPTION
Ticket Jira : https://passculture.atlassian.net/browse/PC-37693
Sentry : https://pass-culture.sentry.io/issues/60958168/