### PR TITLE
(PC-35943)[API] fix: circular import in celery tasks

### DIFF
--- a/api/src/pcapi/celery_tasks/sendinblue.py
+++ b/api/src/pcapi/celery_tasks/sendinblue.py
@@ -1,8 +1,6 @@
 from brevo_python.rest import ApiException as SendinblueApiException
 
 from pcapi.celery_tasks.tasks import celery_async_task
-from pcapi.core.external import sendinblue
-from pcapi.core.mails.transactional.send_transactional_email import send_transactional_email
 from pcapi.tasks.serialization.sendinblue_tasks import SendTransactionalEmailRequest
 from pcapi.tasks.serialization.sendinblue_tasks import UpdateSendinblueContactRequest
 
@@ -13,6 +11,8 @@ from pcapi.tasks.serialization.sendinblue_tasks import UpdateSendinblueContactRe
     model=UpdateSendinblueContactRequest,
 )
 def update_contact_attributes_task_celery(payload: UpdateSendinblueContactRequest) -> None:
+    from pcapi.core.external import sendinblue
+
     sendinblue.make_update_request(payload)
 
 
@@ -22,6 +22,8 @@ def update_contact_attributes_task_celery(payload: UpdateSendinblueContactReques
     model=SendTransactionalEmailRequest,
 )
 def send_transactional_email_primary_task_celery(payload: SendTransactionalEmailRequest) -> None:
+    from pcapi.core.mails.transactional import send_transactional_email
+
     send_transactional_email(payload)
 
 
@@ -31,4 +33,6 @@ def send_transactional_email_primary_task_celery(payload: SendTransactionalEmail
     model=SendTransactionalEmailRequest,
 )
 def send_transactional_email_secondary_task_celery(payload: SendTransactionalEmailRequest) -> None:
+    from pcapi.core.mails.transactional import send_transactional_email
+
     send_transactional_email(payload)

--- a/api/tests/core/mails/mails_celery_test.py
+++ b/api/tests/core/mails/mails_celery_test.py
@@ -47,7 +47,7 @@ class SendinblueBackendTest:
             "tate.walker@example.com",
         ]
     )
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_mail(self, mock_send_transactional_email_secondary_task_celery):
         backend = self._get_backend_for_test()
         backend(use_pro_subaccount=False).send_mail(
@@ -65,7 +65,7 @@ class SendinblueBackendTest:
         assert task_param.reply_to == self.expected_sent_data.reply_to
         assert task_param.enable_unsubscribe == self.expected_sent_data.enable_unsubscribe
 
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_mail_with_no_sender(self, mock_send_transactional_email_secondary_task_celery):
         self.mock_template = models.TemplatePro(
             id_prod=1,
@@ -163,7 +163,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         return import_string("pcapi.core.mails.backends.sendinblue.ToDevSendinblueBackend")
 
     @pytest.mark.settings(WHITELISTED_EMAIL_RECIPIENTS=["test@example.com"])
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_mail_to_dev(self, mock_send_transactional_email_secondary_task_celery):
         backend = self._get_backend_for_test()
         backend(use_pro_subaccount=False).send_mail(
@@ -180,7 +180,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         assert task_param.sender == self.expected_sent_data_to_dev.sender
         assert task_param.reply_to == self.expected_sent_data_to_dev.reply_to
 
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_mail_test_user(self, mock_send_transactional_email_secondary_task_celery):
         users_factories.UserFactory(email=self.recipients[0], roles=[users_models.UserRole.TEST])
 
@@ -196,7 +196,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         ["avery.kelly@example.com", "sandy.zuko@passculture-test.app"],
     )
     @pytest.mark.settings(WHITELISTED_EMAIL_RECIPIENTS=["avery.kelly@example.com", "*@passculture-test.app"])
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_mail_whitelisted(self, mock_send_transactional_email_secondary_task_celery, recipient):
         backend = self._get_backend_for_test()
         backend(use_pro_subaccount=False).send_mail(
@@ -208,7 +208,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         assert list(task_param.recipients) == [recipient]
 
     @pytest.mark.settings(IS_STAGING=True, IS_E2E_TESTS=True, END_TO_END_TESTS_EMAIL_ADDRESS="qa-test@passculture.app")
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_mail_whitelisted_qa_staging(self, mock_send_transactional_email_secondary_task_celery):
         recipient = "qa-test+123@passculture.app"
         users_factories.UserFactory(email=recipient)
@@ -221,7 +221,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
         assert list(task_param.recipients) == [recipient]
 
     @pytest.mark.settings(IS_TESTING=True, IS_E2E_TESTS=True, END_TO_END_TESTS_EMAIL_ADDRESS="qa-test@passculture.app")
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_mail_whitelisted_qa_testing(
         self, mock_send_transactional_email_secondary_task_celery, recipient="qa-test+123@passculture.app"
     ):
@@ -238,7 +238,7 @@ class ToDevSendinblueBackendTest(SendinblueBackendTest):
 @pytest.mark.features(WIP_ASYNCHRONOUS_CELERY_MAILS=True)
 class SendTest:
     @pytest.mark.settings(IS_TESTING=True, EMAIL_BACKEND="pcapi.core.mails.backends.sendinblue.ToDevSendinblueBackend")
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_to_ehp_false_in_testing(self, mock_send_transactional_email_secondary_task_celery, caplog):
         mock_template_send_ehp_false = models.Template(
             id_prod=11, id_not_prod=12, tags=["some", "stuff"], send_to_ehp=False
@@ -260,7 +260,7 @@ class SendTest:
         )
 
     @pytest.mark.settings(IS_TESTING=True, EMAIL_BACKEND="pcapi.core.mails.backends.sendinblue.ToDevSendinblueBackend")
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_payload_json_serializable(self, mock_send_transactional_email_secondary_task_celery, caplog):
         mock_template_send_ehp_false = models.Template(
             id_prod=179, id_not_prod=179, tags=["some", "stuff"], send_to_ehp=True
@@ -278,7 +278,7 @@ class SendTest:
         assert mock_send_transactional_email_secondary_task_celery.call_args.args[0].params["CREDIT"] == 139.9
 
     @pytest.mark.settings(IS_TESTING=True, EMAIL_BACKEND="pcapi.core.mails.backends.sendinblue.ToDevSendinblueBackend")
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_to_ehp_true_in_testing(self, mock_send_transactional_email_secondary_task_celery, caplog):
         mock_template_send_ehp_true = models.Template(
             id_prod=11, id_not_prod=12, tags=["some", "stuff"], send_to_ehp=True
@@ -300,7 +300,7 @@ class SendTest:
         ],
     )
     @pytest.mark.settings(EMAIL_BACKEND="pcapi.core.mails.backends.sendinblue.SendinblueBackend")
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_mail_to_pro_with_FF(
         self,
         mock_send_transactional_email_secondary_task_celery,
@@ -330,7 +330,7 @@ class SendTest:
         ],
     )
     @pytest.mark.settings(IS_TESTING=True, EMAIL_BACKEND="pcapi.core.mails.backends.sendinblue.SendinblueBackend")
-    @patch("pcapi.celery_tasks.sendinblue.send_transactional_email")
+    @patch("pcapi.core.mails.transactional.send_transactional_email")
     def test_send_mail_to_pro_with_FF_in_ehp(
         self,
         mock_send_transactional_email_secondary_task_celery,


### PR DESCRIPTION
Exception suite au merge de https://github.com/pass-culture/pass-culture-main/pull/18695 hier.

```
pc-celery-worker    | Error:
pc-celery-worker    | Unable to load celery application.
pc-celery-worker    | While trying to load the module pcapi.celery_tasks.celery_worker the following error occurred:
pc-celery-worker    | Traceback (most recent call last):
pc-celery-worker    |   File "/home/pcapi/.local/lib/python3.11/site-packages/celery/app/utils.py", line 383, in find_app
pc-celery-worker    |     sym = symbol_by_name(app, imp=imp)
pc-celery-worker    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pc-celery-worker    |   File "/home/pcapi/.local/lib/python3.11/site-packages/kombu/utils/imports.py", line 64, in symbol_by_name
pc-celery-worker    |     return getattr(module, cls_name) if cls_name else module
pc-celery-worker    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
pc-celery-worker    | AttributeError: module 'pcapi.celery_tasks' has no attribute 'celery_worker'
pc-celery-worker    |
pc-celery-worker    | During handling of the above exception, another exception occurred:
pc-celery-worker    |
pc-celery-worker    | Traceback (most recent call last):
pc-celery-worker    |   File "/home/pcapi/.local/lib/python3.11/site-packages/celery/bin/celery.py", line 141, in celery
pc-celery-worker    |     app = find_app(app)
pc-celery-worker    |           ^^^^^^^^^^^^^
pc-celery-worker    |   File "/home/pcapi/.local/lib/python3.11/site-packages/celery/app/utils.py", line 386, in find_app
pc-celery-worker    |     sym = imp(app)
pc-celery-worker    |           ^^^^^^^^
pc-celery-worker    |   File "/home/pcapi/.local/lib/python3.11/site-packages/celery/utils/imports.py", line 109, in import_from_cwd
pc-celery-worker    |     return imp(module, package=package)
pc-celery-worker    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pc-celery-worker    |   File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
pc-celery-worker    |     return _bootstrap._gcd_import(name[level:], package, level)
pc-celery-worker    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pc-celery-worker    |   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
pc-celery-worker    |   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
pc-celery-worker    |   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
pc-celery-worker    |   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
pc-celery-worker    |   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
pc-celery-worker    |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
pc-celery-worker    |   File "/usr/src/app/src/pcapi/celery_tasks/celery_worker.py", line 1, in <module>
pc-celery-worker    |     from pcapi.celery_tasks import sendinblue  # noqa: F401
pc-celery-worker    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pc-celery-worker    |   File "/usr/src/app/src/pcapi/celery_tasks/sendinblue.py", line 4, in <module>
pc-celery-worker    |     from pcapi.core.external import sendinblue
pc-celery-worker    |   File "/usr/src/app/src/pcapi/core/external/sendinblue.py", line 19, in <module>
pc-celery-worker    |     from pcapi.celery_tasks.sendinblue import update_contact_attributes_task_celery
pc-celery-worker    | ImportError: cannot import name 'update_contact_attributes_task_celery' from partially initialized module 'pcapi.celery_tasks.sendinblue' (most likely due to a circular import) (/usr/src/app/src/pcapi/celery_tasks/sendinblue.py)
```
