### PR TITLE
(BSR)[PRO] ci: fix Biome VS yarn version bump linting conflict

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,7 +1,7 @@
 // We have to add a root config for Biome in order to use its IDE plugin when opening the monorepo from the root.
 // https://biomejs.dev/guides/big-projects/#monorepo
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
   "root": true,
   "formatter": {
     "enabled": false

--- a/pro/biome.jsonc
+++ b/pro/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
   // https://biomejs.dev/guides/big-projects/#monorepo
   "root": false,
   "extends": "//",
@@ -204,6 +204,19 @@
   },
 
   "overrides": [
+    // -------------------------------------------------------------------------
+    // package.json
+    // We don't want Biome linting to conflict with Yarn `JSON.stringify` formatting when Yarn updates version or dependencies.
+
+    {
+      "includes": ["package.json"],
+      "json": {
+        "formatter": {
+          "expand": "always"
+        }
+      }
+    },
+
     // -------------------------------------------------------------------------
     // CSS
 

--- a/pro/package.json
+++ b/pro/package.json
@@ -133,8 +133,14 @@
     "node": ">=20 <21"
   },
   "packageManager": "yarn@1.22.22",
-  "browserslist": [">0.2%", "not dead", "not op_mini all"],
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
+  ],
   "babel": {
-    "presets": ["react-app"]
+    "presets": [
+      "react-app"
+    ]
   }
 }


### PR DESCRIPTION
Lorsqu'on run :

```
❯ yarn version --new-version "1.0.0-beta3"                                                                                                                          ✘ 130 
yarn version v1.22.22
info Current version: 0.0.0
info New version: 1.0.0-beta3
✨  Done in 0.01s.

❯ git diff                                                                                                                                                            ✘ 1 
diff --git a/pro/package.json b/pro/package.json
index c909c5893f..35a09d6d34 100644
--- a/pro/package.json
+++ b/pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pass-culture/pass-culture-pro",
-  "version": "0.0.0",
+  "version": "1.0.0-beta3",
   "private": true,
   "homepage": "/",
   "type": "module",
@@ -133,8 +133,14 @@
     "node": ">=20 <21"
   },
   "packageManager": "yarn@1.22.22",
-  "browserslist": [">0.2%", "not dead", "not op_mini all"],
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not op_mini all"
+  ],
   "babel": {
-    "presets": ["react-app"]
+    "presets": [
+      "react-app"
+    ]
   }
 }
 ```

## Avant ce fix

```
❯ yarn biome check --diagnostic-level=error
yarn run v1.22.22
$ /Users/Ivan/Workspace/pass-culture/pass-culture-main/pro/node_modules/.bin/biome check --diagnostic-level=error
package.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ✖ Formatter would have printed the following content:
  
    134 134 │     },
    135 135 │     "packageManager": "yarn@1.22.22",
    136     │ - ··"browserslist":·[
    137     │ - ····">0.2%",
    138     │ - ····"not·dead",
    139     │ - ····"not·op_mini·all"
    140     │ - ··],
        136 │ + ··"browserslist":·[">0.2%",·"not·dead",·"not·op_mini·all"],
    141 137 │     "babel": {
    142     │ - ····"presets":·[
    143     │ - ······"react-app"
    144     │ - ····]
        138 │ + ····"presets":·["react-app"]
    145 139 │     }
    146 140 │   }
  

Checked 1713 files in 479ms. No fixes applied.
Found 1 error.
````

## Après ce fix

```
❯ yarn biome check --diagnostic-level=error
yarn run v1.22.22
$ /Users/Ivan/Workspace/pass-culture/pass-culture-main/pro/node_modules/.bin/biome check --diagnostic-level=error
Checked 1713 files in 451ms. No fixes applied.
✨  Done in 0.69s.
```