### PR TITLE
(PC-37943)[API] fix: pro: offer: opening hours: 404 if unknown error

### DIFF
--- a/api/src/pcapi/core/offers/exceptions.py
+++ b/api/src/pcapi/core/offers/exceptions.py
@@ -119,7 +119,9 @@ class BookingLimitDatetimeTooLate(OfferException):  # (tcoudray-pass, 14/05/2025
 
 
 class OfferNotFound(Exception):
-    pass
+    def __init__(self, offer_id: int | None = None) -> None:
+        self.offer_id = offer_id
+        super().__init__()
 
 
 class ProductNotFound(Exception):

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -974,7 +974,7 @@ def get_offer_by_id(offer_id: int, load_options: OFFER_LOAD_OPTIONS = ()) -> mod
 
         return query.one()
     except sa_orm.exc.NoResultFound:
-        raise exceptions.OfferNotFound()
+        raise exceptions.OfferNotFound(offer_id=offer_id)
 
 
 def get_offer_and_extradata(offer_id: int) -> models.Offer | None:

--- a/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
+++ b/api/src/pcapi/routes/error_handlers/generic_error_handlers.py
@@ -15,6 +15,7 @@ from werkzeug.exceptions import NotFound
 import pcapi.core.finance.exceptions as finance_exceptions
 from pcapi.connectors.entreprise import exceptions as sirene_exceptions
 from pcapi.core import core_exception
+from pcapi.core.offers.exceptions import OfferNotFound
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import DateTimeCastError
 from pcapi.models.api_errors import DecimalCastError
@@ -43,6 +44,12 @@ def restize_not_found_route_errors(error: NotFound) -> ApiErrorResponse | HtmlEr
         return "", 404
 
     return app.generate_error_response({}, backoffice_template_name="errors/not_found.html"), 404
+
+
+@app.errorhandler(OfferNotFound)
+def restize_offer_not_found_error(error: OfferNotFound) -> ApiErrorResponse:
+    error_details = {"offer": error.offer_id} if error.offer_id is not None else {}
+    return app.generate_error_response(error_details), 404
 
 
 @app.errorhandler(ApiErrors)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37943)

Bug : la route du portail pro qui permet de récupérer les horaires d'ouverture d'une offre ne gère pas le cas où l'offre n'existe pas.

### Implémentation

Etant donné que l'erreur `OfferNotFound` est courante, je propose d'ajouter un gestionnaire global pour. Cela permettrait de simplifier bon nombre de routes et d'éviter des oublis dans ce genre.

Note : passer -1 en tant qu'identifiant d'offre renvoie bien une 404, mais l'erreur n'est pas générée par notre code (voire le test modifié dans cette PR pour s'en rendre compte).