### PR TITLE
(BSR) style: finalize Biome integration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,8 @@
     "dbaeumer.vscode-eslint",
     "vitest.explorer",
     "stylelint.vscode-stylelint",
-    "biomejs.biome"
+    "biomejs.biome",
+    "charliermarsh.ruff",
+    "ms-python.mypy-type-checker"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,10 @@
 {
+  "biome.lsp.bin": "pro/node_modules/.bin/biome",
+  "editor.formatOnSave": true,
+   "editor.codeActionsOnSave": {
+    "source.addMissingImports": "always",
+    "source.fixAll.biome": "explicit"
+  },
   "mypy-type-checker.cwd": "${workspaceFolder}/api",
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "mypy-type-checker.preferDaemon": true,
@@ -10,5 +16,23 @@
     "-s",
     "--color=yes",
     "-W ignore::DeprecationWarning"
-  ]
+  ],
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -39,17 +39,20 @@ Le repo `main` contient les 4 projets suivants :
   - `npm install --global yarn` (NPM)
   - autres méthodes [dans la doc de Yarn](https://classic.yarnpkg.com/lang/en/docs/install/)
 - GPG (outil de (dé)chiffrement)
-
   - [GPG Suite](https://gpgtools.org/) (MacOS)
   - `sudo apt install gpg` (Linux)
-
 - [Commitizen](https://commitizen-tools.github.io/commitizen/#installation) (CLI pour écrire des commits au bon format)
-
   - `pip install -U commitizen` ou `brew install commitizen`
 
-- Pour MacOS spécifiquement
+Pour les devs **qui n'utilisent PAS VSCode** et qui ouvrent le projet à partir du dossier racine `pass-culture-main` dans leur IDE :
+- [Biome](https://biomejs.dev/guides/getting-started/) (Linter JS/JSON/CSS/HTML pour le Frontend)
+  - `npm i -g @biomejs/biome` ou `brew install biome`
+  - Installer l'[extension correspondant à ton IDE si dispo](https://biomejs.dev/guides/editors/first-party-extensions/)
+  - Prendre garde à ce que ta version Biome globale soit la même que celle déclarée dans les dev-deps `pro/package.json`.
+
+- Pour MacOS spécifiquement :
   - CoreUtils: `brew install coreutils libxmlsec1`
-- Pour Linux spécifiquement
+- Pour Linux spécifiquement :
   - L'API a besoin des paquets suivants, à installer avec `sudo apt install python3-dev libpq-dev xmlsec1 libpango-1.0-0 libpangoft2-1.0-0` pour les distributions Ubuntu
 
 #### Installer les CLI

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,15 +1,19 @@
 // We have to add a root config for Biome in order to use its IDE plugin when opening the monorepo from the root.
 // https://biomejs.dev/guides/big-projects/#monorepo
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
-  "root": true,
-  "formatter": {
-    "enabled": false
-  },
-  "linter": {
-    "enabled": false
-  },
-  "assist": {
-    "enabled": false
-  }
+	"$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+	"root": true,
+	"files": {
+		"includes": ["pro/**", "biome.jsonc"],
+		"ignoreUnknown": true
+	},
+	"assist": {
+		"enabled": false
+	},
+	"formatter": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": false
+	}
 }

--- a/pro/.vscode/settings.json
+++ b/pro/.vscode/settings.json
@@ -1,14 +1,25 @@
 {
+  "editor.defaultFormatter": null,
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "biomejs.biome",
-  "biome.enabled": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.biome": "explicit",
-    "source.addMissingImports": "always"
+    "source.addMissingImports": "always",
+    "source.fixAll.biome": "explicit"
   },
   "stylelint.validate": ["css", "scss"],
+  "[html]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
   "[scss]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"

--- a/pro/biome.jsonc
+++ b/pro/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
   // https://biomejs.dev/guides/big-projects/#monorepo
   "root": false,
   "extends": "//",

--- a/pro/package.json
+++ b/pro/package.json
@@ -13,7 +13,7 @@
     "build:production": "VITE_APP_VERSION=$(node -pe 'require(\"./package.json\").version') vite build --mode production",
     "generate:api:client:local": "./scripts/generate_api_client_local.sh",
     "generate:api:client:local:no:docker": "PCAPI_HOST=localhost:5001 ./scripts/generate_api_client_local.sh",
-    "lint:js": "biome check",
+    "lint:js": "biome check --no-errors-on-unmatched",
     "lint:js:fix": "yarn lint:js --write",
     "lint:scss": "stylelint '**/*.scss'",
     "lint:scss:fix": "yarn lint:scss --fix",


### PR DESCRIPTION
- Finalise une config VSCode qui fonctionne out-of-the-box qu'on ouvre le projet par la racine ou par le dossier `pro/`.
- Corrige le check Biome en erreur au precommit lorsqu'aucun fichier ne peut être linté car exclus.
- Plus d'erreur Biome dans les IDE lors de l'enregistrement de fichiers JSONC-like.
- Petite note dans la documentation pour le setup non-VSCode.
- Plus besoin d'installer Biome en global / à part pour les devs sous VSCode.