### PR TITLE
(BSR) fix: force metropolitan postcode in test format price in euros

### DIFF
--- a/api/tests/core/mails/transactional/test_utils.py
+++ b/api/tests/core/mails/transactional/test_utils.py
@@ -25,7 +25,7 @@ class FormatPriceTest:
         ],
     )
     def test_format_price_in_euros(self, price, expected, factory):
-        target = factory()
+        target = factory(postalCode="63170")
         assert format_price(price, target) == expected
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Forcer un code postal métropolitain pour éviter le crash du test `test_format_price_in_euros`