### PR TITLE
(PC-37860)[PRO] fix: Redirect to offer creation first step directly w…

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/IndividualOfferConfirmation.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/IndividualOfferConfirmation.spec.tsx
@@ -31,7 +31,8 @@ vi.mock('@/commons/utils/config', async () => {
 })
 
 const renderOffer = (
-  contextOverride: Partial<IndividualOfferContextValues>
+  contextOverride: Partial<IndividualOfferContextValues>,
+  features?: string[]
 ) => {
   const contextValue = individualOfferContextValuesFactory(contextOverride)
 
@@ -52,6 +53,7 @@ const renderOffer = (
     {
       user: sharedCurrentUserFactory(),
       initialRouterEntries: ['/confirmation'],
+      features,
     }
   )
 }
@@ -137,5 +139,13 @@ describe('IndividualOfferConfirmation', () => {
       'href',
       `/offre/creation?structure=${offererId}&lieu=${venueId}`
     )
+  })
+
+  it('should redirect to offer creation first step if the FF WIP_ENABLE_NEW_OFFER_CREATION_FLOW is enabled', () => {
+    renderOffer(contextOverride, ['WIP_ENABLE_NEW_OFFER_CREATION_FLOW'])
+
+    expect(
+      screen.getByRole('link', { name: 'Créer une nouvelle offre' })
+    ).toHaveAttribute('href', `/offre/individuelle/creation/details`)
   })
 })

--- a/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/components/IndividualOfferConfirmationScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/components/IndividualOfferConfirmationScreen.tsx
@@ -2,6 +2,12 @@ import {
   type GetIndividualOfferResponseModel,
   OfferStatus,
 } from '@/apiClient/v1'
+import {
+  INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
+  OFFER_WIZARD_MODE,
+} from '@/commons/core/Offers/constants'
+import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
+import { useActiveFeature } from '@/commons/hooks/useActiveFeature'
 import { isDateValid } from '@/commons/utils/date'
 import { DisplayOfferInAppLink } from '@/components/DisplayOfferInAppLink/DisplayOfferInAppLink'
 import fullLinkIcon from '@/icons/full-link.svg'
@@ -20,6 +26,10 @@ interface IndividualOfferConfirmationScreenProps {
 export const IndividualOfferConfirmationScreen = ({
   offer,
 }: IndividualOfferConfirmationScreenProps): JSX.Element => {
+  const isNewOfferCreationFlowFFEnabled = useActiveFeature(
+    'WIP_ENABLE_NEW_OFFER_CREATION_FLOW'
+  )
+
   const isPublishedInTheFuture =
     isDateValid(offer.publicationDate) &&
     new Date() < new Date(offer.publicationDate)
@@ -70,7 +80,15 @@ export const IndividualOfferConfirmationScreen = ({
 
       <div className={styles['confirmation-actions']}>
         <ButtonLink
-          to={`/offre/creation${queryString}`}
+          to={
+            isNewOfferCreationFlowFFEnabled
+              ? getIndividualOfferUrl({
+                  step: INDIVIDUAL_OFFER_WIZARD_STEP_IDS.DETAILS,
+                  mode: OFFER_WIZARD_MODE.CREATION,
+                  isOnboarding: false,
+                })
+              : `/offre/creation${queryString}`
+          }
           isExternal
           className={styles['confirmation-action']}
           variant={ButtonVariant.SECONDARY}


### PR DESCRIPTION
…hen WIP_ENABLE_NEW_OFFER_CREATION_FLOW  is enabled

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37860)

Quand le FF `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` est activé : 
Rediriger vers la première étape de création d'offre indiv (détails) quand on clic sur "Créer une nouvelle offre" depuis la page de confirmation de création d'offre.
