### PR TITLE
(PC-38094)[PRO] fix: hide budget before 2025-10-01T06:00:00.000Z

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
@@ -1,3 +1,5 @@
+import { fromZonedTime } from 'date-fns-tz'
+
 import { AdageHeaderLink } from '@/apiClient/adage'
 import { ButtonLink } from '@/ui-kit/Button/ButtonLink'
 import { ButtonVariant } from '@/ui-kit/Button/types'
@@ -14,7 +16,10 @@ export const AdageHeaderBudget = ({
   institutionBudget,
 }: AdageHeaderBudgetProps) => {
   // TODO (nizac, 2025-09-22): To remove after the 2025-10-01
-  const limitDate = new Date('2025-10-01T00:00:00')
+  const limitDate = fromZonedTime(
+    new Date('2025-10-01T08:00:00'),
+    'Europe/Paris'
+  )
 
   if (Date.now() < limitDate.getTime()) {
     return

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
+import { fromZonedTime } from 'date-fns-tz'
 
 import { AdageFrontRoles, type AuthenticatedResponse } from '@/apiClient/adage'
 import { AdageHeaderLink } from '@/apiClient/adage/models/AdageHeaderLink'
@@ -206,9 +207,11 @@ describe('AdageHeader', () => {
   })
 
   it('should not display the budget if the date is before 2025-10-01', async () => {
-    vi.spyOn(Date, 'now').mockReturnValue(
-      new Date('2025-09-30T23:59:00').getTime()
+    const parisDate = fromZonedTime(
+      new Date('2025-10-01 07:59:59'),
+      'Europe/Paris'
     )
+    vi.spyOn(Date, 'now').mockReturnValue(parisDate.getTime())
     renderAdageHeader(user)
     await waitFor(() =>
       expect(screen.queryByText('Solde prévisionnel')).not.toBeInTheDocument()
@@ -217,9 +220,11 @@ describe('AdageHeader', () => {
   })
 
   it('should display the budget if the date is after 2025-10-01', async () => {
-    vi.spyOn(Date, 'now').mockReturnValue(
-      new Date('2025-10-01T00:01:00').getTime()
+    const parisDate = fromZonedTime(
+      new Date('2025-10-01 08:00:00'),
+      'Europe/Paris'
     )
+    vi.spyOn(Date, 'now').mockReturnValue(parisDate.getTime())
     renderAdageHeader(user)
     await waitFor(() =>
       expect(screen.queryByText('Solde prévisionnel')).toBeInTheDocument()


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-38094)

- Hide budget in adage iframe if date is before 01/10/2025 08:00:00 (2025-10-01T06:00:00.000Z = UTC)

## 🖼️ Before & After Images

Before 2025-10-01 08:00:00

<img width="682" height="250" alt="image" src="https://github.com/user-attachments/assets/c3ca8dc9-b8cb-49f9-974c-8c233f653b82" />


After 2025-10-01 08:00:00

<img width="616" height="277" alt="image" src="https://github.com/user-attachments/assets/5c904655-02ae-4638-9efd-357cf4c1fe00" />
