### PR TITLE
(PC-37625)[API] feat: rename formatted price parameter for brevo templates

### DIFF
--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
@@ -48,7 +48,7 @@ def get_booking_cancellation_by_beneficiary_email_data(
             "IS_EXTERNAL": booking.isExternal,
             "OFFER_NAME": offer.name,
             "OFFER_PRICE": float(booking.total_amount),
-            "FORMATTED_OFFER_PRICE": format_price(booking.total_amount, beneficiary),
+            "FORMATTED_PRICE": format_price(booking.total_amount, beneficiary),
             "USER_FIRST_NAME": beneficiary.firstName,
             "CAN_BOOK_AGAIN": can_book_again,
             "OFFER_LINK": offer_app_link(offer),

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary.py
@@ -37,7 +37,7 @@ def get_booking_cancellation_by_pro_to_beneficiary_email_data(
             "IS_EXTERNAL": booking.isExternal,
             "OFFER_NAME": offer.name,
             "OFFER_PRICE": booking.total_amount,
-            "FORMATTED_OFFER_PRICE": format_price(booking.total_amount, beneficiary),
+            "FORMATTED_PRICE": format_price(booking.total_amount, beneficiary),
             "OFFERER_NAME": offer.venue.managingOfferer.name,
             "REASON": booking.cancellationReason.value if booking.cancellationReason else None,
             "REJECTED": rejected_by_fraud_action,

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_confirmation_to_beneficiary.py
@@ -82,7 +82,7 @@ def get_booking_confirmation_to_beneficiary_email_data(
             "EVENT_DATE": formatted_event_beginning_date,
             "EVENT_HOUR": formatted_event_beginning_time,
             "OFFER_PRICE": stock_price,
-            "FORMATTED_OFFER_PRICE": format_price(booking.total_amount, beneficiary),
+            "FORMATTED_PRICE": format_price(booking.total_amount, beneficiary),
             "OFFER_PRICE_CATEGORY": booking.priceCategoryLabel,
             "OFFER_TAGS": ",".join([criterion.name for criterion in offer.criteria]),
             "OFFER_TOKEN": bookings_common.get_booking_token(booking),

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_test.py
@@ -73,7 +73,7 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
             "IS_FREE_OFFER": False,
             "OFFER_NAME": "Test thing name",
             "OFFER_PRICE": 10.20,
-            "FORMATTED_OFFER_PRICE": "10,20 €",
+            "FORMATTED_PRICE": "10,20 €",
             "USER_FIRST_NAME": "Fabien",
             "OFFER_LINK": "https://webapp-v2.example.com/offre/123456",
         }
@@ -104,7 +104,7 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
             "IS_FREE_OFFER": False,
             "OFFER_NAME": "Test event name",
             "OFFER_PRICE": 10.20,
-            "FORMATTED_OFFER_PRICE": "10,20 €",
+            "FORMATTED_PRICE": "10,20 €",
             "USER_FIRST_NAME": "Fabien",
             "OFFER_LINK": "https://webapp-v2.example.com/offre/123456",
         }
@@ -128,7 +128,7 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
 
         # Then
         assert email_data.params["OFFER_PRICE"] == 20.00
-        assert email_data.params["FORMATTED_OFFER_PRICE"] == "20 €"
+        assert email_data.params["FORMATTED_PRICE"] == "20 €"
 
     def test_should_return_the_formatted_price_in_xpf(self):
         # Given
@@ -139,4 +139,4 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
 
         # Then
         assert email_data.params["OFFER_PRICE"] == 20.00
-        assert email_data.params["FORMATTED_OFFER_PRICE"] == "2385 F"
+        assert email_data.params["FORMATTED_PRICE"] == "2385 F"

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_by_pro_to_beneficiary_test.py
@@ -51,7 +51,7 @@ class SendinblueSendWarningToBeneficiaryAfterProBookingCancellationTest:
             "IS_ONLINE": False,
             "OFFER_NAME": booking.stock.offer.name,
             "OFFER_PRICE": decimal.Decimal("10.10"),
-            "FORMATTED_OFFER_PRICE": "10,10 €",
+            "FORMATTED_PRICE": "10,10 €",
             "OFFERER_NAME": booking.offerer.name,
             "REASON": "OFFERER",
             "REJECTED": False,
@@ -105,7 +105,7 @@ class SendinblueSendWarningToBeneficiaryAfterProBookingCancellationTest:
             "IS_ONLINE": False,
             "OFFER_NAME": booking.stock.offer.name,
             "OFFER_PRICE": decimal.Decimal("10.10"),
-            "FORMATTED_OFFER_PRICE": "10,10 €",
+            "FORMATTED_PRICE": "10,10 €",
             "OFFERER_NAME": booking.offerer.name,
             "REASON": "OFFERER",
             "REJECTED": False,
@@ -128,7 +128,7 @@ class SendinblueSendWarningToBeneficiaryAfterProBookingCancellationTest:
         )
         mail_params = mails_testing.outbox[0]["params"]
         assert mail_params["OFFER_PRICE"] == 20.00
-        assert mail_params["FORMATTED_OFFER_PRICE"] == "2385 F"
+        assert mail_params["FORMATTED_PRICE"] == "2385 F"
 
 
 @pytest.mark.usefixtures("db_session")
@@ -159,7 +159,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
             "IS_THING": False,
             "OFFER_NAME": booking.stock.offer.name,
             "OFFER_PRICE": decimal.Decimal("10.10"),
-            "FORMATTED_OFFER_PRICE": "10,10 €",
+            "FORMATTED_PRICE": "10,10 €",
             "OFFERER_NAME": booking.offerer.name,
             "REASON": None,
             "REJECTED": False,
@@ -195,7 +195,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
             "IS_THING": True,
             "OFFER_NAME": booking.stock.offer.name,
             "OFFER_PRICE": decimal.Decimal("10.10"),
-            "FORMATTED_OFFER_PRICE": "10,10 €",
+            "FORMATTED_PRICE": "10,10 €",
             "OFFERER_NAME": booking.offerer.name,
             "REASON": None,
             "REJECTED": False,
@@ -228,7 +228,7 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
             "IS_THING": False,
             "OFFER_NAME": booking.stock.offer.name,
             "OFFER_PRICE": decimal.Decimal("10.10"),
-            "FORMATTED_OFFER_PRICE": "10,10 €",
+            "FORMATTED_PRICE": "10,10 €",
             "OFFERER_NAME": booking.offerer.name,
             "REASON": None,
             "REJECTED": False,
@@ -281,4 +281,4 @@ class SendinblueRetrieveDataToWarnUserAfterProBookingCancellationTest:
 
         # Then
         assert sendinblue_data.params["OFFER_PRICE"] == 20.00
-        assert sendinblue_data.params["FORMATTED_OFFER_PRICE"] == "2385 F"
+        assert sendinblue_data.params["FORMATTED_PRICE"] == "2385 F"

--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -52,7 +52,7 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
             "EVENT_HOUR": "13h48",
             "OFFER_PRICE_CATEGORY": booking.priceCategoryLabel,
             "OFFER_PRICE": f"{booking.total_amount} €" if booking.stock.price > 0 else "Gratuit",
-            "FORMATTED_OFFER_PRICE": "" if booking.stock.price > 0 else "Gratuit",
+            "FORMATTED_PRICE": "" if booking.stock.price > 0 else "Gratuit",
             "OFFER_TAGS": "",
             "OFFER_TOKEN": booking.token,
             "OFFER_CATEGORY": booking.stock.offer.category.id,
@@ -88,7 +88,7 @@ def test_should_return_event_specific_data_for_email_when_offer_is_an_event_send
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
     email_data = get_booking_confirmation_to_beneficiary_email_data(booking)
 
-    expected = get_expected_base_sendinblue_email_data(booking, mediation, FORMATTED_OFFER_PRICE="23,99 €")
+    expected = get_expected_base_sendinblue_email_data(booking, mediation, FORMATTED_PRICE="23,99 €")
     assert email_data == expected
 
 
@@ -107,7 +107,7 @@ def test_should_return_event_specific_data_for_email_when_offer_is_a_duo_event_s
         IS_DUO_EVENT=True,
         IS_SINGLE_EVENT=False,
         OFFER_PRICE="47.98 €",
-        FORMATTED_OFFER_PRICE="47,98 €",
+        FORMATTED_PRICE="47,98 €",
     )
     assert email_data == expected
 
@@ -133,7 +133,7 @@ def test_should_return_thing_specific_data_for_email_when_offer_is_a_thing_sendi
         IS_EVENT=False,
         IS_SINGLE_EVENT=False,
         OFFER_NAME="Super bien culturel",
-        FORMATTED_OFFER_PRICE="23,99 €",
+        FORMATTED_PRICE="23,99 €",
         CAN_EXPIRE=True,
         EXPIRATION_DELAY=30,
         BOOKING_LINK=f"https://webapp-v2.example.com/reservation/{booking.id}/details",
@@ -228,7 +228,7 @@ def test_should_return_offer_features():
         CAN_EXPIRE=True,
         EXPIRATION_DELAY=30,
         BOOKING_LINK=f"https://webapp-v2.example.com/reservation/{booking.id}/details",
-        FORMATTED_OFFER_PRICE="23,99 €",
+        FORMATTED_PRICE="23,99 €",
     )
     assert email_data == expected
 
@@ -237,7 +237,7 @@ def test_should_return_formatted_offer_price_in_xpf():
     booking = BookingFactory(stock__price=20, user__postalCode="98818")
     email_data = get_booking_confirmation_to_beneficiary_email_data(booking)
 
-    assert email_data.params["FORMATTED_OFFER_PRICE"] == "2385 F"
+    assert email_data.params["FORMATTED_PRICE"] == "2385 F"
 
 
 class DigitalOffersSendinblueTest:
@@ -303,7 +303,7 @@ class DigitalOffersSendinblueTest:
             IS_SINGLE_EVENT=False,
             OFFER_NAME="Super offre numérique",
             OFFER_PRICE="10.10 €",
-            FORMATTED_OFFER_PRICE="10,10 €",
+            FORMATTED_PRICE="10,10 €",
             OFFER_TOKEN=booking.activationCode.code,
             CAN_EXPIRE=False,
             IS_DIGITAL_BOOKING_WITH_ACTIVATION_CODE_AND_NO_EXPIRATION_DATE=True,


### PR DESCRIPTION
Renommer le paramètre Brevo `FORMATTED_OFFER_PRICE` en `FORMATTED_PRICE`


