### PR TITLE
(BSR)[API] feat: Get city centroid address without Insee code restriction

### DIFF
--- a/api/src/pcapi/connectors/api_adresse.py
+++ b/api/src/pcapi/connectors/api_adresse.py
@@ -636,7 +636,13 @@ class ApiAdresseBackend(BaseBackend):
         enforce_reliability: bool = False,
     ) -> AddressInfo:
         address = f"{postal_code} {city}" if postal_code is not None else city
-        result = self.find_ban_address(address=address, insee_code=insee_code, enforce_reliability=enforce_reliability)
+        try:
+            result = self.find_ban_address(
+                address=address, insee_code=insee_code, enforce_reliability=enforce_reliability
+            )
+        except NoResultException:
+            result = self.find_ban_address(address=address, enforce_reliability=enforce_reliability)
+
         if result.type not in ("municipality", "locality"):
             logger.info(
                 "No BAN city centroid found for query", extra={"queried_address": city, "insee_code": insee_code}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

If no city is found in BAN database when looking with an Insee code, try again without any Insee code restriction - Here we'd rather have a very approximate address than no address at all

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
