### PR TITLE
(PC-37790)[BO] fix: do not raise an alert when deleting an expired token (Boost)

### DIFF
--- a/api/src/pcapi/connectors/boost.py
+++ b/api/src/pcapi/connectors/boost.py
@@ -248,8 +248,8 @@ def _check_response_is_ok(response: requests.Response, cinema_api_token: str | N
         reason = _extract_reason_from_response(response)
         message = _extract_message_from_response(response)
         error_message = _filter_token(reason, cinema_api_token)
-        if response.status_code == 401 and message == "Invalid JWT Token":
-            raise BoostInvalidTokenException("Boost token is invalid")
+        if response.status_code == 401:
+            raise BoostInvalidTokenException(f"Boost: {message}")
         raise BoostAPIException(f"Error on Boost API on {request_detail} : {error_message} - {message}")
 
 

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/boost.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/boost.py
@@ -125,7 +125,9 @@ class BoostContext(PivotContext):
             raise NotFound()
         try:
             boost.logout(pivot)
-        except (requests.exceptions.RequestException, BoostInvalidTokenException, BoostAPIException) as exc:
+        except BoostInvalidTokenException:
+            pass  # when the token is no longer valid, no need to raise an alert before its deletion
+        except (requests.exceptions.RequestException, BoostAPIException) as exc:
             logger.exception(
                 "Unexpected error from Boost logout API", extra={"exc": exc, "cinema_url": pivot.cinemaUrl}
             )


### PR DESCRIPTION
Ticket Jira : https://passculture.atlassian.net/browse/PC-37790
Sentry : https://pass-culture.sentry.io/issues/45196284/