### PR TITLE
(PC-37561)[BO] feat: store user profile refresh campaign history

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-1ed8548280cd (pre) (head)
-864fbd2feb03 (post) (head)
+0cebf2b2aac6 (pre) (head)
+5674186430f7 (post) (head)

--- a/api/src/pcapi/alembic/versions/20251106T084817_cf83b540d8b8_action_history_user_profile_refresh_campaign.py
+++ b/api/src/pcapi/alembic/versions/20251106T084817_cf83b540d8b8_action_history_user_profile_refresh_campaign.py
@@ -1,0 +1,30 @@
+"""Add `userProfileRefreshCampaign` field to `ActionHistory` model"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "cf83b540d8b8"
+down_revision = "1ed8548280cd"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("action_history", sa.Column("userProfileRefreshCampaignId", sa.BigInteger(), nullable=True))
+    op.create_foreign_key(
+        "action_history_userProfileRefreshCampaign_fkey",
+        "action_history",
+        "user_profile_refresh_campaign",
+        ["userProfileRefreshCampaignId"],
+        ["id"],
+        ondelete="CASCADE",
+        postgresql_not_valid=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("action_history_userProfileRefreshCampaign_fkey", "action_history", type_="foreignkey")
+    op.drop_column("action_history", "userProfileRefreshCampaignId")

--- a/api/src/pcapi/alembic/versions/20251106T085143_4069d8fed0c7_validate_fkey_action_history_user_profile_refresh_campaign.py
+++ b/api/src/pcapi/alembic/versions/20251106T085143_4069d8fed0c7_validate_fkey_action_history_user_profile_refresh_campaign.py
@@ -1,0 +1,24 @@
+"""Validate constraint action_history_userProfileRefreshCampaign_fkey"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "4069d8fed0c7"
+down_revision = "864fbd2feb03"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET SESSION statement_timeout='300s'")
+    op.execute("""ALTER TABLE action_history VALIDATE CONSTRAINT "action_history_userProfileRefreshCampaign_fkey" """)
+    op.execute("""ALTER TABLE action_history VALIDATE CONSTRAINT "check_action_resource" """)
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass

--- a/api/src/pcapi/alembic/versions/20251106T085329_5674186430f7_create_index_ix_action_history_userprofilerefreshcampaignid.py
+++ b/api/src/pcapi/alembic/versions/20251106T085329_5674186430f7_create_index_ix_action_history_userprofilerefreshcampaignid.py
@@ -1,0 +1,37 @@
+"""Create index ix_action_history_userProfileRefreshCampaignId"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "5674186430f7"
+down_revision = "4069d8fed0c7"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("COMMIT")
+    op.create_index(
+        "ix_action_history_userProfileRefreshCampaignId",
+        "action_history",
+        ["userProfileRefreshCampaignId"],
+        unique=False,
+        postgresql_where=sa.text('"userProfileRefreshCampaignId" IS NOT NULL'),
+        if_not_exists=True,
+        postgresql_concurrently=True,
+    )
+    op.execute("BEGIN")
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.drop_index(
+        "ix_action_history_userProfileRefreshCampaignId",
+        table_name="action_history",
+        postgresql_concurrently=True,
+        if_exists=True,
+    )
+    op.execute("BEGIN")

--- a/api/src/pcapi/alembic/versions/20251106T085517_0cebf2b2aac6_update_check_action_resource_constraint_user_profile_refresh_campaign.py
+++ b/api/src/pcapi/alembic/versions/20251106T085517_0cebf2b2aac6_update_check_action_resource_constraint_user_profile_refresh_campaign.py
@@ -1,0 +1,45 @@
+"""Update check_action_resource_constraint to add userProfileRefreshCampaign field"""
+
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "0cebf2b2aac6"
+down_revision = "cf83b540d8b8"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("""ALTER TABLE action_history DROP CONSTRAINT IF EXISTS "check_action_resource" """)
+    op.execute(
+        """
+ALTER TABLE action_history ADD CONSTRAINT "check_action_resource" CHECK
+(
+    (
+        (num_nonnulls("userId", "offererId", "venueId", "financeIncidentId", "bankAccountId", "ruleId", "chronicleId", "userProfileRefreshCampaignId") >= 1)
+        OR ("actionType" = 'BLACKLIST_DOMAIN_NAME'::text)
+        OR ("actionType" = 'REMOVE_BLACKLISTED_DOMAIN_NAME'::text)
+        OR ("actionType" = 'ROLE_PERMISSIONS_CHANGED'::text)
+    )
+) NOT VALID;
+        """,
+    )
+
+
+def downgrade() -> None:
+    op.execute("""ALTER TABLE action_history DROP CONSTRAINT IF EXISTS "check_action_resource" """)
+    op.execute(
+        """
+ALTER TABLE action_history ADD CONSTRAINT "check_action_resource" CHECK
+(
+    (
+        (num_nonnulls("userId", "offererId", "venueId", "financeIncidentId", "bankAccountId", "ruleId", "chronicleId") >= 1)
+        OR ("actionType" = 'BLACKLIST_DOMAIN_NAME'::text)
+        OR ("actionType" = 'REMOVE_BLACKLISTED_DOMAIN_NAME'::text)
+        OR ("actionType" = 'ROLE_PERMISSIONS_CHANGED'::text)
+    )
+) NOT VALID;
+        """,
+    )

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1616,6 +1616,7 @@ def set_offerer_pending(
         bank_account=None,  # otherwise mypy does not accept extra_data dict
         rule=None,  # otherwise mypy does not accept extra_data dict
         chronicle=None,  # otherwise mypy does not accept extra_data dict
+        user_profile_refresh_campaign=None,
         comment=comment,
         **extra_data,
     )

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -1280,5 +1280,7 @@ class UserTagCategoryMappingFactory(BaseFactory):
 
 
 class UserProfileRefreshCampaignFactory(BaseFactory):
+    campaignDate = factory.Faker("future_datetime")
+
     class Meta:
         model = models.UserProfileRefreshCampaign

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -1448,3 +1448,11 @@ class UserProfileRefreshCampaign(PcObject, Model):
     isActive: sa_orm.Mapped[bool] = sa_orm.mapped_column(
         sa.Boolean, nullable=False, server_default=expression.true(), default=True
     )
+
+    action_history: sa_orm.Mapped[list["ActionHistory"]] = sa_orm.relationship(
+        "ActionHistory",
+        foreign_keys="ActionHistory.userProfileRefreshCampaignId",
+        back_populates="userProfileRefreshCampaign",
+        order_by=ACTION_HISTORY_ORDER_BY,
+        passive_deletes=True,
+    )

--- a/api/src/pcapi/db_utils.py
+++ b/api/src/pcapi/db_utils.py
@@ -165,6 +165,7 @@ tables_to_clean: list[type[Model]] = [
     users_models.GdprUserAnonymization,
     users_models.GdprUserDataExtract,
     users_models.SingleSignOn,
+    users_models.UserProfileRefreshCampaign,
     users_models.UserTagCategoryMapping,
     users_models.UserTagCategory,
     users_models.UserTagMapping,

--- a/api/src/pcapi/routes/backoffice/admin/user_profile_refresh_campaigns_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/admin/user_profile_refresh_campaigns_blueprint.py
@@ -3,13 +3,18 @@ from flask import redirect
 from flask import render_template
 from flask import request
 from flask import url_for
+from flask_login import current_user
+from sqlalchemy import orm as sa_orm
 from werkzeug.exceptions import NotFound
 
+from pcapi.core.history import api as history_api
+from pcapi.core.history import models as history_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.admin import forms
+from pcapi.utils import date as date_utils
 
 
 user_profile_refresh_campaigns_blueprint = utils.child_backoffice_blueprint(
@@ -20,11 +25,33 @@ user_profile_refresh_campaigns_blueprint = utils.child_backoffice_blueprint(
 )
 
 
+def _deactivate_existing_campaigns(excluded_campaign_id: int) -> list[int]:
+    filters = [users_models.UserProfileRefreshCampaign.isActive == True]
+    if excluded_campaign_id is not None:
+        filters.append(users_models.UserProfileRefreshCampaign.id != excluded_campaign_id)
+    deactivated_campaign_ids = []
+    campaigns_to_deactivate = db.session.query(users_models.UserProfileRefreshCampaign).filter(*filters).all()
+    for campaign_to_deactivate in campaigns_to_deactivate:
+        deactivated_campaign_ids.append(campaign_to_deactivate.id)
+        campaign_to_deactivate.isActive = False
+        db.session.add(campaign_to_deactivate)
+        history_api.add_action(
+            history_models.ActionType.USER_PROFILE_REFRESH_CAMPAIGN_UPDATED,
+            author=current_user,
+            user_profile_refresh_campaign=campaign_to_deactivate,
+            comment=f"Désactivation suite à l'activation de la campagne #{excluded_campaign_id}",
+            modified_info={"isActive": {"old_info": True, "new_info": False}},
+        )
+
+    return deactivated_campaign_ids
+
+
 @user_profile_refresh_campaigns_blueprint.route("", methods=["GET"])
 def list_campaigns() -> utils.BackofficeResponse:
     creation_form = forms.UserProfileRefreshCampaignForm()
     campaigns = (
         db.session.query(users_models.UserProfileRefreshCampaign)
+        .options(sa_orm.joinedload(users_models.UserProfileRefreshCampaign.action_history))
         .order_by(users_models.UserProfileRefreshCampaign.id)
         .all()
     )
@@ -47,11 +74,21 @@ def create_campaign() -> utils.BackofficeResponse:
             code=303,
         )
 
+    new_campaign_is_active = bool(form.is_active.data)
     campaign = users_models.UserProfileRefreshCampaign(
-        campaignDate=form.campaign_date.data,
-        isActive=bool(form.is_active.data),
+        campaignDate=date_utils.datetime_to_localized_datetime(form.campaign_date.data),
+        isActive=new_campaign_is_active,
     )
     db.session.add(campaign)
+    db.session.flush()
+    if new_campaign_is_active:
+        _deactivate_existing_campaigns(campaign.id)
+    history_api.add_action(
+        history_models.ActionType.USER_PROFILE_REFRESH_CAMPAIGN_CREATED,
+        author=current_user,
+        user_profile_refresh_campaign=campaign,
+        modified_info={"isActive": {"new_info": new_campaign_is_active}},
+    )
     db.session.flush()
     flash("Campagne de mise à jour de données créée avec succès.", "success")
 
@@ -67,10 +104,13 @@ def get_campaign_edit_form(campaign_id: int) -> utils.BackofficeResponse:
 
     form = forms.UserProfileRefreshCampaignForm()
     form.is_active.data = campaign.isActive
-    form.campaign_date.data = campaign.campaignDate
+    form.campaign_date.data = date_utils.default_timezone_to_local_datetime(
+        campaign.campaignDate, date_utils.METROPOLE_TIMEZONE
+    ).replace(tzinfo=None)
 
     return render_template(
         "components/dynamic/modal_form.html",
+        alert="L'activation de la campagne actuelle désactivera toutes les autres campagnes.",
         target_id=f"#campaign-row-{campaign_id}",
         form=form,
         dst=url_for("backoffice_web.user_profile_refresh_campaigns.edit_campaign", campaign_id=campaign_id),
@@ -93,16 +133,35 @@ def edit_campaign(campaign_id: int) -> utils.BackofficeResponse:
         flash(utils.build_form_error_msg(form), "warning")
         return redirect(request.referrer, 400)
 
-    campaign.isActive = form.is_active.data
-    campaign.campaignDate = form.campaign_date.data
-    db.session.add(campaign)
-    db.session.flush()
+    new_campaign_date = date_utils.datetime_to_localized_datetime(form.campaign_date.data).replace(tzinfo=None)
+    modified_info = {}
+    if campaign.isActive != form.is_active.data:
+        modified_info["isActive"] = {"old_info": campaign.isActive, "new_info": form.is_active.data}
+    if campaign.campaignDate != new_campaign_date:
+        modified_info["campaignDate"] = {"old_info": campaign.campaignDate, "new_info": new_campaign_date}
 
-    flash("La campagne a été modifiée", "success")
+    deactivated_campaign_ids = []
+    if modified_info:
+        history_api.add_action(
+            history_models.ActionType.USER_PROFILE_REFRESH_CAMPAIGN_UPDATED,
+            author=current_user,
+            user_profile_refresh_campaign=campaign,
+            modified_info=modified_info,
+        )
+        campaign.isActive = form.is_active.data
+        campaign.campaignDate = new_campaign_date
+        db.session.add(campaign)
+        if campaign.isActive:
+            deactivated_campaign_ids = _deactivate_existing_campaigns(campaign_id)
+
+        db.session.flush()
+
+        flash("La campagne a été mise à jour", "success")
 
     campaigns = (
         db.session.query(users_models.UserProfileRefreshCampaign)
-        .filter(users_models.UserProfileRefreshCampaign.id == campaign_id)
+        .filter(users_models.UserProfileRefreshCampaign.id.in_(deactivated_campaign_ids + [campaign_id]))
+        .options(sa_orm.joinedload(users_models.UserProfileRefreshCampaign.action_history))
         .all()
     )
 

--- a/api/src/pcapi/routes/backoffice/templates/admin/roles.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/roles.html
@@ -28,33 +28,35 @@
                   {% endfor %}
                 </tr>
               </thead>
-              {% if not get_setting("BACKOFFICE_ROLES_WITHOUT_GOOGLE_GROUPS") %}
-                <tr>
-                  <td>&nbsp;</td>
-                  {% for role in roles %}
-                    <td class="border-start text-center">
-                      {% set link = "https://groups.google.com/a/passculture.app/g/backoffice-" + get_setting('ENV') + "-" + role.name + "/members" %}
-                      <a href="{{ link }}"
-                         target="_blank"
-                         rel="noreferrer noopener"
-                         class="link-primary"
-                         title="Voir les membres du groupe Google">
-                        <i class="bi bi-google"></i>
-                      </a>
-                    </td>
-                  {% endfor %}
+              <tbody>
+                {% if not get_setting("BACKOFFICE_ROLES_WITHOUT_GOOGLE_GROUPS") %}
+                  <tr>
+                    <td>&nbsp;</td>
+                    {% for role in roles %}
+                      <td class="border-start text-center">
+                        {% set link = "https://groups.google.com/a/passculture.app/g/backoffice-" + get_setting('ENV') + "-" + role.name + "/members" %}
+                        <a href="{{ link }}"
+                           target="_blank"
+                           rel="noreferrer noopener"
+                           class="link-primary"
+                           title="Voir les membres du groupe Google">
+                          <i class="bi bi-google"></i>
+                        </a>
+                      </td>
+                    {% endfor %}
+                  </tr>
                 {% endif %}
-              </tr>
-              {% for permission, perm_roles in permissions.items() %}
-                <tr class="border-top">
-                  <td class="text-nowrap">{{ permission | format_permission_name }}</td>
-                  {% for role in roles %}
-                    <td class="border-start text-center">
-                      {% if role.name in perm_roles %}<span title="{{ role.name }}">x</span>{% endif %}
-                    </td>
-                  {% endfor %}
-                </tr>
-              {% endfor %}
+                {% for permission, perm_roles in permissions.items() %}
+                  <tr class="border-top">
+                    <td class="text-nowrap">{{ permission | format_permission_name }}</td>
+                    {% for role in roles %}
+                      <td class="border-start text-center">
+                        {% if role.name in perm_roles %}<span title="{{ role.name }}">x</span>{% endif %}
+                      </td>
+                    {% endfor %}
+                  </tr>
+                {% endfor %}
+              </tbody>
               <thead>
                 <tr class="border-top"
                     style="line-height: 13em">

--- a/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list.html
@@ -39,12 +39,16 @@
   {% set button_text = "Créer" %}
   {% set dst = url_for("backoffice_web.user_profile_refresh_campaigns.create_campaign") %}
   {% set ajax_submit = False %}
-  <div class="modal fade modal-{{ modal_size }}"
+  <div class="modal fade modal-xl"
        id="create-campaign-modal"
        tabindex="-1"
        aria-labelledby="create-campaign-label"
        aria-hidden="false">
-    <div class="modal-dialog modal-dialog-centered">{% include "components/dynamic/modal_form.html" %}</div>
+    <div class="modal-dialog modal-dialog-centered">
+      {% with alert = "La création d'une campagne active désactivera toutes les autres campagnes." %}
+        {% include "components/dynamic/modal_form.html" %}
+      {% endwith %}
+    </div>
   </div>
   {% for campaign in rows %}
     {{ build_dynamic_modal(url_for('backoffice_web.user_profile_refresh_campaigns.get_campaign_edit_form', campaign_id=campaign.id) , "edit-campaign-modal-" + campaign.id|string) }}

--- a/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list_rows.html
+++ b/api/src/pcapi/routes/backoffice/templates/admin/user_profile_refresh_campaigns/list_rows.html
@@ -1,24 +1,86 @@
 {% for campaign in rows %}
   <tr id="campaign-row-{{ campaign.id  }}">
-    {% if has_permission("MANAGE_USER_PROFILE_REFRESH_CAMPAIGN") %}
-      <td>
-        <div class="dropdown">
-          <button type="button"
-                  data-bs-toggle="dropdown"
-                  aria-expanded="false"
-                  class="btn p-0">
-            <i class="bi bi-three-dots-vertical"></i>
-          </button>
-          <ul class="dropdown-menu">
+    <td>
+      <div class="dropdown">
+        <button type="button"
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
+                class="btn p-0">
+          <i class="bi bi-three-dots-vertical"></i>
+        </button>
+        <ul class="dropdown-menu">
+          {% if has_permission("MANAGE_USER_PROFILE_REFRESH_CAMPAIGN") %}
             <li class="dropdown-item">
               <a class="btn btn-sm d-block w-100 text-start px-3"
                  data-bs-toggle="modal"
                  data-bs-target="#edit-campaign-modal-{{ campaign.id }}">Modifier</a>
             </li>
-          </ul>
+          {% endif %}
+          {% if campaign.action_history %}
+            <li class="dropdown-item">
+              <a class="btn btn-sm d-block w-100 text-start px-3"
+                 type="button"
+                 data-bs-toggle="modal"
+                 data-bs-target="#campaign-history-{{ campaign.id }}">Voir l'historique</a>
+            </li>
+          {% endif %}
+        </ul>
+      </div>
+      <div class="modal fade modal-xl"
+           id="campaign-history-{{ campaign.id }}">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h4 class="modal-title">Historique de la campagne #{{ campaign.id }}</h4>
+              <button type="button"
+                      class="btn-close"
+                      data-bs-dismiss="modal"
+                      aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body">
+              <table id="history-table-{{ campaign.id }}"
+                     class="table">
+                <thead>
+                  <tr>
+                    <th>Action</th>
+                    <th>Utilisateur</th>
+                    <th>Date</th>
+                    <th>Informations</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for action in campaign.action_history | reverse %}
+                    <tr>
+                      <td>{{ action.actionType | format_user_profile_refresh_campaign_action_type }}</td>
+                      <td>
+                        {% if action.authorUser %}{{ action.authorUser.full_name }}{% endif %}
+                      </td>
+                      <td>{{ action.actionDate | format_date_time }}</td>
+                      <td>
+                        {% if action.comment %}<p>{{ action.comment }}</p>{% endif %}
+                        {% set modified_info = action.extraData.get('modified_info', {}) %}
+                        {% if modified_info %}
+                          {% for field, modifications in modified_info.items() %}
+                            <p>
+                              <span class="text-decoration-underline">{{ field | format_modified_info_name | escape }} :</span>
+                              {{ modifications | format_modified_info_values(field, campaign) }}
+                            </p>
+                          {% endfor %}
+                        {% endif %}
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            <div class="modal-footer">
+              <button class="btn btn-primary"
+                      data-bs-dismiss="modal">Fermer</button>
+            </div>
+          </div>
         </div>
-      </td>
-    {% endif %}
+      </div>
+    </td>
     <td>{{ campaign.id }}</td>
     <td>{{ campaign.isActive | format_bool_badge }}</td>
     <td>{{ campaign.campaignDate | format_date_time }}</td>

--- a/api/src/pcapi/routes/backoffice/templates/components/dynamic/modal_form.html
+++ b/api/src/pcapi/routes/backoffice/templates/components/dynamic/modal_form.html
@@ -17,9 +17,9 @@
               aria-label="Fermer"></button>
     </div>
     <div class="modal-body row">
-      <div class="d-flex flex-column">
+      <div class="d-flex flex-column gap-1">
         {% if alert %}
-          <div class="alert alert-warning px-4"
+          <div class="alert alert-warning mw-100"
                role="alert">{{ alert }}</div>
         {% endif %}
         {% if info %}

--- a/api/src/pcapi/routes/backoffice/templates/offerer/get/details/addresses.html
+++ b/api/src/pcapi/routes/backoffice/templates/offerer/get/details/addresses.html
@@ -24,24 +24,25 @@
                 {{ title }}
               {% endif %}
             {% endfor %}
-          {% else %}
-            <td></td>
-          {% endif %}
-          <td>{{ address.street | empty_string_if_null }} {{ address.postalCode }} {{ address.city }}</td>
-          <td>{{ links.build_external_address_link(address) }}</td>
-          <td>
-            {% set search_params = {
-                          "search-0-search_field": "OFFERER",
-                          "search-0-operator": "IN",
-                          "search-0-offerer": offerer_id,
-                          "search-1-search_field": "ADDRESS",
-                          "search-1-operator": "IN",
-                          "search-1-address": address.id,
-                        } %}
-            <a href="{{ url_for('backoffice_web.offer.list_offers', **search_params) }}"
-               class="link-primary">individuelles</a>
           </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+        {% else %}
+          <td></td>
+        {% endif %}
+        <td>{{ address.street | empty_string_if_null }} {{ address.postalCode }} {{ address.city }}</td>
+        <td>{{ links.build_external_address_link(address) }}</td>
+        <td>
+          {% set search_params = {
+                      "search-0-search_field": "OFFERER",
+                      "search-0-operator": "IN",
+                      "search-0-offerer": offerer_id,
+                      "search-1-search_field": "ADDRESS",
+                      "search-1-operator": "IN",
+                      "search-1-address": address.id,
+                    } %}
+          <a href="{{ url_for('backoffice_web.offer.list_offers', **search_params) }}"
+             class="link-primary">individuelles</a>
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>

--- a/api/src/pcapi/static/backoffice/js/addons/pc-table-manager.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-table-manager.js
@@ -71,7 +71,7 @@ class PcTableManager extends PcAddOn {
   }
 
   #initializeTableFromHtml = ($table) => {
-    const lines = $table.querySelectorAll("tr")
+    const lines = $table.querySelectorAll(":scope > tbody > tr")
     const configuration = this.#initializeHeaders($table)
     lines.forEach(($line) => {
       this.#initializeRow(configuration, $line)
@@ -80,7 +80,7 @@ class PcTableManager extends PcAddOn {
   }
 
   #initializeRow = (configuration, $line) => {
-    const cells = $line.querySelectorAll("td")
+    const cells = $line.querySelectorAll(":scope > td")
     if (cells !== null) {
       for (let i=0; i < Math.min(cells.length, configuration.columns.length); i++) {
         cells[i].classList.add(configuration.columns[i].id)
@@ -95,7 +95,7 @@ class PcTableManager extends PcAddOn {
       displayMenu: String($table.dataset.pcTableMenuHide).toLowerCase() !== "true",
       columns: [],
     }
-    $table.querySelectorAll("th").forEach(($column) => {
+    $table.querySelectorAll(":scope > thead > tr > th").forEach(($column) => {
       headerNumber++
       const columnConfiguration = {}
       const text_content = $column.textContent.replaceAll(/\n/g, '').trim()
@@ -337,7 +337,7 @@ class PcTableManager extends PcAddOn {
     }
 
     $table.classList.add('d-none')
-    $table.querySelectorAll("tr").forEach(($line) => {
+    $table.querySelectorAll(":scope > thead > tr, :scope > tbody > tr").forEach(($line) => {
       this.#applyConfigurationOnLine(configuration, $line)
     })
     $table.classList.remove('d-none')
@@ -403,7 +403,7 @@ class PcTableManager extends PcAddOn {
         const configuration = this.configurations[tableId]
         const defaultConfiguration = this.defaultConfigurations[tableId]
         tempTable.innerHTML = event.detail.serverResponse
-        const $newLines = tempTable.querySelectorAll("tr")
+        const $newLines = tempTable.querySelectorAll(":scope > tbody > tr")
         // re-arrange each line's columns to fit applied filters
         $newLines.forEach(($newLine) => {
           this.#initializeRow(defaultConfiguration, $newLine)

--- a/api/src/pcapi/utils/date.py
+++ b/api/src/pcapi/utils/date.py
@@ -180,6 +180,10 @@ def date_to_localized_datetime(date_: date | None, time_: time) -> datetime | No
     return pytz.timezone(METROPOLE_TIMEZONE).localize(naive_utc_datetime).astimezone(pytz.utc)
 
 
+def datetime_to_localized_datetime(dt: datetime) -> datetime:
+    return pytz.timezone(METROPOLE_TIMEZONE).localize(dt).astimezone(pytz.utc)
+
+
 def to_department_midnight(dt: datetime | date, department_code: str | None) -> datetime:
     local_tz = get_department_timezone(department_code)
     return datetime.combine(date(dt.year, dt.month, dt.day), time.min, ZoneInfo(local_tz))

--- a/api/tests/routes/backoffice/chronicles_test.py
+++ b/api/tests/routes/backoffice/chronicles_test.py
@@ -380,8 +380,7 @@ class UpdateChronicleContentTest(PostEndpointHelper):
         db.session.refresh(chronicle)
 
         # ensure that the row is rendered
-        row = html_parser.get_tag(response.data, tag="tr", id=f"chronicle-row-{chronicle.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"chronicle-row-{chronicle.id}")
         assert cells[3] == "new content"
 
 
@@ -438,8 +437,7 @@ class PublishChronicleTest(PostEndpointHelper):
         assert chronicle.isActive
 
         # ensure that the row is rendered
-        row = html_parser.get_tag(response.data, tag="tr", id=f"chronicle-row-{chronicle.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"chronicle-row-{chronicle.id}")
         assert cells[5] == "Oui"
 
         action_log = db.session.query(history_models.ActionHistory).one()
@@ -510,8 +508,7 @@ class UnpublishChronicleTest(PostEndpointHelper):
         assert not chronicle.isActive
 
         # ensure that the row is rendered
-        row = html_parser.get_tag(response.data, tag="tr", id=f"chronicle-row-{chronicle.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"chronicle-row-{chronicle.id}")
         assert cells[5] == "Non"
 
         action_log = db.session.query(history_models.ActionHistory).one()

--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -559,8 +559,7 @@ class MarkCollectiveBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{cancelled.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{cancelled.id}")
         assert cells[1] == str(cancelled.id)
 
         db.session.refresh(cancelled)
@@ -580,8 +579,7 @@ class MarkCollectiveBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{non_cancelled.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{non_cancelled.id}")
         assert cells[1] == str(non_cancelled.id)
 
         db.session.refresh(non_cancelled)
@@ -607,8 +605,7 @@ class CancelCollectiveBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{confirmed.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{confirmed.id}")
         assert cells[1] == str(confirmed.id)
 
         db.session.refresh(confirmed)
@@ -631,8 +628,7 @@ class CancelCollectiveBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking_id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking_id}")
         assert cells[1] == str(booking_id)
 
         booking = db.session.query(educational_models.CollectiveBooking).filter_by(id=booking_id).one()
@@ -654,8 +650,7 @@ class CancelCollectiveBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking_id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking_id}")
         assert cells[1] == str(booking_id)
 
         booking = db.session.query(educational_models.CollectiveBooking).filter_by(id=booking_id).one()

--- a/api/tests/routes/backoffice/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice/collective_offer_templates_test.py
@@ -479,13 +479,9 @@ class ValidateCollectiveOfferTemplateTest(PostEndpointHelper):
         )
         assert response.status_code == 200
 
-        row = html_parser.get_tag(
-            response.data,
-            tag="tr",
-            id=f"collective-offer-template-row-{collective_offer_template_to_validate.id}",
-            is_xml=True,
+        cells = html_parser.extract_plain_row(
+            response.data, id=f"collective-offer-template-row-{collective_offer_template_to_validate.id}"
         )
-        cells = html_parser.extract(row, "td", is_xml=True)
         assert cells[2] == str(collective_offer_template_to_validate.id)
 
         assert collective_offer_template_to_validate.isActive is True
@@ -580,13 +576,10 @@ class RejectCollectiveOfferTemplateTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(
+        cells = html_parser.extract_plain_row(
             response.data,
-            tag="tr",
             id=f"collective-offer-template-row-{collective_offer_template_to_reject.id}",
-            is_xml=True,
         )
-        cells = html_parser.extract(row, "td", is_xml=True)
         assert cells[2] == str(collective_offer_template_to_reject.id)
 
         assert collective_offer_template_to_reject.isActive is False
@@ -663,10 +656,10 @@ class BatchCollectiveOfferTemplatesValidateTest(PostEndpointHelper):
             assert collective_offer_template.lastValidationType is OfferValidationType.MANUAL
             assert collective_offer_template.validation is OfferValidationStatus.APPROVED
             assert collective_offer_template.lastValidationAuthor == legit_user
-            row = html_parser.get_tag(
-                response.data, tag="tr", id=f"collective-offer-template-row-{collective_offer_template.id}", is_xml=True
+            cells = html_parser.extract_plain_row(
+                response.data,
+                id=f"collective-offer-template-row-{collective_offer_template.id}",
             )
-            cells = html_parser.extract(row, "td", is_xml=True)
             assert cells[2] == str(collective_offer_template.id)
 
         received_dict = {email["To"]: email["template"] for email in mails_testing.outbox}
@@ -734,10 +727,10 @@ class BatchCollectiveOfferTemplatesRejectTest(PostEndpointHelper):
                 collective_offer_template.rejectionReason
                 is educational_models.CollectiveOfferRejectionReason.WRONG_DATE
             )
-            row = html_parser.get_tag(
-                response.data, tag="tr", id=f"collective-offer-template-row-{collective_offer_template.id}", is_xml=True
+            cells = html_parser.extract_plain_row(
+                response.data,
+                id=f"collective-offer-template-row-{collective_offer_template.id}",
             )
-            cells = html_parser.extract(row, "td", is_xml=True)
             assert cells[2] == str(collective_offer_template.id)
 
         assert len(mails_testing.outbox) == 3

--- a/api/tests/routes/backoffice/collective_offers_test.py
+++ b/api/tests/routes/backoffice/collective_offers_test.py
@@ -1101,10 +1101,10 @@ class ValidateCollectiveOfferTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"collective-offer-row-{collective_offer_to_validate.id}", is_xml=True
+        cells = html_parser.extract_plain_row(
+            response.data,
+            id=f"collective-offer-row-{collective_offer_to_validate.id}",
         )
-        cells = html_parser.extract(row, "td", is_xml=True)
         assert cells[2] == str(collective_offer_to_validate.id)
         assert cells[6] == "• Validée"
 
@@ -1318,10 +1318,7 @@ class RejectCollectiveOfferTest(PostEndpointHelper):
         )
         assert response.status_code == 200
 
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"collective-offer-row-{collective_offer_to_reject.id}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"collective-offer-row-{collective_offer_to_reject.id}")
         assert cells[2] == str(collective_offer_to_reject.id)
         assert cells[6] == "• Rejetée Tarif erroné"
 
@@ -1393,10 +1390,7 @@ class BatchCollectiveOffersValidateTest(PostEndpointHelper):
             assert collective_offer.isActive is True
             assert collective_offer.lastValidationType is OfferValidationType.MANUAL
             assert collective_offer.validation is OfferValidationStatus.APPROVED
-            row = html_parser.get_tag(
-                response.data, tag="tr", id=f"collective-offer-row-{collective_offer.id}", is_xml=True
-            )
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"collective-offer-row-{collective_offer.id}")
             assert cells[2] == str(collective_offer.id)
             assert cells[6] == "• Validée"
 
@@ -1502,10 +1496,7 @@ class BatchCollectiveOffersRejectTest(PostEndpointHelper):
             assert collective_offer.validation is OfferValidationStatus.REJECTED
             assert collective_offer.lastValidationAuthor == legit_user
             assert collective_offer.rejectionReason == reason
-            row = html_parser.get_tag(
-                response.data, tag="tr", id=f"collective-offer-row-{collective_offer.id}", is_xml=True
-            )
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"collective-offer-row-{collective_offer.id}")
             assert cells[2] == str(collective_offer.id)
             assert "• Rejetée" in cells[6]
 

--- a/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
+++ b/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
@@ -545,8 +545,7 @@ class EditCustomReimbursementRuleTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"custom-reimbursement-rule-row-{rule.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"custom-reimbursement-rule-row-{rule.id}")
         assert cells[1] == str(rule.id)
 
         db.session.refresh(rule)
@@ -568,8 +567,7 @@ class EditCustomReimbursementRuleTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"custom-reimbursement-rule-row-{rule.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"custom-reimbursement-rule-row-{rule.id}")
         assert cells[1] == str(rule.id)
 
         db.session.refresh(rule)
@@ -588,8 +586,7 @@ class EditCustomReimbursementRuleTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"custom-reimbursement-rule-row-{rule.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"custom-reimbursement-rule-row-{rule.id}")
         assert cells[1] == str(rule.id)
 
         db.session.refresh(rule)
@@ -605,8 +602,7 @@ class EditCustomReimbursementRuleTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"custom-reimbursement-rule-row-{rule.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"custom-reimbursement-rule-row-{rule.id}")
         assert cells[1] == str(rule.id)
 
         db.session.refresh(rule)

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -1818,8 +1818,7 @@ class CreateOverpaymentTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         incidents = db.session.query(finance_models.FinanceIncident).all()
@@ -1857,8 +1856,7 @@ class CreateOverpaymentTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         alerts = flash.get_htmx_flash_messages(authenticated_client)
@@ -1906,8 +1904,7 @@ class CreateOverpaymentTest(PostEndpointHelper):
 
         assert response.status_code == 200
         for booking in selected_bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
         assert db.session.query(finance_models.FinanceIncident).count() == 1
@@ -1954,8 +1951,7 @@ class CreateOverpaymentTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         alerts = flash.get_htmx_flash_messages(authenticated_client)
@@ -2163,8 +2159,7 @@ class CreateCommercialGestureTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         assert db.session.query(finance_models.FinanceIncident).count() == 1
@@ -2200,8 +2195,7 @@ class CreateCommercialGestureTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         assert db.session.query(finance_models.FinanceIncident).count() == 0
@@ -2231,8 +2225,7 @@ class CreateCommercialGestureTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         assert db.session.query(finance_models.FinanceIncident).count() == 0
@@ -2261,8 +2254,7 @@ class CreateCommercialGestureTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         assert db.session.query(finance_models.FinanceIncident).count() == 0  # didn't create new incident
@@ -2306,8 +2298,7 @@ class CreateCommercialGestureTest(PostEndpointHelper):
 
         assert response.status_code == 200
         for booking in selected_bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
         alerts = flash.get_htmx_flash_messages(authenticated_client)
@@ -2344,8 +2335,7 @@ class CreateCollectiveBookingOverpaymentTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{collective_booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{collective_booking.id}")
         assert cells[1] == str(collective_booking.id)
 
         finance_incidents = db.session.query(finance_models.FinanceIncident).all()
@@ -2390,8 +2380,7 @@ class CreateCollectiveBookingOverpaymentTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{collective_booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{collective_booking.id}")
         assert cells[1] == str(collective_booking.id)
 
         assert db.session.query(finance_models.FinanceIncident).count() == expected_incident_count
@@ -2421,8 +2410,7 @@ class CreateCollectiveBookingOverpaymentTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{collective_booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{collective_booking.id}")
         assert cells[1] == str(collective_booking.id)
 
         assert db.session.query(finance_models.FinanceIncident).count() == 2

--- a/api/tests/routes/backoffice/individual_bookings_test.py
+++ b/api/tests/routes/backoffice/individual_bookings_test.py
@@ -759,8 +759,7 @@ class MarkBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{cancelled.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{cancelled.id}")
         assert cells[2] == str(cancelled.id)
 
         db.session.refresh(cancelled)
@@ -780,8 +779,7 @@ class MarkBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         booking = db.session.query(bookings_models.Booking).filter_by(id=booking.id).one()
@@ -802,8 +800,7 @@ class MarkBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         booking = db.session.query(bookings_models.Booking).filter_by(id=booking.id).one()
@@ -829,8 +826,7 @@ class MarkBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         booking = db.session.query(bookings_models.Booking).filter_by(id=booking.id).one()
@@ -854,8 +850,7 @@ class MarkBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking_id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking_id}")
         assert cells[2] == str(booking_id)
 
         booking = db.session.query(bookings_models.Booking).filter_by(id=booking_id).one()
@@ -878,8 +873,7 @@ class MarkBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking_id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking_id}")
         assert cells[2] == str(booking_id)
 
         booking = db.session.query(bookings_models.Booking).filter_by(id=booking_id).one()
@@ -901,8 +895,7 @@ class MarkBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{festival_booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{festival_booking.id}")
         assert cells[2] == str(festival_booking.id)
         assert festival_booking.user.achievements
 
@@ -923,8 +916,7 @@ class CancelBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{confirmed.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{confirmed.id}")
         assert cells[2] == str(confirmed.id)
 
         db.session.refresh(confirmed)
@@ -950,8 +942,7 @@ class CancelBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking_to_cancel.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking_to_cancel.id}")
         assert cells[2] == str(booking_to_cancel.id)
 
         db.session.refresh(booking_to_cancel)
@@ -971,8 +962,7 @@ class CancelBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{pricing.bookingId}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{pricing.bookingId}")
         assert cells[2] == str(pricing.bookingId)
 
         db.session.refresh(pricing)
@@ -996,8 +986,7 @@ class CancelBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{reimbursed.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{reimbursed.id}")
         assert cells[2] == str(reimbursed.id)
 
         db.session.refresh(reimbursed)
@@ -1021,8 +1010,7 @@ class CancelBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{cancelled.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{cancelled.id}")
         assert cells[2] == str(cancelled.id)
 
         db.session.refresh(cancelled)
@@ -1108,8 +1096,7 @@ class CancelBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         db.session.refresh(booking)
@@ -1168,8 +1155,7 @@ class CancelBookingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking_to_cancel.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking_to_cancel.id}")
         assert cells[2] == str(booking_to_cancel.id)
 
         db.session.refresh(booking_to_cancel)
@@ -1213,8 +1199,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
             assert booking.status is bookings_models.BookingStatus.USED
             assert booking.validationAuthorType == bookings_models.BookingValidationAuthorType.BACKOFFICE
 
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
     def test_batch_mark_as_used_cancelled_bookings(self, legit_user, authenticated_client):
@@ -1233,8 +1218,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
             assert booking.status is bookings_models.BookingStatus.USED
             assert booking.validationAuthorType == bookings_models.BookingValidationAuthorType.BACKOFFICE
 
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
     def test_batch_mark_as_used_with_already_used_bookings(self, legit_user, authenticated_client):
@@ -1250,8 +1234,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
 
         assert response.status_code == 200
         for booking in bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
         assert bookings[0].status is bookings_models.BookingStatus.USED
@@ -1282,8 +1265,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
         )
         assert response.status_code == 200
         for booking in bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
         db.session.refresh(expired_booking)
@@ -1312,8 +1294,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
         assert response.status_code == 200
 
         for booking in bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
     def test_batch_mark_as_used_bookings_insufficient_stock(self, legit_user, authenticated_client):
@@ -1341,8 +1322,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
         assert response.status_code == 200
 
         for booking in bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
     def test_batch_mark_as_used_when_offerer_is_closed(self, legit_user, authenticated_client):
@@ -1357,8 +1337,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
         assert cells[2] == str(booking.id)
 
         alerts = flash.get_htmx_flash_messages(authenticated_client)
@@ -1422,8 +1401,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
 
-        row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{festival_booking.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{festival_booking.id}")
         assert cells[2] == str(festival_booking.id)
 
         assert festival_booking.user.achievements
@@ -1490,8 +1468,7 @@ class BatchCancelIndividualBookingsTest(PostEndpointHelper):
         )
         assert response.status_code == 200
         for booking in bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
 
@@ -1555,8 +1532,7 @@ class BatchTagFraudulentBookingsTest(PostEndpointHelper):
 
         assert response.status_code == 200
         for booking in bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
         all_tags = db.session.query(bookings_models.FraudulentBookingTag).all()
@@ -1606,8 +1582,7 @@ class BatchTagFraudulentBookingsTest(PostEndpointHelper):
 
         assert response.status_code == 200
         for booking in bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
         all_tags = db.session.query(bookings_models.FraudulentBookingTag).all()
@@ -1684,8 +1659,7 @@ class BatchRemoveFraudulentBookingTagTest(PostEndpointHelper):
 
         assert response.status_code == 200
         for booking in bookings:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"booking-row-{booking.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"booking-row-{booking.id}")
             assert cells[2] == str(booking.id)
 
         all_tags = db.session.query(bookings_models.FraudulentBookingTag).all()

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -2912,8 +2912,7 @@ class ValidateOffererTest(ActivateOffererHelper):
 
         assert response.status_code == 200
 
-        row = html_parser.get_tag(response.data, tag="tr", id=f"offerer-row-{offerer.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"offerer-row-{offerer.id}")
         assert cells[2] == str(offerer.id)
 
     def test_validate_rejected_offerer(self, legit_user, authenticated_client):
@@ -3079,8 +3078,7 @@ class RejectOffererTest(DeactivateOffererHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"offerer-row-{offerer.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"offerer-row-{offerer.id}")
         assert cells[2] == str(offerer.id)
 
     def test_reject_offerer_keep_pro_role(self, authenticated_client):
@@ -3213,8 +3211,7 @@ class SetOffererPendingTest(DeactivateOffererHelper):
 
         assert response.status_code == 200
 
-        row = html_parser.get_tag(response.data, tag="tr", id=f"offerer-row-{offerer.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"offerer-row-{offerer.id}")
         assert cells[2] == str(offerer.id)
 
     def test_set_offerer_pending_keep_pro_role(self, authenticated_client):
@@ -3681,8 +3678,7 @@ class ValidateOffererAttachmentTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"user-offerer-row-{user_offerer.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"user-offerer-row-{user_offerer.id}")
         assert cells[2] == str(user_offerer.user.id)
 
     def test_validate_offerer_attachment_returns_404_if_offerer_is_not_found(self, authenticated_client, offerer):
@@ -3761,8 +3757,7 @@ class RejectOffererAttachmentTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"user-offerer-row-{user_offerer.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"user-offerer-row-{user_offerer.id}")
         assert cells[2] == str(user_offerer.user.id)
 
     def test_reject_offerer_returns_404_if_offerer_attachment_is_not_found(self, authenticated_client, offerer):
@@ -3807,8 +3802,7 @@ class SetOffererAttachmentPendingTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(response.data, tag="tr", id=f"user-offerer-row-{user_offerer.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"user-offerer-row-{user_offerer.id}")
         assert cells[2] == str(user_offerer.user.id)
 
     def test_set_offerer_attachment_pending_keep_pro_role(self, authenticated_client):
@@ -4087,8 +4081,7 @@ class BatchOffererValidateTest(PostEndpointHelper):
                 }
 
             # ensure that the row is rendered
-            row = html_parser.get_tag(response.data, tag="tr", id=f"offerer-row-{offerer.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"offerer-row-{offerer.id}")
             assert cells[2] == str(offerer.id)
 
 
@@ -4154,8 +4147,7 @@ class SetBatchOffererPendingTest(PostEndpointHelper):
                 }
             }
             # ensure that the row is rendered
-            row = html_parser.get_tag(response.data, tag="tr", id=f"offerer-row-{offerer.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"offerer-row-{offerer.id}")
             assert cells[2] == str(offerer.id)
 
 
@@ -4210,8 +4202,7 @@ class BatchOffererRejectTest(PostEndpointHelper):
             assert action.extraData == {"rejection_reason": rejection_reason}
 
             # ensure that the row is rendered
-            row = html_parser.get_tag(response.data, tag="tr", id=f"offerer-row-{offerer.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"offerer-row-{offerer.id}")
             assert cells[2] == str(offerer.id)
 
 
@@ -4248,8 +4239,7 @@ class BatchOffererAttachmentValidateTest(PostEndpointHelper):
             assert action.userId == user_offerer.user.id
             assert action.offererId == user_offerer.offerer.id
             assert action.venueId is None
-            row = html_parser.get_tag(response.data, tag="tr", id=f"user-offerer-row-{user_offerer.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"user-offerer-row-{user_offerer.id}")
             assert cells[2] == str(user_offerer.user.id)
 
         assert len(mails_testing.outbox) == len(user_offerers)
@@ -4317,8 +4307,7 @@ class SetBatchOffererAttachmentPendingTest(PostEndpointHelper):
             assert action.offererId == user_offerer.offerer.id
             assert action.venueId is None
             assert action.comment == "test comment"
-            row = html_parser.get_tag(response.data, tag="tr", id=f"user-offerer-row-{user_offerer.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"user-offerer-row-{user_offerer.id}")
             assert cells[2] == str(user_offerer.user.id)
 
 
@@ -4371,8 +4360,7 @@ class BatchOffererAttachmentRejectTest(PostEndpointHelper):
             assert action.offererId == user_offerer.offerer.id
             assert action.comment == "test comment"
             assert action.venueId is None
-            row = html_parser.get_tag(response.data, tag="tr", id=f"user-offerer-row-{user_offerer.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"user-offerer-row-{user_offerer.id}")
             assert cells[2] == str(user_offerer.user.id)
 
         assert len(mails_testing.outbox) == len(user_offerers)

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -1722,8 +1722,7 @@ class EditOfferTest(PostEndpointHelper):
         )
         assert response.status_code == 200
         # ensure that the row is rendered
-        row = html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offer_to_edit.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"offer-row-{offer_to_edit.id}")
         assert len(cells) == 25
         i = count()
         assert cells[next(i)] == ""  # Checkbox
@@ -1866,9 +1865,9 @@ class BatchEditOfferTest(PostEndpointHelper):
         response = self.post_to_endpoint(authenticated_client, form=base_form, expected_num_queries=10)
         assert response.status_code == 200
         # ensure rows are rendered
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[0].id}", is_xml=True)
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[1].id}", is_xml=True)
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[2].id}", is_xml=True)
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[0].id}")
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[1].id}")
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[2].id}")
 
         for offer in offers:
             assert offer.rankingWeight == chosen_ranking_weight
@@ -2193,8 +2192,7 @@ class ValidateOfferTest(PostEndpointHelper):
         )
         assert response.status_code == 200
         # ensure that the row is rendered
-        row = html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offer_to_validate.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"offer-row-{offer_to_validate.id}")
         assert len(cells) == 25
         i = count()
         assert cells[next(i)] == ""  # Checkbox
@@ -2310,8 +2308,7 @@ class RejectOfferTest(PostEndpointHelper):
         )
         assert response.status_code == 200
         # ensure that the row is rendered
-        row = html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offer_to_reject.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"offer-row-{offer_to_reject.id}")
         assert len(cells) == 25
         i = count()
         assert cells[next(i)] == ""  # Checkbox
@@ -2412,9 +2409,9 @@ class BatchOfferValidateTest(PostEndpointHelper):
 
         assert response.status_code == 200
         # ensure rows are rendered
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[0].id}", is_xml=True)
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[1].id}", is_xml=True)
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[2].id}", is_xml=True)
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[0].id}")
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[1].id}")
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[2].id}")
         for offer in offers:
             db.session.refresh(offer)
             assert offer.lastValidationDate.strftime("%d/%m/%Y") == datetime.date.today().strftime("%d/%m/%Y")
@@ -3599,8 +3596,7 @@ class ActivateOfferTest(PostEndpointHelper):
         )
         assert response.status_code == 200
         # ensure that the row is rendered
-        row = html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offer_to_activate.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"offer-row-{offer_to_activate.id}")
         assert len(cells) == 25
         i = count()
         assert cells[next(i)] == ""  # Checkbox
@@ -3696,8 +3692,7 @@ class DeactivateOfferTest(PostEndpointHelper):
         )
         assert response.status_code == 200
         # ensure that the row is rendered
-        row = html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offer_to_deactivate.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"offer-row-{offer_to_deactivate.id}")
         assert len(cells) == 25
         i = count()
         assert cells[next(i)] == ""  # Checkbox
@@ -3774,9 +3769,9 @@ class BatchOfferActivateTest(PostEndpointHelper):
 
         assert response.status_code == 200
         # ensure rows are rendered
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[0].id}", is_xml=True)
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[1].id}", is_xml=True)
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[2].id}", is_xml=True)
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[0].id}")
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[1].id}")
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[2].id}")
         for offer in offers:
             db.session.refresh(offer)
             assert offer.isActive is True
@@ -3805,9 +3800,9 @@ class BatchOfferDeactivateTest(PostEndpointHelper):
 
         assert response.status_code == 200
         # ensure rows are rendered
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[0].id}", is_xml=True)
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[1].id}", is_xml=True)
-        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[2].id}", is_xml=True)
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[0].id}")
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[1].id}")
+        html_parser.get_tag(response.data, tag="tr", id=f"offer-row-{offers[2].id}")
         for offer in offers:
             db.session.refresh(offer)
             assert offer.isActive is False

--- a/api/tests/routes/backoffice/operations_test.py
+++ b/api/tests/routes/backoffice/operations_test.py
@@ -626,10 +626,7 @@ class SetResponseStatusTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"operation-response-row-{event_response.id}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"operation-response-row-{event_response.id}")
         assert cells[2] == str(event_response.id)
         db.session.refresh(event_response)
         assert event_response.status == response_status
@@ -682,10 +679,7 @@ class BatchValidateResponsesStatusTest(PostEndpointHelper):
         )
         assert response.status_code == 200
         for event_response in (event_response1, event_response2):
-            row = html_parser.get_tag(
-                response.data, tag="tr", id=f"operation-response-row-{event_response.id}", is_xml=True
-            )
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"operation-response-row-{event_response.id}")
             assert cells[2] == str(event_response.id)
         db.session.refresh(event_response1)
         db.session.refresh(event_response2)

--- a/api/tests/routes/backoffice/update_request_test.py
+++ b/api/tests/routes/backoffice/update_request_test.py
@@ -585,10 +585,7 @@ class InstructTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
 
         mock_make_on_going.assert_called_once()
@@ -612,10 +609,7 @@ class InstructTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
 
         alerts = flash.get_htmx_flash_messages(authenticated_client)
@@ -644,10 +638,7 @@ class InstructTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
 
         alerts = flash.get_htmx_flash_messages(authenticated_client)
@@ -917,10 +908,7 @@ class AcceptTest(PostEndpointHelper):
         )
         assert response.status_code == 200
         mock_make_accepted.assert_called_once()
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
 
         db.session.refresh(update_request)
@@ -1066,10 +1054,7 @@ class AcceptTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
         mock_make_accepted.assert_called_once()
 
@@ -1102,10 +1087,7 @@ class AcceptTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
         mock_make_accepted.assert_called_once()
 
@@ -1190,10 +1172,7 @@ class AcceptTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
         mock_make_accepted.assert_not_called()
 
@@ -1302,10 +1281,7 @@ class AskForCorrectionTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
         mock_send_user_message.assert_called_once()
 
@@ -1345,10 +1321,7 @@ class AskForCorrectionTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
         mock_send_user_message.assert_not_called()
 
@@ -1385,10 +1358,7 @@ class AskForCorrectionTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
         mock_send_user_message.assert_called_once()
 
@@ -1419,10 +1389,7 @@ class AskForCorrectionTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
         mock_execute_query.assert_called_once()
 
@@ -1523,10 +1490,7 @@ class IdentityTheftTest(PostEndpointHelper):
         )
 
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
         mock_make_refused.assert_called_once()
 
@@ -1563,10 +1527,7 @@ class IdentityTheftTest(PostEndpointHelper):
             headers={"hx-request": "true"},
         )
         assert response.status_code == 200
-        row = html_parser.get_tag(
-            response.data, tag="tr", id=f"request-row-{update_request.dsApplicationId}", is_xml=True
-        )
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"request-row-{update_request.dsApplicationId}")
         assert str(update_request.dsApplicationId) in cells[1]
         mock_make_refused.assert_called_once()
 

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -2826,8 +2826,7 @@ class BatchEditVenuesTest(PostEndpointHelper):
         assert response.status_code == 200
 
         for venue in venues:
-            row = html_parser.get_tag(response.data, tag="tr", id=f"venue-row-{venue.id}", is_xml=True)
-            cells = html_parser.extract(row, "td", is_xml=True)
+            cells = html_parser.extract_plain_row(response.data, id=f"venue-row-{venue.id}")
             assert cells[1] == str(venue.id)
 
         assert set(venues[0].criteria) == {criteria[0], new_criterion}  # 1 kept, 1 removed, 1 added
@@ -2862,8 +2861,7 @@ class BatchEditVenuesTest(PostEndpointHelper):
         response = self.post_to_endpoint(authenticated_client, form=form_data)
         assert response.status_code == 200
 
-        row = html_parser.get_tag(response.data, tag="tr", id=f"venue-row-{venues[0].id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"venue-row-{venues[0].id}")
         assert cells[1] == str(venues[0].id)
 
         assert set(venues[0].criteria) == {criteria[0], new_criterion}
@@ -2899,8 +2897,7 @@ class BatchEditVenuesTest(PostEndpointHelper):
         response = self.post_to_endpoint(authenticated_client, form=form_data)
         assert response.status_code == 200
 
-        row = html_parser.get_tag(response.data, tag="tr", id=f"venue-row-{venue.id}", is_xml=True)
-        cells = html_parser.extract(row, "td", is_xml=True)
+        cells = html_parser.extract_plain_row(response.data, id=f"venue-row-{venue.id}")
         assert cells[1] == str(venue.id)
 
         assert venue.isPermanent is set_permanent


### PR DESCRIPTION
[Ticket Jira](https://passculture.atlassian.net/browse/PC-37561)

Stockage de l'historique des modifications des campagnes de mise à jour des données :

 - [x] Ajout de la colonne `userProfileRefreshCampaign` dans le modèle `ActionHistory`
 - [x] Création des ActionHistory lors de la mise à jour de et de la création des campagnes
 - [x] Désactivation de toutes les campagnes existantes lors de l'activation d'une nouvelle campagne
 - [x] Affichage des l'historique des modifications des campagne dans la page dédiée :
<img width="1162" height="347" alt="Capture d’écran 2025-09-26 à 17 44 38" src="https://github.com/user-attachments/assets/5848b51a-e104-4d1d-baa1-a8671b0a5af8" />
