### PR TITLE
(BSR)[API] feat: use a fixed api key for public api in sandbox

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_collective_api_provider.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_collective_api_provider.py
@@ -10,8 +10,11 @@ from pcapi.core.providers.factories import VenueProviderFactory
 from pcapi.core.providers.models import Provider
 
 
-def create_collective_api_provider(venues: Sequence[Venue]) -> Provider:
-    "Create api_keys with shape : collective_{offererId}_clear{offererId}"
+def create_collective_api_provider(venues: Sequence[Venue], api_key_prefix: str | None = None) -> Provider:
+    """
+    Create Api Key with shape: collective_{offererId}_clear{offererId}
+    If api_key_prefix is given, the key will be <api_key_prefix>_clear
+    """
 
     provider = PublicApiProviderFactory.create(name=factory.Sequence("Collective API Provider {}".format))
 
@@ -20,8 +23,14 @@ def create_collective_api_provider(venues: Sequence[Venue]) -> Provider:
 
     offerer = venues[0].managingOfferer
     OffererProviderFactory.create(offerer=offerer, provider=provider)
-    ApiKeyFactory.create(
-        offerer=offerer, provider=provider, prefix=f"collective_{offerer.id}", secret=f"clear{offerer.id}"
-    )
+
+    if api_key_prefix is not None:
+        prefix = api_key_prefix
+        secret = "clear"
+    else:
+        prefix = f"collective_{offerer.id}"
+        secret = f"clear{offerer.id}"
+
+    ApiKeyFactory.create(offerer=offerer, provider=provider, prefix=prefix, secret=secret)
 
     return provider

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -226,7 +226,7 @@ def create_eac_offers(
 
     # eac_with_displayed_status_cases
     offerer = next(o for o in offerers if o.name == "eac_with_displayed_status_cases")
-    provider = create_collective_api_provider(offerer.managedVenues)
+    provider = create_collective_api_provider(offerer.managedVenues, api_key_prefix="displayed_status")
 
     venue_pc_pro = next(v for v in offerer.managedVenues if "PC_PRO" in v.name)
     create_collective_offers_with_different_displayed_status(


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

La valeur de la clef api dans la sandbox côté collectif est liée à l'id de l'offerer et donc se décale régulièrement. On permet ici de lui donner une valeur fixe

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
