### PR TITLE
Revert "(PC-37496)[PRO] fix: Prevent updating the stocks of an expire…

### DIFF
--- a/pro/src/components/IndividualOffer/StocksThing/utils/__specs__/getFormReadOnlyFields.spec.ts
+++ b/pro/src/components/IndividualOffer/StocksThing/utils/__specs__/getFormReadOnlyFields.spec.ts
@@ -17,11 +17,7 @@ describe('StockThingForm::utils::getFormReadOnlyFields', () => {
     offer = getIndividualOfferFactory()
     currentStock = {} as StockThingFormValues
   })
-  const disabledStatus = [
-    OfferStatus.REJECTED,
-    OfferStatus.PENDING,
-    OfferStatus.EXPIRED,
-  ]
+  const disabledStatus = [OfferStatus.REJECTED, OfferStatus.PENDING]
   it.each(disabledStatus)(
     'should disabled field for disable statuts "%s"',
     (status: OfferStatus) => {
@@ -66,7 +62,7 @@ describe('StockThingForm::utils::getFormReadOnlyFields', () => {
     ])
   })
 
-  it('should not disable field for allociné synchronized offer', () => {
+  it('should not disabled field for allociné synchronized offer', () => {
     offer.lastProvider = { name: 'allociné' }
     currentStock = {
       activationCodes: [] as string[],

--- a/pro/src/components/IndividualOffer/StocksThing/utils/getFormReadOnlyFields.ts
+++ b/pro/src/components/IndividualOffer/StocksThing/utils/getFormReadOnlyFields.ts
@@ -1,8 +1,11 @@
-import {
-  type GetIndividualOfferResponseModel,
-  type GetOfferStockResponseModel,
-  OfferStatus,
+import type {
+  GetIndividualOfferResponseModel,
+  GetOfferStockResponseModel,
 } from '@/apiClient/v1'
+import {
+  OFFER_STATUS_PENDING,
+  OFFER_STATUS_REJECTED,
+} from '@/commons/core/Offers/constants'
 import { isAllocineProvider } from '@/commons/core/Providers/utils/utils'
 
 import { STOCK_THING_FORM_DEFAULT_VALUES } from '../constants'
@@ -14,9 +17,8 @@ export const getFormReadOnlyFields = (
   currentStock: StockThingFormValues
 ): string[] => {
   const isDisabledStatus = [
-    OfferStatus.REJECTED,
-    OfferStatus.PENDING,
-    OfferStatus.EXPIRED,
+    OFFER_STATUS_REJECTED,
+    OFFER_STATUS_PENDING,
   ].includes(offer.status)
   const isOfferSynchronized = !!offer.lastProvider
   const isOfferSynchronizedAllocine =


### PR DESCRIPTION
…d offer."

This reverts commit f9e16b67a826090a2960215797e922ac67ddb4e6.

## 🎯 Related Ticket or 🔧 Changes Made

BSR de revert d'un commit qui empêchait la modification d'un stock d'offre (dont la sous-catégorie n'est pas isEvent) quand celle-ci est expirée.
