### PR TITLE
(PC-38013)[PRO] feat: hide budget before 2025-10-01 (NON UTC)

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
@@ -13,6 +13,13 @@ export const AdageHeaderBudget = ({
   logAdageLinkClick,
   institutionBudget,
 }: AdageHeaderBudgetProps) => {
+  // TODO (nizac, 2025-09-22): To remove after the 2025-10-01
+  const limitDate = new Date('2025-10-01T00:00:00')
+
+  if (Date.now() < limitDate.getTime()) {
+    return
+  }
+
   return (
     <div className={styles['adage-header-budget']}>
       <ButtonLink

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
@@ -59,6 +59,9 @@ describe('AdageHeader', () => {
     vi.spyOn(apiAdage, 'getEducationalInstitutionWithBudget').mockResolvedValue(
       defaultEducationalInstitution
     )
+    vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2025-10-01T10:00:00').getTime()
+    )
   })
 
   it('should render adage header', async () => {
@@ -200,5 +203,27 @@ describe('AdageHeader', () => {
         screen.queryByRole('link', { name: /Mes Favoris (10)/ })
       ).toBeInTheDocument()
     })
+  })
+
+  it('should not display the budget if the date is before 2025-10-01', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2025-09-30T23:59:00').getTime()
+    )
+    renderAdageHeader(user)
+    await waitFor(() =>
+      expect(screen.queryByText('Solde prévisionnel')).not.toBeInTheDocument()
+    )
+    expect(screen.queryByText('1 000 €')).not.toBeInTheDocument()
+  })
+
+  it('should display the budget if the date is after 2025-10-01', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2025-10-01T00:01:00').getTime()
+    )
+    renderAdageHeader(user)
+    await waitFor(() =>
+      expect(screen.queryByText('Solde prévisionnel')).toBeInTheDocument()
+    )
+    expect(screen.queryByText('1 000 €')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-38013)

- Hide budget on Adage Iframe if date is before 2025-10-01

## 🖼️ Before & After Images

Before

<img width="823" height="227" alt="image" src="https://github.com/user-attachments/assets/6dd4c032-e5b2-4279-b53a-8b2f1234a26c" />


After

<img width="798" height="197" alt="image" src="https://github.com/user-attachments/assets/fcc099b8-faf3-45ad-84cc-2a52913e1812" />

