### PR TITLE
(BSR)[API] fix: test_ubble_workflow_with_eligibility_change_with_first_attempt_at_18

### DIFF
--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -501,7 +501,9 @@ class UbbleWorkflowV2Test:
         )
         requests_mock.get(
             f"{settings.UBBLE_API_URL}/v2/identity-verifications/{fraud_check.thirdPartyId}",
-            json=build_ubble_identification_v2_response(age_at_registration=19),
+            json=build_ubble_identification_v2_response(
+                age_at_registration=19, created_on=datetime.datetime.utcnow() - relativedelta(months=2)
+            ),
         )
 
         ubble_subscription_api.update_ubble_workflow(fraud_check)


### PR DESCRIPTION
Test failed from 2025-09-29 because of hardcoded created_on in UBBLE_IDENTIFICATION_V2_RESPONSE
