### PR TITLE
(PC-37815)[API] feat: pro: new offer creation route

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -212,7 +212,7 @@ def _get_internal_accessibility_compliance(venue: offerers_models.Venue) -> dict
 
 
 def create_draft_offer(
-    body: offers_schemas.PostDraftOfferBodyModel,
+    body: offers_schemas.deprecated.PostDraftOfferBodyModel,
     venue: offerers_models.Venue,
     product: offers_models.Product | None = None,
     is_from_private_api: bool = True,
@@ -410,10 +410,34 @@ def create_offer(
     venue: offerers_models.Venue,
     offerer_address: offerers_models.OffererAddress | None = None,
     provider: providers_models.Provider | None = None,
+    product: offers_models.Product | None = None,
     is_from_private_api: bool = False,
     venue_provider: providers_models.VenueProvider | None = None,
 ) -> models.Offer:
+    """Main entry point to offer creation
+
+    Note:
+        For some historical reason this function was only used by public
+        API calls and the internal API calls were using another function.
+        Both should use the same entrypoint but this is still a work in
+        progress since some rules are slightly different.
+    """
     body.extra_data = _format_extra_data(body.subcategory_id, body.extra_data) or {}
+
+    if is_from_private_api:
+        # TODO(jbaudet): should be ok to remove from this if-block since
+        # only internal api calls will pass product as a parameter.
+        validation.check_product_for_venue_and_subcategory(product, body.subcategory_id, venue.venueTypeCode)
+
+        # TODO(jbaudet): should be ok to remove from this if-block
+        # but let's be sure before doing anything stupid
+        if feature.FeatureToggle.WIP_ENABLE_NEW_OFFER_CREATION_FLOW.is_active():
+            validation.check_accessibility_compliance(
+                audio_disability_compliant=body.audio_disability_compliant,
+                mental_disability_compliant=body.mental_disability_compliant,
+                motor_disability_compliant=body.motor_disability_compliant,
+                visual_disability_compliant=body.visual_disability_compliant,
+            )
 
     validation.check_offer_withdrawal(
         withdrawal_type=body.withdrawal_type,
@@ -433,6 +457,30 @@ def create_offer(
     validation.check_offer_name_does_not_contain_ean(body.name)
 
     fields = body.dict(by_alias=True)
+    fields.pop("videoUrl", None)
+
+    if is_from_private_api:
+        if not feature.FeatureToggle.WIP_ENABLE_NEW_OFFER_CREATION_FLOW.is_active():
+            disability_fields = {
+                "audioDisabilityCompliant",
+                "mentalDisabilityCompliant",
+                "motorDisabilityCompliant",
+                "visualDisabilityCompliant",
+            }
+            if not any(field for field in disability_fields if field in fields):
+                fields.update(_get_accessibility_compliance_fields(venue))
+
+        if not body.withdrawal_details:
+            fields.update({"withdrawalDetails": venue.withdrawalDetails})
+
+        subcategory = subcategories.ALL_SUBCATEGORIES_DICT[body.subcategory_id]
+        fields.update({"isDuo": bool(subcategory and subcategory.is_event and subcategory.can_be_duo)})
+
+        keys_to_remove = {"venueId", "callId"}
+        if product:
+            keys_to_remove |= {"extraData", "description", "durationMinutes"}
+
+        fields = {k: v for k, v in fields.items() if k not in keys_to_remove}
 
     offerer_address = offerer_address or venue.offererAddress
 
@@ -442,12 +490,18 @@ def create_offer(
     offer = models.Offer(
         **fields,
         venue=venue,
+        product=product,
         offererAddress=offerer_address,
         lastProvider=provider,
         validation=models.OfferValidationStatus.DRAFT,
         publicationDatetime=None,
     )
     repository.add_to_session(offer)
+
+    if body.video_url:
+        offer_metadata = models.OfferMetaData(offer=offer, videoUrl=body.video_url)
+        db.session.add(offer_metadata)
+
     db.session.flush()
 
     # This log is used for analytics purposes.

--- a/api/src/pcapi/core/offers/schemas/__init__.py
+++ b/api/src/pcapi/core/offers/schemas/__init__.py
@@ -18,46 +18,10 @@ from pcapi.serialization import utils as serialization_utils
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 from pcapi.validation.routes.offers import check_video_url
 
+from . import deprecated  # noqa: F401
+
 
 OFFER_DESCRIPTION_MAX_LENGTH = 10_000
-
-
-class PostDraftOfferBodyModel(BaseModel):
-    name: str
-    subcategory_id: str
-    venue_id: int
-    description: str | None = Field(max_length=OFFER_DESCRIPTION_MAX_LENGTH)
-    url: HttpUrl | None = None
-    extra_data: typing.Any = None
-    duration_minutes: int | None = None
-    product_id: int | None
-    video_url: HttpUrl | None
-    # These props become mandatory when `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` feature flag is enabled.
-    # They are optional here in order to not break the existing POST `/offers/drafts` route while both flows coexist.
-    audio_disability_compliant: bool | None
-    mental_disability_compliant: bool | None
-    motor_disability_compliant: bool | None
-    visual_disability_compliant: bool | None
-
-    @validator("name", pre=True)
-    def validate_name(cls, name: str, values: dict) -> str:
-        check_offer_name_length_is_valid(name)
-        return name
-
-    @validator("video_url", pre=True)
-    def clean_video_url(cls, v: str) -> str | None:
-        if v == "":
-            return None
-        return v
-
-    @validator("video_url")
-    def validate_video_url(cls, video_url: HttpUrl, values: dict) -> str:
-        check_video_url(video_url)
-        return video_url
-
-    class Config:
-        alias_generator = serialization_utils.to_camel
-        extra = "forbid"
 
 
 class PatchDraftOfferBodyModel(BaseModel):
@@ -91,7 +55,7 @@ class PatchDraftOfferBodyModel(BaseModel):
 
     @validator("subcategory_id", pre=True)
     def validate_subcategory_id(cls, subcategory_id: str, values: dict) -> str:
-        from .validation import check_offer_subcategory_is_valid
+        from pcapi.core.offers.validation import check_offer_subcategory_is_valid
 
         check_offer_subcategory_is_valid(subcategory_id)
         return subcategory_id
@@ -122,6 +86,7 @@ class CreateOffer(BaseModel):
     withdrawal_delay: int | None = None
     withdrawal_details: str | None = None
     withdrawal_type: offers_models.WithdrawalTypeEnum | None = None
+    video_url: HttpUrl | None = None
 
     # is_national must be placed after url so that the validator
     # can access the url field in the dict of values

--- a/api/src/pcapi/core/offers/schemas/deprecated.py
+++ b/api/src/pcapi/core/offers/schemas/deprecated.py
@@ -1,0 +1,51 @@
+import typing
+
+from pydantic.v1 import Field
+from pydantic.v1 import HttpUrl
+from pydantic.v1 import validator
+
+from pcapi.routes.serialization import BaseModel
+from pcapi.serialization import utils as serialization_utils
+from pcapi.validation.routes.offers import check_offer_name_length_is_valid
+from pcapi.validation.routes.offers import check_video_url
+
+
+OFFER_DESCRIPTION_MAX_LENGTH = 10_000
+
+
+class PostDraftOfferBodyModel(BaseModel):
+    name: str
+    subcategory_id: str
+    venue_id: int
+    description: str | None = Field(max_length=OFFER_DESCRIPTION_MAX_LENGTH)
+    url: HttpUrl | None = None
+    extra_data: typing.Any = None
+    duration_minutes: int | None = None
+    product_id: int | None
+    video_url: HttpUrl | None
+    # These props become mandatory when `WIP_ENABLE_NEW_OFFER_CREATION_FLOW` feature flag is enabled.
+    # They are optional here in order to not break the existing POST `/offers/drafts` route while both flows coexist.
+    audio_disability_compliant: bool | None
+    mental_disability_compliant: bool | None
+    motor_disability_compliant: bool | None
+    visual_disability_compliant: bool | None
+
+    @validator("name", pre=True)
+    def validate_name(cls, name: str, values: dict) -> str:
+        check_offer_name_length_is_valid(name)
+        return name
+
+    @validator("video_url", pre=True)
+    def clean_video_url(cls, v: str) -> str | None:
+        if v == "":
+            return None
+        return v
+
+    @validator("video_url")
+    def validate_video_url(cls, video_url: HttpUrl, values: dict) -> str:
+        check_video_url(video_url)
+        return video_url
+
+    class Config:
+        alias_generator = serialization_utils.to_camel
+        extra = "forbid"

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -239,7 +239,7 @@ def delete_draft_offers(body: offers_serialize.DeleteOfferRequestBody) -> None:
     offers_api.batch_delete_draft_offers(query)
 
 
-@private_api.route("/offers/draft", methods=["POST"])
+@private_api.route("/v2/offers", methods=["POST"])
 @login_required
 @spectree_serialize(
     response_model=offers_serialize.GetIndividualOfferResponseModel,
@@ -247,9 +247,75 @@ def delete_draft_offers(body: offers_serialize.DeleteOfferRequestBody) -> None:
     api=blueprint.pro_private_schema,
 )
 @atomic()
+def create_offer(body: offers_serialize.PostOfferBodyModel) -> offers_serialize.GetIndividualOfferResponseModel:
+    venue: offerers_models.Venue = first_or_404(
+        db.session.query(offerers_models.Venue)
+        .filter(offerers_models.Venue.id == body.venue_id)
+        .options(
+            sa_orm.joinedload(offerers_models.Venue.offererAddress).joinedload(offerers_models.OffererAddress.address)
+        )
+    )
+    offerer_address: offerers_models.OffererAddress | None = None
+    offerer_address = (
+        offerers_api.get_offerer_address_from_address(venue.managingOffererId, body.address)
+        if body.address
+        else venue.offererAddress
+    )
+    rest.check_user_has_access_to_offerer(current_user, venue.managingOffererId)
+
+    ean_code = body.extra_data.get("ean", None) if body.extra_data is not None else None
+    product = (
+        db.session.query(models.Product)
+        .filter(models.Product.ean == ean_code)
+        .filter(models.Product.id == body.product_id)
+        .one_or_none()
+    )
+
+    create_offer_schema = offers_schemas.CreateOffer(  # type: ignore[call-arg]
+        name=body.name,
+        subcategoryId=body.subcategory_id,
+        audioDisabilityCompliant=body.audio_disability_compliant,
+        mentalDisabilityCompliant=body.mental_disability_compliant,
+        motorDisabilityCompliant=body.motor_disability_compliant,
+        visualDisabilityCompliant=body.visual_disability_compliant,
+        bookingContact=body.booking_contact,
+        bookingEmail=body.booking_email,
+        description=body.description,
+        durationMinutes=body.duration_minutes,
+        externalTicketOfficeUrl=body.external_ticket_office_url,
+        ean=ean_code,
+        extraData=body.extra_data,
+        idAtProvider=None,
+        isDuo=None,
+        url=body.url,
+        withdrawalDelay=body.withdrawal_delay,
+        withdrawalDetails=body.withdrawal_details,
+        withdrawalType=body.withdrawal_type,
+        videoUrl=body.video_url,
+        isNational=body.is_national,
+    )
+
+    offer = offers_api.create_offer(
+        create_offer_schema, offerer_address=offerer_address, venue=venue, product=product, is_from_private_api=True
+    )
+    return offers_serialize.GetIndividualOfferResponseModel.from_orm(offer)
+
+
+@private_api.route("/offers/draft", methods=["POST"])
+@login_required
+@spectree_serialize(
+    deprecated=True,
+    response_model=offers_serialize.GetIndividualOfferResponseModel,
+    on_success_status=201,
+    api=blueprint.pro_private_schema,
+)
+@atomic()
 def post_draft_offer(
-    body: offers_schemas.PostDraftOfferBodyModel,
+    body: offers_schemas.deprecated.PostDraftOfferBodyModel,
 ) -> offers_serialize.GetIndividualOfferResponseModel:
+    """
+    [DEPRECATED] Please migrate to new (generic/standard) offer creation route
+    """
     venue: offerers_models.Venue = first_or_404(
         db.session.query(offerers_models.Venue)
         .filter(offerers_models.Venue.id == body.venue_id)
@@ -316,7 +382,9 @@ def patch_draft_offer(
     api=blueprint.pro_private_schema,
 )
 @atomic()
-def post_offer(body: offers_serialize.PostOfferBodyModel) -> offers_serialize.GetIndividualOfferResponseModel:
+def post_offer(
+    body: offers_serialize.deprecated.PostOfferBodyModel,
+) -> offers_serialize.GetIndividualOfferResponseModel:
     venue: offerers_models.Venue = first_or_404(
         db.session.query(offerers_models.Venue)
         .filter(offerers_models.Venue.id == body.venue_id)

--- a/api/src/pcapi/routes/serialization/offers_serialize/__init__.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize/__init__.py
@@ -32,6 +32,8 @@ from pcapi.serialization.utils import validate_datetime
 from pcapi.utils.date import format_into_utc_date
 from pcapi.validation.routes.offers import check_offer_name_length_is_valid
 
+from . import deprecated  # noqa: F401
+
 
 class SubcategoryGetterDict(GetterDict):
     def get(self, key: str, default: Any | None = None) -> Any:
@@ -73,44 +75,6 @@ class CategoryResponseModel(BaseModel):
         alias_generator = to_camel
         allow_population_by_field_name = True
         orm_mode = True
-
-
-class PostOfferBodyModel(BaseModel):
-    address: offerers_schemas.AddressBodyModel | None
-    audio_disability_compliant: bool
-    booking_contact: EmailStr | None
-    booking_email: EmailStr | None
-    description: str | None
-    duration_minutes: int | None
-    external_ticket_office_url: HttpUrl | None
-    extra_data: dict[str, typing.Any] | None
-    is_duo: bool | None
-    is_national: bool | None
-    mental_disability_compliant: bool
-    motor_disability_compliant: bool
-    name: str
-    subcategory_id: str
-    url: HttpUrl | None
-    venue_id: int
-    visual_disability_compliant: bool
-    withdrawal_delay: int | None
-    withdrawal_details: str | None
-    withdrawal_type: offers_models.WithdrawalTypeEnum | None
-
-    @validator("name", pre=True)
-    def validate_name(cls, name: str, values: dict) -> str:
-        check_offer_name_length_is_valid(name)
-        return name
-
-    @validator("withdrawal_type")
-    def validate_withdrawal_type(cls, value: offers_models.WithdrawalTypeEnum) -> offers_models.WithdrawalTypeEnum:
-        if value == offers_models.WithdrawalTypeEnum.IN_APP:
-            raise ValueError("Withdrawal type cannot be in_app for manually created offers")
-        return value
-
-    class Config:
-        alias_generator = to_camel
-        extra = "forbid"
 
 
 class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
@@ -663,3 +627,50 @@ class VideoMetatdataQueryModel(BaseModel):
 
 class OfferHighlightResquestsResponseModel(BaseModel):
     highlight_requests: list[str]
+
+
+class OfferVideo(ConfiguredBaseModel):
+    id: str
+    title: str | None
+    thumbnailUrl: str | None
+    duration: int | None
+
+
+class PostOfferBodyModel(BaseModel):
+    address: offerers_schemas.AddressBodyModel | None
+    audio_disability_compliant: bool
+    booking_contact: EmailStr | None
+    booking_email: EmailStr | None
+    description: str | None
+    duration_minutes: int | None
+    external_ticket_office_url: HttpUrl | None
+    extra_data: dict[str, typing.Any] | None
+    is_duo: bool | None
+    is_national: bool | None
+    mental_disability_compliant: bool
+    motor_disability_compliant: bool
+    name: str
+    product_id: int | None
+    subcategory_id: str
+    url: HttpUrl | None
+    venue_id: int
+    video_url: HttpUrl | None = None
+    visual_disability_compliant: bool
+    withdrawal_delay: int | None
+    withdrawal_details: str | None
+    withdrawal_type: offers_models.WithdrawalTypeEnum | None
+
+    @validator("name", pre=True)
+    def validate_name(cls, name: str, values: dict) -> str:
+        check_offer_name_length_is_valid(name)
+        return name
+
+    @validator("withdrawal_type")
+    def validate_withdrawal_type(cls, value: offers_models.WithdrawalTypeEnum) -> offers_models.WithdrawalTypeEnum:
+        if value == offers_models.WithdrawalTypeEnum.IN_APP:
+            raise ValueError("Withdrawal type cannot be in_app for manually created offers")
+        return value
+
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"

--- a/api/src/pcapi/routes/serialization/offers_serialize/deprecated.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize/deprecated.py
@@ -1,0 +1,49 @@
+import typing
+
+from pydantic.v1 import EmailStr
+from pydantic.v1 import HttpUrl
+from pydantic.v1 import validator
+
+from pcapi.core.offerers import schemas as offerers_schemas
+from pcapi.core.offers import models as offers_models
+from pcapi.routes.serialization import BaseModel
+from pcapi.serialization.utils import to_camel
+from pcapi.validation.routes.offers import check_offer_name_length_is_valid
+
+
+class PostOfferBodyModel(BaseModel):
+    address: offerers_schemas.AddressBodyModel | None
+    audio_disability_compliant: bool
+    booking_contact: EmailStr | None
+    booking_email: EmailStr | None
+    description: str | None
+    duration_minutes: int | None
+    external_ticket_office_url: HttpUrl | None
+    extra_data: dict[str, typing.Any] | None
+    is_duo: bool | None
+    is_national: bool | None
+    mental_disability_compliant: bool
+    motor_disability_compliant: bool
+    name: str
+    subcategory_id: str
+    url: HttpUrl | None
+    venue_id: int
+    visual_disability_compliant: bool
+    withdrawal_delay: int | None
+    withdrawal_details: str | None
+    withdrawal_type: offers_models.WithdrawalTypeEnum | None
+
+    @validator("name", pre=True)
+    def validate_name(cls, name: str, values: dict) -> str:
+        check_offer_name_length_is_valid(name)
+        return name
+
+    @validator("withdrawal_type")
+    def validate_withdrawal_type(cls, value: offers_models.WithdrawalTypeEnum) -> offers_models.WithdrawalTypeEnum:
+        if value == offers_models.WithdrawalTypeEnum.IN_APP:
+            raise ValueError("Withdrawal type cannot be in_app for manually created offers")
+        return value
+
+    class Config:
+        alias_generator = to_camel
+        extra = "forbid"

--- a/api/tests/core/offers/test_commands.py
+++ b/api/tests/core/offers/test_commands.py
@@ -23,7 +23,7 @@ class OfferCommandsTest:
         a_year_ago = datetime.date.today() - timedelta(days=366)
         offer_id = offers_factories.OfferFactory(dateCreated=a_year_ago, dateUpdated=a_year_ago).id
 
-        run_command(app, "delete_unbookable_unbooked_old_offers")
+        run_command(app, "delete_unbookable_unbooked_old_offers", "0", f"{offer_id * 2}")
 
         assert db.session.get(offers_models.Offer, offer_id) is not None
 
@@ -34,7 +34,7 @@ class OfferCommandsTest:
         offer = offers_factories.OfferFactory(dateCreated=a_year_ago, dateUpdated=a_year_ago)
         offer_id = offer.id
 
-        run_command(app, "delete_unbookable_unbooked_old_offers")
+        run_command(app, "delete_unbookable_unbooked_old_offers", "0", f"{offer_id * 2}")
 
         assert db.session.query(offers_models.Offer).filter_by(id=offer_id).count() == 0
 

--- a/api/tests/core/offers/test_schemas.py
+++ b/api/tests/core/offers/test_schemas.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class PostDraftOfferBodyModelTest:
     def test_post_draft_offer_body_model(self):
         venue = offerers_factories.VirtualVenueFactory()
-        _ = schemas.PostDraftOfferBodyModel(
+        _ = schemas.deprecated.PostDraftOfferBodyModel(
             name="Name",
             subcategoryId=subcategories.ABO_PLATEFORME_VIDEO.id,
             venueId=venue.id,

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -1,17 +1,751 @@
+import contextlib
 from decimal import Decimal
 
 import pytest
 
 import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import WithdrawalTypeEnum
+from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
 
 
-@pytest.mark.usefixtures("db_session")
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def shared_response_json_checks(offer, response_json):
+    assert response_json["id"] == offer.id
+    assert response_json["name"] == offer.name
+    assert not response_json["publicationDate"]
+    assert not response_json["publicationDatetime"]
+    assert not response_json["bookingAllowedDatetime"]
+
+
+def shared_offer_checks(offer, payload):
+    assert offer.name == payload["name"]
+    assert offer.venueId == payload["venueId"]
+    assert offer.subcategoryId == payload["subcategoryId"]
+    assert not offer.publicationDate
+    assert not offer.publicationDatetime
+    assert not offer.bookingAllowedDatetime
+    assert not offer.isActive
+
+
+@contextlib.contextmanager
+def assert_changes(model, delta):
+    before_count = db.session.query(model).count()
+
+    yield
+
+    after_count = db.session.query(model).count()
+    assert after_count == before_count + delta
+
+
+@contextlib.contextmanager
+def assert_no_changes(model):
+    with assert_changes(model, 0):
+        yield
+
+
+def default_address_payload():
+    return {"city": "Paris", "latitude": "2.0", "longitude": "48.0", "postalCode": "75002", "street": "1 rue des rues"}
+
+
+def offer_minimal_shared_data(subcategory_id, venue):
+    return {
+        "name": f"some {subcategory_id} offer",
+        "subcategoryId": subcategory_id,
+        "venueId": venue.id,
+        "audioDisabilityCompliant": False,
+        "mentalDisabilityCompliant": False,
+        "motorDisabilityCompliant": False,
+        "visualDisabilityCompliant": False,
+    }
+
+
+def offer_optional_shared_data(**kwargs):
+    return {
+        "bookingContact": "booking.contact@test.fr",
+        "bookingEmail": "booking.email@test.fr",
+        "description": "some description",
+        **kwargs,
+    }
+
+
+@pytest.fixture(name="venue")
+def venue_fixture():
+    return offerers_factories.VenueFactory()
+
+
+@pytest.fixture(name="user")
+def user_fixture(venue):
+    return offerers_factories.UserOffererFactory(offerer=venue.managingOfferer, user__email="user@example.com").user
+
+
+@pytest.fixture(name="auth_client")
+def auth_client_fixture(client, user):
+    return client.with_session_auth(user.email)
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+THINGS_WITH_EAN = {
+    subcategories.LIVRE_PAPIER.id,
+    subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
+    subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+THINGS_RANDOM = {
+    subcategories.ABO_BIBLIOTHEQUE.id,
+    subcategories.ABO_CONCERT.id,
+    subcategories.ABO_MEDIATHEQUE.id,
+    subcategories.ABO_PRATIQUE_ART.id,
+    subcategories.ACHAT_INSTRUMENT.id,
+    subcategories.CARTE_CINE_ILLIMITE.id,
+    subcategories.CARTE_CINE_MULTISEANCES.id,
+    subcategories.CARTE_JEUNES.id,
+    subcategories.CARTE_MUSEE.id,
+    subcategories.ESCAPE_GAME.id,
+    subcategories.LIVRE_AUDIO_PHYSIQUE.id,
+    subcategories.LOCATION_INSTRUMENT.id,
+    subcategories.MATERIEL_ART_CREATIF.id,
+    subcategories.PARTITION.id,
+    subcategories.SUPPORT_PHYSIQUE_FILM.id,
+}
+
+
+THINGS = THINGS_WITH_EAN | THINGS_RANDOM
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+DIGITAL_THING = {
+    subcategories.TELECHARGEMENT_MUSIQUE.id,
+    subcategories.LIVRE_NUMERIQUE.id,
+    subcategories.PLATEFORME_PRATIQUE_ARTISTIQUE.id,
+    subcategories.AUTRE_SUPPORT_NUMERIQUE.id,
+    subcategories.MUSEE_VENTE_DISTANCE.id,
+    subcategories.VISITE_VIRTUELLE.id,
+    subcategories.PRATIQUE_ART_VENTE_DISTANCE.id,
+    subcategories.ABO_PLATEFORME_VIDEO.id,
+    subcategories.ABO_PRESSE_EN_LIGNE.id,
+    subcategories.APP_CULTURELLE.id,
+    subcategories.JEU_EN_LIGNE.id,
+    subcategories.CINE_VENTE_DISTANCE.id,
+    subcategories.ABO_LIVRE_NUMERIQUE.id,
+    subcategories.ABO_JEU_VIDEO.id,
+    subcategories.PODCAST.id,
+    subcategories.TELECHARGEMENT_LIVRE_AUDIO.id,
+    subcategories.ABO_PLATEFORME_MUSIQUE.id,
+    subcategories.VOD.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+DIGITAL_ACTIVITY = {
+    subcategories.SPECTACLE_ENREGISTRE.id,
+    subcategories.SPECTACLE_VENTE_DISTANCE.id,
+}
+
+
+DIGITAL = DIGITAL_THING | DIGITAL_ACTIVITY
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+CANNOT_BE_CREATED = {
+    subcategories.ACTIVATION_EVENT.id,
+    subcategories.CAPTATION_MUSIQUE.id,
+    subcategories.OEUVRE_ART.id,
+    subcategories.BON_ACHAT_INSTRUMENT.id,
+    subcategories.ACTIVATION_THING.id,
+    subcategories.ABO_LUDOTHEQUE.id,
+    subcategories.JEU_SUPPORT_PHYSIQUE.id,
+    subcategories.DECOUVERTE_METIERS.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_SUBSCRIPTION = {
+    subcategories.ABO_SPECTACLE.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_ONLINE = {
+    subcategories.LIVESTREAM_MUSIQUE.id,
+    subcategories.RENCONTRE_EN_LIGNE.id,
+    subcategories.LIVESTREAM_PRATIQUE_ARTISTIQUE.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_ONLINE_EVENT = {
+    subcategories.LIVESTREAM_EVENEMENT.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_WITHDRAWABLE = {
+    subcategories.SPECTACLE_REPRESENTATION.id,
+    subcategories.FESTIVAL_SPECTACLE.id,
+    subcategories.FESTIVAL_ART_VISUEL.id,
+    subcategories.CONCERT.id,
+    subcategories.FESTIVAL_MUSIQUE.id,
+    subcategories.EVENEMENT_MUSIQUE.id,
+}
+
+
+# TODO(jbaudet - 09/2025): warning: this might not be accurate
+# delete this TODO if nothing has changed in a couple of months
+ACTIVITY_RANDOM = {
+    subcategories.ATELIER_PRATIQUE_ART.id,
+    subcategories.CINE_PLEIN_AIR.id,
+    subcategories.CONCOURS.id,
+    subcategories.CONFERENCE.id,
+    subcategories.EVENEMENT_CINE.id,
+    subcategories.EVENEMENT_JEU.id,
+    subcategories.EVENEMENT_PATRIMOINE.id,
+    subcategories.FESTIVAL_CINE.id,
+    subcategories.FESTIVAL_LIVRE.id,
+    subcategories.RENCONTRE.id,
+    subcategories.RENCONTRE_JEU.id,
+    subcategories.SALON.id,
+    subcategories.SEANCE_CINE.id,
+    subcategories.SEANCE_ESSAI_PRATIQUE_ART.id,
+    subcategories.VISITE.id,
+    subcategories.VISITE_GUIDEE.id,
+}
+
+
+ACTIVITY = ACTIVITY_SUBSCRIPTION | ACTIVITY_ONLINE | ACTIVITY_ONLINE_EVENT | ACTIVITY_WITHDRAWABLE | ACTIVITY_RANDOM
+
+
+ALL = THINGS | DIGITAL | ACTIVITY
+
+
+class CreateOfferBase:
+    endpoint = "/v2/offers"
+
+    success_num_queries = 1  # fetch user session
+    success_num_queries += 1  # fetch user
+    success_num_queries += 1  # fetch venue
+    success_num_queries += 1  # user offerer check
+    success_num_queries += 1  # fetch product
+    success_num_queries += 1  # fetch FF
+    success_num_queries += 1  # create offer
+    success_num_queries += 1  # fetch mediation
+    success_num_queries += 1  # fetch stocks
+    success_num_queries += 1  # fetch price categories
+    success_num_queries += 1  # fetch offerer address
+    success_num_queries += 1  # fetch offer meta data
+    success_num_queries += 1  # fetch user
+    success_num_queries += 1  # fetch offerer
+    success_num_queries += 1  # check national program (?)
+    success_num_queries += 1  # check venue has collective offers (?)
+    success_num_queries += 1  # check offer regarding offer status (?)
+    success_num_queries += 1  # check offer's venue has at least one cancelled booking (?)
+
+
+class CreateThingsTest(CreateOfferBase):
+    @pytest.mark.parametrize("subcategory_id", THINGS)
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+
+    # TODO(jbaudet): most of `THINGS` subcategories should not accept any EAN
+    # but for now... it is valid.
+    @pytest.mark.parametrize("subcategory_id", THINGS)
+    def test_create_offer_with_ean_and_no_product_is_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "bookingEmail": "booking.email@test.com",
+            "description": "some description",
+            "extraData": {"ean": "0000000000001"},
+        }
+
+        with assert_changes(Offer, 1):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+        assert offer.ean == "0000000000001"
+        assert offer.description == payload["description"]
+        assert not offer.productId
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            # TODO(jbaudet): fill this list after offer creation has been
+            # cleaned up. For example an `ABO_BIBLIOTHEQUE` should not accept
+            # any duration
+            {"url": "https://example.thing@test.com"},
+            {"withdrawalType": "in_app"},
+        ],
+        ids=["url", "withdrawal_type"],
+    )
+    def test_create_offer_with_non_thing_field_is_not_ok(self, auth_client, venue, extra):
+        subcategory_id = sorted(THINGS)[0]
+        payload = {**offer_minimal_shared_data(subcategory_id, venue), **extra}
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+
+
+class CreateThingWithEanTest(CreateOfferBase):
+    @pytest.mark.parametrize("subcategory_id", THINGS_WITH_EAN)
+    def test_create_offer_with_product_is_ok(self, auth_client, venue, subcategory_id):
+        product = offers_factories.ProductFactory(subcategoryId=subcategory_id)
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "bookingEmail": "booking.email@test.com",
+            "description": "some description",
+            "extraData": {"ean": product.ean},
+            "productId": product.id,
+        }
+
+        with assert_changes(Offer, 1):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+        assert offer.ean == product.ean
+        assert offer.description == product.description
+        assert offer.productId == product.id
+
+    def test_create_offer_with_unknown_product_is_ok(self, auth_client, venue):
+        """
+        It does not seem to be logical.
+        """
+        subcategory_id = sorted(THINGS_WITH_EAN)[0]
+        product = offers_factories.ProductFactory(subcategoryId=subcategory_id)
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"ean": product.ean},
+            "productId": 0,
+        }
+
+        with assert_changes(Offer, 1):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+        assert offer.ean == product.ean
+        assert not offer.productId
+
+
+@pytest.mark.parametrize("subcategory_id", DIGITAL_THING)
+class CreateDigitalOfferTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        default_url = "https://default.url@test.com"
+        payload = {**offer_minimal_shared_data(subcategory_id, venue), "url": default_url}
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+
+                assert response.status_code == 201
+                assert response.json["url"] == default_url
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert offer.url == default_url
+        assert not offer.isEvent
+
+    def test_create_offer_without_url_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "url" in response.json
+
+
+@pytest.mark.parametrize("subcategory_id", DIGITAL_ACTIVITY)
+class CreateDigitalEventTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        activity_url = "https://activity.online@test.com"
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "url": activity_url,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert not offer.isEvent
+
+    def test_create_offer_without_url_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+
+    def test_create_offer_without_show_type_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "url": "https://some.url@test.com",
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "showType" in response.json
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_SUBSCRIPTION)
+class CreateActivitySubscriptionTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert not offer.isEvent
+
+    def test_create_offer_without_show_type_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "showType" in response.json
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_ONLINE)
+class CreateActivityOnlineTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        activity_url = "https://activity.online@test.com"
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "url": activity_url,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert offer.isEvent
+
+    def test_create_offer_with_show_type_is_ok(self, auth_client, venue, subcategory_id):
+        activity_url = "https://activity.online@test.com"
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "url": activity_url,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert offer.isEvent
+
+    def test_create_offer_without_url_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_ONLINE_EVENT)
+class CreateActivityOnlineEventTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        activity_url = "https://activity.online@test.com"
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "url": activity_url,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert offer.isDigital
+        assert offer.isEvent
+
+    def test_create_offer_without_url_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "url" in response.json
+
+    def test_create_offer_without_show_type_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "url": "https://some.url@test.com",
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert "showType" in response.json
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_WITHDRAWABLE)
+class CreateActivityWithdrawableTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    @pytest.mark.parametrize("withdrawal_type", ["by_email", "on_site", "no_ticket"])
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id, withdrawal_type):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "bookingContact": "booking.contact@test.com",
+            "withdrawalType": withdrawal_type,
+            "withdrawalDelay": 10 if withdrawal_type != "no_ticket" else None,
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert offer.isEvent
+
+    def test_create_event_with_address_is_ok(self, auth_client, venue, subcategory_id):
+        address_data = default_address_payload()
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "bookingContact": "booking.contact@test.com",
+            "withdrawalType": "by_email",
+            "withdrawalDelay": 10,
+            "address": address_data,
+        }
+
+        with assert_changes(Offer, 1):
+            num_queries = self.success_num_queries
+            num_queries += 1  # insert address
+            num_queries += 1  # insert offerer address
+            num_queries += 1  # fetch offerer address
+            with assert_num_queries(num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert offer.isEvent
+
+        address = offer.offererAddress.address
+        assert address.postalCode == address_data["postalCode"]
+        assert address.city == address_data["city"]
+        assert address.street == address_data["street"]
+        assert address.latitude == Decimal(address_data["latitude"])
+        assert address.longitude == Decimal(address_data["longitude"])
+
+    def test_create_offer_with_in_app_withdrawal_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+            "bookingContact": "booking.contact@test.com",
+            "withdrawalType": "in_app",
+        }
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert response.json == {"withdrawalType": ["Withdrawal type cannot be in_app for manually created offers"]}
+
+    def test_create_offer_without_withdraw_information_is_not_ok(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert response.json == {
+                "offer": ["Une offre qui a un ticket retirable doit avoir un type de retrait renseigné"]
+            }
+
+
+@pytest.mark.parametrize("subcategory_id", ACTIVITY_RANDOM)
+class CreateActivityRandomTest(CreateOfferBase):
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_succesful(self, auth_client, venue, subcategory_id):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+
+        shared_response_json_checks(offer, response.json)
+        shared_offer_checks(offer, payload)
+
+        assert not offer.isDigital
+        assert offer.isEvent
+        assert not offer.showSubType
+
+    def test_create_offer_with_showtype_is_ok(self, auth_client, venue, subcategory_id):
+        payload = {
+            **offer_minimal_shared_data(subcategory_id, venue),
+            "extraData": {"showType": 100, "showSubType": 101},
+        }
+
+        with assert_changes(Offer, 1):
+            with assert_num_queries(self.success_num_queries):
+                response = auth_client.post(self.endpoint, json=payload)
+                assert response.status_code == 201
+
+        offer = db.session.query(Offer).one()
+        offer.showSubType == 101
+
+
+@pytest.mark.parametrize("subcategory_id", CANNOT_BE_CREATED)
+class CannotCreateOfferTest:
+    endpoint = "/v2/offers"
+
+    def test_create_offer_with_minimal_payload_is_not_authorized(self, auth_client, venue, subcategory_id):
+        payload = {**offer_minimal_shared_data(subcategory_id, venue)}
+        response = auth_client.post(self.endpoint, json=payload)
+
+        assert response.status_code == 400
+        assert response.json == {
+            "subcategory": ["Une offre ne peut être créée ou éditée en utilisant cette sous-catégorie"]
+        }
+
+
+@pytest.mark.parametrize("subcategory_id", ALL)
+class CreateOfferErrorTest:
+    endpoint = "/v2/offers"
+
+    @pytest.mark.parametrize("missing_key", ["name", "subcategoryId", "venueId"])
+    def test_cannot_create_offer_without_missing_shared_minimal_data(
+        self, auth_client, venue, subcategory_id, missing_key
+    ):
+        payload = offer_minimal_shared_data(subcategory_id, venue)
+        payload.pop(missing_key)
+
+        with assert_no_changes(Offer):
+            response = auth_client.post(self.endpoint, json=payload)
+            assert response.status_code == 400
+            assert missing_key in response.json
+
+
 class Returns200Test:
     def test_created_offer_should_be_inactive(self, client):
         venue = offerers_factories.VenueFactory()
@@ -22,7 +756,7 @@ class Returns200Test:
         data = {
             "venueId": venue.id,
             "name": "Celeste",
-            "subcategoryId": subcategories.LIVRE_PAPIER.id,
+            "subcategoryId": subcategories.ABO_BIBLIOTHEQUE.id,
             "mentalDisabilityCompliant": True,
             "audioDisabilityCompliant": False,
             "visualDisabilityCompliant": False,

--- a/pro/src/apiClient/adage/services/DefaultService.ts
+++ b/pro/src/apiClient/adage/services/DefaultService.ts
@@ -49,7 +49,7 @@ export class DefaultService {
       url: '/adage-iframe/authenticate',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -64,7 +64,7 @@ export class DefaultService {
       url: '/adage-iframe/collective/academies',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -75,7 +75,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public bookCollectiveOffer(
-    requestBody: BookCollectiveOfferRequest,
+    requestBody?: BookCollectiveOfferRequest,
   ): CancelablePromise<BookCollectiveOfferResponse> {
     return this.httpRequest.request({
       method: 'POST',
@@ -85,7 +85,7 @@ export class DefaultService {
       errors: {
         400: `Bad Request`,
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -100,7 +100,7 @@ export class DefaultService {
       url: '/adage-iframe/collective/favorites',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -115,7 +115,7 @@ export class DefaultService {
       url: '/adage-iframe/collective/institution',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -137,7 +137,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -159,7 +159,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -172,7 +172,7 @@ export class DefaultService {
    */
   public createCollectiveRequest(
     offerId: number,
-    requestBody: PostCollectiveRequestBodyModel,
+    requestBody?: PostCollectiveRequestBodyModel,
   ): CancelablePromise<CollectiveRequestResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -185,7 +185,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -200,7 +200,7 @@ export class DefaultService {
       url: '/adage-iframe/collective/offers/my_institution',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -222,7 +222,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -243,7 +243,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -264,7 +264,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -280,7 +280,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -291,7 +291,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logBookingModalButtonClick(
-    requestBody: StockIdBody,
+    requestBody?: StockIdBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -301,7 +301,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -312,7 +312,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logCatalogView(
-    requestBody: CatalogViewBody,
+    requestBody?: CatalogViewBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -322,7 +322,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -333,7 +333,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logConsultPlaylistElement(
-    requestBody: PlaylistBody,
+    requestBody?: PlaylistBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -343,7 +343,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -354,7 +354,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logContactModalButtonClick(
-    requestBody: OfferBody,
+    requestBody?: OfferBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -364,7 +364,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -375,7 +375,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logContactUrlClick(
-    requestBody: OfferIdBody,
+    requestBody?: OfferIdBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -385,7 +385,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -396,7 +396,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logFavOfferButtonClick(
-    requestBody: OfferFavoriteBody,
+    requestBody?: OfferFavoriteBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -406,7 +406,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -417,7 +417,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logHasSeenWholePlaylist(
-    requestBody: PlaylistBody,
+    requestBody?: PlaylistBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -427,7 +427,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -438,7 +438,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logHeaderLinkClick(
-    requestBody: AdageHeaderLogBody,
+    requestBody?: AdageHeaderLogBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -448,7 +448,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -459,7 +459,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logOpenHighlightBanner(
-    requestBody: HighlightBannerBody,
+    requestBody?: HighlightBannerBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -469,7 +469,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -480,7 +480,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logOfferDetailsButtonClick(
-    requestBody: StockIdBody,
+    requestBody?: StockIdBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -490,7 +490,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -501,7 +501,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logOfferListViewSwitch(
-    requestBody: OfferListSwitch,
+    requestBody?: OfferListSwitch,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -511,7 +511,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -522,7 +522,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logOfferTemplateDetailsButtonClick(
-    requestBody: OfferIdBody,
+    requestBody?: OfferIdBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -532,7 +532,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -543,7 +543,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logHasSeenAllPlaylist(
-    requestBody: AdageBaseModel,
+    requestBody?: AdageBaseModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -553,7 +553,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -564,7 +564,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logRequestFormPopinDismiss(
-    requestBody: CollectiveRequestBody,
+    requestBody?: CollectiveRequestBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -574,7 +574,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -585,7 +585,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logOpenSatisfactionSurvey(
-    requestBody: AdageBaseModel,
+    requestBody?: AdageBaseModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -595,7 +595,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -606,7 +606,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logSearchButtonClick(
-    requestBody: SearchBody,
+    requestBody?: SearchBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -616,7 +616,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -627,7 +627,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logSearchShowMore(
-    requestBody: TrackingShowMoreBody,
+    requestBody?: TrackingShowMoreBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -637,7 +637,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -648,7 +648,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logTrackingAutocompleteSuggestionClick(
-    requestBody: TrackingAutocompleteSuggestionBody,
+    requestBody?: TrackingAutocompleteSuggestionBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -658,7 +658,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -669,7 +669,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logTrackingCtaShare(
-    requestBody: TrackingCTAShareBody,
+    requestBody?: TrackingCTAShareBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -679,7 +679,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -690,7 +690,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logTrackingFilter(
-    requestBody: TrackingFilterBody,
+    requestBody?: TrackingFilterBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -700,7 +700,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -711,7 +711,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public logTrackingMap(
-    requestBody: AdageBaseModel,
+    requestBody?: AdageBaseModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -721,7 +721,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -736,7 +736,7 @@ export class DefaultService {
       url: '/adage-iframe/playlists/classroom',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -751,7 +751,7 @@ export class DefaultService {
       url: '/adage-iframe/playlists/local-offerers',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -766,7 +766,7 @@ export class DefaultService {
       url: '/adage-iframe/playlists/new_offerers',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -782,7 +782,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -793,7 +793,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public saveRedactorPreferences(
-    requestBody: RedactorPreferences,
+    requestBody?: RedactorPreferences,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -802,7 +802,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -818,7 +818,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -844,7 +844,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -870,7 +870,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }

--- a/pro/src/apiClient/v1/services/DefaultService.ts
+++ b/pro/src/apiClient/v1/services/DefaultService.ts
@@ -173,7 +173,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -194,7 +194,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -242,7 +242,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -266,7 +266,7 @@ export class DefaultService {
         403: `Vous n'avez pas les droits nécessaires pour voir cette contremarque`,
         404: `La contremarque n'existe pas`,
         410: `La requête est refusée car la contremarque n'a pas encore été validée, a été annulée, ou son remboursement a été initié`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -295,7 +295,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -324,7 +324,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -372,7 +372,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -387,7 +387,7 @@ export class DefaultService {
       url: '/bookings/pro/userHasBookings',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -412,7 +412,7 @@ export class DefaultService {
         404: `La contremarque n'existe pas`,
         410: `Cette contremarque a été validée.
         En l’invalidant vous indiquez qu’elle n’a pas été utilisée et vous ne serez pas remboursé.`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -437,7 +437,7 @@ export class DefaultService {
         404: `La contremarque n'existe pas`,
         410: `Cette contremarque a été validée.
         En l’invalidant vous indiquez qu’elle n’a pas été utilisée et vous ne serez pas remboursé.`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -473,7 +473,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -509,7 +509,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -545,7 +545,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -560,7 +560,7 @@ export class DefaultService {
       url: '/collective/bookings/pro/userHasBookings',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -581,7 +581,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -596,7 +596,7 @@ export class DefaultService {
       url: '/collective/educational-domains',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -647,7 +647,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -658,7 +658,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public createCollectiveOffer(
-    requestBody: PostCollectiveOfferBodyModel,
+    requestBody?: PostCollectiveOfferBodyModel,
   ): CancelablePromise<CollectiveOfferResponseIdModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -667,7 +667,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -678,7 +678,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public createCollectiveOfferTemplate(
-    requestBody: PostCollectiveOfferTemplateBodyModel,
+    requestBody?: PostCollectiveOfferTemplateBodyModel,
   ): CancelablePromise<CollectiveOfferResponseIdModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -687,7 +687,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -698,7 +698,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public patchCollectiveOffersTemplateActiveStatus(
-    requestBody: PatchCollectiveOfferActiveStatusBodyModel,
+    requestBody?: PatchCollectiveOfferActiveStatusBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -707,7 +707,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -718,7 +718,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public patchCollectiveOffersTemplateArchive(
-    requestBody: PatchCollectiveOfferArchiveBodyModel,
+    requestBody?: PatchCollectiveOfferArchiveBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -727,7 +727,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -748,7 +748,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -769,7 +769,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -782,7 +782,7 @@ export class DefaultService {
    */
   public editCollectiveOfferTemplate(
     offerId: number,
-    requestBody: PatchCollectiveOfferTemplateBodyModel,
+    requestBody?: PatchCollectiveOfferTemplateBodyModel,
   ): CancelablePromise<GetCollectiveOfferTemplateResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -794,7 +794,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -815,7 +815,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -828,7 +828,7 @@ export class DefaultService {
    */
   public attachOfferTemplateImage(
     offerId: number,
-    formData: AttachImageFormModel,
+    formData?: AttachImageFormModel,
   ): CancelablePromise<AttachImageResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -840,7 +840,7 @@ export class DefaultService {
       mediaType: 'multipart/form-data',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -862,7 +862,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -873,7 +873,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public patchCollectiveOffersArchive(
-    requestBody: PatchCollectiveOfferArchiveBodyModel,
+    requestBody?: PatchCollectiveOfferArchiveBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -882,7 +882,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -933,7 +933,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -984,7 +984,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1008,7 +1008,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1029,7 +1029,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1042,7 +1042,7 @@ export class DefaultService {
    */
   public editCollectiveOffer(
     offerId: number,
-    requestBody: PatchCollectiveOfferBodyModel,
+    requestBody?: PatchCollectiveOfferBodyModel,
   ): CancelablePromise<GetCollectiveOfferResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -1054,7 +1054,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1077,7 +1077,7 @@ export class DefaultService {
         400: `Bad Request`,
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1098,7 +1098,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1111,7 +1111,7 @@ export class DefaultService {
    */
   public patchCollectiveOffersEducationalInstitution(
     offerId: number,
-    requestBody: PatchCollectiveOfferEducationalInstitution,
+    requestBody?: PatchCollectiveOfferEducationalInstitution,
   ): CancelablePromise<GetCollectiveOfferResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -1124,7 +1124,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1145,7 +1145,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1158,7 +1158,7 @@ export class DefaultService {
    */
   public attachOfferImage(
     offerId: number,
-    formData: AttachImageFormModel,
+    formData?: AttachImageFormModel,
   ): CancelablePromise<AttachImageResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1170,7 +1170,7 @@ export class DefaultService {
       mediaType: 'multipart/form-data',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1192,7 +1192,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1203,7 +1203,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public createCollectiveStock(
-    requestBody: CollectiveStockCreationBodyModel,
+    requestBody?: CollectiveStockCreationBodyModel,
   ): CancelablePromise<CollectiveStockResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1214,7 +1214,7 @@ export class DefaultService {
         400: `Bad Request`,
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1227,7 +1227,7 @@ export class DefaultService {
    */
   public editCollectiveStock(
     collectiveStockId: number,
-    requestBody: CollectiveStockEditionBodyModel,
+    requestBody?: CollectiveStockEditionBodyModel,
   ): CancelablePromise<CollectiveStockResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -1242,7 +1242,7 @@ export class DefaultService {
         401: `Unauthorized`,
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1258,7 +1258,7 @@ export class DefaultService {
       errors: {
         401: `Unauthorized`,
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1283,7 +1283,7 @@ export class DefaultService {
       errors: {
         401: `Unauthorized`,
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1298,7 +1298,7 @@ export class DefaultService {
       url: '/features',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1313,7 +1313,7 @@ export class DefaultService {
       url: '/finance/bank-accounts',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1334,7 +1334,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1355,7 +1355,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1376,7 +1376,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1400,7 +1400,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1411,7 +1411,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public createOfferer(
-    requestBody: CreateOffererQueryModel,
+    requestBody?: CreateOffererQueryModel,
   ): CancelablePromise<PostOffererResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1420,7 +1420,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1441,7 +1441,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1468,7 +1468,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1479,7 +1479,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public saveNewOnboardingData(
-    requestBody: SaveNewOnboardingDataQueryModel,
+    requestBody?: SaveNewOnboardingDataQueryModel,
   ): CancelablePromise<PostOffererResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1488,7 +1488,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1509,7 +1509,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1530,7 +1530,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1545,7 +1545,7 @@ export class DefaultService {
   public linkVenueToBankAccount(
     offererId: number,
     bankAccountId: number,
-    requestBody: LinkVenueToBankAccountBodyModel,
+    requestBody?: LinkVenueToBankAccountBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -1558,7 +1558,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1579,7 +1579,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1600,7 +1600,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1613,7 +1613,7 @@ export class DefaultService {
    */
   public inviteMember(
     offererId: number,
-    requestBody: InviteMemberQueryModel,
+    requestBody?: InviteMemberQueryModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1625,7 +1625,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1638,7 +1638,7 @@ export class DefaultService {
    */
   public inviteMemberAgain(
     offererId: number,
-    requestBody: InviteMemberQueryModel,
+    requestBody?: InviteMemberQueryModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1650,7 +1650,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1671,7 +1671,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1697,7 +1697,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1718,7 +1718,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1739,7 +1739,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1787,7 +1787,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1798,7 +1798,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public postOffer(
-    requestBody: PostOfferBodyModel,
+    requestBody?: PostOfferBodyModel,
   ): CancelablePromise<GetIndividualOfferResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1807,7 +1807,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1818,7 +1818,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public patchOffersActiveStatus(
-    requestBody: PatchOfferActiveStatusBodyModel,
+    requestBody?: PatchOfferActiveStatusBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -1827,7 +1827,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1838,7 +1838,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public patchAllOffersActiveStatus(
-    requestBody: PatchAllOffersActiveStatusBodyModel,
+    requestBody?: PatchAllOffersActiveStatusBodyModel,
   ): CancelablePromise<any> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -1847,7 +1847,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1862,7 +1862,7 @@ export class DefaultService {
       url: '/offers/categories',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1873,7 +1873,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public deleteDraftOffers(
-    requestBody: DeleteOfferRequestBody,
+    requestBody?: DeleteOfferRequestBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1882,7 +1882,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1893,7 +1893,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public deleteHeadlineOffer(
-    requestBody: HeadlineOfferDeleteBodyModel,
+    requestBody?: HeadlineOfferDeleteBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1902,18 +1902,19 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
   /**
-   * post_draft_offer <POST>
+   * @deprecated
+   * [DEPRECATED] Please migrate to new (generic/standard) offer creation route
    * @param requestBody
    * @returns GetIndividualOfferResponseModel Created
    * @throws ApiError
    */
   public postDraftOffer(
-    requestBody: PostDraftOfferBodyModel,
+    requestBody?: PostDraftOfferBodyModel,
   ): CancelablePromise<GetIndividualOfferResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -1922,7 +1923,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1935,7 +1936,7 @@ export class DefaultService {
    */
   public patchDraftOffer(
     offerId: number,
-    requestBody: PatchDraftOfferBodyModel,
+    requestBody?: PatchDraftOfferBodyModel,
   ): CancelablePromise<GetIndividualOfferResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -1947,7 +1948,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1962,7 +1963,7 @@ export class DefaultService {
       url: '/offers/music-types',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1973,7 +1974,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public patchPublishOffer(
-    requestBody: PatchOfferPublishBodyModel,
+    requestBody?: PatchOfferPublishBodyModel,
   ): CancelablePromise<GetIndividualOfferResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -1983,7 +1984,7 @@ export class DefaultService {
       errors: {
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -1994,7 +1995,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public createThumbnail(
-    formData: CreateThumbnailBodyModel,
+    formData?: CreateThumbnailBodyModel,
   ): CancelablePromise<CreateThumbnailResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2003,7 +2004,7 @@ export class DefaultService {
       mediaType: 'multipart/form-data',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2024,7 +2025,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2035,7 +2036,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public upsertHeadlineOffer(
-    requestBody: HeadlineOfferCreationBodyModel,
+    requestBody?: HeadlineOfferCreationBodyModel,
   ): CancelablePromise<HeadLineOfferResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2044,7 +2045,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2065,7 +2066,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2078,7 +2079,7 @@ export class DefaultService {
    */
   public patchOffer(
     offerId: number,
-    requestBody: PatchOfferBodyModel,
+    requestBody?: PatchOfferBodyModel,
   ): CancelablePromise<GetIndividualOfferResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -2090,7 +2091,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2103,7 +2104,7 @@ export class DefaultService {
    */
   public postHighlightRequestOffer(
     offerId: number,
-    requestBody: CreateOfferHighlightRequestBodyModel,
+    requestBody?: CreateOfferHighlightRequestBodyModel,
   ): CancelablePromise<OfferHighlightResquestsResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2115,7 +2116,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2136,7 +2137,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2156,7 +2157,7 @@ export class DefaultService {
    */
   public upsertOfferOpeningHours(
     offerId: number,
-    requestBody: OfferOpeningHoursSchema,
+    requestBody?: OfferOpeningHoursSchema,
   ): CancelablePromise<OfferOpeningHoursSchema> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -2168,7 +2169,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2181,7 +2182,7 @@ export class DefaultService {
    */
   public postPriceCategories(
     offerId: number,
-    requestBody: PriceCategoryBody,
+    requestBody?: PriceCategoryBody,
   ): CancelablePromise<GetIndividualOfferResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2193,7 +2194,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2217,7 +2218,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2238,7 +2239,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2282,7 +2283,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2295,7 +2296,7 @@ export class DefaultService {
    */
   public deleteAllFilteredStocks(
     offerId: number,
-    requestBody: DeleteFilteredStockListBody,
+    requestBody?: DeleteFilteredStockListBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2307,7 +2308,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2320,7 +2321,7 @@ export class DefaultService {
    */
   public deleteStocks(
     offerId: number,
-    requestBody: DeleteStockListBody,
+    requestBody?: DeleteStockListBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2332,7 +2333,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2356,7 +2357,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2386,7 +2387,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2397,7 +2398,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public createThingStock(
-    requestBody: ThingStockCreateBodyModel,
+    requestBody?: ThingStockCreateBodyModel,
   ): CancelablePromise<StockIdResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2406,7 +2407,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2417,7 +2418,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public bulkUpdateEventStocks(
-    requestBody: EventStocksBulkUpdateBodyModel,
+    requestBody?: EventStocksBulkUpdateBodyModel,
   ): CancelablePromise<StocksResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -2426,7 +2427,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2437,7 +2438,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public bulkCreateEventStocks(
-    requestBody: EventStocksBulkCreateBodyModel,
+    requestBody?: EventStocksBulkCreateBodyModel,
   ): CancelablePromise<StocksResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2446,7 +2447,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2467,7 +2468,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2480,7 +2481,7 @@ export class DefaultService {
    */
   public updateThingStock(
     stockId: number,
-    requestBody: ThingStockUpdateBodyModel,
+    requestBody?: ThingStockUpdateBodyModel,
   ): CancelablePromise<StockIdResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -2492,7 +2493,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2513,7 +2514,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2524,7 +2525,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public postCheckToken(
-    requestBody: CheckTokenBodyModel,
+    requestBody?: CheckTokenBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2534,7 +2535,7 @@ export class DefaultService {
       errors: {
         400: `Bad Request`,
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2555,7 +2556,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2566,7 +2567,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public cookiesConsent(
-    requestBody: CookieConsentRequest,
+    requestBody?: CookieConsentRequest,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2576,7 +2577,7 @@ export class DefaultService {
       errors: {
         400: `Bad Request`,
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2591,7 +2592,7 @@ export class DefaultService {
       url: '/users/current',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2602,7 +2603,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public postUserEmail(
-    requestBody: UserResetEmailBodyModel,
+    requestBody?: UserResetEmailBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2611,7 +2612,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2626,7 +2627,7 @@ export class DefaultService {
       url: '/users/email_pending_validation',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2637,7 +2638,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public patchUserIdentity(
-    requestBody: UserIdentityBodyModel,
+    requestBody?: UserIdentityBodyModel,
   ): CancelablePromise<UserIdentityResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -2646,7 +2647,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2657,7 +2658,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public submitUserReview(
-    requestBody: SubmitReviewRequestModel,
+    requestBody?: SubmitReviewRequestModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2666,7 +2667,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2677,7 +2678,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public postNewPassword(
-    requestBody: NewPasswordBodyModel,
+    requestBody?: NewPasswordBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2687,7 +2688,7 @@ export class DefaultService {
       errors: {
         400: `Bad Request`,
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2698,7 +2699,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public postChangePassword(
-    requestBody: ChangePasswordBodyModel,
+    requestBody?: ChangePasswordBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2708,7 +2709,7 @@ export class DefaultService {
       errors: {
         400: `Bad Request`,
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2719,7 +2720,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public patchUserPhone(
-    requestBody: UserPhoneBodyModel,
+    requestBody?: UserPhoneBodyModel,
   ): CancelablePromise<UserPhoneResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -2728,7 +2729,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2739,7 +2740,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public resetPassword(
-    requestBody: ResetPasswordBodyModel,
+    requestBody?: ResetPasswordBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2748,7 +2749,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2763,7 +2764,7 @@ export class DefaultService {
       url: '/users/rgs-seen',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2774,7 +2775,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public signin(
-    requestBody: LoginUserBodyModel,
+    requestBody?: LoginUserBodyModel,
   ): CancelablePromise<SharedLoginUserResponseModel> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2783,7 +2784,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2798,7 +2799,7 @@ export class DefaultService {
       url: '/users/signout',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2809,7 +2810,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public signupPro(
-    requestBody: ProUserCreationBodyV2Model,
+    requestBody?: ProUserCreationBodyV2Model,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -2818,7 +2819,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2833,7 +2834,7 @@ export class DefaultService {
       url: '/users/tuto-seen',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2844,7 +2845,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public patchValidateEmail(
-    requestBody: ChangeProEmailBody,
+    requestBody?: ChangeProEmailBody,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -2853,7 +2854,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2874,7 +2875,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2895,7 +2896,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2925,7 +2926,27 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
+      },
+    });
+  }
+  /**
+   * create_offer <POST>
+   * @param requestBody
+   * @returns GetIndividualOfferResponseModel Created
+   * @throws ApiError
+   */
+  public createOffer(
+    requestBody?: PostOfferBodyModel,
+  ): CancelablePromise<GetIndividualOfferResponseModel> {
+    return this.httpRequest.request({
+      method: 'POST',
+      url: '/v2/offers',
+      body: requestBody,
+      mediaType: 'application/json',
+      errors: {
+        403: `Forbidden`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2946,7 +2967,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2961,7 +2982,7 @@ export class DefaultService {
       url: '/venue-labels',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2976,7 +2997,7 @@ export class DefaultService {
       url: '/venue-types',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -2997,7 +3018,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3008,7 +3029,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public createVenueProvider(
-    requestBody: PostVenueProviderBody,
+    requestBody?: PostVenueProviderBody,
   ): CancelablePromise<VenueProviderResponse> {
     return this.httpRequest.request({
       method: 'POST',
@@ -3017,7 +3038,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3028,7 +3049,7 @@ export class DefaultService {
    * @throws ApiError
    */
   public updateVenueProvider(
-    requestBody: PostVenueProviderBody,
+    requestBody?: PostVenueProviderBody,
   ): CancelablePromise<VenueProviderResponse> {
     return this.httpRequest.request({
       method: 'PUT',
@@ -3037,7 +3058,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3060,7 +3081,7 @@ export class DefaultService {
         401: `Unauthorized`,
         403: `Forbidden`,
         404: `Not Found`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3081,7 +3102,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3108,7 +3129,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3123,7 +3144,7 @@ export class DefaultService {
       url: '/venues-educational-statuses',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3144,7 +3165,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3165,7 +3186,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3178,7 +3199,7 @@ export class DefaultService {
    */
   public editVenue(
     venueId: number,
-    requestBody: EditVenueBodyModel,
+    requestBody?: EditVenueBodyModel,
   ): CancelablePromise<GetVenueResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -3190,7 +3211,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3211,7 +3232,7 @@ export class DefaultService {
       },
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3224,7 +3245,7 @@ export class DefaultService {
    */
   public editVenueCollectiveData(
     venueId: number,
-    requestBody: EditVenueCollectiveDataBodyModel,
+    requestBody?: EditVenueCollectiveDataBodyModel,
   ): CancelablePromise<GetVenueResponseModel> {
     return this.httpRequest.request({
       method: 'PATCH',
@@ -3236,7 +3257,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }
@@ -3249,7 +3270,7 @@ export class DefaultService {
    */
   public linkVenueToPricingPoint(
     venueId: number,
-    requestBody: LinkVenueToPricingPointBodyModel,
+    requestBody?: LinkVenueToPricingPointBodyModel,
   ): CancelablePromise<void> {
     return this.httpRequest.request({
       method: 'POST',
@@ -3261,7 +3282,7 @@ export class DefaultService {
       mediaType: 'application/json',
       errors: {
         403: `Forbidden`,
-        422: `Unprocessable Content`,
+        422: `Unprocessable Entity`,
       },
     });
   }


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37815)

Ajout d'une nouvelle route de création d'offre, appelée à remplacer celle de création d'offre brouillon. L'idée étant de revoir le parcours de création d'offre du portail pro en créant directement une offre sans chercher d'étape intermédiaire et de notion de brouillon qui complique les choses et qui n'a pas réellement de sens.

### Au passage

Le coeur du commit est relativement court, les plus importants ajouts se situent au niveau des tests. Afin d'y voir un peu plus clair j'ai regroupé les créations par ensemble de sous-catégories pour commencer à identifier les règles implicites en place et avoir une idée de certaines incohérences (je n'ai rien mis ou presque à ce niveau-là dans les tests pour éviter d'en avoir beaucoup trop). Pour avoir fait des essais en **testing** en contournant le portail pro, on peut créer des offres qui mélanges beaucoup de choses...