### PR TITLE
(BSR)[API] chore: tranform an exception into a warning in `CineDigitalServiceAPI.get_shows`

### DIFF
--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -162,12 +162,11 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
     def get_shows(self) -> list[cds_serializers.ShowCDS]:
         data = self._authenticated_get(f"{self.base_url}shows")
         shows = parse_obj_as(list[cds_serializers.ShowCDS], data)
-        if shows:
-            return shows
 
-        raise cds_exceptions.CineDigitalServiceAPIException(
-            f"Shows not found in Cine Digital Service API for cinemaId={self.cinema_id} & url={self.base_url}"
-        )
+        if not shows:
+            logger.warning("[CDS] Api call returned no show", extra={"cinemaId": self.cinema_id, "url": self.base_url})
+
+        return shows
 
     def get_show(self, show_id: int) -> cds_serializers.ShowCDS:
         """

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -170,10 +170,11 @@ class CineDigitalServiceGetShowTest:
 
         assert show.id == 2
 
-    def test_should_raise_exception_if_show_not_found(self, caplog, requests_mock):
+    @pytest.mark.parametrize("response_json", [ONE_SHOW_RESPONSE_JSON, []])
+    def test_should_raise_exception_if_show_not_found(self, response_json, requests_mock):
         requests_mock.get(
             "https://accountid_test.apiUrl_test/shows?api_token=token_test",
-            json=ONE_SHOW_RESPONSE_JSON,
+            json=response_json,
         )
         cine_digital_service = CineDigitalServiceAPI(
             cinema_id="test_id",
@@ -181,18 +182,8 @@ class CineDigitalServiceGetShowTest:
             cinema_api_token="token_test",
         )
 
-        with caplog.at_level(logging.DEBUG, logger="pcapi.core.external_bookings.cds.client"):
-            with pytest.raises(external_bookings_exceptions.ExternalBookingShowDoesNotExistError):
-                cine_digital_service.get_show(4)
-
-        assert len(caplog.records) == 1
-        assert caplog.records[0].message == "[CINEMA] Call to external API"
-        assert caplog.records[0].extra == {
-            "api_client": "CineDigitalServiceAPI",
-            "method": "GET https://accountid_test.apiUrl_test/shows",
-            "cinema_id": "test_id",
-            "response": ONE_SHOW_RESPONSE_JSON,
-        }
+        with pytest.raises(external_bookings_exceptions.ExternalBookingShowDoesNotExistError):
+            cine_digital_service.get_show(4)
 
     @pytest.mark.parametrize(
         "seatmap, expected_result",

--- a/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
@@ -415,6 +415,27 @@ class CDSStocksTest:
 
     @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies")
     @patch("pcapi.settings.CDS_API_URL", "fakeUrl/")
+    def test_synchronization_shouldnt_not_fail_if_api_returns_no_show(self, mock_get_venue_movies, requests_mock):
+        _, venue_provider = setup_cinema()
+        requests_mock.get(
+            "https://account_id.fakeurl/cinemas?api_token=token",
+            json=[fixtures.CINEMA_WITH_INTERNET_SALE_GAUGE_ACTIVE_FALSE],
+        )
+        requests_mock.get("https://account_id.fakeurl/mediaoptions?api_token=token", json=fixtures.MEDIA_OPTIONS)
+        mocked_movies = [fixtures.MOVIE_1, fixtures.MOVIE_2]
+        mock_get_venue_movies.return_value = mocked_movies
+
+        requests_mock.get("https://account_id.fakeurl/shows?api_token=token", json=[])
+        requests_mock.get(
+            "https://account_id.fakeurl/vouchertype?api_token=token",
+            json=[fixtures.VOUCHER_TYPE_PC_1, fixtures.VOUCHER_TYPE_PC_2],
+        )
+
+        cds_stocks = CDSStocks(venue_provider=venue_provider)
+        cds_stocks.updateObjects()
+
+    @patch("pcapi.core.external_bookings.cds.client.CineDigitalServiceAPI.get_venue_movies")
+    @patch("pcapi.settings.CDS_API_URL", "fakeUrl/")
     def test_synchronization_do_not_duplicate_stocks_when_beginning_datetime_changed(
         self, mock_get_venue_movies, requests_mock
     ):


### PR DESCRIPTION

## 🎯 Related Ticket or 🔧 Changes Made


Avoid spamming Sentry with irrelevant exceptions: https://pass-culture.sentry.io/issues/33117308/

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
