### PR TITLE
(BSR)[BO] chore: bump jsbeautifier to fix a broken dependencie

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2729,13 +2729,14 @@ files = [
 
 [[package]]
 name = "jsbeautifier"
-version = "1.15.1"
+version = "1.15.4"
 description = "JavaScript unobfuscator and beautifier."
 optional = false
 python-versions = "*"
 groups = ["dev"]
 files = [
-    {file = "jsbeautifier-1.15.1.tar.gz", hash = "sha256:ebd733b560704c602d744eafc839db60a1ee9326e30a2a80c4adb8718adc1b24"},
+    {file = "jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528"},
+    {file = "jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592"},
 ]
 
 [package.dependencies]
@@ -6959,4 +6960,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "9cc6925dd9ea20d1b516d815dceb3f064db203d019b2262634b03f08de5737f8"
+content-hash = "d1c48be65b82a921164c970de2947be3689f3b0b926e96c37eae9237a9cfb6cc"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -102,6 +102,7 @@ optional = true
 commitizen = "^4.9.1"
 debugpy = "^1.8.16"
 djlint = "1.36.4"
+jsbeautifier = "1.15.4"  # djlint requires 1.15.1 which is broken
 fakeredis = "^2.31.1"
 mypy = "1.13.0"
 pgcli = "^4.3.0"


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

la dépendance de djlint a jsbeautifier qui est cassé avec jsbeautifier 1.15.1, est réparé si on le bump a 1.15.4
