### PR TITLE
(BSR)[API] feat: clean artist index after sandbox creation

### DIFF
--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -810,6 +810,16 @@ def unindex_offer_ids(offer_ids: abc.Collection[int]) -> None:
     _reindex_artists_from_offers(offer_ids)
 
 
+def unindex_all_artists() -> None:
+    backend = _get_backend()
+    try:
+        backend.unindex_all_artists()
+    except Exception:
+        if not settings.CATCH_INDEXATION_EXCEPTIONS:
+            raise
+        logger.exception("Could not unindex all artists")
+
+
 def unindex_all_offers() -> None:
     if not settings.ENABLE_UNINDEXING_ALL:
         raise ValueError("It is forbidden to unindex all offers on this environment")

--- a/api/src/pcapi/sandboxes/scripts/save_sandbox.py
+++ b/api/src/pcapi/sandboxes/scripts/save_sandbox.py
@@ -62,6 +62,7 @@ def _index_all_offers() -> None:
 def _index_all_artists() -> None:
     logger.info("Reindexing artists")
 
+    search.unindex_all_artists()
     query = db.session.query(artists_models.Artist).with_entities(artists_models.Artist.id)
     search.reindex_artist_ids([artist_id for (artist_id,) in query])
 


### PR DESCRIPTION
Les `id` des artistes sont des UUID, donc aléatoire à chaque création de la sandbox. Si on ne clean pas l'index, les artistes vont se retrouver dupliquer chaque semaine