### PR TITLE
(BSR)[API] chore: rename `provider_api_key_required` to `api_key_required`

### DIFF
--- a/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
@@ -26,8 +26,8 @@ from pcapi.routes.serialization import ConfiguredBaseModel
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.transaction_manager import atomic
+from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class BookedCollectiveOffer(ConfiguredBaseModel):
 @blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/confirm", methods=["POST"])
 @atomic()
 @utils.exclude_prod_environment
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     on_success_status=204,
@@ -87,7 +87,7 @@ def confirm_collective_booking(booking_id: int) -> None:
 @blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/cancel", methods=["POST"])
 @atomic()
 @utils.exclude_prod_environment
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     on_success_status=204,
@@ -130,7 +130,7 @@ def adage_mock_cancel_collective_booking(booking_id: int) -> None:
 @blueprints.public_api.route("/v2/collective/bookings/<int:booking_id>/use", methods=["POST"])
 @atomic()
 @utils.exclude_prod_environment
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     on_success_status=204,
@@ -177,7 +177,7 @@ def use_collective_booking(booking_id: int) -> None:
 @blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/pending", methods=["POST"])
 @atomic()
 @utils.exclude_prod_environment
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     on_success_status=204,
@@ -232,7 +232,7 @@ def reset_collective_booking(booking_id: int) -> None:
 @blueprints.public_api.route("/v2/collective/adage_mock/bookings/<int:booking_id>/reimburse", methods=["POST"])
 @atomic()
 @utils.exclude_prod_environment
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     on_success_status=204,
@@ -277,7 +277,7 @@ def reimburse_collective_booking(booking_id: int) -> None:
 @blueprints.public_api.route("/v2/collective/adage_mock/offer/<int:offer_id>/book", methods=["POST"])
 @atomic()
 @utils.exclude_prod_environment
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     on_success_status=200,

--- a/api/src/pcapi/routes/public/collective/endpoints/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/bookings.py
@@ -20,13 +20,13 @@ from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.transaction_manager import atomic
 from pcapi.utils.transaction_manager import on_commit
+from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/bookings/<int:booking_id>", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_BOOKINGS],

--- a/api/src/pcapi/routes/public/collective/endpoints/domains.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/domains.py
@@ -8,12 +8,12 @@ from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.cache import cached_view
 from pcapi.utils.transaction_manager import atomic
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
+from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/educational-domains", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFER_ATTRIBUTES],

--- a/api/src/pcapi/routes/public/collective/endpoints/educational_institutions.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/educational_institutions.py
@@ -7,12 +7,12 @@ from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.transaction_manager import atomic
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
+from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/educational-institutions/", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFER_ATTRIBUTES],

--- a/api/src/pcapi/routes/public/collective/endpoints/national_programs.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/national_programs.py
@@ -7,12 +7,12 @@ from pcapi.routes.serialization import national_programs as serialization
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.transaction_manager import atomic
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
+from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/national-programs/", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFER_ATTRIBUTES],

--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -20,8 +20,8 @@ from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.image_conversion import DO_NOT_CROP
 from pcapi.utils.transaction_manager import atomic
+from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 PATCH_NON_NULLABLE_FIELDS = (
@@ -50,7 +50,7 @@ PATCH_NON_NULLABLE_FIELDS = (
 
 @blueprints.public_api.route("/v2/collective/offers/", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],
@@ -90,7 +90,7 @@ def get_collective_offers_public(
 
 @blueprints.public_api.route("/v2/collective/offers/<int:offer_id>", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],
@@ -129,7 +129,7 @@ def get_collective_offer_public(offer_id: int) -> offers_serialization.GetPublic
 
 @blueprints.public_api.route("/v2/collective/offers/", methods=["POST"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],
@@ -254,7 +254,7 @@ def post_collective_offer_public(
 
 @blueprints.public_api.route("/v2/collective/offers/<int:offer_id>", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],
@@ -506,7 +506,7 @@ def patch_collective_offer_public(
 
 @blueprints.public_api.route("/v2/collective/offers/archive", methods=["POST"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFERS],
@@ -546,7 +546,7 @@ def archive_collective_offers(
 
 @blueprints.public_api.route("/v2/collective/offers/formats", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFER_ATTRIBUTES],

--- a/api/src/pcapi/routes/public/collective/endpoints/students_levels.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/students_levels.py
@@ -7,12 +7,12 @@ from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.transaction_manager import atomic
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
+from pcapi.validation.routes.users_authentifications import api_key_required
 
 
 @blueprints.public_api.route("/v2/collective/student-levels", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.COLLECTIVE_OFFER_ATTRIBUTES],

--- a/api/src/pcapi/routes/public/collective/endpoints/venues.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/venues.py
@@ -9,13 +9,13 @@ from pcapi.routes.public.serialization import venues as venues_serialization
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.transaction_manager import atomic
+from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.deprecated_collective_public_api.route("/v2/collective/venues", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.deprecated_collective_public_api_schema,
     tags=[tags.DEPRECATED_COLLECTIVE_VENUES],
@@ -47,7 +47,7 @@ def list_venues() -> serialization.CollectiveOffersListVenuesResponseModel:
 
 @blueprints.deprecated_collective_public_api.route("/v2/collective/offerer_venues", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.deprecated_collective_public_api_schema,
     tags=[tags.DEPRECATED_COLLECTIVE_VENUES],

--- a/api/src/pcapi/routes/public/individual_offers/v1/addresses.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/addresses.py
@@ -13,7 +13,7 @@ from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.transaction_manager import atomic
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
+from pcapi.validation.routes.users_authentifications import api_key_required
 
 from .serializers.addresses import AddressModel
 from .serializers.addresses import AddressResponse
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 @blueprints.public_api.route("/public/offers/v1/addresses/<int:address_id>", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.ADDRESSES],
@@ -57,7 +57,7 @@ def get_address(
 
 @blueprints.public_api.route("/public/offers/v1/addresses/search", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.ADDRESSES],
@@ -115,7 +115,7 @@ def search_addresses(query: AddressModel) -> SearchAddressResponse:
 
 @blueprints.public_api.route("/public/offers/v1/addresses", methods=["POST"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.ADDRESSES],

--- a/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/bookings.py
@@ -20,8 +20,8 @@ from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.transaction_manager import atomic
+from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 from . import bookings_serialization as serialization
 
@@ -100,7 +100,7 @@ def _get_paginated_and_filtered_bookings(
 
 @blueprints.public_api.route("/public/bookings/v1/bookings", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     response_model=serialization.GetFilteredBookingsResponse,
@@ -160,7 +160,7 @@ def _get_booking_by_token(token: str) -> booking_models.Booking | None:
 
 @blueprints.public_api.route("/public/bookings/v1/token/<string:token>", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     response_model=serialization.GetBookingResponse,
@@ -203,7 +203,7 @@ def get_booking_by_token(token: str) -> serialization.GetBookingResponse:
 
 @blueprints.public_api.route("/public/bookings/v1/use/token/<token>", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     on_success_status=204,
     api=spectree_schemas.public_api_schema,
@@ -251,7 +251,7 @@ def validate_booking_by_token(token: str) -> None:
 
 @blueprints.public_api.route("/public/bookings/v1/keep/token/<token>", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     on_success_status=204,
     api=spectree_schemas.public_api_schema,
@@ -299,7 +299,7 @@ def cancel_booking_validation_by_token(token: str) -> None:
 
 @blueprints.public_api.route("/public/bookings/v1/cancel/token/<token>", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     on_success_status=204,
     api=spectree_schemas.public_api_schema,

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -30,8 +30,8 @@ from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.custom_keys import get_field
 from pcapi.utils.transaction_manager import atomic
+from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 from . import serialization
 from . import utils
@@ -52,7 +52,7 @@ def _deserialize_has_ticket(
 
 @blueprints.public_api.route("/public/offers/v1/events", methods=["POST"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFERS],
@@ -169,7 +169,7 @@ def post_event_offer(body: events_serializers.EventOfferCreation) -> events_seri
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFERS],
@@ -202,7 +202,7 @@ def get_event(event_id: int) -> events_serializers.EventOfferResponse:
 
 @blueprints.public_api.route("/public/offers/v1/events", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFERS],
@@ -237,7 +237,7 @@ def get_events(query: serialization.GetOffersQueryParams) -> events_serializers.
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFERS],
@@ -324,7 +324,7 @@ def edit_event(event_id: int, body: events_serializers.EventOfferEdition) -> eve
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/price_categories", methods=["POST"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_PRICES],
@@ -391,7 +391,7 @@ def post_event_price_categories(
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/price_categories", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_PRICES],
@@ -436,7 +436,7 @@ def get_event_price_categories(
     "/public/offers/v1/events/<int:event_id>/price_categories/<int:price_category_id>", methods=["PATCH"]
 )
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_PRICES],
@@ -496,7 +496,7 @@ def patch_event_price_category(
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/dates", methods=["POST"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_STOCKS],
@@ -580,7 +580,7 @@ def post_event_stocks(
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/dates", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_STOCKS],
@@ -641,7 +641,7 @@ def get_event_stocks(
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/dates/<int:stock_id>", methods=["DELETE"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_STOCKS],
@@ -682,7 +682,7 @@ def delete_event_stock(event_id: int, stock_id: int) -> None:
 
 @blueprints.public_api.route("/public/offers/v1/events/<int:event_id>/dates/<int:stock_id>", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.EVENT_OFFER_STOCKS],
@@ -768,7 +768,7 @@ def patch_event_stock(
         )
     ),
 )
-@provider_api_key_required
+@api_key_required
 def get_event_categories() -> events_serializers.GetEventCategoriesResponse:
     """
     Get Event Categories

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -36,8 +36,8 @@ from pcapi.utils import chunks as chunks_utils
 from pcapi.utils import image_conversion
 from pcapi.utils.custom_keys import get_field
 from pcapi.utils.transaction_manager import atomic
+from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 from . import constants
 from . import serialization
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 
 @blueprints.public_api.route("/public/offers/v1/show_types", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.OFFER_ATTRIBUTES],
@@ -80,7 +80,7 @@ def get_show_types() -> serialization.GetShowTypesResponse:
 
 @blueprints.public_api.route("/public/offers/v1/music_types", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.OFFER_ATTRIBUTES],
@@ -113,7 +113,7 @@ def get_music_types() -> serialization.GetMusicTypesResponse:
 
 @blueprints.public_api.route("/public/offers/v1/music_types/all", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.OFFER_ATTRIBUTES],
@@ -145,7 +145,7 @@ def get_all_titelive_music_types() -> serialization.GetTiteliveMusicTypesRespons
 
 @blueprints.public_api.route("/public/offers/v1/music_types/event", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.OFFER_ATTRIBUTES],
@@ -177,7 +177,7 @@ def get_event_titelive_music_types() -> serialization.GetTiteliveEventMusicTypes
 
 @blueprints.public_api.route("/public/offers/v1/products", methods=["POST"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -282,7 +282,7 @@ def post_product_offer(body: products_serializers.ProductOfferCreation) -> seria
 
 @blueprints.public_api.route("/public/offers/v1/products/ean", methods=["POST"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_EAN_OFFERS],
@@ -363,7 +363,7 @@ def _serialize_products_from_body(
 
 @blueprints.public_api.route("/public/offers/v1/products/<int:product_id>", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -396,7 +396,7 @@ def get_product(product_id: int) -> serialization.ProductOfferResponse:
 
 @blueprints.public_api.route("/public/offers/v1/products/ean", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_EAN_OFFERS],
@@ -434,7 +434,7 @@ def get_product_by_ean(
 
 @blueprints.public_api.route("/public/offers/v1/products/ean/check_availability", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_EAN_OFFERS],
@@ -518,7 +518,7 @@ def _retrieve_offer_by_eans_query(eans: list[str], venueId: int) -> sa_orm.Query
 
 @blueprints.public_api.route("/public/offers/v1/products", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -568,7 +568,7 @@ def _check_offer_can_be_edited(offer: offers_models.Offer) -> None:
 
 @blueprints.public_api.route("/public/offers/v1/products", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -657,7 +657,7 @@ def edit_product(body: products_serializers.ProductOfferEdition) -> serializatio
 
 @blueprints.public_api.route("/public/offers/v1/products/categories", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PRODUCT_OFFERS],
@@ -687,7 +687,7 @@ def get_product_categories() -> serialization.GetProductCategoriesResponse:
 
 @blueprints.public_api.route("/public/offers/v1/<int:offer_id>/image", methods=["POST"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.IMAGE],

--- a/api/src/pcapi/routes/public/individual_offers/v1/providers.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/providers.py
@@ -10,13 +10,13 @@ from pcapi.routes.public.serialization import venues as venues_serialization
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.transaction_manager import atomic
+from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 @blueprints.public_api.route("/public/providers/v1/provider", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PROVIDERS],
@@ -40,7 +40,7 @@ def get_provider() -> providers_serialization.ProviderResponse:
 
 @blueprints.public_api.route("/public/providers/v1/provider", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.PROVIDERS],
@@ -75,7 +75,7 @@ def update_provider(body: providers_serialization.ProviderUpdate) -> providers_s
 
 @blueprints.public_api.route("/public/providers/v1/venues/<int:venue_id>", methods=["PATCH"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     on_success_status=204,
     api=spectree_schemas.public_api_schema,

--- a/api/src/pcapi/routes/public/individual_offers/v1/venues.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/venues.py
@@ -17,8 +17,8 @@ from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils.siren import SIRET_OR_RIDET_RE
 from pcapi.utils.siren import is_siret_or_ridet
 from pcapi.utils.transaction_manager import atomic
+from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
-from pcapi.validation.routes.users_authentifications import provider_api_key_required
 
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 @blueprints.public_api.route("/public/offers/v1/offerer_venues", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.VENUES],
@@ -53,7 +53,7 @@ def get_offerer_venues(
 
 @blueprints.public_api.route("/public/offers/v1/venues/<siret>", methods=["GET"])
 @atomic()
-@provider_api_key_required
+@api_key_required
 @spectree_serialize(
     api=spectree_schemas.public_api_schema,
     tags=[tags.VENUES],

--- a/api/src/pcapi/validation/routes/users_authentifications.py
+++ b/api/src/pcapi/validation/routes/users_authentifications.py
@@ -45,12 +45,9 @@ def brevo_webhook(route_function: typing.Callable) -> typing.Callable:
     return wrapper
 
 
-def provider_api_key_required(route_function: typing.Callable) -> typing.Callable:
+def api_key_required(route_function: typing.Callable) -> typing.Callable:
     """
-    Require the user to be authenticated as a provider using an API key.
-
-    Prevent old API key (that authenticates an offerer) bearer to access routes requiring an
-    authenticated provider.
+    Require the user to be authenticated as a provider using an API key
     """
     add_security_scheme(route_function, API_KEY_AUTH_NAME)
 
@@ -59,7 +56,7 @@ def provider_api_key_required(route_function: typing.Callable) -> typing.Callabl
         _fill_current_api_key()
         public_utils.setup_public_api_log_extra(route_function)
 
-        if not g.current_api_key or not g.current_api_key.provider:
+        if not g.current_api_key:
             raise api_errors.UnauthorizedError(errors={"auth": "API key required"})
 
         sentry_sdk.set_tag("provider-name", g.current_api_key.provider.name)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

As `ApiKey.provider` cannot be null, specifying `provider_api_key` is irrelevant

- [ ] Travail pair testé en environnement de preview
