### PR TITLE
(BSR)[API] chore: init task metrics for worker to 0

### DIFF
--- a/api/src/pcapi/celery_tasks/celery_worker.py
+++ b/api/src/pcapi/celery_tasks/celery_worker.py
@@ -9,3 +9,9 @@ if settings.CELERY_WORKER_ENABLE_METRICS:
     metrics.start_metrics_server()
 
 celery_app = flask_app.extensions["celery"]
+registered_tasks = sorted(task for task in celery_app.tasks.keys() if not task.startswith("celery"))
+
+# Initialize metrics with 0 value but with correct labels
+for task in registered_tasks:
+    for metric in metrics.metrics_list:
+        metric.labels(task=task)

--- a/api/src/pcapi/celery_tasks/metrics.py
+++ b/api/src/pcapi/celery_tasks/metrics.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from prometheus_client import REGISTRY
 from prometheus_client import CollectorRegistry
 from prometheus_client import Counter
@@ -15,33 +17,45 @@ if settings.PROMETHEUS_MULTIPROC_DIR:
 else:
     registry = REGISTRY
 
+# When adding a task metric you should initialize it at 0 for all tasks by
+# calling <metric_object>.labels(task="my-task")
+metrics_list: List[Counter | Gauge | Histogram] = []
 tasks_counter = Counter(
     "celery_tasks_total",
     "Total number of Celery tasks started",
     labelnames=["task"],
     registry=registry,
 )
+metrics_list += [tasks_counter]
+
 tasks_in_progress = Gauge(
     "celery_tasks_in_progress", "Number of Celery tasks started running", labelnames=["task"], registry=registry
 )
+metrics_list += [tasks_in_progress]
+
 tasks_succeeded_counter = Counter(
     "celery_tasks_succeeded_total",
     "Total number of Celery tasks that succeeded",
     labelnames=["task"],
     registry=registry,
 )
+metrics_list += [tasks_succeeded_counter]
+
 tasks_failed_counter = Counter(
     "celery_tasks_failed_total",
     "Total number of Celery tasks started that failed",
     labelnames=["task"],
     registry=registry,
 )
+metrics_list += [tasks_failed_counter]
+
 tasks_execution_time_histogram = Histogram(
     "celery_tasks_execution_time",
     "Time needed to run tasks",
     labelnames=["task"],
     registry=registry,
 )
+metrics_list += [tasks_execution_time_histogram]
 
 
 def start_metrics_server() -> None:


### PR DESCRIPTION
Initialization des métriques à 0 mais labellisées avec le nom des tâches ce qui permet des requêtes bien plus faciles ensuite sur prometheus