### PR TITLE
(BSR)[API] ci: remove environment key from algolia config step

### DIFF
--- a/.github/workflows/dev_on_workflow_deploy.yml
+++ b/.github/workflows/dev_on_workflow_deploy.yml
@@ -297,7 +297,6 @@ jobs:
     if: |
       inputs.apply_algolia_config == true &&
       (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped')
-    environment: ${{ inputs.environment }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
# But de la PR

Ne pas faire apparaître le job apply algolia config dans les déploiements.
