### PR TITLE
(PC-37688)[API] fix: do not create offer metadata if it has no video url

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -246,8 +246,11 @@ def create_draft_offer(
         validation=models.OfferValidationStatus.DRAFT,
         product=product,
     )
-    offer_metadata = models.OfferMetaData(offer=offer, videoUrl=body.video_url)
-    db.session.add_all([offer, offer_metadata])
+
+    if body.video_url:
+        offer_metadata = models.OfferMetaData(offer=offer, videoUrl=body.video_url)
+        db.session.add(offer_metadata)
+    db.session.add(offer)
     db.session.flush()
 
     update_external_pro(venue.bookingEmail)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1191,6 +1191,7 @@ class CreateDraftOfferTest:
         assert offer.validation == models.OfferValidationStatus.DRAFT
         assert not offer.product
         assert db.session.query(models.Offer).count() == 1
+        assert offer.metaData is None
 
     def test_cannot_create_draft_offer_with_ean_in_name(self):
         venue = offerers_factories.VenueFactory()
@@ -1317,7 +1318,7 @@ class UpdateDraftOfferTest:
         offer = api.update_draft_offer(offer, body)
         db.session.flush()
 
-        assert offer.metaData.videoUrl == None
+        assert offer.metaData.videoUrl is None
 
     def test_cannot_update_if_ean_in_name(self):
         offer = factories.OfferFactory(
@@ -1389,6 +1390,7 @@ class CreateOfferTest:
         assert offer.visualDisabilityCompliant
         assert offer.validation == models.OfferValidationStatus.DRAFT
         assert offer.extraData == {}
+        assert offer.metaData is None
         assert not offer.bookingEmail
         assert db.session.query(models.Offer).count() == 1
         assert offer.offererAddress == offerer_address


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37688)

prevents offer update to create empty metadata

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [x] Travail pair testé en environnement de preview
