### PR TITLE
(BSR)[API] perf: treat offers by batch in cron command

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -670,7 +670,11 @@ def reindex_recently_published_offers(publication_datetime: datetime.datetime | 
     offer_query = offers_repository.get_offers_by_publication_datetime(publication_datetime=publication_datetime)
     offer_query = offers_repository.exclude_offers_from_inactive_venue_provider(offer_query)
 
-    search.async_index_offer_ids([offer.id for offer in offer_query], reason=search.IndexationReason.OFFER_PUBLICATION)
+    ids_to_reindex = []
+    for (offer_id,) in offer_query.with_entities(offers_models.Offer.id).yield_per(1000):
+        ids_to_reindex.append(offer_id)
+
+    search.async_index_offer_ids(ids_to_reindex, reason=search.IndexationReason.OFFER_PUBLICATION)
 
 
 def send_future_offer_reminders(booking_allowed_datetime: datetime.datetime | None = None) -> None:

--- a/api/src/pcapi/core/offers/commands.py
+++ b/api/src/pcapi/core/offers/commands.py
@@ -19,14 +19,6 @@ logger = logging.getLogger(__name__)
 blueprint = Blueprint(__name__, __name__)
 
 
-# Deprecated. Remove when we have a new cron job calling `reindex_recently_published_offers`
-@blueprint.cli.command("activate_future_offers")
-@cron_decorators.log_cron_with_transaction
-@cron_decorators.cron_require_feature(FeatureToggle.ENABLE_RECURRENT_CRON)
-def activate_future_offers() -> None:
-    offers_api.reindex_recently_published_offers()
-
-
 @blueprint.cli.command("reindex_recently_published_offers")
 @cron_decorators.log_cron_with_transaction
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_RECURRENT_CRON)

--- a/api/tests/core/offers/test_commands.py
+++ b/api/tests/core/offers/test_commands.py
@@ -57,17 +57,6 @@ class OfferCommandsTest:
 
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     @pytest.mark.usefixtures("clean_database")
-    def test_deprecated_future_offer_command(self, mock_reindex_offers, app):
-        offer = offers_factories.OfferFactory(publicationDatetime=datetime.date.today())
-        user = users_factories.BeneficiaryFactory()
-        reminders_factories.OfferReminderFactory(user=user, offer=offer)
-
-        run_command(app, "activate_future_offers")
-
-        mock_reindex_offers.assert_called_once()
-
-    @mock.patch("pcapi.core.search.async_index_offer_ids")
-    @pytest.mark.usefixtures("clean_database")
     def test_reindex_recently_published_offers_command(self, mock_reindex_offers, app):
         offer = offers_factories.OfferFactory(publicationDatetime=datetime.date.today())
         user = users_factories.BeneficiaryFactory()


### PR DESCRIPTION
Proposition d'optimisation.
Étape un pour réactiver le cron `reindex_recently_published_offers`