### PR TITLE
(BSR)[PRO] fix: Set a start date for fetching bookings in offer booki…

### DIFF
--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryBookings/components/IndividualOfferSummaryBookingsScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryBookings/components/IndividualOfferSummaryBookingsScreen.tsx
@@ -50,6 +50,7 @@ export const IndividualOfferSummaryBookingsScreen = ({
       const { bookings } = await getFilteredIndividualBookingsAdapter({
         ...DEFAULT_PRE_FILTERS,
         offerId: String(offer.id),
+        bookingBeginningDate: '2015-01-01',
         bookingEndingDate: format(new Date(), FORMAT_ISO_DATE_ONLY),
       })
       return bookings


### PR DESCRIPTION
…ngs tab.

## 🎯 Related Ticket or 🔧 Changes Made

BSR

Envoyer une date loin dans le passé pour la liste des réservaitions d'une offre. Sinon la date par défait est le mois dernier (et on doit envoyer une date a l'api), et donc on n'a pas toutes les résas qui s'affichent.
