### PR TITLE
(PC-37905)[PRO] feat: Edit banner logics in new individual offer flow.

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.spec.tsx
@@ -7,6 +7,7 @@ import { IndividualOfferContext } from '@/commons/context/IndividualOfferContext
 import {
   getIndividualOfferFactory,
   individualOfferContextValuesFactory,
+  subcategoryFactory,
 } from '@/commons/utils/factories/individualApiFactories'
 import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
 import { renderWithProviders } from '@/commons/utils/renderWithProviders'
@@ -105,6 +106,22 @@ describe('IndividualOfferPracticalInfosForm', () => {
 
     expect(
       screen.getByLabelText('Email auquel envoyer les notifications *')
+    ).toBeInTheDocument()
+  })
+
+  it('should show a warning callout with a 10 days expiration if the offer is a physical book', () => {
+    renderIndividualOfferPracticalInfosForm({
+      offer: getIndividualOfferFactory({
+        subcategoryId: SubcategoryIdEnum.LIVRE_PAPIER,
+        isEvent: false,
+      }),
+      subCategory: subcategoryFactory({ id: SubcategoryIdEnum.LIVRE_PAPIER }),
+    })
+
+    expect(
+      screen.getByText(
+        /la réservation sera automatiquement annulée et remise en vente au bout de 10 jours/
+      )
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.tsx
@@ -1,9 +1,10 @@
 import { useFormContext } from 'react-hook-form'
 
-import type {
-  GetIndividualOfferWithAddressResponseModel,
-  GetOfferStockResponseModel,
-  SubcategoryResponseModel,
+import {
+  type GetIndividualOfferWithAddressResponseModel,
+  type GetOfferStockResponseModel,
+  SubcategoryIdEnum,
+  type SubcategoryResponseModel,
 } from '@/apiClient/v1'
 import { REIMBURSEMENT_RULES } from '@/commons/core/Finances/constants'
 import { CATEGORY_STATUS } from '@/commons/core/Offers/constants'
@@ -49,6 +50,9 @@ export function IndividualOfferPracticalInfosForm({
       subCategory?.reimbursementRule === REIMBURSEMENT_RULES.BOOK) &&
     hasNonFreeStock
 
+  const reimbursmentDelay =
+    subCategory?.id === SubcategoryIdEnum.LIVRE_PAPIER ? 10 : 30
+
   const isPhysicalAndOffline =
     !subCategory?.isEvent &&
     subCategory?.onlineOfflinePlatform === CATEGORY_STATUS.OFFLINE
@@ -69,7 +73,7 @@ export function IndividualOfferPracticalInfosForm({
                 ? ' pour que votre structure soit remboursée'
                 : ''}
               , sinon la réservation sera automatiquement annulée et remise en
-              vente.
+              vente au bout de {reimbursmentDelay} jours.
             </Callout>
           </FormLayout.Row>
         )}

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/IndividualOfferTimetableScreen.module.scss
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/IndividualOfferTimetableScreen.module.scss
@@ -3,7 +3,3 @@
 .group {
     margin-bottom: rem.torem(32px);
 }
-
-.cancel-banner {
-    margin-bottom: rem.torem(32px);
-}

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/IndividualOfferTimetableScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/IndividualOfferTimetableScreen.tsx
@@ -23,7 +23,6 @@ import { useNotification } from '@/commons/hooks/useNotification'
 import { StocksThing } from '@/components/IndividualOffer/StocksThing/StocksThing'
 import { RadioButtonGroup } from '@/design-system/RadioButtonGroup/RadioButtonGroup'
 import { StocksCalendar } from '@/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar'
-import { StocksCalendarCancelBanner } from '@/pages/IndividualOfferSummary/IndividualOfferSummaryStocks/components/IndividualOfferSummaryStocksCalendarScreen/IndividualOfferSummaryStocksCalendarScreen'
 import { cleanOpeningHours } from '@/pages/VenueEdition/serializers'
 
 import { areOpeningHoursEmpty } from '../commons/areOpeningHoursEmpty'
@@ -163,11 +162,6 @@ export function IndividualOfferTimetableScreen({
 
   return (
     <FormProvider {...form}>
-      {!isNewOfferCreationFlowFFEnabled && (
-        <div className={styles['cancel-banner']}>
-          <StocksCalendarCancelBanner />
-        </div>
-      )}
       <form onSubmit={form.handleSubmit(onSubmit)}>
         {isOfferTimetableTypeEditable && (
           <div className={styles['group']}>

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.module.scss
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.module.scss
@@ -51,3 +51,7 @@
 .count {
   margin-bottom: rem.torem(8px);
 }
+
+.cancel-banner {
+  margin-top: rem.torem(24px);
+}

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/commons/config/swrQueryKeys'
 import { Events } from '@/commons/core/FirebaseEvents/constants'
 import { OFFER_WIZARD_MODE } from '@/commons/core/Offers/constants'
+import { isOfferDisabled } from '@/commons/core/Offers/utils/isOfferDisabled'
 import { isOfferSynchronized } from '@/commons/core/Offers/utils/typology'
 import { useNotification } from '@/commons/hooks/useNotification'
 import { getDepartmentCode } from '@/commons/utils/getDepartmentCode'
@@ -36,6 +37,7 @@ import type {
 import { RecurrenceForm } from './RecurrenceForm/RecurrenceForm'
 import styles from './StocksCalendar.module.scss'
 import { StocksCalendarActionsBar } from './StocksCalendarActionsBar/StocksCalendarActionsBar'
+import { StocksCalendarCancelBanner } from './StocksCalendarCancelBanner/StocksCalendarCancelBanner'
 import { StocksCalendarFilters } from './StocksCalendarFilters/StocksCalendarFilters'
 import { StocksCalendarTable } from './StocksCalendarTable/StocksCalendarTable'
 
@@ -188,6 +190,11 @@ export function StocksCalendar({
       )}
       {isLoading && offer.hasStocks && (
         <Spinner className={styles['spinner']} />
+      )}
+      {!isOfferDisabled(offer.status) && (
+        <div className={styles['cancel-banner']}>
+          <StocksCalendarCancelBanner />
+        </div>
       )}
       {!offer.hasStocks && (
         <div className={styles['no-stocks-content']}>

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarCancelBanner/StocksCalendarCancelBanner.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendarCancelBanner/StocksCalendarCancelBanner.tsx
@@ -1,0 +1,20 @@
+import { Callout } from '@/ui-kit/Callout/Callout'
+
+const HOW_TO_CANCEL_EVENT_URL =
+  'https://aide.passculture.app/hc/fr/articles/4411992053649--Acteurs-Culturels-Comment-annuler-ou-reporter-un-%C3%A9v%C3%A9nement-'
+
+export const StocksCalendarCancelBanner = () => (
+  <Callout
+    links={[
+      {
+        href: HOW_TO_CANCEL_EVENT_URL,
+        label: 'Comment reporter ou annuler un évènement ?',
+        isExternal: true,
+      },
+    ]}
+  >
+    Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas
+    le faire à moins de 48h de l’évènement. Vous pouvez annuler un évènement en
+    supprimant la ligne de stock associée. Cette action est irréversible.
+  </Callout>
+)

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryStocks/components/IndividualOfferSummaryStocksCalendarScreen/IndividualOfferSummaryStocksCalendarScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryStocks/components/IndividualOfferSummaryStocksCalendarScreen/IndividualOfferSummaryStocksCalendarScreen.tsx
@@ -4,18 +4,13 @@ import {
   OFFER_WIZARD_MODE,
 } from '@/commons/core/Offers/constants'
 import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
-import { isOfferDisabled } from '@/commons/core/Offers/utils/isOfferDisabled'
 import { SummarySection } from '@/components/SummaryLayout/SummarySection'
 import { StocksCalendar } from '@/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar'
 import { getStockWarningText } from '@/pages/IndividualOfferSummary/commons/getStockWarningText'
-import { Callout } from '@/ui-kit/Callout/Callout'
 
 type StocksCalendarSummaryScreenProps = {
   offer: GetIndividualOfferWithAddressResponseModel
 }
-
-const HOW_TO_CANCEL_EVENT_URL =
-  'https://aide.passculture.app/hc/fr/articles/4411992053649--Acteurs-Culturels-Comment-annuler-ou-reporter-un-%C3%A9v%C3%A9nement-'
 
 export function IndividualOfferSummaryStocksCalendarScreen({
   offer,
@@ -34,8 +29,6 @@ export function IndividualOfferSummaryStocksCalendarScreen({
     >
       {getStockWarningText(offer)}
 
-      {!isOfferDisabled(offer.status) && <StocksCalendarCancelBanner />}
-
       <StocksCalendar
         offer={offer}
         mode={OFFER_WIZARD_MODE.READ_ONLY}
@@ -44,19 +37,3 @@ export function IndividualOfferSummaryStocksCalendarScreen({
     </SummarySection>
   )
 }
-
-export const StocksCalendarCancelBanner = () => (
-  <Callout
-    links={[
-      {
-        href: HOW_TO_CANCEL_EVENT_URL,
-        label: 'Comment reporter ou annuler un évènement ?',
-        isExternal: true,
-      },
-    ]}
-  >
-    Les bénéficiaires ont 48h pour annuler leur réservation. Ils ne peuvent pas
-    le faire à moins de 48h de l’évènement. Vous pouvez annuler un évènement en
-    supprimant la ligne de stock associée. Cette action est irréversible.
-  </Callout>
-)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37905)

- Modification de la banner d'expiration à la nouvelle étape "informations pratiques" pour les livres papier (sous FF `WIP_ENABLE_NEW_OFFER_CREATION_FLOW`)
- Déplacement de la banner d'annulation pour qu'elle soit tout le temps juste avant le tableau des stocks
