### PR TITLE
(PC-37688)[API] script: clean empty offer metadata

### DIFF
--- a/api/src/pcapi/scripts/clean_empty_offer_metadata/main.py
+++ b/api/src/pcapi/scripts/clean_empty_offer_metadata/main.py
@@ -1,0 +1,44 @@
+"""
+Job console documentation here: https://www.notion.so/passcultureapp/Documentation-Job-Console-769beeacd5a146de9c97b6f8ee544276
+Assumed path to the script (copy-paste in github actions):
+
+https://github.com/pass-culture/pass-culture-main/blob/ogeber/pc-37688-clean-empty-offer-metadata/api/src/pcapi/scripts/clean_empty_offer_metadata/main.py
+
+"""
+
+import argparse
+import logging
+
+from pcapi.app import app
+from pcapi.core.offers.models import OfferMetaData
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+
+def delete_empty_offer_metadata() -> None:
+    db.session.query(OfferMetaData).filter(
+        OfferMetaData.videoUrl.is_(None),
+        OfferMetaData.videoDuration.is_(None),
+        OfferMetaData.videoExternalId.is_(None),
+        OfferMetaData.videoThumbnailUrl.is_(None),
+        OfferMetaData.videoTitle.is_(None),
+    ).delete(synchronize_session=False)
+
+
+if __name__ == "__main__":
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--not-dry", action="store_true")
+    args = parser.parse_args()
+
+    delete_empty_offer_metadata()
+
+    if args.not_dry:
+        logger.info("Finished")
+        db.session.commit()
+    else:
+        logger.info("Finished dry run, rollback")
+        db.session.rollback()

--- a/api/tests/scripts/clean_empty_offer_metadata/test_main.py
+++ b/api/tests/scripts/clean_empty_offer_metadata/test_main.py
@@ -1,0 +1,40 @@
+import pytest
+
+from pcapi.core.offers import factories
+from pcapi.core.offers.models import Offer
+from pcapi.core.offers.models import OfferMetaData
+from pcapi.models import db
+from pcapi.scripts.clean_empty_offer_metadata.main import delete_empty_offer_metadata
+
+
+@pytest.mark.usefixtures("db_session")
+def test_delete_empty_offer_metadata(db_session):
+    offer_1 = factories.OfferFactory()
+    offer_2 = factories.OfferFactory()
+
+    empty_meta = factories.OfferMetaDataFactory(
+        offer=offer_1,
+        videoUrl=None,
+        videoDuration=None,
+        videoExternalId=None,
+        videoThumbnailUrl=None,
+        videoTitle=None,
+    )
+
+    non_empty_meta = factories.OfferMetaDataFactory(
+        offer=offer_2,
+        videoUrl="https://www.youtube.com/watch?v=ZjSlDZhwHs8",
+        videoDuration=3,
+        videoExternalId="ZjSlDZhwHs8",
+        videoThumbnailUrl=None,
+        videoTitle="Gilbert Organisé",
+    )
+
+    db.session.add_all([empty_meta, non_empty_meta])
+    db.session.commit()
+
+    delete_empty_offer_metadata()
+
+    assert db_session.query(Offer).count() == 2
+    assert db_session.query(OfferMetaData).count() == 1
+    assert db_session.query(OfferMetaData).first().videoUrl == "https://www.youtube.com/watch?v=ZjSlDZhwHs8"


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37688)

There are empty offerMetaData in db, this script will delete them (after [another PR](https://github.com/pass-culture/pass-culture-main/pull/18944) which provides code to create such kind of useless data)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
