### PR TITLE
(PC-38117)[API] script: Add bank account on venues

### DIFF
--- a/api/src/pcapi/scripts/add_venue_bank_account_from_pricing_point/main.py
+++ b/api/src/pcapi/scripts/add_venue_bank_account_from_pricing_point/main.py
@@ -1,0 +1,97 @@
+"""
+Job console documentation here: https://www.notion.so/passcultureapp/Documentation-Job-Console-769beeacd5a146de9c97b6f8ee544276
+Assumed path to the script (copy-paste in github actions):
+
+https://github.com/pass-culture/pass-culture-main/blob/pcharlet/pc-38117-script-add-venue-bank-account/api/src/pcapi/scripts/add_venue_bank_account_from_pricing_point/main.py
+
+"""
+
+import argparse
+import csv
+import logging
+import os
+import typing
+
+from pcapi.app import app
+from pcapi.core.history import models as history_models
+from pcapi.core.offerers import models as offerers_models
+from pcapi.models import db
+from pcapi.utils.date import get_naive_utc_now
+from pcapi.utils.transaction_manager import atomic
+from pcapi.utils.transaction_manager import mark_transaction_as_invalid
+
+
+logger = logging.getLogger(__name__)
+
+ORIGIN_VENUE_ID_HEADER = "origin_venue_id"
+
+
+def _get_rows() -> typing.Iterator[dict]:
+    namespace_dir = os.path.dirname(os.path.abspath(__file__))
+    with open(f"{namespace_dir}/bank_accounts_update.csv", "r", encoding="utf-8") as csv_file:
+        csv_rows = csv.DictReader(csv_file, delimiter=",")
+        yield from csv_rows
+
+
+@atomic()
+def main(not_dry: bool) -> None:
+    if not not_dry:
+        logger.info("Dry run mode enabled, no changes will be made to the database")
+        mark_transaction_as_invalid()
+    for row in _get_rows():
+        origin_venue_id = int(row[ORIGIN_VENUE_ID_HEADER])
+        logger.info("Starting to update bank account for venue %d", origin_venue_id)
+
+        origin_venue = (
+            db.session.query(offerers_models.Venue).filter(offerers_models.Venue.id == origin_venue_id).one_or_none()
+        )
+        if origin_venue is None:
+            logger.info("Origin venue not found. id: %d", origin_venue_id)
+            continue
+        elif origin_venue.current_pricing_point is None:
+            logger.info("Pricing point not found for venue id: %d", origin_venue_id)
+            continue
+        elif origin_venue.current_pricing_point.current_bank_account is None:
+            logger.info("No bank account found for pricing point %d", origin_venue.current_pricing_point.id)
+            continue
+        elif origin_venue.current_bank_account is not None:
+            logger.info(
+                "Origin venue already has a bank account. origin_venue_id: %d, bank_account_id: %d",
+                origin_venue.id,
+                origin_venue.current_bank_account.id,
+            )
+            continue
+
+        assert origin_venue  # helps mypy
+        link = offerers_models.VenueBankAccountLink(
+            bankAccount=origin_venue.current_pricing_point.current_bank_account,
+            venue=origin_venue,
+            timespan=(get_naive_utc_now(),),
+        )
+        logger.info(
+            "Ajout du compte bancaire %d pour la venue %d",
+            origin_venue.current_pricing_point.current_bank_account.id,
+            origin_venue.id,
+        )
+        action_history = history_models.ActionHistory(
+            actionType=history_models.ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED,
+            venue=origin_venue,
+            bankAccount=origin_venue.current_pricing_point.current_bank_account,
+        )
+        db.session.add_all((link, action_history))
+
+
+if __name__ == "__main__":
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--not-dry", action="store_true")
+    args = parser.parse_args()
+
+    main(not_dry=args.not_dry)
+
+    if args.not_dry:
+        db.session.commit()
+        logger.info("Finished")
+    else:
+        logger.info("Finished dry run, rollback")

--- a/api/tests/scripts/add_venue_bank_account_from_pricing_point/test_main.py
+++ b/api/tests/scripts/add_venue_bank_account_from_pricing_point/test_main.py
@@ -1,0 +1,93 @@
+import typing
+
+import pytest
+
+from pcapi.core.finance import factories as finance_factories
+from pcapi.core.history import models as history_models
+from pcapi.core.history.models import ActionType
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offerers import models as finance_models
+from pcapi.models import db
+from pcapi.scripts.add_venue_bank_account_from_pricing_point import main
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def fake_iterator(origin_venue_id) -> typing.Iterator[dict]:
+    yield {"origin_venue_id": str(origin_venue_id)}
+
+
+def test_add_bank_account_to_venue_without_bank_account(monkeypatch):
+    origin_venue = offerers_factories.VenueFactory.create()
+    pricing_point_venue = offerers_factories.VenueFactory.create()
+    bank_account = finance_factories.BankAccountFactory.create()
+    offerers_factories.VenueBankAccountLinkFactory.create(
+        venue=pricing_point_venue,
+        bankAccount=bank_account,
+    )
+    offerers_factories.VenuePricingPointLinkFactory.create(
+        venue=origin_venue,
+        pricingPoint=pricing_point_venue,
+    )
+    offerers_factories.VenuePricingPointLinkFactory.create(
+        venue=pricing_point_venue,
+        pricingPoint=pricing_point_venue,
+    )
+
+    monkeypatch.setattr(main, "_get_rows", lambda: fake_iterator(origin_venue.id))
+
+    main.main(not_dry=True)
+
+    link = (
+        db.session.query(finance_models.VenueBankAccountLink)
+        .filter_by(venueId=origin_venue.id, bankAccountId=bank_account.id)
+        .first()
+    )
+    assert link is not None
+
+    action = (
+        db.session.query(history_models.ActionHistory)
+        .filter_by(
+            actionType=ActionType.LINK_VENUE_BANK_ACCOUNT_CREATED,
+            venueId=origin_venue.id,
+            bankAccountId=bank_account.id,
+        )
+        .first()
+    )
+    assert action is not None
+
+
+def test_add_bank_account_to_venue_with_bank_account(monkeypatch):
+    origin_venue = offerers_factories.VenueFactory()
+    bank_account = finance_factories.BankAccountFactory()
+    offerers_factories.VenueBankAccountLinkFactory(
+        venue=origin_venue,
+        bankAccountId=bank_account,
+    )
+
+    pricing_point_venue = offerers_factories.VenueFactory()
+    bank_account_2 = finance_factories.BankAccountFactory()
+    offerers_factories.VenueBankAccountLinkFactory(
+        venue=pricing_point_venue,
+        bankAccount=bank_account_2,
+    )
+    offerers_factories.VenuePricingPointLinkFactory.create(
+        venue=origin_venue,
+        pricingPoint=pricing_point_venue,
+    )
+    offerers_factories.VenuePricingPointLinkFactory.create(
+        venue=pricing_point_venue,
+        pricingPoint=pricing_point_venue,
+    )
+
+    monkeypatch.setattr(main, "_get_rows", lambda: fake_iterator(origin_venue.id))
+
+    main.main(not_dry=True)
+
+    link = (
+        db.session.query(finance_models.VenueBankAccountLink)
+        .filter_by(venueId=origin_venue.id, bankAccountId=bank_account_2.id)
+        .first()
+    )
+    assert link is None


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-38117)

Ajoute un compte bancaire à une liste d'ids de venue. Le compte bancaire est celui du venue pricing point.
- Si l'id n'est pas trouvé -> log
- Si la venue n'a pas de pricing point -> log
- Si la pricing point n'a pas de CB -> log
- Si la venue a déjà un CB -> log
- Sinon, ajout du CB et log

- [ ] Travail pair testé en environnement de preview
