### PR TITLE
(BSR)[BO] fix: ugly underlined space

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/components/clipboard.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/clipboard.html
@@ -1,5 +1,6 @@
 {% macro copy_to_clipboard(text_to_copy, tooltip_title) %}
-  <a href="">
+  <a href=""
+     style="text-decoration: none">
     <i class="bi bi-copy pc-clipboard text-body"
        data-bs-toggle="tooltip"
        data-bs-placement="top"


### PR DESCRIPTION
Avant : 
<img width="390" height="70" alt="image" src="https://github.com/user-attachments/assets/af408eda-7c56-4798-90cf-77d4c69f8ce3" />

Après : 
<img width="390" height="70" alt="image" src="https://github.com/user-attachments/assets/e1777766-b02b-471b-a584-e391389b206c" />

