### PR TITLE
(PC-37116)[PRO] fix: Redirect back to offer type screen when back fro…

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreenNext.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreenNext.spec.tsx
@@ -1321,7 +1321,7 @@ describe('IndividualOfferDetailsScreenNext', () => {
       })
     })
 
-    it('should not render when the offer is not set', async () => {
+    it('should redirect to the offer creation type screen', async () => {
       renderDetailsScreen({
         props: {
           venues: [venueListItemFactory({ id: 189 })],
@@ -1336,7 +1336,7 @@ describe('IndividualOfferDetailsScreenNext', () => {
       })
       await userEvent.click(screen.getByText('Retour'))
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('/onboarding/offre/creation')
+        expect(mockNavigate).toHaveBeenCalledWith('/onboarding/individuel')
       })
     })
   })

--- a/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreenNext.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDetails/components/IndividualOfferDetailsScreenNext.tsx
@@ -86,20 +86,16 @@ export const IndividualOfferDetailsScreenNext = ({
   } = useIndividualOfferImageUpload(initialOfferImage)
 
   const isNewOfferDraft = !initialOffer
-  const isNewOfferCreationFlowFeatureActive = true
   const availableVenues = filterAvailableVenues(venues)
   const availableVenuesAsOptions = getVenuesAsOptions(availableVenues)
 
   const getInitialValues = () => {
     return isNewOfferDraft
-      ? getInitialValuesFromVenues(
-          availableVenues,
-          isNewOfferCreationFlowFeatureActive
-        )
+      ? getInitialValuesFromVenues(availableVenues, true)
       : getInitialValuesFromOffer({
           offer: initialOffer,
           subcategories: subCategories,
-          isNewOfferCreationFlowFeatureActive,
+          isNewOfferCreationFlowFeatureActive: true,
         })
   }
 
@@ -127,7 +123,7 @@ export const IndividualOfferDetailsScreenNext = ({
   const readOnlyFields = getFormReadOnlyFields(
     initialOffer,
     hasSelectedProduct,
-    isNewOfferCreationFlowFeatureActive
+    true
   )
 
   const onSubmit = async (formValues: DetailsFormValues): Promise<void> => {
@@ -145,18 +141,12 @@ export const IndividualOfferDetailsScreenNext = ({
 
       if (isNewOfferDraft) {
         response = await api.postDraftOffer(
-          serializeDetailsPostData(
-            formValues,
-            isNewOfferCreationFlowFeatureActive
-          )
+          serializeDetailsPostData(formValues, true)
         )
       } else if (!shouldNotPatchData && initialOfferId) {
         response = await api.patchDraftOffer(
           initialOfferId,
-          serializeDetailsPatchData(
-            formValues,
-            isNewOfferCreationFlowFeatureActive
-          )
+          serializeDetailsPatchData(formValues, true)
         )
       }
 
@@ -219,10 +209,8 @@ export const IndividualOfferDetailsScreenNext = ({
 
   const handlePreviousStepOrBackToReadOnly = () => {
     if (mode === OFFER_WIZARD_MODE.CREATION) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      navigate(`${isOnboarding ? '/onboarding' : ''}/offre/creation`)
+      navigate(isOnboarding ? '/onboarding/individuel' : '/offre/creation')
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       navigate(
         getIndividualOfferUrl({
           offerId: initialOffer?.id,

--- a/pro/src/pages/OfferType/OfferType/OfferType.spec.tsx
+++ b/pro/src/pages/OfferType/OfferType/OfferType.spec.tsx
@@ -35,4 +35,14 @@ describe('OfferType', () => {
       })
     ).not.toBeInTheDocument()
   })
+
+  it('should not show the individual categories options if the FF WIP_ENABLE_NEW_OFFER_CREATION_FLOW is enabled', () => {
+    renderOfferTypeScreen({}, ['WIP_ENABLE_NEW_OFFER_CREATION_FLOW'])
+
+    expect(
+      screen.queryByRole('heading', {
+        name: 'Votre offre est',
+      })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/pro/src/pages/OfferType/OfferType/OfferType.tsx
+++ b/pro/src/pages/OfferType/OfferType/OfferType.tsx
@@ -190,9 +190,8 @@ export const OfferTypeScreen = ({ collectiveOnly }: OfferTypeScreenProps) => {
               />
             )}
 
-            {offer.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO && (
-              <IndividualOfferType />
-            )}
+            {offer.offerType === OFFER_TYPES.INDIVIDUAL_OR_DUO &&
+              !isNewOfferCreationFlowFeatureActive && <IndividualOfferType />}
 
             {offer.offerType === OFFER_TYPES.EDUCATIONAL &&
               (isOffererLoading ? (


### PR DESCRIPTION
…nt onboarding details step.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37116)

Rediriger vers la page de choix de type de création "Manuelle" / "Auto" dans l'onboarding quand on revient en arrière depuis l'étape 1 de création d'offre lorsque le FF `WIP_ENABLE_NEW_OFFER_CREATION_FLOW ` est actif (parce que dans ce cas, on n'a plus de carrefour).
