### PR TITLE
(BSR)[PRO] fix: Do not send withdrawalDelay when whithdrawalType is N…

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/getPatchOfferBody.spec.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/getPatchOfferBody.spec.ts
@@ -3,22 +3,22 @@ import { WithdrawalTypeEnum } from '@/apiClient/v1'
 import { getPatchOfferBody } from '../getPatchOfferBody'
 import type { IndividualOfferPracticalInfosFormValues } from '../types'
 
+const defaultFormValues: IndividualOfferPracticalInfosFormValues = {
+  bookingAllowedMode: 'later',
+  bookingAllowedDate: '2050-12-12',
+  bookingAllowedTime: '12:12',
+  bookingContact: 'bookingContact@example.co',
+  receiveNotificationEmails: true,
+  bookingEmail: 'bookingEmail@example.co',
+  externalTicketOfficeUrl: 'http://url.co',
+  withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
+  withdrawalDelay: '10',
+  withdrawalDetails: 'Withdrawal details',
+}
+
 describe('getPatchOfferBody', () => {
   it('should create the patch body from the form values', () => {
-    const formValues: IndividualOfferPracticalInfosFormValues = {
-      bookingAllowedMode: 'later',
-      bookingAllowedDate: '2050-12-12',
-      bookingAllowedTime: '12:12',
-      bookingContact: 'bookingContact@example.co',
-      receiveNotificationEmails: true,
-      bookingEmail: 'bookingEmail@example.co',
-      externalTicketOfficeUrl: 'http://url.co',
-      withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
-      withdrawalDelay: '10',
-      withdrawalDetails: 'Withdrawal details',
-    }
-
-    expect(getPatchOfferBody(formValues, '56', false)).toEqual(
+    expect(getPatchOfferBody(defaultFormValues, '56', false)).toEqual(
       expect.objectContaining({
         bookingAllowedDatetime: expect.stringContaining('T'),
         bookingContact: 'bookingContact@example.co',
@@ -27,6 +27,24 @@ describe('getPatchOfferBody', () => {
         withdrawalType: WithdrawalTypeEnum.BY_EMAIL,
         withdrawalDelay: 10,
         withdrawalDetails: 'Withdrawal details',
+      })
+    )
+  })
+
+  it('should not send the withdrawal delay if the withdrawal type is NO_TICKET', () => {
+    expect(
+      getPatchOfferBody(
+        {
+          ...defaultFormValues,
+          withdrawalDelay: '10',
+          withdrawalType: WithdrawalTypeEnum.NO_TICKET,
+        },
+        '56',
+        false
+      )
+    ).toEqual(
+      expect.objectContaining({
+        withdrawalDelay: null,
       })
     )
   })

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/getPatchOfferBody.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/getPatchOfferBody.ts
@@ -8,14 +8,14 @@ export function getPatchOfferBody(
   departmentCode: string,
   shouldSendMail: boolean
 ) {
-  const withdrawalDelayNullishValue =
+  const withdrawalDelayValue = formValues.withdrawalDelay
+    ? Number(formValues.withdrawalDelay)
+    : null
+
+  const withdrawalDelayInBody =
     formValues.withdrawalType === WithdrawalTypeEnum.NO_TICKET
       ? null
-      : undefined
-  const withdrawalDelay =
-    formValues.withdrawalDelay === undefined
-      ? withdrawalDelayNullishValue
-      : Number(formValues.withdrawalDelay)
+      : withdrawalDelayValue
 
   const formattedBookabilityDate =
     formValues.bookingAllowedDate && formValues.bookingAllowedTime
@@ -35,7 +35,7 @@ export function getPatchOfferBody(
       ? null
       : formValues.externalTicketOfficeUrl,
     shouldSendMail: shouldSendMail,
-    withdrawalDelay,
+    withdrawalDelay: withdrawalDelayInBody,
     withdrawalDetails: formValues.withdrawalDetails ?? undefined,
     withdrawalType: formValues.withdrawalType,
     bookingAllowedDatetime:


### PR DESCRIPTION
…O_TICKET.

## 🎯 Related Ticket or 🔧 Changes Made

BSR

Ne pas caster le `withdrawalDelay` en nombre si la valeur est "" (string vide), sinon on envoie `0` à l'api et elle est pas contente