### PR TITLE
(BSR)[BO] fix: Avoid 'Lieu de naissance : None'

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
+++ b/api/src/pcapi/routes/backoffice/templates/accounts/get/general.html
@@ -53,7 +53,7 @@
                 {% if user.birth_date %}<span>{{ user.birth_date | format_date }} ({{ user.age | empty_string_if_null }} ans)</span>{% endif %}
               </p>
               <p class="mb-1">
-                <span class="fw-bold">Lieu de naissance :</span> <span>{{ user.birthPlace }}</span>
+                <span class="fw-bold">Lieu de naissance :</span> <span>{{ user.birthPlace | empty_string_if_null }}</span>
               </p>
               {% if user.dateOfBirth and user.dateOfBirth.date() != user.birth_date %}
                 <p class="mb-1">


### PR DESCRIPTION
Éviter un « None » disgracieux sur le lieu de naissance dans la page de détails d'un jeune : 
<img width="251" height="91" alt="image" src="https://github.com/user-attachments/assets/1c827682-68ec-456e-86bf-b07371aec7c0" />
