### PR TITLE
(PC-37852)[BO] feat: localize datetime in user profile refresh page

### DIFF
--- a/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list.html
@@ -16,12 +16,15 @@
               type="button">Créer une nouvelle campagne</button>
     </div>
   {% endif %}
+  <div class="alert alert-info mw-100">
+    La date de référence définit les jeunes qui seront exposés à la demande de mise à jour&nbsp;: tous les jeunes dont la dernière mise à jour d’informations (adresse, ville, statut) est plus ancienne que la date limite seront ciblés.
+  </div>
 {% endblock before_table %}
 {% block table_header %}
   {% if has_permission("MANAGE_USER_PROFILE_REFRESH_CAMPAIGN") %}<th scope="col"></th>{% endif %}
   <th scope="col">Id</th>
   <th scope="col">Active</th>
-  <th scope="col">Date de début</th>
+  <th scope="col">Date de référence</th>
   <th scope="col">Date de création</th>
   <th scope="col">Date de mise à jour</th>
 {% endblock table_header %}

--- a/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list_rows.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list_rows.html
@@ -21,8 +21,8 @@
     {% endif %}
     <td>{{ campaign.id }}</td>
     <td>{{ campaign.isActive | format_bool_badge }}</td>
-    <td>{{ campaign.campaignDate }}</td>
-    <td>{{ campaign.creationDate }}</td>
-    <td>{{ campaign.updateDate }}</td>
+    <td>{{ campaign.campaignDate | format_date_time }}</td>
+    <td>{{ campaign.creationDate | format_date_time }}</td>
+    <td>{{ campaign.updateDate | format_date_time }}</td>
   </tr>
 {% endfor %}

--- a/api/tests/routes/backoffice/admin_test.py
+++ b/api/tests/routes/backoffice/admin_test.py
@@ -742,11 +742,11 @@ class ListUserProfileRefreshCampaignTest(GetEndpointWithoutPermissionHelper):
         assert {r["Id"] for r in rows} == {str(campaign1.id), str(campaign2.id)}
 
         row1 = [r for r in rows if r["Id"] == str(campaign1.id)][0]
-        assert row1["Date de début"] == "2026-01-01 01:01:00"
+        assert row1["Date de référence"] == "01/01/2026 à 02h01"
         assert row1["Active"] == "Oui"
 
         row2 = [r for r in rows if r["Id"] == str(campaign2.id)][0]
-        assert row2["Date de début"] == "2027-01-01 01:01:00"
+        assert row2["Date de référence"] == "01/01/2027 à 02h01"
         assert row2["Active"] == "Non"
 
 
@@ -861,7 +861,7 @@ class EditUserProfileRefreshCampaignTest(PostEndpointHelper):
         assert cells[0] == "Modifier"
         assert cells[1] == str(campaign.id)
         assert cells[2] == "Oui"
-        assert cells[3] == "2027-01-01 01:01:00"
+        assert cells[3] == "01/01/2027 à 02h01"
 
         assert campaign.campaignDate == datetime.datetime.strptime("2027-01-01 01:01", "%Y-%m-%d %H:%M")
         assert campaign.isActive is True
@@ -888,7 +888,7 @@ class EditUserProfileRefreshCampaignTest(PostEndpointHelper):
         assert cells[0] == "Modifier"
         assert cells[1] == str(campaign.id)
         assert cells[2] == "Non"
-        assert cells[3] == "2026-01-01 01:01:00"
+        assert cells[3] == "01/01/2026 à 02h01"
 
         assert campaign.campaignDate == datetime.datetime.strptime("2026-01-01 01:01", "%Y-%m-%d %H:%M")
         assert campaign.isActive is False


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37852)

Improve user profile refresh page in the backoffice:
 - Add more details to the `startDate` column
 - Localize displayed datetimes

Before:

<img width="1374" height="342" alt="Capture d’écran 2025-09-23 à 17 09 13" src="https://github.com/user-attachments/assets/2d2d0ae8-1476-4413-afd0-b2a5dd88c0f5" />


After:

<img width="1350" height="443" alt="Capture d’écran 2025-09-23 à 17 08 55" src="https://github.com/user-attachments/assets/d7ece94e-d9f7-4939-a60b-2221e895009c" />
