### PR TITLE
(PC-37863)[API] feat: add index on `depositId` for table `recredit`

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 aae08bded987 (pre) (head)
-8d1adabb3690 (post) (head)
+343cd453bc6f (post) (head)

--- a/api/src/pcapi/alembic/versions/20250911T083244_343cd453bc6f_add_index_deposit_id_in_recredit.py
+++ b/api/src/pcapi/alembic/versions/20250911T083244_343cd453bc6f_add_index_deposit_id_in_recredit.py
@@ -1,0 +1,40 @@
+"""Add index on 'depositId' foreign key field of recredit table"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "343cd453bc6f"
+down_revision = "8d1adabb3690"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.create_index(
+            "ix_recredit_depositId",
+            table_name="recredit",
+            columns=["depositId"],
+            unique=False,
+            postgresql_using="btree",
+            if_not_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET SESSION statement_timeout='300s'")
+        op.drop_index(
+            "ix_recredit_depositId",
+            table_name="recredit",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )
+        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -150,7 +150,7 @@ class RecreditType(enum.Enum):
 
 class Recredit(PcObject, Base, Model):
     __tablename__ = "recredit"
-    depositId: int = sa.Column(sa.BigInteger, sa.ForeignKey("deposit.id"), nullable=False)
+    depositId: int = sa.Column(sa.BigInteger, sa.ForeignKey("deposit.id"), nullable=False, index=True)
 
     deposit: sa_orm.Mapped[Deposit] = sa_orm.relationship(
         "Deposit", foreign_keys=[depositId], back_populates="recredits"


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37863)

Test en staging :
```
pcapi-staging=> explain analyze SELECT
  recredit.id AS recredit_id,
  recredit."depositId" AS "recredit_depositId",
  recredit."dateCreated" AS "recredit_dateCreated",
  recredit.amount AS recredit_amount,
  recredit."recreditType" AS "recredit_recreditType",
  recredit.comment AS recredit_comment
FROM
  recredit
WHERE
  6365020 = recredit."depositId"
ORDER BY
  recredit."dateCreated" DESC;
                                                           QUERY PLAN                                                            
---------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=56119.67..56119.67 rows=2 width=116) (actual time=172.257..176.092 rows=1 loops=1)
   Sort Key: "dateCreated" DESC
   Sort Method: quicksort  Memory: 25kB
   ->  Gather  (cost=1000.00..56119.66 rows=2 width=116) (actual time=171.966..176.059 rows=1 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Parallel Seq Scan on recredit  (cost=0.00..55119.46 rows=1 width=116) (actual time=148.429..165.451 rows=0 loops=3)
               Filter: (6365020 = "depositId")
               Rows Removed by Filter: 1273631
 Planning Time: 0.398 ms
 Execution Time: 176.248 ms
(11 rows)

pcapi-staging=> create index concurrently if not exists ix_recredit_depositId on recredit ("depositId");
CREATE INDEX
pcapi-staging=> explain analyze SELECT                                                                  
  recredit.id AS recredit_id,
  recredit."depositId" AS "recredit_depositId",
  recredit."dateCreated" AS "recredit_dateCreated",
  recredit.amount AS recredit_amount,
  recredit."recreditType" AS "recredit_recreditType",
  recredit.comment AS recredit_comment
FROM
  recredit
WHERE
  6365020 = recredit."depositId"
ORDER BY
  recredit."dateCreated" DESC
;
                                                               QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=2.65..2.65 rows=2 width=116) (actual time=0.029..0.030 rows=1 loops=1)
   Sort Key: "dateCreated" DESC
   Sort Method: quicksort  Memory: 25kB
   ->  Index Scan using ix_recredit_depositid on recredit  (cost=0.43..2.64 rows=2 width=116) (actual time=0.021..0.021 rows=1 loops=1)
         Index Cond: ("depositId" = 6365020)
 Planning Time: 0.358 ms
 Execution Time: 0.087 ms
(7 rows)
```
