### PR TITLE
(PC-38098)[API] feat: Do not index or book Caledonian offers before launch date

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -41,6 +41,7 @@ from pcapi.models import Model
 from pcapi.models import db
 from pcapi.models.accessibility_mixin import AccessibilityMixin
 from pcapi.models.deactivable_mixin import DeactivableMixin
+from pcapi.models.feature import FeatureToggle
 from pcapi.models.has_address_mixin import HasAddressMixin
 from pcapi.models.has_thumb_mixin import HasThumbMixin
 from pcapi.models.pc_object import PcObject
@@ -488,6 +489,8 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
 
     @property
     def is_eligible_for_search(self) -> bool:
+        if self.is_caledonian and not FeatureToggle.WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE.is_active():
+            return False
         return (
             bool(self.isOpenToPublic)
             and self.managingOfferer.isActive

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -33,6 +33,7 @@ from pcapi.models import Model
 from pcapi.models import db
 from pcapi.models.accessibility_mixin import AccessibilityMixin
 from pcapi.models.deactivable_mixin import DeactivableMixin
+from pcapi.models.feature import FeatureToggle
 from pcapi.models.has_thumb_mixin import HasThumbMixin
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
@@ -935,6 +936,8 @@ class Offer(PcObject, Model, ValidationMixin, AccessibilityMixin):
     @hybrid_property
     def isReleased(self) -> bool:
         offerer = self.venue.managingOfferer
+        if offerer.is_caledonian and not FeatureToggle.WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE.is_active():
+            return False
         return self._released and offerer.isActive and offerer.isValidated
 
     @isReleased.expression  # type: ignore[no-redef]

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -333,6 +333,8 @@ def get_offers_details(offer_ids: list[int]) -> sa_orm.Query:
                 offerers_models.Offerer.name,
                 offerers_models.Offerer.validationStatus,
                 offerers_models.Offerer.isActive,
+                offerers_models.Offerer.siren,  # Remove along with WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE
+                offerers_models.Offerer.postalCode,  # Remove along with WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE
             )
         )
         .options(sa_orm.joinedload(models.Offer.venue).joinedload(offerers_models.Venue.googlePlacesInfo))

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -516,6 +516,8 @@ def get_base_query_for_offer_indexation() -> sa_orm.Query:
                     offerers_models.Offerer.name,
                     offerers_models.Offerer.isActive,
                     offerers_models.Offerer.validationStatus,
+                    offerers_models.Offerer.siren,  # Remove along with WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE
+                    offerers_models.Offerer.postalCode,  # Remove along with WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE
                 )
             )
             .options(

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -161,6 +161,8 @@ class FeatureToggle(enum.Enum):
     )
     WIP_ENABLE_NEW_OFFER_CREATION_FLOW = "Activer le nouveau parcours de création d'offre"
     WIP_ENABLE_OHO = "Activer la création d'offre individuelle sur plages horaires"
+    # TODO (prouzet, 2025-09-25) Remove feature flag after pass Culture is launched in NC
+    WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE = "Permettre l'indexation et la réservation des offres en Nouvelle-Calédonie"
 
     def is_active(self) -> bool:
         if flask.has_request_context():
@@ -226,6 +228,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_DISABLE_NOTIFY_USERS_BOOKINGS_NOT_RETRIEVED,
     FeatureToggle.WIP_DISABLE_SEND_NOTIFICATIONS_FAVORITES_NOT_BOOKED,
     FeatureToggle.WIP_DISABLE_TODAY_STOCK_NOTIFICATION,
+    FeatureToggle.WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE,
     FeatureToggle.WIP_ENABLE_NEW_COLLECTIVE_OFFERS_AND_BOOKINGS_STRUCTURE,
     FeatureToggle.WIP_ENABLE_NEW_COLLECTIVE_OFFER_DETAIL_PAGE,
     FeatureToggle.WIP_ENABLE_NEW_FINANCE_WORKFLOW,

--- a/api/src/pcapi/routes/native/v1/favorites.py
+++ b/api/src/pcapi/routes/native/v1/favorites.py
@@ -128,7 +128,13 @@ def get_favorites_for(user: User, favorite_id: int | None = None) -> list[Favori
             sa_orm.joinedload(Favorite.offer)
             .joinedload(Offer.venue)
             .joinedload(Venue.managingOfferer)
-            .load_only(Offerer.validationStatus, Offerer.isActive, Offerer.name)
+            .load_only(
+                Offerer.validationStatus,
+                Offerer.isActive,
+                Offerer.name,
+                Offerer.siren,  # Remove along with WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE
+                Offerer.postalCode,  # Remove along with WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE
+            )
         )
         .options(
             sa_orm.joinedload(Favorite.offer)

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -415,6 +415,21 @@ class BookOfferTest:
             "user_id": beneficiary.id,
         }
 
+    @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=False)
+    def test_caledonian_offer_is_not_bookable_before_launch_date(self):
+        stock = offers_factories.StockFactory(offer__venue=offerers_factories.CaledonianVenueFactory())
+
+        with pytest.raises(exceptions.StockIsNotBookable):
+            api.book_offer(beneficiary=users_factories.BeneficiaryGrant18Factory(), stock_id=stock.id, quantity=1)
+
+    @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=True)
+    def test_caledonian_offer_is_bookable_after_launch_date(self):
+        stock = offers_factories.StockFactory(offer__venue=offerers_factories.CaledonianVenueFactory())
+
+        booking = api.book_offer(beneficiary=users_factories.BeneficiaryGrant18Factory(), stock_id=stock.id, quantity=1)
+
+        assert booking.status is BookingStatus.CONFIRMED
+
     class WhenBookingWithActivationCodeTest:
         def test_book_offer_with_first_activation_code_available(self):
             # Given

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -218,6 +218,20 @@ class VenueIsEligibleForSearchTest:
             offers_factories.OfferFactory(venue=venue)
         assert venue.is_eligible_for_search == is_eligible_for_search
 
+        @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=False)
+        def test_caledonian_venue_is_note_eligible_for_search_before_launch_date(self):
+            venue = factories.CaledonianVenueFactory(venueTypeCode=offerers_schemas.VenueTypeCode.BOOKSTORE)
+            offers_factories.OfferFactory(venue=venue)
+
+            assert venue.is_eligible_for_search is False
+
+        @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=True)
+        def test_caledonian_venue_is_eligible_for_search_after_launch_date(self):
+            venue = factories.CaledonianVenueFactory(venueTypeCode=offerers_schemas.VenueTypeCode.BOOKSTORE)
+            offers_factories.OfferFactory(venue=venue)
+
+            assert venue.is_eligible_for_search is False
+
 
 class VenueHasActiveIndividualOffersTest:
     def test_has_active_individual_offer_property(self):

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -6,6 +6,7 @@ from sqlalchemy import exc as sa_exc
 
 import pcapi.core.bookings.constants as bookings_constants
 import pcapi.core.bookings.factories as bookings_factories
+import pcapi.core.offerers.schemas as offerers_schemas
 import pcapi.core.providers.factories as providers_factories
 import pcapi.utils.db as db_utils
 from pcapi.core.categories import subcategories
@@ -1057,3 +1058,17 @@ class OfferIsSearchableTest:
         factories.StockFactory(offer=offer)
 
         assert offer.is_eligible_for_search is is_eligible_for_search
+
+    @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=False)
+    def test_caledonian_venue_is_note_eligible_for_search_before_launch_date(self):
+        venue = offerers_factories.CaledonianVenueFactory(venueTypeCode=offerers_schemas.VenueTypeCode.BOOKSTORE)
+        offer = factories.StockFactory(offer__venue=venue).offer
+
+        assert offer.is_eligible_for_search is False
+
+    @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=True)
+    def test_caledonian_venue_is_eligible_for_search_after_launch_date(self):
+        venue = offerers_factories.CaledonianVenueFactory(venueTypeCode=offerers_schemas.VenueTypeCode.BOOKSTORE)
+        offer = factories.StockFactory(offer__venue=venue).offer
+
+        assert offer.is_eligible_for_search is True

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -278,6 +278,22 @@ class ReindexOfferIdsTest:
             == serialization.Last30DaysBookingsRange.VERY_LOW.value
         )
 
+    @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=False)
+    def test_caledonian_offer_is_not_indexed_before_launch_date(self):
+        offer_id = offers_factories.StockFactory(offer__venue=offerers_factories.CaledonianVenueFactory()).offer.id
+
+        assert search_testing.search_store["offers"] == {}
+        search.reindex_offer_ids([offer_id])
+        assert search_testing.search_store["offers"] == {}
+
+    @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=True)
+    def test_caledonian_offer_is_indexed_after_launch_date(self):
+        offer_id = offers_factories.StockFactory(offer__venue=offerers_factories.CaledonianVenueFactory()).offer.id
+
+        assert search_testing.search_store["offers"] == {}
+        search.reindex_offer_ids([offer_id])
+        assert offer_id in search_testing.search_store["offers"]
+
 
 class ReindexVenueIdsTest:
     def test_index_new_venue(self):
@@ -326,6 +342,23 @@ class ReindexVenueIdsTest:
 
         search.reindex_venue_ids([indexable_venue.id, venue1.id, venue2.id, venue3.id])
         assert search_testing.search_store["venues"].keys() == {indexable_venue.id}
+
+    @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=False)
+    def test_caledonian_venue_is_not_indexed_before_launch_date(self):
+        offer_id = offers_factories.StockFactory(offer__venue=offerers_factories.CaledonianVenueFactory()).offer.id
+
+        assert search_testing.search_store["venues"] == {}
+        search.reindex_offer_ids([offer_id])
+        assert offer_id not in search_testing.search_store["offers"]
+
+    @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=True)
+    def test_caledonian_venue_is_indexed_after_launch_date(self):
+        venue = offerers_factories.CaledonianVenueFactory()
+        offers_factories.StockFactory(offer__venue=venue)
+
+        assert search_testing.search_store["offers"] == {}
+        search.reindex_venue_ids([venue.id])
+        assert search_testing.search_store["offers"] == {}
 
 
 @pytest.mark.settings(REDIS_OFFER_IDS_CHUNK_SIZE=3)

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -3972,6 +3972,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
             expired_stock_2.beginningDatetime, "%d/%m/%Y à %Hh%M"
         )
 
+    @pytest.mark.features(WIP_ENABLE_CALEDONIAN_OFFERS_BOOKABLE=True)
     @pytest.mark.parametrize(
         "quantity,booked_quantity,expected_remaining,venue_factory,expected_price,expected_timezone",
         [


### PR DESCRIPTION
Ticket Jira : https://passculture.atlassian.net/browse/PC-38098

Note : L'expression SQL de l'_hybrid property_ `isReleased` ne tient pas compte du FF et de `is_caledonian` mais elle n'est utilisée dans les filtres que pour des compteurs et statistiques.