### PR TITLE
(PC-37695)[API] feat: remove offer_meta_data when emptied in update offer

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -264,11 +264,14 @@ def update_draft_offer(offer: models.Offer, body: offers_schemas.PatchDraftOffer
 
     if "videoUrl" in fields:
         new_video_url = fields.pop("videoUrl")
-        if offer.metaData:
-            offer.metaData.videoUrl = new_video_url
+        if not new_video_url:
+            if offer.metaData:
+                db.session.delete(offer.metaData)
         else:
-            offer.metaData = models.OfferMetaData(offer=offer, videoUrl=new_video_url)
-        db.session.add(offer.metaData)
+            if not offer.metaData:
+                offer.metaData = models.OfferMetaData(offer=offer)
+            offer.metaData.videoUrl = new_video_url
+            db.session.add(offer.metaData)
 
     body_ean = body.extra_data.get("ean", None) if body.extra_data else None
     if body_ean:

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1317,8 +1317,9 @@ class UpdateDraftOfferTest:
         )
         offer = api.update_draft_offer(offer, body)
         db.session.flush()
+        db.session.refresh(offer)
 
-        assert offer.metaData.videoUrl is None
+        assert offer.metaData is None
 
     def test_cannot_update_if_ean_in_name(self):
         offer = factories.OfferFactory(


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37695)

Delete OfferMetaData from DB if front sends empty videoUrl field

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [x] Travail pair testé en environnement de preview
