### PR TITLE
(PC-37680)[PRO] fix: display offer status label instead of key in excel export

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "python.testing.pytestArgs": [
     "-vv",
     "-s",
+    "--color=yes",
     "-W ignore::DeprecationWarning"
   ]
 }

--- a/api/src/pcapi/core/educational/api/export.py
+++ b/api/src/pcapi/core/educational/api/export.py
@@ -9,6 +9,7 @@ import sqlalchemy.orm as sa_orm
 import xlsxwriter
 
 from pcapi.core.educational import models
+from pcapi.core.educational.utils import format_collective_offer_displayed_status
 from pcapi.core.offerers import models as offerers_models
 from pcapi.utils import date as date_utils
 from pcapi.utils import export as utils_export
@@ -103,7 +104,7 @@ def _get_collective_offer_export_data(
     result = CollectiveOfferExportData(
         offer_name=collective_offer.name,
         offer_id=collective_offer.id,
-        offer_status=collective_offer.displayedStatus.value,
+        offer_status=format_collective_offer_displayed_status(collective_offer.displayedStatus).lower(),
         offer_location_type=FORMAT_LOCATION_TYPE[collective_offer.locationType],
         offer_location=_format_location(collective_offer),
         venue_common_name=venue.common_name,

--- a/api/src/pcapi/core/educational/constants.py
+++ b/api/src/pcapi/core/educational/constants.py
@@ -1,5 +1,8 @@
+import typing
 from datetime import datetime
 from itertools import chain
+
+from pcapi.core.educational import models
 
 
 INSTITUTION_TYPES = {
@@ -196,3 +199,18 @@ ALL_INTERVENTION_AREA = [
 ]
 
 MEG_BEGINNING_DATE = datetime(2023, 9, 1)
+
+COLLECTIVE_OFFER_DISPLAYED_STATUS_LABELS: typing.Dict[models.CollectiveOfferDisplayedStatus, str] = {
+    models.CollectiveOfferDisplayedStatus.PUBLISHED: "Publiée",
+    models.CollectiveOfferDisplayedStatus.UNDER_REVIEW: "En instruction",
+    models.CollectiveOfferDisplayedStatus.REJECTED: "Non conforme",
+    models.CollectiveOfferDisplayedStatus.PREBOOKED: "Préréservée",
+    models.CollectiveOfferDisplayedStatus.BOOKED: "Réservée",
+    models.CollectiveOfferDisplayedStatus.HIDDEN: "En pause",
+    models.CollectiveOfferDisplayedStatus.EXPIRED: "Expirée",
+    models.CollectiveOfferDisplayedStatus.ENDED: "Terminée",
+    models.CollectiveOfferDisplayedStatus.CANCELLED: "Annulée",
+    models.CollectiveOfferDisplayedStatus.REIMBURSED: "Remboursée",
+    models.CollectiveOfferDisplayedStatus.ARCHIVED: "Archivée",
+    models.CollectiveOfferDisplayedStatus.DRAFT: "Brouillon",
+}

--- a/api/src/pcapi/core/educational/utils.py
+++ b/api/src/pcapi/core/educational/utils.py
@@ -8,6 +8,7 @@ from psycopg2.extras import DateTimeRange
 
 from pcapi.core.educational import exceptions
 from pcapi.core.educational import models
+from pcapi.core.educational.constants import COLLECTIVE_OFFER_DISPLAYED_STATUS_LABELS
 from pcapi.core.users.utils import ALGORITHM_RS_256
 from pcapi.utils import requests
 
@@ -123,3 +124,9 @@ def get_collective_offer_full_address(offer: models.CollectiveOffer | models.Col
 
         case _:
             return None
+
+
+def format_collective_offer_displayed_status(
+    displayed_status: models.CollectiveOfferDisplayedStatus,
+) -> str:
+    return COLLECTIVE_OFFER_DISPLAYED_STATUS_LABELS.get(displayed_status) or displayed_status.value

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -27,6 +27,7 @@ from pcapi.core.categories.subcategories import ALL_SUBCATEGORIES_DICT
 from pcapi.core.chronicles import models as chronicles_models
 from pcapi.core.criteria import models as criteria_models
 from pcapi.core.educational import models as educational_models
+from pcapi.core.educational.utils import format_collective_offer_displayed_status
 from pcapi.core.finance import api as finance_api
 from pcapi.core.finance import models as finance_models
 from pcapi.core.finance import utils as finance_utils
@@ -714,38 +715,6 @@ def format_offer_status(status: offer_mixin.OfferStatus) -> str:
             return "En pause"
         case _:
             return status.value
-
-
-def format_collective_offer_displayed_status(
-    displayed_status: educational_models.CollectiveOfferDisplayedStatus,
-) -> str:
-    match displayed_status:
-        case educational_models.CollectiveOfferDisplayedStatus.PUBLISHED:
-            return "Publiée"
-        case educational_models.CollectiveOfferDisplayedStatus.UNDER_REVIEW:
-            return "En instruction"
-        case educational_models.CollectiveOfferDisplayedStatus.REJECTED:
-            return "Non conforme"
-        case educational_models.CollectiveOfferDisplayedStatus.PREBOOKED:
-            return "Préréservée"
-        case educational_models.CollectiveOfferDisplayedStatus.BOOKED:
-            return "Réservée"
-        case educational_models.CollectiveOfferDisplayedStatus.HIDDEN:
-            return "En pause"
-        case educational_models.CollectiveOfferDisplayedStatus.EXPIRED:
-            return "Expirée"
-        case educational_models.CollectiveOfferDisplayedStatus.ENDED:
-            return "Terminée"
-        case educational_models.CollectiveOfferDisplayedStatus.CANCELLED:
-            return "Annulée"
-        case educational_models.CollectiveOfferDisplayedStatus.REIMBURSED:
-            return "Remboursée"
-        case educational_models.CollectiveOfferDisplayedStatus.ARCHIVED:
-            return "Archivée"
-        case educational_models.CollectiveOfferDisplayedStatus.DRAFT:
-            return "Brouillon"
-        case _:
-            return displayed_status.value
 
 
 def format_offer_category(subcategory_id: str) -> str:

--- a/api/tests/routes/pro/get_collective_offers_csv_test.py
+++ b/api/tests/routes/pro/get_collective_offers_csv_test.py
@@ -8,6 +8,7 @@ import pytz
 from pcapi.core import testing
 from pcapi.core.educational import factories
 from pcapi.core.educational import models
+from pcapi.core.educational.utils import format_collective_offer_displayed_status
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users.factories import ProFactory
@@ -77,7 +78,7 @@ class Returns200Test:
             "Numéro de l'offre": offer.id,
             "Type de localisation de l'offre": "À une adresse précise",
             "Localisation de l'offre": offer.offererAddress.address.fullAddress,
-            "Statut de l'offre": offer.displayedStatus.value,
+            "Statut de l'offre": format_collective_offer_displayed_status(offer.displayedStatus).lower(),
             "Etablissement": offer.institution.full_name,
             "Code postal de l'établissement": offer.institution.postalCode,
             "UAI de l'établissement": offer.institution.institutionId,
@@ -115,7 +116,7 @@ class Returns200Test:
         assert reader[0] == {
             "Nom de l'offre": "Special name &@🤡%",
             "Numéro de l'offre": offer.id,
-            "Statut de l'offre": offer.displayedStatus.value,
+            "Statut de l'offre": format_collective_offer_displayed_status(offer.displayedStatus).lower(),
             "Type de localisation de l'offre": "À déterminer avec l'enseignant",
             "Localisation de l'offre": "Chez toi",
             "Structure": venue.common_name,
@@ -155,7 +156,7 @@ class Returns200Test:
             assert row == {
                 "Nom de l'offre": offer.name,
                 "Numéro de l'offre": offer.id,
-                "Statut de l'offre": "BOOKED",
+                "Statut de l'offre": "réservée",
                 "Type de localisation de l'offre": "En établissement scolaire",
                 "Localisation de l'offre": "",
                 "Structure": venue.common_name,

--- a/api/tests/routes/pro/get_collective_offers_excel_test.py
+++ b/api/tests/routes/pro/get_collective_offers_excel_test.py
@@ -8,6 +8,7 @@ import pytz
 from pcapi.core import testing
 from pcapi.core.educational import factories
 from pcapi.core.educational import models
+from pcapi.core.educational.utils import format_collective_offer_displayed_status
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users.factories import ProFactory
@@ -79,7 +80,7 @@ class Returns200Test:
         assert row_values == [
             offer.name,
             offer.id,
-            offer.displayedStatus.value,
+            format_collective_offer_displayed_status(offer.displayedStatus).lower(),
             "À une adresse précise",
             offer.offererAddress.address.fullAddress,
             venue.common_name,
@@ -119,7 +120,7 @@ class Returns200Test:
         assert row_values == [
             "Special name &@🤡%",
             offer.id,
-            offer.displayedStatus.value,
+            format_collective_offer_displayed_status(offer.displayedStatus).lower(),
             "À déterminer avec l'enseignant",
             "Chez toi",
             venue.common_name,
@@ -163,7 +164,7 @@ class Returns200Test:
             assert row_values == [
                 offer.name,
                 offer.id,
-                "BOOKED",
+                "réservée",
                 "En établissement scolaire",
                 None,
                 venue.common_name,


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37680)


- Use label instead of key for offer status in excel export

- [ ] Travail pair testé en environnement local
