### PR TITLE
(BSR)[API] fix: fix failing tests on collective location

### DIFF
--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -1223,7 +1223,7 @@ def get_collective_offer_by_id_query(offer_id: int) -> sa_orm.Query:
 
 def get_collective_offer_by_id(offer_id: int) -> models.CollectiveOffer:
     try:
-        return get_collective_offer_by_id_query(offer_id=offer_id).one()
+        return get_collective_offer_by_id_query(offer_id=offer_id).populate_existing().one()
     except sa_orm.exc.NoResultFound:
         raise exceptions.CollectiveOfferNotFound()
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Les tests suivants sont en erreur sur master : 

```
FAILED tests/routes/pro/get_collective_offer_test.py::Returns200Test::test_location_address_venue - Failed: 7 queries executed, 6 expected
FAILED tests/routes/pro/patch_collective_offer_test.py::Returns200Test::test_location_address_venue - assert 500 == 200
```

Sans doute du au chargement dans la session de test des objets OA, et notamment l'expression isLinkedToVenue

populate_existing avait déjà fixé des cas similaires, on tente la même chose ici

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
