### PR TITLE
(BSR)[PRO] feat: remove BIC from front pro

### DIFF
--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -120,7 +120,6 @@ class BankAccountResponseModel(BaseModel):
     isActive: bool
     label: str
     obfuscatedIban: str
-    bic: str
     dsApplicationId: int | None
     status: finance_models.BankAccountApplicationStatus
     dateCreated: datetime.datetime

--- a/api/tests/routes/pro/get_collective_offer_template_test.py
+++ b/api/tests/routes/pro/get_collective_offer_template_test.py
@@ -32,9 +32,7 @@ class Returns200Test:
 
         response_json = response.json
         assert "iban" not in response_json["venue"]
-        assert "bic" not in response_json["venue"]
         assert "iban" not in response_json["venue"]["managingOfferer"]
-        assert "bic" not in response_json["venue"]["managingOfferer"]
         assert "validationStatus" not in response_json["venue"]["managingOfferer"]
         assert response_json["venue"]["departementCode"] == offer.venue.offererAddress.address.departmentCode
         assert response_json["venue"]["managingOfferer"] == {

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -71,9 +71,7 @@ class Returns200Test:
 
         response_json = response.json
         assert "iban" not in response_json["venue"]
-        assert "bic" not in response_json["venue"]
         assert "iban" not in response_json["venue"]["managingOfferer"]
-        assert "bic" not in response_json["venue"]["managingOfferer"]
         assert "validationStatus" not in response_json["venue"]["managingOfferer"]
         assert "thumbUrl" in response_json
         assert response_json["id"] == offer.id

--- a/api/tests/routes/pro/get_offerers_bank_accounts_test.py
+++ b/api/tests/routes/pro/get_offerers_bank_accounts_test.py
@@ -88,7 +88,6 @@ class OfferersBankAccountTest:
         bank_account = bank_accounts.pop()
         assert bank_account["label"] == expected_bank_account.label
         assert bank_account["obfuscatedIban"] == f"XXXX XXXX XXXX {expected_bank_account.iban[-4:]}"
-        assert bank_account["bic"] == expected_bank_account.bic
         assert bank_account["isActive"] is True
         assert bank_account["status"] == "accepte"
         assert not bank_account["linkedVenues"]
@@ -168,7 +167,6 @@ class OfferersBankAccountTest:
         bank_account = bank_accounts.pop()
         assert bank_account["label"] == expected_bank_account.label
         assert bank_account["obfuscatedIban"] == f"XXXX XXXX XXXX {expected_bank_account.iban[-4:]}"
-        assert bank_account["bic"] == expected_bank_account.bic
         assert bank_account["isActive"] is True
 
     @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -213,7 +213,6 @@ class Returns200Test:
             "hasAdageId": True,
             "adageInscriptionDate": format_into_utc_date(venue.adageInscriptionDate),
             "bankAccount": {
-                "bic": bank_account_link.bankAccount.bic,
                 "dateCreated": format_into_utc_date(bank_account_link.bankAccount.dateCreated),
                 "dsApplicationId": bank_account_link.bankAccount.dsApplicationId,
                 "id": bank_account_link.bankAccount.id,

--- a/pro/src/apiClient/v1/models/BankAccountResponseModel.ts
+++ b/pro/src/apiClient/v1/models/BankAccountResponseModel.ts
@@ -5,7 +5,6 @@
 import type { BankAccountApplicationStatus } from './BankAccountApplicationStatus';
 import type { LinkedVenues } from './LinkedVenues';
 export type BankAccountResponseModel = {
-  bic: string;
   dateCreated: string;
   dsApplicationId?: number | null;
   id: number;

--- a/pro/src/commons/utils/factories/individualApiFactories.ts
+++ b/pro/src/commons/utils/factories/individualApiFactories.ts
@@ -434,7 +434,6 @@ export const defaultGetBookingResponse: GetBookingResponse = {
 }
 
 export const defaultBankAccount: BankAccountResponseModel = {
-  bic: 'CCOPFRPP',
   dateCreated: '2020-05-07',
   dsApplicationId: 1,
   id: 1,

--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -50,8 +50,7 @@ export const ReimbursementBankAccount = ({
           {bankAccount.label}
         </div>
         <div className={styles['informations-section-content']}>
-          <div>IBAN : **** {bankAccount.obfuscatedIban.slice(-4)}</div>
-          <div>BIC : {bankAccount.bic}</div>
+          IBAN : **** {bankAccount.obfuscatedIban.slice(-4)}
         </div>
       </div>
       {bankAccount.status === BankAccountApplicationStatus.EN_CONSTRUCTION ||

--- a/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
+++ b/pro/src/components/ReimbursementBankAccount/__specs__/ReimbursementBankAccount.spec.tsx
@@ -59,7 +59,6 @@ describe('ReimbursementBankAccount', () => {
       isActive: true,
       label: 'Bank account label',
       obfuscatedIban: 'XXXX XXXX XXXX 0637',
-      bic: 'BDFEFRPP',
       dsApplicationId: 6,
       status: BankAccountApplicationStatus.ACCEPTE,
       dateCreated: '2023-09-22T12:44:05.410448',
@@ -81,7 +80,6 @@ describe('ReimbursementBankAccount', () => {
 
     expect(screen.getByText('Bank account label')).toBeInTheDocument()
     expect(screen.getByText('IBAN : **** 0637')).toBeInTheDocument()
-    expect(screen.getByText('BIC : BDFEFRPP')).toBeInTheDocument()
 
     expect(screen.getByText(/en cours de validation/)).toBeInTheDocument()
     expect(screen.getByText('Voir le dossier')).toBeInTheDocument()
@@ -96,7 +94,6 @@ describe('ReimbursementBankAccount', () => {
 
     expect(screen.getByText('Bank account label')).toBeInTheDocument()
     expect(screen.getByText('IBAN : **** 0637')).toBeInTheDocument()
-    expect(screen.getByText('BIC : BDFEFRPP')).toBeInTheDocument()
 
     expect(screen.getByText(/informations manquantes/)).toBeInTheDocument()
     expect(screen.getByText(/Compléter le dossier/)).toBeInTheDocument()
@@ -111,7 +108,6 @@ describe('ReimbursementBankAccount', () => {
 
     expect(screen.getByText('Bank account label')).toBeInTheDocument()
     expect(screen.getByText('IBAN : **** 0637')).toBeInTheDocument()
-    expect(screen.getByText('BIC : BDFEFRPP')).toBeInTheDocument()
 
     expect(screen.getByText(/en cours de validation/)).toBeInTheDocument()
     expect(screen.getByText('Voir le dossier')).toBeInTheDocument()

--- a/pro/src/pages/Reimbursements/__specs__/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/__specs__/BankInformations.spec.tsx
@@ -21,7 +21,6 @@ import { BankInformations } from '@/pages/Reimbursements/BankInformations/BankIn
 import type { ReimbursementsContextProps } from '@/pages/Reimbursements/Reimbursements'
 
 const defaultBankAccountResponseModel: BankAccountResponseModel = {
-  bic: 'bic',
   dateCreated: '2020-05-07',
   dsApplicationId: 1,
   id: 1,


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

L'information du BIC n'est plus utile côté finance, elle ne sert donc plus dans PC Pro

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
