### PR TITLE
(BSR)[ADAGE] feat: add option in generate_fake_adage_token command to…

### DIFF
--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -36,11 +36,12 @@ def reindex_all_collective_offers() -> None:
 @blueprint.cli.command("generate_fake_adage_token")
 @click.option("--readonly", is_flag=True, help="Generate a readonly token.")
 @click.option("--cannot-prebook", is_flag=True, help="Generate a token that cannot prebook.")
-def generate_fake_adage_token(readonly: bool, cannot_prebook: bool) -> None:
+@click.option("--uai", type=str, help="UAI of the institution. Will take the default value if not given.")
+def generate_fake_adage_token(readonly: bool, cannot_prebook: bool, uai: str | None) -> None:
     """
     TO BE USED IN LOCAL ENV
     """
-    token = create_adage_jwt_fake_valid_token(readonly=readonly, can_prebook=not cannot_prebook)
+    token = create_adage_jwt_fake_valid_token(readonly=readonly, can_prebook=not cannot_prebook, uai=uai)
     print(f"Adage localhost URL: http://localhost:3001/adage-iframe?token={token}")
 
 

--- a/api/src/pcapi/core/educational/utils.py
+++ b/api/src/pcapi/core/educational/utils.py
@@ -56,7 +56,7 @@ def log_information_for_data_purpose(
 UAI_FOR_FAKE_TOKEN = "0910620E"
 
 
-def create_adage_jwt_fake_valid_token(readonly: bool, can_prebook: bool = True) -> str:
+def create_adage_jwt_fake_valid_token(readonly: bool, can_prebook: bool = True, uai: str | None = None) -> str:
     with open("tests/routes/adage_iframe/private_keys_for_tests/valid_rsa_private_key", "rb") as reader:
         authenticated_informations = {
             "civilite": "M.",
@@ -67,7 +67,7 @@ def create_adage_jwt_fake_valid_token(readonly: bool, can_prebook: bool = True) 
             "canPrebook": can_prebook,
         }
         if not readonly:
-            authenticated_informations["uai"] = UAI_FOR_FAKE_TOKEN
+            authenticated_informations["uai"] = uai if uai is not None else UAI_FOR_FAKE_TOKEN
             authenticated_informations["lat"] = 48.8566  # Paris
             authenticated_informations["lon"] = 2.3522  # Paris
 


### PR DESCRIPTION
… change institution

## 🎯 Related Ticket or 🔧 Changes Made

La commande `generate_fake_adage_token` permet d'accéder à l'iframe en local mais seulement sur l'établissement avec l'UAI `UAI_FOR_FAKE_TOKEN`. On ajoute un paramètre pour pouvoir sélectionner un autre établissement (si on veut tester différents ministères par exemple)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
