### PR TITLE
(PC-37719)[PRO] feat: Create a more flexible function to know if the …

### DIFF
--- a/pro/src/commons/context/IndividualOfferContext/IndividualOfferContext.tsx
+++ b/pro/src/commons/context/IndividualOfferContext/IndividualOfferContext.tsx
@@ -25,11 +25,6 @@ export interface IndividualOfferContextValues {
   subCategories: SubcategoryResponseModel[]
   isEvent: boolean | null
   setIsEvent: (isEvent: boolean | null) => void
-  // Both isAccessibilityFilled and setIsAccessibilityFilled are
-  // used as a workaround to make the form context sync with the offer context
-  // so the stepper can be updated depending on form changes.
-  isAccessibilityFilled: boolean
-  setIsAccessibilityFilled: (isAccessibilityFilled: boolean) => void
   /** Real boolean guarded by early `<Splinner />` return while fetching offer data in context provider. */
   hasPublishedOfferWithSameEan: boolean
 }
@@ -38,11 +33,9 @@ export const IndividualOfferContext =
   createContext<IndividualOfferContextValues>({
     categories: [],
     hasPublishedOfferWithSameEan: false,
-    isAccessibilityFilled: true,
     isEvent: null,
     offer: null,
     offerId: null,
-    setIsAccessibilityFilled: () => undefined,
     // TODO (igabriele, 2025-08-20): Rename that to `setIsControlledEvent`.
     setIsEvent: () => undefined,
     subCategories: [],
@@ -60,7 +53,6 @@ export const IndividualOfferContextProvider = ({
   children,
 }: IndividualOfferContextProviderProps) => {
   const [isControlledEvent, setIsEvent] = useState<boolean | null>(null)
-  const [isAccessibilityFilled, setIsAccessibilityFilled] = useState(true)
   const { offerId: offerIdAsString } = useParams<{
     offerId: string
   }>()
@@ -136,11 +128,9 @@ export const IndividualOfferContextProvider = ({
       value={{
         categories: categoriesQuery.data.categories,
         hasPublishedOfferWithSameEan: Boolean(publishedOfferWithSameEAN),
-        isAccessibilityFilled,
         isEvent: offer?.isEvent ?? isControlledEvent,
         offer: offer ?? null,
         offerId,
-        setIsAccessibilityFilled,
         setIsEvent,
         subCategories: categoriesQuery.data.subcategories,
       }}

--- a/pro/src/commons/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
+++ b/pro/src/commons/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
@@ -117,16 +117,6 @@ describe('IndividualOfferContextProvider', () => {
       expect(result.current.isEvent).toBe(true)
       expect(result.current.offerId).toBeNull()
     })
-
-    it('should allow toggling isAccessibilityFilled via setter', async () => {
-      const { result } = await renderUseIndividualOfferContext()
-
-      expect(result.current.isAccessibilityFilled).toBe(true)
-
-      await waitFor(() => void result.current.setIsAccessibilityFilled(false))
-
-      expect(result.current.isAccessibilityFilled).toBe(false)
-    })
   })
 
   describe('when there is an offerId in the URL', () => {
@@ -211,16 +201,6 @@ describe('IndividualOfferContextProvider', () => {
       await waitFor(() => void result.current.setIsEvent(true))
 
       expect(result.current.isEvent).toBe(false)
-    })
-
-    it('should allow toggling isAccessibilityFilled via setter', async () => {
-      const { result } = await renderUseIndividualOfferContext()
-
-      expect(result.current.isAccessibilityFilled).toBe(true)
-
-      await waitFor(() => void result.current.setIsAccessibilityFilled(false))
-
-      expect(result.current.isAccessibilityFilled).toBe(false)
     })
   })
 })

--- a/pro/src/commons/utils/factories/individualApiFactories.ts
+++ b/pro/src/commons/utils/factories/individualApiFactories.ts
@@ -193,8 +193,6 @@ export const individualOfferContextValuesFactory = (
     subCategories: [],
     isEvent: null,
     setIsEvent: () => {},
-    isAccessibilityFilled: true,
-    setIsAccessibilityFilled: () => {},
     ...customIndividualOfferContextValues,
   }
 }

--- a/pro/src/components/IndividualOfferLayout/IndividualOfferNavigation/IndividualOfferNavigation.spec.tsx
+++ b/pro/src/components/IndividualOfferLayout/IndividualOfferNavigation/IndividualOfferNavigation.spec.tsx
@@ -9,6 +9,7 @@ import {
   OFFER_WIZARD_MODE,
 } from '@/commons/core/Offers/constants'
 import { getIndividualOfferPath } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
+import { getAddressResponseIsLinkedToVenueModelFactory } from '@/commons/utils/factories/commonOffersApiFactories'
 import {
   getIndividualOfferFactory,
   individualOfferContextValuesFactory,
@@ -192,6 +193,7 @@ describe('IndividualOfferNavigation', () => {
       const offerWithNumerousStepsBase = getIndividualOfferFactory({
         isEvent: true,
         priceCategories: [priceCategoryFactory()],
+        address: getAddressResponseIsLinkedToVenueModelFactory(),
         hasStocks: false,
       })
       const contextValuesWithNumerousSteps =
@@ -373,6 +375,22 @@ describe('IndividualOfferNavigation', () => {
           listitem.textContent?.match(FF_LABELS.links.SUMMARY)
         )
       ).toBeDefined()
+    })
+
+    it('should display the expected active steps when the offer is completed', () => {
+      const contextValues = individualOfferContextValuesFactory({
+        isEvent: true,
+        offer: getIndividualOfferFactory({
+          audioDisabilityCompliant: true,
+          address: getAddressResponseIsLinkedToVenueModelFactory(),
+        }),
+      })
+
+      renderIndividualOfferNavigation({ contextValues, options })
+
+      const locationStep = screen.getByRole('link', { name: '6 Récapitulatif' })
+
+      expect(locationStep).toBeInTheDocument()
     })
   })
 })

--- a/pro/src/components/IndividualOfferLayout/IndividualOfferNavigation/IndividualOfferNavigation.tsx
+++ b/pro/src/components/IndividualOfferLayout/IndividualOfferNavigation/IndividualOfferNavigation.tsx
@@ -23,7 +23,7 @@ import { getSteps, type StepPattern } from './utils/getSteps'
 export const IndividualOfferNavigation = () => {
   const { pathname } = useLocation()
   const isOnboarding = pathname.indexOf('onboarding') !== -1
-  const { offer, isEvent, isAccessibilityFilled } = useIndividualOfferContext()
+  const { offer, isEvent, subCategories } = useIndividualOfferContext()
   const activeStep = useActiveStep(
     Object.values(INDIVIDUAL_OFFER_WIZARD_STEP_IDS)
   )
@@ -53,11 +53,8 @@ export const IndividualOfferNavigation = () => {
   // Steps are passed as argument since they are not static.
   const lastSubmittedStepIndex = getLastSubmittedStepIndex({
     offer,
+    subCategory: subCategories.find((cat) => offer?.subcategoryId === cat.id),
     orderedSteps: steps,
-    externalConditions: {
-      accessibility: isAccessibilityFilled,
-      priceCategories: Boolean(offer?.priceCategories?.length),
-    },
   })
 
   const stepList = steps.map(

--- a/pro/src/components/IndividualOfferLayout/IndividualOfferNavigation/utils/getSteps.tsx
+++ b/pro/src/components/IndividualOfferLayout/IndividualOfferNavigation/utils/getSteps.tsx
@@ -45,7 +45,7 @@ export const getSteps = ({
         ? 'Localisation'
         : 'Informations pratiques',
       canGoBeyondStep: (offer) => {
-        return Boolean(offer.address)
+        return Boolean(offer.address ?? offer.url)
       },
     },
   ]

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsEanSearch/DetailsEanSearch.spec.tsx
@@ -32,8 +32,6 @@ const contextValue: IndividualOfferContextValues = {
   offer: null,
   isEvent: null,
   setIsEvent: vi.fn(),
-  isAccessibilityFilled: false,
-  setIsAccessibilityFilled: vi.fn(),
   hasPublishedOfferWithSameEan: false,
 }
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsSubForm/DetailsSubForm.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/DetailsForm/DetailsSubForm/DetailsSubForm.spec.tsx
@@ -26,8 +26,6 @@ const contextValue: IndividualOfferContextValues = {
   offer: null,
   isEvent: null,
   setIsEvent: vi.fn(),
-  isAccessibilityFilled: false,
-  setIsAccessibilityFilled: vi.fn(),
   hasPublishedOfferWithSameEan: false,
 }
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/commons/__specs__/validationSchema.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/commons/__specs__/validationSchema.spec.tsx
@@ -6,7 +6,6 @@ import { getValidationSchema } from '../validationSchema'
 describe('getValidationSchema', () => {
   const baseParams = {
     isOfferOnline: false,
-    setIsAccessibilityFilled: () => {},
   }
 
   const validInformationFormValuesBase: UsefulInformationFormValues = {

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/commons/validationSchema.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/commons/validationSchema.ts
@@ -13,11 +13,9 @@ const isAnyTrue = (values: Record<string, boolean>): boolean =>
 export const getValidationSchema = ({
   conditionalFields,
   isOfferOnline,
-  setIsAccessibilityFilled,
 }: {
   conditionalFields: string[]
   isOfferOnline: boolean
-  setIsAccessibilityFilled: (isAccessibilityFilled: boolean) => void
 }) => {
   const maybeLocationSchema = isOfferOnline ? {} : { ...locationSchema }
 
@@ -27,11 +25,7 @@ export const getValidationSchema = ({
       .test({
         name: 'is-any-true',
         message: 'Veuillez sélectionner au moins un critère d’accessibilité',
-        test: (values) => {
-          const isAccessibilityFilled = isAnyTrue(values)
-          setIsAccessibilityFilled(isAccessibilityFilled)
-          return isAccessibilityFilled
-        },
+        test: (values) => isAnyTrue(values),
       })
       .shape({
         mental: yup.boolean().required(),

--- a/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferInformations/components/IndividualOfferInformationsScreen.tsx
@@ -57,11 +57,8 @@ export const IndividualOfferInformationsScreen = ({
   const notify = useNotification()
   const mode = useOfferWizardMode()
   const { mutate } = useSWRConfig()
-  const {
-    subCategories,
-    hasPublishedOfferWithSameEan,
-    setIsAccessibilityFilled,
-  } = useIndividualOfferContext()
+  const { subCategories, hasPublishedOfferWithSameEan } =
+    useIndividualOfferContext()
 
   const saveEditionChangesButtonRef = useRef<HTMLButtonElement>(null)
 
@@ -91,7 +88,6 @@ export const IndividualOfferInformationsScreen = ({
   const validationSchema = getValidationSchema({
     conditionalFields,
     isOfferOnline: getIsOfferSubcategoryOnline(offer, subCategories),
-    setIsAccessibilityFilled,
   })
 
   const initialValues = getInitialValuesFromOffer(offer, {

--- a/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/IndividualOfferLocationScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/IndividualOfferLocationScreen.spec.tsx
@@ -66,9 +66,7 @@ const renderIndividualOfferLocationScreen: RenderComponentFunction<
   const contextValues: IndividualOfferContextValues = {
     categories: MOCKED_CATEGORIES,
     hasPublishedOfferWithSameEan: false,
-    isAccessibilityFilled: false,
     isEvent: null,
-    setIsAccessibilityFilled: vi.fn(),
     setIsEvent: vi.fn(),
     subCategories: MOCKED_SUBCATEGORIES,
     offer,

--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/IndividualOfferMedia.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/IndividualOfferMedia.spec.tsx
@@ -19,11 +19,19 @@ const renderIndividualOfferMedia = () => {
   return renderWithProviders(
     <IndividualOfferContextProvider>
       <IndividualOfferMedia />
-    </IndividualOfferContextProvider>
+    </IndividualOfferContextProvider>,
+    { storeOverrides: {} }
   )
 }
 
 describe('IndividialOfferMedia', () => {
+  beforeEach(() => {
+    vi.spyOn(api, 'getCategories').mockResolvedValue({
+      categories: [],
+      subcategories: [],
+    })
+  })
+
   it('should render a spinner until offer is fetched', () => {
     renderIndividualOfferMedia()
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceCategories/components/__specs__/PriceCategories.submit.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceCategories/components/__specs__/PriceCategories.submit.spec.tsx
@@ -40,8 +40,6 @@ const renderPriceCategories = (
     subCategories: [],
     isEvent: null,
     setIsEvent: () => {},
-    isAccessibilityFilled: false,
-    setIsAccessibilityFilled: () => {},
     hasPublishedOfferWithSameEan: false,
   }
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceCategories/components/__specs__/PriceCategoriesForm.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceCategories/components/__specs__/PriceCategoriesForm.spec.tsx
@@ -36,8 +36,6 @@ const renderPriceCategoriesForm = (
     subCategories: [subcategoryFactory({ id: offer.subcategoryId, canBeDuo })],
     isEvent: null,
     setIsEvent: () => {},
-    isAccessibilityFilled: false,
-    setIsAccessibilityFilled: () => {},
     hasPublishedOfferWithSameEan: false,
   }
   return renderWithProviders(

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/IndividualOfferPriceTableScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/IndividualOfferPriceTableScreen.spec.tsx
@@ -46,9 +46,7 @@ const renderPriceTableScreen: RenderComponentFunction<
   const contextValues: IndividualOfferContextValues = {
     categories: [],
     hasPublishedOfferWithSameEan: false,
-    isAccessibilityFilled: false,
     isEvent: null,
-    setIsAccessibilityFilled: vi.fn(),
     setIsEvent: vi.fn(),
     subCategories: MOCKED_SUBCATEGORIES,
     offer,

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
@@ -104,9 +104,7 @@ const renderIndividualOfferSummaryScreen: RenderComponentFunction<
     categories: MOCKED_CATEGORIES,
     hasPublishedOfferWithSameEan: false,
     isEvent: false,
-    isAccessibilityFilled: false,
     offer,
-    setIsAccessibilityFilled: vi.fn(),
     setIsEvent: vi.fn(),
     subCategories: MOCKED_SUBCATEGORIES,
     ...params.contextValues,
@@ -191,10 +189,8 @@ describe('IndividualOfferSummaryScreen', () => {
   const contextValuesBase: IndividualOfferContextValues = {
     categories: MOCKED_CATEGORIES,
     hasPublishedOfferWithSameEan: false,
-    isAccessibilityFilled: false,
     isEvent: false,
     offer: offerBase,
-    setIsAccessibilityFilled: vi.fn(),
     setIsEvent: vi.fn(),
     subCategories: MOCKED_SUBCATEGORIES,
   }

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/IndividualOfferSummaryPriceTable.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/IndividualOfferSummaryPriceTable.spec.tsx
@@ -51,11 +51,9 @@ const renderIndividualOfferSummaryPriceTable: RenderComponentFunction<
   const contextValues: IndividualOfferContextValues = {
     categories: MOCKED_CATEGORIES,
     hasPublishedOfferWithSameEan: false,
-    isAccessibilityFilled: false,
     isEvent: params.offer?.isEvent ?? null,
     offer: params.offer,
     offerId: params.offer?.id ?? params.offerId ?? null,
-    setIsAccessibilityFilled: vi.fn(),
     setIsEvent: vi.fn(),
     subCategories: MOCKED_SUBCATEGORIES,
     ...params.contextValues,

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/components/IndividualOfferSummaryPriceTableScreen.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/components/IndividualOfferSummaryPriceTableScreen.spec.tsx
@@ -49,10 +49,8 @@ const renderIndividualOfferSummaryPriceTableScreen: RenderComponentFunction<
     subCategories: MOCKED_SUBCATEGORIES,
     hasPublishedOfferWithSameEan: false,
     isEvent: params.offer.isEvent,
-    isAccessibilityFilled: false,
     offer: params.offer,
     offerId: params.offer.id,
-    setIsAccessibilityFilled: vi.fn(),
     setIsEvent: vi.fn(),
     ...params.contextValues,
   }


### PR DESCRIPTION
…step of the creation of an individual offer can be reached.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37719)

Le problème : chaque étape du stepper individuel ne doit être accessible via le stepper qu'à certaines conditions (cf chantier Rétention). Dans le cadre du nouveau parcours, on a besoin de pouvoir dire si une étape a été déjà passée ou non en fonction :
- De plusieurs clés sur offer + un FF pour l'accessibilité
- De la longueur de la liste des priceCategories de l'offre
- Des propriétés de la sous catégorie de l'offre

Pour rendre plus flexible le calcul de la possiiblité de passer l'étape, et puisque les cas particuliers sont nombreux, cette PR revoir le système actuel pour se baser sur une seule fonction `canGoBeyondStep`.