### PR TITLE
(PC-37947)[API] chore: Remove error case for pass Culture SIRET

### DIFF
--- a/api/src/pcapi/connectors/entreprise/api.py
+++ b/api/src/pcapi/connectors/entreprise/api.py
@@ -83,7 +83,3 @@ def is_valid_siret(search_input: str | int) -> bool:
         and (isinstance(search_input, int) or search_input.isnumeric())
         and len(str(search_input)) == 14
     )
-
-
-def is_pass_culture_siret(search_input: str | int) -> bool:
-    return str(search_input) == settings.PASS_CULTURE_SIRET

--- a/api/src/pcapi/connectors/entreprise/backends/api_entreprise.py
+++ b/api/src/pcapi/connectors/entreprise/backends/api_entreprise.py
@@ -94,11 +94,6 @@ class EntrepriseBackend(BaseBackend):
         if not siren_utils.is_valid_siren(siren):
             raise exceptions.InvalidFormatException("SIREN invalide")
 
-        # Pass Culture also acts as an offerer which organizes events.
-        # Avoid HTTP 422 Unprocessable Content "Le paramètre recipient est identique au SIRET/SIREN appelé."
-        if siren == settings.PASS_CULTURE_SIRET[:9]:
-            raise exceptions.EntrepriseException("Pass Culture")
-
     def _check_siret_can_be_requested(self, siret: str) -> None:
         if not siren_utils.is_valid_siret(siret):
             raise exceptions.InvalidFormatException("SIRET invalide")

--- a/api/src/pcapi/routes/pro/structure_data.py
+++ b/api/src/pcapi/routes/pro/structure_data.py
@@ -27,8 +27,6 @@ logger = logging.getLogger(__name__)
 def get_structure_data(search_input: str) -> sirene_serializers.StructureDataBodyModel:
     if not api_entreprise.is_valid_siret(search_input):
         raise sirene_exceptions.InvalidFormatException()
-    if api_entreprise.is_pass_culture_siret(search_input):
-        raise ApiErrors(errors={"global": ["Ce SIRET est déjà inscrit sur le pass Culture."]})
     try:
         data = offerers_api.find_structure_data(search_input)
         address = offerers_api.find_ban_address_from_insee_address(data.diffusible, data.address)

--- a/api/tests/connectors/api_entreprise_test.py
+++ b/api/tests/connectors/api_entreprise_test.py
@@ -7,7 +7,6 @@ import pytest
 import requests_mock
 import time_machine
 
-from pcapi import settings
 from pcapi.connectors.entreprise import api
 from pcapi.connectors.entreprise import exceptions
 
@@ -204,14 +203,6 @@ def test_get_siren_invalid_parameter():
 
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
-def test_get_siren_pass_culture():
-    siren = settings.PASS_CULTURE_SIRET[:9]
-    with pytest.raises(exceptions.EntrepriseException) as error:
-        api.get_siren(siren)
-    assert str(error.value) == "Pass Culture"
-
-
-@pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
 def test_get_invalid_siren():
     siren = "111111111"
 
@@ -355,14 +346,6 @@ def test_get_siret_closing_in_the_future():
         siret_info = api.get_siret_open_data(siret)
         assert siret_info.siret == siret
         assert siret_info.active is True
-
-
-@pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")
-def test_get_siret_pass_culture():
-    siren = settings.PASS_CULTURE_SIRET
-    with pytest.raises(exceptions.EntrepriseException) as error:
-        api.get_siret(siren)
-    assert str(error.value) == "Pass Culture"
 
 
 @pytest.mark.settings(ENTREPRISE_BACKEND="pcapi.connectors.entreprise.backends.api_entreprise.EntrepriseBackend")

--- a/api/tests/routes/pro/get_structure_data_test.py
+++ b/api/tests/routes/pro/get_structure_data_test.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 
 import pcapi.core.users.factories as users_factories
-from pcapi import settings
 from pcapi.connectors import api_adresse
 from pcapi.connectors.entreprise import exceptions as sirene_exceptions
 from pcapi.core.testing import assert_num_queries
@@ -84,16 +83,6 @@ class Returns400Test:
 
         assert response.status_code == 400
         message = "Le format de ce SIREN ou SIRET est incorrect."
-        assert response.json == {"global": [message]}
-
-    def test_search_structure_by_pass_culture_siret(self, client):
-        pro = users_factories.ProFactory()
-        client = client.with_session_auth(pro.email)
-
-        response = client.get(f"{GET_STRUCTURE_DATA_URL}{settings.PASS_CULTURE_SIRET}")
-
-        assert response.status_code == 400
-        message = "Ce SIRET est déjà inscrit sur le pass Culture."
         assert response.json == {"global": [message]}
 
     def test_search_inactive_siret(self, client):


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37947)

API Entreprise used to return a specific error code when caller's SIRET and searched SIRET where identical. This error is not sent anymore, and the specific checks are now useless.

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
