### PR TITLE
(PC-38017)[PRO] feat: redirect to offer list template

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.spec.tsx
@@ -93,4 +93,17 @@ describe('CollectiveOfferSummary', () => {
       expect(screen.queryByText('n°2')).not.toBeInTheDocument()
     )
   })
+
+  it('should have the correct url for the list button when offer isTemplate is true', async () => {
+    offer = getCollectiveOfferTemplateFactory({
+      isTemplate: true,
+    })
+
+    renderCollectiveOfferSummaryEdition(offer)
+
+    const listButton = await screen.findByRole('link', {
+      name: /Retour à la liste des offres/i,
+    })
+    expect(listButton).toHaveAttribute('href', '/offres/vitrines')
+  })
 })

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -69,7 +69,7 @@ export const CollectiveOfferSummaryEdition = ({
         <ActionsBarSticky.Left>
           <ButtonLink
             variant={ButtonVariant.PRIMARY}
-            to={computeCollectiveOffersUrl({})}
+            to={computeCollectiveOffersUrl({}, undefined, offer.isTemplate)}
           >
             Retour à la liste des offres
           </ButtonLink>


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-38017)

Lorsque l'on ouvre le récapitulatif d'une offre vitrine, et que l'on clique sur "Retour à la liste des offres" on veut rediriger vers la liste des offres vitrines et non réservable