### PR TITLE
(PC-37739)[PRO] fix: Allow stock edition for allociné synchronized of…

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarTable/StocksCalendarTable.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarTable/StocksCalendarTable.spec.tsx
@@ -99,6 +99,24 @@ describe('StocksCalendarTable', () => {
     ).not.toBeInTheDocument()
   })
 
+  it('should render the edit options when the offer is synchronized with allociné', () => {
+    renderStocksCalendarTable({
+      offer: getIndividualOfferFactory({
+        lastProvider: { name: 'Allociné' },
+      }),
+      stocks: [
+        getOfferStockFactory({
+          beginningDatetime: addDays(new Date(), 1).toISOString(),
+        }),
+      ],
+      mode: OFFER_WIZARD_MODE.EDITION,
+    })
+
+    expect(
+      screen.getByRole('button', { name: 'Modifier la date' })
+    ).toBeInTheDocument()
+  })
+
   it('should not render the delete and edit options when the offer is disabled (because it is pending)', () => {
     renderStocksCalendarTable({
       offer: getIndividualOfferFactory({ status: OfferStatus.PENDING }),

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarTable/StocksCalendarTable.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarTable/StocksCalendarTable.tsx
@@ -8,7 +8,10 @@ import type {
 } from '@/apiClient/v1'
 import { OFFER_WIZARD_MODE } from '@/commons/core/Offers/constants'
 import { isOfferDisabled } from '@/commons/core/Offers/utils/isOfferDisabled'
-import { isOfferSynchronized } from '@/commons/core/Offers/utils/typology'
+import {
+  isOfferAllocineSynchronized,
+  isOfferSynchronized,
+} from '@/commons/core/Offers/utils/typology'
 import { useIsCaledonian } from '@/commons/hooks/useIsCaledonian'
 import { useNotification } from '@/commons/hooks/useNotification'
 import { FORMAT_DD_MM_YYYY, FORMAT_HH_mm } from '@/commons/utils/date'
@@ -121,6 +124,7 @@ export function StocksCalendarTable({
             departmentCode={departmentCode}
             priceCategories={offer.priceCategories}
             onUpdateStock={handleUpdateStock}
+            offer={offer}
           />
         )}
       </DialogBuilder>
@@ -188,7 +192,8 @@ export function StocksCalendarTable({
               !isOfferDisabled(offer.status) &&
               stock.beginningDatetime &&
               !isBefore(stock.beginningDatetime, new Date()) &&
-              !isOfferSynchronized(offer)
+              (!isOfferSynchronized(offer) ||
+                isOfferAllocineSynchronized(offer))
 
             return (
               <tr key={stock.id} className={styles['tr']}>

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/StocksCalendarTableEditStock.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/StocksCalendarTableEditStock.tsx
@@ -8,6 +8,7 @@ import type {
   GetIndividualOfferResponseModel,
   GetOfferStockResponseModel,
 } from '@/apiClient/v1'
+import { isOfferAllocineSynchronized } from '@/commons/core/Offers/utils/typology'
 import { useIsCaledonian } from '@/commons/hooks/useIsCaledonian'
 import { MandatoryInfo } from '@/components/FormLayout/FormLayoutMandatoryInfo'
 import { getPriceCategoryOptions } from '@/pages/IndividualOffer/commons/getPriceCategoryOptions'
@@ -39,9 +40,11 @@ export type StocksCalendarTableEditStockProps = {
   departmentCode: string
   priceCategories: GetIndividualOfferResponseModel['priceCategories']
   onUpdateStock: (body: EventStockUpdateBodyModel) => void
+  offer: GetIndividualOfferResponseModel
 }
 
 export function StocksCalendarTableEditStock({
+  offer,
   stock,
   departmentCode,
   priceCategories,
@@ -55,6 +58,8 @@ export function StocksCalendarTableEditStock({
       validationSchema
     ),
   })
+
+  const isAllocineSynchro = isOfferAllocineSynchronized(offer)
 
   const formValues = form.watch()
 
@@ -85,6 +90,7 @@ export function StocksCalendarTableEditStock({
               required
               error={form.formState.errors.date?.message}
               minDate={new Date()}
+              disabled={isAllocineSynchro}
             />
             <TimePicker
               {...form.register('time')}
@@ -92,6 +98,7 @@ export function StocksCalendarTableEditStock({
               label="Horaire"
               required
               error={form.formState.errors.time?.message}
+              disabled={isAllocineSynchro}
             />
           </div>
           <h2 className={styles['title']}>Places et tarifs</h2>

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/specs/StocksCalendarTableEditStock.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarTable/StocksCalendarTableEditStock/specs/StocksCalendarTableEditStock.spec.tsx
@@ -4,7 +4,10 @@ import userEvent from '@testing-library/user-event'
 import { addDays } from 'date-fns'
 import { FormProvider, useForm } from 'react-hook-form'
 
-import { getOfferStockFactory } from '@/commons/utils/factories/individualApiFactories'
+import {
+  getIndividualOfferFactory,
+  getOfferStockFactory,
+} from '@/commons/utils/factories/individualApiFactories'
 import { renderWithProviders } from '@/commons/utils/renderWithProviders'
 
 import {
@@ -35,6 +38,7 @@ function renderStocksCalendarTableEditStock(
             stock={getOfferStockFactory()}
             priceCategories={[{ id: 1, label: 'tarif', price: 12 }]}
             onUpdateStock={() => vi.fn()}
+            offer={getIndividualOfferFactory()}
             {...props}
           />
         </FormProvider>
@@ -118,5 +122,14 @@ describe('StocksCalendarTableEditStock', () => {
     expect(
       screen.queryByText('Veuillez indiquer une quantité supérieure à 0')
     ).not.toBeInTheDocument()
+  })
+
+  it('should disable the date and time edition if the offer is an allociné synchro', () => {
+    renderStocksCalendarTableEditStock({
+      offer: getIndividualOfferFactory({ lastProvider: { name: 'Allociné' } }),
+    })
+
+    expect(screen.getAllByLabelText(/Date/)[0]).toBeDisabled()
+    expect(screen.getByLabelText(/Horaire/)).toBeDisabled()
   })
 })


### PR DESCRIPTION
…fer stocks.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37739)

Dans l'édition de stocks horodatés d'offres indiv synchronisées :
On devrait avoir le droit de modifier les quantité/tarif/date limite de résa des stocks d'offres synchro, mais seulement si c'est une synchro Allociné (aujourd'hui le bouton d'édition n'apparait pas à partir du moment où l'offre est synchro).
