### PR TITLE
(PC-38103)[API] feat: update `CineDigitalServiceAPI.get_show` to raise `ExternalBookingShowDoesNotExistError`

### DIFF
--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -181,14 +181,17 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
         )
 
     def get_show(self, show_id: int) -> cds_serializers.ShowCDS:
+        """
+        Fetch all shows and filter them using `show_id`
+
+        :raise: `ExternalBookingShowDoesNotExistError` if no show has the given `show_id`
+        """
         data = self._authenticated_get(f"{self.base_url}shows")
         shows = parse_obj_as(list[cds_serializers.ShowCDS], data)
         for show in shows:
             if show.id == show_id:
                 return show
-        raise cds_exceptions.CineDigitalServiceAPIException(
-            f"Show #{show_id} not found in Cine Digital Service API for cinemaId={self.cinema_id} & url={self.base_url}"
-        )
+        raise external_bookings_exceptions.ExternalBookingShowDoesNotExistError()
 
     def get_venue_movies(self) -> list[cds_serializers.MediaCDS]:
         data = self._authenticated_get(f"{self.base_url}media")

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -182,7 +182,7 @@ class CineDigitalServiceGetShowTest:
         )
 
         with caplog.at_level(logging.DEBUG, logger="pcapi.core.external_bookings.cds.client"):
-            with pytest.raises(cds_exceptions.CineDigitalServiceAPIException) as cds_exception:
+            with pytest.raises(external_bookings_exceptions.ExternalBookingShowDoesNotExistError):
                 cine_digital_service.get_show(4)
 
         assert len(caplog.records) == 1
@@ -193,11 +193,6 @@ class CineDigitalServiceGetShowTest:
             "cinema_id": "test_id",
             "response": ONE_SHOW_RESPONSE_JSON,
         }
-
-        assert (
-            str(cds_exception.value)
-            == "Show #4 not found in Cine Digital Service API for cinemaId=test_id & url=https://accountid_test.apiUrl_test/"
-        )
 
     @pytest.mark.parametrize(
         "seatmap, expected_result",

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -676,6 +676,76 @@ class PostBookingTest:
         assert post_adapter.last_request == None
 
     @time_machine.travel("2022-10-12 17:09:25")
+    @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
+    def test_handle_cds_showtime_does_not_exist_case(
+        self,
+        client,
+        requests_mock,
+    ):
+        users_factories.BeneficiaryGrant18Factory(email=self.identifier, dateOfBirth=datetime(2007, 1, 1))
+
+        id_at_provider = "test_id_at_provider"
+
+        provider = db.session.query(providers_models.Provider).filter_by(localClass="CDSStocks").first()
+        venue_provider = providers_factories.VenueProviderFactory(
+            provider=provider, venueIdAtOfferProvider=id_at_provider
+        )
+        pivot = providers_factories.CinemaProviderPivotFactory(
+            venue=venue_provider.venue, provider=provider, idAtProvider=id_at_provider
+        )
+        providers_factories.CDSCinemaDetailsFactory(
+            accountId="accountid_test",
+            cinemaProviderPivot=pivot,
+            cinemaApiToken="token_test",
+        )
+        stock = offers_factories.EventStockFactory(
+            lastProvider=provider,
+            offer__subcategoryId=subcategories.SEANCE_CINE.id,
+            offer__lastProvider=provider,
+            offer__withdrawalType=offer_models.WithdrawalTypeEnum.IN_APP,
+            offer__venue=venue_provider.venue,
+            quantity=1,
+            idAtProviders="#1",
+        )
+        requests_mock.get(
+            "https://accountid_test.apiUrl_test/shows",
+            status_code=200,
+            json=[
+                {
+                    "id": 123456,  # id does not match
+                    "remaining_place": 88,
+                    "internet_remaining_place": 10,
+                    "disableseatmap": False,
+                    "is_empty_seatmap": False,
+                    "showtime": "2022-03-28T12:00:00.000+0200",
+                    "is_cancelled": False,
+                    "is_deleted": False,
+                    "showsTariffPostypeCollection": [{"tariffid": {"id": 96}}],
+                    "screenid": {"id": 10},
+                    "mediaid": {"id": 52},
+                    "showsMediaoptionsCollection": [
+                        {"mediaoptionsid": {"id": 12}},
+                    ],
+                },
+            ],
+        )
+
+        post_adapter = requests_mock.post(
+            "https://accountid_test.apiUrl_test/transaction/create?api_token=token_test",
+            json={},
+        )
+
+        response = client.with_token(self.identifier).post(
+            "/native/v1/bookings", json={"stockId": stock.id, "quantity": 1}
+        )
+
+        assert response.status_code == 400
+        assert response.json == {"code": "PROVIDER_SHOW_DOES_NOT_EXIST"}
+        assert stock.isSoftDeleted
+        assert len(db.session.query(bookings_models.Booking).all()) == 0
+        assert post_adapter.last_request == None
+
+    @time_machine.travel("2022-10-12 17:09:25")
     def test_bookings_with_external_event_api_return_less_tickets_than_quantity(self, client, requests_mock):
         external_booking_url = "https://book_my_offer.com/confirm"
         cancel_booking_url = "https://book_my_offer.com/cancel"


### PR DESCRIPTION
Raise `ExternalBookingShowDoesNotExistError` if no show has given `show_id`

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-38103)

L'exception `ExternalBookingShowDoesNotExistError` est attrapée au niveau de `book_offer` qui soft delete le stock dans ce cas là.


- [ ] Travail pair testé en environnement de preview
