### PR TITLE
(PC-37941)[PRO] fix: debounce teacher search input to prevent

### DIFF
--- a/pro/src/pages/CollectiveOfferVisibility/components/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/components/CollectiveOfferVisibility/CollectiveOfferVisibility.tsx
@@ -2,6 +2,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { useEffect, useMemo, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import useSWR from 'swr'
+import { useDebouncedCallback } from 'use-debounce'
 import type { InferType } from 'yup'
 
 import { api } from '@/apiClient/api'
@@ -217,7 +218,7 @@ export const CollectiveOfferVisibilityScreen = ({
     ])
   }, [requestInformations, institutionsOptions, reset])
 
-  const onSearchTeacher = async (pattern: string) => {
+  const onSearchTeacher = useDebouncedCallback(async (pattern: string) => {
     const selectedInstitution = institutionsOptions.find(
       (institution) => institution.value === watch('institution')
     )
@@ -258,7 +259,7 @@ export const CollectiveOfferVisibilityScreen = ({
     } catch {
       notify.error(GET_DATA_ERROR_MESSAGE)
     }
-  }
+  }, 1000)
 
   return (
     <>

--- a/pro/src/pages/CollectiveOfferVisibility/components/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
+++ b/pro/src/pages/CollectiveOfferVisibility/components/CollectiveOfferVisibility/__specs__/CollectiveOfferVisibility.spec.tsx
@@ -34,6 +34,11 @@ vi.mock('@/apiClient/api', () => ({
   },
 }))
 
+vi.mock('use-debounce', async () => ({
+  ...(await vi.importActual('use-debounce')),
+  useDebouncedCallback: vi.fn((fn) => fn),
+}))
+
 const institutions: EducationalInstitutionResponseModel[] = [
   {
     id: 12,


### PR DESCRIPTION
multiple API calls

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37941)

- First step: add a debounce on the teacher input to prevent multiple calls to the PC API that fallbacks to ADAGE API
- Next step: desynchronised PC API calls to ADAGE API calls 

## 🖼️ Before & After Images

<img width="691" height="312" alt="image" src="https://github.com/user-attachments/assets/36c9ab18-7b05-429f-b2da-3bfb57abef39" />
