### PR TITLE
(PC-38010)[PRO] fix: revalidate cache in indiv. offer media page to fix stepper (dirty quick fix)

### DIFF
--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/IndividualOfferMediaScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/IndividualOfferMediaScreen.tsx
@@ -159,7 +159,11 @@ export const IndividualOfferMediaScreen = ({
               videoUrl: formValues.videoUrl,
             }),
             {
-              revalidate: false,
+              // FIXME: patchDraftOffer lacks a proper return type,
+              // we cant use it to update the cache - its not a quick fix
+              // on backend side and will be tackled in https://passculture.atlassian.net/browse/PC-38009.
+              // revalidate: false when fixed.
+              revalidate: true,
             }
           )
         }


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-38010)

- Revalidation du cache en attendant de trouver un fix backend - puisque le retour du PATCH videoUrl utilisé pour mettre à jour le cache n'avait pas de clé address, l'étape "Localisation" était considérée comme non franchie, ainsi que toutes les étapes suivantes. On revalide le cache pour réaliser un GET offer qui lui comprend toujours l'objet entier. À terme on réalise un fix backend pour que l'objet offre retourné sur des POST / PATCH soit toujours complet.

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
