### PR TITLE
(PC-37816)[API] feat: pro: new offer creation route

### DIFF
--- a/api/src/pcapi/core/offers/schemas/__init__.py
+++ b/api/src/pcapi/core/offers/schemas/__init__.py
@@ -18,46 +18,10 @@ from pcapi.serialization import utils as serialization_utils
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 from pcapi.validation.routes.offers import check_video_url
 
+from . import deprecated  # noqa: F401
+
 
 OFFER_DESCRIPTION_MAX_LENGTH = 10_000
-
-
-class PostDraftOfferBodyModel(BaseModel):
-    name: str
-    subcategory_id: str
-    venue_id: int
-    description: str | None = Field(max_length=OFFER_DESCRIPTION_MAX_LENGTH)
-    url: HttpUrl | None = None
-    extra_data: typing.Any = None
-    duration_minutes: int | None = None
-    product_id: int | None
-    video_url: HttpUrl | None
-    # These props become mandatory when `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` feature flag is enabled.
-    # They are optional here in order to not break the existing POST `/offers/drafts` route while both flows coexist.
-    audio_disability_compliant: bool | None
-    mental_disability_compliant: bool | None
-    motor_disability_compliant: bool | None
-    visual_disability_compliant: bool | None
-
-    @validator("name", pre=True)
-    def validate_name(cls, name: str, values: dict) -> str:
-        check_offer_name_length_is_valid(name)
-        return name
-
-    @validator("video_url", pre=True)
-    def clean_video_url(cls, v: str) -> str | None:
-        if v == "":
-            return None
-        return v
-
-    @validator("video_url")
-    def validate_video_url(cls, video_url: HttpUrl, values: dict) -> str:
-        check_video_url(video_url)
-        return video_url
-
-    class Config:
-        alias_generator = serialization_utils.to_camel
-        extra = "forbid"
 
 
 class PatchDraftOfferBodyModel(BaseModel):
@@ -91,7 +55,7 @@ class PatchDraftOfferBodyModel(BaseModel):
 
     @validator("subcategory_id", pre=True)
     def validate_subcategory_id(cls, subcategory_id: str, values: dict) -> str:
-        from .validation import check_offer_subcategory_is_valid
+        from pcapi.core.offers.validation import check_offer_subcategory_is_valid
 
         check_offer_subcategory_is_valid(subcategory_id)
         return subcategory_id
@@ -122,6 +86,7 @@ class CreateOffer(BaseModel):
     withdrawal_delay: int | None = None
     withdrawal_details: str | None = None
     withdrawal_type: offers_models.WithdrawalTypeEnum | None = None
+    video_url: HttpUrl | None = None
 
     # is_national must be placed after url so that the validator
     # can access the url field in the dict of values

--- a/api/src/pcapi/core/offers/schemas/deprecated.py
+++ b/api/src/pcapi/core/offers/schemas/deprecated.py
@@ -1,0 +1,51 @@
+import typing
+
+from pydantic.v1 import Field
+from pydantic.v1 import HttpUrl
+from pydantic.v1 import validator
+
+from pcapi.routes.serialization import BaseModel
+from pcapi.serialization import utils as serialization_utils
+from pcapi.validation.routes.offers import check_offer_name_length_is_valid
+from pcapi.validation.routes.offers import check_video_url
+
+
+OFFER_DESCRIPTION_MAX_LENGTH = 10_000
+
+
+class PostDraftOfferBodyModel(BaseModel):
+    name: str
+    subcategory_id: str
+    venue_id: int
+    description: str | None = Field(max_length=OFFER_DESCRIPTION_MAX_LENGTH)
+    url: HttpUrl | None = None
+    extra_data: typing.Any = None
+    duration_minutes: int | None = None
+    product_id: int | None
+    video_url: HttpUrl | None
+    # These props become mandatory when `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` feature flag is enabled.
+    # They are optional here in order to not break the existing POST `/offers/drafts` route while both flows coexist.
+    audio_disability_compliant: bool | None
+    mental_disability_compliant: bool | None
+    motor_disability_compliant: bool | None
+    visual_disability_compliant: bool | None
+
+    @validator("name", pre=True)
+    def validate_name(cls, name: str, values: dict) -> str:
+        check_offer_name_length_is_valid(name)
+        return name
+
+    @validator("video_url", pre=True)
+    def clean_video_url(cls, v: str) -> str | None:
+        if v == "":
+            return None
+        return v
+
+    @validator("video_url")
+    def validate_video_url(cls, video_url: HttpUrl, values: dict) -> str:
+        check_video_url(video_url)
+        return video_url
+
+    class Config:
+        alias_generator = serialization_utils.to_camel
+        extra = "forbid"

--- a/api/src/pcapi/routes/serialization/offers_serialize/__init__.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize/__init__.py
@@ -32,6 +32,8 @@ from pcapi.serialization.utils import validate_datetime
 from pcapi.utils.date import format_into_utc_date
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 
+from . import deprecated  # noqa: F401
+
 
 class SubcategoryGetterDict(GetterDict):
     def get(self, key: str, default: Any | None = None) -> Any:
@@ -73,44 +75,6 @@ class CategoryResponseModel(BaseModel):
         alias_generator = to_camel
         allow_population_by_field_name = True
         orm_mode = True
-
-
-class PostOfferBodyModel(BaseModel):
-    address: offerers_schemas.AddressBodyModel | None
-    audio_disability_compliant: bool
-    booking_contact: EmailStr | None
-    booking_email: EmailStr | None
-    description: str | None
-    duration_minutes: int | None
-    external_ticket_office_url: HttpUrl | None
-    extra_data: dict[str, typing.Any] | None
-    is_duo: bool | None
-    is_national: bool | None
-    mental_disability_compliant: bool
-    motor_disability_compliant: bool
-    name: str
-    subcategory_id: str
-    url: HttpUrl | None
-    venue_id: int
-    visual_disability_compliant: bool
-    withdrawal_delay: int | None
-    withdrawal_details: str | None
-    withdrawal_type: offers_models.WithdrawalTypeEnum | None
-
-    @validator("name", pre=True)
-    def validate_name(cls, name: str, values: dict) -> str:
-        check_offer_name_length_is_valid(name)
-        return name
-
-    @validator("withdrawal_type")
-    def validate_withdrawal_type(cls, value: offers_models.WithdrawalTypeEnum) -> offers_models.WithdrawalTypeEnum:
-        if value == offers_models.WithdrawalTypeEnum.IN_APP:
-            raise ValueError("Withdrawal type cannot be in_app for manually created offers")
-        return value
-
-    class Config:
-        alias_generator = to_camel
-        extra = "forbid"
 
 
 class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
@@ -663,3 +627,50 @@ class VideoMetatdataQueryModel(BaseModel):
 
 class OfferHighlightResquestsResponseModel(BaseModel):
     highlight_requests: list[str]
+
+
+class OfferVideo(ConfiguredBaseModel):
+    id: str
+    title: str | None
+    thumbnailUrl: str | None
+    duration: int | None
+
+
+class PostOfferBodyModel(BaseModel):
+    address: offerers_schemas.AddressBodyModel | None
+    audio_disability_compliant: bool
+    booking_contact: EmailStr | None
+    booking_email: EmailStr | None
+    description: str | None
+    duration_minutes: int | None
+    external_ticket_office_url: HttpUrl | None
+    extra_data: dict[str, typing.Any] | None
+    is_duo: bool | None
+    is_national: bool | None
+    mental_disability_compliant: bool
+    motor_disability_compliant: bool
+    name: str
+    product_id: int | None
+    subcategory_id: str
+    url: HttpUrl | None
+    venue_id: int
+    video_url: HttpUrl | None = None
+    visual_disability_compliant: bool
+    withdrawal_delay: int | None
+    withdrawal_details: str | None
+    withdrawal_type: offers_models.WithdrawalTypeEnum | None
+
+    @validator("name", pre=True)
+    def validate_name(cls, name: str, values: dict) -> str:
+        check_offer_name_length_is_valid(name)
+        return name
+
+    @validator("withdrawal_type")
+    def validate_withdrawal_type(cls, value: offers_models.WithdrawalTypeEnum) -> offers_models.WithdrawalTypeEnum:
+        if value == offers_models.WithdrawalTypeEnum.IN_APP:
+            raise ValueError("Withdrawal type cannot be in_app for manually created offers")
+        return value
+
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"

--- a/api/src/pcapi/routes/serialization/offers_serialize/deprecated.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize/deprecated.py
@@ -1,0 +1,49 @@
+import typing
+
+from pydantic.v1 import EmailStr
+from pydantic.v1 import HttpUrl
+from pydantic.v1 import validator
+
+from pcapi.core.offerers import schemas as offerers_schemas
+from pcapi.core.offers import models as offers_models
+from pcapi.routes.serialization import BaseModel
+from pcapi.serialization.utils import to_camel
+from pcapi.validation.routes.offers import check_offer_name_length_is_valid
+
+
+class PostOfferBodyModel(BaseModel):
+    address: offerers_schemas.AddressBodyModel | None
+    audio_disability_compliant: bool
+    booking_contact: EmailStr | None
+    booking_email: EmailStr | None
+    description: str | None
+    duration_minutes: int | None
+    external_ticket_office_url: HttpUrl | None
+    extra_data: dict[str, typing.Any] | None
+    is_duo: bool | None
+    is_national: bool | None
+    mental_disability_compliant: bool
+    motor_disability_compliant: bool
+    name: str
+    subcategory_id: str
+    url: HttpUrl | None
+    venue_id: int
+    visual_disability_compliant: bool
+    withdrawal_delay: int | None
+    withdrawal_details: str | None
+    withdrawal_type: offers_models.WithdrawalTypeEnum | None
+
+    @validator("name", pre=True)
+    def validate_name(cls, name: str, values: dict) -> str:
+        check_offer_name_length_is_valid(name)
+        return name
+
+    @validator("withdrawal_type")
+    def validate_withdrawal_type(cls, value: offers_models.WithdrawalTypeEnum) -> offers_models.WithdrawalTypeEnum:
+        if value == offers_models.WithdrawalTypeEnum.IN_APP:
+            raise ValueError("Withdrawal type cannot be in_app for manually created offers")
+        return value
+
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"

--- a/api/tests/core/offers/test_commands.py
+++ b/api/tests/core/offers/test_commands.py
@@ -23,7 +23,7 @@ class OfferCommandsTest:
         a_year_ago = datetime.date.today() - timedelta(days=366)
         offer_id = offers_factories.OfferFactory(dateCreated=a_year_ago, dateUpdated=a_year_ago).id
 
-        run_command(app, "delete_unbookable_unbooked_old_offers")
+        run_command(app, "delete_unbookable_unbooked_old_offers", "0", f"{offer_id * 2}")
 
         assert db.session.get(offers_models.Offer, offer_id) is not None
 
@@ -34,7 +34,7 @@ class OfferCommandsTest:
         offer = offers_factories.OfferFactory(dateCreated=a_year_ago, dateUpdated=a_year_ago)
         offer_id = offer.id
 
-        run_command(app, "delete_unbookable_unbooked_old_offers")
+        run_command(app, "delete_unbookable_unbooked_old_offers", "0", f"{offer_id * 2}")
 
         assert db.session.query(offers_models.Offer).filter_by(id=offer_id).count() == 0
 

--- a/api/tests/core/offers/test_schemas.py
+++ b/api/tests/core/offers/test_schemas.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class PostDraftOfferBodyModelTest:
     def test_post_draft_offer_body_model(self):
         venue = offerers_factories.VirtualVenueFactory()
-        _ = schemas.PostDraftOfferBodyModel(
+        _ = schemas.deprecated.PostDraftOfferBodyModel(
             name="Name",
             subcategoryId=subcategories.ABO_PLATEFORME_VIDEO.id,
             venueId=venue.id,

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -1,17 +1,751 @@
+import contextlib
 from decimal import Decimal
 
 import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import WithdrawalTypeEnum
+from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
 
 
-@pytest.mark.usefixtures("db_session")
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def shared_response_json_checks(offer, response_json):
+    assert response_json["id"] == offer.id
+    assert response_json["name"] == offer.name
+    assert not response_json["publicationDate"]
+    assert not response_json["publicationDatetime"]
+    assert not response_json["bookingAllowedDatetime"]
+
+
+def shared_offer_checks(offer, payload):
+    assert offer.name == payload["name"]
+    assert offer.venueId == payload["venueId"]
+    assert offer.subcategoryId == payload["subcategoryId"]
+    assert not offer.publicationDate
+    assert not offer.publicationDatetime
+    assert not offer.bookingAllowedDatetime
+    assert not offer.isActive
+
+
+@contextlib.contextmanager
+def assert_changes(model, delta):
+    before_count = db.session.query(model).count()
+
+    yield
+
+    after_count = db.session.query(model).count()
+    assert after_count == before_count + delta
+
+
+@contextlib.contextmanager
+def assert_no_changes(model):
+    with assert_changes(model, 0):
+        yield
+
+
+def default_address_payload():
+    return {"city": "Paris", "latitude": "2.0", "longitude": "48.0", "postalCode": "75002", "street": "1 rue des rues"}
+
+
+def offer_minimal_shared_data(subcategory_id, venue):
+    return {
+        "name": f"some {subcategory_id} offer",
+        "subcategoryId": subcategory_id,
+        "venueId": venue.id,
+        "audioDisabilityCompliant": False,
+        "mentalDisabilityCompliant": False,
+        "motorDisabilityCompliant": False,
+        "visualDisabilityCompliant": False,
+    }
+
+
+def offer_optional_shared_data(**kwargs):
+    return {
+        "bookingContact": "booking.contact@test.fr",
+        "bookingEmail": "booking.email@test.fr",
+        "description": "some description",
+        **kwargs,
+    }
+
+
+@pytest.fixture(name="venue")
+def venue_fixture():
+    return offerers_factories.VenueFactory()
+
+
+@pytest.fixture(name="user")
+def user_fixture(venue):
+    return offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com").user
+
+
+@pytest.fixture(name="auth_client")
+def auth_client_fixture(client, user):
+    return client.with_session_auth(user.email)
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+THINGS_WITH_EAN = {
+    subcategories.LIVRE_PAPIER.id,
+    subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
+    subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+THINGS_RANDOM = {
+    subcategories.ABO_BIBLIOTHEQUE.id,
+    subcategories.ABO_CONCERT.id,
+    subcategories.ABO_MEDIATHEQUE.id,
+    subcategories.ABO_PRATIQUE_ART.id,
+    subcategories.ACHAT_INSTRUMENT.id,
+    subcategories.CARTE_CINE_ILLIMITE.id,
+    subcategories.CARTE_CINE_MULTISEANCES.id,
+    subcategories.CARTE_JEUNES.id,
+    subcategories.CARTE_MUSEE.id,
+    subcategories.ESCAPE_GAME.id,
+    subcategories.LIVRE_AUDIO_PHYSIQUE.id,
+    subcategories.LOCATION_INSTRUMENT.id,
+    subcategories.MATERIEL_ART_CREATIF.id,
+    subcategories.PARTITION.id,
+    subcategories.SUPPORT_PHYSIQUE_FILM.id,
+}
+
+
+THINGS = THINGS_WITH_EAN | THINGS_RANDOM
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+DIGITAL_THING = {
+    subcategories.TELECHARGEMENT_MUSIQUE.id,
+    subcategories.LIVRE_NUMERIQUE.id,
+    subcategories.PLATEFORME_PRATIQUE_ARTISTIQUE.id,
+    subcategories.AUTRE_SUPPORT_NUMERIQUE.id,
+    subcategories.MUSEE_VENTE_DISTANCE.id,
+    subcategories.VISITE_VIRTUELLE.id,
+    subcategories.PRATIQUE_ART_VENTE_DISTANCE.id,
+    subcategories.ABO_PLATEFORME_VIDEO.id,
+    subcategories.ABO_PRESSE_EN_LIGNE.id,
+    subcategories.APP_CULTURELLE.id,
+    subcategories.JEU_EN_LIGNE.id,
+    subcategories.CINE_VENTE_DISTANCE.id,
+    subcategories.ABO_LIVRE_NUMERIQUE.id,
+    subcategories.ABO_JEU_VIDEO.id,
+    subcategories.PODCAST.id,
+    subcategories.TELECHARGEMENT_LIVRE_AUDIO.id,
+    subcategories.ABO_PLATEFORME_MUSIQUE.id,
+    subcategories.VOD.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+DIGITAL_ACTIVITY = {
+    subcategories.SPECTACLE_ENREGISTRE.id,
+    subcategories.SPECTACLE_VENTE_DISTANCE.id,
+}
+
+
+DIGITAL = DIGITAL_THING | DIGITAL_ACTIVITY
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+CANNOT_BE_CREATED = {
+    subcategories.ACTIVATION_EVENT.id,
+    subcategories.CAPTATION_MUSIQUE.id,
+    subcategories.OEUVRE_ART.id,
+    subcategories.BON_ACHAT_INSTRUMENT.id,
+    subcategories.ACTIVATION_THING.id,
+    subcategories.ABO_LUDOTHEQUE.id,
+    subcategories.JEU_SUPPORT_PHYSIQUE.id,
+    subcategories.DECOUVERTE_METIERS.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_SUBSCRIPTION = {
+    subcategories.ABO_SPECTACLE.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_ONLINE = {
+    subcategories.LIVESTREAM_MUSIQUE.id,
+    subcategories.RENCONTRE_EN_LIGNE.id,
+    subcategories.LIVESTREAM_PRATIQUE_ARTISTIQUE.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_ONLINE_EVENT = {
+    subcategories.LIVESTREAM_EVENEMENT.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_WITHDRAWABLE = {
+    subcategories.SPECTACLE_REPRESENTATION.id,
+    subcategories.FESTIVAL_SPECTACLE.id,
+    subcategories.FESTIVAL_ART_VISUEL.id,
+    subcategories.CONCERT.id,
+    subcategories.FESTIVAL_MUSIQUE.id,
+    subcategories.EVENEMENT_MUSIQUE.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_RANDOM = {
+    subcategories.ATELIER_PRATIQUE_ART.id,
+    subcategories.CINE_PLEIN_AIR.id,
+    subcategories.CONCOURS.id,
+    subcategories.CONFERENCE.id,
+    subcategories.EVENEMENT_CINE.id,
+    subcategories.EVENEMENT_JEU.id,
+    subcategories.EVENEMENT_PATRIMOINE.id,
+    subcategories.FESTIVAL_CINE.id,
+    subcategories.FESTIVAL_LIVRE.id,
+    subcategories.RENCONTRE.id,
+    subcategories.RENCONTRE_JEU.id,
+    subcategories.SALON.id,
+    subcategories.SEANCE_CINE.id,
+    subcategories.SEANCE_ESSAI_PRATIQUE_ART.id,
+    subcategories.VISITE.id,
+    subcategories.VISITE_GUIDEE.id,
+}
+
+
+ACTIVITY = ACTIVITY_SUBSCRIPTION | ACTIVITY_ONLINE | ACTIVITY_ONLINE_EVENT | ACTIVITY_WITHDRAWABLE | ACTIVITY_RANDOM
+
+
+ALL = THINGS | DIGITAL | ACTIVITY
+
+
+class CreateOfferBase:
+    endpoint = "/v2/offers"
+
+    success_num_queries = 1  # fetch user session
+    success_num_queries += 1  # fetch user
+    success_num_queries += 1  # fetch venue
+    success_num_queries += 1  # user offerer check
+    success_num_queries += 1  # fetch product
+    success_num_queries += 1  # fetch FF
+    success_num_queries += 1  # create offer
+    success_num_queries += 1  # fetch mediation
+    success_num_queries += 1  # fetch stocks
+    success_num_queries += 1  # fetch price categories
+    success_num_queries += 1  # fetch offerer address
+    success_num_queries += 1  # fetch offer meta data
+    success_num_queries += 1  # fetch user
+    success_num_queries += 1  # fetch offerer
+    success_num_queries += 1  # check national program (?)
+    success_num_queries += 1  # check venue has collective offers (?)
+    success_num_queries += 1  # check offer regarding offer status (?)
+    success_num_queries += 1  # check offer's venue has at least one cancelled booking (?)
+
+
+class CreateThingsTest(CreateOfferBase):
+    @pytest.mark.parametrize("subcategory_id", THINGS)
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+
+    # TODO(jbaudet): most of `THINGS` subcategories should not accept any EAN
+    # but for now... it is valid.
+    @pytest.mark.parametrize("subcategory_id", THINGS)
+    def test_create_offer_with_ean_and_no_product_is_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "bookingEmail": "booking.email@test.com",
+            "description": "some description",
+            "extraData": {"ean": "0000000000001"},
+        }
+
+        with assert_changes(Offer, 1):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+        assert offer.ean == "0000000000001"
+        assert offer.description == payload["description"]
+        assert not offer.productId
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            # TODO(jbaudet): fill this list after offer creation has been
+            # cleaned up. For example an `ABO_BIBLIOTHEQUE` should not accept
+            # any duration
+            {"url": "https://example.thing@test.com"},
+            {"withdrawalType": "in_app"},
+        ],
+        ids=["url", "withdrawal_type"],
+    )
+    def test_create_offer_with_non_thing_field_is_not_ok(self, auth_client, venue, extra):
+        subcategory_id = sorted(THINGS)[0]
+        payload = {**offer_minimal_shared_data(subcategory_id, venue), **extra}
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+
+
+class CreateThingWithEanTest(CreateOfferBase):
+    @pytest.mark.parametrize("subcategory_id", THINGS_WITH_EAN)
+    def test_create_offer_with_product_is_ok(self, auth_client, venue, subcategory_id):
+        product = offers_factories.ProductFactory(subcategoryId=subcategory_id)
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "bookingEmail": "booking.email@test.com",
+            "description": "some description",
+            "extraData": {"ean": product.ean},
+            "productId": product.id,
+        }
+
+        with assert_changes(Offer, 1):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+        assert offer.ean == product.ean
+        assert offer.description == product.description
+        assert offer.productId == product.id
+
+    def test_create_offer_with_unknown_product_is_ok(self, auth_client, venue):
+        """
+        It does not seem to be logical.
+        """
+        subcategory_id = sorted(THINGS_WITH_EAN)[0]
+        product = offers_factories.ProductFactory(subcategoryId=subcategory_id)
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"ean": product.ean},
+            "productId": 0,
+        }
+
+        with assert_changes(Offer, 1):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+        assert offer.ean == product.ean
+        assert not offer.productId
+
+
+@pytest.mark.parametrize("subcategory_id", DIGITAL_THING)
+class CreateDigitalOfferTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        default_url = "https://default.url@test.com"
+        payload = {**offer_minimal_shared_data(subcategory_id, venue), "url": default_url}
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+
+                assert response.status_code == 201
+                assert response.json["url"] == default_url
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert offer.url == default_url
+        assert not offer.isEvent
+
+    def test_create_offer_without_url_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "url" in response.json
+
+
+@pytest.mark.parametrize("subcategory_id", DIGITAL_ACTIVITY)
+class CreateDigitalEventTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        activity_url = "https://activity.online@test.com"
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "url": activity_url,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert not offer.isEvent
+
+    def test_create_offer_without_url_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+
+    def test_create_offer_without_show_type_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "url": "https://some.url@test.com",
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "showType" in response.json
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_SUBSCRIPTION)
+class CreateActivitySubscriptionTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+
+    def test_create_offer_without_show_type_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "showType" in response.json
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_ONLINE)
+class CreateActivityOnlineTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        activity_url = "https://activity.online@test.com"
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "url": activity_url,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert offer.isEvent
+
+    def test_create_offer_with_show_type_is_ok(self, auth_client, venue, subcategory_id):
+        activity_url = "https://activity.online@test.com"
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "url": activity_url,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert offer.isEvent
+
+    def test_create_offer_without_url_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_ONLINE_EVENT)
+class CreateActivityOnlineEventTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        activity_url = "https://activity.online@test.com"
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "url": activity_url,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert offer.isEvent
+
+    def test_create_offer_without_url_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "url" in response.json
+
+    def test_create_offer_without_show_type_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "url": "https://some.url@test.com",
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "showType" in response.json
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_WITHDRAWABLE)
+class CreateActivityWithdrawableTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    @pytest.mark.parametrize("withdrawal_type", ["by_email", "on_site", "no_ticket"])
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id, withdrawal_type):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "bookingContact": "booking.contact@test.com",
+            "withdrawalType": withdrawal_type,
+            "withdrawalDelay": 10 if withdrawal_type != "no_ticket" else None,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert offer.isEvent
+
+    def test_create_event_with_address_is_ok(self, auth_client, venue, subcategory_id):
+        address_data = default_address_payload()
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "bookingContact": "booking.contact@test.com",
+            "withdrawalType": "by_email",
+            "withdrawalDelay": 10,
+            "address": address_data,
+        }
+
+        with assert_changes(Offer, 1):
+            num_queries = self.success_num_queries
+            num_queries += 1  # insert address
+            num_queries += 1  # insert offerer address
+            num_queries += 1  # fetch offerer address
+            with assert_num_queries(num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert offer.isEvent
+
+        address = offer.offererAddress.address
+        assert address.postalCode == address_data["postalCode"]
+        assert address.city == address_data["city"]
+        assert address.street == address_data["street"]
+        assert address.latitude == Decimal(address_data["latitude"])
+        assert address.longitude == Decimal(address_data["longitude"])
+
+    def test_create_offer_with_in_app_withdrawal_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "bookingContact": "booking.contact@test.com",
+            "withdrawalType": "in_app",
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert response.json == {"withdrawalType": ["Withdrawal type cannot be in_app for manually created offers"]}
+
+    def test_create_offer_without_withdraw_information_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert response.json == {
+                "offer": ["Une offre qui a un ticket retirable doit avoir un type de retrait renseigné"]
+            }
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_RANDOM)
+class CreateActivityRandomTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert offer.isEvent
+        assert not offer.showSubType
+
+    def test_create_offer_with_showtype_is_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+        offer.showSubType == 101
+
+
+@pytest.mark.parametrize("subcategory_id", CANNOT_BE_CREATED)
+class CannotCreateOfferTest:
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_not_authorized(self, auth_client, venue, subcategory_id):
+        payload = {**offer_minimal_shared_data(subcategory_id, venue)}
+        response = auth_client.post(self.endpoint, json=payload)
+
+        assert response.status_code == 400
+        assert response.json == {
+            "subcategory": ["Une offre ne peut être créée ou éditée en utilisant cette sous-catégorie"]
+        }
+
+
+@pytest.mark.parametrize("subcategory_id", ALL)
+class CreateOfferErrorTest:
+    endpoint = "/v2/offers"
+
+    @pytest.mark.parametrize("missing_key", ["name", "subcategoryId", "venueId"])
+    def test_cannot_create_offer_without_missing_shared_minimal_data(
+        self, auth_client, venue, subcategory_id, missing_key
+    ):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+        payload.pop(missing_key)
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert missing_key in response.json
+
+
 class Returns200Test:
     def test_created_offer_should_be_inactive(self, client):
         venue = offerers_factories.VenueFactory()
@@ -22,7 +756,7 @@ class Returns200Test:
         data = {
             "venueId": venue.id,
             "name": "Celeste",
-            "subcategoryId": subcategories.LIVRE_PAPIER.id,
+            "subcategoryId": subcategories.ABO_BIBLIOTHEQUE.id,
             "mentalDisabilityCompliant": True,
             "audioDisabilityCompliant": False,
             "visualDisabilityCompliant": False,

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -1907,7 +1907,8 @@ export class DefaultService {
     });
   }
   /**
-   * post_draft_offer <POST>
+   * @deprecated
+   * [DEPRECATED] Please migrate to new (generic/standard) offer creation route
    * @param requestBody
    * @returns GetIndividualOfferResponseModel Created
    * @throws ApiError
@@ -2926,6 +2927,26 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         422: `Unprocessable Content`,
+      },
+    });
+  }
+  /**
+   * create_offer <POST>
+   * @param requestBody
+   * @returns GetIndividualOfferResponseModel Created
+   * @throws ApiError
+   */
+  public createOffer(
+    requestBody?: PostOfferBodyModel,
+  ): CancelablePromise<GetIndividualOfferResponseModel> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/v2/offers',
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
       },
     });
   }


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37816)

Ajout d'une nouvelle route de création d'offre, appelée à remplacer celle de création d'offre brouillon. L'idée étant de revoir le parcours de création d'offre du portail pro en créant directement une offre sans chercher d'étape intermédiaire et de notion de brouillon qui complique les choses et qui n'a pas réellement de sens.

### Au passage

Le coeur du commit est relativement court, les plus importants ajouts se situent au niveau des tests. Afin d'y voir un peu plus clair j'ai regroupé les créations par ensemble de sous-catégories pour commencer à identifier les règles implicites en place et avoir une idée de certaines incohérences (je n'ai rien mis ou presque à ce niveau-là dans les tests pour éviter d'en avoir beaucoup trop). Pour avoir fait des essais en **testing** en contournant le portail pro, on peut créer des offres qui mélanges beaucoup de choses...