### PR TITLE
(BSR)[API] chore: remove BIC from finance csv

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -1386,7 +1386,6 @@ def _row_formatter(row: typing.Any) -> tuple:
         _clean_for_accounting(row.iban),
         "",
         "",
-        _clean_for_accounting(row.bic),
         _clean_for_accounting(row.offerer_siren),
         "",
         "EXO",
@@ -1422,7 +1421,6 @@ def _generate_bank_accounts_file(cutoff: datetime.datetime) -> pathlib.Path:
         "IBAN",
         "Compte de trésorerie",
         "Nature économique",
-        "BIC",
         "SIREN",
         "Numéro de TVA Intracom",
         "Zone de taxes",
@@ -1442,7 +1440,6 @@ def _generate_bank_accounts_file(cutoff: datetime.datetime) -> pathlib.Path:
             models.BankAccount.id,
             models.BankAccount.label,
             models.BankAccount.iban,
-            models.BankAccount.bic,
             offerers_models.Offerer.name,
             offerers_models.Offerer.siren,
             offerers_models.Offerer.street,
@@ -1459,7 +1456,6 @@ def _generate_bank_accounts_file(cutoff: datetime.datetime) -> pathlib.Path:
         offerers_models.Offerer.postalCode.label("offerer_postal_code"),
         models.BankAccount.label.label("label"),
         models.BankAccount.iban.label("iban"),
-        models.BankAccount.bic.label("bic"),
     )
 
     return _write_csv("bank_accounts", header, rows=query, row_formatter=_row_formatter)

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -2023,13 +2023,9 @@ def test_generate_bank_accounts_file(clean_temp_files):
     venue_4 = offerers_factories.VenueFactory(managingOfferer=offerer)
     venue_5 = offerers_factories.VenueFactory(managingOfferer=offerer)
     venue_6 = offerers_factories.VenueFactory(managingOfferer=offerer)
-    bank_account_1 = factories.BankAccountFactory(
-        label="old-label", iban="older-iban", bic="older-bic", offerer=offerer
-    )
-    bank_account_2 = factories.BankAccountFactory(label="some-label", iban="some-iban", bic="some-bic", offerer=offerer)
-    bank_account_3 = factories.BankAccountFactory(
-        label="newer-label", iban="newer-iban", bic="newer-bic", offerer=offerer
-    )
+    bank_account_1 = factories.BankAccountFactory(label="old-label", iban="older-iban", offerer=offerer)
+    bank_account_2 = factories.BankAccountFactory(label="some-label", iban="some-iban", offerer=offerer)
+    bank_account_3 = factories.BankAccountFactory(label="newer-label", iban="newer-iban", offerer=offerer)
     bank_account_4 = factories.BankAccountFactory(label="Fourth bank account", offerer=offerer)
     _bank_account_5 = factories.BankAccountFactory(label="Fifth bank account", offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
@@ -2101,7 +2097,6 @@ def test_generate_bank_accounts_file(clean_temp_files):
             "IBAN": bank_account.iban,
             "Compte de trésorerie": "",
             "Nature économique": "",
-            "BIC": bank_account.bic,
             "SIREN": bank_account.offerer.siren,
             "Numéro de TVA Intracom": "",
             "Zone de taxes": "EXO",

--- a/api/tests/core/finance/test_api_legacy.py
+++ b/api/tests/core/finance/test_api_legacy.py
@@ -615,13 +615,9 @@ def test_generate_bank_accounts_file(clean_temp_files):
     venue_4 = offerers_factories.VenueFactory(managingOfferer=offerer)
     venue_5 = offerers_factories.VenueFactory(managingOfferer=offerer)
     venue_6 = offerers_factories.VenueFactory(managingOfferer=offerer)
-    bank_account_1 = factories.BankAccountFactory(
-        label="old-label", iban="older-iban", bic="older-bic", offerer=offerer
-    )
-    bank_account_2 = factories.BankAccountFactory(label="some-label", iban="some-iban", bic="some-bic", offerer=offerer)
-    bank_account_3 = factories.BankAccountFactory(
-        label="newer-label", iban="newer-iban", bic="newer-bic", offerer=offerer
-    )
+    bank_account_1 = factories.BankAccountFactory(label="old-label", iban="older-iban", offerer=offerer)
+    bank_account_2 = factories.BankAccountFactory(label="some-label", iban="some-iban", offerer=offerer)
+    bank_account_3 = factories.BankAccountFactory(label="newer-label", iban="newer-iban", offerer=offerer)
     bank_account_4 = factories.BankAccountFactory(label="Fourth bank account", offerer=offerer)
     _bank_account_5 = factories.BankAccountFactory(label="Fifth bank account", offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
@@ -693,7 +689,6 @@ def test_generate_bank_accounts_file(clean_temp_files):
             "IBAN": bank_account.iban,
             "Compte de trésorerie": "",
             "Nature économique": "",
-            "BIC": bank_account.bic,
             "SIREN": bank_account.offerer.siren,
             "Numéro de TVA Intracom": "",
             "Zone de taxes": "EXO",


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Les BICs ne sont pas utilisés par l'outil comptable.

- [ ] Travail pair testé en environnement de preview
