### PR TITLE
(BSR)[API] refactor: deprecate datetime.utcnow

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -211,8 +211,9 @@ extend-select = [
   # "PLR0914",  # too-many-locals -> preview mode only
   # "PLR0915",  # too-many-statements
   # "PLR0917",  # too-many-positional-arguments -> preview mode only
-  "S704",   # unsafe-markup-use
-  "TID251", # banned-api (requests)
+  "S704",    # unsafe-markup-use
+  "TID251",  # banned-api (requests)
+  "DTZ003",  # call-datetime-utcnow
 ]
 
 ignore = [
@@ -231,7 +232,14 @@ ignore = [
 case-sensitive = true
 force-single-line = true
 lines-after-imports = 2
-section-order = ["future", "standard-library", "third-party", "first-party", "tests", "local-folder"]
+section-order = [
+  "future",
+  "standard-library",
+  "third-party",
+  "first-party",
+  "tests",
+  "local-folder",
+]
 
 [tool.ruff.lint.isort.sections]
 tests = ["tests"]

--- a/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
+++ b/api/src/pcapi/connectors/beneficiaries/educonnect/educonnect_connector.py
@@ -16,6 +16,7 @@ from pcapi.core.users import constants
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from . import exceptions
 from . import models
@@ -154,7 +155,7 @@ def _get_mocked_user_for_performance_tests(user_id: str) -> models.EduconnectUse
 
     return users_factories.EduconnectUserFactory.create(
         birth_date=user.dateOfBirth.date(),
-        connection_datetime=datetime.utcnow(),
+        connection_datetime=date_utils.get_naive_utc_now(),
         educonnect_id=f"educonnect-id_perf-test_{user.id}",
         first_name="".join(random.choice(string.ascii_letters) for _ in range(10)),
         ine_hash=f"inehash_perf-test_{user.id}",

--- a/api/src/pcapi/connectors/dms/serializer.py
+++ b/api/src/pcapi/connectors/dms/serializer.py
@@ -21,6 +21,7 @@ from pcapi.core.subscription.dms import schemas as dms_schemas
 from pcapi.core.users import models as users_models
 from pcapi.routes.serialization import BaseModel
 from pcapi.serialization.utils import without_timezone
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import FrenchParserInfo
 
 
@@ -356,10 +357,10 @@ class MarkWithoutContinuationApplicationDetail(BaseModel):
 
     @property
     def should_be_marked_without_continuation(self) -> bool:
-        dead_line_application = datetime.utcnow() - timedelta(
+        dead_line_application = date_utils.get_naive_utc_now() - timedelta(
             days=int(settings.DS_MARK_WITHOUT_CONTINUATION_APPLICATION_DEADLINE)
         )
-        dead_line_annotation = datetime.utcnow() - timedelta(
+        dead_line_annotation = date_utils.get_naive_utc_now() - timedelta(
             days=int(settings.DS_MARK_WITHOUT_CONTINUATION_ANNOTATION_DEADLINE)
         )
 

--- a/api/src/pcapi/connectors/dms/utils.py
+++ b/api/src/pcapi/connectors/dms/utils.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 
 from pcapi.connectors.dms import models as ds_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.lock import lock
 
 
@@ -26,7 +27,7 @@ def import_ds_applications(
         .first()
     )
     if last_import and last_import.isProcessing:
-        if datetime.datetime.utcnow() < last_import.latestImportDatetime + datetime.timedelta(days=1):
+        if date_utils.get_naive_utc_now() < last_import.latestImportDatetime + datetime.timedelta(days=1):
             logger.info("[DS] Procedure %s is already being processed.", procedure_number)
         else:
             last_import.isProcessing = False
@@ -50,7 +51,7 @@ def import_ds_applications(
 
         current_import = ds_models.LatestDmsImport(
             procedureId=procedure_number,
-            latestImportDatetime=datetime.datetime.utcnow(),
+            latestImportDatetime=date_utils.get_naive_utc_now(),
             isProcessing=True,
             processedApplications=[],
         )

--- a/api/src/pcapi/connectors/typeform.py
+++ b/api/src/pcapi/connectors/typeform.py
@@ -11,6 +11,7 @@ from datetime import datetime
 import pydantic.v1 as pydantic_v1
 
 from pcapi import settings
+from pcapi.utils import date as date_utils
 from pcapi.utils import email as email_utils
 from pcapi.utils import module_loading
 from pcapi.utils import requests
@@ -132,7 +133,7 @@ class TestingBackend(BaseBackend):
         return TypeformForm(
             form_id=form_id,
             title=title,
-            date_created=datetime.utcnow(),
+            date_created=date_utils.get_naive_utc_now(),
             fields=[
                 TypeformQuestion(field_id=f"{form_id}-{i:04}", title=question)
                 for i, question in enumerate(self.QUESTIONS)
@@ -145,7 +146,7 @@ class TestingBackend(BaseBackend):
         return [
             TypeformResponse(
                 response_id=f"{form_id}-response",
-                date_submitted=datetime.utcnow(),
+                date_submitted=date_utils.get_naive_utc_now(),
                 phone_number="0199000123",
                 email="spilgrim@example.com",
                 answers=[

--- a/api/src/pcapi/core/achievements/api.py
+++ b/api/src/pcapi/core/achievements/api.py
@@ -1,11 +1,10 @@
-import datetime
-
 from pcapi.core.achievements import exceptions as achievements_exceptions
 from pcapi.core.achievements import models as achievements_models
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.categories import subcategories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 def unlock_achievement(booking: bookings_models.Booking) -> achievements_models.Achievement | None:
@@ -102,6 +101,6 @@ def mark_achievements_as_seen(user: users_models.User, achievement_ids: list[int
         )
 
     for achievement in achievements:
-        achievement.seenDate = datetime.datetime.utcnow()
+        achievement.seenDate = date_utils.get_naive_utc_now()
 
     db.session.flush()

--- a/api/src/pcapi/core/achievements/factories.py
+++ b/api/src/pcapi/core/achievements/factories.py
@@ -5,6 +5,7 @@ import factory
 import pcapi.core.bookings.factories as booking_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core.factories import BaseFactory
+from pcapi.utils import date as date_utils
 
 from . import models
 
@@ -15,6 +16,6 @@ class AchievementFactory(BaseFactory):
 
     user = factory.SubFactory(users_factories.BeneficiaryFactory)
     name = models.AchievementEnum.FIRST_BOOK_BOOKING
-    unlockedDate = factory.LazyFunction(datetime.datetime.utcnow)
+    unlockedDate = factory.LazyFunction(date_utils.get_naive_utc_now)
     seenDate: datetime.datetime | None = None
     booking = factory.SubFactory(booking_factories.BookingFactory)

--- a/api/src/pcapi/core/achievements/models.py
+++ b/api/src/pcapi/core/achievements/models.py
@@ -8,6 +8,7 @@ import sqlalchemy.orm as sa_orm
 import pcapi.utils.db as db_utils
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 
 
 if typing.TYPE_CHECKING:
@@ -44,7 +45,7 @@ class Achievement(PcObject, Model):
 
     name: sa_orm.Mapped[AchievementEnum] = sa_orm.mapped_column(db_utils.MagicEnum(AchievementEnum), nullable=False)
     unlockedDate: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
     # For when the user has seen the achievement success modal in the native app:
     seenDate: sa_orm.Mapped[datetime | None] = sa_orm.mapped_column(sa.DateTime, nullable=True)

--- a/api/src/pcapi/core/bookings/factories.py
+++ b/api/src/pcapi/core/bookings/factories.py
@@ -10,6 +10,7 @@ import pcapi.core.users.factories as users_factories
 from pcapi.core.factories import BaseFactory
 from pcapi.core.finance.models import DepositType
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.token import random_token
 
 from . import api
@@ -96,19 +97,19 @@ class BookingFactory(BaseFactory):
 
 class UsedBookingFactory(BookingFactory):
     status = models.BookingStatus.USED
-    dateUsed = factory.LazyFunction(datetime.datetime.utcnow)
+    dateUsed = factory.LazyFunction(date_utils.get_naive_utc_now)
 
 
 class CancelledBookingFactory(BookingFactory):
     status = models.BookingStatus.CANCELLED
-    cancellationDate = factory.LazyFunction(datetime.datetime.utcnow)  # type: ignore[assignment]
+    cancellationDate = factory.LazyFunction(date_utils.get_naive_utc_now)  # type: ignore[assignment]
     cancellationReason = models.BookingCancellationReasons.BENEFICIARY
 
 
 class ReimbursedBookingFactory(BookingFactory):
     status = models.BookingStatus.REIMBURSED
-    dateUsed = factory.LazyFunction(datetime.datetime.utcnow)
-    reimbursementDate = factory.LazyFunction(datetime.datetime.utcnow)
+    dateUsed = factory.LazyFunction(date_utils.get_naive_utc_now)
+    reimbursementDate = factory.LazyFunction(date_utils.get_naive_utc_now)
 
 
 class ExternalBookingFactory(BaseFactory):

--- a/api/src/pcapi/core/bookings/repository.py
+++ b/api/src/pcapi/core/bookings/repository.py
@@ -26,6 +26,7 @@ from pcapi.core.offers import models as offers_models
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.users.models import User
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import export as utils_export
 from pcapi.utils.token import random_token
 
@@ -1081,7 +1082,7 @@ def offerer_has_ongoing_bookings(offerer_id: int) -> bool:
 
 
 def find_individual_bookings_event_happening_tomorrow_query() -> list[models.Booking]:
-    tomorrow = datetime.utcnow() + timedelta(days=1)
+    tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
     tomorrow_min = datetime.combine(tomorrow, time.min)
     tomorrow_max = datetime.combine(tomorrow, time.max)
 

--- a/api/src/pcapi/core/bookings/utils.py
+++ b/api/src/pcapi/core/bookings/utils.py
@@ -92,7 +92,7 @@ def convert_collective_booking_dates_utc_to_venue_timezone(
 
 
 def get_cooldown_datetime_by_subcategories(sub_category_id: str) -> datetime:
-    return datetime.utcnow() - timedelta(
+    return date_utils.get_naive_utc_now() - timedelta(
         seconds=(
             SUGGEST_REACTION_COOLDOWN_IN_SECONDS[sub_category_id]
             if sub_category_id in SUGGEST_REACTION_COOLDOWN_IN_SECONDS

--- a/api/src/pcapi/core/chronicles/api.py
+++ b/api/src/pcapi/core/chronicles/api.py
@@ -12,6 +12,7 @@ from pcapi.connectors import typeform
 from pcapi.core.offers import models as offers_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.transaction_manager import atomic
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
 
@@ -28,7 +29,7 @@ def anonymize_unlinked_chronicles() -> None:
     db.session.query(models.Chronicle).filter(
         models.Chronicle.userId.is_(None),
         models.Chronicle.email != constants.ANONYMIZED_EMAIL,
-        models.Chronicle.dateCreated < datetime.utcnow() - relativedelta(years=2),
+        models.Chronicle.dateCreated < date_utils.get_naive_utc_now() - relativedelta(years=2),
     ).update({"email": constants.ANONYMIZED_EMAIL}, synchronize_session=False)
 
 

--- a/api/src/pcapi/core/chronicles/models.py
+++ b/api/src/pcapi/core/chronicles/models.py
@@ -15,6 +15,7 @@ from pcapi.core.users.models import User
 from pcapi.models import Model
 from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 
 
@@ -80,7 +81,7 @@ class Chronicle(PcObject, Model, DeactivableMixin):
     )
     content: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text, nullable=False)
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
     # used to reconciliate data if the form changed on typeform
     identifierChoiceId: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text(), nullable=True)

--- a/api/src/pcapi/core/educational/api/adage.py
+++ b/api/src/pcapi/core/educational/api/adage.py
@@ -22,6 +22,7 @@ from pcapi.core.offerers import repository as offerers_repository
 from pcapi.core.offerers.repository import get_emails_by_venue
 from pcapi.models import db
 from pcapi.routes.serialization import venues_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils.cache import get_from_cache
 from pcapi.utils.clean_accents import clean_accents
 from pcapi.utils.transaction_manager import atomic
@@ -232,7 +233,7 @@ def synchronize_adage_ids_on_venues(debug: bool = False, since_date: datetime | 
                     update_external_pro(email)
                 if venue.managingOfferer.isValidated:
                     send_eac_offerer_activation_email(venue, list(emails))
-                venue.adageInscriptionDate = datetime.utcnow()
+                venue.adageInscriptionDate = date_utils.get_naive_utc_now()
 
             new_adage_id = venue_to_adage_id.get(venue.id)
             if new_adage_id:

--- a/api/src/pcapi/core/educational/api/booking.py
+++ b/api/src/pcapi/core/educational/api/booking.py
@@ -25,6 +25,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.routes.serialization import collective_bookings_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils.transaction_manager import atomic
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
 from pcapi.utils.transaction_manager import on_commit
@@ -50,7 +51,7 @@ def book_collective_offer(
         raise exceptions.EducationalYearNotFound()
     validation.check_user_can_prebook_collective_stock(redactor_informations.uai, stock)
 
-    utcnow = datetime.datetime.utcnow()
+    utcnow = date_utils.get_naive_utc_now()
     booking = educational_models.CollectiveBooking(
         educationalInstitution=educational_institution,
         educationalYear=educational_year,
@@ -550,7 +551,7 @@ def _cancel_expired_collective_bookings(batch_size: int = 500) -> None:
                 {
                     "status": educational_models.CollectiveBookingStatus.CANCELLED,
                     "cancellationReason": educational_models.CollectiveBookingCancellationReasons.EXPIRED,
-                    "cancellationDate": datetime.datetime.utcnow(),
+                    "cancellationDate": date_utils.get_naive_utc_now(),
                 },
                 synchronize_session=False,
             )

--- a/api/src/pcapi/core/educational/api/dms.py
+++ b/api/src/pcapi/core/educational/api/dms.py
@@ -8,6 +8,7 @@ from pcapi.connectors.dms import api as dms_api
 from pcapi.connectors.dms import models as dms_models
 from pcapi.core.educational import models as educational_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -31,7 +32,7 @@ def import_dms_applications(procedure_number: int, ignore_previous: bool = False
     """import dms applications for eac status"""
     previous_import = _get_previous_import(procedure_number)
     if previous_import and previous_import.isProcessing:
-        if datetime.datetime.utcnow() < previous_import.latestImportDatetime + datetime.timedelta(days=1):
+        if date_utils.get_naive_utc_now() < previous_import.latestImportDatetime + datetime.timedelta(days=1):
             logger.info(
                 "[DMS] Procedure %s is already being processed.",
                 procedure_number,
@@ -65,7 +66,7 @@ def update_dms_applications_for_procedure(procedure_number: int, since: datetime
 
     current_import = dms_models.LatestDmsImport(
         procedureId=procedure_number,
-        latestImportDatetime=datetime.datetime.utcnow(),
+        latestImportDatetime=date_utils.get_naive_utc_now(),
         isProcessing=True,
         processedApplications=[],
     )

--- a/api/src/pcapi/core/educational/api/institution.py
+++ b/api/src/pcapi/core/educational/api/institution.py
@@ -15,6 +15,7 @@ from pcapi.core.educational import repository
 from pcapi.core.educational.adage_backends.serialize import AdageEducationalInstitution
 from pcapi.core.educational.constants import INSTITUTION_TYPES
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 from pcapi.utils import postal_code as postal_code_utils
 
@@ -277,7 +278,7 @@ def get_current_year_remaining_credit(institution: models.EducationalInstitution
 
       current year deposit amount - sum of confirmed bookings amounts
     """
-    educational_year = repository.find_educational_year_by_date(datetime.utcnow())
+    educational_year = repository.find_educational_year_by_date(date_utils.get_naive_utc_now())
     assert educational_year is not None
 
     deposit = repository.find_educational_deposit_by_institution_id_and_year(institution.id, educational_year.adageId)
@@ -294,7 +295,7 @@ def create_missing_educational_institution_from_adage(destination_uai: str) -> m
     Fetch known adage institutions of the current year and create the
     missing institution inside or database if the target uai exists.
     """
-    year = repository.find_educational_year_by_date(datetime.utcnow())
+    year = repository.find_educational_year_by_date(date_utils.get_naive_utc_now())
     if year is None:
         raise exceptions.EducationalYearNotFound()
 
@@ -332,7 +333,7 @@ def create_educational_institution_from_adage(
 
 def synchronise_institutions_geolocation(adage_year_id: str | None = None) -> None:
     if adage_year_id is None:
-        year = repository.find_educational_year_by_date(datetime.utcnow())
+        year = repository.find_educational_year_by_date(date_utils.get_naive_utc_now())
         if year is None:
             raise exceptions.EducationalYearNotFound()
         adage_year_id = year.adageId

--- a/api/src/pcapi/core/educational/api/offer.py
+++ b/api/src/pcapi/core/educational/api/offer.py
@@ -45,6 +45,7 @@ from pcapi.routes.adage_iframe.serialization.offers import PostCollectiveRequest
 from pcapi.routes.public import utils as public_utils
 from pcapi.routes.public.collective.serialization import offers as public_api_collective_offers_serialize
 from pcapi.routes.serialization import collective_offers_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils import image_conversion
 from pcapi.utils import rest
 from pcapi.utils.transaction_manager import is_managed_transaction
@@ -919,7 +920,7 @@ def check_can_move_collective_offer_venue(
             .with_entities(models.CollectiveStock.id)
             .filter(
                 models.CollectiveStock.collectiveOfferId == collective_offer.id,
-                models.CollectiveStock.startDatetime < datetime.datetime.utcnow(),
+                models.CollectiveStock.startDatetime < date_utils.get_naive_utc_now(),
             )
             .count()
         )

--- a/api/src/pcapi/core/educational/api/shared.py
+++ b/api/src/pcapi/core/educational/api/shared.py
@@ -4,6 +4,7 @@ from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import repository as educational_repository
 from pcapi.core.educational import utils as educational_utils
+from pcapi.utils import date as date_utils
 
 
 def update_collective_stock_booking(
@@ -52,7 +53,7 @@ def _update_collective_booking_cancellation_limit_date(
 ) -> None:
     # if the input date has a timezone (resp. does not have one), we need to compare it with an aware datetime (resp. a naive datetime)
     now = (
-        datetime.datetime.utcnow()
+        date_utils.get_naive_utc_now()
         if new_start_datetime.tzinfo is None
         else datetime.datetime.now(datetime.timezone.utc)
     )
@@ -70,4 +71,4 @@ def _update_collective_booking_pending(expired_booking: educational_models.Colle
 def _should_update_collective_booking_pending(
     booking: educational_models.CollectiveBooking | None, booking_limit: datetime.datetime
 ) -> bool:
-    return booking is not None and booking.is_expired and booking_limit > datetime.datetime.utcnow()
+    return booking is not None and booking.is_expired and booking_limit > date_utils.get_naive_utc_now()

--- a/api/src/pcapi/core/educational/commands.py
+++ b/api/src/pcapi/core/educational/commands.py
@@ -15,6 +15,7 @@ from pcapi.core.educational.api import booking as educational_api_booking
 from pcapi.core.educational.api.dms import import_dms_applications_for_all_eac_procedures
 from pcapi.core.educational.utils import create_adage_jwt_fake_valid_token
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.blueprint import Blueprint
 from pcapi.utils.repository import transaction
 
@@ -99,7 +100,7 @@ def check_deposit_csv(path: str) -> None:
 @cron_decorators.log_cron_with_transaction
 def synchronize_venues_from_adage_cultural_partners(debug: bool = False, with_timestamp: bool = False) -> None:
     # Change to use datetime arithmetic
-    since_date = datetime.datetime.utcnow() - datetime.timedelta(days=2) if with_timestamp else None
+    since_date = date_utils.get_naive_utc_now() - datetime.timedelta(days=2) if with_timestamp else None
     adage_api.synchronize_adage_ids_on_venues(debug=debug, since_date=since_date)
     # This commit is very much needed at this time.
     # log_cron_with_transaction will only commit IF the session is dirty
@@ -114,7 +115,7 @@ def synchronize_venues_from_adage_cultural_partners(debug: bool = False, with_ti
 @cron_decorators.log_cron_with_transaction
 def synchronize_offerers_from_adage_cultural_partners(with_timestamp: bool = False) -> None:
     # Change to use datetime arithmetic
-    since_date = datetime.datetime.utcnow() - datetime.timedelta(days=2) if with_timestamp else None
+    since_date = date_utils.get_naive_utc_now() - datetime.timedelta(days=2) if with_timestamp else None
     with transaction():
         adage_cultural_partners = adage_api.get_cultural_partners(since_date=since_date)
         adage_api.synchronize_adage_ids_on_offerers(adage_cultural_partners.partners)

--- a/api/src/pcapi/core/educational/factories.py
+++ b/api/src/pcapi/core/educational/factories.py
@@ -13,6 +13,7 @@ from pcapi.core.factories import BaseFactory
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import OfferValidationType
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 
 
@@ -61,7 +62,7 @@ class CollectiveOfferFactory(BaseFactory[models.CollectiveOffer]):
     mentalDisabilityCompliant = False
     motorDisabilityCompliant = False
     visualDisabilityCompliant = False
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=5))
+    dateCreated = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=5))
     students = [models.StudentLevels.GENERAL2]
     contactEmail = "collectiveofferfactory+contact@example.com"
     bookingEmails = ["collectiveofferfactory+booking@example.com", "collectiveofferfactory+booking@example2.com"]
@@ -88,7 +89,7 @@ class CollectiveOfferFactory(BaseFactory[models.CollectiveOffer]):
                 kwargs["lastValidationType"] = OfferValidationType.AUTO
 
             if "lastValidationDate" not in kwargs:
-                stock_date_created = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+                stock_date_created = date_utils.get_naive_utc_now() - datetime.timedelta(days=3)
                 kwargs["lastValidationDate"] = stock_date_created + datetime.timedelta(minutes=10)
 
         return super()._create(model_class, *args, **kwargs)
@@ -121,7 +122,7 @@ class CollectiveOfferTemplateFactory(BaseFactory[models.CollectiveOfferTemplate]
     motorDisabilityCompliant = False
     visualDisabilityCompliant = False
 
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=5))
+    dateCreated = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=5))
     students = [models.StudentLevels.GENERAL2]
     contactEmail = "collectiveofferfactory+contact@example.com"
     contactPhone = "+33199006328"
@@ -130,8 +131,8 @@ class CollectiveOfferTemplateFactory(BaseFactory[models.CollectiveOfferTemplate]
     locationType = models.CollectiveLocationType.TO_BE_DEFINED
     interventionArea = ["2A", "2B"]
     dateRange = db_utils.make_timerange(
-        start=datetime.datetime.utcnow() + datetime.timedelta(days=1),
-        end=datetime.datetime.utcnow() + datetime.timedelta(days=7),
+        start=date_utils.get_naive_utc_now() + datetime.timedelta(days=1),
+        end=date_utils.get_naive_utc_now() + datetime.timedelta(days=7),
     )
     formats = [EacFormat.PROJECTION_AUDIOVISUELLE]
 
@@ -183,11 +184,11 @@ class CollectiveStockFactory(BaseFactory[models.CollectiveStock]):
         model = models.CollectiveStock
 
     collectiveOffer = factory.SubFactory(CollectiveOfferFactory)
-    startDatetime = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=1))
+    startDatetime = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() + datetime.timedelta(days=1))
     endDatetime = factory.LazyAttribute(lambda o: o.startDatetime)
     bookingLimitDatetime = factory.LazyAttribute(lambda stock: stock.startDatetime - datetime.timedelta(minutes=60))
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=3))
-    dateModified = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1))
+    dateCreated = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=3))
+    dateModified = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=1))
     numberOfTickets = 25
     price = 100
     priceDetail = factory.LazyAttribute(lambda stock: f"Prix: {stock.price}€ pour {stock.numberOfTickets} tickets")
@@ -217,7 +218,7 @@ def _get_educational_year_beginning(date_time: datetime.datetime) -> int:
 
 
 def _get_current_educational_year() -> int:
-    current_date = datetime.datetime.utcnow()
+    current_date = date_utils.get_naive_utc_now()
 
     return _get_educational_year_beginning(current_date)
 
@@ -271,7 +272,7 @@ class CollectiveBookingFactory(BaseFactory[models.CollectiveBooking]):
         model = models.CollectiveBooking
 
     collectiveStock = factory.SubFactory(CollectiveStockFactory)
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=2))
+    dateCreated = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=2))
     offerer = factory.SelfAttribute("collectiveStock.collectiveOffer.venue.managingOfferer")
     venue = factory.SelfAttribute("collectiveStock.collectiveOffer.venue")
     cancellationLimitDate: factory.declarations.BaseDeclaration = factory.LazyAttribute(
@@ -280,47 +281,47 @@ class CollectiveBookingFactory(BaseFactory[models.CollectiveBooking]):
         )
     )
     confirmationLimitDate: factory.declarations.BaseDeclaration = factory.LazyFunction(
-        lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
     )
     educationalInstitution = factory.SubFactory(EducationalInstitutionFactory)
     educationalYear = factory.SubFactory(EducationalYearFactory)
     educationalRedactor = factory.SubFactory(EducationalRedactorFactory)
     confirmationDate: factory.declarations.BaseDeclaration | None = factory.LazyFunction(
-        lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
     )
 
 
 class CancelledCollectiveBookingFactory(CollectiveBookingFactory):
     status = models.CollectiveBookingStatus.CANCELLED
-    cancellationDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(hours=1))
+    cancellationDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(hours=1))
     cancellationReason = factory.Iterator(models.CollectiveBookingCancellationReasons)
 
 
 class PendingCollectiveBookingFactory(CollectiveBookingFactory):
-    cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=10))
-    confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=10))
+    cancellationLimitDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() + datetime.timedelta(days=10))
+    confirmationLimitDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() + datetime.timedelta(days=10))
     confirmationDate = None
     status = models.CollectiveBookingStatus.PENDING
 
 
 class UsedCollectiveBookingFactory(CollectiveBookingFactory):
     status = models.CollectiveBookingStatus.USED
-    dateUsed = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=5))
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=20))
-    confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=12))
-    confirmationDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=6))
+    dateUsed = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=5))
+    dateCreated = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=20))
+    confirmationLimitDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=12))
+    confirmationDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=6))
 
 
 class ReimbursedCollectiveBookingFactory(UsedCollectiveBookingFactory):
     status = models.CollectiveBookingStatus.REIMBURSED
-    reimbursementDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1))
+    reimbursementDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=1))
 
 
 class ConfirmedCollectiveBookingFactory(CollectiveBookingFactory):
     status = models.CollectiveBookingStatus.CONFIRMED
-    cancellationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1))
-    confirmationDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1))
-    confirmationLimitDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() + datetime.timedelta(days=1))
+    cancellationLimitDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=1))
+    confirmationDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=1))
+    confirmationLimitDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() + datetime.timedelta(days=1))
 
 
 class CollectiveDmsApplicationWithNoVenueFactory(BaseFactory[models.CollectiveDmsApplication]):
@@ -331,9 +332,9 @@ class CollectiveDmsApplicationWithNoVenueFactory(BaseFactory[models.CollectiveDm
     state = "en_construction"
     procedure = 1  # could be any positive integer
     application = factory.Sequence(int)
-    lastChangeDate = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
-    depositDate = datetime.datetime.utcnow() - datetime.timedelta(days=10)
-    expirationDate = datetime.datetime.utcnow() + datetime.timedelta(days=365)
+    lastChangeDate = date_utils.get_naive_utc_now() - datetime.timedelta(hours=1)
+    depositDate = date_utils.get_naive_utc_now() - datetime.timedelta(days=10)
+    expirationDate = date_utils.get_naive_utc_now() + datetime.timedelta(days=365)
     buildDate = factory.SelfAttribute("lastChangeDate")
 
 
@@ -409,7 +410,7 @@ class CollectiveOfferBaseFactory(CollectiveOfferFactory):
 
 class ArchivedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     isActive = False
-    dateArchived = factory.LazyFunction(datetime.datetime.utcnow)
+    dateArchived = factory.LazyFunction(date_utils.get_naive_utc_now)
 
 
 class RejectedCollectiveOfferFactory(CollectiveOfferBaseFactory):
@@ -420,7 +421,7 @@ class RejectedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     def create_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
         # a rejected offer has a stock because it completed the creation process
         CollectiveStockFactory.create(
-            startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=10), collectiveOffer=self
+            startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=10), collectiveOffer=self
         )
 
 
@@ -432,7 +433,7 @@ class UnderReviewCollectiveOfferFactory(CollectiveOfferBaseFactory):
     def create_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
         # an offer under review has a stock because it completed the creation process
         CollectiveStockFactory.create(
-            startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=10), collectiveOffer=self
+            startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=10), collectiveOffer=self
         )
 
 
@@ -446,13 +447,13 @@ class PublishedCollectiveOfferFactory(CollectiveOfferBaseFactory):
 
     @factory.post_generation
     def create_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        future = datetime.datetime.utcnow() + datetime.timedelta(days=10)
+        future = date_utils.get_naive_utc_now() + datetime.timedelta(days=10)
         CollectiveStockFactory.create(startDatetime=future, collectiveOffer=self)
 
 
 class ArchivedPublishedCollectiveOfferFactory(PublishedCollectiveOfferFactory):
     isActive = False
-    dateArchived = factory.LazyFunction(datetime.datetime.utcnow)
+    dateArchived = factory.LazyFunction(date_utils.get_naive_utc_now)
 
 
 class HiddenCollectiveOfferFactory(CollectiveOfferBaseFactory):
@@ -464,7 +465,7 @@ class ExpiredWithoutBookingCollectiveOfferFactory(CollectiveOfferBaseFactory):
 
     @factory.post_generation
     def create_expired_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         CollectiveStockFactory.create(bookingLimitDatetime=yesterday, collectiveOffer=self)
 
 
@@ -473,7 +474,7 @@ class ExpiredWithBookingCollectiveOfferFactory(CollectiveOfferBaseFactory):
 
     @factory.post_generation
     def create_expired_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         stock = CollectiveStockFactory.create(bookingLimitDatetime=yesterday, collectiveOffer=self)
         PendingCollectiveBookingFactory.create(collectiveStock=stock)
 
@@ -481,7 +482,7 @@ class ExpiredWithBookingCollectiveOfferFactory(CollectiveOfferBaseFactory):
 class PrebookedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_prebooked_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         stock = CollectiveStockFactory.create(startDatetime=tomorrow, collectiveOffer=self)
         PendingCollectiveBookingFactory.create(collectiveStock=stock)
 
@@ -489,14 +490,14 @@ class PrebookedCollectiveOfferFactory(CollectiveOfferBaseFactory):
 class CancelledWithoutBookingCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_cancelled_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        in_past = datetime.datetime.utcnow() - datetime.timedelta(days=4)
+        in_past = date_utils.get_naive_utc_now() - datetime.timedelta(days=4)
         CollectiveStockFactory.create(startDatetime=in_past, collectiveOffer=self)
 
 
 class CancelledWithPendingBookingCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_cancelled_booking(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        in_past = datetime.datetime.utcnow() - datetime.timedelta(days=4)
+        in_past = date_utils.get_naive_utc_now() - datetime.timedelta(days=4)
         stock = CollectiveStockFactory.create(startDatetime=in_past, collectiveOffer=self)
         CancelledCollectiveBookingFactory.create(collectiveStock=stock, confirmationDate=None)
 
@@ -504,7 +505,7 @@ class CancelledWithPendingBookingCollectiveOfferFactory(CollectiveOfferBaseFacto
 class CancelledWithBookingCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_cancelled_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        in_past = datetime.datetime.utcnow() - datetime.timedelta(days=4)
+        in_past = date_utils.get_naive_utc_now() - datetime.timedelta(days=4)
         stock = CollectiveStockFactory.create(startDatetime=in_past, collectiveOffer=self)
         CancelledCollectiveBookingFactory.create(
             collectiveStock=stock, cancellationReason=models.CollectiveBookingCancellationReasons.OFFERER
@@ -514,7 +515,7 @@ class CancelledWithBookingCollectiveOfferFactory(CollectiveOfferBaseFactory):
 class CancelledDueToExpirationCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_cancelled_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        in_past = datetime.datetime.utcnow() - datetime.timedelta(days=4)
+        in_past = date_utils.get_naive_utc_now() - datetime.timedelta(days=4)
         stock = CollectiveStockFactory.create(startDatetime=in_past, collectiveOffer=self)
         CancelledCollectiveBookingFactory.create(
             collectiveStock=stock, cancellationReason=models.CollectiveBookingCancellationReasons.EXPIRED
@@ -524,7 +525,7 @@ class CancelledDueToExpirationCollectiveOfferFactory(CollectiveOfferBaseFactory)
 class BookedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_booked_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         stock = CollectiveStockFactory.create(startDatetime=tomorrow, collectiveOffer=self)
         ConfirmedCollectiveBookingFactory.create(collectiveStock=stock)
 
@@ -532,7 +533,7 @@ class BookedCollectiveOfferFactory(CollectiveOfferBaseFactory):
 class EndedCollectiveOfferConfirmedBookingFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_booking(self, _create: bool, _extracted: typing.Any, **kwargs: typing.Any) -> None:
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         stock = CollectiveStockFactory.create(startDatetime=yesterday, collectiveOffer=self)
         ConfirmedCollectiveBookingFactory.create(collectiveStock=stock)
 
@@ -540,7 +541,7 @@ class EndedCollectiveOfferConfirmedBookingFactory(CollectiveOfferBaseFactory):
 class EndedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_booking(self, _create: bool, _extracted: typing.Any, **kwargs: typing.Any) -> None:
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+        yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=3)
         stock = CollectiveStockFactory.create(startDatetime=yesterday, collectiveOffer=self)
         UsedCollectiveBookingFactory.create(collectiveStock=stock)
 
@@ -548,14 +549,14 @@ class EndedCollectiveOfferFactory(CollectiveOfferBaseFactory):
 class ReimbursedCollectiveOfferFactory(CollectiveOfferBaseFactory):
     @factory.post_generation
     def create_reimbursed_stock(self, _create: bool, _extracted: typing.Any, **_kwargs: typing.Any) -> None:
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         stock = CollectiveStockFactory.create(startDatetime=yesterday, collectiveOffer=self)
         ReimbursedCollectiveBookingFactory.create(collectiveStock=stock)
 
 
 class ArchivedReimbursedCollectiveOfferFactory(ReimbursedCollectiveOfferFactory):
     isActive = False
-    dateArchived = factory.LazyFunction(datetime.datetime.utcnow)
+    dateArchived = factory.LazyFunction(date_utils.get_naive_utc_now)
 
 
 class CollectiveOfferOnSchoolLocationFactory(PublishedCollectiveOfferFactory):
@@ -643,7 +644,7 @@ def create_collective_offer_template_by_status(
 ) -> models.CollectiveOfferTemplate:
     match status:
         case models.CollectiveOfferDisplayedStatus.ARCHIVED:
-            kwargs.update({"isActive": False, "dateArchived": datetime.datetime.utcnow()})
+            kwargs.update({"isActive": False, "dateArchived": date_utils.get_naive_utc_now()})
             return CollectiveOfferTemplateFactory.create(**kwargs)
 
         case models.CollectiveOfferDisplayedStatus.REJECTED:
@@ -667,7 +668,7 @@ def create_collective_offer_template_by_status(
             return CollectiveOfferTemplateFactory.create(**kwargs)
 
         case models.CollectiveOfferDisplayedStatus.ENDED:
-            now = datetime.datetime.utcnow()
+            now = date_utils.get_naive_utc_now()
             start = now - datetime.timedelta(days=14)
             date_range = db_utils.make_timerange(start=start, end=now - datetime.timedelta(days=7))
             return CollectiveOfferTemplateFactory.create(**kwargs, dateRange=date_range, dateCreated=start)

--- a/api/src/pcapi/core/educational/models.py
+++ b/api/src/pcapi/core/educational/models.py
@@ -25,6 +25,7 @@ from pcapi.core.finance import models as finance_models
 from pcapi.models import offer_mixin
 from pcapi.models.accessibility_mixin import AccessibilityMixin
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 from pcapi.utils import image_conversion
 from pcapi.utils.phone_number import ParsedPhoneNumber
@@ -514,13 +515,13 @@ class CollectiveOffer(
     durationMinutes = sa_orm.mapped_column(sa.Integer, nullable=True)
 
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
 
     dateArchived: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(sa.DateTime, nullable=True)
 
     dateUpdated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now, onupdate=date_utils.get_naive_utc_now
     )
 
     students: sa_orm.Mapped[list[StudentLevels]] = sa_orm.mapped_column(
@@ -783,7 +784,7 @@ class CollectiveOffer(
         if not self.collectiveStock:
             return None
 
-        delta = self.collectiveStock.bookingLimitDatetime - datetime.datetime.utcnow()
+        delta = self.collectiveStock.bookingLimitDatetime - date_utils.get_naive_utc_now()
         return delta.days
 
     def get_sort_criterion(self) -> tuple[bool, int, datetime.datetime]:
@@ -1032,11 +1033,11 @@ class CollectiveOfferTemplate(
     durationMinutes = sa_orm.mapped_column(sa.Integer, nullable=True)
 
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
 
     dateUpdated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now, onupdate=date_utils.get_naive_utc_now
     )
 
     students: sa_orm.Mapped[list[StudentLevels]] = sa_orm.mapped_column(
@@ -1251,7 +1252,7 @@ class CollectiveOfferTemplate(
     def hasEndDatePassed(self) -> bool:
         if not self.end:
             return False
-        return self.end < datetime.datetime.utcnow()
+        return self.end < date_utils.get_naive_utc_now()
 
     @hasEndDatePassed.inplace.expression
     @classmethod
@@ -1358,11 +1359,11 @@ class CollectiveStock(PcObject, models.Model):
     __tablename__ = "collective_stock"
 
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
 
     dateModified: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, onupdate=date_utils.get_naive_utc_now
     )
 
     startDatetime: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False)
@@ -1413,7 +1414,7 @@ class CollectiveStock(PcObject, models.Model):
 
     @hybrid_property
     def hasBookingLimitDatetimePassed(self) -> bool:
-        return self.bookingLimitDatetime <= datetime.datetime.utcnow()
+        return self.bookingLimitDatetime <= date_utils.get_naive_utc_now()
 
     @hasBookingLimitDatetimePassed.inplace.expression
     @classmethod
@@ -1422,7 +1423,7 @@ class CollectiveStock(PcObject, models.Model):
 
     @hybrid_property
     def hasStartDatetimePassed(self) -> bool:
-        return self.startDatetime <= datetime.datetime.utcnow()
+        return self.startDatetime <= date_utils.get_naive_utc_now()
 
     @hasStartDatetimePassed.inplace.expression
     @classmethod
@@ -1431,7 +1432,7 @@ class CollectiveStock(PcObject, models.Model):
 
     @hybrid_property
     def hasEndDatetimePassed(self) -> bool:
-        return self.endDatetime <= datetime.datetime.utcnow()
+        return self.endDatetime <= date_utils.get_naive_utc_now()
 
     @hasEndDatetimePassed.inplace.expression
     @classmethod
@@ -1440,7 +1441,7 @@ class CollectiveStock(PcObject, models.Model):
 
     @hybrid_property
     def isEventExpired(self) -> bool:
-        return self.startDatetime <= datetime.datetime.utcnow()
+        return self.startDatetime <= date_utils.get_naive_utc_now()
 
     @isEventExpired.inplace.expression
     @classmethod
@@ -1461,7 +1462,7 @@ class CollectiveStock(PcObject, models.Model):
         return non_cancelled_bookings[0] if non_cancelled_bookings else None
 
     def is_two_days_past_end(self) -> bool:
-        return self.endDatetime + datetime.timedelta(days=2) < datetime.datetime.utcnow()
+        return self.endDatetime + datetime.timedelta(days=2) < date_utils.get_naive_utc_now()
 
     @property
     def isSoldOut(self) -> bool:
@@ -1590,7 +1591,7 @@ class EducationalDeposit(PcObject, models.Model):
     amount: sa_orm.Mapped[decimal.Decimal] = sa_orm.mapped_column(sa.Numeric(10, 2), nullable=False)
 
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
 
     isFinal: sa_orm.Mapped[bool] = sa_orm.mapped_column(sa.Boolean, nullable=False, default=True)
@@ -1659,7 +1660,7 @@ class CollectiveBooking(PcObject, models.Model):
     __tablename__ = "collective_booking"
 
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
     sa.Index("ix_collective_booking_date_created", dateCreated)
 
@@ -1772,7 +1773,7 @@ class CollectiveBooking(PcObject, models.Model):
         if self.status is CollectiveBookingStatus.USED and not cancel_even_if_used:
             raise exceptions.CollectiveBookingIsAlreadyUsed
         self.status = CollectiveBookingStatus.CANCELLED
-        self.cancellationDate = datetime.datetime.utcnow()
+        self.cancellationDate = date_utils.get_naive_utc_now()
         self.cancellationReason = reason
         self.cancellationUserId = author_id
         self.dateUsed = None
@@ -1788,7 +1789,7 @@ class CollectiveBooking(PcObject, models.Model):
         if self.confirmationDate:
             if self.collectiveStock.is_two_days_past_end():
                 self.status = CollectiveBookingStatus.USED
-                self.dateUsed = datetime.datetime.utcnow()
+                self.dateUsed = date_utils.get_naive_utc_now()
             else:
                 self.status = CollectiveBookingStatus.CONFIRMED
         else:
@@ -1799,16 +1800,16 @@ class CollectiveBooking(PcObject, models.Model):
             raise booking_exceptions.ConfirmationLimitDateHasPassed()
 
         self.status = CollectiveBookingStatus.CONFIRMED
-        self.confirmationDate = datetime.datetime.utcnow()
+        self.confirmationDate = date_utils.get_naive_utc_now()
 
     @hybrid_property
     def isConfirmed(self) -> bool:
-        return self.cancellationLimitDate <= datetime.datetime.utcnow()
+        return self.cancellationLimitDate <= date_utils.get_naive_utc_now()
 
     @isConfirmed.inplace.expression
     @classmethod
     def _isConfirmedExpression(cls) -> sa.ColumnElement[bool]:
-        return cls.cancellationLimitDate <= datetime.datetime.utcnow()
+        return cls.cancellationLimitDate <= date_utils.get_naive_utc_now()
 
     @hybrid_property
     def is_used_or_reimbursed(self) -> bool:
@@ -1846,10 +1847,13 @@ class CollectiveBooking(PcObject, models.Model):
         return f"{self.educationalRedactor.firstName} {self.educationalRedactor.lastName}"
 
     def has_confirmation_limit_date_passed(self) -> bool:
-        return self.confirmationLimitDate <= datetime.datetime.utcnow()
+        return self.confirmationLimitDate <= date_utils.get_naive_utc_now()
 
     def mark_as_refused(self) -> None:
-        if self.status != CollectiveBookingStatus.PENDING and self.cancellationLimitDate <= datetime.datetime.utcnow():
+        if (
+            self.status != CollectiveBookingStatus.PENDING
+            and self.cancellationLimitDate <= date_utils.get_naive_utc_now()
+        ):
             raise exceptions.EducationalBookingNotRefusable()
         cancellation_reason = (
             CollectiveBookingCancellationReasons.REFUSED_BY_INSTITUTE
@@ -2147,7 +2151,7 @@ class NationalProgram(PcObject, models.Model):
     __tablename__ = "national_program"
     name: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text, unique=True, nullable=True)
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
     domains: sa_orm.Mapped[list["EducationalDomain"]] = sa_orm.relationship(
         "EducationalDomain",

--- a/api/src/pcapi/core/educational/repository.py
+++ b/api/src/pcapi/core/educational/repository.py
@@ -22,6 +22,7 @@ from pcapi.core.providers import models as providers_models
 from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.models import offer_mixin
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 from pcapi.utils.clean_accents import clean_accents
 
@@ -44,14 +45,14 @@ BOOKING_DATE_STATUS_MAPPING: dict[models.CollectiveBookingStatusFilter, sa_orm.I
 
 
 def find_bookings_starting_in_x_days(number_of_days: int) -> list[models.CollectiveBooking]:
-    target_day = datetime.utcnow() + timedelta(days=number_of_days)
+    target_day = date_utils.get_naive_utc_now() + timedelta(days=number_of_days)
     start = datetime.combine(target_day, time.min)
     end = datetime.combine(target_day, time.max)
     return find_bookings_in_interval(start, end, models.CollectiveStock.startDatetime)
 
 
 def find_bookings_ending_in_x_days(number_of_days: int) -> list[models.CollectiveBooking]:
-    target_day = datetime.utcnow() + timedelta(days=number_of_days)
+    target_day = date_utils.get_naive_utc_now() + timedelta(days=number_of_days)
     start = datetime.combine(target_day, time.min)
     end = datetime.combine(target_day, time.max)
     return find_bookings_in_interval(start, end, models.CollectiveStock.endDatetime)
@@ -1529,7 +1530,7 @@ def search_educational_institution(
 
 
 def find_pending_booking_confirmation_limit_date_in_3_days() -> list[models.CollectiveBooking]:
-    target_day = datetime.utcnow() + timedelta(days=3)
+    target_day = date_utils.get_naive_utc_now() + timedelta(days=3)
     start = datetime.combine(target_day, time.min)
     end = datetime.combine(target_day, time.max)
     query = (
@@ -1574,7 +1575,7 @@ def get_booking_related_bank_account(booking_id: int) -> offerers_models.VenueBa
             offerers_models.VenueBankAccountLink,
             sa.and_(
                 offerers_models.VenueBankAccountLink.bankAccountId == finance_models.BankAccount.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .join(offerers_models.Venue, offerers_models.VenueBankAccountLink.venueId == offerers_models.Venue.id)
@@ -1664,7 +1665,7 @@ def has_collective_offers_for_program_and_venue_ids(program_name: str, venue_ids
             models.CollectiveOffer.venueId.in_(venue_ids),
             models.CollectiveOffer.validation == offer_mixin.OfferValidationStatus.APPROVED,
             models.EducationalInstitutionProgram.name == program_name,
-            models.EducationalInstitutionProgramAssociation.timespan.contains(datetime.utcnow()),
+            models.EducationalInstitutionProgramAssociation.timespan.contains(date_utils.get_naive_utc_now()),
         )
         .exists()
     )

--- a/api/src/pcapi/core/educational/utils.py
+++ b/api/src/pcapi/core/educational/utils.py
@@ -10,6 +10,7 @@ from pcapi.core.educational import exceptions
 from pcapi.core.educational import models
 from pcapi.core.educational.constants import COLLECTIVE_OFFER_DISPLAYED_STATUS_LABELS
 from pcapi.core.users.utils import ALGORITHM_RS_256
+from pcapi.utils import date as date_utils
 from pcapi.utils import requests
 
 
@@ -63,7 +64,7 @@ def create_adage_jwt_fake_valid_token(readonly: bool, can_prebook: bool = True, 
             "nom": "TEST",
             "prenom": "COMPTE",
             "mail": "compte.test@education.gouv.fr",
-            "exp": datetime.utcnow() + timedelta(days=1),
+            "exp": date_utils.get_naive_utc_now() + timedelta(days=1),
             "canPrebook": can_prebook,
         }
         if not readonly:

--- a/api/src/pcapi/core/external/attributes/api.py
+++ b/api/src/pcapi/core/external/attributes/api.py
@@ -26,6 +26,7 @@ from pcapi.core.users import models as users_models
 from pcapi.core.users import repository as users_repository
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
+from pcapi.utils import date as date_utils
 from pcapi.utils.transaction_manager import on_commit
 
 
@@ -78,7 +79,7 @@ def update_external_pro(email: str | None) -> None:
     from pcapi.tasks.serialization.external_pro_tasks import UpdateProAttributesRequest
 
     if email:
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         on_commit(
             partial(
                 update_sib_pro_attributes_task.delay,
@@ -263,7 +264,7 @@ def get_pro_attributes(email: str) -> models.ProAttributes:
             offerers_models.VenueBankAccountLink,
             sa.and_(
                 offerers_models.Venue.id == offerers_models.VenueBankAccountLink.venueId,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .options(

--- a/api/src/pcapi/core/external/automations/venue.py
+++ b/api/src/pcapi/core/external/automations/venue.py
@@ -12,6 +12,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import models as offers_models
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.utils import date as date_utils
 
 
 YIELD_COUNT_PER_DB_QUERY = 1000
@@ -42,7 +43,7 @@ def get_inactive_venues_emails() -> Iterable[str]:
         .join(bookings_models.Booking)
         .filter(
             bookings_models.Booking.status != bookings_models.BookingStatus.CANCELLED,
-            bookings_models.Booking.dateCreated >= datetime.utcnow() - relativedelta(days=90),
+            bookings_models.Booking.dateCreated >= date_utils.get_naive_utc_now() - relativedelta(days=90),
         )
         .exists()
     )

--- a/api/src/pcapi/core/external/zendesk_sell_backends/zendesk_sell.py
+++ b/api/src/pcapi/core/external/zendesk_sell_backends/zendesk_sell.py
@@ -10,6 +10,7 @@ from pcapi.core.external.zendesk_sell_backends.base import ContactNotFoundError
 from pcapi.core.external.zendesk_sell_backends.base import ZendeskCustomFieldsNames
 from pcapi.core.external.zendesk_sell_backends.base import ZendeskCustomFieldsShort
 from pcapi.core.offerers import models as offerers_models
+from pcapi.utils import date as date_utils
 from pcapi.utils import requests
 from pcapi.utils import urls
 from pcapi.utils.regions import get_region_name_from_department
@@ -395,7 +396,7 @@ class ZendeskSellBackend(ZendeskSellReadOnlyBackend):
                     ZendeskCustomFieldsNames.REGION.value: get_region_name_from_department(department_code).upper(),
                     ZendeskCustomFieldsNames.TYPAGE.value: ["Lieu"],
                     ZendeskCustomFieldsNames.BACKOFFICE_LINK.value: urls.build_backoffice_venue_link(venue.id),
-                    ZendeskCustomFieldsNames.UPDATED_IN_PRODUCT.value: datetime.datetime.utcnow().isoformat(),
+                    ZendeskCustomFieldsNames.UPDATED_IN_PRODUCT.value: date_utils.get_naive_utc_now().isoformat(),
                 },
             }
         }
@@ -432,7 +433,7 @@ class ZendeskSellBackend(ZendeskSellReadOnlyBackend):
                     ZendeskCustomFieldsNames.SIREN.value: offerer.siren,
                     ZendeskCustomFieldsNames.TYPAGE.value: ["Structure"],
                     ZendeskCustomFieldsNames.BACKOFFICE_LINK.value: urls.build_backoffice_offerer_link(offerer.id),
-                    ZendeskCustomFieldsNames.UPDATED_IN_PRODUCT.value: datetime.datetime.utcnow().isoformat(),
+                    ZendeskCustomFieldsNames.UPDATED_IN_PRODUCT.value: date_utils.get_naive_utc_now().isoformat(),
                 },
             }
         }

--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -1,4 +1,3 @@
-import datetime
 import functools
 import logging
 
@@ -28,6 +27,7 @@ from pcapi.models import feature
 from pcapi.models.feature import FeatureToggle
 from pcapi.tasks.serialization.external_api_booking_notification_tasks import BookingAction
 from pcapi.tasks.serialization.external_api_booking_notification_tasks import ExternalApiBookingNotificationRequest
+from pcapi.utils import date as date_utils
 from pcapi.utils import requests
 from pcapi.utils.queue import add_to_queue
 from pcapi.utils.transaction_manager import on_commit
@@ -231,7 +231,7 @@ def book_event_ticket(
             REDIS_EXTERNAL_BOOKINGS_NAME,
             {
                 "barcode": ticket.barcode,
-                "timestamp": datetime.datetime.utcnow().timestamp(),
+                "timestamp": date_utils.get_naive_utc_now().timestamp(),
                 "booking_type": RedisExternalBookingType.EVENT,
                 "cancel_event_info": {
                     "provider_id": provider.id,
@@ -259,7 +259,7 @@ def _verify_and_return_tickets_with_same_quantity_as_booking(
             REDIS_EXTERNAL_BOOKINGS_NAME,
             {
                 "barcode": tickets[0].barcode,
-                "timestamp": datetime.datetime.utcnow().timestamp(),
+                "timestamp": date_utils.get_naive_utc_now().timestamp(),
                 "booking_type": RedisExternalBookingType.EVENT,
                 "cancel_event_info": {
                     "provider_id": stock.offer.lastProvider.id,

--- a/api/src/pcapi/core/external_bookings/boost/client.py
+++ b/api/src/pcapi/core/external_bookings/boost/client.py
@@ -17,6 +17,7 @@ import pcapi.core.users.models as users_models
 from pcapi import settings
 from pcapi.core.external_bookings.decorators import catch_cinema_provider_request_timeout
 from pcapi.core.providers.models import BoostCinemaDetails
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 from pcapi.utils import requests
 from pcapi.utils.date import get_naive_utc_now
@@ -338,7 +339,7 @@ class BoostClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             {
                 "barcode": sale_confirmation_response.data.code,
                 "venue_id": booking.venueId,
-                "timestamp": datetime.datetime.utcnow().timestamp(),
+                "timestamp": date_utils.get_naive_utc_now().timestamp(),
                 "booking_type": bookings_constants.RedisExternalBookingType.CINEMA,
             },
         )

--- a/api/src/pcapi/core/external_bookings/cds/client.py
+++ b/api/src/pcapi/core/external_bookings/cds/client.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import logging
 import math
@@ -19,6 +18,7 @@ from pcapi.core.bookings.constants import REDIS_EXTERNAL_BOOKINGS_NAME
 from pcapi.core.bookings.constants import RedisExternalBookingType
 from pcapi.core.external_bookings.decorators import catch_cinema_provider_request_timeout
 from pcapi.core.external_bookings.models import Ticket
+from pcapi.utils import date as date_utils
 from pcapi.utils import requests
 from pcapi.utils.queue import add_to_queue
 
@@ -342,7 +342,7 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
         create_transaction_body = cds_serializers.CreateTransactionBodyCDS(  # type: ignore[call-arg]
             cinema_id=self.cinema_id,
             is_cancelled=False,
-            transaction_date=datetime.datetime.utcnow().strftime(CDS_DATE_FORMAT),
+            transaction_date=date_utils.get_naive_utc_now().strftime(CDS_DATE_FORMAT),
             ticket_sale_collection=ticket_sale_collection,
             payement_collection=payement_collection,
         ).json(by_alias=True)
@@ -357,7 +357,7 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
                 {
                     "barcode": ticket.barcode,
                     "venue_id": booking.venueId,
-                    "timestamp": datetime.datetime.utcnow().timestamp(),
+                    "timestamp": date_utils.get_naive_utc_now().timestamp(),
                     "booking_type": RedisExternalBookingType.CINEMA,
                 },
             )
@@ -393,7 +393,7 @@ class CineDigitalServiceAPI(external_bookings_models.ExternalBookingsClientAPI):
             ticket_sale = cds_serializers.TicketSaleCDS(  # type: ignore[call-arg]
                 id=(i + 1) * -1,
                 cinema_id=self.cinema_id,
-                operation_date=datetime.datetime.utcnow().strftime(CDS_DATE_FORMAT),
+                operation_date=date_utils.get_naive_utc_now().strftime(CDS_DATE_FORMAT),
                 is_cancelled=False,
                 seat_col=seats_to_book[i].seatCol if bool(seats_to_book) else None,
                 seat_row=seats_to_book[i].seatRow if bool(seats_to_book) else None,

--- a/api/src/pcapi/core/external_bookings/cgr/client.py
+++ b/api/src/pcapi/core/external_bookings/cgr/client.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import logging
 
@@ -19,6 +18,7 @@ from pcapi.core.external_bookings.exceptions import ExternalBookingNotEnoughSeat
 from pcapi.core.external_bookings.exceptions import ExternalBookingShowDoesNotExistError
 from pcapi.core.providers.models import CGRCinemaDetails
 from pcapi.core.providers.repository import get_cgr_cinema_details
+from pcapi.utils import date as date_utils
 from pcapi.utils import requests
 from pcapi.utils.crypto import decrypt
 from pcapi.utils.queue import add_to_queue
@@ -173,7 +173,7 @@ class CGRClientAPI(external_bookings_models.ExternalBookingsClientAPI):
             {
                 "barcode": response.QrCode,
                 "venue_id": booking.venueId,
-                "timestamp": datetime.datetime.utcnow().timestamp(),
+                "timestamp": date_utils.get_naive_utc_now().timestamp(),
                 "booking_type": RedisExternalBookingType.CINEMA,
             },
         )

--- a/api/src/pcapi/core/external_bookings/ems/client.py
+++ b/api/src/pcapi/core/external_bookings/ems/client.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import logging
 
@@ -13,6 +12,7 @@ from pcapi.core.external_bookings.decorators import catch_cinema_provider_reques
 from pcapi.core.external_bookings.exceptions import ExternalBookingNotEnoughSeatsError
 from pcapi.core.users import models as users_models
 from pcapi.models.feature import FeatureToggle
+from pcapi.utils import date as date_utils
 from pcapi.utils.requests import exceptions as requests_exception
 
 from . import constants
@@ -73,7 +73,7 @@ class EMSClientAPI(external_bookings_models.ExternalBookingsClientAPI):
                     {
                         "cinema_id": self.cinema_id,
                         "token": booking.token,
-                        "timestamp": datetime.datetime.utcnow().timestamp(),
+                        "timestamp": date_utils.get_naive_utc_now().timestamp(),
                     }
                 )
 

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -167,7 +167,7 @@ def add_event(
 
     elif motive == models.FinanceEventMotive.BOOKING_UNUSED:
         # The value is irrelevant because the event won't be priced.
-        value_date = datetime.datetime.utcnow()
+        value_date = date_utils.get_naive_utc_now()
 
         status = models.FinanceEventStatus.NOT_TO_BE_PRICED
         pricing_point_id = None
@@ -278,7 +278,7 @@ def price_events(
     # recent event that may have been COMMITed to the database just
     # before another event with a slightly older date (see note in
     # module docstring).
-    threshold = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
+    threshold = date_utils.get_naive_utc_now() - datetime.timedelta(minutes=1)
     window = (min_date, threshold)
 
     errored_pricing_point_ids = set()
@@ -1119,7 +1119,7 @@ def _generate_cashflows(batch: models.CashflowBatch) -> None:
                         .first()
                     )
                     if last_cashflow:
-                        last_cashflow_age = (datetime.datetime.utcnow() - last_cashflow.creationDate).days
+                        last_cashflow_age = (date_utils.get_naive_utc_now() - last_cashflow.creationDate).days
                     else:
                         last_cashflow_age = 0
 
@@ -1332,7 +1332,7 @@ def _write_csv(
     row_formatter: typing.Callable[[typing.Iterable], typing.Iterable] = lambda row: row,
     compress: bool = False,
 ) -> pathlib.Path:
-    local_now = pytz.utc.localize(datetime.datetime.utcnow()).astimezone(utils.ACCOUNTING_TIMEZONE)
+    local_now = pytz.utc.localize(date_utils.get_naive_utc_now()).astimezone(utils.ACCOUNTING_TIMEZONE)
     filename = filename_base + local_now.strftime("_%Y%m%d_%H%M") + ".csv"
     # Store file in a dedicated directory within "/tmp". It's easier
     # to clean files in tests that way.
@@ -1804,7 +1804,7 @@ def _mark_free_pricings_as_invoiced() -> None:
                 "cancelled": bookings_models.BookingStatus.CANCELLED.value,
                 "reimbursed": bookings_models.BookingStatus.REIMBURSED.value,
                 "pricing_ids": tuple(pricing_ids),
-                "reimbursement_date": datetime.datetime.utcnow(),
+                "reimbursement_date": date_utils.get_naive_utc_now(),
             },
         )
 
@@ -2383,7 +2383,7 @@ def _generate_invoice_legacy(
                 "cancelled": bookings_models.BookingStatus.CANCELLED.value,
                 "reimbursed": bookings_models.BookingStatus.REIMBURSED.value,
                 "cashflow_ids": tuple(cashflow_ids),
-                "reimbursement_date": datetime.datetime.utcnow(),
+                "reimbursement_date": date_utils.get_naive_utc_now(),
             },
         )
 
@@ -2877,7 +2877,7 @@ def validate_invoice(invoice_id: int) -> None:
                 "cancelled": bookings_models.BookingStatus.CANCELLED.value,
                 "reimbursed": bookings_models.BookingStatus.REIMBURSED.value,
                 "cashflow_id": cashflow_id,
-                "reimbursement_date": datetime.datetime.utcnow(),
+                "reimbursement_date": date_utils.get_naive_utc_now(),
             },
         )
 
@@ -3071,7 +3071,7 @@ def edit_reimbursement_rule(
     rule: models.CustomReimbursementRule,
     end_date: datetime.datetime,
 ) -> models.CustomReimbursementRule:
-    if end_date.date() <= datetime.datetime.utcnow().date():
+    if end_date.date() <= date_utils.get_naive_utc_now().date():
         error = "La date de fin doit être postérieure à la date du jour."
         raise exceptions.WrongDateForReimbursementRule(error)
     # To avoid complexity, we do not allow to edit the end date of a
@@ -3143,7 +3143,7 @@ def update_bank_account_venues_links(
             link_bulk_update_mapping.append(
                 {
                     "id": link.id,
-                    "timespan": db_utils.make_timerange(link.timespan.lower, datetime.datetime.utcnow()),
+                    "timespan": db_utils.make_timerange(link.timespan.lower, date_utils.get_naive_utc_now()),
                 }
             )
             action_history_bulk_insert_mapping.append(
@@ -3176,7 +3176,7 @@ def update_bank_account_venues_links(
                 {
                     "venueId": venue_id,
                     "bankAccountId": bank_account.id,
-                    "timespan": db_utils.make_timerange(datetime.datetime.utcnow()),
+                    "timespan": db_utils.make_timerange(date_utils.get_naive_utc_now()),
                 }
             )
             action_history_bulk_insert_mapping.append(
@@ -3221,7 +3221,7 @@ def create_overpayment_finance_incident(
         venueId=bookings[0].venueId,
         details={
             "authorId": author.id,
-            "createdAt": datetime.datetime.utcnow().isoformat(),
+            "createdAt": date_utils.get_naive_utc_now().isoformat(),
         },
         zendeskId=zendesk_id,
         origin=origin,
@@ -3282,7 +3282,7 @@ def create_overpayment_finance_incident_collective_booking(
         venueId=booking.venueId,
         details={
             "authorId": author.id,
-            "createdAt": datetime.datetime.utcnow().isoformat(),
+            "createdAt": date_utils.get_naive_utc_now().isoformat(),
         },
         zendeskId=zendesk_id,
         origin=origin,
@@ -3325,7 +3325,7 @@ def create_finance_commercial_gesture(
         venueId=bookings[0].venueId,
         details={
             "authorId": author.id,
-            "createdAt": datetime.datetime.utcnow().isoformat(),
+            "createdAt": date_utils.get_naive_utc_now().isoformat(),
         },
         zendeskId=zendesk_id,
         origin=origin,
@@ -3393,7 +3393,7 @@ def create_finance_commercial_gesture_collective_booking(
         venueId=booking.venueId,
         details={
             "authorId": author.id,
-            "createdAt": datetime.datetime.utcnow().isoformat(),
+            "createdAt": date_utils.get_naive_utc_now().isoformat(),
         },
         zendeskId=zendesk_id,
         origin=origin,
@@ -3468,7 +3468,7 @@ def validate_finance_overpayment_incident(
 ) -> None:
     from pcapi.core.bookings import api as bookings_api
 
-    incident_validation_date = datetime.datetime.utcnow()
+    incident_validation_date = date_utils.get_naive_utc_now()
     finance_events = []
     for booking_incident in finance_incident.booking_finance_incidents:
         finance_events.extend(
@@ -3544,7 +3544,7 @@ def validate_finance_commercial_gesture(
     finance_incident: models.FinanceIncident,
     author: users_models.User,
 ) -> None:
-    incident_validation_date = datetime.datetime.utcnow()
+    incident_validation_date = date_utils.get_naive_utc_now()
     finance_events = []
     for booking_incident in finance_incident.booking_finance_incidents:
         finance_events += _create_finance_events_from_incident(
@@ -3619,7 +3619,7 @@ def deprecate_venue_bank_account_links(bank_account: models.BankAccount) -> None
     """
     for link in bank_account.venueLinks:
         if link.timespan.upper is None:
-            link.timespan = db_utils.make_timerange(link.timespan.lower, datetime.datetime.utcnow())
+            link.timespan = db_utils.make_timerange(link.timespan.lower, date_utils.get_naive_utc_now())
             action_history = history_models.ActionHistory(
                 venueId=link.venueId,
                 bankAccountId=bank_account.id,
@@ -3631,7 +3631,7 @@ def deprecate_venue_bank_account_links(bank_account: models.BankAccount) -> None
 
 
 def mark_bank_account_without_continuation(ds_application_id: int) -> None:
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
 
     bank_account = (
         db.session.query(models.BankAccount)
@@ -3682,7 +3682,7 @@ def clean_duplicate_bank_accounts() -> None:
     """
     other_bank_account = sa_orm.aliased(models.BankAccount)
     other_link = sa_orm.aliased(offerers_models.VenueBankAccountLink)
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
 
     bank_accounts = (
         db.session.query(models.BankAccount)

--- a/api/src/pcapi/core/finance/external.py
+++ b/api/src/pcapi/core/finance/external.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import time
 
@@ -11,6 +10,7 @@ from pcapi.core.finance import conf
 from pcapi.core.finance import models as finance_models
 from pcapi.models import db
 from pcapi.notifications.internal import send_internal_message
+from pcapi.utils import date as date_utils
 from pcapi.workers.export_csv_and_send_notification_emails_job import export_csv_and_send_notification_emails_job
 
 
@@ -60,7 +60,7 @@ def push_bank_accounts(count: int) -> None:
                 db.session.query(finance_models.BankAccount).filter(
                     finance_models.BankAccount.id == bank_account_id
                 ).update(
-                    {"lastCegidSyncDate": datetime.datetime.utcnow()},
+                    {"lastCegidSyncDate": date_utils.get_naive_utc_now()},
                     synchronize_session=False,
                 )
                 db.session.commit()

--- a/api/src/pcapi/core/finance/factories.py
+++ b/api/src/pcapi/core/finance/factories.py
@@ -14,6 +14,7 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.factories import UsedCollectiveBookingFactory
 from pcapi.core.factories import BaseFactory
 from pcapi.core.finance import reimbursement_rules
+from pcapi.utils import date as date_utils
 
 from . import api
 from . import conf
@@ -108,7 +109,7 @@ class FinanceEventFactory(BaseFactory):
         model = models.FinanceEvent
 
     valueDate = factory.LazyAttribute(lambda o: (o.booking or o.collectiveBooking).dateUsed)
-    pricingOrderingDate = factory.LazyFunction(datetime.datetime.utcnow)
+    pricingOrderingDate = factory.LazyFunction(date_utils.get_naive_utc_now)
     status = models.FinanceEventStatus.PRICED
     motive = models.FinanceEventMotive.BOOKING_USED
     booking = factory.SubFactory(bookings_factories.UsedBookingFactory)
@@ -223,8 +224,8 @@ class CustomReimbursementRuleFactory(BaseFactory):
     offer = factory.SubFactory(offers_factories.OfferFactory)
     timespan = factory.LazyFunction(
         lambda: [
-            datetime.datetime.utcnow() - datetime.timedelta(days=365),
-            datetime.datetime.utcnow() + datetime.timedelta(days=365),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
+            date_utils.get_naive_utc_now() + datetime.timedelta(days=365),
         ]
     )
     amount = 500
@@ -260,7 +261,7 @@ class CashflowBatchFactory(BaseFactory):
     class Meta:
         model = models.CashflowBatch
 
-    cutoff = factory.LazyFunction(datetime.datetime.utcnow)
+    cutoff = factory.LazyFunction(date_utils.get_naive_utc_now)
     label = factory.Sequence("VIR{}".format)
 
 
@@ -350,7 +351,7 @@ class FinanceIncidentFactory(BaseFactory):
     kind = models.IncidentType.OVERPAYMENT
     status = models.IncidentStatus.CREATED
     details = {
-        "createdAt": datetime.datetime.utcnow().isoformat(),
+        "createdAt": date_utils.get_naive_utc_now().isoformat(),
         "author": "Sandy Box",
         "validator": "",
         "validatedAt": "",
@@ -366,7 +367,7 @@ class FinanceCommercialGestureFactory(BaseFactory):
     kind = models.IncidentType.COMMERCIAL_GESTURE
     status = models.IncidentStatus.CREATED
     details = {
-        "createdAt": datetime.datetime.utcnow().isoformat(),
+        "createdAt": date_utils.get_naive_utc_now().isoformat(),
         "authorId": 1,
         "validator": "",
         "validatedAt": "",

--- a/api/src/pcapi/core/finance/models.py
+++ b/api/src/pcapi/core/finance/models.py
@@ -28,6 +28,7 @@ from pcapi.models import Model
 from pcapi.models import db
 from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 
 from . import utils
 
@@ -302,7 +303,7 @@ class BankAccount(PcObject, Model, DeactivableMixin):
     @property
     def current_link(self) -> "offerers_models.VenueBankAccountLink | None":
         for link in self.venueLinks:
-            if link.timespan.upper is None and link.timespan.lower <= datetime.datetime.utcnow():
+            if link.timespan.upper is None and link.timespan.lower <= date_utils.get_naive_utc_now():
                 return link
         return None
 
@@ -1086,7 +1087,7 @@ class PaymentStatus(PcObject, Model):
         "Payment", foreign_keys=[paymentId], back_populates="statuses"
     )
     date: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
     status: sa_orm.Mapped[TransactionStatus] = sa_orm.mapped_column(sa.Enum(TransactionStatus), nullable=False)
     detail: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.VARCHAR(), nullable=True)

--- a/api/src/pcapi/core/finance/repository.py
+++ b/api/src/pcapi/core/finance/repository.py
@@ -72,7 +72,7 @@ def has_active_or_future_custom_reimbursement_rule(offer: offers_models.Offer) -
     apply to subcategories of an offerer are ignored (because they
     define a *rate*).
     """
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     timespan = db_utils.make_timerange(start=now, end=None)
     query = (
         db.session.query(models.CustomReimbursementRule)
@@ -532,14 +532,14 @@ def get_bank_account_with_current_venues_links(offerer_id: int, bank_account_id:
             offerers_models.VenuePricingPointLink,
             sa.and_(
                 offerers_models.VenuePricingPointLink.venueId == offerers_models.Venue.id,
-                offerers_models.VenuePricingPointLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenuePricingPointLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .outerjoin(
             offerers_models.VenueBankAccountLink,
             sa.and_(
                 offerers_models.VenueBankAccountLink.venueId == offerers_models.Venue.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .options(

--- a/api/src/pcapi/core/finance/siret_api.py
+++ b/api/src/pcapi/core/finance/siret_api.py
@@ -1,4 +1,3 @@
-import datetime
 from collections import defaultdict
 from decimal import Decimal
 
@@ -11,6 +10,7 @@ from pcapi.core.history import models as history_models
 from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 from pcapi.utils.transaction_manager import atomic
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
@@ -244,7 +244,7 @@ def remove_siret(
 ) -> None:
     check_can_remove_siret(venue, comment, override_revenue_check=override_revenue_check)
     old_siret = venue.siret
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
 
     new_siret: str | None = None
     if new_pricing_point_id:
@@ -319,7 +319,7 @@ def remove_siret(
 
 
 def _force_close_custom_reimbursement_rules_for_venue(venue: offerers_models.Venue) -> None:
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
 
     custom_reimbursement_rules = db.session.query(finance_models.CustomReimbursementRule).filter(
         finance_models.CustomReimbursementRule.venueId == venue.id,
@@ -364,7 +364,7 @@ def remove_pricing_point_link(
 ) -> None:
     check_can_remove_pricing_point(venue, override_revenue_check)
 
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
 
     try:
         # End this pricing point

--- a/api/src/pcapi/core/fraud/commands.py
+++ b/api/src/pcapi/core/fraud/commands.py
@@ -8,6 +8,7 @@ from pcapi import settings
 from pcapi.core.subscription.dms import api as dms_api
 from pcapi.core.subscription.ubble.api import update_pending_ubble_applications
 from pcapi.core.subscription.ubble.archive_past_identification_pictures import archive_past_identification_pictures
+from pcapi.utils import date as date_utils
 from pcapi.utils.blueprint import Blueprint
 
 
@@ -87,7 +88,7 @@ def ubble_archive_past_identifications_automation() -> None:
     # call the archive function on the last 6 months for the statuses "None"
     # (the archive process has never been executed)
     # and "False" (the archive process has executed but failed)
-    end_date = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    end_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
     start_date = end_date - datetime.timedelta(days=186)
     archive_past_identification_pictures(start_date, end_date, None)
     archive_past_identification_pictures(start_date, end_date, False)

--- a/api/src/pcapi/core/fraud/factories.py
+++ b/api/src/pcapi/core/fraud/factories.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-
 import factory.fuzzy
 
 import pcapi.core.users.factories as users_factories
 from pcapi.core import factories
 from pcapi.core.fraud import models
+from pcapi.utils import date as date_utils
 
 
 class BlacklistedDomainNameFactory(factories.BaseFactory):
@@ -21,5 +20,5 @@ class ProductWhitelistFactory(factories.BaseFactory):
     comment = factory.Sequence("OK {} !".format)
     title = factory.Sequence("Ducobu #{} !".format)
     ean = factory.fuzzy.FuzzyText(length=13)
-    dateCreated = factory.LazyFunction(datetime.utcnow)
+    dateCreated = factory.LazyFunction(date_utils.get_naive_utc_now)
     author = factory.SubFactory(users_factories.AdminFactory)

--- a/api/src/pcapi/core/fraud/models.py
+++ b/api/src/pcapi/core/fraud/models.py
@@ -6,6 +6,7 @@ import sqlalchemy.orm as sa_orm
 
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 
 
 if TYPE_CHECKING:
@@ -24,7 +25,7 @@ class BlacklistedDomainName(PcObject, Model):
     __tablename__ = "blacklisted_domain_name"
     domain: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text, nullable=False, unique=True)
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
 
 
@@ -37,7 +38,7 @@ class ProductWhitelist(PcObject, Model):
     title: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text, nullable=False)
     ean: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.String(length=13), nullable=False, unique=True, index=True)
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
     comment: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text, nullable=False)
     authorId: sa_orm.Mapped[int] = sa_orm.mapped_column(sa.BigInteger, sa.ForeignKey("user.id"), nullable=False)

--- a/api/src/pcapi/core/history/factories.py
+++ b/api/src/pcapi/core/history/factories.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import factory
 from dateutil.relativedelta import relativedelta
 
@@ -7,6 +5,7 @@ import pcapi.core.users.constants as users_constants
 import pcapi.core.users.factories as users_factories
 from pcapi.core.factories import BaseFactory
 from pcapi.core.history import models
+from pcapi.utils import date as date_utils
 
 
 class ActionHistoryFactory(BaseFactory):
@@ -23,17 +22,17 @@ class SuspendedUserActionHistoryFactory(ActionHistoryFactory):
         reason = users_constants.SuspensionReason.FRAUD_SUSPICION
 
     user = factory.SubFactory(
-        users_factories.UserFactory, isActive=False, dateCreated=datetime.utcnow() - relativedelta(days=2)
+        users_factories.UserFactory, isActive=False, dateCreated=date_utils.get_naive_utc_now() - relativedelta(days=2)
     )
     actionType = models.ActionType.USER_SUSPENDED
-    actionDate = factory.LazyFunction(lambda: datetime.utcnow() - relativedelta(days=1))
+    actionDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - relativedelta(days=1))
     extraData = factory.LazyAttribute(lambda o: {"reason": o.reason.value})
 
 
 class UnsuspendedUserActionHistoryFactory(ActionHistoryFactory):
     user = factory.SubFactory(users_factories.UserFactory)
     actionType = models.ActionType.USER_UNSUSPENDED
-    actionDate = factory.LazyFunction(lambda: datetime.utcnow() - relativedelta(days=1))
+    actionDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - relativedelta(days=1))
 
 
 class BlacklistDomainNameFactory(ActionHistoryFactory):

--- a/api/src/pcapi/core/history/models.py
+++ b/api/src/pcapi/core/history/models.py
@@ -1,4 +1,3 @@
-import datetime
 import enum
 import typing
 
@@ -11,6 +10,7 @@ from pcapi.core.chronicles import models as chronicles_models
 from pcapi.core.users import models as users_models
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 
 
@@ -121,7 +121,7 @@ class ActionHistory(PcObject, Model):
 
     # nullable because of old suspensions without date migrated here; but mandatory for new actions
     actionDate = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, server_default=sa.func.now(), default=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, server_default=sa.func.now(), default=date_utils.get_naive_utc_now
     )
 
     # User (beneficiary, pro, admin...) who *initiated* the action

--- a/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/booking_cancellation_by_beneficiary.py
@@ -1,11 +1,10 @@
-import datetime
-
 from pcapi.core import mails
 from pcapi.core.bookings.models import Booking
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.mails.transactional.utils import format_price
 from pcapi.core.offers.utils import offer_app_link
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.date import utc_datetime_to_department_timezone
@@ -22,7 +21,7 @@ def get_booking_cancellation_by_beneficiary_email_data(
     if (
         beneficiary.deposit
         and beneficiary.deposit.expirationDate
-        and beneficiary.deposit.expirationDate > datetime.datetime.utcnow()
+        and beneficiary.deposit.expirationDate > date_utils.get_naive_utc_now()
     ):
         can_book_again = True
 

--- a/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/bookings/new_booking_to_pro.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 
@@ -13,6 +11,7 @@ from pcapi.core.mails.transactional.sendinblue_template_ids import Transactional
 from pcapi.core.mails.transactional.utils import format_price
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.mailing import get_event_datetime
@@ -31,7 +30,7 @@ def get_new_booking_to_pro_email_data(
             offerers_models.VenueBankAccountLink,
             sa.and_(
                 offerers_models.Venue.id == offerers_models.VenueBankAccountLink.venueId,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .outerjoin(

--- a/api/src/pcapi/core/mails/transactional/pro/first_venue_approved_offer_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/first_venue_approved_offer_to_pro.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 
@@ -14,6 +12,7 @@ from pcapi.core.offerers.models import Venue
 from pcapi.core.offerers.models import VenueBankAccountLink
 from pcapi.core.offers.models import Offer
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.urls import build_pc_pro_offer_link
 
 
@@ -24,7 +23,8 @@ def get_first_venue_approved_offer_email_data(offer: Offer) -> models.Transactio
         .outerjoin(
             VenueBankAccountLink,
             sa.and_(
-                Venue.id == VenueBankAccountLink.venueId, VenueBankAccountLink.timespan.contains(datetime.utcnow())
+                Venue.id == VenueBankAccountLink.venueId,
+                VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .outerjoin(finance_models.BankAccount, VenueBankAccountLink.bankAccountId == finance_models.BankAccount.id)

--- a/api/src/pcapi/core/mails/transactional/pro/reset_password_to_pro.py
+++ b/api/src/pcapi/core/mails/transactional/pro/reset_password_to_pro.py
@@ -1,11 +1,10 @@
-from datetime import datetime
-
 import pcapi.core.users.models as users_models
 from pcapi.core import mails
 from pcapi.core import token as token_utils
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.date import utc_datetime_to_department_timezone
@@ -30,7 +29,7 @@ def send_reset_password_email_to_pro(token: token_utils.Token) -> None:
 
 
 def get_reset_password_from_connected_pro_email_data(user: users_models.User) -> models.TransactionalEmailData:
-    now = utc_datetime_to_department_timezone(datetime.utcnow(), user.departementCode)
+    now = utc_datetime_to_department_timezone(date_utils.get_naive_utc_now(), user.departementCode)
 
     return models.TransactionalEmailData(
         template=TransactionalEmail.RESET_PASSWORD_TO_CONNECTED_PRO.value,

--- a/api/src/pcapi/core/mails/transactional/users/email_address_change_confirmation.py
+++ b/api/src/pcapi/core/mails/transactional/users/email_address_change_confirmation.py
@@ -1,16 +1,16 @@
-from datetime import datetime
-
 from pcapi.core import mails
 from pcapi.core import token as token_utils
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.users import constants
+from pcapi.utils import date as date_utils
 from pcapi.utils.urls import generate_app_link
 
 
 def get_email_confirmation_email_data(email: str, token: token_utils.Token) -> models.TransactionalEmailData:
     expiration_date = (
-        token.get_expiration_date_from_token() or datetime.utcnow() + constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME
+        token.get_expiration_date_from_token()
+        or date_utils.get_naive_utc_now() + constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME
     )
     expiration_timestamp = int(expiration_date.timestamp())
     email_confirmation_link = generate_app_link(

--- a/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
+++ b/api/src/pcapi/core/mails/transactional/users/online_event_reminder.py
@@ -69,7 +69,7 @@ def _get_online_bookings_happening_soon() -> sa_orm.query.Query:
     'Soon' means in the next hour but not in the next 30 minutes.
     This is to send the reminder at least 30 minutes before the event starts.
     """
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     # We normalize the minute to 0 or 30 to get the next-next 30 minutes
     normalized_minute = 0 if now.minute < 30 else 30
     normalized_now = now.replace(minute=normalized_minute, second=0, microsecond=0)

--- a/api/src/pcapi/core/mails/transactional/users/suspicious_login_email.py
+++ b/api/src/pcapi/core/mails/transactional/users/suspicious_login_email.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-
 import pcapi.core.users.models as users_models
 from pcapi.core import mails
 from pcapi.core import token as token_utils
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.date import utc_datetime_to_department_timezone
 from pcapi.utils.urls import generate_app_link
@@ -32,7 +31,7 @@ def get_suspicious_login_email_data(
     )
 
     localized_login_datetime = utc_datetime_to_department_timezone(
-        login_info.dateCreated if login_info else datetime.utcnow(), user.departementCode
+        login_info.dateCreated if login_info else date_utils.get_naive_utc_now(), user.departementCode
     )
 
     if login_info:

--- a/api/src/pcapi/core/mails/transactional/users/ubble/reminder_emails.py
+++ b/api/src/pcapi/core/mails/transactional/users/ubble/reminder_emails.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 import sqlalchemy as sa
@@ -14,6 +13,7 @@ from pcapi import settings
 from pcapi.core.mails.transactional import send_subscription_document_error_email
 from pcapi.core.users import eligibility_api
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -53,9 +53,9 @@ def _find_users_to_remind(
                 [subscription_models.FraudCheckStatus.KO, subscription_models.FraudCheckStatus.SUSPICIOUS]
             ),
             subscription_models.BeneficiaryFraudCheck.dateCreated
-            < datetime.datetime.utcnow() - relativedelta(days=days_ago),
+            < date_utils.get_naive_utc_now() - relativedelta(days=days_ago),
             subscription_models.BeneficiaryFraudCheck.dateCreated
-            >= datetime.datetime.utcnow() - relativedelta(days=days_ago + 1),
+            >= date_utils.get_naive_utc_now() - relativedelta(days=days_ago + 1),
         )
         .all()
     )

--- a/api/src/pcapi/core/mails/transactional/users/update_request_set_to_without_continuation.py
+++ b/api/src/pcapi/core/mails/transactional/users/update_request_set_to_without_continuation.py
@@ -1,14 +1,13 @@
-import datetime
-
 from pcapi.core import mails
 from pcapi.core.mails import models
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_date_formatted_for_email
 
 
 def send_beneficiary_update_request_set_to_without_continuation(recipient_email: str) -> None:
     data = models.TransactionalEmailData(
         template=TransactionalEmail.UPDATE_REQUEST_MARKED_WITHOUT_CONTINUATION.value,
-        params={"DATE_FILECLASSIFIED_DMS": get_date_formatted_for_email(datetime.datetime.utcnow())},
+        params={"DATE_FILECLASSIFIED_DMS": get_date_formatted_for_email(date_utils.get_naive_utc_now())},
     )
     mails.send(recipients=[recipient_email], data=data)

--- a/api/src/pcapi/core/offerers/factories.py
+++ b/api/src/pcapi/core/offerers/factories.py
@@ -11,6 +11,7 @@ from pcapi.core.factories import BaseFactory
 from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.utils import crypto
+from pcapi.utils import date as date_utils
 from pcapi.utils import siren as siren_utils
 from pcapi.utils.date import timespan_str_to_numrange
 
@@ -210,7 +211,7 @@ class CollectiveVenueFactory(VenueFactory):
     isPermanent = True
 
     adageId = factory.Sequence(str)
-    adageInscriptionDate = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=365))
+    adageInscriptionDate = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=365))
 
     managingOfferer = factory.SubFactory(CollectiveOffererFactory)
 
@@ -268,7 +269,7 @@ class VenuePricingPointLinkFactory(BaseFactory):
     )
     timespan = factory.LazyFunction(
         lambda: [
-            datetime.datetime.utcnow() - datetime.timedelta(days=365),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
             None,
         ]
     )
@@ -282,7 +283,7 @@ class VenueBankAccountLinkFactory(BaseFactory):
     bankAccount = factory.SubFactory(
         "pcapi.core.finance.factories.BankAccountFactory", offerer=factory.SelfAttribute("..venue.managingOfferer")
     )
-    timespan = factory.LazyFunction(lambda: [datetime.datetime.utcnow() - datetime.timedelta(days=365), None])
+    timespan = factory.LazyFunction(lambda: [date_utils.get_naive_utc_now() - datetime.timedelta(days=365), None])
 
 
 class OpeningHoursFactory(BaseFactory):
@@ -430,7 +431,7 @@ class OffererInvitationFactory(BaseFactory):
 
     offerer = factory.SubFactory(OffererFactory)
     email = factory.Sequence("invited.pro{}@example.net".format)
-    dateCreated = datetime.datetime.utcnow()
+    dateCreated = date_utils.get_naive_utc_now()
     user = factory.SubFactory(users_factories.ProFactory)
     status = models.InvitationStatus.PENDING
 

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -50,6 +50,7 @@ from pcapi.models.pc_object import PcObject
 from pcapi.models.soft_deletable_mixin import SoftDeletableMixin
 from pcapi.models.validation_status_mixin import ValidationStatusMixin
 from pcapi.utils import crypto
+from pcapi.utils import date as date_utils
 from pcapi.utils import regions as regions_utils
 from pcapi.utils import siren as siren_utils
 from pcapi.utils.date import METROPOLE_TIMEZONE
@@ -275,7 +276,9 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
     )
     venueLabel: sa_orm.Mapped["VenueLabel"] = sa_orm.relationship("VenueLabel", foreign_keys=[venueLabelId])
 
-    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
+    )
 
     withdrawalDetails: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
 
@@ -684,7 +687,7 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
 
     @property
     def current_pricing_point_id(self) -> int | None:
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         return (
             db.session.query(VenuePricingPointLink.pricingPointId)
             .filter(
@@ -698,7 +701,7 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
     def current_pricing_point_link(self) -> "VenuePricingPointLink | None":
         # Unlike current_pricing_point_id, this property uses pricing_point_links joinedloaded with the venue, which
         # avoids additional SQL query
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
 
         for link in self.pricing_point_links:
             lower = link.timespan.lower
@@ -718,7 +721,7 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
 
     @property
     def current_bank_account_link(self) -> "VenueBankAccountLink | None":
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
 
         for link in self.bankAccountLinks:
             lower = link.timespan.lower
@@ -881,7 +884,7 @@ class AccessibilityProvider(PcObject, Model):
         MutableDict.as_mutable(JSONB), nullable=True
     )
     lastUpdateAtProvider: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
 
 
@@ -1102,7 +1105,9 @@ class Offerer(
     __tablename__ = "offerer"
     thumb_path_component = "offerers"
 
-    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
+    )
 
     name: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.String(140), nullable=False)
 
@@ -1280,7 +1285,9 @@ class UserOfferer(PcObject, Model, ValidationStatusMixin):
     )
 
     # dateCreated will remain null for all rows already in this table before this field was added
-    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=True, default=datetime.utcnow)
+    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now
+    )
 
     __table_args__ = (
         sa.UniqueConstraint(
@@ -1300,7 +1307,7 @@ class ApiKey(PcObject, Model):
         "Provider", foreign_keys=[providerId], back_populates="apiKeys"
     )
     dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
     prefix: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True, unique=True)
     secret: sa_orm.Mapped[bytes] = sa_orm.mapped_column(LargeBinary, nullable=True)
@@ -1392,7 +1399,9 @@ class OffererInvitation(PcObject, Model):
     )
     offerer: sa_orm.Mapped[Offerer] = sa_orm.relationship("Offerer", foreign_keys=[offererId])
     email: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text, nullable=False)
-    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
+    )
     userId: sa_orm.Mapped[int] = sa_orm.mapped_column(
         sa.BigInteger, sa.ForeignKey("user.id"), nullable=False, index=True
     )
@@ -1578,7 +1587,9 @@ class NonPaymentNotice(PcObject, Model):
     dateReceived: sa_orm.Mapped[date] = sa_orm.mapped_column(
         sa.Date, nullable=False, server_default=sa.func.current_date()
     )
-    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
+    )
     emitterName: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text(), nullable=False)
     emitterEmail: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text(), nullable=False)
     reference: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text(), nullable=False)

--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -13,6 +13,7 @@ from pcapi.core.offers import models as offers_models
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models import offer_mixin
+from pcapi.utils import date as date_utils
 
 from . import exceptions
 from . import models
@@ -738,7 +739,7 @@ def get_offerer_bank_accounts(offerer_id: int) -> models.Offerer | None:
             models.VenuePricingPointLink,
             sa.and_(
                 models.VenuePricingPointLink.venueId == models.Venue.id,
-                models.VenuePricingPointLink.timespan.contains(datetime.datetime.utcnow()),
+                models.VenuePricingPointLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .outerjoin(
@@ -746,7 +747,7 @@ def get_offerer_bank_accounts(offerer_id: int) -> models.Offerer | None:
             sa.and_(
                 finance_models.BankAccount.id == models.VenueBankAccountLink.bankAccountId,
                 models.Venue.id == models.VenueBankAccountLink.venueId,
-                models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .options(
@@ -812,7 +813,7 @@ def get_venues_with_non_free_offers_without_bank_accounts(offerer_id: int) -> li
             models.VenueBankAccountLink,
             sa.and_(
                 models.VenueBankAccountLink.venueId == models.Venue.id,
-                models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .with_entities(models.Venue.id)
@@ -839,7 +840,7 @@ def get_offerers_venues_with_pricing_point(
             models.VenuePricingPointLink,
             sa.and_(
                 models.VenuePricingPointLink.venueId == models.Venue.id,
-                models.VenuePricingPointLink.timespan.contains(datetime.datetime.utcnow()),
+                models.VenuePricingPointLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
             isouter=include_without_pricing_points,
         )
@@ -878,7 +879,7 @@ def get_offerers_venues_with_pricing_point(
             models.VenueBankAccountLink,
             sa.and_(
                 models.VenueBankAccountLink.venueId == models.Venue.id,
-                models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         ).options(
             sa_orm.contains_eager(models.Venue.bankAccountLinks).load_only(

--- a/api/src/pcapi/core/offerers/synchronize_venues_banners_with_google_places.py
+++ b/api/src/pcapi/core/offerers/synchronize_venues_banners_with_google_places.py
@@ -11,6 +11,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.search import async_index_venue_ids
 from pcapi.core.search.models import IndexationReason
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import image_conversion
 
 
@@ -168,7 +169,7 @@ def synchronize_venues_banners_with_google_places(
     for venue in venues:
         try:
             if venue.googlePlacesInfo:
-                if (datetime.datetime.utcnow() - venue.googlePlacesInfo.updateDate).days > 62:
+                if (date_utils.get_naive_utc_now() - venue.googlePlacesInfo.updateDate).days > 62:
                     continue
             else:
                 # TODO: CLEAN_OA - remove these conditions when there is no virtual Venue anymore

--- a/api/src/pcapi/core/offerers/update_offerer_stats.py
+++ b/api/src/pcapi/core/offerers/update_offerer_stats.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 import sqlalchemy as sa
 
@@ -9,6 +8,7 @@ from pcapi.connectors.big_query.queries.offerer_stats import OffererDailyViewsLa
 from pcapi.connectors.big_query.queries.offerer_stats import OffererTopOffersAndTotalViewsLast30Days
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ def update_offerer_daily_views_stats() -> None:
             offererId=daily_views_row.offererId,
             table=DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
             jsonData=dict(offerers_models.OffererStatsData(daily_views=list(daily_views_row.dailyViews[::-1]))),
-            syncDate=datetime.utcnow(),
+            syncDate=date_utils.get_naive_utc_now(),
         )
         daily_views.append(daily_views_model)
         counter += 1
@@ -66,7 +66,7 @@ def update_offerer_top_views_stats() -> None:
                     top_offers=top_offers_row.topOffers, total_views_last_30_days=top_offers_row.totalViews
                 )
             ),
-            syncDate=datetime.utcnow(),
+            syncDate=date_utils.get_naive_utc_now(),
         )
         top_offers.append(top_offers_model)
         counter += 1
@@ -87,7 +87,7 @@ def delete_offerer_old_stats() -> None:
         offerers_ids_chunk = [offerer_id for (offerer_id,) in offerers_ids_chunk]
         db.session.query(offerers_models.OffererStats).filter(
             offerers_models.OffererStats.offererId.in_(offerers_ids_chunk),
-            offerers_models.OffererStats.syncDate < datetime.utcnow().date(),
+            offerers_models.OffererStats.syncDate < date_utils.get_naive_utc_now().date(),
         ).delete()
         db.session.commit()
         index += step

--- a/api/src/pcapi/core/offers/factories.py
+++ b/api/src/pcapi/core/offers/factories.py
@@ -20,6 +20,7 @@ from pcapi.core.providers.constants import TITELIVE_MUSIC_GENRES_BY_GTL_ID
 from pcapi.core.providers.titelive_gtl import GTLS
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationType
+from pcapi.utils import date as date_utils
 
 from . import models
 
@@ -308,7 +309,7 @@ class HeadlineOfferFactory(BaseFactory[models.HeadlineOffer]):
         venue=factory.SubFactory(offerers_factories.VenueFactory, venueTypeCode=VenueTypeCode.LIBRARY),
     )
     venue = factory.SelfAttribute("offer.venue")
-    timespan = (datetime.datetime.utcnow(),)
+    timespan = (date_utils.get_naive_utc_now(),)
 
     @factory.post_generation
     def without_mediation(
@@ -378,7 +379,7 @@ class StockFactory(BaseFactory[models.Stock]):
     beginningDatetime: factory.declarations.BaseDeclaration | None = factory.Maybe(
         "offer.isEvent",
         factory.LazyFunction(
-            lambda: datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
+            lambda: date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
         ),
         None,
     )
@@ -396,7 +397,7 @@ class ThingStockFactory(StockFactory):
 class EventStockFactory(StockFactory):
     offer = factory.SubFactory(EventOfferFactory)
     beginningDatetime = factory.LazyFunction(
-        lambda: datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
+        lambda: date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
     )
     bookingLimitDatetime = factory.LazyAttribute(lambda stock: stock.beginningDatetime - datetime.timedelta(minutes=60))
     priceCategory = factory.SubFactory(
@@ -409,7 +410,7 @@ class EventStockFactory(StockFactory):
 
 class CinemaStockProviderFactory(EventStockFactory):
     beginningDatetime = factory.LazyFunction(
-        lambda: datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
+        lambda: date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
     )
     bookingLimitDatetime = factory.LazyAttribute(lambda stock: stock.beginningDatetime - datetime.timedelta(minutes=60))
 

--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -147,7 +147,7 @@ class ProductMediation(PcObject, Model):
     __tablename__ = "product_mediation"
 
     dateModifiedAtLastProvider: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now
     )
     imageType: sa_orm.Mapped[ImageType] = sa_orm.mapped_column(
         db_utils.MagicEnum(ImageType, use_values=False), nullable=False
@@ -188,7 +188,7 @@ class Product(PcObject, Model, HasThumbMixin):
     thumb_path_component = "products"
 
     dateModifiedAtLastProvider: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now
     )
     description: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
     durationMinutes: sa_orm.Mapped[int | None] = sa_orm.mapped_column(sa.Integer, nullable=True)
@@ -318,10 +318,10 @@ class Mediation(PcObject, Model, HasThumbMixin, DeactivableMixin):
     )
     credit: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.String(255), nullable=True)
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
     dateModifiedAtLastProvider: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now
     )
     lastProviderId: sa_orm.Mapped[int | None] = sa_orm.mapped_column(
         sa.BigInteger, sa.ForeignKey("provider.id"), nullable=True
@@ -349,10 +349,10 @@ class Stock(PcObject, Model, SoftDeletableMixin):
     beginningDatetime: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(sa.DateTime, nullable=True)
     bookingLimitDatetime = sa_orm.mapped_column(sa.DateTime, nullable=True)
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
     dateModified: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
     dnBookedQuantity: sa_orm.Mapped[int] = sa_orm.mapped_column(
         sa.BigInteger, nullable=False, server_default=sa.text("0")
@@ -393,7 +393,7 @@ class Stock(PcObject, Model, SoftDeletableMixin):
     )
 
     dateModifiedAtLastProvider: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now
     )
 
     fieldsUpdated: sa_orm.Mapped[list[str]] = sa_orm.mapped_column(
@@ -440,7 +440,7 @@ class Stock(PcObject, Model, SoftDeletableMixin):
 
     @hybrid_property
     def hasBookingLimitDatetimePassed(self) -> bool:
-        return bool(self.bookingLimitDatetime and self.bookingLimitDatetime <= datetime.datetime.utcnow())
+        return bool(self.bookingLimitDatetime and self.bookingLimitDatetime <= date_utils.get_naive_utc_now())
 
     @hasBookingLimitDatetimePassed.inplace.expression
     @classmethod
@@ -462,7 +462,7 @@ class Stock(PcObject, Model, SoftDeletableMixin):
 
     @hybrid_property
     def isEventExpired(self) -> bool:
-        return bool(self.beginningDatetime and self.beginningDatetime <= datetime.datetime.utcnow())
+        return bool(self.beginningDatetime and self.beginningDatetime <= date_utils.get_naive_utc_now())
 
     @isEventExpired.inplace.expression
     @classmethod
@@ -483,13 +483,13 @@ class Stock(PcObject, Model, SoftDeletableMixin):
         if not self.beginningDatetime or self.offer.validation == OfferValidationStatus.DRAFT:
             return True
         limit_date_for_stock_deletion = self.beginningDatetime + bookings_constants.AUTO_USE_AFTER_EVENT_TIME_DELAY
-        return limit_date_for_stock_deletion >= datetime.datetime.utcnow()
+        return limit_date_for_stock_deletion >= date_utils.get_naive_utc_now()
 
     @hybrid_property
     def isSoldOut(self) -> bool:
         return (
             self.isSoftDeleted
-            or (self.beginningDatetime is not None and self.beginningDatetime <= datetime.datetime.utcnow())
+            or (self.beginningDatetime is not None and self.beginningDatetime <= date_utils.get_naive_utc_now())
             or (self.remainingQuantity != "unlimited" and self.remainingQuantity <= 0)
         )
 
@@ -664,7 +664,7 @@ class HeadlineOffer(PcObject, Model):
 
     @hybrid_property
     def isActive(self) -> bool:
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         has_images = self.offer.mediations or (self.offer.product.images if self.offer.product else None)
         if now in self.timespan and self.offer.status == OfferStatus.ACTIVE and has_images:
             return True
@@ -796,13 +796,13 @@ class Offer(PcObject, Model, ValidationMixin, AccessibilityMixin):
         "Criterion", back_populates="offers", secondary=OfferCriterion.__table__
     )
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
     dateModifiedAtLastProvider: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now
     )
     dateUpdated: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now, onupdate=date_utils.get_naive_utc_now
     )
 
     finalizationDatetime: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(sa.DateTime, nullable=True)
@@ -1019,7 +1019,7 @@ class Offer(PcObject, Model, ValidationMixin, AccessibilityMixin):
         for stock in self.stocks:
             if (
                 not stock.isSoftDeleted
-                and (stock.beginningDatetime is None or stock.beginningDatetime > datetime.datetime.utcnow())
+                and (stock.beginningDatetime is None or stock.beginningDatetime > date_utils.get_naive_utc_now())
                 and (stock.remainingQuantity == "unlimited" or stock.remainingQuantity > 0)
             ):
                 return False

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -25,6 +25,7 @@ from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models import offer_mixin
 from pcapi.utils import custom_keys
+from pcapi.utils import date as date_utils
 from pcapi.utils import string as string_utils
 from pcapi.utils.decorators import retry
 
@@ -649,7 +650,7 @@ def check_stock_consistency() -> list[int]:
 
 
 def find_event_stocks_happening_in_x_days(number_of_days: int) -> sa_orm.Query:
-    target_day = datetime.datetime.utcnow() + datetime.timedelta(days=number_of_days)
+    target_day = date_utils.get_naive_utc_now() + datetime.timedelta(days=number_of_days)
     start = datetime.datetime.combine(target_day, datetime.time.min)
     end = datetime.datetime.combine(target_day, datetime.time.max)
 
@@ -745,7 +746,7 @@ def get_available_activation_code(stock: models.Stock) -> models.ActivationCode 
             code
             for code in stock.activationCodes
             if code.bookingId is None
-            and (code.expirationDate is None or code.expirationDate > datetime.datetime.utcnow())
+            and (code.expirationDate is None or code.expirationDate > date_utils.get_naive_utc_now())
         ),
         None,
     )
@@ -818,7 +819,7 @@ def get_current_headline_offer(offerer_id: int) -> models.HeadlineOffer | None:
         )
         .filter(
             offerers_models.Offerer.id == offerer_id,
-            models.HeadlineOffer.timespan.contains(datetime.datetime.utcnow()),
+            models.HeadlineOffer.timespan.contains(date_utils.get_naive_utc_now()),
         )
         .one_or_none()
     )
@@ -844,7 +845,7 @@ def get_inactive_headline_offers() -> list[models.HeadlineOffer]:
             ),
             sa.or_(
                 # We don't want to fetch HeadlineOffers that have already been marked as finished
-                sa.func.upper(models.HeadlineOffer.timespan) > datetime.datetime.utcnow(),
+                sa.func.upper(models.HeadlineOffer.timespan) > date_utils.get_naive_utc_now(),
                 sa.func.upper(models.HeadlineOffer.timespan).is_(None),
             ),
         )

--- a/api/src/pcapi/core/operations/factories.py
+++ b/api/src/pcapi/core/operations/factories.py
@@ -5,6 +5,7 @@ import factory.fuzzy
 
 from pcapi.core.factories import BaseFactory
 from pcapi.core.users import factories as users_factories
+from pcapi.utils import date as date_utils
 
 from . import models
 
@@ -14,7 +15,7 @@ class SpecialEventFactory(BaseFactory):
         model = models.SpecialEvent
 
     externalId = factory.Sequence("ExtIdEvt{:04}".format)
-    dateCreated = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=2))
+    dateCreated = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=2))
     title = factory.Sequence("Opération #{}".format)
     eventDate = factory.LazyFunction(lambda: datetime.date.today() + datetime.timedelta(days=7))
     endImportDate = factory.LazyFunction(lambda: datetime.date.today() + datetime.timedelta(days=6))
@@ -35,7 +36,7 @@ class SpecialEventResponseFactory(BaseFactory):
 
     event = factory.SubFactory(SpecialEventFactory)
     externalId = factory.Sequence("ExtIdRes{:04}".format)
-    dateSubmitted = factory.LazyFunction(lambda: datetime.datetime.utcnow() - datetime.timedelta(days=1))
+    dateSubmitted = factory.LazyFunction(lambda: date_utils.get_naive_utc_now() - datetime.timedelta(days=1))
     user: factory.declarations.BaseDeclaration | None = factory.SubFactory(users_factories.BeneficiaryFactory)
     phoneNumber: factory.declarations.BaseDeclaration | str | None = factory.SelfAttribute("user.phoneNumber")
     email: factory.declarations.BaseDeclaration = factory.SelfAttribute("user.email")

--- a/api/src/pcapi/core/operations/models.py
+++ b/api/src/pcapi/core/operations/models.py
@@ -9,13 +9,14 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users import models as users_models
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 from pcapi.utils.db import MagicEnum
 
 
 class SpecialEvent(PcObject, Model):
     __tablename__ = "special_event"
     dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
     externalId: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text(), index=True, unique=True, nullable=False)
     title: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text(), nullable=False)

--- a/api/src/pcapi/core/providers/factories.py
+++ b/api/src/pcapi/core/providers/factories.py
@@ -10,6 +10,7 @@ import pcapi.core.providers.repository as providers_repository
 from pcapi.core.factories import BaseFactory
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
+from pcapi.utils import date as date_utils
 from pcapi.utils.crypto import encrypt
 
 from . import models
@@ -134,7 +135,7 @@ class BoostCinemaDetailsFactory(BaseFactory[models.BoostCinemaDetails]):
     cinemaProviderPivot = factory.SubFactory(BoostCinemaProviderPivotFactory)
     cinemaUrl = factory.Sequence("https://boost-cinema-{}.example.com/".format)
     token = factory.LazyFunction(secrets.token_urlsafe)
-    tokenExpirationDate = factory.LazyAttribute(lambda _: datetime.datetime.utcnow() + datetime.timedelta(hours=24))
+    tokenExpirationDate = factory.LazyAttribute(lambda _: date_utils.get_naive_utc_now() + datetime.timedelta(hours=24))
 
 
 class CGRCinemaDetailsFactory(BaseFactory):
@@ -193,4 +194,4 @@ class LocalProviderEventFactory(BaseFactory):
 
     provider = factory.SubFactory(ProviderFactory)
     type = models.LocalProviderEventType.SyncStart
-    date = factory.LazyAttribute(lambda _: datetime.datetime.utcnow() - datetime.timedelta(days=30))
+    date = factory.LazyAttribute(lambda _: date_utils.get_naive_utc_now() - datetime.timedelta(days=30))

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -14,6 +14,7 @@ from pcapi.core.offerers.models import Venue
 from pcapi.models import Model
 from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 
 
 if typing.TYPE_CHECKING:
@@ -342,7 +343,7 @@ class LocalProviderEvent(PcObject, Model):
     providerId: sa_orm.Mapped[int] = sa_orm.mapped_column(sa.BigInteger, sa.ForeignKey("provider.id"), nullable=False)
     provider: sa_orm.Mapped["Provider"] = sa_orm.relationship("Provider", foreign_keys=[providerId])
     date: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
     )
     type: sa_orm.Mapped[LocalProviderEventType] = sa_orm.mapped_column(sa.Enum(LocalProviderEventType), nullable=False)
     payload: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.String(50), nullable=True)

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import Iterable
 from typing import Sequence
 
@@ -11,6 +10,7 @@ import pcapi.core.offers.models as offers_models
 from pcapi.core.categories import subcategories
 from pcapi.core.offerers.models import Venue
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from . import constants
 from . import models
@@ -234,7 +234,7 @@ def _get_future_provider_events_requiring_a_ticketing_system_query(
 
     # Events with future stocks
     events_query = events_query.filter(
-        offers_models.Stock.beginningDatetime >= datetime.datetime.utcnow(),
+        offers_models.Stock.beginningDatetime >= date_utils.get_naive_utc_now(),
     )
 
     return events_query

--- a/api/src/pcapi/core/providers/titelive_api.py
+++ b/api/src/pcapi/core/providers/titelive_api.py
@@ -19,6 +19,7 @@ from pcapi.connectors.serialization.titelive_serializers import TiteliveWorkType
 from pcapi.core.offers import models as offers_models
 from pcapi.core.offers.exceptions import NotUpdateProductOrOffers
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 from pcapi.utils import requests
 
@@ -111,7 +112,7 @@ class TiteliveSearchTemplate(abc.ABC, typing.Generic[TiteliveWorkType]):
     ) -> providers_models.LocalProviderEvent:
         message = f"{self.titelive_base.value} : {message}" if message else self.titelive_base.value
         return providers_models.LocalProviderEvent(
-            date=datetime.datetime.utcnow(),
+            date=date_utils.get_naive_utc_now(),
             payload=message,
             provider=self.provider,
             type=provider_event_type,

--- a/api/src/pcapi/core/providers/titelive_bq_book_search.py
+++ b/api/src/pcapi/core/providers/titelive_bq_book_search.py
@@ -22,6 +22,7 @@ from pcapi.core.providers.titelive_book_search import get_book_format
 from pcapi.core.providers.titelive_book_search import get_gtl_id
 from pcapi.core.providers.titelive_book_search import get_ineligibility_reasons
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.repository import transaction
 
 
@@ -59,7 +60,7 @@ class BigQueryProductSync:
     ) -> providers_models.LocalProviderEvent:
         message = f"{self.titelive_base.value} : {message}" if message else self.titelive_base.value
         return providers_models.LocalProviderEvent(
-            date=datetime.datetime.utcnow(),
+            date=date_utils.get_naive_utc_now(),
             payload=message,
             provider=provider,
             type=event_type,

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -21,6 +21,7 @@ from pcapi.core.search.backends import algolia
 from pcapi.core.search.models import IndexationReason
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
+from pcapi.utils import date as date_utils
 from pcapi.utils import requests
 from pcapi.utils.module_loading import import_string
 from pcapi.utils.transaction_manager import atomic
@@ -619,7 +620,7 @@ def get_offers_booking_count_by_id(
         .filter(
             offers_models.Offer.id.in_(offer_ids),
             offers_models.Offer.isActive,
-            bookings_models.Booking.dateCreated >= datetime.datetime.utcnow() - datetime.timedelta(days=days),
+            bookings_models.Booking.dateCreated >= date_utils.get_naive_utc_now() - datetime.timedelta(days=days),
             bookings_models.Booking.status != bookings_models.BookingStatus.CANCELLED,
         )
         .group_by(offers_models.Offer.id)

--- a/api/src/pcapi/core/search/serialization.py
+++ b/api/src/pcapi/core/search/serialization.py
@@ -262,7 +262,7 @@ class AlgoliaSerializationMixin:
                 "gtlCodeLevel3": gtl_code_3,
                 "gtlCodeLevel4": gtl_code_4,
                 "headlinesCount": headlines_count or None,
-                "indexedAt": datetime.datetime.utcnow().isoformat(),
+                "indexedAt": date_utils.get_naive_utc_now().isoformat(),
                 "hasUrl": offer.hasUrl,
                 "isDuo": offer.isDuo,
                 "isEducational": False,

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -32,6 +32,7 @@ from pcapi.core.users import utils as users_utils
 from pcapi.core.users import young_status as young_status_module
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
+from pcapi.utils import date as date_utils
 from pcapi.workers import apps_flyer_job
 
 from . import exceptions
@@ -598,7 +599,7 @@ def _is_ubble_allowed_if_subscription_overflow(user: users_models.User) -> bool:
 
     future_age = users_utils.get_age_at_date(
         user.birth_date,
-        datetime.datetime.utcnow() + datetime.timedelta(days=settings.UBBLE_SUBSCRIPTION_LIMITATION_DAYS),  # type: ignore[arg-type]
+        date_utils.get_naive_utc_now() + datetime.timedelta(days=settings.UBBLE_SUBSCRIPTION_LIMITATION_DAYS),  # type: ignore[arg-type]
         user.departementCode,
     )
     eligibility_ranges = users_constants.ELIGIBILITY_UNDERAGE_RANGE + [users_constants.ELIGIBILITY_AGE_18]

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -32,6 +32,7 @@ from pcapi.core.users import utils as users_utils
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 from pcapi.utils.postal_code import PostalCode
 
@@ -693,7 +694,7 @@ def _process_instructor_annotation(application_content: dms_schemas.DMSContent, 
         from_draft=(application_content.state == dms_models.GraphQLApplicationStates.draft.value),
     )
     application_content.state = dms_models.GraphQLApplicationStates.refused.value
-    application_content.processed_datetime = datetime.datetime.utcnow()
+    application_content.processed_datetime = date_utils.get_naive_utc_now()
     return True
 
 
@@ -943,7 +944,7 @@ def handle_inactive_dms_applications(procedure_number: int, with_never_eligible_
 
 
 def _has_inactivity_delay_expired(dms_application: dms_models.DmsApplicationResponse) -> bool:
-    date_with_delay = datetime.datetime.utcnow() - relativedelta(days=settings.DMS_INACTIVITY_TOLERANCE_DELAY)
+    date_with_delay = date_utils.get_naive_utc_now() - relativedelta(days=settings.DMS_INACTIVITY_TOLERANCE_DELAY)
 
     if dms_application.latest_modification_datetime >= date_with_delay:
         return False

--- a/api/src/pcapi/core/subscription/educonnect/api.py
+++ b/api/src/pcapi/core/subscription/educonnect/api.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 import pcapi.core.mails.transactional as transactional_mails
@@ -10,6 +9,7 @@ from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription import schemas as subscription_schemas
 from pcapi.core.subscription.educonnect import schemas as educonnect_schemas
 from pcapi.core.users import models as users_models
+from pcapi.utils import date as date_utils
 
 from . import exceptions
 from . import messages
@@ -28,7 +28,7 @@ def handle_educonnect_authentication(
         first_name=educonnect_user.first_name,
         ine_hash=educonnect_user.ine_hash,
         last_name=educonnect_user.last_name,
-        registration_datetime=datetime.datetime.utcnow(),
+        registration_datetime=date_utils.get_naive_utc_now(),
         school_uai=educonnect_user.school_uai,
         student_level=educonnect_user.student_level,
     )

--- a/api/src/pcapi/core/subscription/factories.py
+++ b/api/src/pcapi/core/subscription/factories.py
@@ -22,6 +22,7 @@ from pcapi.core.subscription.ubble import schemas as ubble_schemas
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
 from pcapi.models.feature import FeatureToggle
+from pcapi.utils import date as date_utils
 
 
 # This factory is here instead of in the `pcapi.core.users.factories` module because it needs both UserFactory and BeneficiaryFraudCheckFactory.
@@ -88,7 +89,7 @@ class DMSContentFactory(factory.Factory):
     phone = factory.Sequence("+33612{:06}".format)
     postal_code = "75008"
     procedure_number = factory.Faker("pyint")
-    registration_datetime = LazyAttribute(lambda _: datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S"))
+    registration_datetime = LazyAttribute(lambda _: date_utils.get_naive_utc_now().strftime("%Y-%m-%dT%H:%M:%S"))
 
 
 class UbbleContentFactory(factory.Factory):
@@ -110,7 +111,7 @@ class UbbleContentFactory(factory.Factory):
     supported: float | None = None
     identification_id: str | None = None
     identification_url: str | None = None
-    registration_datetime = factory.LazyFunction(datetime.utcnow)
+    registration_datetime = factory.LazyFunction(date_utils.get_naive_utc_now)
 
 
 class EduconnectContentFactory(factory.Factory):
@@ -125,7 +126,7 @@ class EduconnectContentFactory(factory.Factory):
     first_name = factory.Faker("first_name")
     ine_hash = factory.Sequence(lambda _: "".join(random.choices(string.ascii_lowercase + string.digits, k=32)))
     last_name = factory.Faker("last_name")
-    registration_datetime = factory.LazyFunction(datetime.utcnow)
+    registration_datetime = factory.LazyFunction(date_utils.get_naive_utc_now)
     civility = users_models.GenderEnum.F
 
 
@@ -160,7 +161,7 @@ class BeneficiaryFraudCheckFactory(factories.BaseFactory):
     type = subscription_models.FraudCheckType.UBBLE
     thirdPartyId = factory.LazyFunction(lambda: str(uuid.uuid4()))
     status = subscription_models.FraudCheckStatus.PENDING
-    dateCreated = factory.LazyFunction(datetime.utcnow)
+    dateCreated = factory.LazyFunction(date_utils.get_naive_utc_now)
 
     @factory.lazy_attribute
     def eligibilityType(

--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -10,6 +10,7 @@ from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 from pcapi.utils.db import MagicEnum
 
 
@@ -161,7 +162,7 @@ class BeneficiaryFraudCheck(PcObject, Model):
     __tablename__ = "beneficiary_fraud_check"
 
     dateCreated: sa_orm.Mapped[datetime.datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, server_default=sa.func.now(), default=datetime.datetime.utcnow
+        sa.DateTime, nullable=False, server_default=sa.func.now(), default=date_utils.get_naive_utc_now
     )
     # The eligibility is null when the user is not eligible
     eligibilityType: sa_orm.Mapped[users_models.EligibilityType | None] = sa_orm.mapped_column(
@@ -183,7 +184,7 @@ class BeneficiaryFraudCheck(PcObject, Model):
         MagicEnum(FraudCheckType, use_values=False), nullable=False
     )
     updatedAt: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow, onupdate=sa.func.now()
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now, onupdate=sa.func.now()
     )
     userId: sa_orm.Mapped[int] = sa_orm.mapped_column(
         sa.BigInteger, sa.ForeignKey("user.id"), index=True, nullable=False
@@ -274,7 +275,7 @@ class OrphanDmsApplication(PcObject, Model):
         sa.BigInteger, primary_key=True, nullable=False
     )  # refers to DMS application "number"
     dateCreated: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.datetime.utcnow
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now
     )  # no sql default because the column was added after table creation
     email: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True, index=True)
     latest_modification_datetime: sa_orm.Mapped[datetime.datetime | None] = sa_orm.mapped_column(

--- a/api/src/pcapi/core/subscription/phone_validation/sending_limit.py
+++ b/api/src/pcapi/core/subscription/phone_validation/sending_limit.py
@@ -6,6 +6,7 @@ from redis import Redis
 
 from pcapi import settings
 from pcapi.core.users.models import User
+from pcapi.utils import date as date_utils
 
 
 @dataclass
@@ -42,7 +43,7 @@ def get_remaining_sms_sending_attempts(redis: Redis, user: User) -> int:
 def get_attempt_limitation_expiration_time(redis: Redis, user: User) -> datetime | None:
     ttl = redis.ttl(_sent_SMS_counter_key_name(user))
     if ttl > 0:
-        return datetime.utcnow() + timedelta(seconds=ttl)
+        return date_utils.get_naive_utc_now() + timedelta(seconds=ttl)
 
     return None
 

--- a/api/src/pcapi/core/token/__init__.py
+++ b/api/src/pcapi/core/token/__init__.py
@@ -18,6 +18,7 @@ from flask import current_app as app
 from pcapi import settings
 from pcapi.core.users import exceptions as users_exceptions
 from pcapi.core.users import utils
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -82,7 +83,7 @@ class AbstractToken(abc.ABC):
         if ttl < 0:
             # -2 if doesn't exist, -1 if no expiration
             return None
-        return datetime.utcnow() + timedelta(seconds=ttl)
+        return date_utils.get_naive_utc_now() + timedelta(seconds=ttl)
 
     @classmethod
     def delete(cls: typing.Type[T], type_: TokenType, key_suffix: int | str | None) -> None:
@@ -165,7 +166,7 @@ class Token(AbstractToken):
             "data": data or {},
         }
         if ttl:
-            payload["exp"] = (datetime.utcnow() + ttl).timestamp()
+            payload["exp"] = (date_utils.get_naive_utc_now() + ttl).timestamp()
 
         encoded_token = utils.encode_jwt_payload(payload)
         if ttl is None or ttl > timedelta(0):
@@ -275,7 +276,7 @@ class UUIDToken(AbstractToken):
             "data": data or {},
         }
         if ttl:
-            payload["exp"] = (datetime.utcnow() + ttl).timestamp()
+            payload["exp"] = (date_utils.get_naive_utc_now() + ttl).timestamp()
         encoded_token = utils.encode_jwt_payload(payload)
 
         if ttl is None or ttl > timedelta(0):
@@ -379,7 +380,7 @@ class AsymetricToken(AbstractToken):
             "data": data or {},
         }
         if ttl:
-            payload["exp"] = (datetime.utcnow() + ttl).timestamp()
+            payload["exp"] = (date_utils.get_naive_utc_now() + ttl).timestamp()
 
         encoded_token = utils.encode_jwt_payload_rs256(payload, private_key=private_key)
         if ttl is None or ttl > timedelta(0):
@@ -409,7 +410,7 @@ def create_passwordless_login_token(user_id: int, ttl: timedelta) -> str:
     Returns:
         A JWT token (str)
     """
-    issued_at = datetime.utcnow()
+    issued_at = date_utils.get_naive_utc_now()
     expiration_date = issued_at + ttl
 
     jti = str(uuid.uuid4())

--- a/api/src/pcapi/core/users/ds.py
+++ b/api/src/pcapi/core/users/ds.py
@@ -17,6 +17,7 @@ from pcapi.core.users import models as users_models
 from pcapi.core.users import repository
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import email as email_utils
 from pcapi.utils import phone_number as phone_number_utils
 
@@ -208,7 +209,7 @@ def check_set_without_continuation(user_request: users_models.UserAccountUpdateR
         and data["dateLastInstructorMessage"] is not None
         and data["dateLastInstructorMessage"]
         + relativedelta(days=settings.DS_MARK_WITHOUT_CONTINUATION_UDPATE_REQUEST_DEADLINE)
-        < datetime.datetime.utcnow().astimezone(datetime.timezone.utc)
+        < date_utils.get_naive_utc_now().astimezone(datetime.timezone.utc)
         and data["dateLastInstructorMessage"] > last_user_action_date
     ):
         try:

--- a/api/src/pcapi/core/users/eligibility_api.py
+++ b/api/src/pcapi/core/users/eligibility_api.py
@@ -31,7 +31,7 @@ def decide_eligibility(
         return None
 
     if at_datetime is None:
-        at_datetime = datetime.datetime.utcnow()
+        at_datetime = date_utils.get_naive_utc_now()
 
     current_age = users_utils.get_age_from_birth_date(birth_date, user.departementCode)
     if not (15 <= current_age <= 20):
@@ -53,7 +53,7 @@ def decide_eligibility(
     if first_age_17_to_18_registration_date:
         return get_eligibility_at_date(birth_date, first_age_17_to_18_registration_date, user.departementCode)
 
-    current_eligibility = get_eligibility_at_date(birth_date, datetime.datetime.utcnow(), user.departementCode)
+    current_eligibility = get_eligibility_at_date(birth_date, date_utils.get_naive_utc_now(), user.departementCode)
     return current_eligibility
 
 
@@ -61,7 +61,7 @@ def get_pre_decree_or_current_eligibility(user: users_models.User) -> users_mode
     if user.birth_date is None:
         return None
 
-    pre_decree_eligibility = get_pre_decree_eligibility(user, user.birth_date, datetime.datetime.utcnow())
+    pre_decree_eligibility = get_pre_decree_eligibility(user, user.birth_date, date_utils.get_naive_utc_now())
     return pre_decree_eligibility or user.eligibility
 
 

--- a/api/src/pcapi/core/users/email/repository.py
+++ b/api/src/pcapi/core/users/email/repository.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import sqlalchemy.orm as sa_orm
 
 from pcapi.core.users import constants
@@ -7,6 +5,7 @@ from pcapi.core.users.models import EmailHistoryEventTypeEnum
 from pcapi.core.users.models import User
 from pcapi.core.users.models import UserEmailHistory
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 def _query_ordered_email_update_entry(user: User) -> sa_orm.Query:
@@ -17,7 +16,7 @@ def _query_ordered_email_update_entry(user: User) -> sa_orm.Query:
 
 
 def get_latest_pending_email_validation(user: User) -> None | UserEmailHistory:
-    creation_date_limit = datetime.utcnow() - constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
+    creation_date_limit = date_utils.get_naive_utc_now() - constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
     latest_entry = (
         _query_ordered_email_update_entry(user).filter(UserEmailHistory.creationDate >= creation_date_limit).first()
     )

--- a/api/src/pcapi/core/users/email/update.py
+++ b/api/src/pcapi/core/users/email/update.py
@@ -16,6 +16,7 @@ from pcapi.core.users import repository as users_repository
 from pcapi.core.users.email.send import send_pro_user_emails_for_email_change
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 from pcapi.utils.repository import transaction
 from pcapi.utils.urls import generate_app_link
@@ -384,7 +385,7 @@ def get_active_token_expiration(user: models.User) -> datetime | None:
 
 
 def generate_email_change_token_expiration_date() -> datetime:
-    return datetime.utcnow() + constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
+    return date_utils.get_naive_utc_now() + constants.EMAIL_CHANGE_TOKEN_LIFE_TIME
 
 
 def check_user_password(user: models.User, password: str) -> None:

--- a/api/src/pcapi/core/users/factories.py
+++ b/api/src/pcapi/core/users/factories.py
@@ -31,6 +31,7 @@ from pcapi.models.beneficiary_import import BeneficiaryImportSources
 from pcapi.models.beneficiary_import_status import BeneficiaryImportStatus
 from pcapi.models.beneficiary_import_status import ImportStatus
 from pcapi.utils import crypto
+from pcapi.utils import date as date_utils
 from pcapi.utils import regions
 from pcapi.utils import repository
 
@@ -57,7 +58,7 @@ class BaseUserFactory(BaseFactory):
     class Params:
         age = 40
 
-    dateCreated = LazyFunction(datetime.utcnow)
+    dateCreated = LazyFunction(date_utils.get_naive_utc_now)
     dateOfBirth = LazyAttribute(
         lambda o: datetime.combine((o.dateCreated - relativedelta(years=o.age)).date(), time.min)
     )
@@ -155,7 +156,7 @@ class PhoneValidatedUserFactory(EmailValidatedUserFactory):
             obj.phoneValidationStatus = models.PhoneValidationStatusType.VALIDATED
             fraud_checks.append(
                 subscription_factories.PhoneValidationFraudCheckFactory.create(
-                    user=obj, dateCreated=kwargs.get("dateCreated", datetime.utcnow())
+                    user=obj, dateCreated=kwargs.get("dateCreated", date_utils.get_naive_utc_now())
                 )
             )
         return fraud_checks
@@ -210,7 +211,7 @@ class ProfileCompletedUserFactory(PhoneValidatedUserFactory):
         import pcapi.core.subscription.factories as subscription_factories
 
         fraud_checks = super().beneficiary_fraud_checks(obj, **kwargs)
-        profile_completion_kwargs: dict = {"dateCreated": kwargs.get("dateCreated", datetime.utcnow())}
+        profile_completion_kwargs: dict = {"dateCreated": kwargs.get("dateCreated", date_utils.get_naive_utc_now())}
         if "eligibilityType" in kwargs:
             profile_completion_kwargs["eligibilityType"] = kwargs["eligibilityType"]
         fraud_checks.append(
@@ -310,7 +311,7 @@ class HonorStatementValidatedUserFactory(IdentityValidatedUserFactory):
         fraud_checks = super().beneficiary_fraud_checks(obj, **kwargs)
         fraud_checks.append(
             subscription_factories.HonorStatementFraudCheckFactory.create(
-                user=obj, dateCreated=kwargs.get("dateCreated", datetime.utcnow())
+                user=obj, dateCreated=kwargs.get("dateCreated", date_utils.get_naive_utc_now())
             )
         )
         return fraud_checks
@@ -595,8 +596,8 @@ class BeneficiaryGrant18Factory(BaseFactory):
     email = factory.LazyFunction(lambda: f"jeanne.doux_{uuid.uuid4()}@example.com")
     address = factory.Sequence("{} rue des machines".format)
     city = "Paris"
-    dateCreated = LazyAttribute(lambda _: datetime.utcnow())
-    lastConnectionDate = LazyAttribute(lambda _: datetime.utcnow() - relativedelta(days=1))
+    dateCreated = LazyAttribute(lambda _: date_utils.get_naive_utc_now())
+    lastConnectionDate = LazyAttribute(lambda _: date_utils.get_naive_utc_now() - relativedelta(days=1))
     dateOfBirth = LazyAttribute(  # LazyAttribute to allow freez_time overrides
         lambda _: datetime.combine(date.today(), time(0, 0))
         - relativedelta(years=users_constants.ELIGIBILITY_AGE_18, months=1)
@@ -1023,7 +1024,7 @@ class DepositGrantFactory(BaseFactory):
     class Meta:
         model = finance_models.Deposit
 
-    dateCreated = LazyAttribute(lambda _: datetime.utcnow())
+    dateCreated = LazyAttribute(lambda _: date_utils.get_naive_utc_now())
     source = "factory"
     user = factory.SubFactory(UserFactory)
 
@@ -1041,7 +1042,7 @@ class DepositGrantFactory(BaseFactory):
             age = 18  # The calling functions are responsible for setting the correct age. If age is not in the range, we generate a deposit for 18yo.
 
         if "type" not in kwargs:
-            date_created = kwargs.get("dateCreated", datetime.utcnow())
+            date_created = kwargs.get("dateCreated", date_utils.get_naive_utc_now())
             if date_created >= settings.CREDIT_V3_DECREE_DATETIME:
                 kwargs["type"] = finance_models.DepositType.GRANT_17_18
             else:
@@ -1216,8 +1217,8 @@ class UserAccountUpdateRequestFactory(BaseFactory):
         firstName="Instructeur",
         lastName="du Backoffice",
     )
-    dateLastUserMessage = LazyAttribute(lambda _: datetime.utcnow() - relativedelta(days=1))
-    dateLastInstructorMessage = factory.LazyAttribute(lambda _: datetime.utcnow() - relativedelta(days=3))
+    dateLastUserMessage = LazyAttribute(lambda _: date_utils.get_naive_utc_now() - relativedelta(days=1))
+    dateLastInstructorMessage = factory.LazyAttribute(lambda _: date_utils.get_naive_utc_now() - relativedelta(days=3))
 
 
 class EmailUpdateRequestFactory(UserAccountUpdateRequestFactory):
@@ -1246,7 +1247,7 @@ class GdprUserDataExtractBeneficiaryFactory(BaseFactory):
     class Meta:
         model = models.GdprUserDataExtract
 
-    dateCreated = LazyAttribute(lambda _: datetime.utcnow() - timedelta(days=1))
+    dateCreated = LazyAttribute(lambda _: date_utils.get_naive_utc_now() - timedelta(days=1))
     user = factory.SubFactory(BeneficiaryFactory)
     authorUser = factory.SubFactory(AdminFactory)
 
@@ -1255,7 +1256,7 @@ class GdprUserAnonymizationFactory(BaseFactory):
     class Meta:
         model = models.GdprUserAnonymization
 
-    dateCreated = LazyAttribute(lambda _: datetime.utcnow() - timedelta(days=1))
+    dateCreated = LazyAttribute(lambda _: date_utils.get_naive_utc_now() - timedelta(days=1))
     user = factory.SubFactory(BeneficiaryFactory)
 
 

--- a/api/src/pcapi/core/users/generator.py
+++ b/api/src/pcapi/core/users/generator.py
@@ -7,6 +7,7 @@ import pcapi.core.users.factories as users_factories
 import pcapi.core.users.models as users_models
 from pcapi import settings
 from pcapi.core.users import constants as users_constants
+from pcapi.utils import date as date_utils
 
 from . import exceptions
 
@@ -33,7 +34,7 @@ class GenerateUserData:
     id_provider: GeneratedIdProvider = GeneratedIdProvider.UBBLE
     step: GeneratedSubscriptionStep = GeneratedSubscriptionStep.EMAIL_VALIDATION
     transition_17_18: bool = False
-    date_created: datetime.datetime = datetime.datetime.utcnow()
+    date_created: datetime.datetime = date_utils.get_naive_utc_now()
     postal_code: str | None = None
 
 

--- a/api/src/pcapi/core/users/models.py
+++ b/api/src/pcapi/core/users/models.py
@@ -37,6 +37,7 @@ from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.pc_object import PcObject
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.utils import crypto
+from pcapi.utils import date as date_utils
 from pcapi.utils import regions as regions_utils
 from pcapi.utils.db import MagicEnum
 from pcapi.utils.phone_number import ParsedPhoneNumber
@@ -212,7 +213,9 @@ class User(PcObject, Model, DeactivableMixin):
     culturalSurveyFilledDate: sa_orm.Mapped[datetime | None] = sa_orm.mapped_column(sa.DateTime, nullable=True)
     # culturalSurveyId is obsolete. the column is kept for backward compatibility with the existing data
     culturalSurveyId: sa_orm.Mapped[UUID | None] = sa_orm.mapped_column(postgresql.UUID(as_uuid=True), nullable=True)
-    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
+    )
     dateOfBirth: sa_orm.Mapped[datetime | None] = sa_orm.mapped_column(sa.DateTime, nullable=True)  # declared at signup
     departementCode: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.String(3), nullable=True)
     email: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.String(120), nullable=False, unique=True)
@@ -556,7 +559,7 @@ class User(PcObject, Model, DeactivableMixin):
     def eligibility(self) -> EligibilityType | None:
         from pcapi.core.users import eligibility_api
 
-        return eligibility_api.decide_eligibility(self, self.birth_date, datetime.utcnow())
+        return eligibility_api.decide_eligibility(self, self.birth_date, date_utils.get_naive_utc_now())
 
     @hybrid_property
     def full_name(self) -> str:
@@ -587,7 +590,7 @@ class User(PcObject, Model, DeactivableMixin):
             return False
         if not self.deposit.expirationDate:
             return True
-        return self.deposit.expirationDate > datetime.utcnow()
+        return self.deposit.expirationDate > date_utils.get_naive_utc_now()
 
     @property
     def is_eligible(self) -> bool:
@@ -980,7 +983,7 @@ class Favorite(PcObject, Model):
     )
     offer: sa_orm.Mapped["Offer"] = sa_orm.relationship("Offer", foreign_keys=[offerId], back_populates="favorites")
 
-    dateCreated = sa_orm.mapped_column(sa.DateTime, nullable=True, default=datetime.utcnow)
+    dateCreated = sa_orm.mapped_column(sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now)
 
     __table_args__ = (
         sa.UniqueConstraint(
@@ -1137,10 +1140,10 @@ class UserAccountUpdateRequest(PcObject, Model):
         MagicEnum(dms_models.GraphQLApplicationStates), nullable=False
     )
     dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
     dateLastStatusUpdate: sa_orm.Mapped[datetime | None] = sa_orm.mapped_column(
-        sa.DateTime, nullable=True, default=datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=True, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
     # Information about applicant, used to match with a single user
     firstName: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
@@ -1287,7 +1290,9 @@ class TrustedDevice(PcObject, Model):
 
     source: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
     os: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
-    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
+    )
 
 
 class LoginDeviceHistory(PcObject, Model):
@@ -1303,7 +1308,9 @@ class LoginDeviceHistory(PcObject, Model):
     source = sa_orm.mapped_column(sa.Text, nullable=True)
     os = sa_orm.mapped_column(sa.Text, nullable=True)
     location = sa_orm.mapped_column(sa.Text, nullable=True)
-    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
+    )
 
 
 class SingleSignOn(PcObject, Model):
@@ -1334,7 +1341,9 @@ class SingleSignOn(PcObject, Model):
 class GdprUserDataExtract(PcObject, Model):
     __tablename__ = "gdpr_user_data_extract"
 
-    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
+    )
 
     dateProcessed: sa_orm.Mapped[datetime | None] = sa_orm.mapped_column(sa.DateTime, nullable=True)
 
@@ -1355,14 +1364,14 @@ class GdprUserDataExtract(PcObject, Model):
 
     @property
     def is_expired(self) -> bool:
-        return datetime.utcnow() > self.expirationDate
+        return date_utils.get_naive_utc_now() > self.expirationDate
 
 
 class GdprUserAnonymization(PcObject, Model):
     __tablename__ = "gdpr_user_anonymization"
 
     dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.utcnow, server_default=func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=func.now()
     )
     userId: sa_orm.Mapped[int] = sa_orm.mapped_column(sa.BigInteger, sa.ForeignKey("user.id"), nullable=False)
     user: sa_orm.Mapped[sa_orm.Mapped[User]] = sa_orm.relationship(User, foreign_keys=[userId])
@@ -1426,7 +1435,9 @@ class UserProfileRefreshCampaign(PcObject, Model):
     __tablename__ = "user_profile_refresh_campaign"
 
     campaignDate: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False)
-    creationDate: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
+    creationDate: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now
+    )
     updateDate: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
         sa.DateTime, nullable=False, server_default=sa.func.now(), onupdate=sa.func.now()
     )

--- a/api/src/pcapi/core/users/utils.py
+++ b/api/src/pcapi/core/users/utils.py
@@ -7,6 +7,7 @@ import jwt
 from dateutil.relativedelta import relativedelta
 
 from pcapi import settings
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import utc_datetime_to_department_timezone
 
 
@@ -64,7 +65,7 @@ def get_age_at_date(birth_date: date, specified_datetime: datetime, department_c
 
 
 def get_age_from_birth_date(birth_date: date, department_code: str | None = None) -> int:
-    return get_age_at_date(birth_date, datetime.utcnow(), department_code)
+    return get_age_at_date(birth_date, date_utils.get_naive_utc_now(), department_code)
 
 
 def format_login_location(country_name: str | None, city_name: str | None) -> str | None:

--- a/api/src/pcapi/core/users/young_status.py
+++ b/api/src/pcapi/core/users/young_status.py
@@ -1,9 +1,9 @@
 import dataclasses
 import enum
-from datetime import datetime
 
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.users import models
+from pcapi.utils import date as date_utils
 
 
 class YoungStatusType(enum.Enum):
@@ -61,7 +61,7 @@ def young_status(user: models.User) -> YoungStatus:
         return Suspended()
 
     if user.is_beneficiary:
-        if user.deposit_expiration_date and user.deposit_expiration_date < datetime.utcnow():
+        if user.deposit_expiration_date and user.deposit_expiration_date < date_utils.get_naive_utc_now():
             return ExBeneficiary()
 
         return Beneficiary()

--- a/api/src/pcapi/local_providers/allocine/allocine_stocks.py
+++ b/api/src/pcapi/local_providers/allocine/allocine_stocks.py
@@ -23,6 +23,7 @@ from pcapi.local_providers.movie_festivals import constants as movie_festivals_c
 from pcapi.local_providers.providable_info import ProvidableInfo
 from pcapi.models import Model
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_department_timezone
 from pcapi.utils.date import get_naive_utc_now
 from pcapi.utils.date import local_datetime_to_default_timezone
@@ -71,7 +72,7 @@ class AllocineStocks(LocalProvider):
             offers_models.Offer,
             id_at_providers=venue_movie_unique_id,
             new_id_at_provider=venue_movie_unique_id,
-            date_modified_at_provider=datetime.utcnow(),
+            date_modified_at_provider=date_utils.get_naive_utc_now(),
         )
         providable_information_list.append(offer_providable_information)
 
@@ -81,7 +82,7 @@ class AllocineStocks(LocalProvider):
                 offers_models.Stock,
                 id_at_providers=id_at_providers,
                 new_id_at_provider=id_at_providers,
-                date_modified_at_provider=datetime.utcnow(),
+                date_modified_at_provider=date_utils.get_naive_utc_now(),
             )
             providable_information_list.append(stock_providable_information)
 

--- a/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/boost/boost_stocks.py
@@ -24,6 +24,7 @@ from pcapi.local_providers.movie_festivals import constants as movie_festivals_c
 from pcapi.local_providers.providable_info import ProvidableInfo
 from pcapi.models import Model
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_naive_utc_now
 
 
@@ -77,13 +78,13 @@ class BoostStocks(LocalProvider):
 
         provider_movie_unique_id = _build_movie_uuid(self.showtime_details.film.id, self.venue)
         offer_providable_info = self.create_providable_info(
-            offers_models.Offer, provider_movie_unique_id, datetime.utcnow(), provider_movie_unique_id
+            offers_models.Offer, provider_movie_unique_id, date_utils.get_naive_utc_now(), provider_movie_unique_id
         )
         providable_information_list.append(offer_providable_info)
 
         showtime_id = _build_stock_uuid(self.showtime_details.film.id, self.venue, self.showtime_details.id)
         stock_providable_info = self.create_providable_info(
-            offers_models.Stock, showtime_id, datetime.utcnow(), showtime_id
+            offers_models.Stock, showtime_id, date_utils.get_naive_utc_now(), showtime_id
         )
         providable_information_list.append(stock_providable_info)
 

--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -27,6 +27,7 @@ from pcapi.local_providers.movie_festivals import constants as movie_festivals_c
 from pcapi.local_providers.providable_info import ProvidableInfo
 from pcapi.models import Model
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 ACCEPTED_MEDIA_OPTIONS_TICKET_LABEL = {
@@ -83,7 +84,7 @@ class CDSStocks(LocalProvider):
 
         venue_movie_unique_id = _build_movie_uuid(self.movie_information.id, self.venue)
         offer_providable_info = self.create_providable_info(
-            offers_models.Offer, venue_movie_unique_id, datetime.utcnow(), venue_movie_unique_id
+            offers_models.Offer, venue_movie_unique_id, date_utils.get_naive_utc_now(), venue_movie_unique_id
         )
         providable_information_list.append(offer_providable_info)
 
@@ -92,7 +93,7 @@ class CDSStocks(LocalProvider):
                 self.movie_information.id, self.venue, show["show_information"]
             )
             stock_providable_info = self.create_providable_info(
-                offers_models.Stock, stock_showtime_unique_id, datetime.utcnow(), stock_showtime_unique_id
+                offers_models.Stock, stock_showtime_unique_id, date_utils.get_naive_utc_now(), stock_showtime_unique_id
             )
             providable_information_list.append(stock_providable_info)
 

--- a/api/src/pcapi/local_providers/cinema_providers/cgr/cgr_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cgr/cgr_stocks.py
@@ -23,6 +23,7 @@ from pcapi.local_providers.movie_festivals import constants as movie_festivals_c
 from pcapi.local_providers.providable_info import ProvidableInfo
 from pcapi.models import Model
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import date as utils_date
 
 
@@ -65,7 +66,7 @@ class CGRStocks(LocalProvider):
         offer_providable_info = self.create_providable_info(
             pc_object=offers_models.Offer,
             id_at_providers=provider_offer_unique_id,
-            date_modified_at_provider=datetime.datetime.utcnow(),
+            date_modified_at_provider=date_utils.get_naive_utc_now(),
             new_id_at_provider=provider_offer_unique_id,
         )
         providable_information_list.append(offer_providable_info)
@@ -75,7 +76,7 @@ class CGRStocks(LocalProvider):
             stock_providable_info = self.create_providable_info(
                 pc_object=offers_models.Stock,
                 id_at_providers=stock_showtime_unique_id,
-                date_modified_at_provider=datetime.datetime.utcnow(),
+                date_modified_at_provider=date_utils.get_naive_utc_now(),
                 new_id_at_provider=stock_showtime_unique_id,
             )
             providable_information_list.append(stock_providable_info)

--- a/api/src/pcapi/local_providers/cinema_providers/ems/ems_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/ems/ems_stocks.py
@@ -20,6 +20,7 @@ from pcapi.local_providers.cinema_providers.constants import ShowtimeFeatures
 from pcapi.local_providers.movie_festivals import api as movie_festivals_api
 from pcapi.local_providers.movie_festivals import constants as movie_festivals_constants
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.validation.models import entity_validator
 
 
@@ -83,7 +84,7 @@ class EMSStocks:
 
             self.created_offers.add(offer)
 
-        self.venue_provider.lastSyncDate = datetime.datetime.utcnow()
+        self.venue_provider.lastSyncDate = date_utils.get_naive_utc_now()
         db.session.add(self.venue_provider)
 
         db.session.commit()

--- a/api/src/pcapi/local_providers/local_provider.py
+++ b/api/src/pcapi/local_providers/local_provider.py
@@ -19,6 +19,7 @@ from pcapi.models import Model
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.has_thumb_mixin import HasThumbMixin
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 from pcapi.validation.models import entity_validator
 
@@ -301,7 +302,7 @@ class LocalProvider(Iterator):
         self.log_provider_event(providers_models.LocalProviderEventType.SyncEnd)
 
         if self.venue_provider is not None:
-            self.venue_provider.lastSyncDate = datetime.utcnow()
+            self.venue_provider.lastSyncDate = date_utils.get_naive_utc_now()
             repository.save(self.venue_provider)
 
     def postTreatment(self) -> None:

--- a/api/src/pcapi/local_providers/providable_info.py
+++ b/api/src/pcapi/local_providers/providable_info.py
@@ -3,6 +3,7 @@ import typing
 from datetime import datetime
 
 import pcapi.core.offers.models as offers_models
+from pcapi.utils import date as date_utils
 
 
 @dataclasses.dataclass
@@ -10,4 +11,4 @@ class ProvidableInfo:
     type: typing.Type[offers_models.Offer | offers_models.Stock] = offers_models.Offer
     id_at_providers: str = "1"
     new_id_at_provider: str = ""
-    date_modified_at_provider: datetime = dataclasses.field(default_factory=datetime.utcnow)
+    date_modified_at_provider: datetime = dataclasses.field(default_factory=date_utils.get_naive_utc_now)

--- a/api/src/pcapi/models/beneficiary_import_status.py
+++ b/api/src/pcapi/models/beneficiary_import_status.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import relationship
 
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 
 
 if typing.TYPE_CHECKING:
@@ -46,7 +47,7 @@ class BeneficiaryImportStatus(PcObject, Model):
     )
 
     date: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
-        sa.DateTime, nullable=False, default=datetime.utcnow, server_default=sa.func.now()
+        sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now, server_default=sa.func.now()
     )
 
     detail: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.String(255), nullable=True)

--- a/api/src/pcapi/models/event_occurence.py
+++ b/api/src/pcapi/models/event_occurence.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import PriceCategory
+from pcapi.utils import date as date_utils
 
 
 class EventOccurrence:
@@ -12,7 +13,7 @@ class EventOccurrence:
         offer: Offer,
         price: decimal.Decimal,
         price_category: PriceCategory,
-        beginning_datetime: datetime = datetime.utcnow() + timedelta(hours=2),
+        beginning_datetime: datetime = date_utils.get_naive_utc_now() + timedelta(hours=2),
     ) -> None:
         self.offer = offer
         self.offerId = offer.id

--- a/api/src/pcapi/routes/adage_iframe/authentication.py
+++ b/api/src/pcapi/routes/adage_iframe/authentication.py
@@ -1,5 +1,3 @@
-import datetime
-
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational import repository as educational_repository
 from pcapi.core.educational.api import adage as educational_api_adage
@@ -18,6 +16,7 @@ from pcapi.routes.adage_iframe.serialization.adage_authentication import (
 )
 from pcapi.routes.adage_iframe.serialization.redactor import RedactorPreferences
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils.transaction_manager import atomic
 
 
@@ -83,5 +82,5 @@ def _get_programs(institution: educational_models.EducationalInstitution | None)
         return []
     return [
         EducationalInstitutionProgramModel.from_orm(program)
-        for program in institution.programs_at_date(datetime.datetime.utcnow())
+        for program in institution.programs_at_date(date_utils.get_naive_utc_now())
     ]

--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -57,6 +57,7 @@ from pcapi.routes.backoffice import search_utils
 from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.forms import empty as empty_forms
 from pcapi.routes.backoffice.users import forms as user_forms
+from pcapi.utils import date as date_utils
 from pcapi.utils import email as email_utils
 from pcapi.utils.transaction_manager import atomic
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
@@ -99,7 +100,7 @@ def _load_current_deposit_data(query: sa_orm.Query, join_needed: bool = True) ->
             finance_models.Deposit,
             sa.and_(
                 users_models.User.id == finance_models.Deposit.userId,
-                finance_models.Deposit.expirationDate > datetime.datetime.utcnow(),
+                finance_models.Deposit.expirationDate > date_utils.get_naive_utc_now(),
             ),
         )
     return query.options(sa_orm.contains_eager(users_models.User.deposits))
@@ -394,7 +395,7 @@ def render_public_account_details(
     history = get_public_account_history(user)
     duplicate_user_id = None
     eligibility_history = get_eligibility_history(user)
-    user_current_eligibility = eligibility_api.get_eligibility_at_date(user.birth_date, datetime.datetime.utcnow())
+    user_current_eligibility = eligibility_api.get_eligibility_at_date(user.birth_date, date_utils.get_naive_utc_now())
 
     if user_current_eligibility is not None and user_current_eligibility.value in eligibility_history:
         subscription_items = [

--- a/api/src/pcapi/routes/backoffice/accounts/update_request_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/update_request_blueprint.py
@@ -68,7 +68,7 @@ def _get_account_update_requests_query() -> sa_orm.Query:
             finance_models.Deposit,
             sa.and_(
                 finance_models.Deposit.userId == users_models.User.id,
-                finance_models.Deposit.expirationDate > datetime.datetime.utcnow(),
+                finance_models.Deposit.expirationDate > date_utils.get_naive_utc_now(),
             ),
         )
         .outerjoin(aliased_instructor, users_models.UserAccountUpdateRequest.lastInstructorId == aliased_instructor.id)
@@ -323,7 +323,7 @@ def get_accept_form(ds_application_id: int) -> utils.BackofficeResponse:
             finance_models.Deposit,
             sa.and_(
                 finance_models.Deposit.userId == users_models.User.id,
-                finance_models.Deposit.expirationDate > datetime.datetime.utcnow(),
+                finance_models.Deposit.expirationDate > date_utils.get_naive_utc_now(),
             ),
         )
         .options(

--- a/api/src/pcapi/routes/backoffice/auth.py
+++ b/api/src/pcapi/routes/backoffice/auth.py
@@ -20,6 +20,7 @@ from pcapi.core.users import repository as users_repository
 from pcapi.core.users.backoffice import api as backoffice_api
 from pcapi.flask_app import backoffice_oauth
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from . import blueprint
 from . import utils
@@ -43,7 +44,7 @@ def login() -> utils.BackofficeResponse:
         if not local_admin:
             local_admin = create_local_admin_user(local_admin_email, "Local", "Admin")
 
-        local_admin.lastConnectionDate = datetime.datetime.utcnow()
+        local_admin.lastConnectionDate = date_utils.get_naive_utc_now()
         local_admin.add_admin_role()
         backoffice_api.upsert_roles(local_admin, list(perm_models.Roles))
         db.session.flush()
@@ -98,7 +99,7 @@ def authorize() -> utils.BackofficeResponse:
             last_name=google_user["family_name"],
         )
 
-    user.lastConnectionDate = datetime.datetime.utcnow()
+    user.lastConnectionDate = date_utils.get_naive_utc_now()
     user.add_admin_role()
     backoffice_api.upsert_roles(user, roles)
     db.session.flush()

--- a/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bank_account/blueprint.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from io import BytesIO
 
 import sqlalchemy.orm as sa_orm
@@ -27,6 +26,7 @@ from pcapi.routes.backoffice.forms import empty as empty_forms
 from pcapi.routes.backoffice.pro import forms as pro_forms
 from pcapi.routes.backoffice.pro.utils import get_connect_as
 from pcapi.routes.serialization import reimbursement_csv_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils import urls
 from pcapi.utils.human_ids import humanize
 
@@ -94,7 +94,7 @@ def get_linked_venues(bank_account_id: int) -> utils.BackofficeResponse:
         db.session.query(offerers_models.VenueBankAccountLink)
         .filter(
             offerers_models.VenueBankAccountLink.bankAccountId == bank_account_id,
-            offerers_models.VenueBankAccountLink.timespan.contains(datetime.utcnow()),
+            offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
         )
         .join(offerers_models.VenueBankAccountLink.venue)  # excludes soft-deleted
         .options(
@@ -191,7 +191,7 @@ def download_reimbursement_details(bank_account_id: int) -> utils.BackofficeResp
         for details in finance_repository.find_all_invoices_finance_details([invoice.id for invoice in invoices])
     ]
     export_data = reimbursement_csv_serialize.generate_reimbursement_details_csv(reimbursement_details)
-    export_date = datetime.utcnow().strftime("%Y-%m-%d-%H-%M")
+    export_date = date_utils.get_naive_utc_now().strftime("%Y-%m-%d-%H-%M")
     return send_file(
         BytesIO(export_data.encode("utf-8-sig")),
         as_attachment=True,

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offer_templates_blueprint.py
@@ -336,7 +336,7 @@ def _batch_validate_or_reject_collective_offer_templates(
             old_validation_status = collective_offer_template.validation
             new_validation_status = validation
             collective_offer_template.validation = new_validation_status
-            collective_offer_template.lastValidationDate = datetime.datetime.utcnow()
+            collective_offer_template.lastValidationDate = date_utils.get_naive_utc_now()
             collective_offer_template.lastValidationType = OfferValidationType.MANUAL
             collective_offer_template.lastValidationAuthorUserId = current_user.id
             if validation is OfferValidationStatus.APPROVED:

--- a/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/collective_offers/collective_offers_blueprint.py
@@ -1,4 +1,3 @@
-import datetime
 import re
 import typing
 
@@ -40,6 +39,7 @@ from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.collective_offers import forms
 from pcapi.routes.backoffice.forms import empty as empty_forms
 from pcapi.routes.backoffice.pro.utils import get_connect_as
+from pcapi.utils import date as date_utils
 from pcapi.utils import regions as regions_utils
 from pcapi.utils import urls
 from pcapi.utils.transaction_manager import atomic
@@ -617,7 +617,7 @@ def _batch_validate_or_reject_collective_offers(
             old_validation_status = collective_offer.validation
             new_validation_status = validation
             collective_offer.validation = new_validation_status
-            collective_offer.lastValidationDate = datetime.datetime.utcnow()
+            collective_offer.lastValidationDate = date_utils.get_naive_utc_now()
             collective_offer.lastValidationType = offer_mixin.OfferValidationType.MANUAL
             collective_offer.lastValidationAuthorUserId = current_user.id
 
@@ -1083,7 +1083,7 @@ def move_collective_offer(collective_offer_id: int) -> utils.BackofficeResponse:
             offerers_models.VenuePricingPointLink,
             sa.and_(
                 offerers_models.VenuePricingPointLink.venueId == offerers_models.Venue.id,
-                offerers_models.VenuePricingPointLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenuePricingPointLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .options(

--- a/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/custom_reimbursement_rule/blueprint.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 from decimal import Decimal
 
@@ -191,7 +190,7 @@ def list_custom_reimbursement_rules() -> utils.BackofficeResponse:
         "custom_reimbursement_rules/list.html",
         rows=custom_reimbursement_rules,
         form=form,
-        now=datetime.utcnow(),
+        now=date_utils.get_naive_utc_now(),
     )
 
 

--- a/api/src/pcapi/routes/backoffice/dev/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/dev/blueprint.py
@@ -22,6 +22,7 @@ from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.pro.utils import get_connect_as
+from pcapi.utils import date as date_utils
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
 
 from . import forms
@@ -167,7 +168,7 @@ def generate_user() -> utils.BackofficeResponse:
     )
     expiration_date = (
         token.get_expiration_date_from_token()
-        or datetime.datetime.utcnow() + users_constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME
+        or date_utils.get_naive_utc_now() + users_constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME
     )
     expiration_timestamp = int(expiration_date.timestamp())
     return redirect(
@@ -283,7 +284,7 @@ def configure_ubble_v2_response(user_id: int) -> utils.BackofficeResponse:
         params["accessToken"] = token.encoded_token
         expiration_date = (
             token.get_expiration_date_from_token()
-            or datetime.datetime.utcnow() + users_constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME
+            or date_utils.get_naive_utc_now() + users_constants.EMAIL_VALIDATION_TOKEN_LIFE_TIME
         )
         params["expirationTimestamp"] = str(int(expiration_date.timestamp()))
         params["email"] = user.email

--- a/api/src/pcapi/routes/backoffice/filters.py
+++ b/api/src/pcapi/routes/backoffice/filters.py
@@ -44,6 +44,7 @@ from pcapi.core.users import models as users_models
 from pcapi.models import offer_mixin
 from pcapi.models import validation_status_mixin
 from pcapi.routes.backoffice.accounts import serialization as serialization_accounts
+from pcapi.utils import date as date_utils
 from pcapi.utils import urls
 from pcapi.utils.csr import Csr
 from pcapi.utils.csr import get_csr
@@ -168,7 +169,7 @@ def format_role(role: str | None, deposits: list[finance_models.Deposit] | None 
             else:
                 text = "Ancien Pass 18"
             if not last_deposit or (
-                last_deposit.expirationDate and last_deposit.expirationDate <= datetime.datetime.utcnow()
+                last_deposit.expirationDate and last_deposit.expirationDate <= date_utils.get_naive_utc_now()
             ):
                 text += " expiré"
             return text
@@ -179,7 +180,7 @@ def format_role(role: str | None, deposits: list[finance_models.Deposit] | None 
             else:
                 text = "Ancien Pass 15-17"
             if not last_deposit or (
-                last_deposit.expirationDate and last_deposit.expirationDate <= datetime.datetime.utcnow()
+                last_deposit.expirationDate and last_deposit.expirationDate <= date_utils.get_naive_utc_now()
             ):
                 text += " expiré"
             return text
@@ -204,7 +205,7 @@ def format_deposit_used(booking: bookings_models.Booking) -> str:
 
 def format_active_deposit(deposit: finance_models.Deposit | None) -> str:
     if deposit:
-        if not deposit.expirationDate or deposit.expirationDate > datetime.datetime.utcnow():
+        if not deposit.expirationDate or deposit.expirationDate > date_utils.get_naive_utc_now():
             return Markup('<span class="visually-hidden">Oui</span><i class="bi bi-check-circle-fill"></i>')
     return Markup('<span class="visually-hidden">Non</span><i class="bi bi-x-circle-fill"></i>')
 

--- a/api/src/pcapi/routes/backoffice/finance/finance_incidents_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/finance/finance_incidents_blueprint.py
@@ -1407,7 +1407,7 @@ def _get_incident(finance_incident_id: int, **args: typing.Any) -> finance_model
             offerers_models.VenueBankAccountLink,
             sa.and_(
                 offerers_models.Venue.id == offerers_models.VenueBankAccountLink.venueId,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .outerjoin(offerers_models.VenueBankAccountLink.bankAccount)

--- a/api/src/pcapi/routes/backoffice/gdpr_user_extract/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/gdpr_user_extract/blueprint.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
@@ -18,6 +17,7 @@ from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.forms import empty as empty_forms
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -75,7 +75,7 @@ def download_gdpr_extract(extract_id: int) -> utils.BackofficeResponse:
         db.session.query(users_models.GdprUserDataExtract)
         .filter(
             users_models.GdprUserDataExtract.id == extract_id,
-            users_models.GdprUserDataExtract.expirationDate > datetime.utcnow(),
+            users_models.GdprUserDataExtract.expirationDate > date_utils.get_naive_utc_now(),
         )
         .options(joinedload(users_models.GdprUserDataExtract.user).load_only(users_models.User.email))
         .one_or_none()

--- a/api/src/pcapi/routes/backoffice/move_siret.py
+++ b/api/src/pcapi/routes/backoffice/move_siret.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 from flask import flash
@@ -15,6 +13,7 @@ from pcapi.core.finance import siret_api
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
 
 from . import utils
@@ -115,7 +114,7 @@ def _render_confirmation_page(
             finance_models.CustomReimbursementRule.venueId == source_venue.id,
             sa.or_(
                 sa.func.upper(finance_models.CustomReimbursementRule.timespan).is_(None),
-                sa.func.upper(finance_models.CustomReimbursementRule.timespan) >= datetime.utcnow(),
+                sa.func.upper(finance_models.CustomReimbursementRule.timespan) >= date_utils.get_naive_utc_now(),
             ),
         )
         .exists()

--- a/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offerers/offerer_blueprint.py
@@ -41,6 +41,7 @@ from pcapi.routes.backoffice.filters import pluralize
 from pcapi.routes.backoffice.pro import forms as pro_forms
 from pcapi.routes.backoffice.pro.utils import get_connect_as
 from pcapi.routes.serialization import venues_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils import regions as regions_utils
 from pcapi.utils import siren as siren_utils
 from pcapi.utils import urls
@@ -79,7 +80,7 @@ def _load_offerer_data(offerer_id: int) -> sa.engine.Row:
             offerers_models.VenueBankAccountLink,
             sa.and_(
                 offerers_models.VenueBankAccountLink.venueId == offerers_models.Venue.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .filter(
@@ -871,7 +872,7 @@ def get_managed_venues(offerer_id: int) -> utils.BackofficeResponse:
             offerers_models.VenueBankAccountLink,
             sa.and_(
                 offerers_models.VenueBankAccountLink.venueId == offerers_models.Venue.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .options(
@@ -1250,12 +1251,12 @@ def create_individual_subscription(offerer_id: int) -> utils.BackofficeResponse:
     if not offerer.individualSubscription:
         db.session.add(
             offerers_models.IndividualOffererSubscription(
-                offererId=offerer_id, isEmailSent=True, dateEmailSent=datetime.datetime.utcnow()
+                offererId=offerer_id, isEmailSent=True, dateEmailSent=date_utils.get_naive_utc_now()
             )
         )
     elif not offerer.individualSubscription.isEmailSent:
         offerer.individualSubscription.isEmailSent = True
-        offerer.individualSubscription.dateEmailSent = datetime.datetime.utcnow()
+        offerer.individualSubscription.dateEmailSent = date_utils.get_naive_utc_now()
         db.session.add(offerer.individualSubscription)
 
     transactional_mails.send_offerer_individual_subscription_reminder(offerer.UserOfferers[0].user.email)

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -53,6 +53,7 @@ from pcapi.routes.backoffice.filters import format_amount
 from pcapi.routes.backoffice.filters import pluralize
 from pcapi.routes.backoffice.forms import empty as empty_forms
 from pcapi.routes.backoffice.pro.utils import get_connect_as
+from pcapi.utils import date as date_utils
 from pcapi.utils import regions as regions_utils
 from pcapi.utils import repository
 from pcapi.utils import string as string_utils
@@ -586,7 +587,7 @@ def _get_offers_by_ids(
         .select_from(offers_models.Stock)
         .filter(
             offers_models.Stock.offerId == offers_models.Offer.id,
-            offers_models.Stock.bookingLimitDatetime >= datetime.datetime.utcnow(),
+            offers_models.Stock.bookingLimitDatetime >= date_utils.get_naive_utc_now(),
         )
         .correlate(offers_models.Offer)
         .scalar_subquery()
@@ -1137,7 +1138,7 @@ def _batch_validate_offers(offer_ids: list[int]) -> None:
         if offer.validation != new_validation:
             old_validation = offer.validation
             offer.validation = new_validation
-            offer.lastValidationDate = datetime.datetime.utcnow()
+            offer.lastValidationDate = date_utils.get_naive_utc_now()
             offer.lastValidationType = OfferValidationType.MANUAL
             offer.lastValidationAuthorUserId = current_user.id
 
@@ -1185,7 +1186,7 @@ def _batch_reject_offers(offer_ids: list[int]) -> None:
         if offer.validation != new_validation:
             old_validation = offer.validation
             offer.validation = new_validation
-            offer.lastValidationDate = datetime.datetime.utcnow()
+            offer.lastValidationDate = date_utils.get_naive_utc_now()
             offer.lastValidationType = OfferValidationType.MANUAL
             offer.lastValidationAuthorUserId = current_user.id
             offer.publicationDatetime = None
@@ -1651,7 +1652,7 @@ def edit_offer_venue(offer_id: int) -> utils.BackofficeResponse:
                 offerers_models.VenuePricingPointLink,
                 sa.and_(
                     offerers_models.VenuePricingPointLink.venueId == offerers_models.Venue.id,
-                    offerers_models.VenuePricingPointLink.timespan.contains(datetime.datetime.utcnow()),
+                    offerers_models.VenuePricingPointLink.timespan.contains(date_utils.get_naive_utc_now()),
                 ),
             )
             .options(
@@ -1716,7 +1717,7 @@ def move_offer(offer_id: int) -> utils.BackofficeResponse:
                 offerers_models.VenuePricingPointLink,
                 sa.and_(
                     offerers_models.VenuePricingPointLink.venueId == offerers_models.Venue.id,
-                    offerers_models.VenuePricingPointLink.timespan.contains(datetime.datetime.utcnow()),
+                    offerers_models.VenuePricingPointLink.timespan.contains(date_utils.get_naive_utc_now()),
                 ),
             )
             .options(

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/ems.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/ems.py
@@ -10,6 +10,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.providers import models as providers_models
 from pcapi.core.providers import repository as providers_repository
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from .. import forms
 from .base import PivotContext
@@ -90,7 +91,7 @@ class EMSContext(PivotContext):
     def check_if_api_call_is_ok(cls) -> None:
         connector = EMSScheduleConnector()
         try:
-            connector.get_schedules(version=int(datetime.utcnow().timestamp()))
+            connector.get_schedules(version=int(date_utils.get_naive_utc_now().timestamp()))
             flash("Connexion à l'API EMS OK.", "success")
         except Exception as exc:
             logger.exception("Error while checking EMS API information", extra={"exc": exc})

--- a/api/src/pcapi/routes/backoffice/search_utils.py
+++ b/api/src/pcapi/routes/backoffice/search_utils.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 import re
 import typing
 
@@ -11,6 +10,7 @@ from pcapi.core.finance import models as finance_models
 from pcapi.core.users import models as users_models
 from pcapi.models.pc_object import PcObject
 from pcapi.routes.backoffice.forms import search as search_forms
+from pcapi.utils import date as date_utils
 
 
 class UrlForPartial(typing.Protocol):
@@ -78,7 +78,7 @@ def apply_filter_on_beneficiary_status(query: sa_orm.Query, account_search_filte
         finance_models.Deposit,
         sa.and_(
             users_models.User.id == finance_models.Deposit.userId,
-            finance_models.Deposit.expirationDate > datetime.datetime.utcnow(),
+            finance_models.Deposit.expirationDate > date_utils.get_naive_utc_now(),
         ),
     )
 

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -1,6 +1,5 @@
 import decimal
 import logging
-from datetime import datetime
 from functools import partial
 
 import pydantic.v1 as pydantic_v1
@@ -49,6 +48,7 @@ from pcapi.routes.backoffice import utils
 from pcapi.routes.backoffice.forms import empty as empty_forms
 from pcapi.routes.backoffice.pro import forms as pro_forms
 from pcapi.routes.backoffice.pro.utils import get_connect_as
+from pcapi.utils import date as date_utils
 from pcapi.utils import regions as regions_utils
 from pcapi.utils import string as string_utils
 from pcapi.utils import urls
@@ -421,7 +421,7 @@ def get_stats(venue_id: int) -> utils.BackofficeResponse:
             offerers_models.VenueBankAccountLink,
             sa.and_(
                 offerers_models.Venue.id == offerers_models.VenueBankAccountLink.venueId,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .outerjoin(offerers_models.VenueBankAccountLink.bankAccount)
@@ -1297,7 +1297,7 @@ def _render_remove_siret_content(
             finance_models.CustomReimbursementRule.venueId == venue.id,
             sa.or_(
                 sa.func.upper(finance_models.CustomReimbursementRule.timespan).is_(None),
-                sa.func.upper(finance_models.CustomReimbursementRule.timespan) >= datetime.utcnow(),
+                sa.func.upper(finance_models.CustomReimbursementRule.timespan) >= date_utils.get_naive_utc_now(),
             ),
         )
         .exists()

--- a/api/src/pcapi/routes/native/v1/serialization/account.py
+++ b/api/src/pcapi/routes/native/v1/serialization/account.py
@@ -30,6 +30,7 @@ from pcapi.routes.native.v1.serialization import achievements as achievements_se
 from pcapi.routes.native.v1.serialization import subscription as subscription_serialization
 from pcapi.routes.serialization import ConfiguredBaseModel
 from pcapi.routes.shared.price import convert_to_cent
+from pcapi.utils import date as date_utils
 from pcapi.utils.email import sanitize_email
 
 
@@ -174,7 +175,7 @@ class UserProfileGetterDict(GetterDict):
             first_eligible_registration_date = eligibility_api.get_first_eligible_registration_date(
                 user, user.birth_date
             )
-            time_marker = first_eligible_registration_date or datetime.datetime.utcnow()
+            time_marker = first_eligible_registration_date or date_utils.get_naive_utc_now()
             return eligibility_api.get_eligibility_start_datetime(user.birth_date, time_marker, user.departementCode)
         if key == "firstDepositActivationDate":
             return user.first_deposit_activation_date

--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -38,6 +38,7 @@ from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import ConfiguredBaseModel
 from pcapi.routes.shared.price import convert_to_cent
 from pcapi.serialization.utils import to_camel
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -59,7 +60,7 @@ class OfferStockResponseGetterDict(GetterDict):
     def get(self, key: str, default: Any = None) -> Any:
         stock = self._obj
         if key == "cancellation_limit_datetime":
-            return compute_booking_cancellation_limit_date(stock.beginningDatetime, datetime.utcnow())
+            return compute_booking_cancellation_limit_date(stock.beginningDatetime, date_utils.get_naive_utc_now())
 
         if key == "activationCode":
             if not stock.canHaveActivationCodes:

--- a/api/src/pcapi/routes/native/v2/account.py
+++ b/api/src/pcapi/routes/native/v2/account.py
@@ -13,6 +13,7 @@ from pcapi.routes.native.v1.api_errors import account as account_errors
 from pcapi.routes.native.v1.serialization import account as v1_serializers
 from pcapi.routes.native.v1.serialization import authentication as authentication_serializers
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils.transaction_manager import atomic
 
 from .. import blueprint
@@ -40,7 +41,7 @@ def get_email_update_status(user: users_models.User) -> serializers.EmailUpdateS
 
     return serializers.EmailUpdateStatusResponse(
         new_email=latest_email_update_event.newEmail,
-        expired=(email_api.get_active_token_expiration(user) or datetime.min) < datetime.utcnow(),
+        expired=(email_api.get_active_token_expiration(user) or datetime.min) < date_utils.get_naive_utc_now(),
         status=latest_email_update_event.eventType,
         token=new_email_selection_token.encoded_token if new_email_selection_token else None,
         reset_password_token=reset_password_token.encoded_token if reset_password_token else None,

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 from PIL import UnidentifiedImageError
 from flask import request
@@ -24,6 +23,7 @@ from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import collective_offers_serialize
 from pcapi.routes.serialization import educational_redactors
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils.repository import transaction
 from pcapi.utils.rest import check_user_has_access_to_offerer
 from pcapi.utils.transaction_manager import atomic
@@ -426,7 +426,7 @@ def patch_collective_offers_archive(
     collective_offers = repository.get_query_for_collective_offers_by_ids_for_user(current_user, body.ids).all()
 
     try:
-        api_offer.archive_collective_offers(offers=collective_offers, date_archived=datetime.utcnow())
+        api_offer.archive_collective_offers(offers=collective_offers, date_archived=date_utils.get_naive_utc_now())
     except exceptions.CollectiveOfferForbiddenAction:
         raise ApiErrors({"global": ["Cette action n'est pas autorisée sur cette offre"]}, status_code=403)
 
@@ -474,7 +474,9 @@ def patch_collective_offers_template_archive(
     ).all()
 
     try:
-        api_offer.archive_collective_offers_template(offers=collective_offer_templates, date_archived=datetime.utcnow())
+        api_offer.archive_collective_offers_template(
+            offers=collective_offer_templates, date_archived=date_utils.get_naive_utc_now()
+        )
     except exceptions.CollectiveOfferTemplateForbiddenAction:
         raise ApiErrors({"global": ["Cette action n'est pas autorisée sur cette offre"]}, status_code=403)
 

--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 import flask
 from flask_login import current_user
@@ -38,6 +37,7 @@ from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import users as users_serializers
 from pcapi.routes.shared.cookies_consent import CookieConsentRequest
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils.login_manager import discard_session
 from pcapi.utils.login_manager import stamp_session
 from pcapi.utils.rest import check_user_has_access_to_offerer
@@ -86,7 +86,7 @@ def validate_user(token: str) -> None:
     discard_session()
     login_user(user)
     stamp_session(user)
-    flask.session["last_login"] = datetime.utcnow().timestamp()
+    flask.session["last_login"] = date_utils.get_naive_utc_now().timestamp()
     users_api.update_last_connection_date(user)
 
 
@@ -260,7 +260,7 @@ def signin(body: users_serializers.LoginUserBodyModel) -> users_serializers.Shar
     discard_session()
     login_user(user)
     stamp_session(user)
-    flask.session["last_login"] = datetime.utcnow().timestamp()
+    flask.session["last_login"] = date_utils.get_naive_utc_now().timestamp()
     users_api.update_last_connection_date(user)
 
     return users_serializers.SharedLoginUserResponseModel.from_orm(user)
@@ -344,7 +344,7 @@ def connect_as(token: str) -> Response:
     stamp_session(user)
     flask.session["internal_admin_email"] = token_data.internal_admin_email
     flask.session["internal_admin_id"] = token_data.internal_admin_id
-    flask.session["last_login"] = datetime.utcnow().timestamp()
+    flask.session["last_login"] = date_utils.get_naive_utc_now().timestamp()
     return flask.redirect(token_data.redirect_link, code=302)
 
 

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -1,5 +1,3 @@
-import datetime
-
 import flask
 import pydantic.v1 as pydantic_v1
 import sqlalchemy as sa
@@ -25,6 +23,7 @@ from pcapi.models.utils import get_or_404
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import venues_serialize
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils.rest import check_user_has_access_to_offerer
 from pcapi.workers.update_all_venue_offers_accessibility_job import update_all_venue_offers_accessibility_job
 from pcapi.workers.update_all_venue_offers_email_job import update_all_venue_offers_email_job
@@ -53,7 +52,7 @@ def get_venue(venue_id: int) -> venues_serialize.GetVenueResponseModel:
             models.VenueBankAccountLink,
             sa.and_(
                 models.VenueBankAccountLink.venueId == models.Venue.id,
-                models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             ),
         )
         .outerjoin(models.VenueBankAccountLink.bankAccount)

--- a/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/adage_mock/bookings.py
@@ -1,6 +1,5 @@
 import logging
 from contextlib import suppress
-from datetime import datetime
 
 import sqlalchemy.orm as sa_orm
 
@@ -25,6 +24,7 @@ from pcapi.routes.public.documentation_constants import tags
 from pcapi.routes.serialization import ConfiguredBaseModel
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
+from pcapi.utils import date as date_utils
 from pcapi.utils.transaction_manager import atomic
 from pcapi.validation.routes.users_authentifications import api_key_required
 from pcapi.validation.routes.users_authentifications import current_api_key
@@ -157,7 +157,7 @@ def use_collective_booking(booking_id: int) -> None:
         raise ForbiddenError({"code": "ONLY_CONFIRMED_BOOKING_CAN_BE_USED"})
 
     try:
-        booking.dateUsed = datetime.utcnow()
+        booking.dateUsed = date_utils.get_naive_utc_now()
         booking.status = models.CollectiveBookingStatus.USED
 
         finance_api.add_event(
@@ -259,7 +259,7 @@ def reimburse_collective_booking(booking_id: int) -> None:
 
     try:
         booking.status = models.CollectiveBookingStatus.REIMBURSED
-        booking.reimbursementDate = datetime.utcnow()
+        booking.reimbursementDate = date_utils.get_naive_utc_now()
 
         db.session.add(booking)
         db.session.flush()

--- a/api/src/pcapi/routes/public/collective/endpoints/offers.py
+++ b/api/src/pcapi/routes/public/collective/endpoints/offers.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from pcapi.core.categories.models import EacFormat
 from pcapi.core.educational import exceptions as educational_exceptions
 from pcapi.core.educational import repository as educational_repository
@@ -18,6 +16,7 @@ from pcapi.routes.public.documentation_constants import http_responses
 from pcapi.routes.public.documentation_constants import tags
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
+from pcapi.utils import date as date_utils
 from pcapi.utils.image_conversion import DO_NOT_CROP
 from pcapi.utils.transaction_manager import atomic
 from pcapi.validation.routes.users_authentifications import api_key_required
@@ -539,7 +538,7 @@ def archive_collective_offers(
         raise api_errors.ResourceNotFoundError({"ids": f"Les offres suivantes n'ont pas été trouvées: {not_found_ids}"})
 
     try:
-        educational_api_offer.archive_collective_offers(offers=offers, date_archived=datetime.utcnow())
+        educational_api_offer.archive_collective_offers(offers=offers, date_archived=date_utils.get_naive_utc_now())
     except educational_exceptions.CollectiveOfferForbiddenAction:
         raise api_errors.ApiErrors({"global": ["Cette action n'est pas autorisée sur une des offres"]}, status_code=400)
 

--- a/api/src/pcapi/routes/public/collective/serialization/offers.py
+++ b/api/src/pcapi/routes/public/collective/serialization/offers.py
@@ -19,6 +19,7 @@ from pcapi.routes.serialization.national_programs import NationalProgramModel
 from pcapi.routes.shared.collective.serialization import offers as shared_offers
 from pcapi.routes.shared.validation import phone_number_validator
 from pcapi.serialization.utils import to_camel
+from pcapi.utils import date as date_utils
 from pcapi.utils import email as email_utils
 
 
@@ -79,27 +80,27 @@ def validate_booking_limit_datetime(
 
 
 def validate_start_datetime(start_datetime: datetime | None, values: dict[str, typing.Any]) -> datetime | None:
-    # we need a datetime with timezone information which is not provided by datetime.utcnow.
+    # we need a datetime with timezone information which is not provided by date_utils.get_naive_utc_now.
     if not start_datetime:
         return None
 
     if start_datetime.tzinfo is not None:
         if start_datetime < datetime.now(timezone.utc):
             raise ValueError("L'évènement ne peut commencer dans le passé.")
-    elif start_datetime < datetime.utcnow():
+    elif start_datetime < date_utils.get_naive_utc_now():
         raise ValueError("L'évènement ne peut commencer dans le passé.")
     return start_datetime
 
 
 def validate_end_datetime(end_datetime: datetime | None, values: dict[str, typing.Any]) -> datetime | None:
-    # we need a datetime with timezone information which is not provided by datetime.utcnow.
+    # we need a datetime with timezone information which is not provided by date_utils.get_naive_utc_now.
     if not end_datetime:
         return None
 
     if end_datetime.tzinfo is not None:
         if end_datetime < datetime.now(timezone.utc):
             raise ValueError("L'évènement ne peut se terminer dans le passé.")
-    elif end_datetime < datetime.utcnow():
+    elif end_datetime < date_utils.get_naive_utc_now():
         raise ValueError("L'évènement ne peut se terminer dans le passé.")
     return end_datetime
 

--- a/api/src/pcapi/routes/saml/educonnect.py
+++ b/api/src/pcapi/routes/saml/educonnect.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 from urllib.parse import urlencode
 
@@ -23,6 +22,7 @@ from pcapi.models import db
 from pcapi.models.api_errors import UnauthorizedError
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils import date as date_utils
 
 from . import blueprint
 
@@ -77,7 +77,7 @@ def login_educonnect_e2e(user: users_models.User, body: educonnect_serializers.E
     educonnect_user = users_factories.EduconnectUserFactory.create(
         birth_date=body.birthDate,
         civility=users_models.GenderEnum.F,
-        connection_datetime=datetime.datetime.utcnow(),
+        connection_datetime=date_utils.get_naive_utc_now(),
         educonnect_id=f"educonnect-id_e2e-test_{user.id}",
         first_name=body.firstName,
         ine_hash=f"inehash_e2e-test_{user.id}",

--- a/api/src/pcapi/routes/serialization/collective_stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_stock_serialize.py
@@ -44,14 +44,14 @@ def validate_booking_limit_datetime(booking_limit_datetime: datetime | None, val
 
 
 def validate_start_datetime(start_datetime: datetime, values: dict[str, Any], field: ModelField) -> datetime:
-    # we need a datetime with timezone information which is not provided by datetime.utcnow.
+    # we need a datetime with timezone information which is not provided by date_utils.get_naive_utc_now.
     if start_datetime and start_datetime < datetime.now(timezone.utc):
         raise ValueError("L'évènement ne peut commencer dans le passé.")
     return start_datetime
 
 
 def validate_end_datetime(end_datetime: datetime, values: dict[str, Any], field: ModelField) -> datetime:
-    # we need a datetime with timezone information which is not provided by datetime.utcnow.
+    # we need a datetime with timezone information which is not provided by date_utils.get_naive_utc_now.
     start_datetime = values.get("start_datetime")
     if end_datetime and end_datetime < datetime.now(timezone.utc):
         raise ValueError("L'évènement ne peut se terminer dans le passé.")

--- a/api/src/pcapi/routes/serialization/finance_serialize.py
+++ b/api/src/pcapi/routes/serialization/finance_serialize.py
@@ -7,6 +7,7 @@ import pydantic.v1 as pydantic_v1
 import pcapi.core.finance.models as finance_models
 import pcapi.core.finance.utils as finance_utils
 from pcapi.routes.serialization import BaseModel
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -131,7 +132,7 @@ class BankAccountResponseModel(BaseModel):
 
     @classmethod
     def from_orm(cls, bank_account: finance_models.BankAccount) -> "BankAccountResponseModel":
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         bank_account.linkedVenues = pydantic_v1.parse_obj_as(
             list[LinkedVenues],
             [

--- a/api/src/pcapi/routes/serialization/venues_serialize.py
+++ b/api/src/pcapi/routes/serialization/venues_serialize.py
@@ -32,6 +32,7 @@ from pcapi.routes.shared.collective.serialization import offers as shared_offers
 from pcapi.serialization.utils import string_length_validator
 from pcapi.serialization.utils import string_to_boolean_field
 from pcapi.serialization.utils import to_camel
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.image_conversion import CropParam
 from pcapi.utils.image_conversion import CropParams
@@ -186,7 +187,7 @@ class GetVenueResponseGetterDict(base.VenueResponseGetterDict):
             return bool(venue.adageId)
 
         if key == "pricingPoint":
-            now = datetime.utcnow()
+            now = date_utils.get_naive_utc_now()
             for pricing_link in venue.pricing_point_links:
                 if pricing_link.timespan.lower <= now and (
                     not pricing_link.timespan.upper or pricing_link.timespan.upper > now

--- a/api/src/pcapi/sandboxes/scripts/creators/beneficiaries/beneficiaries.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/beneficiaries/beneficiaries.py
@@ -1,18 +1,18 @@
 import logging
-from datetime import datetime
 
 from dateutil.relativedelta import SA
 from dateutil.relativedelta import relativedelta
 
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.users.factories as users_factories
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
 
 
 def create_future_beneficiaries() -> None:
-    coming_saturday = datetime.utcnow() + relativedelta(weekday=SA)
+    coming_saturday = date_utils.get_naive_utc_now() + relativedelta(weekday=SA)
     eighteen_on_saturday = coming_saturday + relativedelta(years=-18)
     users_factories.UserFactory.create(
         email="pctest.non-beneficiary.17-going-on-18.v1@example.com",
@@ -29,7 +29,7 @@ def create_future_beneficiaries() -> None:
 
 
 def create_expiring_beneficiary() -> None:
-    coming_saturday = datetime.utcnow() + relativedelta(weekday=SA)
+    coming_saturday = date_utils.get_naive_utc_now() + relativedelta(weekday=SA)
     users_factories.BeneficiaryGrant18Factory.create(
         email="pctest.beneficiary.deposit-expires-soon@example.com",
         deposit__expirationDate=coming_saturday,

--- a/api/src/pcapi/sandboxes/scripts/creators/big/create_big_offerer.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/big/create_big_offerer.py
@@ -8,6 +8,7 @@ from pcapi.core.offerers.factories import VenueFactory
 from pcapi.core.offerers.factories import VirtualVenueFactory
 from pcapi.core.offers.factories import EventOfferFactory
 from pcapi.core.offers.factories import EventStockFactory
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ def create_big_offerer() -> None:
             stock = EventStockFactory.create(
                 offer=offer_event,
                 quantity=10,
-                beginningDatetime=datetime.datetime.utcnow().replace(second=0, microsecond=0)
+                beginningDatetime=date_utils.get_naive_utc_now().replace(second=0, microsecond=0)
                 + datetime.timedelta(days=20),
             )
             BookingFactory.create(quantity=1, stock=stock)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/__init__.py
@@ -94,6 +94,7 @@ from pcapi.sandboxes.scripts.creators.industrial.create_user_account_update_requ
 from pcapi.sandboxes.scripts.creators.industrial.create_user_offerers import create_user_offerers
 from pcapi.sandboxes.scripts.getters.native import create_accessibility_offers
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 
 
@@ -142,7 +143,7 @@ def save_industrial_sandbox() -> None:
     for name, user in users_by_name.items():
         if "has-booked-some-but-deposit-expired" in name:
             assert user.deposit  # helps mypy
-            user.deposit.expirationDate = datetime.utcnow()
+            user.deposit.expirationDate = date_utils.get_naive_utc_now()
             repository.save(user.deposit)
 
     create_industrial_search_indexed_objects()

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_closed_offerers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_closed_offerers.py
@@ -18,6 +18,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,7 @@ def create_closed_offerers() -> None:
 def _create_closed_offerer(
     name: str, email: str, beneficiary: users_models.User, with_bank_account: bool = False
 ) -> None:
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     siren_caduc_tag = db.session.query(offerers_models.OffererTag).filter_by(name="siren-caduc").one()
 
     offerer = offerers_factories.ClosedOffererFactory.create(

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_future_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_future_offers.py
@@ -5,6 +5,7 @@ import pcapi.core.offers.factories as offer_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.categories.models import Subcategory
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ def _create_future_offer_factory(
 def create_future_offers() -> None:
     # Create future Offers not active, i.e. proper coming soon offers
     for i in range(5):
-        publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=(i + 1) * 5)
+        publication_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=(i + 1) * 5)
         _create_future_offer_factory(
             is_active=False,
             publication_datetime=publication_date,
@@ -52,7 +53,7 @@ def create_future_offers() -> None:
     )
 
     # Create future Offer in the past, i.e. regular offer
-    publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=-30)
+    publication_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=-30)
     _create_future_offer_factory(
         is_active=True,
         publication_datetime=publication_date,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_gdpr_user_extracts.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_gdpr_user_extracts.py
@@ -1,10 +1,10 @@
 import logging
-from datetime import datetime
 
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ def create_gdpr_user_extract_data() -> None:
     users_factories.GdprUserDataExtractBeneficiaryFactory.create(user=list_beneficiary[0], authorUser=author)
     users_factories.GdprUserDataExtractBeneficiaryFactory.create(user=list_underage_beneficiary, authorUser=author)
     users_factories.GdprUserDataExtractBeneficiaryFactory.create(
-        user=list_beneficiary[1], authorUser=author, dateProcessed=datetime.utcnow()
+        user=list_beneficiary[1], authorUser=author, dateProcessed=date_utils.get_naive_utc_now()
     )
 
     logger.info("created GDPR users extract data")

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_app_users.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_app_users.py
@@ -23,6 +23,7 @@ from pcapi.core.users.constants import ELIGIBILITY_AGE_18
 from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -86,7 +87,10 @@ def create_industrial_app_beneficiaries() -> dict[str, User]:
             deposit__version=deposit_version,
         )
         users_factories.DepositGrantFactory.create(
-            user=user, expirationDate=datetime.utcnow(), source="sandbox", type=finance_models.DepositType.GRANT_15_17
+            user=user,
+            expirationDate=date_utils.get_naive_utc_now(),
+            source="sandbox",
+            type=finance_models.DepositType.GRANT_15_17,
         )
 
         user_key = f"jeune{departement_code} {tag} v{deposit_version}"
@@ -268,7 +272,7 @@ def create_short_email_beneficiaries() -> dict[str, User]:
             needsToFillCulturalSurvey=False,
         )
     )
-    with time_machine.travel(datetime.utcnow() - relativedelta(years=3)):
+    with time_machine.travel(date_utils.get_naive_utc_now() - relativedelta(years=3)):
         users.append(
             users_factories.UnderageBeneficiaryFactory.create(
                 email="exunderage_18@example.com",
@@ -287,7 +291,7 @@ def create_short_email_beneficiaries() -> dict[str, User]:
             firstName=fake.first_name(),
             lastName=fake.last_name(),
             needsToFillCulturalSurvey=False,
-            deposit__expirationDate=datetime.utcnow() + relativedelta(years=3),
+            deposit__expirationDate=date_utils.get_naive_utc_now() + relativedelta(years=3),
         )
         if settings.DATABASE_HAS_SPECIFIC_ROLES:
             db.session.execute(sa.text("SELECT disable_booking_update_trigger();"))
@@ -305,7 +309,7 @@ def create_short_email_beneficiaries() -> dict[str, User]:
     users.append(beneficiary_and_exunderage)
 
     with time_machine.travel(
-        datetime.utcnow() - relativedelta(years=finance_conf.GRANT_18_VALIDITY_IN_YEARS, months=5)
+        date_utils.get_naive_utc_now() - relativedelta(years=finance_conf.GRANT_18_VALIDITY_IN_YEARS, months=5)
     ):
         users.append(
             users_factories.BeneficiaryGrant18Factory.create(

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 from datetime import timedelta
 from decimal import Decimal
 from random import choice
@@ -13,6 +12,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.users.api import get_domains_credit
 from pcapi.core.users.models import User
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 
 
@@ -91,8 +91,8 @@ def _create_bookings_for_other_beneficiaries(
             is_used = offer_index % BOOKINGS_USED_REMOVE_MODULO != 0
 
             if is_used:
-                stock.beginningDatetime = datetime.utcnow() - timedelta(days=2)
-                stock.bookingLimitDatetime = datetime.utcnow() - timedelta(days=5)
+                stock.beginningDatetime = date_utils.get_naive_utc_now() - timedelta(days=2)
+                stock.bookingLimitDatetime = date_utils.get_naive_utc_now() - timedelta(days=5)
                 repository.save(stock)
 
             if user_should_have_no_more_money and user not in list_of_users_with_no_more_money:
@@ -108,7 +108,7 @@ def _create_bookings_for_other_beneficiaries(
                 user=user,
                 status=BookingStatus.USED if is_used else BookingStatus.CONFIRMED,
                 stock=stock,
-                dateUsed=datetime.utcnow() - timedelta(days=2) if is_used else None,
+                dateUsed=date_utils.get_naive_utc_now() - timedelta(days=2) if is_used else None,
                 amount=booking_amount if booking_amount is not None else stock.price,
                 token=str(token),
                 offerer=offer.venue.managingOfferer,
@@ -145,15 +145,15 @@ def _create_has_booked_some_bookings(
         is_used = offer_index % BOOKINGS_USED_REMOVE_MODULO != 0
 
         if is_used:
-            stock.beginningDatetime = datetime.utcnow() - timedelta(days=2)
-            stock.bookingLimitDatetime = datetime.utcnow() - timedelta(days=5)
+            stock.beginningDatetime = date_utils.get_naive_utc_now() - timedelta(days=2)
+            stock.bookingLimitDatetime = date_utils.get_naive_utc_now() - timedelta(days=5)
             repository.save(stock)
 
         booking = bookings_factories.BookingFactory.create(
             user=user,
             status=BookingStatus.USED if is_used else BookingStatus.CONFIRMED,
             stock=stock,
-            dateUsed=datetime.utcnow() - timedelta(days=2) if is_used else None,
+            dateUsed=date_utils.get_naive_utc_now() - timedelta(days=2) if is_used else None,
         )
         if is_used:
             finance_factories.UsedBookingFinanceEventFactory.create(booking=booking)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings_for_statistics.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_bookings_for_statistics.py
@@ -13,6 +13,7 @@ from pcapi.core.educational import models as educational_models
 from pcapi.core.educational.models import CollectiveBookingStatus
 from pcapi.core.offers import models as offers_models
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -161,7 +162,7 @@ def _create_booking_for_statistics_with_offer_no_revenue() -> None:
 
 
 def _create_bookings(offers: list[offers_models.Offer]) -> None:
-    january_first = datetime.utcnow().replace(month=1, day=1)
+    january_first = date_utils.get_naive_utc_now().replace(month=1, day=1)
     for offer in offers:
         dates_used = [january_first, january_first - timedelta(days=500), january_first - timedelta(days=800)]
         # Current year in the past, 2 years ago, 3 years ago
@@ -176,8 +177,8 @@ def _create_bookings(offers: list[offers_models.Offer]) -> None:
 
         # Current year in the future, next year
         dates_programmed = [
-            datetime.utcnow().replace(month=12, day=31),
-            datetime.utcnow().replace(month=12, day=31) + timedelta(days=20),
+            date_utils.get_naive_utc_now().replace(month=12, day=31),
+            date_utils.get_naive_utc_now().replace(month=12, day=31) + timedelta(days=20),
         ]
         if isinstance(offer, offers_models.Offer):
             for date_programmed in dates_programmed:

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_commercial_gestures.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_commercial_gestures.py
@@ -17,6 +17,7 @@ from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.backoffice.finance import validation
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 from pcapi.utils.chunks import get_chunks
 
 
@@ -133,7 +134,7 @@ def _create_total_commercial_gesture_collective_offer(
         booking = educational_factories.UsedCollectiveBookingFactory.create(
             collectiveStock__collectiveOffer__venue=venue,
             collectiveStock__price=decimal.Decimal("14") + decimal.Decimal(i),
-            collectiveStock__startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            collectiveStock__startDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             educationalInstitution=deposit.educationalInstitution,
             educationalYear=deposit.educationalYear,
         )
@@ -342,7 +343,7 @@ def _generate_bookings_for_commercial_gesture_creation(venue: offerers_models.Ve
         booking = educational_factories.UsedCollectiveBookingFactory.create(
             collectiveStock__collectiveOffer__venue=venue,
             collectiveStock__price=decimal.Decimal("14") + decimal.Decimal(i),
-            collectiveStock__startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            collectiveStock__startDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             educationalInstitution=deposit.educationalInstitution,
             educationalYear=deposit.educationalYear,
         )
@@ -418,7 +419,7 @@ def create_industrial_commercial_gestures() -> None:
             users_count=3 + i,
         )
 
-    cashflow_batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    cashflow_batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     finance_api.generate_invoices_and_debit_notes_legacy(cashflow_batch)
     db.session.flush()
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_complex_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_complex_offers.py
@@ -1,10 +1,9 @@
-import datetime
-
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 @log_func_duration
@@ -80,7 +79,7 @@ Ut quis egestas neque. Fusce sem nulla, luctus ac sagittis eu, mattis quis purus
         isActive=True,
         isDuo=False,
     )
-    offers_factories.StockFactory.create(offer=movie_offer, bookingLimitDatetime=datetime.datetime.utcnow())
+    offers_factories.StockFactory.create(offer=movie_offer, bookingLimitDatetime=date_utils.get_naive_utc_now())
 
     book_product = offers_factories.ProductFactory.create(
         subcategoryId=subcategories.LIVRE_PAPIER.id,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_institutions.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_institutions.py
@@ -4,6 +4,7 @@ from pcapi import settings
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 # store here UAIs with a ministry that is not EDUCATION_NATIONALE
@@ -178,15 +179,19 @@ def create_deposits(institutions: list[educational_models.EducationalInstitution
                 educationalInstitution=institution,
                 educationalYear=year,
                 amount=amount,
-                isFinal=(year.beginningDate <= datetime.datetime.utcnow()),
+                isFinal=(year.beginningDate <= date_utils.get_naive_utc_now()),
             )
 
 
 def create_years() -> tuple[educational_models.EducationalYear, ...]:
     two_years_ago = educational_factories.create_educational_year(
-        datetime.datetime.utcnow() - datetime.timedelta(days=731)
+        date_utils.get_naive_utc_now() - datetime.timedelta(days=731)
     )
-    last_year = educational_factories.create_educational_year(datetime.datetime.utcnow() - datetime.timedelta(days=365))
-    current_year = educational_factories.create_educational_year(datetime.datetime.utcnow())
-    next_year = educational_factories.create_educational_year(datetime.datetime.utcnow() + datetime.timedelta(days=365))
+    last_year = educational_factories.create_educational_year(
+        date_utils.get_naive_utc_now() - datetime.timedelta(days=365)
+    )
+    current_year = educational_factories.create_educational_year(date_utils.get_naive_utc_now())
+    next_year = educational_factories.create_educational_year(
+        date_utils.get_naive_utc_now() + datetime.timedelta(days=365)
+    )
     return two_years_ago, last_year, current_year, next_year

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_offers.py
@@ -25,6 +25,7 @@ from pcapi.sandboxes.scripts.creators.industrial.create_industrial_eac_data.crea
     create_collective_api_provider,
 )
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 from pcapi.utils.image_conversion import DO_NOT_CROP
 
@@ -247,7 +248,7 @@ def create_offers_base_list(
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 collectiveOffer__author=user_factory.ProFactory.create(email="eac_1_lieu@example.com"),
                 collectiveOffer__formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
-                startDatetime=datetime.utcnow() + timedelta(days=60),
+                startDatetime=date_utils.get_naive_utc_now() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
 
@@ -268,7 +269,7 @@ def create_offers_base_list(
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
                 collectiveOffer__author=user_factory.ProFactory.create(email="eac_1_lieu@example.com"),
                 collectiveOffer__formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
-                startDatetime=datetime.utcnow() + timedelta(days=60),
+                startDatetime=date_utils.get_naive_utc_now() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
 
@@ -280,7 +281,7 @@ def create_offers_base_list(
                 collectiveOffer__venue=next(venue_iterator),
                 collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
-                startDatetime=datetime.utcnow() + timedelta(days=60),
+                startDatetime=date_utils.get_naive_utc_now() + timedelta(days=60),
             )
             add_image_to_offer(stock.collectiveOffer, next(image_iterator))
             offers.append(stock.collectiveOffer)
@@ -312,7 +313,7 @@ def create_offers_base_list(
                 collectiveOffer__institution=institution,
                 collectiveOffer__teacher=redactor,
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
-                startDatetime=datetime.utcnow() + timedelta(days=60),
+                startDatetime=date_utils.get_naive_utc_now() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
 
@@ -327,7 +328,7 @@ def create_offers_base_list(
                 collectiveOffer__interventionArea=[],
                 collectiveOffer__provider=provider,
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
-                startDatetime=datetime.utcnow() + timedelta(days=60),
+                startDatetime=date_utils.get_naive_utc_now() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
 
@@ -339,8 +340,8 @@ def create_offers_base_list(
                 collectiveOffer__venue=next(venue_iterator),
                 collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
-                bookingLimitDatetime=datetime.utcnow() - timedelta(days=2),
-                startDatetime=datetime.utcnow(),
+                bookingLimitDatetime=date_utils.get_naive_utc_now() - timedelta(days=2),
+                startDatetime=date_utils.get_naive_utc_now(),
             )
             offers.append(stock.collectiveOffer)
 
@@ -353,13 +354,13 @@ def create_offers_base_list(
                 collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__validation=OfferValidationStatus.PENDING,
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
-                startDatetime=datetime.utcnow() + timedelta(days=60),
+                startDatetime=date_utils.get_naive_utc_now() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
 
     if offers_next_year:
-        current_year = datetime.utcnow().year
-        target_year = current_year + 2 if datetime.utcnow().month >= 9 else current_year + 1
+        current_year = date_utils.get_naive_utc_now().year
+        target_year = current_year + 2 if date_utils.get_naive_utc_now().month >= 9 else current_year + 1
         for _ in range(size):
             stock = educational_factories.CollectiveStockFactory.create(
                 collectiveOffer__name=f"offer next year {next(number_iterator)} pour {offerer.name}",
@@ -381,7 +382,7 @@ def create_offers_base_list(
                 collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__interventionArea=["56"],
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
-                startDatetime=datetime.utcnow() + timedelta(days=60),
+                startDatetime=date_utils.get_naive_utc_now() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
 
@@ -394,7 +395,7 @@ def create_offers_base_list(
                 collectiveOffer__institution=next(institution_iterator),
                 collectiveOffer__interventionArea=["91"],
                 collectiveOffer__bookingEmails=["toto@totoland.com"],
-                startDatetime=datetime.utcnow() + timedelta(days=60),
+                startDatetime=date_utils.get_naive_utc_now() + timedelta(days=60),
             )
             offers.append(stock.collectiveOffer)
 
@@ -423,7 +424,7 @@ def create_offers_base_list(
                     collectiveOffer__institution=next(institution_iterator),
                     collectiveOffer__nationalProgram=next(national_program_iterator),
                     collectiveOffer__bookingEmails=["toto@totoland.com"],
-                    startDatetime=datetime.utcnow() + timedelta(days=60),
+                    startDatetime=date_utils.get_naive_utc_now() + timedelta(days=60),
                 )
 
     if image_template:
@@ -478,15 +479,15 @@ def create_collective_offers_with_different_displayed_status(
     current_ansco = (
         db.session.query(educational_models.EducationalYear)
         .filter(
-            educational_models.EducationalYear.beginningDate <= datetime.utcnow(),
-            educational_models.EducationalYear.expirationDate >= datetime.utcnow(),
+            educational_models.EducationalYear.beginningDate <= date_utils.get_naive_utc_now(),
+            educational_models.EducationalYear.expirationDate >= date_utils.get_naive_utc_now(),
         )
         .one()
     )
     domains_iterator = cycle(domains)
     institution_iterator = cycle(institutions)
 
-    today = datetime.utcnow()
+    today = date_utils.get_naive_utc_now()
     in_two_weeks = today + timedelta(days=14)
     in_four_weeks = today + timedelta(days=28)
 
@@ -717,7 +718,7 @@ def create_collective_offer_templates_with_different_displayed_status(
 ) -> None:
     domains_iterator = cycle(domains)
 
-    now = datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     two_weeks_ago = now - timedelta(days=14)
     yesterday = now - timedelta(days=1)
     in_two_weeks = now + timedelta(days=14)
@@ -854,8 +855,8 @@ def create_booking_base_list(
     current_ansco = (
         db.session.query(educational_models.EducationalYear)
         .filter(
-            educational_models.EducationalYear.beginningDate <= datetime.utcnow(),
-            educational_models.EducationalYear.expirationDate >= datetime.utcnow(),
+            educational_models.EducationalYear.beginningDate <= date_utils.get_naive_utc_now(),
+            educational_models.EducationalYear.expirationDate >= date_utils.get_naive_utc_now(),
         )
         .one()
     )
@@ -870,15 +871,15 @@ def create_booking_base_list(
                 collectiveStock__collectiveOffer__name=f"PENDING offer {next(number_iterator)} pour {offerer.name}",
                 collectiveStock__collectiveOffer__venue=next(venue_iterator),
                 collectiveStock__collectiveOffer__educational_domains=[next(domains_iterator)],
-                collectiveStock__bookingLimitDatetime=datetime.utcnow() + timedelta(15),
-                collectiveStock__startDatetime=datetime.utcnow() + timedelta(days=20),
+                collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() + timedelta(15),
+                collectiveStock__startDatetime=date_utils.get_naive_utc_now() + timedelta(days=20),
                 educationalYear=current_ansco,
                 educationalInstitution=next(institution_iterator),
                 status=educational_models.CollectiveBookingStatus.PENDING,
                 confirmationDate=None,
-                cancellationLimitDate=datetime.utcnow() + timedelta(days=17),
-                confirmationLimitDate=datetime.utcnow() + timedelta(days=15),
-                dateCreated=datetime.utcnow() - timedelta(days=30),
+                cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=17),
+                confirmationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=15),
+                dateCreated=date_utils.get_naive_utc_now() - timedelta(days=30),
             )
 
     if booked_booking:
@@ -887,15 +888,15 @@ def create_booking_base_list(
                 collectiveStock__collectiveOffer__name=f"BOOKED offer {next(number_iterator)} pour {offerer.name}",
                 collectiveStock__collectiveOffer__venue=next(venue_iterator),
                 collectiveStock__collectiveOffer__educational_domains=[next(domains_iterator)],
-                collectiveStock__startDatetime=datetime.utcnow() + timedelta(days=20),
-                collectiveStock__bookingLimitDatetime=datetime.utcnow() + timedelta(days=15),
+                collectiveStock__startDatetime=date_utils.get_naive_utc_now() + timedelta(days=20),
+                collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() + timedelta(days=15),
                 educationalYear=current_ansco,
                 educationalInstitution=next(institution_iterator),
                 status=educational_models.CollectiveBookingStatus.CONFIRMED,
-                confirmationDate=datetime.utcnow() - timedelta(days=1),
-                cancellationLimitDate=datetime.utcnow() + timedelta(days=17),
-                confirmationLimitDate=datetime.utcnow() + timedelta(days=15),
-                dateCreated=datetime.utcnow() - timedelta(days=30),
+                confirmationDate=date_utils.get_naive_utc_now() - timedelta(days=1),
+                cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=17),
+                confirmationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=15),
+                dateCreated=date_utils.get_naive_utc_now() - timedelta(days=30),
             )
     if confirmed_booking:
         for _i in range(size):
@@ -903,15 +904,15 @@ def create_booking_base_list(
                 collectiveStock__collectiveOffer__name=f"CONFIRMED offer {next(number_iterator)} pour {offerer.name}",
                 collectiveStock__collectiveOffer__venue=next(venue_iterator),
                 collectiveStock__collectiveOffer__educational_domains=[next(domains_iterator)],
-                collectiveStock__startDatetime=datetime.utcnow() + timedelta(days=20),
-                collectiveStock__bookingLimitDatetime=datetime.utcnow() - timedelta(days=5),
+                collectiveStock__startDatetime=date_utils.get_naive_utc_now() + timedelta(days=20),
+                collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() - timedelta(days=5),
                 educationalYear=current_ansco,
                 educationalInstitution=next(institution_iterator),
                 status=educational_models.CollectiveBookingStatus.CONFIRMED,
-                confirmationDate=datetime.utcnow() - timedelta(days=3),
-                cancellationLimitDate=datetime.utcnow(),
-                confirmationLimitDate=datetime.utcnow() - timedelta(days=2),
-                dateCreated=datetime.utcnow() - timedelta(days=30),
+                confirmationDate=date_utils.get_naive_utc_now() - timedelta(days=3),
+                cancellationLimitDate=date_utils.get_naive_utc_now(),
+                confirmationLimitDate=date_utils.get_naive_utc_now() - timedelta(days=2),
+                dateCreated=date_utils.get_naive_utc_now() - timedelta(days=30),
             )
     if used_booking:
         for i in range(size):
@@ -919,17 +920,17 @@ def create_booking_base_list(
                 collectiveStock__collectiveOffer__name=f"USED offer {next(number_iterator)} pour {offerer.name}",
                 collectiveStock__collectiveOffer__venue=next(venue_iterator),
                 collectiveStock__collectiveOffer__educational_domains=[next(domains_iterator)],
-                collectiveStock__startDatetime=datetime.utcnow()
+                collectiveStock__startDatetime=date_utils.get_naive_utc_now()
                 - timedelta(days=i + 2),  # all USED booking must be at least 2 days old
-                collectiveStock__bookingLimitDatetime=datetime.utcnow() - timedelta(days=15),
+                collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() - timedelta(days=15),
                 educationalYear=current_ansco,
                 educationalInstitution=next(institution_iterator),
                 status=educational_models.CollectiveBookingStatus.USED,
-                dateUsed=datetime.utcnow(),
-                confirmationDate=datetime.utcnow() - timedelta(days=5),
-                cancellationLimitDate=datetime.utcnow() - timedelta(days=2),
-                confirmationLimitDate=datetime.utcnow() - timedelta(days=3),
-                dateCreated=datetime.utcnow() - timedelta(days=30),
+                dateUsed=date_utils.get_naive_utc_now(),
+                confirmationDate=date_utils.get_naive_utc_now() - timedelta(days=5),
+                cancellationLimitDate=date_utils.get_naive_utc_now() - timedelta(days=2),
+                confirmationLimitDate=date_utils.get_naive_utc_now() - timedelta(days=3),
+                dateCreated=date_utils.get_naive_utc_now() - timedelta(days=30),
             )
             finance_factories.UsedBookingFinanceEventFactory.create(collectiveBooking=booking)
     if reimbursed_booking:
@@ -938,17 +939,17 @@ def create_booking_base_list(
                 collectiveStock__collectiveOffer__name=f"REIMBURSED offer {next(number_iterator)} pour {offerer.name}",
                 collectiveStock__collectiveOffer__venue=next(venue_iterator),
                 collectiveStock__collectiveOffer__educational_domains=[next(domains_iterator)],
-                collectiveStock__startDatetime=datetime.utcnow() - timedelta(days=15),
-                collectiveStock__bookingLimitDatetime=datetime.utcnow() - timedelta(days=18),
+                collectiveStock__startDatetime=date_utils.get_naive_utc_now() - timedelta(days=15),
+                collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() - timedelta(days=18),
                 educationalYear=current_ansco,
                 educationalInstitution=next(institution_iterator),
                 status=educational_models.CollectiveBookingStatus.REIMBURSED,
-                dateCreated=datetime.utcnow() - timedelta(days=20),
-                dateUsed=datetime.utcnow() - timedelta(days=15),
-                confirmationDate=datetime.utcnow() - timedelta(days=18),
-                cancellationLimitDate=datetime.utcnow() - timedelta(days=16),
-                confirmationLimitDate=datetime.utcnow() - timedelta(days=18),
-                reimbursementDate=datetime.utcnow() - timedelta(days=12),
+                dateCreated=date_utils.get_naive_utc_now() - timedelta(days=20),
+                dateUsed=date_utils.get_naive_utc_now() - timedelta(days=15),
+                confirmationDate=date_utils.get_naive_utc_now() - timedelta(days=18),
+                cancellationLimitDate=date_utils.get_naive_utc_now() - timedelta(days=16),
+                confirmationLimitDate=date_utils.get_naive_utc_now() - timedelta(days=18),
+                reimbursementDate=date_utils.get_naive_utc_now() - timedelta(days=12),
             )
 
             finance_factories.CollectivePricingFactory.create(
@@ -960,17 +961,17 @@ def create_booking_base_list(
                 collectiveStock__collectiveOffer__name=f"CANCELLED BY AC offer {next(number_iterator)} pour {offerer.name}",
                 collectiveStock__collectiveOffer__venue=next(venue_iterator),
                 collectiveStock__collectiveOffer__educational_domains=[next(domains_iterator)],
-                collectiveStock__startDatetime=datetime.utcnow() + timedelta(days=20),
-                collectiveStock__bookingLimitDatetime=datetime.utcnow() + timedelta(days=15),
+                collectiveStock__startDatetime=date_utils.get_naive_utc_now() + timedelta(days=20),
+                collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() + timedelta(days=15),
                 educationalYear=current_ansco,
                 educationalInstitution=next(institution_iterator),
                 status=educational_models.CollectiveBookingStatus.CANCELLED,
                 cancellationReason=educational_models.CollectiveBookingCancellationReasons.OFFERER,
-                cancellationDate=datetime.utcnow() - timedelta(days=1),
-                dateCreated=datetime.utcnow() - timedelta(days=20),
-                confirmationDate=datetime.utcnow() - timedelta(days=12),
-                cancellationLimitDate=datetime.utcnow() + timedelta(days=17),
-                confirmationLimitDate=datetime.utcnow() + timedelta(days=15),
+                cancellationDate=date_utils.get_naive_utc_now() - timedelta(days=1),
+                dateCreated=date_utils.get_naive_utc_now() - timedelta(days=20),
+                confirmationDate=date_utils.get_naive_utc_now() - timedelta(days=12),
+                cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=17),
+                confirmationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=15),
             )
     if cancelled_institution:
         for _i in range(size):
@@ -978,17 +979,17 @@ def create_booking_base_list(
                 collectiveStock__collectiveOffer__name=f"CANCELLED BY EPLE offer {next(number_iterator)} pour {offerer.name}",
                 collectiveStock__collectiveOffer__venue=next(venue_iterator),
                 collectiveStock__collectiveOffer__educational_domains=[next(domains_iterator)],
-                collectiveStock__startDatetime=datetime.utcnow() + timedelta(days=20),
-                collectiveStock__bookingLimitDatetime=datetime.utcnow() + timedelta(days=15),
+                collectiveStock__startDatetime=date_utils.get_naive_utc_now() + timedelta(days=20),
+                collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() + timedelta(days=15),
                 educationalYear=current_ansco,
                 educationalInstitution=next(institution_iterator),
                 status=educational_models.CollectiveBookingStatus.CANCELLED,
                 cancellationReason=educational_models.CollectiveBookingCancellationReasons.REFUSED_BY_INSTITUTE,
-                cancellationDate=datetime.utcnow() - timedelta(days=1),
-                dateCreated=datetime.utcnow() - timedelta(days=20),
-                confirmationDate=datetime.utcnow() - timedelta(days=12),
-                cancellationLimitDate=datetime.utcnow() + timedelta(days=17),
-                confirmationLimitDate=datetime.utcnow() + timedelta(days=15),
+                cancellationDate=date_utils.get_naive_utc_now() - timedelta(days=1),
+                dateCreated=date_utils.get_naive_utc_now() - timedelta(days=20),
+                confirmationDate=date_utils.get_naive_utc_now() - timedelta(days=12),
+                cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=17),
+                confirmationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=15),
             )
 
     if cancelled_expired:
@@ -997,17 +998,17 @@ def create_booking_base_list(
                 collectiveStock__collectiveOffer__name=f"CANCELLED AUTOMATICALLY offer {next(number_iterator)} pour {offerer.name}",
                 collectiveStock__collectiveOffer__venue=next(venue_iterator),
                 collectiveStock__collectiveOffer__educational_domains=[next(domains_iterator)],
-                collectiveStock__startDatetime=datetime.utcnow() + timedelta(days=20),
-                collectiveStock__bookingLimitDatetime=datetime.utcnow() - timedelta(days=15),
+                collectiveStock__startDatetime=date_utils.get_naive_utc_now() + timedelta(days=20),
+                collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() - timedelta(days=15),
                 educationalYear=current_ansco,
                 educationalInstitution=next(institution_iterator),
                 status=educational_models.CollectiveBookingStatus.CANCELLED,
                 cancellationReason=educational_models.CollectiveBookingCancellationReasons.EXPIRED,
-                cancellationDate=datetime.utcnow() - timedelta(days=5),
-                dateCreated=datetime.utcnow() - timedelta(days=20),
+                cancellationDate=date_utils.get_naive_utc_now() - timedelta(days=5),
+                dateCreated=date_utils.get_naive_utc_now() - timedelta(days=20),
                 confirmationDate=None,
-                cancellationLimitDate=datetime.utcnow() - timedelta(days=3),
-                confirmationLimitDate=datetime.utcnow() - timedelta(days=5),
+                cancellationLimitDate=date_utils.get_naive_utc_now() - timedelta(days=3),
+                confirmationLimitDate=date_utils.get_naive_utc_now() - timedelta(days=5),
             )
 
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_eac_data/create_venues.py
@@ -10,6 +10,7 @@ from pcapi.core.finance import factories as finance_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 from pcapi.utils import siren as siren_utils
 
 
@@ -33,7 +34,7 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         name=f"Partenaire culturel {offerer.name} 56",
         reimbursement=True,
         adageId="123546",
-        adageInscriptionDate=datetime.utcnow() - timedelta(days=3),
+        adageInscriptionDate=date_utils.get_naive_utc_now() - timedelta(days=3),
         venueEducationalStatusId=next(educational_status_iterator),
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
         departementCode="56",
@@ -50,7 +51,7 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         managingOfferer=offerer,
         name=f"Partenaire culturel {offerer.name} 91",
         adageId="10837",
-        adageInscriptionDate=datetime.utcnow() - timedelta(days=5),
+        adageInscriptionDate=date_utils.get_naive_utc_now() - timedelta(days=5),
         reimbursement=True,
         venueEducationalStatusId=next(educational_status_iterator),
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
@@ -76,7 +77,7 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         managingOfferer=offerer,
         name=f"Partenaire culturel {offerer.name}",
         adageId="789456",
-        adageInscriptionDate=datetime.utcnow() - timedelta(days=30),
+        adageInscriptionDate=date_utils.get_naive_utc_now() - timedelta(days=30),
         venueEducationalStatusId=next(educational_status_iterator),
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
         siret=siren_utils.complete_siren_or_siret(f"{offerer.siren}0001"),
@@ -88,7 +89,7 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         managingOfferer=offerer,
         name=f"real_venue 1 {offerer.name}",
         adageId="698748",
-        adageInscriptionDate=datetime.utcnow() - timedelta(days=13),
+        adageInscriptionDate=date_utils.get_naive_utc_now() - timedelta(days=13),
         venueEducationalStatusId=next(educational_status_iterator),
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
         siret=siren_utils.complete_siren_or_siret(f"{offerer.siren}0001"),
@@ -226,7 +227,7 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
         siret=siren_utils.complete_siren_or_siret(f"{offerer.siren}0001"),
         adageId="98762",
-        adageInscriptionDate=datetime.utcnow() - timedelta(days=30),
+        adageInscriptionDate=date_utils.get_naive_utc_now() - timedelta(days=30),
     )
     educational_factories.CollectiveDmsApplicationFactory.create(
         venue=venue,
@@ -249,18 +250,18 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
         siret=siren_utils.complete_siren_or_siret(f"{offerer.siren}0001"),
         adageId="98763",
-        adageInscriptionDate=datetime.utcnow(),
+        adageInscriptionDate=date_utils.get_naive_utc_now(),
     )
     educational_factories.CollectiveDmsApplicationFactory.create(
         venue=venue,
         application=next(application_id_generator),
         procedure=57189,
-        lastChangeDate=datetime.utcnow(),
+        lastChangeDate=date_utils.get_naive_utc_now(),
         depositDate=datetime.fromisoformat("2022-05-17 14:43:22+00:00"),
         expirationDate=datetime.fromisoformat("2025-11-08 14:09:31+00:00"),
         buildDate=datetime.fromisoformat("2022-05-17 14:43:22+00:00"),
         instructionDate=datetime.fromisoformat("2022-10-25 12:40:41+00:00"),
-        processingDate=datetime.utcnow(),
+        processingDate=date_utils.get_naive_utc_now(),
         state="accepte",
     )
     # eac_with_two_adage_venues
@@ -355,7 +356,7 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         name=f"{offerer.name} PC_PRO",
         reimbursement=True,
         adageId="123547",
-        adageInscriptionDate=datetime.utcnow() - timedelta(days=3),
+        adageInscriptionDate=date_utils.get_naive_utc_now() - timedelta(days=3),
         venueEducationalStatusId=next(educational_status_iterator),
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
         departementCode="57",
@@ -372,7 +373,7 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         name=f"{offerer.name} PUBLIC_API",
         reimbursement=True,
         adageId="123548",
-        adageInscriptionDate=datetime.utcnow() - timedelta(days=3),
+        adageInscriptionDate=date_utils.get_naive_utc_now() - timedelta(days=3),
         venueEducationalStatusId=next(educational_status_iterator),
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
         departementCode="57",
@@ -391,7 +392,7 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         name=f"{offerer.name} PC_PRO",
         reimbursement=True,
         adageId="123549",
-        adageInscriptionDate=datetime.utcnow() - timedelta(days=3),
+        adageInscriptionDate=date_utils.get_naive_utc_now() - timedelta(days=3),
         venueEducationalStatusId=next(educational_status_iterator),
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
         departementCode="57",
@@ -408,7 +409,7 @@ def create_eac_venues(offerer_list: list[offerers_models.Offerer]) -> None:
         name=f"{offerer.name} PUBLIC_API",
         reimbursement=True,
         adageId="123550",
-        adageInscriptionDate=datetime.utcnow() - timedelta(days=3),
+        adageInscriptionDate=date_utils.get_naive_utc_now() - timedelta(days=3),
         venueEducationalStatusId=next(educational_status_iterator),
         collectiveInterventionArea=ALL_INTERVENTION_AREA,
         departementCode="33",

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_occurrences.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_event_occurrences.py
@@ -19,7 +19,7 @@ from . import utils
 logger = logging.getLogger(__name__)
 
 
-TODAY = datetime.combine(datetime.utcnow(), time(hour=20))
+TODAY = datetime.combine(date_utils.get_naive_utc_now(), time(hour=20))
 EVENT_OCCURRENCE_BEGINNING_DATETIMES = [
     TODAY,
     TODAY + timedelta(days=2),

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_gdpr_users.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_gdpr_users.py
@@ -14,12 +14,13 @@ from pcapi.core.subscription import factories as subscription_factories
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
 
 
-THREE_YEARS_AGO = datetime.datetime.utcnow() - relativedelta(years=3)
+THREE_YEARS_AGO = date_utils.get_naive_utc_now() - relativedelta(years=3)
 
 INCREMENT = itertools.count()
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_incidents.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_incidents.py
@@ -20,6 +20,7 @@ from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.backoffice.finance import validation
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -162,7 +163,7 @@ def _create_one_individual_incident(
             finance_api.price_event(finance_event)
 
     # Mark incident bookings as `REIMBURSED`
-    batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     finance_api.generate_invoices_and_debit_notes_legacy(batch)
 
     assert {b.status for b in bookings} == {bookings_models.BookingStatus.REIMBURSED}, [
@@ -208,7 +209,7 @@ def _create_one_individual_incident(
         for finance_event in booking_finance_incident.finance_events:
             finance_api.price_event(finance_event)
 
-    batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     finance_api.generate_invoices_and_debit_notes_legacy(batch)
 
 
@@ -261,7 +262,7 @@ def _create_one_collective_incident(
             1,
             collectiveStock__collectiveOffer__venue=venue,
             collectiveStock__price=decimal.Decimal("19990"),
-            collectiveStock__startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            collectiveStock__startDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             educationalInstitution=deposit.educationalInstitution,
             educationalYear=deposit.educationalYear,
         )
@@ -270,7 +271,7 @@ def _create_one_collective_incident(
         size=2 if multiple_bookings else 1,
         collectiveStock__collectiveOffer__venue=other_venue or venue,
         collectiveStock__price=decimal.Decimal("30"),
-        collectiveStock__startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        collectiveStock__startDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         educationalInstitution=deposit.educationalInstitution,
         educationalYear=deposit.educationalYear,
     )
@@ -284,7 +285,7 @@ def _create_one_collective_incident(
         finance_api.price_event(finance_event)
 
     # Mark incident bookings as `REIMBURSED`
-    batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     finance_api.generate_invoices_and_debit_notes_legacy(batch)
 
     assert {booking.status for booking in bookings} == {educational_models.CollectiveBookingStatus.REIMBURSED}, [
@@ -296,7 +297,7 @@ def _create_one_collective_incident(
         new_booking = educational_factories.UsedCollectiveBookingFactory.create(
             collectiveStock__collectiveOffer__venue=other_venue or venue,
             collectiveStock__price=decimal.Decimal("20") + decimal.Decimal(i),
-            collectiveStock__startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            collectiveStock__startDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             educationalInstitution=deposit.educationalInstitution,
             educationalYear=deposit.educationalYear,
         )
@@ -323,7 +324,7 @@ def _create_one_collective_incident(
             for finance_event in booking_finance_incident.finance_events:
                 finance_api.price_event(finance_event)
 
-    batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     finance_api.generate_invoices_and_debit_notes_legacy(batch)
 
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_invoices.py
@@ -26,6 +26,7 @@ from pcapi.core.finance import models as finance_models
 from pcapi.core.finance import utils as finance_utils
 from pcapi.models import db
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ def create_industrial_invoices() -> None:
 
     finance_api.price_events()
 
-    batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.utcnow())
+    batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     cashflows_created = db.session.query(finance_models.Cashflow).count()
     logger.info("Created %s Cashflows", cashflows_created)
 
@@ -83,7 +84,7 @@ def create_free_invoice() -> None:
         for finance_event in booking.finance_events:
             finance_api.price_event(finance_event)
 
-    finance_api.generate_cashflows_and_payment_files(cutoff=datetime.utcnow())
+    finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
 
     cashflows = db.session.query(finance_models.Cashflow).filter_by(bankAccount=bank_account).all()
     cashflow_ids = [c.id for c in cashflows]
@@ -195,7 +196,7 @@ def create_specific_invoice() -> None:
     incident_events = []
     for booking_finance_incident in booking_incidents:
         incident_events += finance_api._create_finance_events_from_incident(
-            booking_finance_incident, incident_validation_date=datetime.utcnow()
+            booking_finance_incident, incident_validation_date=date_utils.get_naive_utc_now()
         )
 
     for event in incident_events:
@@ -218,7 +219,7 @@ def create_specific_invoice() -> None:
     for booking in bookings:
         event = db.session.query(finance_models.FinanceEvent).filter_by(booking=booking).one()
         finance_api.price_event(event)
-    finance_api.generate_cashflows_and_payment_files(cutoff=datetime.utcnow())
+    finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     cashflows = db.session.query(finance_models.Cashflow).filter_by(bankAccount=bank_account).all()
     cashflow_ids = [c.id for c in cashflows]
 
@@ -413,7 +414,7 @@ def create_specific_cashflow_batch_without_invoice() -> None:
 
     offerers_factories.OffererStatsFactory.create(
         offerer=offerer,
-        syncDate=datetime.utcnow(),
+        syncDate=date_utils.get_naive_utc_now(),
         table=DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
         jsonData=offerers_models.OffererStatsData(daily_views=daily_views),
     )
@@ -424,7 +425,7 @@ def create_specific_cashflow_batch_without_invoice() -> None:
 
     offerers_factories.OffererStatsFactory.create(
         offerer=offerer,
-        syncDate=datetime.utcnow(),
+        syncDate=date_utils.get_naive_utc_now(),
         table=TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE,
         jsonData=offerers_models.OffererStatsData(
             top_offers=[
@@ -482,6 +483,6 @@ def create_specific_cashflow_batch_without_invoice() -> None:
     for booking in bookings:
         event = db.session.query(finance_models.FinanceEvent).filter_by(booking=booking).one()
         finance_api.price_event(event)
-    finance_api.generate_cashflows_and_payment_files(cutoff=datetime.utcnow())
+    finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
 
     logger.info("Created specific CashflowBatch")

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerer_with_custom_reimbursement_rule.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_offerer_with_custom_reimbursement_rule.py
@@ -3,6 +3,7 @@ import logging
 
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.finance import factories as finance_factories
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -16,7 +17,7 @@ def create_industrial_offerer_with_custom_reimbursement_rule() -> None:
         offerer=offerer,
         subcategories=["FESTIVAL_LIVRE", "FESTIVAL_CINE"],
         timespan=[  # start date in the past => not editable
-            datetime.datetime.utcnow() - datetime.timedelta(days=365),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
             None,
         ],
     )
@@ -24,7 +25,7 @@ def create_industrial_offerer_with_custom_reimbursement_rule() -> None:
         offerer=offerer,
         subcategories=["FESTIVAL_MUSIQUE"],
         timespan=[  # start date in the future, end date not defined => editable
-            datetime.datetime.utcnow() + datetime.timedelta(days=100),
+            date_utils.get_naive_utc_now() + datetime.timedelta(days=100),
             None,
         ],
         amount=None,
@@ -34,7 +35,7 @@ def create_industrial_offerer_with_custom_reimbursement_rule() -> None:
         offerer=offerer,
         subcategories=["FESTIVAL_SPECTACLE"],
         timespan=[  # start date in the future, end date not defined => editable
-            datetime.datetime.utcnow() + datetime.timedelta(days=150),
+            date_utils.get_naive_utc_now() + datetime.timedelta(days=150),
             None,
         ],
         amount=None,
@@ -44,8 +45,8 @@ def create_industrial_offerer_with_custom_reimbursement_rule() -> None:
         offerer=offerer,
         subcategories=["FESTIVAL_ART_VISUEL"],
         timespan=[  # start date in the future but end date defined => not editable
-            datetime.datetime.utcnow() + datetime.timedelta(days=200),
-            datetime.datetime.utcnow() + datetime.timedelta(days=250),
+            date_utils.get_naive_utc_now() + datetime.timedelta(days=200),
+            date_utils.get_naive_utc_now() + datetime.timedelta(days=250),
         ],
         amount=None,
         rate=0.9,
@@ -56,7 +57,7 @@ def create_industrial_offerer_with_custom_reimbursement_rule() -> None:
     )
     finance_factories.CustomReimbursementRuleFactory.create(
         venue=venue,
-        timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=10), None],
+        timespan=[date_utils.get_naive_utc_now() - datetime.timedelta(days=10), None],
         amount=None,
         rate=0.97,
     )

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_new_caledonia_objects.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_new_caledonia_objects.py
@@ -21,6 +21,7 @@ from pcapi.routes.backoffice.finance import validation
 from pcapi.sandboxes.scripts.creators.test_cases import create_movie_products
 from pcapi.sandboxes.scripts.creators.test_cases import create_offer_and_stocks_for_cinemas
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 from pcapi.utils import siren as siren_utils
 
 
@@ -139,15 +140,15 @@ def _create_nc_active_offerer(beneficiary: users_models.User) -> None:
         dsApplicationId="988001",
     )
     offerers_factories.VenueBankAccountLinkFactory.create(
-        venue=venue, bankAccount=bank_account, timespan=(datetime.datetime.utcnow(),)
+        venue=venue, bankAccount=bank_account, timespan=(date_utils.get_naive_utc_now(),)
     )
     offerers_factories.VenueBankAccountLinkFactory.create(
-        venue=second_venue, bankAccount=bank_account, timespan=(datetime.datetime.utcnow(),)
+        venue=second_venue, bankAccount=bank_account, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     event_offer = offers_factories.EventOfferFactory.create(name="Offre d'événement en Nouvelle-Calédonie", venue=venue)
     # 22:00 UTC = 11:00 Noumea time on the day after
-    ref_date = datetime.datetime.utcnow().replace(hour=22, minute=0, second=0, microsecond=0)
+    ref_date = date_utils.get_naive_utc_now().replace(hour=22, minute=0, second=0, microsecond=0)
     event_stocks = [
         offers_factories.EventStockFactory.create(
             offer=event_offer,
@@ -362,7 +363,7 @@ def _create_nc_invoice() -> None:
     incident_events = []
     for booking_finance_incident in booking_incidents:
         incident_events += finance_api._create_finance_events_from_incident(
-            booking_finance_incident, incident_validation_date=datetime.datetime.utcnow()
+            booking_finance_incident, incident_validation_date=date_utils.get_naive_utc_now()
         )
 
     for event in incident_events:
@@ -414,7 +415,7 @@ def _create_nc_invoice() -> None:
         event = db.session.query(finance_models.FinanceEvent).filter_by(booking=booking).one()
         finance_api.price_event(event)
 
-    batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     finance_api.generate_invoices_and_debit_notes_legacy(batch)
 
     logger.info("Created caledonian and metropolitan Invoices")
@@ -444,7 +445,7 @@ def _create_one_nc_individual_incident(beneficiary: users_models.User) -> None:
         validation_author_type=bookings_models.BookingValidationAuthorType.OFFERER,
     )
     finance_api.price_event(incident_booking.finance_events[0])
-    batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     finance_api.generate_invoices_and_debit_notes_legacy(batch)
 
     assert incident_booking.status == bookings_models.BookingStatus.REIMBURSED
@@ -472,5 +473,5 @@ def _create_one_nc_individual_incident(beneficiary: users_models.User) -> None:
         for finance_event in booking_finance_incident.finance_events:
             finance_api.price_event(finance_event)
 
-    batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     finance_api.generate_invoices_and_debit_notes_legacy(batch)

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offer_with_thousand_stocks.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offer_with_thousand_stocks.py
@@ -8,6 +8,7 @@ from pcapi.core.offers.factories import EventOfferFactory
 from pcapi.core.offers.factories import EventStockFactory
 from pcapi.core.offers.factories import PriceCategoryFactory
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -30,7 +31,7 @@ def create_offer_with_thousand_stocks(offerer: Offerer) -> None:
         EventStockFactory.create(
             offer=offer_event,
             quantity=1,
-            beginningDatetime=datetime.datetime.utcnow().replace(second=0, microsecond=0)
+            beginningDatetime=date_utils.get_naive_utc_now().replace(second=0, microsecond=0)
             - datetime.timedelta(days=100)
             + datetime.timedelta(days=i),
             priceCategory=price_category,

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
@@ -17,6 +17,7 @@ from pcapi.core.providers import factories as providers_factories
 from pcapi.core.providers import models as providers_models
 from pcapi.core.users import factories as users_factories
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -61,7 +62,7 @@ def create_offerer_provider(
 
 
 def create_offerer_provider_with_offers(name: str, user_email: str) -> None:
-    now = datetime.datetime.utcnow().replace(second=0, microsecond=0)
+    now = date_utils.get_naive_utc_now().replace(second=0, microsecond=0)
     in_five_days = now + datetime.timedelta(days=5)
     in_ten_days = now + datetime.timedelta(days=10)
     offerer, provider = create_offerer_provider(name, provider_name="TaylorManager", with_ticketing_service=True)
@@ -124,7 +125,7 @@ def create_offerer_provider_with_offers(name: str, user_email: str) -> None:
 
     offerers_factories.OffererStatsFactory.create(
         offerer=offerer,
-        syncDate=datetime.datetime.utcnow(),
+        syncDate=date_utils.get_naive_utc_now(),
         table=DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE,
         jsonData=offerers_models.OffererStatsData(daily_views=daily_views),
     )
@@ -136,7 +137,7 @@ def create_offerer_provider_with_offers(name: str, user_email: str) -> None:
     top_offer = offers[0]
     offerers_factories.OffererStatsFactory.create(
         offerer=offerer,
-        syncDate=datetime.datetime.utcnow(),
+        syncDate=date_utils.get_naive_utc_now(),
         table=TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE,
         jsonData=offerers_models.OffererStatsData(
             top_offers=[offerers_models.TopOffersData(offerId=top_offer.id, numberOfViews=today.day)],

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_several_venues.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_several_venues.py
@@ -7,6 +7,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -49,7 +50,7 @@ def create_offerer_with_several_venues() -> offerers_models.Offerer:
     virtual_venue = offerers_factories.VirtualVenueFactory.create(
         name="Lieu virtuel de la structure avec plusieurs lieux ", managingOfferer=user_offerer.offerer
     )
-    in_two_month = datetime.datetime.utcnow() + datetime.timedelta(days=60)
+    in_two_month = date_utils.get_naive_utc_now() + datetime.timedelta(days=60)
     for i in range(1, 6):
         offer = offers_factories.DigitalOfferFactory.create(
             name=f"Offre avec code d'activation {i}", venue=virtual_venue

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_venue_provider_and_external_bookings.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_with_venue_provider_and_external_bookings.py
@@ -18,6 +18,7 @@ from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.core.users.factories import BeneficiaryGrant18Factory
 from pcapi.models import db
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -99,7 +100,7 @@ def _create_offers(provider: Provider) -> Venue:
             CinemaStockProviderFactory.create(offer=offer_with_past_stock)
             CinemaStockProviderFactory.create(
                 offer=offer_with_past_stock,
-                beginningDatetime=datetime.datetime.utcnow().replace(second=0, microsecond=0)
+                beginningDatetime=date_utils.get_naive_utc_now().replace(second=0, microsecond=0)
                 - datetime.timedelta(days=5),
             )
     return venue

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offers_with_status.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offers_with_status.py
@@ -16,6 +16,7 @@ from pcapi.core.users.models import User
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -65,7 +66,8 @@ def create_offers_fully_booked(user_bene: User, venue: Venue) -> None:
         EventStockFactory.create(offer=offer_with_past_stock, priceCategory=price_category)
         stock_past = EventStockFactory.create(
             offer=offer_with_past_stock,
-            beginningDatetime=datetime.datetime.utcnow().replace(second=0, microsecond=0) - datetime.timedelta(days=5),
+            beginningDatetime=date_utils.get_naive_utc_now().replace(second=0, microsecond=0)
+            - datetime.timedelta(days=5),
             quantity=1,
             priceCategory=price_category,
         )
@@ -84,7 +86,8 @@ def create_offers_expired(venue: Venue) -> None:
         EventStockFactory.create(
             offer=offer_event,
             quantity=1,
-            beginningDatetime=datetime.datetime.utcnow().replace(second=0, microsecond=0) - datetime.timedelta(days=5),
+            beginningDatetime=date_utils.get_naive_utc_now().replace(second=0, microsecond=0)
+            - datetime.timedelta(days=5),
         )
     logger.info("create_offers_expired")
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_user_account_update_requests.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_user_account_update_requests.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 import factory
@@ -10,6 +9,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ def create_user_account_update_requests() -> None:
     )
     history_factories.ActionHistoryFactory.create(
         actionType=history_models.ActionType.INFO_MODIFIED,
-        actionDate=datetime.datetime.utcnow(),
+        actionDate=date_utils.get_naive_utc_now(),
         user=accepted_request.user,
         authorUser=instructor,
         comment=None,

--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -56,6 +56,7 @@ from pcapi.sandboxes.scripts.creators.industrial.create_venue_labels import crea
 from pcapi.sandboxes.scripts.creators.test_cases import venues_mock
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
 from pcapi.sandboxes.scripts.utils.storage_utils import store_public_object_from_sandbox_assets
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 from pcapi.utils.transaction_manager import atomic
 
@@ -766,7 +767,7 @@ def create_offers_with_video_url() -> None:
 
 @log_func_duration
 def create_highlights() -> None:
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     highlights_factories.HighlightFactory.create(
         name="Temps fort passé",
         description="Ceci est un temps fort passé",
@@ -838,7 +839,7 @@ def create_venues_across_cities() -> None:
                     offers_factories.EventStockFactory.create(
                         quantity=random.randint(10, 100),
                         offer=event_offer,
-                        beginningDatetime=datetime.datetime.utcnow()
+                        beginningDatetime=date_utils.get_naive_utc_now()
                         + datetime.timedelta(
                             days=random.randint(30, 59),
                             hours=random.randint(1, 23),
@@ -882,7 +883,7 @@ def create_offers_for_each_subcategory() -> None:
                     offer__venue__longitude=2.37850 if is_in_Paris else 5.37421,
                     price=0 if is_free else i * 2,
                     quantity=i * 10,
-                    beginningDatetime=datetime.datetime.utcnow()
+                    beginningDatetime=date_utils.get_naive_utc_now()
                     + datetime.timedelta(
                         days=i + 7,
                         hours=(3 * i) % 60,
@@ -1085,19 +1086,19 @@ def create_app_beneficiaries() -> None:
     achievements_factories.AchievementFactory.create(
         user=user_with_achievements,
         name=achievements_models.AchievementEnum.FIRST_BOOK_BOOKING,
-        unlockedDate=datetime.datetime.utcnow(),
+        unlockedDate=date_utils.get_naive_utc_now(),
     )
     achievements_factories.AchievementFactory.create(
         user=user_with_achievements,
         name=achievements_models.AchievementEnum.FIRST_SHOW_BOOKING,
-        unlockedDate=datetime.datetime.utcnow(),
-        seenDate=datetime.datetime.utcnow(),
+        unlockedDate=date_utils.get_naive_utc_now(),
+        seenDate=date_utils.get_naive_utc_now(),
     )
     achievements_factories.AchievementFactory.create(
         user=user_with_achievements,
         name=achievements_models.AchievementEnum.FIRST_ART_LESSON_BOOKING,
-        unlockedDate=datetime.datetime.utcnow(),
-        seenDate=datetime.datetime.utcnow(),
+        unlockedDate=date_utils.get_naive_utc_now(),
+        seenDate=date_utils.get_naive_utc_now(),
     )
 
 
@@ -1274,7 +1275,7 @@ def create_users_with_reactions() -> None:
 
 @log_func_duration
 def create_user_that_booked_some_cinema() -> None:
-    seance_cine_start = datetime.datetime.utcnow() - datetime.timedelta(hours=25)
+    seance_cine_start = date_utils.get_naive_utc_now() - datetime.timedelta(hours=25)
     stock = offers_factories.StockFactory.create(
         beginningDatetime=seance_cine_start, quantity=100, offer__subcategoryId=subcategories.SEANCE_CINE.id
     )

--- a/api/src/pcapi/sandboxes/scripts/getters/native.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/native.py
@@ -9,6 +9,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.models import db
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import timespan_str_to_numrange
 
 
@@ -101,7 +102,7 @@ def create_accessibility_offers() -> dict:
         name="Offre cinéma - Audit Access42",
         venue=venue,
         subcategoryId=subcategories.SEANCE_CINE.id,
-        publicationDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        publicationDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
     )
     db.session.add(offer1)
     mediation1 = offers_factories.MediationFactory.build(offer=offer1, credit="Michèlle photo")
@@ -122,7 +123,7 @@ def create_accessibility_offers() -> dict:
         venue=venue,
         name="Offre livre - Audit Access42",
         subcategoryId=subcategories.LIVRE_PAPIER.id,
-        publicationDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        publicationDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
     )
     db.session.add(offer2)
     mediation2 = offers_factories.MediationFactory.build(offer=offer2, credit="Michel photo")
@@ -133,7 +134,7 @@ def create_accessibility_offers() -> dict:
         venue=venue,
         name="Ne pas auditer - Offre livre - Audit Access42",
         subcategoryId=subcategories.CARTE_JEUNES.id,
-        publicationDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        publicationDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
     )
     db.session.add(offer3)
     mediation3 = offers_factories.MediationFactory.build(offer=offer3, credit="Andrée photo")
@@ -144,7 +145,7 @@ def create_accessibility_offers() -> dict:
         venue=venue,
         name="Ne pas auditer - Offre numérique - Audit Access42",
         subcategoryId=subcategories.TELECHARGEMENT_LIVRE_AUDIO.id,
-        publicationDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        publicationDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
     )
     db.session.add(offer4)
     mediation4 = offers_factories.MediationFactory.build(offer=offer4, credit="André photo")

--- a/api/src/pcapi/sandboxes/scripts/getters/pro.py
+++ b/api/src/pcapi/sandboxes/scripts/getters/pro.py
@@ -15,6 +15,7 @@ from pcapi.core.providers import factories as providers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
 from pcapi.sandboxes.scripts.utils.helpers import get_pro_user_helper
+from pcapi.utils import date as date_utils
 
 
 def create_new_pro_user() -> dict:
@@ -307,8 +308,8 @@ def create_pro_user_with_collective_offers() -> dict:
         collectiveOffer__name="Mon offre collective publiée réservable",
         collectiveOffer__venue=venue1,
         collectiveOffer__formats=[EacFormat.CONCERT],
-        startDatetime=datetime.datetime.utcnow() + datetime.timedelta(weeks=2),
-        endDatetime=datetime.datetime.utcnow() + datetime.timedelta(weeks=2),
+        startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(weeks=2),
+        endDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(weeks=2),
     )
 
     offerDraft = educational_factories.DraftCollectiveOfferFactory.create(
@@ -405,7 +406,7 @@ def create_pro_user_with_active_collective_offer() -> dict:
     )
     # Make sur the stock starts during the current year
     stock_start = min(
-        datetime.datetime.utcnow() + datetime.timedelta(days=10),
+        date_utils.get_naive_utc_now() + datetime.timedelta(days=10),
         current_year.expirationDate - datetime.timedelta(days=1),
     )
     offer.collectiveStock.startDatetime = stock_start
@@ -445,7 +446,7 @@ def create_pro_user_with_collective_bookings() -> dict:
     collectiveStock = educational_factories.CollectiveStockFactory.create(
         collectiveOffer__venue=venue,
         collectiveOffer__name="Mon offre",
-        startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=10),
+        startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=10),
     )
     collectiveStock_B = educational_factories.CollectiveStockFactory.create(
         collectiveOffer__venue=venue, collectiveOffer__name="Mon autre offre"
@@ -453,7 +454,7 @@ def create_pro_user_with_collective_bookings() -> dict:
     educational_factories.CollectiveBookingFactory.create(collectiveStock=collectiveStock)
     educational_factories.CollectiveBookingFactory.create(
         collectiveStock__collectiveOffer__name="Encore une autre offre",
-        collectiveStock__startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=10),
+        collectiveStock__startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=10),
         collectiveStock__collectiveOffer__venue=venue,
         educationalInstitution__name="Autre collège",
     )

--- a/api/src/pcapi/scripts/beneficiary/import_test_users.py
+++ b/api/src/pcapi/scripts/beneficiary/import_test_users.py
@@ -30,6 +30,7 @@ from pcapi.routes.serialization import offerers_serialize
 from pcapi.routes.serialization import venues_serialize
 from pcapi.routes.serialization.users import ProUserCreationBodyV2Model
 from pcapi.utils import crypto
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 from pcapi.utils.email import anonymize_email
 from pcapi.utils.email import sanitize_email
@@ -84,7 +85,7 @@ def _create_beneficiary(row: dict, role: UserRole | None) -> User:
 
 
 def _create_pro_user(row: dict) -> User:
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
 
     user = users_api.create_pro_user(
         ProUserCreationBodyV2Model(  # type: ignore[call-arg]

--- a/api/src/pcapi/scripts/full_index_offers.py
+++ b/api/src/pcapi/scripts/full_index_offers.py
@@ -9,6 +9,7 @@ import pytz
 import pcapi.core.offers.models as offers_models
 from pcapi.core import search
 from pcapi.core.search.backends import algolia
+from pcapi.utils import date as date_utils
 from pcapi.utils.blueprint import Blueprint
 
 
@@ -22,7 +23,7 @@ blueprint = Blueprint(__name__, __name__)
 def _get_eta(end: int, current: int, elapsed_per_batch: list[int]) -> str:
     left_to_do = end - current
     eta_seconds = left_to_do / BATCH_SIZE * statistics.mean(elapsed_per_batch)
-    eta_datetime = datetime.datetime.utcnow() + datetime.timedelta(seconds=eta_seconds)
+    eta_datetime = date_utils.get_naive_utc_now() + datetime.timedelta(seconds=eta_seconds)
     eta_datetime = eta_datetime.astimezone(pytz.timezone("Europe/Paris"))
     return eta_datetime.strftime("%d/%m/%Y %H:%M:%S")
 

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -6,6 +6,7 @@ import pydantic.v1 as pydantic_v1
 import pytz
 
 from pcapi.models.api_errors import ApiErrors
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_naive_utc_now
 
 
@@ -149,7 +150,7 @@ def check_date_in_future_and_remove_timezone(value: datetime.datetime | NOW_LITE
     if value.tzinfo is None:
         raise ValueError("The datetime must be timezone-aware.")
     no_tz_value = as_utc_without_timezone(value)
-    if no_tz_value < datetime.datetime.utcnow():
+    if no_tz_value < date_utils.get_naive_utc_now():
         raise ValueError("The datetime must be in the future.")
     return no_tz_value
 

--- a/api/src/pcapi/tasks/cloud_task.py
+++ b/api/src/pcapi/tasks/cloud_task.py
@@ -12,6 +12,7 @@ from google.protobuf import duration_pb2
 from google.protobuf import timestamp_pb2
 
 from pcapi import settings
+from pcapi.utils import date as date_utils
 from pcapi.utils import requests
 
 
@@ -115,7 +116,7 @@ def enqueue_internal_task(
     # id is recommended".
     task_id = hashlib.sha1(json.dumps(payload, sort_keys=True).encode()).hexdigest() if deduplicate else None
 
-    schedule_time = datetime.datetime.utcnow() + relativedelta(seconds=delayed_seconds) if delayed_seconds else None
+    schedule_time = date_utils.get_naive_utc_now() + relativedelta(seconds=delayed_seconds) if delayed_seconds else None
 
     return enqueue_task(
         queue, http_request, task_id=task_id, schedule_time=schedule_time, task_request_timeout=task_request_timeout

--- a/api/src/pcapi/utils/login_manager.py
+++ b/api/src/pcapi/utils/login_manager.py
@@ -18,6 +18,7 @@ from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.apis import private_api
 from pcapi.routes.backoffice.blueprint import backoffice_web
 from pcapi.routes.pro.blueprint import pro_private_api
+from pcapi.utils import date as date_utils
 
 
 logger = logging.getLogger(__name__)
@@ -112,7 +113,7 @@ def manage_pro_session(user: users_models.User | None) -> users_models.User | No
     if getattr(flask.request, "blueprint", "") not in PRO_APIS:
         return user
 
-    current_timestamp = datetime.utcnow().timestamp()
+    current_timestamp = date_utils.get_naive_utc_now().timestamp()
     last_login = datetime.fromtimestamp(flask.session.get("last_login", current_timestamp))
     last_api_call = datetime.fromtimestamp(flask.session.get("last_api_call", current_timestamp))
     valid_session = compute_pro_session_validity(last_login, last_api_call)
@@ -130,7 +131,7 @@ def manage_pro_session(user: users_models.User | None) -> users_models.User | No
 
 
 def compute_pro_session_validity(last_login: datetime, last_api_call: datetime) -> bool:
-    now = datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
 
     if last_login + settings.PRO_SESSION_LOGIN_TIMEOUT_IN_DAYS > now:  # connected less than 14 days ago
         return True

--- a/api/src/pcapi/utils/pdf.py
+++ b/api/src/pcapi/utils/pdf.py
@@ -9,6 +9,8 @@ from datetime import datetime
 
 import weasyprint
 
+from pcapi.utils import date as date_utils
+
 
 PDF_AUTHOR = "Pass Culture"
 url_fetcher_container = threading.local()
@@ -84,7 +86,7 @@ def generate_pdf_from_html(html_content: str, metadata: PdfMetadata | None = Non
     document = weasyprint.HTML(string=html_content, url_fetcher=fetcher.fetch_url).render()
     metadata = metadata or PdfMetadata()
     # a W3C date, as expected by Weasyprint
-    document.metadata.created = (metadata.created or datetime.utcnow()).strftime("%Y-%m-%dT%H:%M:%SZ")
+    document.metadata.created = (metadata.created or date_utils.get_naive_utc_now()).strftime("%Y-%m-%dT%H:%M:%SZ")
     document.metadata.modified = document.metadata.created
     document.metadata.authors = [metadata.author]
     document.metadata.title = metadata.title

--- a/api/src/pcapi/workers/decorators.py
+++ b/api/src/pcapi/workers/decorators.py
@@ -1,7 +1,6 @@
 import logging
 import time
 import typing
-from datetime import datetime
 from functools import wraps
 
 from flask import current_app
@@ -9,6 +8,7 @@ from rq.job import get_current_job
 from rq.queue import Queue
 
 from pcapi import settings
+from pcapi.utils import date as date_utils
 from pcapi.workers.logger import job_extra_description
 
 
@@ -30,8 +30,16 @@ def job(queue: Queue) -> typing.Callable:
                 return
 
             start = time.perf_counter()
-            started_at = current_job.started_at.replace(tzinfo=None) if current_job.started_at else datetime.utcnow()
-            enqueued_at = current_job.enqueued_at.replace(tzinfo=None) if current_job.enqueued_at else datetime.utcnow()
+            started_at = (
+                current_job.started_at.replace(tzinfo=None)
+                if current_job.started_at
+                else date_utils.get_naive_utc_now()
+            )
+            enqueued_at = (
+                current_job.enqueued_at.replace(tzinfo=None)
+                if current_job.enqueued_at
+                else date_utils.get_naive_utc_now()
+            )
             assert enqueued_at is not None  # help mypy
             logger.info(
                 "Started job %s",

--- a/api/tests/core/bookings/external/test_booking_notifications.py
+++ b/api/tests/core/bookings/external/test_booking_notifications.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -12,6 +11,7 @@ from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.notifications.push import testing
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -25,10 +25,10 @@ def test_send_today_events_notifications_only_to_individual_bookings_users():
     creates a job that will send a notification to all of the stock's users
     with a valid (not cancelled) booking, for individual bookings only.
     """
-    in_one_hour = datetime.utcnow() + timedelta(hours=1)
+    in_one_hour = date_utils.get_naive_utc_now() + timedelta(hours=1)
     stock_today = offers_factories.EventStockFactory(beginningDatetime=in_one_hour, offer__name="my_offer")
 
-    next_week = datetime.utcnow() + timedelta(days=7)
+    next_week = date_utils.get_naive_utc_now() + timedelta(days=7)
     stock_next_week = offers_factories.EventStockFactory(beginningDatetime=next_week)
 
     user1 = users_factories.BeneficiaryGrant18Factory()
@@ -64,10 +64,10 @@ def test_send_today_events_notifications_only_to_individual_bookings_users_with_
     creates a job that will send a notification to all of the stock's users
     with a valid (not cancelled) booking, for individual bookings only.
     """
-    in_one_hour = datetime.utcnow() + timedelta(hours=1)
+    in_one_hour = date_utils.get_naive_utc_now() + timedelta(hours=1)
     stock_today = offers_factories.EventStockFactory(beginningDatetime=in_one_hour, offer__name="my_offer")
 
-    next_week = datetime.utcnow() + timedelta(days=7)
+    next_week = date_utils.get_naive_utc_now() + timedelta(days=7)
     stock_next_week = offers_factories.EventStockFactory(beginningDatetime=next_week)
 
     user1 = users_factories.BeneficiaryGrant18Factory()
@@ -94,7 +94,7 @@ def test_send_today_events_notifications_only_to_individual_bookings_users_with_
 def test_notify_users_bookings_not_retrieved() -> None:
     user = users_factories.BeneficiaryGrant18Factory()
     stock = offers_factories.ThingStockFactory()
-    creation_date = datetime.utcnow() - constants.BOOKINGS_AUTO_EXPIRY_DELAY + timedelta(days=3)
+    creation_date = date_utils.get_naive_utc_now() - constants.BOOKINGS_AUTO_EXPIRY_DELAY + timedelta(days=3)
 
     # booking that will expire in three days
     booking = bookings_factories.BookingFactory(user=user, stock=stock, dateCreated=creation_date)
@@ -116,7 +116,7 @@ def test_notify_users_bookings_not_retrieved() -> None:
 def test_notify_users_bookings_not_retrieved_with_FF() -> None:
     user = users_factories.BeneficiaryGrant18Factory()
     stock = offers_factories.ThingStockFactory()
-    creation_date = datetime.utcnow() - constants.BOOKINGS_AUTO_EXPIRY_DELAY + timedelta(days=3)
+    creation_date = date_utils.get_naive_utc_now() - constants.BOOKINGS_AUTO_EXPIRY_DELAY + timedelta(days=3)
 
     # booking that will expire in three days
     bookings_factories.BookingFactory(user=user, stock=stock, dateCreated=creation_date)

--- a/api/tests/core/bookings/test_commands.py
+++ b/api/tests/core/bookings/test_commands.py
@@ -21,6 +21,7 @@ from pcapi.core.offers import models as offer_models
 from pcapi.core.offers.factories import ProductFactory
 from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 
 from tests.test_utils import run_command
@@ -33,7 +34,7 @@ class ArchiveOldBookingsTest:
     @pytest.mark.usefixtures("clean_database")
     def test_basics(self, app):
         # given
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         recent = now - datetime.timedelta(days=29, hours=23)
         old = now - datetime.timedelta(days=30, hours=1)
         offer = offers_factories.OfferFactory(url="http://example.com")
@@ -62,7 +63,7 @@ class ArchiveOldBookingsTest:
     )
     def test_old_subcategories_bookings_are_archived(self, app, subcategoryId):
         # given
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         recent = now - datetime.timedelta(days=29, hours=23)
         old = now - datetime.timedelta(days=30, hours=1)
         stock_free = offers_factories.StockFactory(
@@ -99,7 +100,7 @@ class ArchiveOldBookingsTest:
     )
     def test_old_subcategories_bookings_are_archived_when_no_longer_free(self, app, subcategoryId, client):
         # given
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         recent = now - datetime.timedelta(days=29, hours=23)
         old = now - datetime.timedelta(days=30, hours=1)
         offer = offers_factories.ThingOfferFactory(subcategoryId=subcategoryId)
@@ -176,7 +177,7 @@ class SendEmailReminderTomorrowEventToBeneficiariesTest:
             None,
         ]
 
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         stock = offers_factories.EventStockFactory(
             beginningDatetime=tomorrow,
         )
@@ -191,7 +192,7 @@ class SendEmailReminderTomorrowEventToBeneficiariesTest:
         self,
         mock_get_booking_event_reminder_to_beneficiary_email_data,
     ):
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         stock = offers_factories.EventStockFactory(
             beginningDatetime=tomorrow,
         )
@@ -211,7 +212,7 @@ class SendEmailReminderTomorrowEventToBeneficiariesTest:
         "pcapi.core.mails.transactional.bookings.booking_event_reminder_to_beneficiary.get_booking_event_reminder_to_beneficiary_email_data"
     )
     def should_log_errors(self, mock_get_booking_event_reminder_to_beneficiary_email_data, caplog):
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         stock = offers_factories.EventStockFactory(
             beginningDatetime=tomorrow,
         )
@@ -226,7 +227,7 @@ class SendEmailReminderTomorrowEventToBeneficiariesTest:
             assert caplog.records[0].extra["userId"] == individual_booking_with_error.userId
 
     def should_execute_one_query_only(self):
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         stock = offers_factories.EventStockFactory(beginningDatetime=tomorrow)
         bookings_factories.BookingFactory.create_batch(3, stock=stock)
 

--- a/api/tests/core/bookings/test_factories.py
+++ b/api/tests/core/bookings/test_factories.py
@@ -1,16 +1,15 @@
-import datetime
-
 import pytest
 
 from pcapi.core.bookings.factories import BookingFactory
 from pcapi.core.bookings.models import Booking
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
 class BookingFactoryTest:
     def test_cancellation_limit_date_is_saved_to_db(self):
-        booking = BookingFactory(stock__beginningDatetime=datetime.datetime.utcnow())
+        booking = BookingFactory(stock__beginningDatetime=date_utils.get_naive_utc_now())
         generated_cancellation_limit_date = booking.cancellationLimitDate
 
         booking_from_db = db.session.query(Booking).first()
@@ -22,5 +21,5 @@ class BookingFactoryTest:
         assert not non_event_booking.cancellationLimitDate
 
     def test_cancellation_limit_date_is_generated_for_event(self):
-        event_booking = BookingFactory(stock__beginningDatetime=datetime.datetime.utcnow())
+        event_booking = BookingFactory(stock__beginningDatetime=date_utils.get_naive_utc_now())
         assert event_booking.cancellationLimitDate

--- a/api/tests/core/bookings/test_models.py
+++ b/api/tests/core/bookings/test_models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 from decimal import Decimal
 
@@ -20,6 +19,7 @@ from pcapi.core.offers.factories import ProductFactory
 from pcapi.core.users.factories import BeneficiaryGrant18Factory
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 
 
@@ -129,7 +129,7 @@ class BookingCanReactTest:
         )
         booking = factories.UsedBookingFactory(
             stock__offer=offer,
-            dateUsed=datetime.utcnow(),
+            dateUsed=date_utils.get_naive_utc_now(),
         )
         assert booking.can_react == can_react
 
@@ -169,7 +169,7 @@ class BookingPopUpReactionTest:
         )
         booking = factories.UsedBookingFactory(
             stock__offer=offer,
-            dateUsed=datetime.utcnow() - timedelta(seconds=60 * 24 * 3600),
+            dateUsed=date_utils.get_naive_utc_now() - timedelta(seconds=60 * 24 * 3600),
         )
         assert booking.enable_pop_up_reaction == True
 
@@ -189,7 +189,7 @@ class BookingPopUpReactionTest:
         )
         booking = factories.UsedBookingFactory(
             stock__offer=offer,
-            dateUsed=datetime.utcnow() - timedelta(seconds=60 * 24 * 3600),
+            dateUsed=date_utils.get_naive_utc_now() - timedelta(seconds=60 * 24 * 3600),
         )
         assert booking.enable_pop_up_reaction == pop_up_enabled
 
@@ -209,7 +209,7 @@ class BookingPopUpReactionTest:
         )
         booking = factories.UsedBookingFactory(
             stock__offer=offer,
-            dateUsed=datetime.utcnow() - timedelta(seconds=date_used_seconds),
+            dateUsed=date_utils.get_naive_utc_now() - timedelta(seconds=date_used_seconds),
         )
         assert booking.enable_pop_up_reaction == pop_up_enabled
 
@@ -221,7 +221,7 @@ class BookingPopUpReactionTest:
         booking = factories.UsedBookingFactory(
             user=user,
             stock__offer=offer,
-            dateUsed=datetime.utcnow() - timedelta(seconds=31 * 24 * 3600),
+            dateUsed=date_utils.get_naive_utc_now() - timedelta(seconds=31 * 24 * 3600),
         )
         assert booking.enable_pop_up_reaction == False
 
@@ -234,20 +234,20 @@ class BookingPopUpReactionTest:
         booking = factories.UsedBookingFactory(
             user=user,
             stock__offer=offer,
-            dateUsed=datetime.utcnow() - timedelta(seconds=24 * 3600),
+            dateUsed=date_utils.get_naive_utc_now() - timedelta(seconds=24 * 3600),
         )
         assert booking.enable_pop_up_reaction == False
 
 
 class BookingIsConfirmedPropertyTest:
     def test_booking_is_confirmed_when_cancellation_limit_date_is_in_the_past(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         booking = factories.BookingFactory(cancellation_limit_date=yesterday)
 
         assert booking.isConfirmed is True
 
     def test_booking_is_not_confirmed_when_cancellation_limit_date_is_in_the_future(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         booking = factories.BookingFactory(cancellation_limit_date=tomorrow)
 
         assert booking.isConfirmed is False
@@ -260,7 +260,7 @@ class BookingIsConfirmedPropertyTest:
 
 class BookingIsConfirmedSqlQueryTest:
     def test_booking_is_confirmed_when_cancellation_limit_date_is_in_the_past(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         factories.BookingFactory(cancellation_limit_date=yesterday)
 
         query_result = db.session.query(Booking).filter(Booking.isConfirmed.is_(True)).all()
@@ -268,7 +268,7 @@ class BookingIsConfirmedSqlQueryTest:
         assert len(query_result) == 1
 
     def test_booking_is_not_confirmed_when_cancellation_limit_date_is_in_the_future(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         factories.BookingFactory(cancellation_limit_date=tomorrow)
 
         query_result = db.session.query(Booking).filter(Booking.isConfirmed.is_(False)).all()
@@ -288,29 +288,29 @@ class BookingExpirationDateTest:
         user = BeneficiaryGrant18Factory()
         book_booking = factories.BookingFactory(
             user=user,
-            dateCreated=datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
             stock__price=10,
             stock__offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
         )
         dvd_booking = factories.BookingFactory(
             user=user,
-            dateCreated=datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
             stock__price=10,
             stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         )
         digital_book_booking = factories.BookingFactory(
             user=user,
-            dateCreated=datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
             stock__price=10,
             stock__offer__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
         )
 
         assert book_booking.expirationDate.strftime("%d/%m/%Y") == (
-            datetime.utcnow() + relativedelta(days=10)
+            date_utils.get_naive_utc_now() + relativedelta(days=10)
         ).strftime("%d/%m/%Y")
-        assert dvd_booking.expirationDate.strftime("%d/%m/%Y") == (datetime.utcnow() + relativedelta(days=30)).strftime(
-            "%d/%m/%Y"
-        )
+        assert dvd_booking.expirationDate.strftime("%d/%m/%Y") == (
+            date_utils.get_naive_utc_now() + relativedelta(days=30)
+        ).strftime("%d/%m/%Y")
         assert not digital_book_booking.expirationDate
 
 

--- a/api/tests/core/bookings/test_repository.py
+++ b/api/tests/core/bookings/test_repository.py
@@ -27,13 +27,14 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users.models import User
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_department_timezone
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-NOW = datetime.utcnow()
+NOW = date_utils.get_naive_utc_now()
 YESTERDAY = NOW - timedelta(days=1)
 TWO_DAYS_AGO = NOW - timedelta(days=2)
 THREE_DAYS_AGO = NOW - timedelta(days=3)
@@ -208,9 +209,9 @@ class FindByProUserTest:
 
         offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.ThingStockFactory(
-            offer=offer, price=0, beginningDatetime=datetime.utcnow() + timedelta(hours=98)
+            offer=offer, price=0, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(hours=98)
         )
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         bookings_factories.BookingFactory(
             user=beneficiary,
             stock=stock,
@@ -252,9 +253,9 @@ class FindByProUserTest:
 
         offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.ThingStockFactory(
-            offer=offer, price=0, beginningDatetime=datetime.utcnow() + timedelta(hours=98)
+            offer=offer, price=0, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(hours=98)
         )
-        more_than_two_days_ago = datetime.utcnow() - timedelta(days=3)
+        more_than_two_days_ago = date_utils.get_naive_utc_now() - timedelta(days=3)
         bookings_factories.BookingFactory(
             user=beneficiary, stock=stock, dateCreated=more_than_two_days_ago, token="ABCDEF"
         )
@@ -278,7 +279,7 @@ class FindByProUserTest:
 
         offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=5)
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         bookings_factories.CancelledBookingFactory(
             user=beneficiary,
             stock=stock,
@@ -307,7 +308,7 @@ class FindByProUserTest:
         product = offers_factories.EventProductFactory()
         offer = offers_factories.EventOfferFactory(venue=venue, product=product)
         stock = offers_factories.EventStockFactory(offer=offer, price=5)
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         bookings_factories.UsedBookingFactory(
             user=beneficiary,
             stock=stock,
@@ -339,7 +340,7 @@ class FindByProUserTest:
 
         offer = offers_factories.ThingOfferFactory(venue=venue)
         stock = offers_factories.ThingStockFactory(offer=offer, price=0)
-        today = datetime.utcnow()
+        today = date_utils.get_naive_utc_now()
         bookings_factories.BookingFactory(user=beneficiary, stock=stock, dateCreated=today, token="ABCD")
 
         offerer2 = offerers_factories.OffererFactory(siren="8765432")
@@ -366,8 +367,8 @@ class FindByProUserTest:
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offer = offers_factories.EventOfferFactory(venue=venue)
         stock = offers_factories.EventStockFactory(offer=offer, price=0)
-        today = datetime.utcnow()
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        today = date_utils.get_naive_utc_now()
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         bookings_factories.BookingFactory(user=beneficiary, stock=stock, dateCreated=yesterday, token="ABCD")
         booking2 = bookings_factories.BookingFactory(user=beneficiary, stock=stock, dateCreated=today, token="FGHI")
 
@@ -407,8 +408,10 @@ class FindByProUserTest:
 
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offer = offers_factories.EventOfferFactory(venue=venue, isDuo=True)
-        stock = offers_factories.EventStockFactory(offer=offer, price=0, beginningDatetime=datetime.utcnow())
-        today = datetime.utcnow()
+        stock = offers_factories.EventStockFactory(
+            offer=offer, price=0, beginningDatetime=date_utils.get_naive_utc_now()
+        )
+        today = date_utils.get_naive_utc_now()
         booking = bookings_factories.BookingFactory(user=beneficiary, stock=stock, dateCreated=today, token="FGHI")
 
         bookings_query, total = booking_repository.find_by_pro_user(
@@ -428,8 +431,10 @@ class FindByProUserTest:
 
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offer = offers_factories.EventOfferFactory(venue=venue, isDuo=True)
-        stock = offers_factories.EventStockFactory(offer=offer, price=0, beginningDatetime=datetime.utcnow())
-        today = datetime.utcnow()
+        stock = offers_factories.EventStockFactory(
+            offer=offer, price=0, beginningDatetime=date_utils.get_naive_utc_now()
+        )
+        today = date_utils.get_naive_utc_now()
         booking = bookings_factories.BookingFactory(
             user=beneficiary, stock=stock, dateCreated=today, token="FGHI", quantity=2
         )
@@ -754,17 +759,17 @@ class GetOfferBookingsByStatusCSVTest:
 
         offer = offers_factories.OfferFactory(venue=venue)
         stock = offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.utcnow() + timedelta(days=10)
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=10)
         )
 
         validated_booking = bookings_factories.UsedBookingFactory(stock=stock, user=beneficiary)
         validated_booking_2 = bookings_factories.BookingFactory(
-            stock=stock, cancellation_limit_date=datetime.utcnow() - timedelta(days=1), user=beneficiary_2
+            stock=stock, cancellation_limit_date=date_utils.get_naive_utc_now() - timedelta(days=1), user=beneficiary_2
         )
         bookings_factories.BookingFactory(stock=stock)
 
         stock_2 = offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.utcnow() + timedelta(days=40)
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=40)
         )
         bookings_factories.UsedBookingFactory(stock=stock_2, user=beneficiary_2)
         bookings_factories.BookingFactory(stock=stock_2)
@@ -806,20 +811,20 @@ class GetOfferBookingsByStatusCSVTest:
 
         offer = offers_factories.OfferFactory(venue=venue)
         stock = offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.utcnow() + timedelta(days=10)
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=10)
         )
 
         validated_booking = bookings_factories.UsedBookingFactory(stock=stock, user=beneficiary)
         validated_booking_2 = bookings_factories.BookingFactory(
-            stock=stock, cancellation_limit_date=datetime.utcnow() - timedelta(days=1), user=beneficiary_2
+            stock=stock, cancellation_limit_date=date_utils.get_naive_utc_now() - timedelta(days=1), user=beneficiary_2
         )
         bookings_factories.BookingFactory(stock=stock)
         bookings_factories.CancelledBookingFactory(
-            stock=stock, user=beneficiary_2, cancellation_limit_date=datetime.utcnow() - timedelta(days=2)
+            stock=stock, user=beneficiary_2, cancellation_limit_date=date_utils.get_naive_utc_now() - timedelta(days=2)
         )
 
         stock_2 = offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.utcnow() + timedelta(days=40)
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=40)
         )
         bookings_factories.UsedBookingFactory(stock=stock_2, user=beneficiary_2)
         bookings_factories.BookingFactory(stock=stock_2)
@@ -860,15 +865,17 @@ class GetOfferBookingsByStatusCSVTest:
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
 
         offer = offers_factories.OfferFactory(venue=venue)
-        stock = offers_factories.EventStockFactory(offer=offer, beginningDatetime=datetime.utcnow() + timedelta(days=5))
+        stock = offers_factories.EventStockFactory(
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=5)
+        )
         validated_booking = bookings_factories.UsedBookingFactory(stock=stock, user=beneficiary, quantity=2)
         validated_booking_2 = bookings_factories.BookingFactory(
-            stock=stock, cancellation_limit_date=datetime.utcnow() - timedelta(days=1), user=beneficiary_2
+            stock=stock, cancellation_limit_date=date_utils.get_naive_utc_now() - timedelta(days=1), user=beneficiary_2
         )
         bookings_factories.BookingFactory(stock=stock)
 
         stock_2 = offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.utcnow() + timedelta(days=40)
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=40)
         )
         bookings_factories.UsedBookingFactory(stock=stock_2, user=beneficiary_2)
         bookings_factories.BookingFactory(stock=stock_2)
@@ -913,11 +920,11 @@ class GetOfferBookingsByStatusCSVTest:
 
         offer = offers_factories.OfferFactory(venue=venue)
         stock = offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.utcnow() + timedelta(days=10)
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=10)
         )
         validated_booking = bookings_factories.UsedBookingFactory(stock=stock, user=beneficiary)
         validated_booking_2 = bookings_factories.BookingFactory(
-            stock=stock, cancellation_limit_date=datetime.utcnow() - timedelta(days=1), user=beneficiary_2
+            stock=stock, cancellation_limit_date=date_utils.get_naive_utc_now() - timedelta(days=1), user=beneficiary_2
         )
         reimbursed_booking = bookings_factories.ReimbursedBookingFactory(user=beneficiary_3, stock=stock)
         new_booking = bookings_factories.BookingFactory(user=beneficiary_4, stock=stock)
@@ -956,10 +963,12 @@ class GetOfferBookingsByStatusCSVTest:
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
 
         offer = offers_factories.OfferFactory(venue=venue)
-        stock = offers_factories.EventStockFactory(offer=offer, beginningDatetime=datetime.utcnow() + timedelta(days=5))
+        stock = offers_factories.EventStockFactory(
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=5)
+        )
         validated_booking = bookings_factories.UsedBookingFactory(stock=stock, user=beneficiary, quantity=2)
         validated_booking_2 = bookings_factories.BookingFactory(
-            stock=stock, cancellation_limit_date=datetime.utcnow() - timedelta(days=1), user=beneficiary_2
+            stock=stock, cancellation_limit_date=date_utils.get_naive_utc_now() - timedelta(days=1), user=beneficiary_2
         )
         reimbursed_booking = bookings_factories.ReimbursedBookingFactory(user=beneficiary, stock=stock)
         new_booking = bookings_factories.BookingFactory(user=beneficiary_2, stock=stock, quantity=2)
@@ -1053,7 +1062,7 @@ class FindSoonToBeExpiredBookingsTest:
 
 class FindExpiringBookingsTest:
     def test_find_expired_bookings_before_and_after_enabling_feature_flag(self):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         book_offer = offers_factories.OfferFactory(subcategoryId=subcategories.LIVRE_PAPIER.id)
         movie_offer = offers_factories.OfferFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id)
 
@@ -1094,7 +1103,7 @@ class SoonExpiringBookingsTest:
         bookings_factories.CancelledBookingFactory(stock=stock)
         booking = bookings_factories.BookingFactory(stock=stock)
 
-        creation_date = datetime.utcnow() - timedelta(days=1)
+        creation_date = date_utils.get_naive_utc_now() - timedelta(days=1)
         bookings_factories.BookingFactory(stock=stock, dateCreated=creation_date)
 
         remaining_days = (booking.expirationDate.date() - date.today()).days
@@ -1113,7 +1122,7 @@ class SoonExpiringBookingsTest:
 
 class GetTomorrowEventOfferTest:
     def test_find_tomorrow_event_offer(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
                 beginningDatetime=tomorrow,
@@ -1125,7 +1134,7 @@ class GetTomorrowEventOfferTest:
         assert len(bookings) == 1
 
     def should_not_select_given_before_tomorrow_booking_event(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
                 beginningDatetime=yesterday,
@@ -1137,7 +1146,7 @@ class GetTomorrowEventOfferTest:
         assert len(bookings) == 0
 
     def should_not_select_given_after_tomorrow_booking_event(self):
-        after_tomorrow = datetime.utcnow() + timedelta(days=2)
+        after_tomorrow = date_utils.get_naive_utc_now() + timedelta(days=2)
         bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
                 beginningDatetime=after_tomorrow,
@@ -1149,7 +1158,7 @@ class GetTomorrowEventOfferTest:
         assert len(bookings) == 0
 
     def should_not_select_given_not_booking_event(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         bookings_factories.BookingFactory(stock__beginningDatetime=tomorrow)
 
         bookings = booking_repository.find_individual_bookings_event_happening_tomorrow_query()
@@ -1157,7 +1166,7 @@ class GetTomorrowEventOfferTest:
         assert len(bookings) == 0
 
     def should_do_only_one_query(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
                 beginningDatetime=tomorrow,
@@ -1170,7 +1179,7 @@ class GetTomorrowEventOfferTest:
         assert len(bookings) == 1
 
     def should_not_select_digital_event(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
                 beginningDatetime=tomorrow,
@@ -1190,7 +1199,7 @@ class GetTomorrowEventOfferTest:
         ],
     )
     def should_select_not_digital_event(self, offer_url):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
                 beginningDatetime=tomorrow,
@@ -1203,7 +1212,7 @@ class GetTomorrowEventOfferTest:
         assert len(bookings) == 1
 
     def should_not_select_cancelled_booking(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
                 beginningDatetime=tomorrow,
@@ -1216,7 +1225,7 @@ class GetTomorrowEventOfferTest:
         assert len(bookings) == 0
 
     def should_select_several_bookings_given_one_stock_with_several_bookings(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         stock = offers_factories.EventStockFactory(
             beginningDatetime=tomorrow,
         )
@@ -1228,7 +1237,7 @@ class GetTomorrowEventOfferTest:
         assert len(bookings) == 2
 
     def test_find_tomorrow_event_offer_without_address(self):
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
                 beginningDatetime=tomorrow,

--- a/api/tests/core/bookings/test_validation.py
+++ b/api/tests/core/bookings/test_validation.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -16,6 +15,7 @@ from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.categories import subcategories
 from pcapi.core.finance.models import DepositType
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 
 
@@ -109,7 +109,7 @@ class CheckStockIsBookableTest:
         validation.check_stock_is_bookable(stock, self.booking_quantity)  # should not raise
 
     def test_raise_if_not_bookable(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         stock = offers_factories.StockFactory(bookingLimitDatetime=yesterday)
 
         with pytest.raises(exceptions.StockIsNotBookable) as error:
@@ -200,7 +200,7 @@ class CheckExpenseLimitsDepositVersion2Test:
         return users_factories.BeneficiaryGrant18Factory(**kwargs)
 
     def test_raise_if_deposit_expired(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         beneficiary = self._get_beneficiary(deposit__expirationDate=yesterday)
         offer = offers_factories.OfferFactory(subcategoryId=subcategories.ACHAT_INSTRUMENT.id)
         with pytest.raises(exceptions.UserHasInsufficientFunds):
@@ -259,7 +259,7 @@ class CheckExpenseLimitsDepositVersion2Test:
 class InsufficientFundsSQLCheckTest:
     def _expire_deposit(self, user):
         deposit = user.deposits[0]
-        deposit.expirationDate = datetime.utcnow() - timedelta(days=1)
+        deposit.expirationDate = date_utils.get_naive_utc_now() - timedelta(days=1)
         repository.save(deposit)
 
     def test_insufficient_funds_when_user_has_expired_deposit(self):
@@ -374,20 +374,20 @@ class CheckIsUsableTest:
         validation.check_is_usable(booking)
 
     def should_pass_when_event_begins_in_less_than_48_hours(self):
-        soon = datetime.utcnow() + timedelta(hours=48)
+        soon = date_utils.get_naive_utc_now() + timedelta(hours=48)
         booking = factories.BookingFactory(stock__beginningDatetime=soon)
         validation.check_is_usable(booking)
 
     def should_pass_when_event_begins_in_more_than_72_hours_and_booking_created_more_than_48_hours_ago(self):
-        next_week = datetime.utcnow() + timedelta(weeks=1)
-        three_days_ago = datetime.utcnow() - timedelta(days=3)
+        next_week = date_utils.get_naive_utc_now() + timedelta(weeks=1)
+        three_days_ago = date_utils.get_naive_utc_now() - timedelta(days=3)
         booking = factories.BookingFactory(stock__beginningDatetime=next_week, dateCreated=three_days_ago)
         validation.check_is_usable(booking)
 
     def should_not_validate_when_event_booking_not_confirmed(self):
         # Given
-        next_week = datetime.utcnow() + timedelta(weeks=1)
-        one_day_before = datetime.utcnow() - timedelta(days=1)
+        next_week = date_utils.get_naive_utc_now() + timedelta(weeks=1)
+        one_day_before = date_utils.get_naive_utc_now() - timedelta(days=1)
         booking = factories.BookingFactory(dateCreated=one_day_before, stock__beginningDatetime=next_week)
 
         # When
@@ -403,7 +403,7 @@ class CheckBeneficiaryCanCancelBookingTest:
 
     def test_can_cancel_if_event_is_in_a_long_time(self):
         booking = factories.BookingFactory(
-            stock__beginningDatetime=datetime.utcnow() + timedelta(days=10),
+            stock__beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=10),
         )
         validation.check_beneficiary_can_cancel_booking(booking.user, booking)  # should not raise
 
@@ -420,7 +420,7 @@ class CheckBeneficiaryCanCancelBookingTest:
 
     def test_raise_if_event_too_close(self):
         booking = factories.BookingFactory(
-            stock__beginningDatetime=datetime.utcnow() + timedelta(days=1),
+            stock__beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=1),
         )
         with pytest.raises(exceptions.CannotCancelConfirmedBooking) as exc:
             validation.check_beneficiary_can_cancel_booking(booking.user, booking)
@@ -431,8 +431,8 @@ class CheckBeneficiaryCanCancelBookingTest:
 
     def test_raise_if_booked_long_ago(self):
         booking = factories.BookingFactory(
-            stock__beginningDatetime=datetime.utcnow() + timedelta(days=10),
-            dateCreated=datetime.utcnow() - timedelta(days=2),
+            stock__beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=10),
+            dateCreated=date_utils.get_naive_utc_now() - timedelta(days=2),
         )
         with pytest.raises(exceptions.CannotCancelConfirmedBooking) as exc:
             validation.check_beneficiary_can_cancel_booking(booking.user, booking)
@@ -443,8 +443,8 @@ class CheckBeneficiaryCanCancelBookingTest:
 
     def test_raise_if_event_too_close_and_booked_long_ago(self):
         booking = factories.BookingFactory(
-            stock__beginningDatetime=datetime.utcnow() + timedelta(days=1),
-            dateCreated=datetime.utcnow() - timedelta(days=2),
+            stock__beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=1),
+            dateCreated=date_utils.get_naive_utc_now() - timedelta(days=2),
         )
         with pytest.raises(exceptions.CannotCancelConfirmedBooking) as exc:
             validation.check_beneficiary_can_cancel_booking(booking.user, booking)

--- a/api/tests/core/educational/api/test_booking.py
+++ b/api/tests/core/educational/api/test_booking.py
@@ -11,6 +11,7 @@ import pcapi.core.finance.models as finance_models
 import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.testing import assert_num_queries
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import get_date_formatted_for_email
 from pcapi.utils.date import get_time_formatted_for_email
 from pcapi.utils.mailing import get_event_datetime
@@ -60,7 +61,7 @@ class CancelCollectiveBookingTest:
 class CancelExpiredCollectiveBookingsTest:
     def test_should_cancel_pending_dated_collective_booking_when_confirmation_limit_date_has_passed(self, app) -> None:
         # Given
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         yesterday = now - datetime.timedelta(days=1)
         expired_pending_collective_booking: educational_models.CollectiveBooking = (
             educational_factories.PendingCollectiveBookingFactory(confirmationLimitDate=yesterday)
@@ -72,7 +73,7 @@ class CancelExpiredCollectiveBookingsTest:
         # Then
         assert expired_pending_collective_booking.status == educational_models.CollectiveBookingStatus.CANCELLED
         assert expired_pending_collective_booking.cancellationDate.timestamp() == pytest.approx(
-            datetime.datetime.utcnow().timestamp(), rel=1
+            date_utils.get_naive_utc_now().timestamp(), rel=1
         )
         assert (
             expired_pending_collective_booking.cancellationReason
@@ -83,7 +84,7 @@ class CancelExpiredCollectiveBookingsTest:
         self, app
     ) -> None:
         # Given
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         yesterday = now - datetime.timedelta(days=1)
         confirmed_collective_booking: educational_models.CollectiveBooking = (
             educational_factories.CollectiveBookingFactory(confirmationLimitDate=yesterday)
@@ -99,7 +100,7 @@ class CancelExpiredCollectiveBookingsTest:
         self, app
     ) -> None:
         # Given
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         tomorrow = now + datetime.timedelta(days=1)
         pending_collective_booking: educational_models.CollectiveBooking = (
             educational_factories.PendingCollectiveBookingFactory(confirmationLimitDate=tomorrow)
@@ -113,7 +114,7 @@ class CancelExpiredCollectiveBookingsTest:
 
     def test_handle_expired_bookings_should_cancel_expired_collective_bookings(self, app) -> None:
         # Given
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         yesterday = now - datetime.timedelta(days=1)
         tomorrow = now + datetime.timedelta(days=1)
 
@@ -132,7 +133,7 @@ class CancelExpiredCollectiveBookingsTest:
         assert non_expired_pending_collective_booking.status == educational_models.CollectiveBookingStatus.PENDING
 
     def test_queries_performance_collective_bookings(self, app) -> None:
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         yesterday = now - datetime.timedelta(days=1)
         educational_factories.PendingCollectiveBookingFactory.create_batch(size=10, confirmationLimitDate=yesterday)
         n_queries = +1 + 4 * (1)  # select collective_booking ids  # update collective_booking

--- a/api/tests/core/educational/api/test_edit_collective_offer_stock.py
+++ b/api/tests/core/educational/api/test_edit_collective_offer_stock.py
@@ -14,14 +14,15 @@ from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.models import db
 from pcapi.routes.serialization import collective_stock_serialize
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
 class EditCollectiveOfferStocksTest:
     def test_should_update_all_fields_when_all_changed(self) -> None:
         # Given
-        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
-        initial_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        initial_event_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
+        initial_booking_limit_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
         educational_factories.EducationalYearFactory(
             beginningDate=initial_event_date - datetime.timedelta(days=100),
             expirationDate=initial_event_date + datetime.timedelta(days=100),
@@ -54,8 +55,8 @@ class EditCollectiveOfferStocksTest:
 
     def test_should_update_some_fields_and_keep_non_edited_ones(self) -> None:
         # Given
-        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
-        initial_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        initial_event_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
+        initial_booking_limit_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
         educational_factories.EducationalYearFactory(
             beginningDate=initial_event_date - datetime.timedelta(days=100),
             expirationDate=initial_event_date + datetime.timedelta(days=100),
@@ -85,8 +86,8 @@ class EditCollectiveOfferStocksTest:
 
     def test_should_replace_bookingLimitDatetime_with_new_event_datetime_if_provided_but_none(self) -> None:
         # Given
-        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
-        initial_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        initial_event_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
+        initial_booking_limit_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
         educational_factories.EducationalYearFactory(
             beginningDate=initial_event_date - datetime.timedelta(days=100),
             expirationDate=initial_event_date + datetime.timedelta(days=100),
@@ -114,8 +115,8 @@ class EditCollectiveOfferStocksTest:
         self,
     ) -> None:
         # Given
-        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
-        initial_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        initial_event_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
+        initial_booking_limit_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
         educational_factories.EducationalYearFactory(
             beginningDate=initial_event_date - datetime.timedelta(days=100),
             expirationDate=initial_event_date + datetime.timedelta(days=100),
@@ -169,14 +170,14 @@ class EditCollectiveOfferStocksTest:
         educational_year = educational_factories.EducationalYearFactory(
             beginningDate=datetime.datetime(2020, 9, 1), expirationDate=datetime.datetime(2021, 8, 31)
         )
-        initial_event_date = datetime.datetime.utcnow() + datetime.timedelta(days=20)
-        cancellation_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=5)
+        initial_event_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=20)
+        cancellation_limit_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
         stock_to_be_updated = educational_factories.CollectiveStockFactory(startDatetime=initial_event_date)
         booking = educational_factories.CollectiveBookingFactory(
             collectiveStock=stock_to_be_updated,
             status=CollectiveBookingStatus.PENDING,
             cancellationLimitDate=cancellation_limit_date,
-            confirmationLimitDate=datetime.datetime.utcnow() + datetime.timedelta(days=30),
+            confirmationLimitDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=30),
             educationalYear=educational_year,
         )
 
@@ -193,10 +194,10 @@ class EditCollectiveOfferStocksTest:
 
         # Then
         booking_updated = db.session.query(CollectiveBooking).filter_by(id=booking.id).one()
-        assert booking_updated.cancellationLimitDate == datetime.datetime.utcnow()
+        assert booking_updated.cancellationLimitDate == date_utils.get_naive_utc_now()
 
     def test_should_update_expired_booking(self) -> None:
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         limit = now - datetime.timedelta(days=2)
         stock = educational_factories.CollectiveStockFactory(
             startDatetime=now + datetime.timedelta(days=5), bookingLimitDatetime=limit

--- a/api/tests/core/educational/api/test_import_deposit_institution_deposit_data.py
+++ b/api/tests/core/educational/api/test_import_deposit_institution_deposit_data.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 from decimal import Decimal
 from tempfile import NamedTemporaryFile
@@ -10,6 +9,7 @@ from pcapi.core.educational import models as educational_models
 from pcapi.core.educational.api.institution import import_deposit_institution_csv
 from pcapi.core.educational.api.institution import import_deposit_institution_data
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -47,7 +47,7 @@ class ImportDepositInstitutionDataTest:
         assert institution.phoneNumber == "0600000000"
         assert institution.isActive is True
         assert deposit.amount == Decimal(1250)
-        assert deposit.dateCreated - datetime.utcnow() < timedelta(seconds=5)
+        assert deposit.dateCreated - date_utils.get_naive_utc_now() < timedelta(seconds=5)
         assert deposit.isFinal is False
         assert deposit.ministry == educational_models.Ministry.EDUCATION_NATIONALE
 
@@ -85,7 +85,7 @@ class ImportDepositInstitutionDataTest:
         assert institution.phoneNumber == "0600000000"
         assert institution.isActive is True
         assert deposit.amount == Decimal(1250)
-        assert deposit.dateCreated - datetime.utcnow() < timedelta(seconds=5)
+        assert deposit.dateCreated - date_utils.get_naive_utc_now() < timedelta(seconds=5)
         assert deposit.isFinal is False
         assert deposit.ministry == educational_models.Ministry.EDUCATION_NATIONALE
 
@@ -254,11 +254,11 @@ class ImportDepositInstitutionDataTest:
         assert new_institution.isActive is True
 
         assert deposit.amount == Decimal(1250)
-        assert deposit.dateCreated - datetime.utcnow() < timedelta(seconds=5)
+        assert deposit.dateCreated - date_utils.get_naive_utc_now() < timedelta(seconds=5)
         assert deposit.isFinal is False
         assert deposit.ministry == educational_models.Ministry.EDUCATION_NATIONALE
 
         assert deposit_new_uai.amount == Decimal(1500)
-        assert deposit_new_uai.dateCreated - datetime.utcnow() < timedelta(seconds=5)
+        assert deposit_new_uai.dateCreated - date_utils.get_naive_utc_now() < timedelta(seconds=5)
         assert deposit_new_uai.isFinal is False
         assert deposit_new_uai.ministry == educational_models.Ministry.EDUCATION_NATIONALE

--- a/api/tests/core/educational/api/test_institution.py
+++ b/api/tests/core/educational/api/test_institution.py
@@ -5,6 +5,7 @@ import time_machine
 
 import pcapi.core.educational.api.institution as api
 import pcapi.core.educational.factories as educational_factories
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -18,7 +19,7 @@ def freeze_fixture():
 
 @pytest.fixture(name="current_year_deposit")
 def current_year_deposit_fixture(freeze):
-    now = datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
 
     return educational_factories.EducationalDepositFactory(
         educationalYear__beginningDate=datetime(now.year, 9, 1),

--- a/api/tests/core/educational/api/test_move_collective_offer.py
+++ b/api/tests/core/educational/api/test_move_collective_offer.py
@@ -12,6 +12,7 @@ from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import api
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -26,12 +27,12 @@ def venues_with_same_pricing_point_fixture():
     offerers_factories.VenuePricingPointLinkFactory(
         venue=destination_venue,
         pricingPoint=pricing_point_venue,
-        timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+        timespan=[date_utils.get_naive_utc_now() - datetime.timedelta(days=1), None],
     )
     offerers_factories.VenuePricingPointLinkFactory(
         venue=venue,
         pricingPoint=pricing_point_venue,
-        timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+        timespan=[date_utils.get_naive_utc_now() - datetime.timedelta(days=1), None],
     )
     return venue, destination_venue
 
@@ -139,8 +140,8 @@ class MoveCollectiveOfferSuccessTest:
             venue=destination_venue,
             pricingPoint=destination_venue,
             timespan=[
-                datetime.datetime.utcnow() - datetime.timedelta(days=3),
-                datetime.datetime.utcnow() - datetime.timedelta(days=1),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             ],
         )
         assert collective_offer.venue.current_pricing_point_link is None
@@ -264,7 +265,7 @@ class MoveCollectiveOfferSuccessTest:
         """
         A collective offer on a venue without bank account can be moved to another venue with the bank account
         """
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         venue, destination_venue = venues_with_same_pricing_point
         bank_account = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
         offerers_factories.VenueBankAccountLinkFactory(
@@ -286,7 +287,7 @@ class MoveCollectiveOfferSuccessTest:
         """
         A collective offer on a venue with a bank account can be moved to another venue with the same bank account
         """
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         venue, destination_venue = venues_with_same_pricing_point
         bank_account = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
         offerers_factories.VenueBankAccountLinkFactory(
@@ -357,7 +358,7 @@ class MoveCollectiveOfferFailTest:
         offerers_factories.VenuePricingPointLinkFactory(
             venue=destination_venue,
             pricingPoint=destination_venue,
-            timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+            timespan=[date_utils.get_naive_utc_now() - datetime.timedelta(days=1), None],
         )
         assert collective_offer.venue.current_pricing_point_link is None
         assert destination_venue.current_pricing_point_link is not None
@@ -377,12 +378,12 @@ class MoveCollectiveOfferFailTest:
         offerers_factories.VenuePricingPointLinkFactory(
             venue=invalid_destination_venue,
             pricingPoint=pricing_point_venue_1,
-            timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+            timespan=[date_utils.get_naive_utc_now() - datetime.timedelta(days=1), None],
         )
         offerers_factories.VenuePricingPointLinkFactory(
             venue=venue,
             pricingPoint=pricing_point_venue_2,
-            timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+            timespan=[date_utils.get_naive_utc_now() - datetime.timedelta(days=1), None],
         )
         collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
         with pytest.raises(api.exceptions.NoDestinationVenue):
@@ -399,7 +400,7 @@ class MoveCollectiveOfferFailTest:
         offerers_factories.VenuePricingPointLinkFactory(
             venue=venue,
             pricingPoint=pricing_point_venue_1,
-            timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+            timespan=[date_utils.get_naive_utc_now() - datetime.timedelta(days=1), None],
         )
         collective_offer = educational_factories.CollectiveOfferFactory(venue=venue)
         with pytest.raises(api.exceptions.NoDestinationVenue):
@@ -409,7 +410,7 @@ class MoveCollectiveOfferFailTest:
         assert collective_offer.venue != invalid_destination_venue
 
     def test_move_collective_offer_with_different_banking_account(self, venues_with_same_pricing_point):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         venue, invalid_destination_venue = venues_with_same_pricing_point
         bank_account_1 = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
         bank_account_2 = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)

--- a/api/tests/core/educational/api/test_shared.py
+++ b/api/tests/core/educational/api/test_shared.py
@@ -6,12 +6,13 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models as educational_models
 from pcapi.core.educational.api import shared
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
 class SharedTest:
     def test_update_cancellation_limit_date_naive(self) -> None:
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         start = now + datetime.timedelta(days=35)
         stock = educational_factories.CollectiveStockFactory(startDatetime=start)
         booking = educational_factories.CollectiveBookingFactory(collectiveStock=stock)

--- a/api/tests/core/educational/api/test_synchronize_adage_ids_on_venues.py
+++ b/api/tests/core/educational/api/test_synchronize_adage_ids_on_venues.py
@@ -15,6 +15,7 @@ from pcapi.core.educational.schemas import AdageCulturalPartners
 from pcapi.core.history import models as history_models
 from pcapi.core.offerers.repository import get_emails_by_venue
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 BASE_DATA = {
@@ -56,9 +57,9 @@ def test_synchronize_adage_ids_on_venues(db_session):
     venue2 = offerers_factories.VenueFactory()
     venue3 = offerers_factories.VenueFactory()
     venue4 = offerers_factories.VenueFactory()
-    venue5 = offerers_factories.VenueFactory(adageId="11", adageInscriptionDate=datetime.utcnow())
-    venue6 = offerers_factories.VenueFactory(adageId="1252", adageInscriptionDate=datetime.utcnow())
-    venue7 = offerers_factories.VenueFactory(adageId="128033", adageInscriptionDate=datetime.utcnow())
+    venue5 = offerers_factories.VenueFactory(adageId="11", adageInscriptionDate=date_utils.get_naive_utc_now())
+    venue6 = offerers_factories.VenueFactory(adageId="1252", adageInscriptionDate=date_utils.get_naive_utc_now())
+    venue7 = offerers_factories.VenueFactory(adageId="128033", adageInscriptionDate=date_utils.get_naive_utc_now())
 
     adage_id1 = 128028
     adage_id2 = 128029
@@ -259,10 +260,10 @@ def test_synchronize_adage_ids_on_offerers(db_session):
     venue3 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
     venue4 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
     venue5 = offerers_factories.VenueFactory(
-        managingOfferer__allowedOnAdage=False, adageId="11", adageInscriptionDate=datetime.utcnow()
+        managingOfferer__allowedOnAdage=False, adageId="11", adageInscriptionDate=date_utils.get_naive_utc_now()
     )
     venue6 = offerers_factories.VenueFactory(
-        managingOfferer__allowedOnAdage=False, adageId="1252", adageInscriptionDate=datetime.utcnow()
+        managingOfferer__allowedOnAdage=False, adageId="1252", adageInscriptionDate=date_utils.get_naive_utc_now()
     )
     venue7 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
     venue8 = offerers_factories.VenueFactory(managingOfferer__allowedOnAdage=False)
@@ -402,7 +403,7 @@ def test_synchronize_adage_ids_on_offerers_soft_deleted_venue(db_session, initia
 @patch("pcapi.core.educational.api.adage.send_eac_offerer_activation_email")
 def test_synchronize_adage_ids_on_venues_with_date_filter(mock_send_eac_email, db_session):
     venue1 = offerers_factories.VenueFactory()
-    venue2 = offerers_factories.VenueFactory(adageId="11", adageInscriptionDate=datetime.utcnow())
+    venue2 = offerers_factories.VenueFactory(adageId="11", adageInscriptionDate=date_utils.get_naive_utc_now())
 
     adage_id1 = 128028
     adage_id2 = 128029

--- a/api/tests/core/educational/api/test_update_dms_status.py
+++ b/api/tests/core/educational/api/test_update_dms_status.py
@@ -10,6 +10,7 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational.api.dms import import_dms_applications
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 DEFAULT_API_RESULT = [
@@ -149,7 +150,7 @@ class UpdateDmsStatusTest:
         latest_import = dms_factories.LatestDmsImportFactory(
             procedureId=123,
             isProcessing=True,
-            latestImportDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+            latestImportDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
         )
 
         with patch("pcapi.connectors.dms.api.DMSGraphQLClient", return_value=mock):

--- a/api/tests/core/educational/test_api.py
+++ b/api/tests/core/educational/test_api.py
@@ -20,6 +20,7 @@ from pcapi.core.educational.api import stock as educational_api_stock
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.routes.serialization import collective_stock_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 
 
@@ -109,38 +110,38 @@ class UnindexExpiredOffersTest:
         # Given
         # Expired template offer
         collective_offer_template_1 = educational_factories.CollectiveOfferTemplateFactory(
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=9),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=9),
             dateRange=db_utils.make_timerange(
-                start=datetime.datetime.utcnow() - datetime.timedelta(days=7),
-                end=datetime.datetime.utcnow() - datetime.timedelta(days=3),
+                start=date_utils.get_naive_utc_now() - datetime.timedelta(days=7),
+                end=date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
             ),
         )
         # Non expired template offer
         educational_factories.CollectiveOfferTemplateFactory()
         # Expired template offer
         collective_offer_template_2 = educational_factories.CollectiveOfferTemplateFactory(
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=9),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=9),
             dateRange=db_utils.make_timerange(
-                start=datetime.datetime.utcnow() - datetime.timedelta(days=7),
-                end=datetime.datetime.utcnow() - datetime.timedelta(hours=1),
+                start=date_utils.get_naive_utc_now() - datetime.timedelta(days=7),
+                end=date_utils.get_naive_utc_now() - datetime.timedelta(hours=1),
             ),
         )
         # Archived template offer
         collective_offer_template_3 = educational_factories.CollectiveOfferTemplateFactory(
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=9),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=9),
             dateRange=db_utils.make_timerange(
-                start=datetime.datetime.utcnow() - datetime.timedelta(days=3),
-                end=datetime.datetime.utcnow() + datetime.timedelta(days=3),
+                start=date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
+                end=date_utils.get_naive_utc_now() + datetime.timedelta(days=3),
             ),
-            dateArchived=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            dateArchived=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             isActive=False,
         )
         # Non expired template offer with dateRange overlapping today
         educational_factories.CollectiveOfferTemplateFactory(
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=9),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=9),
             dateRange=db_utils.make_timerange(
-                start=datetime.datetime.utcnow() - datetime.timedelta(days=3),
-                end=datetime.datetime.utcnow() + datetime.timedelta(days=3),
+                start=date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
+                end=date_utils.get_naive_utc_now() + datetime.timedelta(days=3),
             ),
         )
         # When

--- a/api/tests/core/educational/test_integration.py
+++ b/api/tests/core/educational/test_integration.py
@@ -11,12 +11,13 @@ from pcapi.core.finance import factories as finance_factories
 from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
 class EducationalWorkflowTest:
     def test_collective_workflow(self, db_session):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         start_datetime = now + datetime.timedelta(days=1)
 
         venue = offerers_factories.VenueFactory(pricing_point="self")

--- a/api/tests/core/external/external_users_test.py
+++ b/api/tests/core/external/external_users_test.py
@@ -44,6 +44,7 @@ from pcapi.core.users.models import User
 from pcapi.core.users.models import UserRole
 from pcapi.models import db
 from pcapi.notifications.push import testing as batch_testing
+from pcapi.utils import date as date_utils
 
 
 MAX_BATCH_PARAMETER_SIZE = 30
@@ -143,17 +144,17 @@ def test_get_user_attributes_beneficiary_with_v1_deposit():
     FavoriteFactory(
         user=user,
         offer=OfferFactory(subcategoryId=subcategories.VISITE.id),
-        dateCreated=datetime.utcnow() - relativedelta(days=3),
+        dateCreated=date_utils.get_naive_utc_now() - relativedelta(days=3),
     )
     FavoriteFactory(
         user=user,
         offer=OfferFactory(subcategoryId=subcategories.LIVRE_PAPIER.id),
-        dateCreated=datetime.utcnow() - relativedelta(days=2),
+        dateCreated=date_utils.get_naive_utc_now() - relativedelta(days=2),
     )
     last_favorite = FavoriteFactory(
         user=user,
         offer=OfferFactory(subcategoryId=subcategories.LIVRE_PAPIER.id),
-        dateCreated=datetime.utcnow() - relativedelta(days=1),
+        dateCreated=date_utils.get_naive_utc_now() - relativedelta(days=1),
     )
 
     last_date_created = max(booking.dateCreated for booking in [b1, b2])
@@ -213,7 +214,7 @@ def test_get_user_attributes_beneficiary_with_v1_deposit():
 
 
 def test_get_user_attributes_ex_beneficiary_because_of_expiration():
-    with time_machine.travel(datetime.utcnow() - relativedelta(years=3, days=2)):
+    with time_machine.travel(date_utils.get_naive_utc_now() - relativedelta(years=3, days=2)):
         user = BeneficiaryFactory()
 
     with assert_no_duplicated_queries():
@@ -344,7 +345,7 @@ def test_get_user_attributes_beneficiary_because_of_credit():
 @pytest.mark.parametrize("credit_spent", [False, True])
 def test_get_user_attributes_underage_beneficiary_before_18(credit_spent: bool):
     # At 17 years old
-    with time_machine.travel(datetime.utcnow() - relativedelta(months=6)):
+    with time_machine.travel(date_utils.get_naive_utc_now() - relativedelta(months=6)):
         user = UnderageBeneficiaryFactory(subscription_age=17)
 
     if credit_spent:
@@ -364,9 +365,9 @@ def test_get_user_attributes_underage_beneficiary_before_18(credit_spent: bool):
 
 def test_get_user_attributes_ex_underage_beneficiary_who_did_not_claim_credit_18_yet():
     # At 17 years old
-    with time_machine.travel(datetime.utcnow() - relativedelta(years=1)):
+    with time_machine.travel(date_utils.get_naive_utc_now() - relativedelta(years=1)):
         user = UnderageBeneficiaryFactory(
-            subscription_age=17, deposit__expirationDate=datetime.utcnow() + relativedelta(years=1)
+            subscription_age=17, deposit__expirationDate=date_utils.get_naive_utc_now() + relativedelta(years=1)
         )
 
     # At 18 years old
@@ -382,9 +383,9 @@ def test_get_user_attributes_ex_underage_beneficiary_who_did_not_claim_credit_18
 
 def test_get_user_attributes_double_beneficiary():
     # At 17 years old
-    with time_machine.travel(datetime.utcnow() - relativedelta(years=1)):
+    with time_machine.travel(date_utils.get_naive_utc_now() - relativedelta(years=1)):
         user = UnderageBeneficiaryFactory(
-            subscription_age=17, deposit__expirationDate=datetime.utcnow() + relativedelta(years=1)
+            subscription_age=17, deposit__expirationDate=date_utils.get_naive_utc_now() + relativedelta(years=1)
         )
 
     # At 18 years old
@@ -406,7 +407,7 @@ def test_get_user_attributes_double_beneficiary():
 
 def test_get_user_attributes_not_beneficiary():
     user = UserFactory(
-        dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=3),
+        dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=3),
         firstName="Cou",
         lastName="Zin",
         city="Nice",

--- a/api/tests/core/external/sendinblue_test.py
+++ b/api/tests/core/external/sendinblue_test.py
@@ -19,6 +19,7 @@ from pcapi.core.external.sendinblue import format_user_attributes
 from pcapi.core.external.sendinblue import import_contacts_in_sendinblue
 from pcapi.core.external.sendinblue import make_update_request
 from pcapi.tasks.serialization import sendinblue_tasks
+from pcapi.utils import date as date_utils
 
 from . import common_pro_attributes
 from . import common_user_attributes
@@ -359,7 +360,7 @@ class BulkImportUsersDataTest:
         warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
 
         # 40 characters per email address
-        test_time = datetime.utcnow().strftime("%y%m%d.%H%M")
+        test_time = date_utils.get_naive_utc_now().strftime("%y%m%d.%H%M")
         thousands_emails = (f"test.{prefix}.{test_time}.{i:06d}@example.net" for i in range(1, count + 1))
 
         result = add_contacts_to_list(thousands_emails, SENDINBLUE_AUTOMATION_TEST_CONTACT_LIST_ID)
@@ -389,7 +390,7 @@ class BulkImportUsersDataTest:
         # Note that SENDINBLUE_API_KEY must be filled in settings.
         make_update_request(
             sendinblue_tasks.UpdateSendinblueContactRequest(
-                email=f"test.pro.{datetime.utcnow().strftime('%y%m%d.%H%M')}@example.net",
+                email=f"test.pro.{date_utils.get_naive_utc_now().strftime('%y%m%d.%H%M')}@example.net",
                 use_pro_subaccount=True,
                 attributes=format_user_attributes(common_pro_attributes),
                 contact_list_ids=None,
@@ -398,7 +399,7 @@ class BulkImportUsersDataTest:
         )
 
     def test_make_update_request(self):
-        email = f"test.pro.{datetime.utcnow().strftime('%y%m%d.%H%M')}@example.net"
+        email = f"test.pro.{date_utils.get_naive_utc_now().strftime('%y%m%d.%H%M')}@example.net"
         attributes = format_user_attributes(common_pro_attributes)
 
         make_update_request(

--- a/api/tests/core/external/venue_automations_test.py
+++ b/api/tests/core/external/venue_automations_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -12,13 +11,14 @@ import pcapi.core.offers.factories as offers_factories
 from pcapi import settings
 from pcapi.core.external.automations import venue as venue_automations
 from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
 class VenueAutomationsTest:
     def test_get_inactive_venues_emails(self):
-        date_92_days_ago = datetime.utcnow() - relativedelta(days=92)
-        date_70_days_ago = datetime.utcnow() - relativedelta(days=70)
+        date_92_days_ago = date_utils.get_naive_utc_now() - relativedelta(days=92)
+        date_70_days_ago = date_utils.get_naive_utc_now() - relativedelta(days=70)
 
         offerer_validated_92_days_ago = offerers_factories.OffererFactory(dateValidated=date_92_days_ago)
 
@@ -94,7 +94,9 @@ class VenueAutomationsTest:
 
     @patch("pcapi.core.external.sendinblue.brevo_python.api.contacts_api.ContactsApi.import_contacts")
     def test_pro_inactive_venues_automation(self, mock_import_contacts):
-        offerer = offerers_factories.OffererFactory(dateValidated=datetime.utcnow() - relativedelta(days=100))
+        offerer = offerers_factories.OffererFactory(
+            dateValidated=date_utils.get_naive_utc_now() - relativedelta(days=100)
+        )
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offers_factories.EventOfferFactory(venue=venue, validation=OfferValidationStatus.APPROVED)
 

--- a/api/tests/core/external_bookings/boost/test_client.py
+++ b/api/tests/core/external_bookings/boost/test_client.py
@@ -17,6 +17,7 @@ import pcapi.core.users.factories as users_factories
 from pcapi import settings
 from pcapi.core.external_bookings.boost import client as boost_client
 from pcapi.utils import date
+from pcapi.utils import date as date_utils
 
 from tests.local_providers.cinema_providers.boost import fixtures
 
@@ -148,7 +149,7 @@ class AuthenticatedGetTest:
         cinema_details = providers_factories.BoostCinemaDetailsFactory(
             cinemaUrl="https://cinema.example.com/",
             token="invalid-token",
-            tokenExpirationDate=datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            tokenExpirationDate=date_utils.get_naive_utc_now() + datetime.timedelta(hours=10),
         )
         cinema_str_id = cinema_details.cinemaProviderPivot.idAtProvider
         boost_api_client = boost_client.BoostClientAPI(cinema_str_id)
@@ -170,7 +171,7 @@ class AuthenticatedGetTest:
         assert get_adapter.last_request.headers["Authorization"] == "Bearer new-token"
         assert json_data == {"key": "value"}
         assert cinema_details.token == "new-token"
-        assert cinema_details.tokenExpirationDate == datetime.datetime.utcnow() + datetime.timedelta(hours=24)
+        assert cinema_details.tokenExpirationDate == date_utils.get_naive_utc_now() + datetime.timedelta(hours=24)
 
     def test_should_raise_if_error(self, requests_mock):
         cinema_details = providers_factories.BoostCinemaDetailsFactory(

--- a/api/tests/core/external_bookings/cds/test_client.py
+++ b/api/tests/core/external_bookings/cds/test_client.py
@@ -13,6 +13,7 @@ import pcapi.core.external_bookings.exceptions as external_bookings_exceptions
 import pcapi.core.users.factories as users_factories
 from pcapi.core.external_bookings.cds import serializers as cds_serializers
 from pcapi.core.external_bookings.cds.client import CineDigitalServiceAPI
+from pcapi.utils import date as date_utils
 
 
 def create_show_cds(
@@ -23,7 +24,7 @@ def create_show_cds(
     is_empty_seatmap: str | bool = False,
     remaining_place: int = 88,
     internet_remaining_place: int = 100,
-    showtime: datetime.datetime = datetime.datetime.utcnow(),
+    showtime: datetime.datetime = date_utils.get_naive_utc_now(),
     shows_tariff_pos_type_ids=(),
     screen_id: int = 50,
     media_id: int = 52,
@@ -795,7 +796,7 @@ class CineDigitalServiceGetVoucherForShowTest:
             is_empty_seatmap=True,
             remaining_place=88,
             internet_remaining_place=20,
-            showtime=datetime.datetime.utcnow(),
+            showtime=date_utils.get_naive_utc_now(),
             shows_tariff_pos_type_collection=[cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=5))],
             screen=cds_serializers.IdObjectCDS(id=1),
             media=cds_serializers.IdObjectCDS(id=52),
@@ -829,7 +830,7 @@ class CineDigitalServiceGetVoucherForShowTest:
             is_empty_seatmap=False,
             remaining_place=88,
             internet_remaining_place=20,
-            showtime=datetime.datetime.utcnow(),
+            showtime=date_utils.get_naive_utc_now(),
             shows_tariff_pos_type_collection=[
                 cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=3)),
                 cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=2)),

--- a/api/tests/core/finance/test_backends.py
+++ b/api/tests/core/finance/test_backends.py
@@ -16,6 +16,7 @@ from pcapi.core.finance.backend.dummy import bank_accounts as dummy_bank_account
 from pcapi.core.finance.backend.dummy import invoices as dummy_invoices
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.users.factories import BeneficiaryFactory
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 
 
@@ -693,7 +694,7 @@ class CegidFinanceBackendTest:
     @pytest.mark.usefixtures("mock_cegid_auth")
     def test_push_invoice(self, cegid_config, requests_mock):
         with time_machine.travel("2025-01-25", tick=False):
-            now = datetime.datetime.utcnow()
+            now = date_utils.get_naive_utc_now()
         offerer = offerers_factories.OffererFactory(name="Association de coiffeurs", siren="853318459")
         bank_account = finance_factories.BankAccountFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(
@@ -728,7 +729,7 @@ class CegidFinanceBackendTest:
         finance_event = finance_factories.FinanceEventFactory(
             bookingFinanceIncident=booking_finance_incident,
             booking=None,
-            valueDate=datetime.datetime.utcnow(),
+            valueDate=date_utils.get_naive_utc_now(),
             pricingPoint=venue,
             venue=venue,
         )
@@ -971,7 +972,7 @@ class CegidFinanceBackendTest:
     def test_push_debit_note(self, cegid_config, requests_mock):
         test_date = "2025-01-25"
         with time_machine.travel(test_date, tick=False):
-            now = datetime.datetime.utcnow()
+            now = date_utils.get_naive_utc_now()
         offerer = offerers_factories.OffererFactory(name="Association de coiffeurs", siren="853318459")
         bank_account = finance_factories.BankAccountFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(
@@ -1216,7 +1217,7 @@ class CegidFinanceBackendTest:
         iban_uuid = str(faker.uuid4())
         bic_uuid = str(faker.uuid4())
 
-        iso_now = f"{datetime.datetime.utcnow().isoformat()}+00"
+        iso_now = f"{date_utils.get_naive_utc_now().isoformat()}+00"
 
         response_data = {
             "APAccount": {"value": "467500"},
@@ -1352,7 +1353,7 @@ class CegidFinanceBackendTest:
         vendor_uuid = str(faker.uuid4())
         iban_uuid = str(faker.uuid4())
         bic_uuid = str(faker.uuid4())
-        iso_now = f"{datetime.datetime.utcnow().isoformat()}+00"
+        iso_now = f"{date_utils.get_naive_utc_now().isoformat()}+00"
 
         response_vendor_data = {
             "APAccount": {"value": "467500"},

--- a/api/tests/core/finance/test_commands.py
+++ b/api/tests/core/finance/test_commands.py
@@ -18,6 +18,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = [
@@ -119,7 +120,7 @@ def test_generate_cashflows_calls_generate_invoices(run_command):
     offerer = offerers_factories.OffererFactory()
     bank_account = finance_factories.BankAccountFactory(offerer=offerer)
     venue = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self", bank_account=bank_account)
-    past = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+    past = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
 
     with time_machine.travel(past):
         user = users_factories.BeneficiaryGrant18Factory()

--- a/api/tests/core/finance/test_commands_legacy.py
+++ b/api/tests/core/finance/test_commands_legacy.py
@@ -18,6 +18,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import human_ids
 
 
@@ -59,9 +60,9 @@ def test_generate_invoices_internal_notification(run_command, css_font_http_requ
 
 
 def test_when_there_is_a_debit_note_to_generate_on_total_incident(run_command, css_font_http_request_mock):
-    sixteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=16)
-    fifteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=15)
-    fourteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=14)
+    sixteen_days_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=16)
+    fifteen_days_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=15)
+    fourteen_days_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=14)
 
     user = users_factories.RichBeneficiaryFactory()
     venue_kwargs = {
@@ -124,12 +125,12 @@ def test_when_there_is_a_debit_note_to_generate_on_total_incident(run_command, c
         newTotalAmount=-previous_incident_booking.booking.total_amount * 100,
     )
     incident_event = finance_api._create_finance_events_from_incident(
-        booking_total_incident, datetime.datetime.utcnow()
+        booking_total_incident, date_utils.get_naive_utc_now()
     )
 
     finance_api.price_event(incident_event[0])
 
-    second_batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    second_batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
 
     run_command(
         "generate_invoices",
@@ -147,9 +148,9 @@ def test_when_there_is_a_debit_note_to_generate_on_total_incident(run_command, c
 
 
 def test_when_there_is_a_debit_note_to_generate_on_partial_incident(run_command, css_font_http_request_mock):
-    sixteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=16)
-    fifteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=15)
-    fourteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=14)
+    sixteen_days_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=16)
+    fifteen_days_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=15)
+    fourteen_days_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=14)
 
     user = users_factories.RichBeneficiaryFactory()
     venue_kwargs = {
@@ -212,13 +213,13 @@ def test_when_there_is_a_debit_note_to_generate_on_partial_incident(run_command,
         newTotalAmount=((previous_incident_booking.booking.total_amount * 100) / 2),
     )
     incident_events = finance_api._create_finance_events_from_incident(
-        booking_partial_incident, datetime.datetime.utcnow()
+        booking_partial_incident, date_utils.get_naive_utc_now()
     )
 
     for incident_event in incident_events:
         finance_api.price_event(incident_event)
 
-    second_batch = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    second_batch = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     run_command(
         "generate_invoices",
         "--batch-id",
@@ -269,7 +270,7 @@ def test_generate_invoice_file_with_debit_note(run_command, tmp_path, monkeypatc
     initial_finance_event = finance_events[0]
     finance_api.price_event(initial_finance_event)
 
-    cashflow_batch1 = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    cashflow_batch1 = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     run_command(
         "generate_invoices",
         "--batch-id",
@@ -366,7 +367,7 @@ def test_generate_invoice_file_with_debit_note(run_command, tmp_path, monkeypatc
     ####################################################################################################
     # Generate the cashflows and the invoice csv that should include both lines for income and outcome #
     ####################################################################################################
-    cashflow_batch2 = finance_api.generate_cashflows_and_payment_files(cutoff=datetime.datetime.utcnow())
+    cashflow_batch2 = finance_api.generate_cashflows_and_payment_files(cutoff=date_utils.get_naive_utc_now())
     run_command(
         "generate_invoices",
         "--batch-id",

--- a/api/tests/core/finance/test_ds.py
+++ b/api/tests/core/finance/test_ds.py
@@ -31,6 +31,7 @@ from pcapi.core.offerers.factories import VenueFactory
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 import tests.connector_creators.demarches_simplifiees_creators as dms_creators
 from tests.connector_creators import demarches_simplifiees_creators as ds_creators
@@ -68,7 +69,7 @@ class ImportDSBankAccountApplicationsTest:
         latest_import = ds_factories.LatestDmsImportFactory(
             procedureId=settings.DS_BANK_ACCOUNT_PROCEDURE_ID,
             isProcessing=True,
-            latestImportDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+            latestImportDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
         )
 
         import_ds_applications(settings.DS_BANK_ACCOUNT_PROCEDURE_ID, update_ds_applications_for_procedure)
@@ -128,8 +129,10 @@ class MarkWithoutApplicationTooOldApplicationsTest:
         application_id = random.randint(1, 100000)
         status = BankAccountApplicationStatus.DRAFT
         BankAccountFactory(dsApplicationId=application_id, status=status)
-        dead_line_application = (datetime.datetime.utcnow() - datetime.timedelta(days=91)).astimezone().isoformat()
-        dead_line_annotation = (datetime.datetime.utcnow() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        dead_line_application = (date_utils.get_naive_utc_now() - datetime.timedelta(days=91)).astimezone().isoformat()
+        dead_line_annotation = (
+            (date_utils.get_naive_utc_now() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        )
         application_meta_data = {
             "state": ds_models.GraphQLApplicationStates.draft.value,
             "last_modification_date": dead_line_application,
@@ -171,7 +174,7 @@ class MarkWithoutApplicationTooOldApplicationsTest:
         bank_account = db.session.query(BankAccount).filter_by(dsApplicationId=application_id).one()
         assert bank_account.status == BankAccountApplicationStatus.WITHOUT_CONTINUATION
         assert bank_account.statusHistory[0].timespan.lower.timestamp() == pytest.approx(
-            datetime.datetime.utcnow().timestamp()
+            date_utils.get_naive_utc_now().timestamp()
         )
 
     @patch("pcapi.connectors.dms.api.DMSGraphQLClient.archive_application")
@@ -183,8 +186,10 @@ class MarkWithoutApplicationTooOldApplicationsTest:
         application_id = random.randint(1, 100000)
         status = BankAccountApplicationStatus.ON_GOING
         BankAccountFactory(dsApplicationId=application_id, status=status)
-        dead_line_application = (datetime.datetime.utcnow() - datetime.timedelta(days=91)).astimezone().isoformat()
-        dead_line_annotation = (datetime.datetime.utcnow() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        dead_line_application = (date_utils.get_naive_utc_now() - datetime.timedelta(days=91)).astimezone().isoformat()
+        dead_line_annotation = (
+            (date_utils.get_naive_utc_now() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        )
         application_meta_data = {
             "state": ds_models.GraphQLApplicationStates.on_going.value,
             "last_modification_date": dead_line_application,
@@ -226,7 +231,7 @@ class MarkWithoutApplicationTooOldApplicationsTest:
         bank_account = db.session.query(BankAccount).filter_by(dsApplicationId=application_id).one()
         assert bank_account.status == BankAccountApplicationStatus.WITHOUT_CONTINUATION
         assert bank_account.statusHistory[0].timespan.lower.timestamp() == pytest.approx(
-            datetime.datetime.utcnow().timestamp()
+            date_utils.get_naive_utc_now().timestamp()
         )
 
     @patch("pcapi.connectors.dms.api.DMSGraphQLClient.archive_application")
@@ -239,8 +244,10 @@ class MarkWithoutApplicationTooOldApplicationsTest:
         application_id = random.randint(1, 100000)
         status = BankAccountApplicationStatus.DRAFT
         BankAccountFactory(dsApplicationId=application_id, status=status)
-        dead_line_application = (datetime.datetime.utcnow() - datetime.timedelta(days=91)).astimezone().isoformat()
-        dead_line_annotation = (datetime.datetime.utcnow() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        dead_line_application = (date_utils.get_naive_utc_now() - datetime.timedelta(days=91)).astimezone().isoformat()
+        dead_line_annotation = (
+            (date_utils.get_naive_utc_now() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        )
         application_meta_data = {
             "state": ds_models.GraphQLApplicationStates.draft.value,
             "last_modification_date": dead_line_application,
@@ -285,8 +292,10 @@ class MarkWithoutApplicationTooOldApplicationsTest:
         application_id = random.randint(1, 100000)
         status = BankAccountApplicationStatus.DRAFT
         BankAccountFactory(dsApplicationId=application_id, status=status)
-        dead_line_application = (datetime.datetime.utcnow() - datetime.timedelta(days=31)).astimezone().isoformat()
-        dead_line_annotation = (datetime.datetime.utcnow() - datetime.timedelta(days=2 * 31)).astimezone().isoformat()
+        dead_line_application = (date_utils.get_naive_utc_now() - datetime.timedelta(days=31)).astimezone().isoformat()
+        dead_line_annotation = (
+            (date_utils.get_naive_utc_now() - datetime.timedelta(days=2 * 31)).astimezone().isoformat()
+        )
         application_meta_data = {
             "state": ds_models.GraphQLApplicationStates.draft.value,
             "last_modification_date": dead_line_application,
@@ -331,8 +340,10 @@ class MarkWithoutApplicationTooOldApplicationsTest:
         application_id = random.randint(1, 100000)
         status = BankAccountApplicationStatus.DRAFT
         BankAccountFactory(dsApplicationId=application_id, status=status)
-        dead_line_application = (datetime.datetime.utcnow() - datetime.timedelta(days=29)).astimezone().isoformat()
-        dead_line_annotation = (datetime.datetime.utcnow() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        dead_line_application = (date_utils.get_naive_utc_now() - datetime.timedelta(days=29)).astimezone().isoformat()
+        dead_line_annotation = (
+            (date_utils.get_naive_utc_now() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        )
         application_meta_data = {
             "state": ds_models.GraphQLApplicationStates.draft.value,
             "last_modification_date": dead_line_application,
@@ -377,8 +388,10 @@ class MarkWithoutApplicationTooOldApplicationsTest:
         application_id = random.randint(1, 100000)
         status = BankAccountApplicationStatus.DRAFT
         BankAccountFactory(dsApplicationId=application_id, status=status)
-        dead_line_application = (datetime.datetime.utcnow() - datetime.timedelta(days=91)).astimezone().isoformat()
-        dead_line_annotation = (datetime.datetime.utcnow() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        dead_line_application = (date_utils.get_naive_utc_now() - datetime.timedelta(days=91)).astimezone().isoformat()
+        dead_line_annotation = (
+            (date_utils.get_naive_utc_now() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        )
         application_meta_data = {
             "state": ds_models.GraphQLApplicationStates.draft.value,
             "last_modification_date": dead_line_application,
@@ -424,16 +437,18 @@ class MarkWithoutApplicationTooOldApplicationsTest:
         status = BankAccountApplicationStatus.DRAFT
         bank_account = BankAccountFactory(dsApplicationId=application_id, status=status)
         status_history = BankAccountStatusHistoryFactory(
-            bankAccount=bank_account, status=status, timespan=(datetime.datetime.utcnow(),)
+            bankAccount=bank_account, status=status, timespan=(date_utils.get_naive_utc_now(),)
         )
         venue = VenueFactory(managingOfferer=bank_account.offerer)
         # This shouldn't happen but we need to be sure that if any venue is linked to a bank account
         # that is going to be marked without continuation, it's unlinked.
         # We don't want any Cashflow to be generated using non valid bank accounts
         VenueBankAccountLinkFactory(bankAccount=bank_account, venue=venue)
-        fields_application = (datetime.datetime.utcnow() - datetime.timedelta(days=91)).astimezone().isoformat()
-        dead_line_application = (datetime.datetime.utcnow() - datetime.timedelta(days=91)).astimezone().isoformat()
-        dead_line_annotation = (datetime.datetime.utcnow() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        fields_application = (date_utils.get_naive_utc_now() - datetime.timedelta(days=91)).astimezone().isoformat()
+        dead_line_application = (date_utils.get_naive_utc_now() - datetime.timedelta(days=91)).astimezone().isoformat()
+        dead_line_annotation = (
+            (date_utils.get_naive_utc_now() - datetime.timedelta(days=6 * 31)).astimezone().isoformat()
+        )
         application_meta_data = {
             "state": ds_models.GraphQLApplicationStates.draft.value,
             "last_modification_date": dead_line_application,

--- a/api/tests/core/finance/test_external.py
+++ b/api/tests/core/finance/test_external.py
@@ -1,4 +1,3 @@
-import datetime
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +10,7 @@ from pcapi.core.finance.backend.dummy import bank_accounts as dummy_bank_account
 from pcapi.core.finance.backend.dummy import invoices as dummy_invoices
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = [
@@ -29,7 +29,7 @@ class ExternalFinanceTest:
         bank_account = finance_factories.BankAccountFactory(offerer=offerer)
         assert bank_account.lastCegidSyncDate is None
 
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         with time_machine.travel(now, tick=False):
             external.push_bank_accounts(10)
         db.session.flush()

--- a/api/tests/core/finance/test_integration.py
+++ b/api/tests/core/finance/test_integration.py
@@ -12,6 +12,7 @@ from pcapi.core.finance import api
 from pcapi.core.finance import factories
 from pcapi.core.finance import models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = [
@@ -23,11 +24,11 @@ pytestmark = [
 def test_integration_full_workflow(css_font_http_request_mock):
     # A booking is manually marked as used. Check the whole workflow
     # until the invoice is generated.
-    initial_dt = datetime.datetime.utcnow()
+    initial_dt = date_utils.get_naive_utc_now()
     venue = offerers_factories.VenueFactory(pricing_point="self")
     bank_account = factories.BankAccountFactory(offerer=venue.managingOfferer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue, bankAccount=bank_account, timespan=(datetime.datetime.utcnow() - datetime.timedelta(days=10),)
+        venue=venue, bankAccount=bank_account, timespan=(date_utils.get_naive_utc_now() - datetime.timedelta(days=10),)
     )
     booking = bookings_factories.BookingFactory(stock__offer__venue=venue)
 
@@ -47,7 +48,7 @@ def test_integration_full_workflow(css_font_http_request_mock):
         assert pricing.booking == booking
         assert pricing.status == models.PricingStatus.VALIDATED
 
-    cutoff = datetime.datetime.utcnow()
+    cutoff = date_utils.get_naive_utc_now()
     batch = api.generate_cashflows_and_payment_files(cutoff)
     assert len(pricing.cashflows) == 1
     cashflow = pricing.cashflows[0]
@@ -67,7 +68,7 @@ def test_integration_full_workflow(css_font_http_request_mock):
 def test_integration_partial_auto_mark_as_used():
     # A booking is manually marked as used. Check only until the
     # generation of the pricing.
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     venue = offerers_factories.VenueFactory(pricing_point="self")
     bank_account = factories.BankAccountFactory(offerer=venue.managingOfferer)
     offerers_factories.VenueBankAccountLinkFactory(venue=venue, bankAccount=bank_account)
@@ -102,7 +103,7 @@ def test_integration_partial_auto_mark_as_used():
 
 def test_integration_partial_used_then_cancelled():
     # A booking is manually marked as used, then cancelled.
-    initial_dt = datetime.datetime.utcnow()
+    initial_dt = date_utils.get_naive_utc_now()
     venue = offerers_factories.VenueFactory(pricing_point="self")
     bank_account = factories.BankAccountFactory(offerer=venue.managingOfferer)
     offerers_factories.VenueBankAccountLinkFactory(venue=venue, bankAccount=bank_account)

--- a/api/tests/core/finance/test_models.py
+++ b/api/tests/core/finance/test_models.py
@@ -14,6 +14,7 @@ from pcapi.core.finance import factories
 from pcapi.core.finance import models
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 
 
@@ -198,14 +199,14 @@ class BankAccountRulesTest:
         factories.BankAccountStatusHistoryFactory(
             bankAccount=bank_account,
             status=models.BankAccountApplicationStatus.DRAFT,
-            timespan=(datetime.datetime.utcnow(),),
+            timespan=(date_utils.get_naive_utc_now(),),
         )
 
         with pytest.raises(sa_exc.IntegrityError):
             factories.BankAccountStatusHistoryFactory(
                 bankAccount=bank_account,
                 status=models.BankAccountApplicationStatus.ON_GOING,
-                timespan=(datetime.datetime.utcnow(),),
+                timespan=(date_utils.get_naive_utc_now(),),
             )
 
 

--- a/api/tests/core/finance/test_reimbursement.py
+++ b/api/tests/core/finance/test_reimbursement.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 from decimal import Decimal
 
@@ -14,13 +13,14 @@ import pcapi.core.users.factories as users_factories
 from pcapi.core.bookings.models import Booking
 from pcapi.core.categories import subcategories
 from pcapi.core.finance import reimbursement_rules
+from pcapi.utils import date as date_utils
 
 
 def create_non_digital_thing_booking(quantity=1, price=10, user=None, date_used=None, subcategory_id=None):
     booking_kwargs = {}
     if user:
         booking_kwargs["user"] = user
-    booking_kwargs["dateUsed"] = date_used or datetime.utcnow()
+    booking_kwargs["dateUsed"] = date_used or date_utils.get_naive_utc_now()
     offer_kwargs = {}
     if subcategory_id:
         offer_kwargs = {"subcategoryId": subcategory_id}
@@ -40,14 +40,16 @@ def create_digital_booking(quantity=1, price=10, user=None, subcategory_id=None)
         price=price,
         offer=offers_factories.DigitalOfferFactory(**subcategory_kwargs),
     )
-    return bookings_factories.UsedBookingFactory(user=user, stock=stock, quantity=quantity, dateUsed=datetime.utcnow())
+    return bookings_factories.UsedBookingFactory(
+        user=user, stock=stock, quantity=quantity, dateUsed=date_utils.get_naive_utc_now()
+    )
 
 
 def create_event_booking(quantity=1, price=10, user=None, date_used=None):
     booking_kwargs = {}
     if user:
         booking_kwargs["user"] = user
-    booking_kwargs["dateUsed"] = date_used or datetime.utcnow()
+    booking_kwargs["dateUsed"] = date_used or date_utils.get_naive_utc_now()
     user = user or users_factories.BeneficiaryGrant18Factory()
     stock = offers_factories.StockFactory(
         price=price,
@@ -308,47 +310,49 @@ class ReimbursementRuleIsActiveTest:
         def group(self):
             return None
 
-    booking = Booking(dateCreated=datetime.utcnow() + timedelta(days=365), dateUsed=datetime.utcnow())
+    booking = Booking(
+        dateCreated=date_utils.get_naive_utc_now() + timedelta(days=365), dateUsed=date_utils.get_naive_utc_now()
+    )
 
     def test_is_active_if_rule_has_no_start_nor_end(self):
         rule = self.DummyRule(None, None)
         assert rule.is_active(self.booking)
 
     def test_is_active_if_valid_since_yesterday_without_end_date(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         rule = self.DummyRule(valid_from=yesterday)
         assert rule.is_active(self.booking)
 
     def test_is_active_if_valid_since_yesterday_with_end_date(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        tomorrow = datetime.utcnow() + timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + timedelta(days=1)
         rule = self.DummyRule(valid_from=yesterday, valid_until=tomorrow)
         assert rule.is_active(self.booking)
 
     def test_is_not_active_if_not_yet_valid_without_end_date(self):
-        future = datetime.utcnow() + timedelta(weeks=3)
+        future = date_utils.get_naive_utc_now() + timedelta(weeks=3)
         rule = self.DummyRule(valid_from=future)
         assert not rule.is_active(self.booking)
 
     def test_is_not_active_if_not_yet_valid_with_end_date(self):
-        future = datetime.utcnow() + timedelta(weeks=3)
-        far_future = datetime.utcnow() + timedelta(weeks=5)
+        future = date_utils.get_naive_utc_now() + timedelta(weeks=3)
+        far_future = date_utils.get_naive_utc_now() + timedelta(weeks=5)
         rule = self.DummyRule(valid_from=future, valid_until=far_future)
         assert not rule.is_active(self.booking)
 
     def test_is_active_if_no_start_date_and_until_later(self):
-        future = datetime.utcnow() + timedelta(weeks=3)
+        future = date_utils.get_naive_utc_now() + timedelta(weeks=3)
         rule = self.DummyRule(valid_until=future)
         assert rule.is_active(self.booking)
 
     def test_is_not_active_if_rule_is_not_valid_anymore_with_no_start_date(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         rule = self.DummyRule(valid_until=yesterday)
         assert not rule.is_active(self.booking)
 
     def test_is_not_active_if_rule_is_not_valid_anymore_with_start_date(self):
-        a_month_ago = datetime.utcnow() - timedelta(days=30)
-        yesterday = datetime.utcnow() - timedelta(days=1)
+        a_month_ago = date_utils.get_naive_utc_now() - timedelta(days=30)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
         rule = self.DummyRule(valid_from=a_month_ago, valid_until=yesterday)
         assert not rule.is_active(self.booking)
 
@@ -356,8 +360,8 @@ class ReimbursementRuleIsActiveTest:
 @pytest.mark.usefixtures("db_session")
 class CustomRuleFinderTest:
     def test_offer_rule(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        far_in_the_past = datetime.utcnow() - timedelta(days=800)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
+        far_in_the_past = date_utils.get_naive_utc_now() - timedelta(days=800)
         booking = bookings_factories.UsedBookingFactory(stock__offer__venue__pricing_point="self")
         offer = booking.stock.offer
         old_booking = bookings_factories.UsedBookingFactory(stock=booking.stock, dateUsed=far_in_the_past)
@@ -369,8 +373,8 @@ class CustomRuleFinderTest:
         assert finder.get_rule(unrelated_booking) is None  # no rule for this bookings's offer
 
     def test_venue_rule(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        far_in_the_past = datetime.utcnow() - timedelta(days=800)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
+        far_in_the_past = date_utils.get_naive_utc_now() - timedelta(days=800)
         pricing_point = offerers_factories.VenueFactory(pricing_point="self")
         linked_venue = offerers_factories.VenueFactory(pricing_point=pricing_point)
 
@@ -387,8 +391,8 @@ class CustomRuleFinderTest:
         assert finder.get_rule(unrelated_booking) is None  # no rule for this bookings's venue
 
     def test_offerer_without_category_rule(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        far_in_the_past = datetime.utcnow() - timedelta(days=800)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
+        far_in_the_past = date_utils.get_naive_utc_now() - timedelta(days=800)
         booking = bookings_factories.UsedBookingFactory(stock__offer__venue__pricing_point="self")
         offerer = booking.offerer
         old_booking = bookings_factories.UsedBookingFactory(
@@ -403,8 +407,8 @@ class CustomRuleFinderTest:
         assert finder.get_rule(unrelated_booking) is None  # no rule for this bookings's offerer
 
     def test_offerer_with_category_rule(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        far_in_the_past = datetime.utcnow() - timedelta(days=800)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
+        far_in_the_past = date_utils.get_naive_utc_now() - timedelta(days=800)
         offerer_booking = bookings_factories.UsedBookingFactory(
             stock__offer__subcategoryId=subcategories.FESTIVAL_CINE.id, stock__offer__venue__pricing_point="self"
         )
@@ -432,8 +436,8 @@ class CustomRuleFinderTest:
         assert finder.get_rule(unrelated_booking) is None  # no rule for this bookings's offerer
 
     def test_rule_priorities(self):
-        yesterday = datetime.utcnow() - timedelta(days=1)
-        far_in_the_past = datetime.utcnow() - timedelta(days=800)
+        yesterday = date_utils.get_naive_utc_now() - timedelta(days=1)
+        far_in_the_past = date_utils.get_naive_utc_now() - timedelta(days=800)
         pricing_point = offerers_factories.VenueFactory(pricing_point="self")
         offerer = pricing_point.managingOfferer
         yesterday_booking = bookings_factories.UsedBookingFactory(stock__offer__venue=pricing_point)

--- a/api/tests/core/finance/test_repository.py
+++ b/api/tests/core/finance/test_repository.py
@@ -9,6 +9,7 @@ from pcapi.core.finance import factories
 from pcapi.core.finance import models
 from pcapi.core.finance import repository
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -178,21 +179,21 @@ class HasReimbursementTest:
 
 class HasActiveOrFutureCustomRemibursementRuleTest:
     def test_active_rule(self):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         timespan = (now - datetime.timedelta(days=1), now + datetime.timedelta(days=1))
         rule = factories.CustomReimbursementRuleFactory(timespan=timespan)
         offer = rule.offer
         assert repository.has_active_or_future_custom_reimbursement_rule(offer)
 
     def test_future_rule(self):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         timespan = (now + datetime.timedelta(days=1), None)
         rule = factories.CustomReimbursementRuleFactory(timespan=timespan)
         offer = rule.offer
         assert repository.has_active_or_future_custom_reimbursement_rule(offer)
 
     def test_past_rule(self):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         timespan = (now - datetime.timedelta(days=2), now - datetime.timedelta(days=1))
         rule = factories.CustomReimbursementRuleFactory(timespan=timespan)
         offer = rule.offer

--- a/api/tests/core/finance/test_validation.py
+++ b/api/tests/core/finance/test_validation.py
@@ -8,6 +8,7 @@ from pcapi.core.finance import factories
 from pcapi.core.finance import models
 from pcapi.core.finance import validation
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -15,7 +16,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 class CustomReimbursementRuleValidationTest:
     def _make_rule(self, **kwargs):
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         kwargs.setdefault("offererId", 1)
         kwargs.setdefault("rate", 0.8)
         kwargs.setdefault("subcategories", [])

--- a/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_cancellation_by_beneficiary_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -16,6 +15,7 @@ from pcapi.core.mails.transactional.sendinblue_template_ids import Transactional
 from pcapi.core.offers.factories import EventStockFactory
 from pcapi.core.offers.factories import ThingStockFactory
 from pcapi.core.users.factories import BeneficiaryGrant18Factory
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -54,7 +54,7 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
             user=BeneficiaryGrant18Factory(email="fabien@example.com", firstName="Fabien"),
             stock=ThingStockFactory(
                 price=10.20,
-                beginningDatetime=datetime.utcnow() - timedelta(days=1),
+                beginningDatetime=date_utils.get_naive_utc_now() - timedelta(days=1),
                 offer__name="Test thing name",
                 offer__id=123456,
             ),
@@ -85,7 +85,7 @@ class MakeBeneficiaryBookingCancellationEmailSendinblueDataTest:
             user=BeneficiaryGrant18Factory(email="fabien@example.com", firstName="Fabien"),
             stock=EventStockFactory(
                 price=10.20,
-                beginningDatetime=datetime.utcnow(),
+                beginningDatetime=date_utils.get_naive_utc_now(),
                 offer__name="Test event name",
                 offer__id=123456,
             ),

--- a/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_confirmation_to_beneficiary_test.py
@@ -20,6 +20,7 @@ from pcapi.core.mails.transactional.bookings.booking_confirmation_to_beneficiary
 )
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.offers.models import WithdrawalTypeEnum
+from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 
 
@@ -28,7 +29,9 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 @time_machine.travel("2032-10-15 12:48:00")
 def test_sendinblue_send_email():
-    booking = BookingFactory(stock=offers_factories.EventStockFactory(price=1.99), dateCreated=datetime.utcnow())
+    booking = BookingFactory(
+        stock=offers_factories.EventStockFactory(price=1.99), dateCreated=date_utils.get_naive_utc_now()
+    )
     send_individual_booking_confirmation_email_to_beneficiary(booking)
 
     assert len(mails_testing.outbox) == 1
@@ -84,7 +87,9 @@ def get_expected_base_sendinblue_email_data(booking, mediation, **overrides):
 
 @time_machine.travel("2032-10-15 12:48:00")
 def test_should_return_event_specific_data_for_email_when_offer_is_an_event_sendinblue():
-    booking = BookingFactory(stock=offers_factories.EventStockFactory(price=23.99), dateCreated=datetime.utcnow())
+    booking = BookingFactory(
+        stock=offers_factories.EventStockFactory(price=23.99), dateCreated=date_utils.get_naive_utc_now()
+    )
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
     email_data = get_booking_confirmation_to_beneficiary_email_data(booking)
 
@@ -95,7 +100,7 @@ def test_should_return_event_specific_data_for_email_when_offer_is_an_event_send
 @time_machine.travel("2032-10-15 12:48:00")
 def test_should_return_event_specific_data_for_email_when_offer_is_a_duo_event_sendinblue():
     booking = BookingFactory(
-        stock=offers_factories.EventStockFactory(price=23.99), dateCreated=datetime.utcnow(), quantity=2
+        stock=offers_factories.EventStockFactory(price=23.99), dateCreated=date_utils.get_naive_utc_now(), quantity=2
     )
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
 
@@ -119,7 +124,7 @@ def test_should_return_thing_specific_data_for_email_when_offer_is_a_thing_sendi
         offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
         offer__name="Super bien culturel",
     )
-    booking = BookingFactory(stock=stock, dateCreated=datetime.utcnow())
+    booking = BookingFactory(stock=stock, dateCreated=date_utils.get_naive_utc_now())
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
 
     email_data = get_booking_confirmation_to_beneficiary_email_data(booking)
@@ -146,7 +151,7 @@ def test_should_use_public_name_when_available_sendinblue():
     booking = BookingFactory(
         stock__offer__venue__name="LIBRAIRIE GENERALE UNIVERSITAIRE COLBERT",
         stock__offer__venue__publicName="Librairie Colbert",
-        dateCreated=datetime.utcnow(),
+        dateCreated=date_utils.get_naive_utc_now(),
     )
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
 
@@ -166,7 +171,7 @@ def test_should_return_withdrawal_details_when_available_sendinblue():
     withdrawal_details = "Conditions de retrait spécifiques."
     booking = BookingFactory(
         stock__offer__withdrawalDetails=withdrawal_details,
-        dateCreated=datetime.utcnow(),
+        dateCreated=date_utils.get_naive_utc_now(),
     )
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
 
@@ -184,7 +189,7 @@ def test_should_return_withdrawal_details_when_available_sendinblue():
 @time_machine.travel("2032-10-15 12:48:00")
 def test_should_return_offer_tags():
     booking = BookingFactory(
-        dateCreated=datetime.utcnow(),
+        dateCreated=date_utils.get_naive_utc_now(),
         stock__offer__criteria=[
             criteria_factories.CriterionFactory(name="Tagged_offer"),
         ],
@@ -209,7 +214,7 @@ def test_should_return_offer_features():
         price=23.99,
     )
     booking = BookingFactory(
-        dateCreated=datetime.utcnow(),
+        dateCreated=date_utils.get_naive_utc_now(),
         stock=stock,
     )
     mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
@@ -249,7 +254,7 @@ class DigitalOffersSendinblueTest:
             stock__offer__subcategoryId=subcategories.VOD.id,
             stock__offer__url="http://example.com",
             stock__offer__name="Super offre numérique",
-            dateCreated=datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
         )
         mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
 
@@ -325,7 +330,7 @@ class DigitalOffersSendinblueTest:
             stock__offer__subcategoryId=subcategories.VOD.id,
             stock__offer__url="http://example.com?token={token}&offerId={offerId}&email={email}",
             stock__offer__name="Super offre numérique",
-            dateCreated=datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
         )
         offers_factories.ActivationCodeFactory(stock=booking.stock, booking=booking, code="code_toto")
         mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
@@ -361,7 +366,7 @@ class DigitalOffersSendinblueTest:
             stock__offer__subcategoryId=subcategories.VOD.id,
             stock__offer__url="http://example.com",
             stock__offer__name="Super offre numérique",
-            dateCreated=datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
         )
         offers_factories.ActivationCodeFactory(
             stock=booking.stock,
@@ -422,7 +427,7 @@ class BooksBookingExpirationDateTestSendinblue:
         booking = BookingFactory(
             stock__offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
             stock__offer__name="Super livre",
-            dateCreated=datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
         )
         mediation = offers_factories.MediationFactory(offer=booking.stock.offer)
 
@@ -450,7 +455,7 @@ class BookingWithWithdrawalTypeTest:
         booking = BookingFactory(
             stock__offer__withdrawalType=withdrawal_type,
             stock__offer__withdrawalDelay=withdrawal_delay,
-            dateCreated=datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
         )
 
         mediation = offers_factories.MediationFactory(offer=booking.stock.offer)

--- a/api/tests/core/mails/transactional/bookings/booking_expiration_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_expiration_to_beneficiary_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -17,6 +16,7 @@ from pcapi.core.mails.transactional.bookings.booking_expiration_to_beneficiary i
 )
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.offers.factories import ProductFactory
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -63,7 +63,7 @@ class SendExpiredBookingsEmailToBeneficiarySendinblueTest:
         assert mails_testing.outbox[1]["params"]["WITHDRAWAL_PERIOD"] == 30
 
     def test_should_get_correct_data_when_expired_bookings_cancelled(self):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         amnesiac_user = users_factories.BeneficiaryGrant18Factory(email="dory@example.com", firstName="Dory")
         long_ago = now - timedelta(days=31)
         dvd = ProductFactory(name="Memento", subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id)

--- a/api/tests/core/mails/transactional/bookings/booking_soon_to_be_expired_to_beneficiary_test.py
+++ b/api/tests/core/mails/transactional/bookings/booking_soon_to_be_expired_to_beneficiary_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -15,6 +14,7 @@ from pcapi.core.mails.transactional.bookings.booking_soon_to_be_expired_to_benef
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.offers.factories import OfferFactory
 from pcapi.core.offers.factories import ProductFactory
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -57,7 +57,7 @@ class SendinblueSendSoonToBeExpiredBookingsEmailToBeneficiaryTest:
         self,
     ):
         # given
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         email = "isasimov@example.com"
         user = users_factories.BeneficiaryGrant18Factory(email=email)
         created_5_days_ago = now - timedelta(days=5)

--- a/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
+++ b/api/tests/core/mails/transactional/pro/offer_validation_to_pro_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -15,6 +14,7 @@ from pcapi.core.mails.transactional.pro.offer_validation_to_pro import send_offe
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.settings import PRO_URL
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -42,7 +42,7 @@ class SendinblueSendOfferValidationTest:
     @time_machine.travel("2032-10-15 12:48:00")
     def test_get_validation_approval_correct_email_metadata_when_future_offer(self):
         # Given
-        publication_date = datetime.utcnow() + timedelta(days=30)
+        publication_date = date_utils.get_naive_utc_now() + timedelta(days=30)
         offer = offers_factories.OfferFactory(
             name="Ma petite offre", venue__name="Mon stade", publicationDatetime=publication_date
         )

--- a/api/tests/core/mails/transactional/pro/pre_anonymization_test.py
+++ b/api/tests/core/mails/transactional/pro/pre_anonymization_test.py
@@ -1,4 +1,3 @@
-import datetime
 from dataclasses import asdict
 
 import pytest
@@ -8,6 +7,7 @@ import pcapi.core.mails.testing as mails_testing
 from pcapi.core.mails.transactional.pro import pre_anonymization
 from pcapi.core.mails.transactional.sendinblue_template_ids import TransactionalEmail
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class SendPreAnonymizationEmailToProTest:
     def test_send_mail(self):
         user_offerer = offerers_factories.DeletedUserOffererFactory(
-            user__lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=-30),
+            user__lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=-30),
         )
 
         pre_anonymization.send_pre_anonymization_email_to_pro(user_offerer.user)

--- a/api/tests/core/mails/transactional/users/online_event_reminder_test.py
+++ b/api/tests/core/mails/transactional/users/online_event_reminder_test.py
@@ -9,6 +9,7 @@ from pcapi.core.categories import subcategories
 from pcapi.core.mails.transactional.users import online_event_reminder
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import utc_datetime_to_department_timezone
 
 
@@ -17,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 
 class OnlineEventReminderTest:
     def setup_method(self):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         normalized_minute = 0 if now.minute < 30 else 30
 
         self.now = now.replace(minute=normalized_minute, second=0, microsecond=0)

--- a/api/tests/core/mails/transactional/users/suspicious_login_email_test.py
+++ b/api/tests/core/mails/transactional/users/suspicious_login_email_test.py
@@ -14,6 +14,7 @@ from pcapi.core.mails.transactional.users.suspicious_login_email import get_susp
 from pcapi.core.mails.transactional.users.suspicious_login_email import send_suspicious_login_email
 from pcapi.core.users import constants
 from pcapi.core.users.models import LoginDeviceHistory
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -32,7 +33,7 @@ class SendinblueSuspiciousLoginEmailTest:
     def setup_method(self):
         with mock.patch("flask.current_app.redis_client", self.mock_redis_client):
             self.user = users_factories.UserFactory()
-            current_time = datetime.utcnow()
+            current_time = date_utils.get_naive_utc_now()
             with time_machine.travel(current_time):
                 self.account_suspension_token = token_utils.Token.create(
                     token_utils.TokenType.SUSPENSION_SUSPICIOUS_LOGIN,

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -46,6 +46,7 @@ from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.routes.serialization import offerers_serialize
 from pcapi.routes.serialization import venues_serialize
+from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 
 import tests
@@ -309,8 +310,8 @@ class DeleteVenueTest:
             2,  # other venues
             pricingPoint=venue_to_delete,
             timespan=[
-                datetime.datetime.utcnow() - datetime.timedelta(days=10),
-                datetime.datetime.utcnow() - datetime.timedelta(days=5),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=5),
             ],
         )
 
@@ -325,14 +326,14 @@ class DeleteVenueTest:
             2,
             pricingPoint=venue_to_delete,
             timespan=[
-                datetime.datetime.utcnow() - datetime.timedelta(days=10),
-                datetime.datetime.utcnow() - datetime.timedelta(days=5),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=5),
             ],
         )
         finance_event = finance_factories.FinanceEventFactory(
             venue=links[1].venue,
             pricingPoint=venue_to_delete,
-            pricingOrderingDate=datetime.datetime.utcnow() - datetime.timedelta(days=7),
+            pricingOrderingDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=7),
         )
         finance_factories.PricingFactory(
             booking=finance_event.booking, pricingPoint=venue_to_delete, event=finance_event
@@ -544,16 +545,16 @@ class DeleteVenueTest:
         "timespan",
         [
             [
-                datetime.datetime.utcnow() - datetime.timedelta(days=150),
-                datetime.datetime.utcnow() - datetime.timedelta(days=50),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=150),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=50),
             ],
             [
-                datetime.datetime.utcnow() - datetime.timedelta(days=100),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=100),
                 None,
             ],
             [
-                datetime.datetime.utcnow() + datetime.timedelta(days=10),
-                datetime.datetime.utcnow() + datetime.timedelta(days=30),
+                date_utils.get_naive_utc_now() + datetime.timedelta(days=10),
+                date_utils.get_naive_utc_now() + datetime.timedelta(days=30),
             ],
         ],
     )
@@ -1398,16 +1399,16 @@ class DeleteOffererTest:
         "timespan",
         [
             [
-                datetime.datetime.utcnow() - datetime.timedelta(days=100),
-                datetime.datetime.utcnow() - datetime.timedelta(days=50),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=100),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=50),
             ],
             [
-                datetime.datetime.utcnow() - datetime.timedelta(days=100),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=100),
                 None,
             ],
             [
-                datetime.datetime.utcnow() + datetime.timedelta(days=10),
-                datetime.datetime.utcnow() + datetime.timedelta(days=30),
+                date_utils.get_naive_utc_now() + datetime.timedelta(days=10),
+                date_utils.get_naive_utc_now() + datetime.timedelta(days=30),
             ],
         ],
     )
@@ -1427,16 +1428,16 @@ class DeleteOffererTest:
         "timespan",
         [
             [
-                datetime.datetime.utcnow() - datetime.timedelta(days=100),
-                datetime.datetime.utcnow() - datetime.timedelta(days=50),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=100),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=50),
             ],
             [
-                datetime.datetime.utcnow() - datetime.timedelta(days=100),
-                datetime.datetime.utcnow() + datetime.timedelta(days=30),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=100),
+                date_utils.get_naive_utc_now() + datetime.timedelta(days=30),
             ],
             [
-                datetime.datetime.utcnow() + datetime.timedelta(days=10),
-                datetime.datetime.utcnow() + datetime.timedelta(days=30),
+                date_utils.get_naive_utc_now() + datetime.timedelta(days=10),
+                date_utils.get_naive_utc_now() + datetime.timedelta(days=30),
             ],
         ],
     )
@@ -2013,12 +2014,12 @@ class CloseOffererTest:
 
         confirmed_booking_2_days_ago = bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
-                offer__venue=venue, beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=2)
+                offer__venue=venue, beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
             )
         )
         confirmed_booking_in_2_days = bookings_factories.BookingFactory(
             stock=offers_factories.EventStockFactory(
-                offer__venue=venue, beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=2)
+                offer__venue=venue, beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=2)
             )
         )
 
@@ -2067,23 +2068,23 @@ class CloseOffererTest:
 
         pending_booking = educational_factories.PendingCollectiveBookingFactory(
             collectiveStock__collectiveOffer__venue=venue,
-            collectiveStock__startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=1),
-            collectiveStock__endDatetime=datetime.datetime.utcnow() + datetime.timedelta(hours=1),
+            collectiveStock__startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=1),
+            collectiveStock__endDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(hours=1),
         )
         confirmed_booking_ends_2_days_ago = educational_factories.ConfirmedCollectiveBookingFactory(
             collectiveStock__collectiveOffer__venue=venue,
-            collectiveStock__startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=2),
-            collectiveStock__endDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+            collectiveStock__startDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
+            collectiveStock__endDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
         )
         confirmed_booking_started_which_ends_in_2_days = educational_factories.ConfirmedCollectiveBookingFactory(
             collectiveStock__collectiveOffer__venue=venue,
-            collectiveStock__startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
-            collectiveStock__endDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=2),
+            collectiveStock__startDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
+            collectiveStock__endDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=2),
         )
         confirmed_booking_starts_in_4_days = educational_factories.ConfirmedCollectiveBookingFactory(
             collectiveStock__collectiveOffer__venue=venue,
-            collectiveStock__startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=4),
-            collectiveStock__endDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=6),
+            collectiveStock__startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=4),
+            collectiveStock__endDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=6),
         )
         used_booking = educational_factories.UsedCollectiveBookingFactory(collectiveStock__collectiveOffer__venue=venue)
         reimbursed_booking = educational_factories.ReimbursedCollectiveBookingFactory(
@@ -2162,7 +2163,7 @@ class AutoDeleteAttachmentsOnClosedOfferersTest:
         offerer = offerers_factories.ClosedOffererFactory()
         user_offerer = offerers_factories.UserOffererFactory(offerer=offerer)
         history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=88),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=88),
             actionType=history_models.ActionType.OFFERER_CLOSED,
             offerer=offerer,
         )
@@ -2177,12 +2178,12 @@ class AutoDeleteAttachmentsOnClosedOfferersTest:
         offerer = offerers_factories.OffererFactory()
         user_offerer = offerers_factories.UserOffererFactory(offerer=offerer)
         history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=95),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=95),
             actionType=history_models.ActionType.OFFERER_CLOSED,
             offerer=offerer,
         )
         history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=85),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=85),
             actionType=history_models.ActionType.OFFERER_VALIDATED,
             offerer=offerer,
         )
@@ -2200,17 +2201,17 @@ class AutoDeleteAttachmentsOnClosedOfferersTest:
         offerer = offerers_factories.ClosedOffererFactory()
         user_offerer = offerers_factories.UserOffererFactory(offerer=offerer)
         history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=100),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=100),
             actionType=history_models.ActionType.OFFERER_CLOSED,
             offerer=offerer,
         )
         history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=98),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=98),
             actionType=history_models.ActionType.OFFERER_VALIDATED,
             offerer=offerer,
         )
         history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=days),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=days),
             actionType=history_models.ActionType.OFFERER_CLOSED,
             offerer=offerer,
         )
@@ -2224,7 +2225,7 @@ class AutoDeleteAttachmentsOnClosedOfferersTest:
         user_offerer_list = offerers_factories.UserOffererFactory.create_batch(3, offerer=offerer)
         pending_user_offerer = offerers_factories.NewUserOffererFactory(offerer=offerer)
         history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=91),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=91),
             actionType=history_models.ActionType.OFFERER_CLOSED,
             offerer=offerer,
         )
@@ -2473,7 +2474,7 @@ class HasVenueAtLeastOneBookableOfferTest:
     def test_expired_event(self):
         venue = offerers_factories.VenueFactory(isPermanent=True)
 
-        one_week_ago = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+        one_week_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=7)
         offers_factories.EventStockFactory(beginningDatetime=one_week_ago, offer__venue=venue)
 
         assert not offerers_api.has_venue_at_least_one_bookable_offer(venue)
@@ -2486,7 +2487,7 @@ class HasVenueAtLeastOneBookableOfferTest:
         offers_factories.EventStockFactory(offer__venue=venue)
 
         # without the previous offer, the venue would not be eligible
-        one_week_ago = datetime.datetime.utcnow() - datetime.timedelta(days=7)
+        one_week_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=7)
         offers_factories.EventStockFactory(beginningDatetime=one_week_ago, offer__venue=venue)
 
         assert offerers_api.has_venue_at_least_one_bookable_offer(venue)
@@ -2500,7 +2501,7 @@ class GetOffererTotalRevenueTest:
         bookings_factories.UsedBookingFactory(
             stock__offer__venue__managingOfferer=offerer,
             stock__price=11.5,
-            dateUsed=datetime.datetime.utcnow() - datetime.timedelta(days=400),
+            dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(days=400),
         )
         bookings_factories.ReimbursedBookingFactory(
             stock__offer__venue__managingOfferer=offerer, stock__price=12, quantity=2
@@ -2517,7 +2518,7 @@ class GetOffererTotalRevenueTest:
         educational_factories.ReimbursedCollectiveBookingFactory(
             collectiveStock__collectiveOffer__venue__managingOfferer=offerer,
             collectiveStock__price=1555,
-            dateUsed=datetime.datetime.utcnow() - datetime.timedelta(days=500),
+            dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(days=500),
         )
         educational_factories.CancelledCollectiveBookingFactory(
             collectiveStock__collectiveOffer__venue__managingOfferer=offerer, collectiveStock__price=6000

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -18,6 +18,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.validation_status_mixin import ValidationStatus
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 
 
@@ -381,13 +382,13 @@ class VenueDmsAdageStatusTest:
     def test_dms_adage_status_when_multiple_dms_application(self):
         venue = factories.VenueFactory()
         educational_factories.CollectiveDmsApplicationFactory.create_batch(
-            2, venue=venue, lastChangeDate=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            2, venue=venue, lastChangeDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         )
         latest = educational_factories.CollectiveDmsApplicationFactory(
-            venue=venue, state="accepte", lastChangeDate=datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+            venue=venue, state="accepte", lastChangeDate=date_utils.get_naive_utc_now() - datetime.timedelta(hours=1)
         )
         educational_factories.CollectiveDmsApplicationFactory.create_batch(
-            2, venue=venue, lastChangeDate=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            2, venue=venue, lastChangeDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         )
 
         assert venue.dms_adage_status == latest.state
@@ -422,7 +423,7 @@ class CurrentPricingPointTest:
 
     def test_pricing_point(self):
         venue = factories.VenueWithoutSiretFactory()
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         factories.VenuePricingPointLinkFactory(
             venue=venue,
             pricingPoint=factories.VenueFactory(managingOfferer=venue.managingOfferer, name="former"),
@@ -463,7 +464,7 @@ class CurrentBankAccountTest:
 
     def test_bank_account_link(self):
         venue = factories.VenueWithoutSiretFactory()
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         factories.VenueBankAccountLinkFactory(
             venue=venue,
             bankAccount=finance_factories.BankAccountFactory(offererId=venue.managingOffererId, label="former"),

--- a/api/tests/core/offerers/test_repository.py
+++ b/api/tests/core/offerers/test_repository.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -13,6 +12,7 @@ from pcapi.core.offerers import repository
 from pcapi.core.offerers import schemas
 from pcapi.core.users import factories as users_factories
 from pcapi.models.offer_mixin import OfferStatus
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -169,7 +169,7 @@ class HasDigitalVenueWithAtLeastOneOfferTest:
 
 class HasNoOfferAndAtLeastOnePhysicalVenueAndCreatedSinceXDaysTest:
     def test_should_return_two_venues_of_offerer_without_offers_and_validated_5_days_ago(self):
-        five_days_ago = datetime.utcnow() - timedelta(days=5)
+        five_days_ago = date_utils.get_naive_utc_now() - timedelta(days=5)
         # Offerer with two physical venues and one offer => venues should not be returned
         offerer_with_two_venues = offerers_factories.OffererFactory(dateValidated=five_days_ago)
         venue_with_offers = offerers_factories.VenueFactory(managingOfferer=offerer_with_two_venues)

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -60,6 +60,7 @@ from pcapi.models.offer_mixin import OfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.notifications.push import testing as push_testing
+from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 from pcapi.utils.requests import ExternalAPIException
 from pcapi.utils.transaction_manager import atomic
@@ -269,7 +270,7 @@ class CreateStockTest:
     def test_does_not_allow_beginning_datetime_for_thing_offers(self):
         # Given
         offer = factories.ThingOfferFactory()
-        beginning_date = datetime.utcnow() + timedelta(days=4)
+        beginning_date = date_utils.get_naive_utc_now() + timedelta(days=4)
 
         # When
         with pytest.raises(api_errors.ApiErrors) as error:
@@ -298,7 +299,7 @@ class CreateStockTest:
                 quantity=None,
                 booking_limit_datetime=None,
                 activation_codes=["ABC", "DEF"],
-                activation_codes_expiration_datetime=datetime.utcnow(),
+                activation_codes_expiration_datetime=date_utils.get_naive_utc_now(),
             )
 
         # Then
@@ -340,7 +341,7 @@ class CreateStockTest:
     def test_does_not_allow_booking_limit_after_beginning_for_an_event_offer(self):
         # Given
         offer = factories.EventOfferFactory()
-        beginning_date = datetime.utcnow() + timedelta(days=4)
+        beginning_date = date_utils.get_naive_utc_now() + timedelta(days=4)
         booking_limit = beginning_date + timedelta(days=4)
 
         # When
@@ -417,9 +418,9 @@ class EditStockTest:
 
     def test_edit_beginning_datetime(self):
         # Given
-        previous_booking_limit = datetime.utcnow() + timedelta(days=4)
-        previous_beginning = datetime.utcnow() + timedelta(days=8)
-        new_beginning = datetime.utcnow() + timedelta(days=15)
+        previous_booking_limit = date_utils.get_naive_utc_now() + timedelta(days=4)
+        previous_beginning = date_utils.get_naive_utc_now() + timedelta(days=8)
+        new_beginning = date_utils.get_naive_utc_now() + timedelta(days=15)
         existing_stock = factories.EventStockFactory(
             price=10, quantity=7, beginningDatetime=previous_beginning, bookingLimitDatetime=previous_booking_limit
         )
@@ -443,9 +444,9 @@ class EditStockTest:
 
     def test_edit_event_without_beginning_update(self):
         # Given
-        previous_booking_limit = datetime.utcnow() + timedelta(days=4)
-        beginning = datetime.utcnow() + timedelta(days=8)
-        new_booking_limit = datetime.utcnow() + timedelta(days=6)
+        previous_booking_limit = date_utils.get_naive_utc_now() + timedelta(days=4)
+        beginning = date_utils.get_naive_utc_now() + timedelta(days=8)
+        new_booking_limit = date_utils.get_naive_utc_now() + timedelta(days=6)
         existing_stock = factories.EventStockFactory(
             price=10, quantity=7, beginningDatetime=beginning, bookingLimitDatetime=previous_booking_limit
         )
@@ -518,7 +519,7 @@ class EditStockTest:
     def test_does_not_allow_price_above_300_euros(self):
         # Given
         existing_stock = factories.EventStockFactory(price=10)
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
 
         # When
         with pytest.raises(api_errors.ApiErrors) as error:
@@ -645,7 +646,7 @@ class EditStockTest:
     def test_does_not_allow_beginning_datetime_for_thing_offers(self):
         # Given
         offer = factories.ThingOfferFactory()
-        beginning_date = datetime.utcnow() + timedelta(days=4)
+        beginning_date = date_utils.get_naive_utc_now() + timedelta(days=4)
         existing_stock = factories.StockFactory(offer=offer, price=10)
 
         # When
@@ -665,8 +666,8 @@ class EditStockTest:
 
     def test_validate_booking_limit_datetime_with_expiration_datetime(self):
         # Given
-        existing_stock = factories.StockFactory(bookingLimitDatetime=datetime.utcnow())
-        factories.ActivationCodeFactory(expirationDate=datetime.utcnow(), stock=existing_stock)
+        existing_stock = factories.StockFactory(bookingLimitDatetime=date_utils.get_naive_utc_now())
+        factories.ActivationCodeFactory(expirationDate=date_utils.get_naive_utc_now(), stock=existing_stock)
 
         # When
         with pytest.raises(api_errors.ApiErrors) as error:
@@ -695,12 +696,12 @@ class EditStockTest:
 
     def test_does_not_allow_booking_limit_after_beginning_for_an_event_offer(self):
         # Given
-        previous_booking_limit = datetime.utcnow()
-        previous_beginning = datetime.utcnow() + timedelta(days=1)
+        previous_booking_limit = date_utils.get_naive_utc_now()
+        previous_beginning = date_utils.get_naive_utc_now() + timedelta(days=1)
         existing_stock = factories.EventStockFactory(
             bookingLimitDatetime=previous_booking_limit, beginningDatetime=previous_beginning
         )
-        beginning_date = datetime.utcnow() + timedelta(days=4)
+        beginning_date = date_utils.get_naive_utc_now() + timedelta(days=4)
         booking_limit = beginning_date + timedelta(days=4)
 
         # When
@@ -719,7 +720,7 @@ class EditStockTest:
 
     def test_does_not_allow_edition_of_a_past_event_stock(self):
         # Given
-        date_in_the_past = datetime.utcnow() - timedelta(days=4)
+        date_in_the_past = date_utils.get_naive_utc_now() - timedelta(days=4)
         existing_stock = factories.EventStockFactory(price=10, beginningDatetime=date_in_the_past)
 
         # When
@@ -738,7 +739,7 @@ class EditStockTest:
         offer = factories.EventOfferFactory(
             lastProvider=providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
         )
-        date_in_the_future = datetime.utcnow() + timedelta(days=4)
+        date_in_the_future = date_utils.get_naive_utc_now() + timedelta(days=4)
         existing_stock = factories.StockFactory(offer=offer, price=10, beginningDatetime=date_in_the_future, quantity=2)
 
         # When
@@ -760,8 +761,8 @@ class EditStockTest:
         offer = factories.EventOfferFactory(
             lastProvider=providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
         )
-        date_in_the_future = datetime.utcnow() + timedelta(days=4)
-        other_date_in_the_future = datetime.utcnow() + timedelta(days=6)
+        date_in_the_future = date_utils.get_naive_utc_now() + timedelta(days=4)
+        other_date_in_the_future = date_utils.get_naive_utc_now() + timedelta(days=6)
         existing_stock = factories.StockFactory(offer=offer, price=10, beginningDatetime=date_in_the_future)
 
         # When
@@ -797,26 +798,32 @@ class EditStockTest:
     @time_machine.travel("2023-10-20 17:00:00", tick=False)
     def test_editing_beginning_datetime_edits_finance_event(self):
         # Given
-        new_beginning_datetime = datetime.utcnow() + timedelta(days=4)
+        new_beginning_datetime = date_utils.get_naive_utc_now() + timedelta(days=4)
 
         pricing_point = offerers_factories.VenueFactory()
         oldest_event = _generate_finance_event_context(
-            pricing_point, stock_date=datetime.utcnow() + timedelta(days=2), used_date=datetime.utcnow()
+            pricing_point,
+            stock_date=date_utils.get_naive_utc_now() + timedelta(days=2),
+            used_date=date_utils.get_naive_utc_now(),
         )
         older_event = _generate_finance_event_context(
-            pricing_point, stock_date=datetime.utcnow() + timedelta(days=6), used_date=datetime.utcnow()
+            pricing_point,
+            stock_date=date_utils.get_naive_utc_now() + timedelta(days=6),
+            used_date=date_utils.get_naive_utc_now(),
         )
         changing_event = _generate_finance_event_context(
-            pricing_point, datetime.utcnow() + timedelta(days=8), used_date=datetime.utcnow()
+            pricing_point, date_utils.get_naive_utc_now() + timedelta(days=8), used_date=date_utils.get_naive_utc_now()
         )
         newest_event = _generate_finance_event_context(
-            pricing_point, stock_date=datetime.utcnow() + timedelta(days=10), used_date=datetime.utcnow()
+            pricing_point,
+            stock_date=date_utils.get_naive_utc_now() + timedelta(days=10),
+            used_date=date_utils.get_naive_utc_now(),
         )
 
         unrelated_event = _generate_finance_event_context(
             offerers_factories.VenueFactory(),
-            stock_date=datetime.utcnow() + timedelta(days=8),
-            used_date=datetime.utcnow(),
+            stock_date=date_utils.get_naive_utc_now() + timedelta(days=8),
+            used_date=date_utils.get_naive_utc_now(),
         )
 
         # When
@@ -826,24 +833,24 @@ class EditStockTest:
         )
 
         # Then
-        assert oldest_event.pricingOrderingDate == datetime.utcnow() + timedelta(days=2)
+        assert oldest_event.pricingOrderingDate == date_utils.get_naive_utc_now() + timedelta(days=2)
         assert oldest_event.status == finance_models.FinanceEventStatus.PRICED
         assert len(oldest_event.pricings) == 1
 
-        assert older_event.pricingOrderingDate == datetime.utcnow() + timedelta(days=6)
+        assert older_event.pricingOrderingDate == date_utils.get_naive_utc_now() + timedelta(days=6)
         assert older_event.status == finance_models.FinanceEventStatus.READY
         assert len(older_event.pricings) == 0
 
-        assert changing_event.pricingOrderingDate == datetime.utcnow() + timedelta(days=4)
+        assert changing_event.pricingOrderingDate == date_utils.get_naive_utc_now() + timedelta(days=4)
         assert changing_event.status == finance_models.FinanceEventStatus.READY
         assert len(changing_event.pricings) == 1
         assert changing_event.pricings[0].status == finance_models.PricingStatus.CANCELLED
 
-        assert newest_event.pricingOrderingDate == datetime.utcnow() + timedelta(days=10)
+        assert newest_event.pricingOrderingDate == date_utils.get_naive_utc_now() + timedelta(days=10)
         assert newest_event.status == finance_models.FinanceEventStatus.READY
         assert len(newest_event.pricings) == 0
 
-        assert unrelated_event.pricingOrderingDate == datetime.utcnow() + timedelta(days=8)
+        assert unrelated_event.pricingOrderingDate == date_utils.get_naive_utc_now() + timedelta(days=8)
         assert unrelated_event.status == finance_models.FinanceEventStatus.PRICED
         assert len(unrelated_event.pricings) == 1
 
@@ -1074,7 +1081,7 @@ class DeleteStockTest:
         assert stock.isSoftDeleted
 
     def test_can_delete_if_event_ended_recently(self):
-        recently = datetime.utcnow() - timedelta(days=1)
+        recently = date_utils.get_naive_utc_now() - timedelta(days=1)
         stock = factories.EventStockFactory(beginningDatetime=recently)
 
         api.delete_stock(stock)
@@ -1082,7 +1089,7 @@ class DeleteStockTest:
         assert stock.isSoftDeleted
 
     def test_cannot_delete_if_too_late(self):
-        too_long_ago = datetime.utcnow() - timedelta(days=3)
+        too_long_ago = date_utils.get_naive_utc_now() - timedelta(days=3)
         stock = factories.EventStockFactory(beginningDatetime=too_long_ago)
 
         with pytest.raises(exceptions.OfferException):
@@ -2539,7 +2546,7 @@ class HeadlineOfferTest:
     def test_make_offer_headline_again(self, mocked_async_index_offer_ids):
         venue = offerers_factories.VenueFactory(venueTypeCode=VenueTypeCode.LIBRARY)
         offer = factories.OfferFactory(publicationDatetime=now_datetime_with_tz, venue=venue)
-        creation_time = datetime.utcnow()
+        creation_time = date_utils.get_naive_utc_now()
         finished_timespan = (creation_time, creation_time + timedelta(days=10))
         old_headline_offer = factories.HeadlineOfferFactory(offer=offer, timespan=finished_timespan)
 
@@ -2567,7 +2574,7 @@ class HeadlineOfferTest:
         factories.StockFactory(offer=offer_2)
         factories.MediationFactory(offer=offer_2)
 
-        ten_days_ago = datetime.utcnow() - timedelta(days=10)
+        ten_days_ago = date_utils.get_naive_utc_now() - timedelta(days=10)
         finished_timespan = (ten_days_ago, ten_days_ago + timedelta(days=1))
         old_headline_offer = factories.HeadlineOfferFactory(offer=offer_1, timespan=finished_timespan)
         new_headline_offer = api.make_offer_headline(offer=offer_2)
@@ -2747,7 +2754,7 @@ class HeadlineOfferTest:
     def test_do_not_update_upper_timespan_of_already_inactive_headline_offers(
         self, mocked_async_index_offer_ids, caplog
     ):
-        creation_time = datetime.utcnow() - timedelta(days=20)
+        creation_time = date_utils.get_naive_utc_now() - timedelta(days=20)
         finished_timespan = (creation_time, creation_time + timedelta(days=10))
         old_headline_offer = factories.HeadlineOfferFactory(timespan=finished_timespan)
 
@@ -2765,9 +2772,9 @@ class HeadlineOfferTest:
 
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_should_not_change_upper_timespan_of_already_deactivated_offers(self, mocked_async_index_offer_ids, caplog):
-        creation_time_1 = datetime.utcnow() - timedelta(days=3)
-        ending_time_1 = datetime.utcnow() - timedelta(days=2)
-        creation_time_2 = datetime.utcnow() - timedelta(days=1)
+        creation_time_1 = date_utils.get_naive_utc_now() - timedelta(days=3)
+        ending_time_1 = date_utils.get_naive_utc_now() - timedelta(days=2)
+        creation_time_2 = date_utils.get_naive_utc_now() - timedelta(days=1)
         finished_timespan = (creation_time_1, ending_time_1)
         unfinished_timespan = (creation_time_2, None)
         old_headline_offer = factories.HeadlineOfferFactory(timespan=finished_timespan)
@@ -2856,7 +2863,7 @@ class HeadlineOfferTest:
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_upsert_headline_offer_on_same_offer(self, mocked_async_index_offer_ids, caplog):
         offer = factories.OfferFactory(venue__venueTypeCode=VenueTypeCode.LIBRARY)
-        creation_time = datetime.utcnow() - timedelta(days=20)
+        creation_time = date_utils.get_naive_utc_now() - timedelta(days=20)
         finished_timespan = (creation_time, creation_time + timedelta(days=10))
         headline_offer = factories.HeadlineOfferFactory(offer=offer, timespan=finished_timespan)
         with caplog.at_level(logging.INFO):
@@ -3796,7 +3803,7 @@ class DeleteStocksTest:
     @time_machine.travel("2020-10-15 00:00:00")
     def test_delete_batch_stocks_filtered_by_date(self):
         # Given
-        beginning_datetime = datetime.utcnow()
+        beginning_datetime = date_utils.get_naive_utc_now()
         offer = factories.OfferFactory()
         stock_1 = factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime)
         stock_2 = factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime + timedelta(days=1))
@@ -3816,7 +3823,7 @@ class DeleteStocksTest:
     @time_machine.travel("2020-10-15 00:00:00")
     def test_delete_batch_stocks_filtered_by_time(self):
         # Given
-        beginning_datetime = datetime.utcnow()
+        beginning_datetime = date_utils.get_naive_utc_now()
         offer = factories.OfferFactory()
         stock_1 = factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime + timedelta(seconds=15))
         stock_2 = factories.EventStockFactory(offer=offer, beginningDatetime=beginning_datetime + timedelta(hours=1))
@@ -4067,7 +4074,7 @@ class GetStocksStatsTest:
     def test_get_stocks_stats(self):
         # Given
         offer = factories.OfferFactory()
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         factories.StockFactory(offer=offer, quantity=10, dnBookedQuantity=5, beginningDatetime=now)
         factories.StockFactory(offer=offer, quantity=20, dnBookedQuantity=5, beginningDatetime=now + timedelta(hours=1))
 
@@ -4108,7 +4115,7 @@ class GetStocksStatsTest:
     def test_get_stocks_stats_with_another_stock_has_unlimited_quantity(self):
         # Given
         offer = factories.OfferFactory()
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         factories.StockFactory(
             beginningDatetime=now + timedelta(hours=1),
             quantity=20,
@@ -4202,7 +4209,7 @@ class UpdateUsedStockPriceTest:
         later_booking = bookings_factories.UsedBookingFactory(
             stock__offer__venue=venue,
             stock__offer__subcategoryId=subcategories.CONFERENCE.id,
-            stock__beginningDatetime=datetime.utcnow() + timedelta(hours=2),
+            stock__beginningDatetime=date_utils.get_naive_utc_now() + timedelta(hours=2),
         )
         later_event = finance_factories.FinanceEventFactory(
             booking=later_booking,
@@ -4620,7 +4627,7 @@ class MoveOfferTest:
         offerers_factories.VenuePricingPointLinkFactory(
             venue=new_venue,
             pricingPoint=new_venue,
-            timespan=[datetime.utcnow() - timedelta(days=1), None],
+            timespan=[date_utils.get_naive_utc_now() - timedelta(days=1), None],
         )
         assert offer.venue.current_pricing_point is None
         assert new_venue.current_pricing_point is not None
@@ -4659,12 +4666,12 @@ class MoveOfferTest:
         offerers_factories.VenuePricingPointLinkFactory(
             venue=offer.venue,
             pricingPoint=offerers_factories.VenueFactory(managingOfferer=offer.venue.managingOfferer),
-            timespan=[datetime.utcnow() - timedelta(days=7), None],
+            timespan=[date_utils.get_naive_utc_now() - timedelta(days=7), None],
         )
         offerers_factories.VenuePricingPointLinkFactory(
             venue=new_venue,
             pricingPoint=offerers_factories.VenueFactory(managingOfferer=new_venue.managingOfferer),
-            timespan=[datetime.utcnow() - timedelta(days=7), None],
+            timespan=[date_utils.get_naive_utc_now() - timedelta(days=7), None],
         )
         assert offer.venue.current_pricing_point != new_venue.current_pricing_point
 
@@ -4721,7 +4728,7 @@ class MoveOfferTest:
         if state == OfferStatus.EXPIRED:
             offer = factories.EventOfferFactory(venue=venue)
             factories.EventStockFactory(
-                offer=offer, quantity=10, beginningDatetime=datetime.utcnow() - timedelta(days=30)
+                offer=offer, quantity=10, beginningDatetime=date_utils.get_naive_utc_now() - timedelta(days=30)
             )
         if state == bookings_models.BookingStatus.CONFIRMED:
             offer = factories.OfferFactory(venue=venue)
@@ -4807,10 +4814,12 @@ class MoveOfferTest:
         offer = factories.OfferFactory()
         new_venue = offerers_factories.VenueFactory(managingOfferer=offer.venue.managingOfferer)
         offerers_factories.VenuePricingPointLinkFactory(
-            venue=offer.venue, pricingPoint=new_venue, timespan=[datetime.utcnow() - timedelta(days=7), None]
+            venue=offer.venue,
+            pricingPoint=new_venue,
+            timespan=[date_utils.get_naive_utc_now() - timedelta(days=7), None],
         )
         offerers_factories.VenuePricingPointLinkFactory(
-            venue=new_venue, pricingPoint=new_venue, timespan=[datetime.utcnow() - timedelta(days=7), None]
+            venue=new_venue, pricingPoint=new_venue, timespan=[date_utils.get_naive_utc_now() - timedelta(days=7), None]
         )
         stock = factories.StockFactory(offer=offer, quantity=2)
         booking = bookings_factories.UsedBookingFactory(stock=stock)

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -24,6 +24,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
 from pcapi.models import offer_mixin
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import utc_datetime_to_department_timezone
 
 
@@ -528,8 +529,8 @@ class GetCappedOffersForFiltersTest:
                 description="expired_thing_offer_with_a_stock_expired_with_zero_remaining_quantity",
             )
 
-            five_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=5)
-            in_five_days = datetime.datetime.utcnow() + datetime.timedelta(days=5)
+            five_days_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=5)
+            in_five_days = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
             beneficiary = users_factories.BeneficiaryGrant18Factory(email="jane.doe@example.com")
             factories.ThingStockFactory(offer=self.sold_old_thing_offer_with_all_stocks_empty, quantity=0)
             factories.ThingStockFactory(
@@ -646,7 +647,7 @@ class GetCappedOffersForFiltersTest:
                 bookingLimitDatetime=five_days_ago,
                 quantity=0,
             )
-            in_six_days = datetime.datetime.utcnow() + datetime.timedelta(days=6)
+            in_six_days = date_utils.get_naive_utc_now() + datetime.timedelta(days=6)
             self.active_event_in_six_days_offer = factories.EventOfferFactory(venue=self.venue)
             factories.EventStockFactory(
                 offer=self.active_event_in_six_days_offer,
@@ -877,7 +878,7 @@ class GetCappedOffersForFiltersTest:
         @pytest.mark.usefixtures("db_session")
         def should_return_only_pending_offers_when_requesting_pending_status(self):
             # given
-            unexpired_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+            unexpired_booking_limit_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
 
             pending_offer = factories.ThingOfferFactory(
                 validation=offer_mixin.OfferStatus.PENDING.name, name="Offre en attente"
@@ -901,7 +902,7 @@ class GetCappedOffersForFiltersTest:
         @pytest.mark.usefixtures("db_session")
         def should_return_only_rejected_offers_when_requesting_rejected_status(self):
             # given
-            unexpired_booking_limit_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+            unexpired_booking_limit_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
 
             rejected_offer = factories.ThingOfferFactory(
                 validation=offer_mixin.OfferValidationStatus.REJECTED,
@@ -958,7 +959,7 @@ class GetCappedOffersForFiltersTest:
             # given
             self.init_test_data()
 
-            in_six_days = datetime.datetime.utcnow() + datetime.timedelta(days=6)
+            in_six_days = date_utils.get_naive_utc_now() + datetime.timedelta(days=6)
             in_six_days_beginning = in_six_days.replace(hour=0, minute=0, second=0)
             in_six_days_ending = in_six_days.replace(hour=23, minute=59, second=59)
 
@@ -984,7 +985,7 @@ class GetCappedOffersForFiltersTest:
 @pytest.mark.usefixtures("db_session")
 class GetOffersByPublicationDateTest:
     def test_get_offers_by_publication_date(self):
-        publication_date_target = datetime.datetime.utcnow().replace(
+        publication_date_target = date_utils.get_naive_utc_now().replace(
             minute=0, second=0, microsecond=0
         ) + datetime.timedelta(days=30)
 
@@ -1099,9 +1100,9 @@ class CheckStockConsistenceTest:
 @pytest.mark.usefixtures("db_session")
 class IncomingEventStocksTest:
     def setup_stocks(self):
-        today = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
-        next_week = datetime.datetime.utcnow() + datetime.timedelta(days=7)
+        today = date_utils.get_naive_utc_now() + datetime.timedelta(hours=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
+        next_week = date_utils.get_naive_utc_now() + datetime.timedelta(days=7)
 
         address_paris = geography_factories.AddressFactory()
         address_overseas = geography_factories.AddressFactory(postalCode="97180", departmentCode="971")
@@ -1224,7 +1225,7 @@ class IncomingEventStocksTest:
         self.setup_stocks()
 
         # add digital offer
-        today = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        today = date_utils.get_naive_utc_now() + datetime.timedelta(hours=1)
         offer = factories.OfferFactory(venue__departementCode="97", venue__postalCode="97180")
         digital_stock = factories.StockWithActivationCodesFactory(beginningDatetime=today, offer=offer)
         bookings_factories.BookingFactory(stock=digital_stock)
@@ -1300,7 +1301,7 @@ class AvailableActivationCodeTest:
         factories.ActivationCodeFactory(booking=booking, stock=stock)  # booked_code
         factories.ActivationCodeFactory(
             stock=stock,
-            expirationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            expirationDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         )  # expired code
 
         # WHEN THEN
@@ -1912,16 +1913,16 @@ class GetHeadlineOfferFiltersTest:
         factories.HeadlineOfferFactory(offer=active_offer)
 
         finished_timespan = (
-            datetime.datetime.utcnow() - datetime.timedelta(days=20),
-            datetime.datetime.utcnow() - datetime.timedelta(days=10),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=20),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
         )
         # alreeady inactive offer headline offer:
         factories.HeadlineOfferFactory(offer=active_offer, timespan=finished_timespan)
 
         another_active_offer = factories.OfferFactory(isActive=True)
         timespan_finishing_in_the_future = (
-            datetime.datetime.utcnow() - datetime.timedelta(days=3),
-            datetime.datetime.utcnow() + datetime.timedelta(days=3),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
+            date_utils.get_naive_utc_now() + datetime.timedelta(days=3),
         )
         # soon to be inactive offer headline offer:
         factories.HeadlineOfferFactory(offer=another_active_offer, timespan=timespan_finishing_in_the_future)
@@ -1943,16 +1944,16 @@ class GetHeadlineOfferFiltersTest:
         inactive_offer_headline_offer = factories.HeadlineOfferFactory(offer=inactive_offer)
 
         finished_timespan = (
-            datetime.datetime.utcnow() - datetime.timedelta(days=20),
-            datetime.datetime.utcnow() - datetime.timedelta(days=10),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=20),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
         )
         # already inactive headline offer
         factories.HeadlineOfferFactory(offer=inactive_offer, timespan=finished_timespan)
 
         another_inactive_offer = factories.OfferFactory(isActive=False)
         timespan_finishing_in_the_future = (
-            datetime.datetime.utcnow() - datetime.timedelta(days=3),
-            datetime.datetime.utcnow() + datetime.timedelta(days=3),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
+            date_utils.get_naive_utc_now() + datetime.timedelta(days=3),
         )
         headline_offer_finishing_in_the_future_but_offer_is_inactive = factories.HeadlineOfferFactory(
             offer=another_inactive_offer, timespan=timespan_finishing_in_the_future
@@ -1976,8 +1977,8 @@ class GetHeadlineOfferFiltersTest:
         headline_offer_without_mediation = factories.HeadlineOfferFactory(offer=offer, without_mediation=True)
 
         finished_timespan = (
-            datetime.datetime.utcnow() - datetime.timedelta(days=20),
-            datetime.datetime.utcnow() - datetime.timedelta(days=10),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=20),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
         )
         # already inactive headline offer without mediation
         factories.HeadlineOfferFactory(offer=offer, timespan=finished_timespan, without_mediation=True)

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -16,6 +16,7 @@ from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.offers.models import WithdrawalTypeEnum
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.models.api_errors import ApiErrors
+from pcapi.utils import date as date_utils
 
 import tests
 
@@ -251,7 +252,7 @@ class CheckRequiredDatesForStockTest:
         with pytest.raises(ApiErrors) as error:
             validation.check_required_dates_for_stock(
                 offer,
-                beginning=datetime.datetime.utcnow(),
+                beginning=date_utils.get_naive_utc_now(),
                 booking_limit_datetime=None,
             )
 
@@ -265,7 +266,7 @@ class CheckRequiredDatesForStockTest:
         validation.check_required_dates_for_stock(
             offer,
             beginning=None,
-            booking_limit_datetime=datetime.datetime.utcnow(),
+            booking_limit_datetime=date_utils.get_naive_utc_now(),
         )
 
     def test_thing_offer_ok_without_booking_limit_datetime(self):
@@ -284,7 +285,7 @@ class CheckRequiredDatesForStockTest:
             validation.check_required_dates_for_stock(
                 offer,
                 beginning=None,
-                booking_limit_datetime=datetime.datetime.utcnow(),
+                booking_limit_datetime=date_utils.get_naive_utc_now(),
             )
         assert error.value.errors["beginningDatetime"] == ["Ce paramètre est obligatoire"]
 
@@ -294,7 +295,7 @@ class CheckRequiredDatesForStockTest:
         with pytest.raises(ApiErrors) as error:
             validation.check_required_dates_for_stock(
                 offer,
-                beginning=datetime.datetime.utcnow(),
+                beginning=date_utils.get_naive_utc_now(),
                 booking_limit_datetime=None,
             )
         assert error.value.errors["bookingLimitDatetime"] == ["Ce paramètre est obligatoire"]
@@ -304,8 +305,8 @@ class CheckRequiredDatesForStockTest:
 
         validation.check_required_dates_for_stock(
             offer,
-            beginning=datetime.datetime.utcnow(),
-            booking_limit_datetime=datetime.datetime.utcnow(),
+            beginning=date_utils.get_naive_utc_now(),
+            booking_limit_datetime=date_utils.get_naive_utc_now(),
         )
 
 
@@ -337,13 +338,13 @@ class CheckStockIsDeletableTest:
         assert error.value.errors["global"] == ["Les offres refusées ne sont pas modifiables"]
 
     def test_recently_begun_event_stock(self):
-        recently = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        recently = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         stock = offers_factories.EventStockFactory(beginningDatetime=recently)
 
         validation.check_stock_is_deletable(stock)
 
     def test_long_begun_event_stock(self):
-        too_long_ago = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+        too_long_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=3)
         stock = offers_factories.EventStockFactory(beginningDatetime=too_long_ago)
 
         with pytest.raises(exceptions.OfferException) as error:
@@ -395,7 +396,7 @@ class CheckStockIsUpdatableTest:
         assert error.value.errors["global"] == ["Les offres importées ne sont pas modifiables"]
 
     def test_past_event_stock(self):
-        recently = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
+        recently = date_utils.get_naive_utc_now() - datetime.timedelta(minutes=1)
         stock = offers_factories.EventStockFactory(beginningDatetime=recently)
 
         with pytest.raises(ApiErrors) as error:
@@ -404,7 +405,7 @@ class CheckStockIsUpdatableTest:
         assert error.value.errors["global"] == ["Les évènements passés ne sont pas modifiables"]
 
     def test_past_event_draft_stock(self):
-        recently = datetime.datetime.utcnow() - datetime.timedelta(minutes=1)
+        recently = date_utils.get_naive_utc_now() - datetime.timedelta(minutes=1)
         stock = offers_factories.EventStockFactory(
             beginningDatetime=recently, offer__validation=OfferValidationStatus.DRAFT
         )
@@ -981,11 +982,11 @@ class CheckOfferIsBookableBeforeStockBookingLimitDatetimeTest:
 class CheckPublicationDateTest:
     def test_check_publication_date_should_raise(self):
         with pytest.raises(exceptions.OfferException):
-            validation.check_publication_date(datetime.datetime.utcnow() + datetime.timedelta(days=750))
+            validation.check_publication_date(date_utils.get_naive_utc_now() + datetime.timedelta(days=750))
 
     def test_check_publication_date_should_raise_not_raise(self):
         for i in [0, 15, 30, 45]:
-            publication_date = datetime.datetime.utcnow().replace(minute=0) + datetime.timedelta(hours=1, minutes=i)
+            publication_date = date_utils.get_naive_utc_now().replace(minute=0) + datetime.timedelta(hours=1, minutes=i)
             assert validation.check_publication_date(publication_date) is None
 
 

--- a/api/tests/core/operations/test_api.py
+++ b/api/tests/core/operations/test_api.py
@@ -10,6 +10,7 @@ from pcapi.core.operations import factories as operations_factories
 from pcapi.core.operations import models as operations_models
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -21,7 +22,7 @@ class CreateSpecialEventFromTypeformTest:
         return_value=typeform.TypeformForm(
             form_id="test",
             title="Mon questionnaire",
-            date_created=datetime.datetime.utcnow() - datetime.timedelta(days=3),
+            date_created=date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
             fields=[
                 typeform.TypeformQuestion(field_id="question1", title="Quel est ton prénom ?"),
                 typeform.TypeformQuestion(field_id="question2", title="Que penses-tu de ce test ?"),

--- a/api/tests/core/providers/test_repository.py
+++ b/api/tests/core/providers/test_repository.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -10,6 +9,7 @@ from pcapi.core.providers import factories
 from pcapi.core.providers import models
 from pcapi.core.providers import repository
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -131,7 +131,7 @@ class GetFutureEventsRequiringTicketingSystemTest:
             lastProvider=provider, venue=venue, withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP
         )
         # Old stock
-        one_day_ago = datetime.utcnow() - timedelta(days=1)
+        one_day_ago = date_utils.get_naive_utc_now() - timedelta(days=1)
         offers_factories.StockFactory(offer=event_offer, beginningDatetime=one_day_ago)
 
         future_events = repository.get_future_events_requiring_ticketing_system(provider)
@@ -169,7 +169,7 @@ class GetFutureEventsRequiringTicketingSystemTest:
         offers_factories.StockFactory(offer=expected_event_offer)
         offers_factories.StockFactory(offer=not_linked_to_ticketing_event_offer)
         offers_factories.StockFactory(offer=linked_to_other_venue_offer)
-        one_day_ago = datetime.utcnow() - timedelta(days=1)
+        one_day_ago = date_utils.get_naive_utc_now() - timedelta(days=1)
         offers_factories.StockFactory(offer=event_with_old_sock, beginningDatetime=one_day_ago)
 
         future_events = repository.get_future_events_requiring_ticketing_system(provider, venue)

--- a/api/tests/core/search/test_api.py
+++ b/api/tests/core/search/test_api.py
@@ -19,6 +19,7 @@ from pcapi.core.search import serialization
 from pcapi.core.search.models import IndexationReason
 from pcapi.core.testing import assert_no_duplicated_queries
 from pcapi.core.testing import assert_num_queries
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -37,8 +38,8 @@ def make_fully_featured_offer(venue: offerers_models.Venue | None = None) -> off
 
 
 def make_future_offer(venue: offerers_models.Venue | None = None) -> offers_models.Offer:
-    publication_date = datetime.datetime.utcnow() - datetime.timedelta(days=1)
-    booking_date = datetime.datetime.utcnow() + datetime.timedelta(days=30)
+    publication_date = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
+    booking_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=30)
     return offers_factories.StockFactory(
         offer__venue=venue or offerers_factories.VenueFactory(),
         offer__publicationDatetime=publication_date,
@@ -49,7 +50,7 @@ def make_future_offer(venue: offerers_models.Venue | None = None) -> offers_mode
 def make_booked_offer() -> offers_models.Offer:
     offer = make_bookable_offer()
     offers_factories.StockFactory(offer=offer)
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     ago_30_days = now - datetime.timedelta(days=30, hours=-1)
     ago_31_days = now - datetime.timedelta(days=30, hours=1)
     bookings = []
@@ -195,8 +196,8 @@ class ReindexOfferIdsTest:
         unbookable = make_unbookable_offer()
         bookable = make_fully_featured_offer()
         future_offer = make_future_offer()
-        past = datetime.datetime.utcnow() - datetime.timedelta(days=10)
-        future = datetime.datetime.utcnow() + datetime.timedelta(days=10)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(days=10)
+        future = date_utils.get_naive_utc_now() + datetime.timedelta(days=10)
         multi_dates_unbookable = offers_factories.EventStockFactory(beginningDatetime=past).offer
         multi_dates_bookable = offers_factories.EventStockFactory(beginningDatetime=past).offer
         offers_factories.EventStockFactory(offer=multi_dates_bookable, beginningDatetime=future)

--- a/api/tests/core/search/test_backend_algolia.py
+++ b/api/tests/core/search/test_backend_algolia.py
@@ -13,6 +13,7 @@ import pcapi.core.offers.factories as offers_factories
 from pcapi.core.search import redis_queues
 from pcapi.core.search import serialization
 from pcapi.core.search.backends import algolia
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -312,7 +313,7 @@ class ProcessingQueueTest:
         # processing queue has been deleted, too.
         assert redis.keys() == []
 
-    @time_machine.travel(datetime.datetime.utcnow(), tick=False)
+    @time_machine.travel(date_utils.get_naive_utc_now(), tick=False)
     def test_processing_queue_is_kept_upon_error(self):
         backend = get_backend()
         redis = backend.redis_client
@@ -326,7 +327,7 @@ class ProcessingQueueTest:
             pass
 
         assert redis.scard(queue) == 0
-        timestamp = datetime.datetime.utcnow().timestamp()
+        timestamp = date_utils.get_naive_utc_now().timestamp()
         processing_queue = f"{queue}:processing:{timestamp}"
         assert redis.smembers(processing_queue) == {"1", "2", "3"}
 
@@ -334,7 +335,7 @@ class ProcessingQueueTest:
         backend = get_backend()
         redis = backend.redis_client
         main_queue = redis_queues.REDIS_OFFER_IDS_NAME
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         timestamp_old_enough = (now - datetime.timedelta(hours=1)).timestamp()
         processing_old_enough = f"{main_queue}:processing:{timestamp_old_enough}"
         redis.sadd(processing_old_enough, "1", "2", "3")

--- a/api/tests/core/search/test_serialize_algolia.py
+++ b/api/tests/core/search/test_serialize_algolia.py
@@ -25,6 +25,7 @@ from pcapi.core.search import get_base_query_for_offer_indexation
 from pcapi.core.search import serialization
 from pcapi.core.search.backends import algolia
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 
 
@@ -414,7 +415,7 @@ def test_serialize_offer_forever_headline():
 
 @time_machine.travel("2025-01-01")
 def test_serialize_offer_temporarily_headline():
-    now = datetime.datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     headline_offer = offers_factories.HeadlineOfferFactory(timespan=(now, now + relativedelta(days=1)))
     serialized = algolia.AlgoliaBackend().serialize_offer(headline_offer.offer, 0)
     assert serialized["offer"]["isHeadline"] is True
@@ -580,7 +581,7 @@ def test_serialize_venue_with_one_bookable_offer():
 
 
 def test_serialize_future_offer():
-    publication_date = datetime.datetime.utcnow() - datetime.timedelta(days=5)
+    publication_date = date_utils.get_naive_utc_now() - datetime.timedelta(days=5)
     booking_allowed_dt = publication_date + datetime.timedelta(days=30)
     beginning_date = datetime.datetime(2032, 1, 4, 12, 15)
 

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -29,6 +29,7 @@ from pcapi.core.users import models as users_models
 from pcapi.core.users.constants import ELIGIBILITY_AGE_18
 from pcapi.core.users.constants import ELIGIBILITY_END_AGE
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 
 from tests.scripts.beneficiary import fixture
@@ -152,7 +153,7 @@ class HandleDmsApplicationTest:
             state=dms_models.GraphQLApplicationStates.accepted,
             email=user.email,
             birth_date=user.dateOfBirth,
-            construction_datetime=datetime.datetime.utcnow().isoformat(),
+            construction_datetime=date_utils.get_naive_utc_now().isoformat(),
         )
 
         dms_subscription_api.handle_dms_application(dms_response)
@@ -173,14 +174,14 @@ class HandleDmsApplicationTest:
 
     def test_handle_dms_application_updates_birth_info(self):
         user = users_factories.ProfileCompletedUserFactory(age=17)
-        seventeen_years_ago = datetime.datetime.utcnow() - relativedelta(years=17, months=1)
+        seventeen_years_ago = date_utils.get_naive_utc_now() - relativedelta(years=17, months=1)
         dms_response = make_parsed_graphql_application(
             application_number=1234,
             state=dms_models.GraphQLApplicationStates.accepted,
             email=user.email,
             birth_date=seventeen_years_ago,
             birth_place="Casablanca",
-            construction_datetime=datetime.datetime.utcnow().isoformat(),
+            construction_datetime=date_utils.get_naive_utc_now().isoformat(),
         )
 
         dms_subscription_api.handle_dms_application(dms_response)
@@ -525,7 +526,7 @@ class HandleDmsApplicationTest:
             application_number=1,
             state=dms_models.GraphQLApplicationStates.on_going,
             email=user.email,
-            birth_date=datetime.datetime.utcnow() - relativedelta(years=ELIGIBILITY_END_AGE, days=-6),
+            birth_date=date_utils.get_naive_utc_now() - relativedelta(years=ELIGIBILITY_END_AGE, days=-6),
             procedure_number=settings.DMS_ENROLLMENT_PROCEDURE_ID_FR,
         )
 
@@ -543,7 +544,7 @@ class HandleDmsApplicationTest:
             application_number=1,
             state=dms_models.GraphQLApplicationStates.on_going,
             email=user.email,
-            birth_date=datetime.datetime.utcnow() - relativedelta(years=ELIGIBILITY_END_AGE, days=-6),
+            birth_date=date_utils.get_naive_utc_now() - relativedelta(years=ELIGIBILITY_END_AGE, days=-6),
             procedure_number=settings.DMS_ENROLLMENT_PROCEDURE_ID_FR,
             application_labels=[{"id": settings.DMS_ENROLLMENT_FR_LABEL_ID_URGENT, "name": "Urgent"}],
         )
@@ -832,7 +833,7 @@ class DmsSubscriptionMessageTest:
             application_number=1,
             state=dms_models.GraphQLApplicationStates.draft,
             email=self.user_email,
-            birth_date=datetime.datetime.utcnow() - relativedelta(years=18),
+            birth_date=date_utils.get_naive_utc_now() - relativedelta(years=18),
         )
         fraud_check = dms_subscription_api.handle_dms_application(dms_response)
 
@@ -852,7 +853,7 @@ class DmsSubscriptionMessageTest:
             application_number=1,
             state=dms_models.GraphQLApplicationStates.draft,
             email=self.user_email,
-            birth_date=datetime.datetime.utcnow(),
+            birth_date=date_utils.get_naive_utc_now(),
         )
         fraud_check = dms_subscription_api.handle_dms_application(wrong_birth_date_application)
 
@@ -872,7 +873,7 @@ class DmsSubscriptionMessageTest:
             application_number=1,
             state=dms_models.GraphQLApplicationStates.draft,
             email=self.user_email,
-            birth_date=datetime.datetime.utcnow(),
+            birth_date=date_utils.get_naive_utc_now(),
             id_piece_number="r2d2",
         )
         fraud_check = dms_subscription_api.handle_dms_application(wrong_birth_date_application)
@@ -893,8 +894,8 @@ class DmsSubscriptionMessageTest:
             application_number=1,
             state=dms_models.GraphQLApplicationStates.on_going,
             email=self.user_email,
-            birth_date=datetime.datetime.utcnow() - relativedelta(years=20),
-            construction_datetime=datetime.datetime.utcnow(),
+            birth_date=date_utils.get_naive_utc_now() - relativedelta(years=20),
+            construction_datetime=date_utils.get_naive_utc_now(),
         )
         fraud_check = dms_subscription_api.handle_dms_application(not_eligible_application)
 
@@ -918,8 +919,8 @@ class DmsSubscriptionMessageTest:
             application_number=1,
             state=dms_models.GraphQLApplicationStates.accepted,
             email=self.user_email,
-            birth_date=datetime.datetime.utcnow() - relativedelta(years=20),
-            construction_datetime=datetime.datetime.utcnow(),
+            birth_date=date_utils.get_naive_utc_now() - relativedelta(years=20),
+            construction_datetime=date_utils.get_naive_utc_now(),
         )
         fraud_check = dms_subscription_api.handle_dms_application(not_eligible_application)
 
@@ -939,7 +940,7 @@ class DmsSubscriptionMessageTest:
             application_number=1,
             state=dms_models.GraphQLApplicationStates.accepted,
             email=self.user_email,
-            birth_date=datetime.datetime.utcnow() - relativedelta(years=18),
+            birth_date=date_utils.get_naive_utc_now() - relativedelta(years=18),
         )
         fraud_check = dms_subscription_api.handle_dms_application(application_ok)
 
@@ -952,7 +953,7 @@ class DmsSubscriptionMessageTest:
             application_number=1,
             state=dms_models.GraphQLApplicationStates.refused,
             email=self.user_email,
-            birth_date=datetime.datetime.utcnow() - relativedelta(years=18),
+            birth_date=date_utils.get_naive_utc_now() - relativedelta(years=18),
         )
         fraud_check = dms_subscription_api.handle_dms_application(refused_application)
 
@@ -974,7 +975,7 @@ class DmsSubscriptionMessageTest:
     def test_duplicate(self, mock_send_user_message):
         first_name = "Jean-Michel"
         last_name = "Doublon"
-        birth_date = datetime.datetime.utcnow() - relativedelta(years=18, days=1)
+        birth_date = date_utils.get_naive_utc_now() - relativedelta(years=18, days=1)
         users_factories.BeneficiaryGrant18Factory(
             firstName=first_name, lastName=last_name, dateOfBirth=birth_date, email="jean-michel@doublon.com"
         )
@@ -1143,7 +1144,7 @@ class ShouldImportDmsApplicationTest:
             application_techid="TECH_ID",
             state=dms_models.GraphQLApplicationStates.draft,
             email=self.user_email,
-            last_modification_date=datetime.datetime.utcnow(),
+            last_modification_date=date_utils.get_naive_utc_now(),
         )
         _process_dms_application_mock.reset_mock()
 
@@ -1311,7 +1312,7 @@ class RunIntegrationTest:
 
     @patch.object(api_dms.DMSGraphQLClient, "get_applications_with_details")
     def test_import_ex_underage_beneficiary(self, get_applications_with_details):
-        with time_machine.travel(datetime.datetime.utcnow() - relativedelta(years=2, month=1)):
+        with time_machine.travel(date_utils.get_naive_utc_now() - relativedelta(years=2, month=1)):
             user = users_factories.UnderageBeneficiaryFactory(
                 email="john.doe@example.com",
                 firstName="john",
@@ -1319,11 +1320,11 @@ class RunIntegrationTest:
                 dateOfBirth=AGE18_ELIGIBLE_BIRTH_DATE,
                 subscription_age=15,
                 phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-                deposit__expirationDate=datetime.datetime.utcnow() + relativedelta(years=2),
+                deposit__expirationDate=date_utils.get_naive_utc_now() + relativedelta(years=2),
             )
         subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
         details = fixture.make_parsed_graphql_application(application_number=123, state="accepte", email=user.email)
-        details.draft_date = datetime.datetime.utcnow().isoformat()
+        details.draft_date = date_utils.get_naive_utc_now().isoformat()
         get_applications_with_details.return_value = [details]
         dms_subscription_api.import_all_updated_dms_applications(6712558)
 
@@ -1384,7 +1385,7 @@ class RunIntegrationTest:
                 application_number=123,
                 state="accepte",
                 email=user.email,
-                construction_datetime=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
+                construction_datetime=date_utils.get_naive_utc_now().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
             )
         ]
         # when
@@ -1444,7 +1445,7 @@ class RunIntegrationTest:
                 state="accepte",
                 email=user.email,
                 birth_date=dms_validated_birth_date,
-                construction_datetime=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
+                construction_datetime=date_utils.get_naive_utc_now().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
             ),
         ]
 
@@ -1491,7 +1492,7 @@ class RunIntegrationTest:
 
     @patch.object(api_dms.DMSGraphQLClient, "get_applications_with_details")
     def test_import_makes_user_beneficiary_after_19_birthday(self, get_applications_with_details):
-        date_of_birth = (datetime.datetime.utcnow() - relativedelta(years=19)).strftime("%Y-%m-%dT%H:%M:%S")
+        date_of_birth = (date_utils.get_naive_utc_now() - relativedelta(years=19)).strftime("%Y-%m-%dT%H:%M:%S")
 
         # Create a user that has validated its email and phone number, meaning it
         # should become beneficiary.
@@ -1508,7 +1509,7 @@ class RunIntegrationTest:
                 state="accepte",
                 email=user.email,
                 # For the user to be automatically credited, the DMS application must be created before user's 19th birthday
-                construction_datetime=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
+                construction_datetime=date_utils.get_naive_utc_now().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
             )
         ]
         dms_subscription_api.import_all_updated_dms_applications(6712558)
@@ -1544,7 +1545,7 @@ class RunIntegrationTest:
                 state="accepte",
                 email=user.email,
                 birth_date=self.BENEFICIARY_BIRTH_DATE,
-                construction_datetime=datetime.datetime.utcnow().isoformat(),
+                construction_datetime=date_utils.get_naive_utc_now().isoformat(),
             )
         ]
         dms_subscription_api.import_all_updated_dms_applications(6712558)
@@ -1626,7 +1627,7 @@ class RunIntegrationTest:
                 application_number=123,
                 state="accepte",
                 email=user.email,
-                construction_datetime=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
+                construction_datetime=date_utils.get_naive_utc_now().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
             )
         ]
         dms_subscription_api.import_all_updated_dms_applications(6712558)
@@ -1742,7 +1743,7 @@ class RunIntegrationTest:
                 application_number=123,
                 state="accepte",
                 city="Strasbourg",
-                construction_datetime=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
+                construction_datetime=date_utils.get_naive_utc_now().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
             )
         ]
         dms_subscription_api.import_all_updated_dms_applications(6712558)
@@ -1796,7 +1797,7 @@ class GraphQLSourceProcessApplicationTest:
                 123,
                 "accepte",
                 email=user.email,
-                construction_datetime=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
+                construction_datetime=date_utils.get_naive_utc_now().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
             ),
         ]
 
@@ -1808,12 +1809,12 @@ class GraphQLSourceProcessApplicationTest:
     @patch.object(api_dms.DMSGraphQLClient, "get_applications_with_details")
     def test_process_accepted_application_user_registered_at_18_dms_at_19(self, get_applications_with_details):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=19, months=4),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=19, months=4),
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
         )
         subscription_factories.ProfileCompletionFraudCheckFactory(
             user=user,
-            dateCreated=datetime.datetime.utcnow() - relativedelta(years=1, months=2),
+            dateCreated=date_utils.get_naive_utc_now() - relativedelta(years=1, months=2),
             eligibilityType=users_models.EligibilityType.AGE18,
         )
 
@@ -1824,7 +1825,7 @@ class GraphQLSourceProcessApplicationTest:
                 email=user.email,
                 birth_date=user.dateOfBirth,
                 # For the user to be automatically credited, the DMS application must be created before user's 19th birthday
-                construction_datetime=(datetime.datetime.utcnow() - relativedelta(months=5)).strftime(
+                construction_datetime=(date_utils.get_naive_utc_now() - relativedelta(months=5)).strftime(
                     "%Y-%m-%dT%H:%M:%S+02:00"
                 ),
             ),
@@ -1838,12 +1839,12 @@ class GraphQLSourceProcessApplicationTest:
     @patch.object(api_dms.DMSGraphQLClient, "get_applications_with_details")
     def test_process_accepted_application_user_registered_at_18_dms_started_at_19(self, get_applications_with_details):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=19, days=1),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=19, days=1),
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
         )
         subscription_factories.ProfileCompletionFraudCheckFactory(
             user=user,
-            dateCreated=datetime.datetime.utcnow() - relativedelta(years=1),
+            dateCreated=date_utils.get_naive_utc_now() - relativedelta(years=1),
         )
 
         get_applications_with_details.return_value = [
@@ -1854,7 +1855,7 @@ class GraphQLSourceProcessApplicationTest:
                 birth_date=user.dateOfBirth,
                 # For the user to be automatically credited, the DMS application must be created before user's 19th birthday
                 # Here it's created after 19yo, so requires a manual review
-                construction_datetime=(datetime.datetime.utcnow()).strftime("%Y-%m-%dT%H:%M:%S+02:00"),
+                construction_datetime=(date_utils.get_naive_utc_now()).strftime("%Y-%m-%dT%H:%M:%S+02:00"),
             ),
         ]
 
@@ -1866,7 +1867,7 @@ class GraphQLSourceProcessApplicationTest:
     @patch.object(api_dms.DMSGraphQLClient, "get_applications_with_details")
     def test_process_accepted_application_user_not_eligible(self, get_applications_with_details):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=19, months=4),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=19, months=4),
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
         )
 
@@ -1876,7 +1877,7 @@ class GraphQLSourceProcessApplicationTest:
                 "accepte",
                 email=user.email,
                 birth_date=user.dateOfBirth,
-                construction_datetime=datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
+                construction_datetime=date_utils.get_naive_utc_now().strftime("%Y-%m-%dT%H:%M:%S+02:00"),
             ),
         ]
 

--- a/api/tests/core/subscription/dms/test_repository.py
+++ b/api/tests/core/subscription/dms/test_repository.py
@@ -1,10 +1,9 @@
-import datetime
-
 import pytest
 
 from pcapi.core.subscription import factories as subscription_factories
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription.dms import repository as dms_repository
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -18,7 +17,7 @@ class RepositoryUnitTest:
         dms_repository.create_orphan_dms_application(
             application_number=88,
             procedure_number=99,
-            latest_modification_datetime=datetime.datetime.utcnow(),
+            latest_modification_datetime=date_utils.get_naive_utc_now(),
             email="john.stiles@example.com",
         )
         assert dms_repository.get_orphan_dms_application_by_application_id(88) is not None

--- a/api/tests/core/subscription/test_factories.py
+++ b/api/tests/core/subscription/test_factories.py
@@ -17,6 +17,7 @@ import pcapi.core.subscription.models as subscription_models
 import pcapi.core.subscription.ubble.schemas as ubble_schemas
 from pcapi import settings
 from pcapi.connectors.serialization import ubble_serializers
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -142,12 +143,12 @@ class UbbleIdentificationDataAttributesFactory(factory.Factory):
 
     @factory.lazy_attribute
     def started_at(self):
-        return None if self.identification_state == IdentificationState.NEW else datetime.datetime.utcnow()
+        return None if self.identification_state == IdentificationState.NEW else date_utils.get_naive_utc_now()
 
     @factory.lazy_attribute
     def ended_at(self):
         return (
-            datetime.datetime.utcnow()
+            date_utils.get_naive_utc_now()
             if self.identification_state
             in (IdentificationState.VALID, IdentificationState.INVALID, IdentificationState.UNPROCESSABLE)
             else None
@@ -158,8 +159,8 @@ class UbbleIdentificationDataAttributesFactory(factory.Factory):
         return {
             IdentificationState.NEW: self.created_at,
             IdentificationState.INITIATED: self.started_at,
-            IdentificationState.ABORTED: datetime.datetime.utcnow(),
-            IdentificationState.PROCESSING: datetime.datetime.utcnow(),
+            IdentificationState.ABORTED: date_utils.get_naive_utc_now(),
+            IdentificationState.PROCESSING: date_utils.get_naive_utc_now(),
             IdentificationState.VALID: self.ended_at,
             IdentificationState.INVALID: self.ended_at,
             IdentificationState.UNPROCESSABLE: self.ended_at,
@@ -174,8 +175,8 @@ class UbbleIdentificationDataAttributesFactory(factory.Factory):
         return {
             IdentificationState.NEW: self.created_at,
             IdentificationState.INITIATED: self.started_at,
-            IdentificationState.ABORTED: datetime.datetime.utcnow(),
-            IdentificationState.PROCESSING: datetime.datetime.utcnow(),
+            IdentificationState.ABORTED: date_utils.get_naive_utc_now(),
+            IdentificationState.PROCESSING: date_utils.get_naive_utc_now(),
             IdentificationState.VALID: self.ended_at,
             IdentificationState.INVALID: self.ended_at,
             IdentificationState.UNPROCESSABLE: self.ended_at,

--- a/api/tests/core/subscription/test_repository.py
+++ b/api/tests/core/subscription/test_repository.py
@@ -9,6 +9,7 @@ import pcapi.core.subscription.models as subscription_models
 import pcapi.core.subscription.repository as subscription_repository
 import pcapi.core.users.factories as users_factories
 import pcapi.core.users.models as users_models
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -63,7 +64,7 @@ class GetRelevantFraudCheckTest:
     )
     def should_get_relevant_identity_fraud_check_when_same_eligibility(self, user_eligibility, fraud_check_type):
         age = 17 if user_eligibility == users_models.EligibilityType.UNDERAGE else 18
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=age))
+        user = users_factories.UserFactory(dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=age))
         fraud_check = subscription_factories.BeneficiaryFraudCheckFactory(
             user=user, eligibilityType=user_eligibility, type=fraud_check_type
         )
@@ -130,7 +131,7 @@ class GetRelevantFraudCheckTest:
             status=subscription_models.FraudCheckStatus.OK,
         )
 
-        year_when_user_is_eighteen = datetime.utcnow() + relativedelta(years=1)
+        year_when_user_is_eighteen = date_utils.get_naive_utc_now() + relativedelta(years=1)
         with time_machine.travel(year_when_user_is_eighteen):
             relevant_fraud_check = subscription_repository.get_relevant_identity_fraud_check(
                 user, users_models.EligibilityType.AGE18
@@ -181,7 +182,7 @@ class GetRelevantFraudCheckTest:
         self, user_eligibility, fraud_check_eligibility, fraud_check_type
     ):
         age = 17 if user_eligibility == users_models.EligibilityType.UNDERAGE else 18
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=age))
+        user = users_factories.UserFactory(dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=age))
         subscription_factories.BeneficiaryFraudCheckFactory(
             user=user, eligibilityType=fraud_check_eligibility, type=fraud_check_type
         )
@@ -189,7 +190,7 @@ class GetRelevantFraudCheckTest:
         assert subscription_repository.get_relevant_identity_fraud_check(user, user_eligibility) is None
 
     def should_get_ok_fraud_check_if_any(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=17))
+        user = users_factories.UserFactory(dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=17))
         fraud_check_ok = subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
             eligibilityType=users_models.EligibilityType.UNDERAGE,
@@ -207,7 +208,7 @@ class GetRelevantFraudCheckTest:
         )
 
     def should_get_pending_fraud_check_when_no_ok(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=17))
+        user = users_factories.UserFactory(dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=17))
         fraud_check_pending = subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
             eligibilityType=users_models.EligibilityType.UNDERAGE,
@@ -225,7 +226,7 @@ class GetRelevantFraudCheckTest:
         )
 
     def should_get_latest_ko_fraud_check_when_no_pending_or_ok(self):
-        user = users_factories.UserFactory(dateOfBirth=datetime.utcnow() - relativedelta(years=17))
+        user = users_factories.UserFactory(dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=17))
         subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
             eligibilityType=users_models.EligibilityType.UNDERAGE,

--- a/api/tests/core/subscription/ubble/end_to_end/test_subscription_via_ubble.py
+++ b/api/tests/core/subscription/ubble/end_to_end/test_subscription_via_ubble.py
@@ -19,6 +19,7 @@ from pcapi.core.subscription.ubble import schemas as ubble_schemas
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import DATE_ISO_FORMAT
 from pcapi.validation.routes import ubble as ubble_routes
 
@@ -35,7 +36,7 @@ IMAGES_DIR = pathlib.Path(tests.__path__[0]) / "files"
 @pytest.mark.usefixtures("db_session")
 class UbbleV2EndToEndTest:
     def test_beneficiary_activation_with_ubble_mocked_response(self, client, ubble_client):
-        seventeen_years_ago = datetime.datetime.utcnow() - relativedelta(years=17, months=1)
+        seventeen_years_ago = date_utils.get_naive_utc_now() - relativedelta(years=17, months=1)
         user = users_factories.UserFactory(
             dateOfBirth=seventeen_years_ago,
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -29,6 +29,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.notifications.push import trigger_events
+from pcapi.utils import date as date_utils
 from pcapi.utils import requests as requests_utils
 from pcapi.utils.date import DATE_ISO_FORMAT
 from pcapi.utils.string import u_nbsp
@@ -364,7 +365,9 @@ class UbbleWorkflowV2Test:
         )
         requests_mock.get(
             f"{settings.UBBLE_API_URL}/v2/identity-verifications/{fraud_check.thirdPartyId}",
-            json=build_ubble_identification_v2_response(age_at_registration=18, created_on=datetime.datetime.utcnow()),
+            json=build_ubble_identification_v2_response(
+                age_at_registration=18, created_on=date_utils.get_naive_utc_now()
+            ),
         )
 
         ubble_subscription_api.update_ubble_workflow(fraud_check)
@@ -374,7 +377,7 @@ class UbbleWorkflowV2Test:
         assert user.has_beneficiary_role is True
 
     def test_ubble_workflow_updates_birth_date(self, requests_mock):
-        sixteen_years_ago = datetime.datetime.utcnow() - relativedelta(years=16, months=1)
+        sixteen_years_ago = date_utils.get_naive_utc_now() - relativedelta(years=16, months=1)
         user = users_factories.UserFactory(dateOfBirth=sixteen_years_ago)
         fraud_check = BeneficiaryFraudCheckFactory(
             type=subscription_models.FraudCheckType.UBBLE,
@@ -397,7 +400,7 @@ class UbbleWorkflowV2Test:
 
     @pytest.mark.features(ENABLE_PHONE_VALIDATION=False)
     def test_ubble_workflow_updates_birth_date_on_eligibility_upgrade(self, requests_mock):
-        last_year = datetime.datetime.utcnow() - relativedelta(years=1)
+        last_year = date_utils.get_naive_utc_now() - relativedelta(years=1)
         with time_machine.travel(last_year):
             user = users_factories.BeneficiaryFactory(
                 age=17,
@@ -425,7 +428,7 @@ class UbbleWorkflowV2Test:
         assert user.has_beneficiary_role
 
     def test_ubble_workflow_with_eligibility_change_17_18(self, requests_mock):
-        seventeen_years_ago = datetime.datetime.utcnow() - relativedelta(years=17, months=1)
+        seventeen_years_ago = date_utils.get_naive_utc_now() - relativedelta(years=17, months=1)
         user = users_factories.UserFactory(dateOfBirth=seventeen_years_ago)
         fraud_check = BeneficiaryFraudCheckFactory(
             type=subscription_models.FraudCheckType.UBBLE,
@@ -456,7 +459,7 @@ class UbbleWorkflowV2Test:
         assert ok_fraud_check.thirdPartyId == original_third_party_id
 
     def test_ubble_workflow_with_eligibility_change_18_19(self, requests_mock):
-        eighteen_years_ago = datetime.datetime.utcnow() - relativedelta(years=18, months=1)
+        eighteen_years_ago = date_utils.get_naive_utc_now() - relativedelta(years=18, months=1)
         user = users_factories.UserFactory(dateOfBirth=eighteen_years_ago)
         fraud_check = BeneficiaryFraudCheckFactory(
             type=subscription_models.FraudCheckType.UBBLE,
@@ -470,7 +473,7 @@ class UbbleWorkflowV2Test:
         requests_mock.get(
             f"{settings.UBBLE_API_URL}/v2/identity-verifications/{fraud_check.thirdPartyId}",
             json=build_ubble_identification_v2_response(
-                birth_date=nineteen_years_ago, created_on=datetime.datetime.utcnow()
+                birth_date=nineteen_years_ago, created_on=date_utils.get_naive_utc_now()
             ),
         )
 
@@ -485,7 +488,7 @@ class UbbleWorkflowV2Test:
     def test_ubble_workflow_with_eligibility_change_with_first_attempt_at_18(self, requests_mock):
         nineteen_years_ago = datetime.date.today() - relativedelta(years=19, months=1)
         user = users_factories.UserFactory(dateOfBirth=nineteen_years_ago)
-        year_when_user_was_eighteen = datetime.datetime.utcnow() - relativedelta(years=1)
+        year_when_user_was_eighteen = date_utils.get_naive_utc_now() - relativedelta(years=1)
         BeneficiaryFraudCheckFactory(
             type=subscription_models.FraudCheckType.UBBLE,
             status=subscription_models.FraudCheckStatus.KO,
@@ -500,12 +503,12 @@ class UbbleWorkflowV2Test:
             user=user,
             thirdPartyId="idv_qwerty1234",
             eligibilityType=users_models.EligibilityType.AGE18,
-            dateCreated=datetime.datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
         )
         requests_mock.get(
             f"{settings.UBBLE_API_URL}/v2/identity-verifications/{fraud_check.thirdPartyId}",
             json=build_ubble_identification_v2_response(
-                age_at_registration=19, created_on=datetime.datetime.utcnow() - relativedelta(months=2)
+                age_at_registration=19, created_on=date_utils.get_naive_utc_now() - relativedelta(months=2)
             ),
         )
 
@@ -519,7 +522,7 @@ class UbbleWorkflowV2Test:
     def test_ubble_workflow_with_eligibility_change_at_21_with_first_attempt_at_18(self, requests_mock):
         twenty_one_years_ago = datetime.date.today() - relativedelta(years=21, months=1)
         user = users_factories.UserFactory(dateOfBirth=twenty_one_years_ago)
-        year_when_user_was_eighteen = datetime.datetime.utcnow() - relativedelta(years=3)
+        year_when_user_was_eighteen = date_utils.get_naive_utc_now() - relativedelta(years=3)
         BeneficiaryFraudCheckFactory(
             type=subscription_models.FraudCheckType.UBBLE,
             status=subscription_models.FraudCheckStatus.KO,
@@ -534,7 +537,7 @@ class UbbleWorkflowV2Test:
             user=user,
             thirdPartyId="idv_qwerty1234",
             eligibilityType=users_models.EligibilityType.AGE18,
-            dateCreated=datetime.datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
         )
         requests_mock.get(
             f"{settings.UBBLE_API_URL}/v2/identity-verifications/{fraud_check.thirdPartyId}",
@@ -634,7 +637,7 @@ class UbbleWorkflowV1Test:
         ubble_mocker,
     ):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
         )
         ProfileCompletionFraudCheckFactory(user=user)
@@ -782,7 +785,7 @@ class UbbleWorkflowV1Test:
         assert user.validatedBirthDate == document_birth_date.date()
 
     def test_ubble_workflow_updates_user_birth_date_when_already_beneficiary(self, ubble_mocker):
-        with time_machine.travel(datetime.datetime.utcnow() - relativedelta(years=1)):
+        with time_machine.travel(date_utils.get_naive_utc_now() - relativedelta(years=1)):
             user = users_factories.BeneficiaryFactory(
                 age=17,
                 beneficiaryFraudChecks__type=subscription_models.FraudCheckType.EDUCONNECT,

--- a/api/tests/core/token/test_token.py
+++ b/api/tests/core/token/test_token.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import logging
 import uuid
-from datetime import datetime
 from datetime import timedelta
 from unittest import mock
 
@@ -17,6 +16,7 @@ from pcapi import settings
 from pcapi.core import token as token_tools
 from pcapi.core.users.exceptions import InvalidToken
 from pcapi.core.users.utils import encode_jwt_payload
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -36,7 +36,7 @@ class TokenTest:
         assert token.type_ == self.token_type
         assert token.encoded_token is not None
         assert token_tools.Token.get_expiration_date(self.token_type, self.user_id).isoformat(timespec="hours") == (
-            datetime.utcnow() + self.ttl
+            date_utils.get_naive_utc_now() + self.ttl
         ).isoformat(timespec="hours")
 
     def test_create_token_with_no_data_no_ttl(self):
@@ -62,7 +62,7 @@ class TokenTest:
         assert token.type_ == old_token.type_
         assert token.encoded_token == old_token.encoded_token
         assert token_tools.Token.get_expiration_date(self.token_type, self.user_id).isoformat(timespec="hours") == (
-            datetime.utcnow() + self.ttl
+            date_utils.get_naive_utc_now() + self.ttl
         ).isoformat(timespec="hours")
 
     def test_get_expiration_date_used_token(self):
@@ -245,7 +245,7 @@ class AsymetricTokenTest:
         assert token_tools.AsymetricToken.get_expiration_date(
             self.token_type,
             token.key_suffix,
-        ).isoformat(timespec="hours") == (datetime.utcnow() + self.ttl).isoformat(timespec="hours")
+        ).isoformat(timespec="hours") == (date_utils.get_naive_utc_now() + self.ttl).isoformat(timespec="hours")
 
     @pytest.mark.settings(DISCORD_JWT_PRIVATE_KEY=wrong_private_key_pem, DISCORD_JWT_PUBLIC_KEY=public_key_pem)
     def test_creating_and_verifying_signature_with_mismatch_private_and_public_keys(self):
@@ -273,7 +273,7 @@ class AsymetricTokenTest:
         assert token.encoded_token == old_token.encoded_token
         assert token_tools.AsymetricToken.get_expiration_date(self.token_type, token.key_suffix).isoformat(
             timespec="hours"
-        ) == (datetime.utcnow() + self.ttl).isoformat(timespec="hours")
+        ) == (date_utils.get_naive_utc_now() + self.ttl).isoformat(timespec="hours")
 
         token = token_tools.AsymetricToken.load_without_checking(
             old_token.encoded_token,
@@ -283,7 +283,7 @@ class AsymetricTokenTest:
         assert token.encoded_token == old_token.encoded_token
         assert token_tools.AsymetricToken.get_expiration_date(self.token_type, token.key_suffix).isoformat(
             timespec="hours"
-        ) == (datetime.utcnow() + self.ttl).isoformat(timespec="hours")
+        ) == (date_utils.get_naive_utc_now() + self.ttl).isoformat(timespec="hours")
 
     @pytest.mark.settings(DISCORD_JWT_PRIVATE_KEY=private_key_pem, DISCORD_JWT_PUBLIC_KEY=public_key_pem)
     def test_load_without_checking_wrong_public_key(self):
@@ -355,7 +355,7 @@ class PasswordLessLoginTokenTest:
         jti = str(mocked_uuid())
         ttl = timedelta(hours=8)
         sub = 1
-        issued_at = datetime.utcnow() - timedelta(hours=5)
+        issued_at = date_utils.get_naive_utc_now() - timedelta(hours=5)
         expiration_date = issued_at + ttl
         exp = int(expiration_date.timestamp())
         iat = int(issued_at.timestamp())

--- a/api/tests/core/users/test_gdpr_api.py
+++ b/api/tests/core/users/test_gdpr_api.py
@@ -40,6 +40,7 @@ from pcapi.core.users import testing as sendinblue_testing
 from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.notifications.push import testing as batch_testing
+from pcapi.utils import date as date_utils
 
 import tests
 from tests.test_utils import StorageFolderManager
@@ -57,12 +58,12 @@ class AnonymizeNonProNonBeneficiaryUsersTest:
     def test_anonymize_non_pro_non_beneficiary_users(self) -> None:
         user_to_anonymize = users_factories.UserFactory(
             firstName="user_to_anonymize",
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             validatedBirthDate=datetime.date.today(),
         )
         user_too_new = users_factories.UserFactory(
             firstName="user_too_new",
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=-11),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=-11),
         )
         user_never_connected = users_factories.UserFactory(firstName="user_never_connected", lastConnectionDate=None)
         user_beneficiary = users_factories.BeneficiaryGrant18Factory(
@@ -151,7 +152,7 @@ class AnonymizeNonProNonBeneficiaryUsersTest:
     def test_anonymize_non_pro_non_beneficiary_user_force_iris_not_found(self) -> None:
         user_to_anonymize = users_factories.UserFactory(
             firstName="user_to_anonymize",
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
         )
 
         gdpr_api.anonymize_non_pro_non_beneficiary_users()
@@ -166,7 +167,7 @@ class AnonymizeNonProNonBeneficiaryUsersTest:
     def test_anonymize_non_pro_non_beneficiary_user_keep_history_on_offerer(self) -> None:
         user_to_anonymize = users_factories.UserFactory(
             firstName="user_to_anonymize",
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
         )
         history_factories.ActionHistoryFactory(
             authorUser=user_to_anonymize,
@@ -190,7 +191,7 @@ class AnonymizeNonProNonBeneficiaryUsersTest:
     def test_anonymize_non_pro_non_beneficiary_user_keep_email_in_brevo_if_used_for_venue(self) -> None:
         user_to_anonymize = users_factories.UserFactory(
             firstName="user_to_anonymize",
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
         )
         offerers_factories.VenueFactory(bookingEmail=user_to_anonymize.email)
 
@@ -221,11 +222,11 @@ class AnonymizeNonProNonBeneficiaryUsersTest:
     def test_anonymize_non_pro_non_beneficiary_user_recently_suspended_with_fraud(self, reason) -> None:
         user_to_anonymize = users_factories.UserFactory(
             firstName="user_to_anonymize",
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             isActive=False,
         )
         history_factories.SuspendedUserActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            actionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             actionType=history_models.ActionType.USER_SUSPENDED,
             reason=reason,
             user=user_to_anonymize,
@@ -241,11 +242,11 @@ class AnonymizeNonProNonBeneficiaryUsersTest:
     def test_anonymize_non_pro_non_beneficiary_user_suspended_5_years_ago_with_fraud(self) -> None:
         user_to_anonymize = users_factories.UserFactory(
             firstName="user_to_anonymize",
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             isActive=False,
         )
         history_factories.SuspendedUserActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            actionDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
             actionType=history_models.ActionType.USER_SUSPENDED,
             reason=users_constants.SuspensionReason.FRAUD_RESELL_PRODUCT,
             user=user_to_anonymize,
@@ -261,11 +262,11 @@ class AnonymizeNonProNonBeneficiaryUsersTest:
     def test_anonymize_non_pro_non_beneficiary_user_recently_suspended_without_fraud(self) -> None:
         user_to_anonymize = users_factories.UserFactory(
             firstName="user_to_anonymize",
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             isActive=False,
         )
         history_factories.SuspendedUserActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            actionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             actionType=history_models.ActionType.USER_SUSPENDED,
             reason=users_constants.SuspensionReason.DEVICE_AT_RISK,
             user=user_to_anonymize,
@@ -283,7 +284,7 @@ class NotifyProUsersBeforeAnonymizationTest:
     # users and joined data
     expected_num_queries = 1
 
-    last_connection_date = datetime.datetime.utcnow() - relativedelta(years=3, days=-30)
+    last_connection_date = date_utils.get_naive_utc_now() - relativedelta(years=3, days=-30)
 
     @pytest.mark.parametrize(
         "offerer_validation_status,user_offerer_validation_status",
@@ -312,7 +313,7 @@ class NotifyProUsersBeforeAnonymizationTest:
         )
         offerers_factories.NonAttachedUserOffererFactory(
             offerer=user_offerer.offerer,
-            user__lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=2, months=8),
+            user__lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=2, months=8),
             validationStatus=user_offerer_validation_status,
         )
 
@@ -327,7 +328,7 @@ class NotifyProUsersBeforeAnonymizationTest:
         user_to_notify = users_factories.NonAttachedProFactory(
             lastConnectionDate=self.last_connection_date,
         )
-        users_factories.NonAttachedProFactory(lastConnectionDate=datetime.datetime.utcnow())
+        users_factories.NonAttachedProFactory(lastConnectionDate=date_utils.get_naive_utc_now())
 
         with assert_num_queries(self.expected_num_queries):
             gdpr_api.notify_pro_users_before_anonymization()
@@ -370,7 +371,7 @@ class NotifyProUsersBeforeAnonymizationTest:
                 users_factories.NonAttachedProFactory(
                     lastConnectionDate=self.last_connection_date - datetime.timedelta(days=1)
                 ),
-                users_factories.NonAttachedProFactory(lastConnectionDate=datetime.datetime.utcnow()),
+                users_factories.NonAttachedProFactory(lastConnectionDate=date_utils.get_naive_utc_now()),
             ]
         )
 
@@ -455,13 +456,13 @@ class AnonymizeProUserTest:
         self, delete_beamer_user_mock, offerer_validation_status, user_offerer_validation_status
     ):
         user_offerer_to_anonymize = offerers_factories.NonAttachedUserOffererFactory(
-            user__lastConnectionDate=datetime.datetime.utcnow() - datetime.timedelta(days=366 * 3),
+            user__lastConnectionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=366 * 3),
             offerer__validationStatus=offerer_validation_status,
             validationStatus=user_offerer_validation_status,
         )
         user_offerer_to_keep = offerers_factories.NonAttachedUserOffererFactory(
             offerer=user_offerer_to_anonymize.offerer,
-            user__lastConnectionDate=datetime.datetime.utcnow(),
+            user__lastConnectionDate=date_utils.get_naive_utc_now(),
         )
 
         gdpr_api.anonymize_pro_users()
@@ -473,9 +474,9 @@ class AnonymizeProUserTest:
     @mock.patch("pcapi.core.users.gdpr_api.delete_beamer_user")
     def test_keep_pro_users_with_activity_less_than_three_years(self, delete_beamer_user_mock):
         users_factories.NonAttachedProFactory(
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=-1)
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=-1)
         )
-        users_factories.NonAttachedProFactory(lastConnectionDate=datetime.datetime.utcnow())
+        users_factories.NonAttachedProFactory(lastConnectionDate=date_utils.get_naive_utc_now())
 
         gdpr_api.anonymize_pro_users()
 
@@ -487,18 +488,18 @@ class AnonymizeProUserTest:
         offerers_factories.DeletedUserOffererFactory(
             user=users_factories.BeneficiaryGrant18Factory(
                 roles=[users_models.UserRole.NON_ATTACHED_PRO, users_models.UserRole.BENEFICIARY],
-                lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=4),
+                lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=4),
             )
         )
         offerers_factories.RejectedUserOffererFactory(
             user=users_factories.UnderageBeneficiaryFactory(
                 roles=[users_models.UserRole.NON_ATTACHED_PRO, users_models.UserRole.UNDERAGE_BENEFICIARY],
-                lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=4),
+                lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=4),
             )
         )
         subscription_factories.BeneficiaryFraudCheckFactory(
             user=offerers_factories.RejectedUserOffererFactory(
-                user__lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=4),
+                user__lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=4),
             ).user
         )
 
@@ -510,7 +511,7 @@ class AnonymizeProUserTest:
     @mock.patch("pcapi.core.users.gdpr_api.delete_beamer_user")
     def test_keep_when_attached_to_another_active_offerer(self, delete_beamer_user_mock):
         user_offerer = offerers_factories.DeletedUserOffererFactory(
-            user__lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=4),
+            user__lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=4),
         )
         offerers_factories.NewUserOffererFactory(user=user_offerer.user)
 
@@ -522,9 +523,9 @@ class AnonymizeProUserTest:
     @mock.patch("pcapi.core.users.gdpr_api.delete_beamer_user")
     def test_anonymize_non_attached_pro_user(self, delete_beamer_user_mock):
         user_to_anonymize = users_factories.NonAttachedProFactory(
-            lastConnectionDate=datetime.datetime.utcnow() - datetime.timedelta(days=366 * 3)
+            lastConnectionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=366 * 3)
         )
-        user_to_keep1 = users_factories.NonAttachedProFactory(lastConnectionDate=datetime.datetime.utcnow())
+        user_to_keep1 = users_factories.NonAttachedProFactory(lastConnectionDate=date_utils.get_naive_utc_now())
         user_to_keep2 = users_factories.NonAttachedProFactory()
 
         gdpr_api.anonymize_pro_users()
@@ -537,7 +538,7 @@ class AnonymizeProUserTest:
     @mock.patch("pcapi.core.users.gdpr_api.delete_beamer_user")
     def test_anonymize_non_attached_never_connected_pro(self, delete_beamer_user_mock):
         user_to_anonymize = users_factories.NonAttachedProFactory(
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=366 * 3)
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=366 * 3)
         )
         user_to_keep = users_factories.NonAttachedProFactory()
 
@@ -565,7 +566,7 @@ class AnonymizeInternalUserTest:
         )
         history_factories.SuspendedUserActionHistoryFactory(
             user=user_to_anonymize,
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=367),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=367),
         )
 
         gdpr_api.anonymize_internal_users()
@@ -594,7 +595,7 @@ class AnonymizeInternalUserTest:
         )
         history_factories.SuspendedUserActionHistoryFactory(
             user=user_to_anonymize,
-            actionDate=datetime.datetime.utcnow(),
+            actionDate=date_utils.get_naive_utc_now(),
         )
 
         gdpr_api.anonymize_internal_users()
@@ -608,11 +609,11 @@ class AnonymizeInternalUserTest:
         )
         history_factories.SuspendedUserActionHistoryFactory(
             user=user_to_anonymize,
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=367),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=367),
         )
         history_factories.SuspendedUserActionHistoryFactory(
             user=user_to_anonymize,
-            actionDate=datetime.datetime.utcnow(),
+            actionDate=date_utils.get_naive_utc_now(),
         )
 
         gdpr_api.anonymize_internal_users()
@@ -626,7 +627,7 @@ class AnonymizeInternalUserTest:
         )
         history_factories.SuspendedUserActionHistoryFactory(
             user=user_to_anonymize,
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=367),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=367),
         )
 
         gdpr_api.anonymize_internal_users()
@@ -639,7 +640,7 @@ class AnonymizeInternalUserTest:
         )
         history_factories.SuspendedUserActionHistoryFactory(
             user=user_to_anonymize,
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=367),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=367),
         )
 
         gdpr_api.anonymize_internal_users()
@@ -658,48 +659,48 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
         user_beneficiary_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_beneficiary_to_anonymize",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
         )
         user_underage_beneficiary_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_underage_beneficiary_to_anonymize",
             age=17,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
         )
         user_with_ready_gdpr_extract_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_beneficiary_to_anonymize",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             gdprUserDataExtracts=[
                 users_factories.GdprUserDataExtractBeneficiaryFactory(
-                    dateProcessed=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+                    dateProcessed=date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
                 )
             ],
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
         )
         user_with_expired_gdpr_extract_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_beneficiary_to_anonymize",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             gdprUserDataExtracts=[
                 users_factories.GdprUserDataExtractBeneficiaryFactory(
-                    dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=8)
+                    dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=8)
                 )
             ],
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
         )
         user_too_new = users_factories.BeneficiaryFactory(
             firstName="user_too_new",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=-11),
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=-11),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
         )
         user_deposit_too_new = users_factories.BeneficiaryFactory(
             firstName="user_deposit_too_new",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=-11),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=-11),
         )
         user_never_connected = users_factories.UserFactory(firstName="user_never_connected", lastConnectionDate=None)
         user_no_role = users_factories.UserFactory(
@@ -796,8 +797,8 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
         user_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_to_anonymize",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
         )
         chronicle = chronicles_factories.ChronicleFactory(
             user=user_to_anonymize,
@@ -814,8 +815,8 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
         user_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_to_anonymize",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
         )
 
         gdpr_api.anonymize_beneficiary_users()
@@ -831,9 +832,9 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
         user_beneficiary_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_beneficiary_to_anonymize",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             gdprUserDataExtracts=[users_factories.GdprUserDataExtractBeneficiaryFactory()],
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
         )
 
         self.import_iris()
@@ -850,11 +851,11 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
 
     def test_anonymize_user_tagged_when_he_is_21(self) -> None:
         user_to_anonymize = users_factories.BeneficiaryFactory(
-            validatedBirthDate=datetime.datetime.utcnow() - relativedelta(years=18, days=1),
+            validatedBirthDate=date_utils.get_naive_utc_now() - relativedelta(years=18, days=1),
         )
         users_factories.GdprUserAnonymizationFactory(user=user_to_anonymize)
 
-        when_user_is_21 = datetime.datetime.utcnow() + relativedelta(years=3)
+        when_user_is_21 = date_utils.get_naive_utc_now() + relativedelta(years=3)
         with time_machine.travel(when_user_is_21):
             gdpr_api.anonymize_beneficiary_users()
             db.session.refresh(user_to_anonymize)
@@ -864,12 +865,12 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
 
     def test_do_not_anonymize_user_tagged_when_he_is_less_than_21(self) -> None:
         user_to_anonymize = users_factories.BeneficiaryFactory(
-            lastConnectionDate=datetime.datetime.utcnow(),
-            validatedBirthDate=datetime.datetime.utcnow() - relativedelta(years=18),
+            lastConnectionDate=date_utils.get_naive_utc_now(),
+            validatedBirthDate=date_utils.get_naive_utc_now() - relativedelta(years=18),
         )
         users_factories.GdprUserAnonymizationFactory(user=user_to_anonymize)
 
-        when_user_is_21 = datetime.datetime.utcnow() + relativedelta(years=3)
+        when_user_is_21 = date_utils.get_naive_utc_now() + relativedelta(years=3)
         with time_machine.travel(when_user_is_21 - relativedelta(days=1)):
             gdpr_api.anonymize_beneficiary_users()
             db.session.refresh(user_to_anonymize)
@@ -896,12 +897,12 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
     )
     def test_do_not_anonymize_user_tagged_when_he_is_21_and_recently_tagged_as_fraud(self, reason) -> None:
         user_to_anonymize = users_factories.BeneficiaryFactory(
-            lastConnectionDate=datetime.datetime.utcnow(),
-            validatedBirthDate=datetime.datetime.utcnow() - relativedelta(years=21, days=12),
+            lastConnectionDate=date_utils.get_naive_utc_now(),
+            validatedBirthDate=date_utils.get_naive_utc_now() - relativedelta(years=21, days=12),
         )
         users_factories.GdprUserAnonymizationFactory(user=user_to_anonymize)
         history_factories.SuspendedUserActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            actionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             actionType=history_models.ActionType.USER_SUSPENDED,
             reason=reason,
             user=user_to_anonymize,
@@ -915,12 +916,12 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
 
     def test_do_not_anonymize_user_tagged_when_he_is_21_and_tagged_as_fraud_5_years_ago(self) -> None:
         user_to_anonymize = users_factories.BeneficiaryFactory(
-            lastConnectionDate=datetime.datetime.utcnow(),
-            validatedBirthDate=datetime.datetime.utcnow() - relativedelta(years=21, days=12),
+            lastConnectionDate=date_utils.get_naive_utc_now(),
+            validatedBirthDate=date_utils.get_naive_utc_now() - relativedelta(years=21, days=12),
         )
         users_factories.GdprUserAnonymizationFactory(user=user_to_anonymize)
         history_factories.SuspendedUserActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            actionDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
             actionType=history_models.ActionType.USER_SUSPENDED,
             reason=users_constants.SuspensionReason.FRAUD_RESELL_PRODUCT,
             user=user_to_anonymize,
@@ -953,12 +954,12 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
         user_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_to_anonymize",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
             isActive=False,
         )
         history_factories.SuspendedUserActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            actionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             actionType=history_models.ActionType.USER_SUSPENDED,
             reason=reason,
             user=user_to_anonymize,
@@ -975,12 +976,12 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
         user_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_to_anonymize",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
             isActive=False,
         )
         history_factories.SuspendedUserActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            actionDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
             actionType=history_models.ActionType.USER_SUSPENDED,
             reason=users_constants.SuspensionReason.FRAUD_RESELL_PRODUCT,
             user=user_to_anonymize,
@@ -1009,12 +1010,12 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
         user_to_anonymize = users_factories.BeneficiaryFactory(
             firstName="user_to_anonymize",
             age=18,
-            lastConnectionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(years=5, days=1),
+            lastConnectionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(years=5, days=1),
             isActive=False,
         )
         history_factories.SuspendedUserActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - relativedelta(years=3, days=1),
+            actionDate=date_utils.get_naive_utc_now() - relativedelta(years=3, days=1),
             actionType=history_models.ActionType.USER_SUSPENDED,
             reason=reason,
             user=user_to_anonymize,
@@ -1030,7 +1031,7 @@ class AnonymizeBeneficiaryUsersTest(StorageFolderManager):
 
 class AnonymizeUserDepositsTest:
     def test_anonymize_user_deposits(self) -> None:
-        now = datetime.datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        now = date_utils.get_naive_utc_now().replace(hour=0, minute=0, second=0, microsecond=0)
         user_recent_deposit = users_factories.BeneficiaryFactory(
             deposit__dateCreated=now - relativedelta(years=6),
             deposit__expirationDate=now - relativedelta(years=5, days=1),
@@ -1059,7 +1060,7 @@ class DeleteGdprExtractTest(StorageFolderManager):
 
     def test_nominal(self):
         # given
-        extract = users_factories.GdprUserDataExtractBeneficiaryFactory(dateProcessed=datetime.datetime.utcnow())
+        extract = users_factories.GdprUserDataExtractBeneficiaryFactory(dateProcessed=date_utils.get_naive_utc_now())
         with open(self.storage_folder / f"{extract.id}.zip", "wb") as fp:
             fp.write(b"[personal data compressed with deflate]")
         # when
@@ -1071,7 +1072,7 @@ class DeleteGdprExtractTest(StorageFolderManager):
 
     def test_extract_file_does_not_exists(self):
         # given
-        extract = users_factories.GdprUserDataExtractBeneficiaryFactory(dateProcessed=datetime.datetime.utcnow())
+        extract = users_factories.GdprUserDataExtractBeneficiaryFactory(dateProcessed=date_utils.get_naive_utc_now())
         # when
         gdpr_api.delete_gdpr_extract(extract.id)
 
@@ -1085,8 +1086,8 @@ class CleanGdprExtractTest(StorageFolderManager):
     def test_delete_expired_extracts(self):
         # given
         extract = users_factories.GdprUserDataExtractBeneficiaryFactory(
-            dateProcessed=datetime.datetime.utcnow() - datetime.timedelta(days=6),
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=8),
+            dateProcessed=date_utils.get_naive_utc_now() - datetime.timedelta(days=6),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=8),
         )
         with open(self.storage_folder / f"{extract.id}.zip", "wb") as fp:
             fp.write(b"[personal data compressed with deflate]")
@@ -1108,7 +1109,7 @@ class CleanGdprExtractTest(StorageFolderManager):
     def test_delete_expired_unprocessed_extracts(self):
         # given
         users_factories.GdprUserDataExtractBeneficiaryFactory(
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=8)
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=8)
         )
         # when
         gdpr_api.clean_gdpr_extracts()
@@ -1118,8 +1119,8 @@ class CleanGdprExtractTest(StorageFolderManager):
     def test_keep_unexpired_extracts(self):
         # given
         extract = users_factories.GdprUserDataExtractBeneficiaryFactory(
-            dateProcessed=datetime.datetime.utcnow() - datetime.timedelta(days=5),
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=6),
+            dateProcessed=date_utils.get_naive_utc_now() - datetime.timedelta(days=5),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=6),
         )
         with open(self.storage_folder / f"{extract.id}.zip", "wb") as fp:
             fp.write(b"[personal data compressed with deflate]")

--- a/api/tests/core/users/test_generator.py
+++ b/api/tests/core/users/test_generator.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 from dateutil.relativedelta import relativedelta
 
@@ -12,6 +10,7 @@ import pcapi.core.subscription.schemas as subscription_schemas
 import pcapi.core.users.generator as users_generator
 import pcapi.core.users.models as users_models
 from pcapi.core.users import constants as users_constants
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -197,7 +196,7 @@ class UserGeneratorTest:
         assert user.age == users_constants.ELIGIBILITY_AGE_18
         assert user.has_underage_beneficiary_role
         assert user.deposit.type == finance_models.DepositType.GRANT_17_18
-        assert user.deposit.expirationDate < datetime.datetime.utcnow()
+        assert user.deposit.expirationDate < date_utils.get_naive_utc_now()
         user_subscription_state = subscription_api.get_user_subscription_state(user)
         assert user_subscription_state.next_step == subscription_schemas.SubscriptionStep.PHONE_VALIDATION
 
@@ -215,7 +214,7 @@ class UserGeneratorTest:
         assert self.has_fraud_check_validated(user, id_provider.value)
 
     def test_user_generated_with_date_created(self):
-        date_in_the_past = datetime.datetime.utcnow() - relativedelta(months=5)
+        date_in_the_past = date_utils.get_naive_utc_now() - relativedelta(months=5)
         user_data = users_generator.GenerateUserData(
             step=users_generator.GeneratedSubscriptionStep.BENEFICIARY, date_created=date_in_the_past
         )

--- a/api/tests/core/users/test_repository.py
+++ b/api/tests/core/users/test_repository.py
@@ -12,6 +12,7 @@ from pcapi.core.users import repository
 from pcapi.core.users.models import UserRole
 from pcapi.core.users.repository import get_users_with_validated_attachment_by_offerer
 from pcapi.core.users.repository import has_access_to_venues
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -112,11 +113,11 @@ class GetNewlyEligibleUsersTest:
         assert set(users) == {user_just_18, user_just_18_ex_underage_beneficiary, user_already_18}
 
     def test_eligible_user_with_discordant_dates_on_declared_one(self):
-        date_to_check = datetime.utcnow() - relativedelta(days=1)
+        date_to_check = date_utils.get_naive_utc_now() - relativedelta(days=1)
         users_factories.BaseUserFactory(
-            dateOfBirth=datetime.utcnow() - relativedelta(years=18),
-            validatedBirthDate=datetime.utcnow() - relativedelta(years=17, months=11),
-            dateCreated=datetime.utcnow() - relativedelta(months=1),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
+            validatedBirthDate=date_utils.get_naive_utc_now() - relativedelta(years=17, months=11),
+            dateCreated=date_utils.get_naive_utc_now() - relativedelta(months=1),
             roles=[UserRole.UNDERAGE_BENEFICIARY],
         )
         users = repository.get_users_that_had_birthday_since(since=date_to_check, age=18)
@@ -124,11 +125,11 @@ class GetNewlyEligibleUsersTest:
 
     @time_machine.travel("2024-02-01")
     def test_eligible_user_with_discordant_dates_on_validated_one(self):
-        date_to_check = datetime.utcnow() - relativedelta(days=1)
+        date_to_check = date_utils.get_naive_utc_now() - relativedelta(days=1)
         user_just_18_discordant_dates = users_factories.BaseUserFactory(
-            dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=1),
-            validatedBirthDate=datetime.utcnow() - relativedelta(years=18),
-            dateCreated=datetime.utcnow() - relativedelta(months=2),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=1),
+            validatedBirthDate=date_utils.get_naive_utc_now() - relativedelta(years=18),
+            dateCreated=date_utils.get_naive_utc_now() - relativedelta(months=2),
             roles=[UserRole.UNDERAGE_BENEFICIARY],
         )
 

--- a/api/tests/core/users/test_utils.py
+++ b/api/tests/core/users/test_utils.py
@@ -10,6 +10,7 @@ from pcapi.core.users.utils import ALGORITHM_RS_256
 from pcapi.core.users.utils import decode_jwt_token_rs256
 from pcapi.core.users.utils import encode_jwt_payload
 from pcapi.core.users.utils import format_login_location
+from pcapi.utils import date as date_utils
 
 from tests.routes.adage_iframe import INVALID_RSA_PRIVATE_KEY_PATH
 from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH
@@ -18,7 +19,7 @@ from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH
 class EncodeJWTPayloadTest:
     def test_encode_jwt_payload(self):
         payload = dict(data="value")
-        expiration_date = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        expiration_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
 
         jwt_token = encode_jwt_payload(payload, expiration_date)
 

--- a/api/tests/core/users/young_status_test.py
+++ b/api/tests/core/users/young_status_test.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -9,13 +8,14 @@ from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.core.users import young_status
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
 def _with_age(age):
-    return datetime.datetime.utcnow() - relativedelta(years=age)
+    return date_utils.get_naive_utc_now() - relativedelta(years=age)
 
 
 class YoungStatusTest:
@@ -31,7 +31,7 @@ class YoungStatusTest:
             user = users_factories.UserFactory(dateOfBirth=_with_age(19))
             subscription_factories.BeneficiaryFraudCheckFactory(
                 resultContent=subscription_factories.DMSContentFactory(
-                    registration_datetime=datetime.datetime.utcnow() - relativedelta(years=1)
+                    registration_datetime=date_utils.get_naive_utc_now() - relativedelta(years=1)
                 ),
                 type=subscription_models.FraudCheckType.DMS,
                 eligibilityType=users_models.EligibilityType.AGE18,
@@ -184,7 +184,7 @@ class YoungStatusTest:
 
     def should_be_ex_beneficiary_when_beneficiary_have_his_deposit_expired(self):
         user = users_factories.BeneficiaryGrant18Factory(
-            deposit__expirationDate=datetime.datetime.utcnow() - relativedelta(days=1)
+            deposit__expirationDate=date_utils.get_naive_utc_now() - relativedelta(days=1)
         )
         assert young_status.young_status(user) == young_status.ExBeneficiary()
 

--- a/api/tests/local_providers/provider_test_utils.py
+++ b/api/tests/local_providers/provider_test_utils.py
@@ -1,4 +1,3 @@
-import datetime
 from pathlib import Path
 
 import pcapi.core.bookings.factories as bookings_factories
@@ -10,6 +9,7 @@ from pcapi.core.offers import models as offers_models
 from pcapi.core.providers.models import VenueProvider
 from pcapi.local_providers.local_provider import LocalProvider
 from pcapi.models import Model
+from pcapi.utils import date as date_utils
 
 import tests
 
@@ -119,7 +119,7 @@ class TestLocalProviderWithThumbIndexAt4(LocalProvider):
 def create_finance_event_to_update(stock, venue_provider):
     """Create the different objects in db for finance event update"""
 
-    booking = bookings_factories.UsedBookingFactory(stock=stock, dateUsed=datetime.datetime.utcnow())
+    booking = bookings_factories.UsedBookingFactory(stock=stock, dateUsed=date_utils.get_naive_utc_now())
     event = finance_factories.FinanceEventFactory(
         booking=booking,
         pricingOrderingDate=stock.beginningDatetime,

--- a/api/tests/models/pc_object_test.py
+++ b/api/tests/models/pc_object_test.py
@@ -5,6 +5,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+from pcapi.utils import date as date_utils
 
 
 class TimeInterval(PcObject, Model):
@@ -26,4 +27,4 @@ class TestPcObject(PcObject, Model):
 time_interval = TimeInterval()
 time_interval.start = datetime(2018, 1, 1, 10, 20, 30, 111000)
 time_interval.end = datetime(2018, 2, 2, 5, 15, 25, 222000)
-now = datetime.utcnow()
+now = date_utils.get_naive_utc_now()

--- a/api/tests/routes/adage_iframe/get_authenticate_test.py
+++ b/api/tests/routes/adage_iframe/get_authenticate_test.py
@@ -8,6 +8,7 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models
 from pcapi.core.educational.api.institution import get_educational_institution_department_code
 from pcapi.core.testing import assert_num_queries
+from pcapi.utils import date as date_utils
 
 from tests.routes.adage_iframe.utils_create_test_token import DEFAULT_LAT
 from tests.routes.adage_iframe.utils_create_test_token import DEFAULT_LON
@@ -92,8 +93,8 @@ class AuthenticateTest:
             institutionId=institution.id,
             program=program,
             timespan=db_utils.make_timerange(
-                start=datetime.datetime.utcnow() - datetime.timedelta(days=2 * 365),
-                end=datetime.datetime.utcnow() - datetime.timedelta(days=365),
+                start=date_utils.get_naive_utc_now() - datetime.timedelta(days=2 * 365),
+                end=date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
             ),
         )
 
@@ -116,7 +117,7 @@ class AuthenticateTest:
             collectiveOffer__institution=institution,
         )
         educational_factories.CollectiveStockFactory(
-            startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=5),
+            startDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=5),
             collectiveOffer__institution=institution,
         )
 
@@ -197,7 +198,7 @@ class AuthenticateTest:
 
     def test_should_return_error_response_when_jwt_expired(self, client, valid_user):
         # Given
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         expired_token = self._create_adage_valid_token_from_expiration_date(
             valid_user, expiration_date=now - datetime.timedelta(days=1)
         )

--- a/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offer_template_test.py
@@ -11,6 +11,7 @@ from pcapi.core.educational.models import StudentLevels
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import offer_mixin
+from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 from pcapi.utils.date import format_into_utc_date
 
@@ -34,8 +35,8 @@ def redactor_fixture():
 @pytest.fixture(name="offer")
 def offer_fixture():
     offer_range = educational_factories.DateRangeFactory(
-        start=datetime.datetime.utcnow() - datetime.timedelta(days=7),
-        end=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        start=date_utils.get_naive_utc_now() - datetime.timedelta(days=7),
+        end=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
     )
     return offer_range
 
@@ -146,10 +147,10 @@ class CollectiveOfferTemplateTest:
 
     def test_get_collective_offer_template_if_inactive(self, eac_client, redactor):
         offer = educational_factories.CollectiveOfferTemplateFactory(
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=9),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=9),
             dateRange=db_utils.make_timerange(
-                start=datetime.datetime.utcnow() - datetime.timedelta(days=7),
-                end=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+                start=date_utils.get_naive_utc_now() - datetime.timedelta(days=7),
+                end=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             ),
         )
 
@@ -163,7 +164,7 @@ class CollectiveOfferTemplateTest:
 
     def test_get_collective_offer_template_without_date_range(self, eac_client, redactor):
         offer = educational_factories.CollectiveOfferTemplateFactory(
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=9),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=9),
             dateRange=None,
         )
 
@@ -318,7 +319,7 @@ class GetCollectiveOfferTemplatesTest:
     def test_one_template_id_with_one_archived_template(self, eac_client, redactor):
         offer = educational_factories.CollectiveOfferTemplateFactory()
         archived_offer = educational_factories.CollectiveOfferTemplateFactory(
-            isActive=False, dateArchived=datetime.datetime.utcnow()
+            isActive=False, dateArchived=date_utils.get_naive_utc_now()
         )
 
         url = url_for(self.endpoint, ids=[offer.id, archived_offer.id])

--- a/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution_test.py
+++ b/api/tests/routes/adage_iframe/get_collective_offers_for_my_institution_test.py
@@ -8,6 +8,7 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.educational import models
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -48,7 +49,7 @@ class CollectiveOfferTest:
             collectiveOffer__offererAddress=offerers_factories.get_offerer_address_with_label_from_venue(venue),
         )
         # this archived offer should not appear in the result
-        stocks[2].collectiveOffer.dateArchived = datetime.utcnow() - timedelta(days=1)
+        stocks[2].collectiveOffer.dateArchived = date_utils.get_naive_utc_now() - timedelta(days=1)
         stocks[2].collectiveOffer.isActive = False
 
         # cancelled booking should not appear in the result

--- a/api/tests/routes/adage_iframe/get_educational_institution_with_budget_test.py
+++ b/api/tests/routes/adage_iframe/get_educational_institution_with_budget_test.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 from flask import url_for
 
 from pcapi.core.educational import factories as educational_factories
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -75,7 +76,7 @@ class EducationalInstitutionTest:
 
 def _build_educational_year(delta: relativedelta | None = None):
     delta = delta if delta else relativedelta(years=0)
-    now = datetime.utcnow() - delta
+    now = date_utils.get_naive_utc_now() - delta
 
     return educational_factories.EducationalYearFactory(
         beginningDate=datetime(now.year, 9, 1),

--- a/api/tests/routes/adage_iframe/utils_create_test_token.py
+++ b/api/tests/routes/adage_iframe/utils_create_test_token.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import jwt
 
 from pcapi.core.users.utils import ALGORITHM_RS_256
+from pcapi.utils import date as date_utils
 
 from tests.routes.adage_iframe import INVALID_RSA_PRIVATE_KEY_PATH
 from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH
@@ -29,7 +30,7 @@ def create_adage_jwt_default_fake_valid_token(
         firstname=firstname,
         email=email,
         uai=uai,
-        expiration_date=datetime.utcnow() + timedelta(days=1),
+        expiration_date=date_utils.get_naive_utc_now() + timedelta(days=1),
         lat=lat,
         lon=lon,
         can_prebook=can_prebook,
@@ -84,7 +85,7 @@ def create_adage_valid_token_with_email(
         firstname=firstname,
         email=email,
         uai=uai,
-        expiration_date=datetime.utcnow() + timedelta(days=1),
+        expiration_date=date_utils.get_naive_utc_now() + timedelta(days=1),
         lat=lat,
         lon=lon,
         can_prebook=can_prebook,
@@ -100,7 +101,7 @@ def create_adage_jwt_fake_invalid_token(
     lat: float | None = None,
     lon: float | None = None,
 ) -> bytes:
-    now = datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     with open(INVALID_RSA_PRIVATE_KEY_PATH, "rb") as reader:
         return jwt.encode(
             {

--- a/api/tests/routes/backoffice/admin_test.py
+++ b/api/tests/routes/backoffice/admin_test.py
@@ -16,6 +16,7 @@ from pcapi.core.users import models as users_models
 from pcapi.core.users.backoffice import api as backoffice_api
 from pcapi.models import db
 from pcapi.models import feature as feature_models
+from pcapi.utils import date as date_utils
 
 from .helpers import button as button_helpers
 from .helpers import html_parser
@@ -504,12 +505,12 @@ class GetBoUserTest(GetEndpointHelper):
 
     def test_get_suspended_bo_user_with_history(self, authenticated_client, legit_user):
         user = users_factories.AdminFactory(
-            isActive=False, roles=[], dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=180)
+            isActive=False, roles=[], dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=180)
         )
 
         history_factories.ActionHistoryFactory(
             actionType=history_models.ActionType.USER_SUSPENDED,
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
             authorUser=legit_user,
             user=user,
             extraData={"reason": users_constants.SuspensionReason.END_OF_CONTRACT},

--- a/api/tests/routes/backoffice/artists_test.py
+++ b/api/tests/routes/backoffice/artists_test.py
@@ -11,6 +11,7 @@ from pcapi.core.permissions import models as perm_models
 from pcapi.core.search.models import IndexationReason
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from .helpers import button as button_helpers
 from .helpers import html_parser
@@ -462,7 +463,7 @@ class ListArtistsTest(GetEndpointHelper):
 
     @pytest.fixture
     def artists(self, db_session):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         artist1 = artist_factories.ArtistFactory(
             name="Daniel Balavoine",
             image="http://example.com/image1.jpg",
@@ -591,7 +592,7 @@ class ListArtistsTest(GetEndpointHelper):
         query_args = {
             "search-0-search_field": "CREATION_DATE",
             "search-0-operator": "DATE_FROM",
-            "search-0-date": (datetime.datetime.utcnow() - datetime.timedelta(days=7)).strftime("%Y-%m-%d"),
+            "search-0-date": (date_utils.get_naive_utc_now() - datetime.timedelta(days=7)).strftime("%Y-%m-%d"),
         }
 
         with assert_num_queries(self.expected_num_queries):

--- a/api/tests/routes/backoffice/autocomplete_test.py
+++ b/api/tests/routes/backoffice/autocomplete_test.py
@@ -17,6 +17,7 @@ from pcapi.core.providers import models as providers_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = [
@@ -291,24 +292,24 @@ class AutocompleteHighlightsTest(AutocompleteTestBase):
             (
                 "co",
                 {
-                    f"Temps costaud - {datetime.datetime.strftime((datetime.datetime.utcnow() + datetime.timedelta(days=11)).date(), '%d/%m/%Y')}"
-                    f" - {datetime.datetime.strftime((datetime.datetime.utcnow() + datetime.timedelta(days=12)).date(), '%d/%m/%Y')}",
+                    f"Temps costaud - {datetime.datetime.strftime((date_utils.get_naive_utc_now() + datetime.timedelta(days=11)).date(), '%d/%m/%Y')}"
+                    f" - {datetime.datetime.strftime((date_utils.get_naive_utc_now() + datetime.timedelta(days=12)).date(), '%d/%m/%Y')}",
                 },
                 3,
             ),
             (
                 "fort",
                 {
-                    f"Temps Fôrt - {datetime.datetime.strftime((datetime.datetime.utcnow() + datetime.timedelta(days=11)).date(), '%d/%m/%Y')}"
-                    f" - {datetime.datetime.strftime((datetime.datetime.utcnow() + datetime.timedelta(days=12)).date(), '%d/%m/%Y')}",
+                    f"Temps Fôrt - {datetime.datetime.strftime((date_utils.get_naive_utc_now() + datetime.timedelta(days=11)).date(), '%d/%m/%Y')}"
+                    f" - {datetime.datetime.strftime((date_utils.get_naive_utc_now() + datetime.timedelta(days=12)).date(), '%d/%m/%Y')}",
                 },
                 3,
             ),
             (
                 "1",
                 {
-                    f"Temps costaud - {datetime.datetime.strftime((datetime.datetime.utcnow() + datetime.timedelta(days=11)).date(), '%d/%m/%Y')}"
-                    f" - {datetime.datetime.strftime((datetime.datetime.utcnow() + datetime.timedelta(days=12)).date(), '%d/%m/%Y')}"
+                    f"Temps costaud - {datetime.datetime.strftime((date_utils.get_naive_utc_now() + datetime.timedelta(days=11)).date(), '%d/%m/%Y')}"
+                    f" - {datetime.datetime.strftime((date_utils.get_naive_utc_now() + datetime.timedelta(days=12)).date(), '%d/%m/%Y')}"
                 },
                 3,
             ),

--- a/api/tests/routes/backoffice/bank_account_test.py
+++ b/api/tests/routes/backoffice/bank_account_test.py
@@ -17,6 +17,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 
 from .helpers import button as button_helpers
@@ -233,7 +234,7 @@ class GetBankAccountHistoryTest(GetEndpointHelper):
         venue = offerers_factories.VenueFactory()
         bank_account = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
         offerers_factories.VenueBankAccountLinkFactory(
-            venue=venue, bankAccount=bank_account, timespan=(datetime.datetime.utcnow(),)
+            venue=venue, bankAccount=bank_account, timespan=(date_utils.get_naive_utc_now(),)
         )
 
         action = history_factories.ActionHistoryFactory(
@@ -262,7 +263,7 @@ class GetBankAccountHistoryTest(GetEndpointHelper):
         venue = offerers_factories.VenueFactory()
         bank_account = finance_factories.BankAccountFactory(offerer=venue.managingOfferer)
         offerers_factories.VenueBankAccountLinkFactory(
-            venue=venue, bankAccount=bank_account, timespan=(datetime.datetime.utcnow(),)
+            venue=venue, bankAccount=bank_account, timespan=(date_utils.get_naive_utc_now(),)
         )
 
         link_action = history_factories.ActionHistoryFactory(
@@ -389,7 +390,7 @@ class DownloadReimbursementDetailsTest(PostEndpointHelper):
             status=finance_models.PricingStatus.INVOICED, booking=booking_finance_incident.booking
         )
         incident_events = finance_api._create_finance_events_from_incident(
-            booking_finance_incident, datetime.datetime.utcnow()
+            booking_finance_incident, date_utils.get_naive_utc_now()
         )
         incident_pricings = []
         for event in incident_events:
@@ -399,7 +400,8 @@ class DownloadReimbursementDetailsTest(PostEndpointHelper):
 
         # Create total overpayment on collective booking
         collective_booking_finance_incident = finance_factories.CollectiveBookingFinanceIncidentFactory(
-            collectiveBooking__collectiveStock__startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=5),
+            collectiveBooking__collectiveStock__startDatetime=date_utils.get_naive_utc_now()
+            - datetime.timedelta(days=5),
             collectiveBooking__collectiveStock__collectiveOffer__venue=venue,
             collectiveBooking__collectiveStock__price=7,
             newTotalAmount=0,
@@ -409,7 +411,7 @@ class DownloadReimbursementDetailsTest(PostEndpointHelper):
             collectiveBooking=collective_booking_finance_incident.collectiveBooking,
         )
         collective_incident_events = finance_api._create_finance_events_from_incident(
-            collective_booking_finance_incident, datetime.datetime.utcnow()
+            collective_booking_finance_incident, date_utils.get_naive_utc_now()
         )
         for event in collective_incident_events:
             pricing = finance_api.price_event(event)

--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -14,6 +14,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from .helpers import flash
 from .helpers import html_parser
@@ -38,8 +39,8 @@ def collective_bookings_fixture() -> tuple:
         educationalInstitution=institution2,
         collectiveStock__collectiveOffer__name="Offer n°1",
         collectiveStock__collectiveOffer__formats=[EacFormat.CONFERENCE_RENCONTRE],
-        collectiveStock__startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=6),
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=4),
+        collectiveStock__startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=6),
+        dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=4),
         venue=venue,
     )
     offerers_factories.UserOffererFactory(offerer=pending.offerer)
@@ -50,10 +51,10 @@ def collective_bookings_fixture() -> tuple:
         collectiveStock__price=1234,
         collectiveStock__collectiveOffer__name="Visite des locaux primitifs du pass Culture",
         collectiveStock__collectiveOffer__formats=[EacFormat.VISITE_GUIDEE],
-        collectiveStock__bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=2),
-        collectiveStock__startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=3),
-        collectiveStock__endDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=24),
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=3),
+        collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=2),
+        collectiveStock__startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=3),
+        collectiveStock__endDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=24),
+        dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
     )
     # 2
     cancelled = educational_factories.CancelledCollectiveBookingFactory(
@@ -62,9 +63,9 @@ def collective_bookings_fixture() -> tuple:
         collectiveStock__price=567.8,
         collectiveStock__collectiveOffer__name="Offer n°2",
         collectiveStock__collectiveOffer__formats=[EacFormat.CONCERT],
-        collectiveStock__bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=3),
-        collectiveStock__startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=7),
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+        collectiveStock__bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=3),
+        collectiveStock__startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=7),
+        dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
         venue=venue,
     )
     # 3
@@ -72,15 +73,15 @@ def collective_bookings_fixture() -> tuple:
         educationalInstitution=institution3,
         collectiveStock__collectiveOffer__name="Offer n°3",
         collectiveStock__collectiveOffer__formats=[EacFormat.PROJECTION_AUDIOVISUELLE],
-        collectiveStock__startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=5),
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        collectiveStock__startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=5),
+        dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
     )
     # 4
     reimbursed = educational_factories.ReimbursedCollectiveBookingFactory(
         educationalInstitution=institution3,
         collectiveStock__collectiveOffer__name="Offer n°4",
         collectiveStock__collectiveOffer__formats=[EacFormat.ATELIER_DE_PRATIQUE],
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=5),
+        dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=5),
     )
 
     return pending, confirmed, cancelled, used, reimbursed

--- a/api/tests/routes/backoffice/collective_offer_templates_test.py
+++ b/api/tests/routes/backoffice/collective_offer_templates_test.py
@@ -20,6 +20,7 @@ from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.routes.backoffice.filters import format_date
+from pcapi.utils import date as date_utils
 
 from .helpers import button as button_helpers
 from .helpers import html_parser
@@ -184,7 +185,7 @@ class ListCollectiveOfferTemplatesTest(GetEndpointHelper):
         for days_ago in (2, 4, 1, 3):
             educational_factories.CollectiveOfferTemplateFactory(
                 name=f"Offre {days_ago}",
-                dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=days_ago),
+                dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=days_ago),
                 validation=offers_models.OfferValidationStatus.PENDING,
                 venue=validated_venue,
             )

--- a/api/tests/routes/backoffice/conftest.py
+++ b/api/tests/routes/backoffice/conftest.py
@@ -19,6 +19,7 @@ from pcapi.core.users import models as users_models
 from pcapi.core.users.backoffice import api as backoffice_api
 from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
+from pcapi.utils import date as date_utils
 
 
 if TYPE_CHECKING:
@@ -387,7 +388,7 @@ def venue_with_nor_contact_or_booking_email_fixture():
 def venue_provider_with_last_sync_fixture(venue_with_accepted_bank_account):
     venue_provider = providers_factories.VenueProviderFactory(
         venue=venue_with_accepted_bank_account,
-        lastSyncDate=datetime.datetime.utcnow(),
+        lastSyncDate=date_utils.get_naive_utc_now(),
     )
     return venue_provider
 
@@ -473,7 +474,7 @@ def offerer_expired_offers(offerer, venue_with_accepted_bank_account):
         size=4,
         offer=factory.Iterator(offers),
         isSoftDeleted=False,
-        bookingLimitDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=10),
+        bookingLimitDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
     )
     return offers
 
@@ -483,7 +484,7 @@ def offerer_expired_collective_offers(offerer, venue_with_accepted_bank_account)
     stocks = educational_factories.CollectiveStockFactory.create_batch(
         size=4,
         price=1337,
-        startDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=10),
+        startDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
     )
     return educational_factories.CollectiveOfferFactory.create_batch(
         size=4,

--- a/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
+++ b/api/tests/routes/backoffice/custom_reimbursement_rules_test.py
@@ -38,8 +38,8 @@ class ListCustomReimbursementRulesTest(GetEndpointHelper):
     expected_num_queries = 3
 
     def test_list_custom_reimbursement_rules(self, authenticated_client):
-        start = datetime.datetime.utcnow() - datetime.timedelta(days=365)
-        end = datetime.datetime.utcnow() + datetime.timedelta(days=365)
+        start = date_utils.get_naive_utc_now() - datetime.timedelta(days=365)
+        end = date_utils.get_naive_utc_now() + datetime.timedelta(days=365)
         offer_rule = finance_factories.CustomReimbursementRuleFactory(amount=2700, timespan=(start, None))
         venue = offerers_factories.VenueFactory()
         venue_rule = finance_factories.CustomReimbursementRuleFactory(venue=venue, rate=0.98, timespan=(start, None))

--- a/api/tests/routes/backoffice/filters_test.py
+++ b/api/tests/routes/backoffice/filters_test.py
@@ -9,6 +9,7 @@ from pcapi.core.finance import models as finance_models
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.routes.backoffice import filters
+from pcapi.utils import date as date_utils
 
 
 pytestmark = [
@@ -60,7 +61,7 @@ class FormatRoleTest:
     def test_ex_beneficiaries(self, age, deposit_type, expected):
         user = users_factories.BeneficiaryFactory(age=age)
         user.deposits[0].type = deposit_type
-        user.deposits[0].expirationDate = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        user.deposits[0].expirationDate = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         result = filters.format_role(user.roles[0], user.deposits)
         assert result == expected
 

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -32,6 +32,7 @@ from pcapi.models import db
 from pcapi.routes.backoffice.filters import format_booking_status
 from pcapi.routes.backoffice.filters import format_date_time
 from pcapi.routes.backoffice.finance import forms as finance_forms
+from pcapi.utils import date as date_utils
 
 from .helpers import flash
 from .helpers import html_parser
@@ -645,7 +646,7 @@ class ValidateFinanceOverpaymentIncidentTest(PostEndpointHelper):
     @pytest.mark.parametrize("force_debit_note", [True, False])
     def test_incident_validation_with_several_bookings(self, authenticated_client, force_debit_note):
         deposit = users_factories.DepositGrantFactory(
-            amount=300, expirationDate=datetime.datetime.utcnow() + relativedelta(years=2)
+            amount=300, expirationDate=date_utils.get_naive_utc_now() + relativedelta(years=2)
         )
         incident = finance_factories.FinanceIncidentFactory()
 
@@ -1034,7 +1035,7 @@ class ValidateFinanceCommercialGestureTest(PostEndpointHelper):
 
     def test_commercial_gesture_validation_with_several_bookings(self, authenticated_client):
         deposit = users_factories.DepositGrantFactory(
-            amount=300, expirationDate=datetime.datetime.utcnow() + relativedelta(years=2)
+            amount=300, expirationDate=date_utils.get_naive_utc_now() + relativedelta(years=2)
         )
         incident = finance_factories.FinanceCommercialGestureFactory()
         # make the participant poor because commercial gesture is not meant to be taken from the user's balance
@@ -1241,7 +1242,7 @@ class CreateIncidentFinanceEventTest:
             incident__kind=incident_type,
             newTotalAmount=0,
         )
-        validation_date = datetime.datetime.utcnow()
+        validation_date = date_utils.get_naive_utc_now()
         finance_events = api._create_finance_events_from_incident(total_booking_incident, validation_date)
 
         assert len(finance_events) == 1
@@ -1267,7 +1268,7 @@ class CreateIncidentFinanceEventTest:
             incident__kind=incident_type,
         )
 
-        validation_date = datetime.datetime.utcnow()
+        validation_date = date_utils.get_naive_utc_now()
         finance_events = api._create_finance_events_from_incident(total_booking_incident, validation_date)
 
         assert len(finance_events) == 1
@@ -1295,7 +1296,7 @@ class CreateIncidentFinanceEventTest:
             newTotalAmount=600,
         )
 
-        validation_date = datetime.datetime.utcnow()
+        validation_date = date_utils.get_naive_utc_now()
         finance_events = api._create_finance_events_from_incident(partial_booking_incident, validation_date)
 
         assert len(finance_events) == 2
@@ -1319,7 +1320,7 @@ class CreateIncidentFinanceEventTest:
             ],
             newTotalAmount=800,
         )
-        validation_date = datetime.datetime.utcnow()
+        validation_date = date_utils.get_naive_utc_now()
 
         finance_events = api._create_finance_events_from_incident(booking_incident, validation_date)
 
@@ -1475,11 +1476,11 @@ class GetOverpaymentIncidentTest(GetEndpointHelper):
             venue=venue,
             bookingFinanceIncident=booking_finance_incident,
             booking=None,
-            valueDate=datetime.datetime.utcnow(),
+            valueDate=date_utils.get_naive_utc_now(),
             status=finance_models.FinanceEventStatus.PRICED,
             pricings=[pricing],
             pricingPoint=venue,
-            pricingOrderingDate=datetime.datetime.utcnow(),
+            pricingOrderingDate=date_utils.get_naive_utc_now(),
         )
 
         url = url_for(self.endpoint, finance_incident_id=finance_incident.id)
@@ -1602,11 +1603,11 @@ class GetCommercialGestureTest(GetEndpointHelper):
             venue=venue,
             bookingFinanceIncident=booking_finance_incident,
             booking=None,
-            valueDate=datetime.datetime.utcnow(),
+            valueDate=date_utils.get_naive_utc_now(),
             status=finance_models.FinanceEventStatus.PRICED,
             pricings=[pricing],
             pricingPoint=venue,
-            pricingOrderingDate=datetime.datetime.utcnow(),
+            pricingOrderingDate=date_utils.get_naive_utc_now(),
         )
 
         url = url_for(self.endpoint, finance_incident_id=finance_incident.id)
@@ -2434,7 +2435,7 @@ class GetIncidentHistoryTest(GetEndpointHelper):
         action = history_factories.ActionHistoryFactory(
             financeIncident=finance_incident,
             actionType=history_models.ActionType.FINANCE_INCIDENT_CREATED,
-            actionDate=datetime.datetime.utcnow() + datetime.timedelta(days=-1),
+            actionDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=-1),
         )
         author = users_factories.UserFactory()
         api.cancel_finance_incident(finance_incident, comment="Je décide d'annuler l'incident", author=author)
@@ -2468,7 +2469,7 @@ class ForceDebitNoteTest(PostEndpointHelper):
         original_pricing = api.price_event(original_event)
         original_pricing.status = finance_models.PricingStatus.INVOICED
 
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         finance_incident = finance_factories.IndividualBookingFinanceIncidentFactory(
             booking=booking, incident__status=finance_models.IncidentStatus.VALIDATED, incident__forceDebitNote=False
         ).incident
@@ -2531,7 +2532,7 @@ class ForceDebitNoteTest(PostEndpointHelper):
         events_to_price.extend(
             api._create_finance_events_from_incident(
                 original_finance_incident.booking_finance_incidents[0],
-                incident_validation_date=datetime.datetime.utcnow(),
+                incident_validation_date=date_utils.get_naive_utc_now(),
             )
         )
         booking = bookings_factories.UsedBookingFactory(stock__offer__venue=venue, amount=20)
@@ -2544,7 +2545,7 @@ class ForceDebitNoteTest(PostEndpointHelper):
         for event in events_to_price:
             api.price_event(event)
 
-        cashflow_batch = api.generate_cashflows_and_payment_files(datetime.datetime.utcnow())
+        cashflow_batch = api.generate_cashflows_and_payment_files(date_utils.get_naive_utc_now())
         generated_cashflow = cashflow_batch.cashflows[0]
         generated_cashflow.status = finance_models.CashflowStatus.ACCEPTED
 
@@ -2581,7 +2582,7 @@ class CancelDebitNoteTest(PostEndpointHelper):
         original_pricing = api.price_event(original_event)
         original_pricing.status = finance_models.PricingStatus.INVOICED
 
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         finance_incident = finance_factories.IndividualBookingFinanceIncidentFactory(
             booking=booking,
             incident__status=finance_models.IncidentStatus.VALIDATED,
@@ -2667,7 +2668,7 @@ class CancelDebitNoteTest(PostEndpointHelper):
         events_to_price.extend(
             api._create_finance_events_from_incident(
                 original_finance_incident.booking_finance_incidents[0],
-                incident_validation_date=datetime.datetime.utcnow(),
+                incident_validation_date=date_utils.get_naive_utc_now(),
             )
         )
         booking = bookings_factories.UsedBookingFactory(stock__offer__venue=venue, amount=20)
@@ -2680,7 +2681,7 @@ class CancelDebitNoteTest(PostEndpointHelper):
         for event in events_to_price:
             api.price_event(event)
 
-        cashflow_batch = api.generate_cashflows_and_payment_files(datetime.datetime.utcnow())
+        cashflow_batch = api.generate_cashflows_and_payment_files(date_utils.get_naive_utc_now())
         generated_cashflow = cashflow_batch.cashflows[0]
         generated_cashflow.status = finance_models.CashflowStatus.ACCEPTED
 

--- a/api/tests/routes/backoffice/individual_bookings_test.py
+++ b/api/tests/routes/backoffice/individual_bookings_test.py
@@ -27,6 +27,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
 from pcapi.routes.backoffice.bookings import forms
+from pcapi.utils import date as date_utils
 
 from tests.connectors.cgr import soap_definitions
 from tests.local_providers.cinema_providers.cgr import fixtures as cgr_fixtures
@@ -60,7 +61,7 @@ def bookings_fixture() -> tuple:
         stock__offer__name="Guide du Routard Sainte-Hélène",
         stock__offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
         stock__offer__withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=4),
+        dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=4),
         validationAuthorType=bookings_models.BookingValidationAuthorType.BACKOFFICE,
     )
     offerers_factories.UserOffererFactory(offerer=used.offerer)
@@ -71,8 +72,8 @@ def bookings_fixture() -> tuple:
         amount=12.5,
         token="CNCL02",
         stock__offer__subcategoryId=subcategories.FESTIVAL_SPECTACLE.id,
-        stock__beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=11),
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=3),
+        stock__beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=11),
+        dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
     )
     confirmed = bookings_factories.BookingFactory(
         id=1000003,
@@ -83,16 +84,16 @@ def bookings_fixture() -> tuple:
         stock__quantity="2",
         stock__offer__name="Guide Ile d'Elbe 1814 Petit Futé",
         stock__offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=2),
-        cancellation_limit_date=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
+        cancellation_limit_date=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
     )
     reimbursed = bookings_factories.ReimbursedBookingFactory(
         id=1000004,
         user=user3,
         token="REIMB3",
         stock__offer__subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
-        stock__beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=12),
-        dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+        stock__beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=12),
+        dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
     )
     booked = bookings_factories.BookingFactory(
         id=1000005,
@@ -103,7 +104,7 @@ def bookings_fixture() -> tuple:
         stock__quantity="1",
         stock__offer__name="Guide Ile d'Elbe 1814 Petit Futé",
         stock__offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
-        dateCreated=datetime.datetime.utcnow(),
+        dateCreated=date_utils.get_naive_utc_now(),
     )
 
     return used, cancelled, confirmed, reimbursed, booked
@@ -172,8 +173,8 @@ class ListIndividualBookingsTest(GetEndpointHelper):
 
         users_factories.DepositGrantFactory(
             bookings=[booking],
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=5),
-            expirationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=5),
+            expirationDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         )
 
         with assert_num_queries(self.expected_num_queries):
@@ -490,7 +491,7 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         offer_id = offer.id
 
         expired_deposit_booking = bookings_factories.UsedBookingFactory(token="EXPIRD", stock__offer=offer)
-        expired_deposit_booking.deposit.expirationDate = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        expired_deposit_booking.deposit.expirationDate = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         db.session.flush()
 
         bookings_factories.UsedBookingFactory(token="ACTIVE", stock__offer=offer)
@@ -513,8 +514,8 @@ class ListIndividualBookingsTest(GetEndpointHelper):
         )
         users_factories.DepositGrantFactory(
             bookings=[expired_deposit_booking],
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=5),
-            expirationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=5),
+            expirationDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         )
 
         new_user = users_factories.BeneficiaryFactory()
@@ -803,7 +804,7 @@ class MarkBookingAsUsedTest(PostEndpointHelper):
         booking = bookings_factories.BookingFactory(
             status=bookings_models.BookingStatus.CANCELLED,
             deposit=users_factories.DepositGrantFactory(
-                expirationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+                expirationDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
             ),
         )
 
@@ -1054,7 +1055,7 @@ class CancelBookingTest(PostEndpointHelper):
         stock = offers_factories.EventStockFactory(
             offer=offer,
             idAtProviders="1111%2222%EMS#3333",
-            beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
         )
         booking = bookings_factories.BookingFactory(stock=stock, user=beneficiary)
         external_bookings_factories.ExternalBookingFactory(
@@ -1139,7 +1140,7 @@ class CancelBookingTest(PostEndpointHelper):
         stock = offers_factories.StockFactory(
             lastProvider=cgr_provider,
             idAtProviders="123%12354114%CGR#111",
-            beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
             offer=offer,
         )
         booking_to_cancel = bookings_factories.BookingFactory(stock=stock)
@@ -1249,7 +1250,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
         expired_booking = bookings_factories.BookingFactory(
             status=bookings_models.BookingStatus.CANCELLED,
             deposit=users_factories.DepositGrantFactory(
-                expirationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+                expirationDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
             ),
         )
         other_booking = bookings_factories.BookingFactory(status=bookings_models.BookingStatus.CANCELLED)
@@ -1305,7 +1306,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
         insufficient_stock_booking = bookings_factories.BookingFactory(
             status=bookings_models.BookingStatus.CANCELLED,
             deposit=users_factories.DepositGrantFactory(
-                expirationDate=datetime.datetime.utcnow() + datetime.timedelta(days=1)
+                expirationDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
             ),
             stock__quantity=0,
         )
@@ -1358,7 +1359,7 @@ class BatchMarkBookingAsUsedTest(PostEndpointHelper):
         insufficient_stock_booking = bookings_factories.BookingFactory(
             status=bookings_models.BookingStatus.CANCELLED,
             deposit=users_factories.DepositGrantFactory(
-                expirationDate=datetime.datetime.utcnow() + datetime.timedelta(days=1)
+                expirationDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
             ),
             stock__quantity=0,
         )
@@ -1519,12 +1520,12 @@ class BatchTagFraudulentBookingsTest(PostEndpointHelper):
         bookings = bookings_factories.BookingFactory.create_batch(3)
         bookings.append(
             bookings_factories.FraudulentBookingTagFactory(
-                dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=4)
+                dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=4)
             ).booking
         )
         bookings.append(
             bookings_factories.FraudulentBookingTagFactory(
-                dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=4)
+                dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=4)
             ).booking
         )
         parameter_ids = ",".join(str(booking.id) for booking in bookings)
@@ -1550,7 +1551,7 @@ class BatchTagFraudulentBookingsTest(PostEndpointHelper):
             db.session.query(bookings_models.FraudulentBookingTag)
             .filter(
                 bookings_models.FraudulentBookingTag.dateCreated
-                > datetime.datetime.utcnow() - datetime.timedelta(days=1)
+                > date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
             )
             .all()
         )
@@ -1565,11 +1566,11 @@ class BatchTagFraudulentBookingsTest(PostEndpointHelper):
         booking_with_other_email = bookings_factories.BookingFactory(stock__offer__bookingEmail="email2@example.com")
         already_fraudulent_booking_with_other_email = bookings_factories.FraudulentBookingTagFactory(
             booking__stock__offer__bookingEmail="email2@example.com",
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=4),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=4),
         ).booking
         already_fraudulent_booking_with_different_email = bookings_factories.FraudulentBookingTagFactory(
             booking__stock__offer__bookingEmail="email3@example.com",
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=4),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=4),
         ).booking
 
         bookings = (
@@ -1601,7 +1602,7 @@ class BatchTagFraudulentBookingsTest(PostEndpointHelper):
             db.session.query(bookings_models.FraudulentBookingTag)
             .filter(
                 bookings_models.FraudulentBookingTag.dateCreated
-                > datetime.datetime.utcnow() - datetime.timedelta(days=1)
+                > date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
             )
             .all()
         )

--- a/api/tests/routes/backoffice/move_siret_test.py
+++ b/api/tests/routes/backoffice/move_siret_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -13,6 +12,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from .helpers import html_parser
 from .helpers.get import GetEndpointHelper
@@ -171,9 +171,9 @@ class PostMoveSiretTest(MoveSiretTestHelper):
     @pytest.mark.parametrize(
         "start_date, end_date",
         [
-            (datetime.utcnow() - timedelta(days=10), None),
-            (datetime.utcnow() - timedelta(days=10), datetime.utcnow() + timedelta(days=10)),
-            (datetime.utcnow() + timedelta(days=10), None),
+            (date_utils.get_naive_utc_now() - timedelta(days=10), None),
+            (date_utils.get_naive_utc_now() - timedelta(days=10), date_utils.get_naive_utc_now() + timedelta(days=10)),
+            (date_utils.get_naive_utc_now() + timedelta(days=10), None),
         ],
     )
     def test_venue_custom_reimbursement_rule(self, authenticated_client, start_date, end_date):
@@ -224,7 +224,7 @@ class ApplyMoveSiretTest(MoveSiretTestHelper):
         target_venue = offerers_factories.VenueWithoutSiretFactory(managingOfferer=source_venue.managingOfferer)
         finance_factories.CustomReimbursementRuleFactory(
             venue=source_venue,
-            timespan=(datetime.utcnow() + timedelta(days=10), None),
+            timespan=(date_utils.get_naive_utc_now() + timedelta(days=10), None),
         )
         form = {
             "source_venue": source_venue.id,

--- a/api/tests/routes/backoffice/multiple_offers_test.py
+++ b/api/tests/routes/backoffice/multiple_offers_test.py
@@ -24,6 +24,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import OfferValidationType
+from pcapi.utils import date as date_utils
 
 from .helpers import button as button_helpers
 from .helpers import html_parser
@@ -349,7 +350,7 @@ class SetProductGcuIncompatibleTest(PostEndpointHelper):
                 assert offer.lastValidationDate == initially_rejected[offer.id]["date"]
             else:
                 assert offer.lastValidationType == OfferValidationType.CGU_INCOMPATIBLE_PRODUCT
-                assert datetime.datetime.utcnow() - offer.lastValidationDate < datetime.timedelta(seconds=5)
+                assert date_utils.get_naive_utc_now() - offer.lastValidationDate < datetime.timedelta(seconds=5)
 
     @pytest.mark.usefixtures("db_session")
     def test_cancel_bookings_and_send_transactional_email(self, authenticated_client):
@@ -398,7 +399,7 @@ class SetProductGcuIncompatibleTest(PostEndpointHelper):
         )
 
         cancelled_booking = bookings_factories.CancelledBookingFactory(
-            stock=stock, dateUsed=factory.LazyFunction(datetime.datetime.utcnow)
+            stock=stock, dateUsed=factory.LazyFunction(date_utils.get_naive_utc_now)
         )
         finance_event = finance_factories.UsedBookingFinanceEventFactory(
             booking=cancelled_booking,
@@ -435,7 +436,7 @@ class SetProductGcuIncompatibleTest(PostEndpointHelper):
         assert product.gcuCompatibilityType == offers_models.GcuCompatibilityType.FRAUD_INCOMPATIBLE
         assert offer.validation == offers_models.OfferValidationStatus.REJECTED
         assert offer.lastValidationType == OfferValidationType.CGU_INCOMPATIBLE_PRODUCT
-        assert datetime.datetime.utcnow() - offer.lastValidationDate < datetime.timedelta(seconds=5)
+        assert date_utils.get_naive_utc_now() - offer.lastValidationDate < datetime.timedelta(seconds=5)
 
         assert (
             db.session.query(bookings_models.Booking).filter(bookings_models.Booking.is_used_or_reimbursed).count() == 2

--- a/api/tests/routes/backoffice/offer_validation_rules_test.py
+++ b/api/tests/routes/backoffice/offer_validation_rules_test.py
@@ -1,4 +1,3 @@
-import datetime
 from operator import attrgetter
 
 import pytest
@@ -12,6 +11,7 @@ from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from .helpers import html_parser
 from .helpers.get import GetEndpointHelper
@@ -1050,7 +1050,7 @@ class ListRulesHistoryTest(GetEndpointHelper):
         rule_creation_history = history_factories.ActionHistoryFactory(
             ruleId=rule.id,
             actionType=history_models.ActionType.RULE_CREATED,
-            actionDate=datetime.datetime.utcnow(),
+            actionDate=date_utils.get_naive_utc_now(),
             authorUser=legit_user,
             comment=None,
             extraData={
@@ -1078,7 +1078,7 @@ class ListRulesHistoryTest(GetEndpointHelper):
         rule_modification_history = history_factories.ActionHistoryFactory(
             ruleId=rule.id,
             actionType=history_models.ActionType.RULE_MODIFIED,
-            actionDate=datetime.datetime.utcnow(),
+            actionDate=date_utils.get_naive_utc_now(),
             authorUser=legit_user,
             comment=None,
             extraData={
@@ -1116,7 +1116,7 @@ class ListRulesHistoryTest(GetEndpointHelper):
         rule_deletion_history = history_factories.ActionHistoryFactory(
             ruleId=rule.id,
             actionType=history_models.ActionType.RULE_DELETED,
-            actionDate=datetime.datetime.utcnow(),
+            actionDate=date_utils.get_naive_utc_now(),
             authorUser=legit_user,
             comment=None,
             extraData={

--- a/api/tests/routes/backoffice/offerers_test.py
+++ b/api/tests/routes/backoffice/offerers_test.py
@@ -37,6 +37,7 @@ from pcapi.routes.backoffice.filters import format_date
 from pcapi.routes.backoffice.filters import format_date_time
 from pcapi.routes.backoffice.offerers import offerer_blueprint
 from pcapi.routes.backoffice.pro.forms import TypeOptions
+from pcapi.utils import date as date_utils
 
 from .helpers import button as button_helpers
 from .helpers import html_parser
@@ -130,7 +131,7 @@ class GetOffererTest(GetEndpointHelper):
         offerers_factories.VenueBankAccountLinkFactory(
             venue=venue_with_accepted_bank_account,
             timespan=[
-                datetime.datetime.utcnow() - datetime.timedelta(days=365),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
                 None,
             ],
             bankAccount=finance_factories.BankAccountFactory(label="Nouveau compte", offererId=offerer.id),
@@ -139,14 +140,14 @@ class GetOffererTest(GetEndpointHelper):
         offerers_factories.VenueBankAccountLinkFactory(
             venue=venue_with_two_bank_accounts,
             timespan=[
-                datetime.datetime.utcnow() - datetime.timedelta(days=365),
-                datetime.datetime.utcnow() - datetime.timedelta(days=1),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             ],
             bankAccount=finance_factories.BankAccountFactory(label="Ancien compte", offererId=offerer.id),
         )
         offerers_factories.VenueBankAccountLinkFactory(
             venue=venue_with_two_bank_accounts,
-            timespan=[datetime.datetime.utcnow() - datetime.timedelta(days=1), None],
+            timespan=[date_utils.get_naive_utc_now() - datetime.timedelta(days=1), None],
             bankAccount=finance_factories.BankAccountFactory(label="Nouveau compte", offererId=offerer.id),
         )
 
@@ -154,8 +155,8 @@ class GetOffererTest(GetEndpointHelper):
         offerers_factories.VenueBankAccountLinkFactory(
             venue=venue_with_expired_bank_account,
             timespan=[
-                datetime.datetime.utcnow() - datetime.timedelta(days=365),
-                datetime.datetime.utcnow() - datetime.timedelta(days=1),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             ],
             bankAccount=finance_factories.BankAccountFactory(label="Ancien compte", offererId=offerer.id),
         )
@@ -1167,7 +1168,7 @@ class GetOffererHistoryTest(GetEndpointHelper):
         history_factories.ActionHistoryFactory(
             # displayed because legit_user has fraud permission
             actionType=history_models.ActionType.FRAUD_INFO_MODIFIED,
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
             authorUser=pro_fraud_admin,
             offerer=offerer,
             comment=None,
@@ -1681,7 +1682,7 @@ class GetOffererVenuesTest(GetEndpointHelper):
     expected_num_queries = 4
 
     def test_get_managed_venues(self, authenticated_client, offerer):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         other_offerer = offerers_factories.OffererFactory()
         venue_1 = offerers_factories.VenueFactory(
             name="Deuxième", publicName="Second", managingOfferer=offerer, isPermanent=True, isOpenToPublic=True
@@ -1849,21 +1850,21 @@ class GetOffererCollectiveDmsApplicationsTest(GetEndpointHelper):
             venue=venue_1,
             application=35,
             state="refuse",
-            depositDate=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            depositDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         )
         educational_factories.CollectiveDmsApplicationFactory(
-            venue=venue_2, application=36, depositDate=datetime.datetime.utcnow() - datetime.timedelta(days=2)
+            venue=venue_2, application=36, depositDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
         )
         educational_factories.CollectiveDmsApplicationFactory(
             venue=venue_1,
             application=37,
             state="accepte",
-            depositDate=datetime.datetime.utcnow() - datetime.timedelta(days=3),
+            depositDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
         )
         educational_factories.CollectiveDmsApplicationWithNoVenueFactory(
             siret="12345678900003",
             application=38,
-            depositDate=datetime.datetime.utcnow() - datetime.timedelta(days=4),
+            depositDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=4),
         )
         educational_factories.CollectiveDmsApplicationFactory(application=39)
         educational_factories.CollectiveDmsApplicationWithNoVenueFactory(siret="12345123456789")
@@ -1879,45 +1880,45 @@ class GetOffererCollectiveDmsApplicationsTest(GetEndpointHelper):
         assert len(rows) == 4
 
         assert rows[0]["ID"] == "35"
-        assert rows[0]["Date de dépôt"] == (datetime.datetime.utcnow() - datetime.timedelta(days=1)).strftime(
+        assert rows[0]["Date de dépôt"] == (date_utils.get_naive_utc_now() - datetime.timedelta(days=1)).strftime(
             "%d/%m/%Y"
         )
         assert rows[0]["État"] == "Refusé"
         assert rows[0]["Date de dernière mise à jour"] == (
-            datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+            date_utils.get_naive_utc_now() - datetime.timedelta(hours=1)
         ).strftime("%d/%m/%Y")
         assert rows[0]["Partenaire culturel"] == venue_1.name
         assert rows[0]["SIRET"] == venue_1.siret
 
         assert rows[1]["ID"] == "36"
-        assert rows[1]["Date de dépôt"] == (datetime.datetime.utcnow() - datetime.timedelta(days=2)).strftime(
+        assert rows[1]["Date de dépôt"] == (date_utils.get_naive_utc_now() - datetime.timedelta(days=2)).strftime(
             "%d/%m/%Y"
         )
         assert rows[1]["État"] == "En construction"
         assert rows[1]["Date de dernière mise à jour"] == (
-            datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+            date_utils.get_naive_utc_now() - datetime.timedelta(hours=1)
         ).strftime("%d/%m/%Y")
         assert rows[1]["Partenaire culturel"] == venue_2.name
         assert rows[1]["SIRET"] == venue_2.siret
 
         assert rows[2]["ID"] == "37"
-        assert rows[2]["Date de dépôt"] == (datetime.datetime.utcnow() - datetime.timedelta(days=3)).strftime(
+        assert rows[2]["Date de dépôt"] == (date_utils.get_naive_utc_now() - datetime.timedelta(days=3)).strftime(
             "%d/%m/%Y"
         )
         assert rows[2]["État"] == "Accepté"
         assert rows[2]["Date de dernière mise à jour"] == (
-            datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+            date_utils.get_naive_utc_now() - datetime.timedelta(hours=1)
         ).strftime("%d/%m/%Y")
         assert rows[2]["Partenaire culturel"] == venue_1.name
         assert rows[2]["SIRET"] == venue_1.siret
 
         assert rows[3]["ID"] == "38"
-        assert rows[3]["Date de dépôt"] == (datetime.datetime.utcnow() - datetime.timedelta(days=4)).strftime(
+        assert rows[3]["Date de dépôt"] == (date_utils.get_naive_utc_now() - datetime.timedelta(days=4)).strftime(
             "%d/%m/%Y"
         )
         assert rows[3]["État"] == "En construction"
         assert rows[3]["Date de dernière mise à jour"] == (
-            datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+            date_utils.get_naive_utc_now() - datetime.timedelta(hours=1)
         ).strftime("%d/%m/%Y")
         assert rows[3]["Partenaire culturel"] == ""
         assert rows[3]["SIRET"] == "12345678900003"
@@ -1945,7 +1946,7 @@ class GetOffererBankAccountTest(GetEndpointHelper):
     expected_num_queries = 3
 
     def test_get_bank_accounts(self, authenticated_client, offerer):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         offerer = offerers_factories.OffererFactory()
         bank1 = finance_factories.BankAccountFactory(
             offerer=offerer,
@@ -2595,7 +2596,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
             )
 
             history_factories.ActionHistoryFactory(
-                actionDate=datetime.datetime.utcnow() - datetime.timedelta(minutes=10),
+                actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(minutes=10),
                 actionType=history_models.ActionType.OFFERER_PENDING,
                 authorUser=other_instructor,
                 offerer=pending2,
@@ -2608,7 +2609,7 @@ class ListOfferersToValidateTest(GetEndpointHelper):
             )
 
             history_factories.ActionHistoryFactory(
-                actionDate=datetime.datetime.utcnow() - datetime.timedelta(minutes=10),
+                actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(minutes=10),
                 actionType=history_models.ActionType.OFFERER_PENDING,
                 authorUser=instructor,
                 offerer=pending3,
@@ -2906,7 +2907,7 @@ class ValidateOffererTest(ActivateOffererHelper):
             venue__managingOfferer=offerer,
             validation=offer_mixin.OfferValidationStatus.APPROVED,
             lastValidationType=offer_mixin.OfferValidationType.AUTO,
-            lastValidationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            lastValidationDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             lastValidationPrice=10.10,
         )
         draft_offer = offers_factories.DraftOfferFactory(
@@ -2921,7 +2922,7 @@ class ValidateOffererTest(ActivateOffererHelper):
         other_offer = offers_factories.OfferFactory(
             validation=offer_mixin.OfferValidationStatus.APPROVED,
             lastValidationType=offer_mixin.OfferValidationType.AUTO,
-            lastValidationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            lastValidationDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             lastValidationPrice=10.10,
         )
 
@@ -2950,7 +2951,7 @@ class ValidateOffererTest(ActivateOffererHelper):
             venue__managingOfferer=offerer,
             validation=offer_mixin.OfferValidationStatus.APPROVED,
             lastValidationType=offer_mixin.OfferValidationType.AUTO,
-            lastValidationDate=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            lastValidationDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             lastValidationPrice=10.10,
         )
 
@@ -3416,7 +3417,7 @@ class ListUserOffererToValidateTest(GetEndpointHelper):
         )
 
         history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(minutes=10),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(minutes=10),
             actionType=history_models.ActionType.USER_OFFERER_PENDING,
             authorUser=other_instructor,
             user=pending2.user,
@@ -3430,7 +3431,7 @@ class ListUserOffererToValidateTest(GetEndpointHelper):
         )
 
         history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(minutes=10),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(minutes=10),
             actionType=history_models.ActionType.USER_OFFERER_PENDING,
             authorUser=instructor,
             user=pending3.user,

--- a/api/tests/routes/backoffice/offers_test.py
+++ b/api/tests/routes/backoffice/offers_test.py
@@ -38,6 +38,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.routes.backoffice.filters import format_date
+from pcapi.utils import date as date_utils
 from pcapi.utils.regions import get_department_code_from_city_code
 
 from .helpers import button as button_helpers
@@ -105,13 +106,13 @@ def offers_fixture(criteria) -> tuple:
         quantity=10,
         dnBookedQuantity=0,
         offer=offer_with_limited_stock,
-        beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=1),
+        beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=1),
     )
     offers_factories.EventStockFactory(
         quantity=10,
         dnBookedQuantity=5,
         offer=offer_with_limited_stock,
-        beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=3),
+        beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=3),
     )
     return offer_with_unlimited_stock, offer_with_limited_stock, offer_with_two_criteria, offer_with_a_lot_of_types
 
@@ -361,13 +362,13 @@ class ListOffersTest(GetEndpointHelper):
         [
             (
                 "DATE_FROM",
-                datetime.datetime.utcnow() + datetime.timedelta(days=1),
-                datetime.datetime.utcnow() - datetime.timedelta(days=1),
+                date_utils.get_naive_utc_now() + datetime.timedelta(days=1),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             ),
             (
                 "DATE_TO",
-                datetime.datetime.utcnow() - datetime.timedelta(days=1),
-                datetime.datetime.utcnow() + datetime.timedelta(days=1),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
+                date_utils.get_naive_utc_now() + datetime.timedelta(days=1),
             ),
         ],
     )
@@ -524,14 +525,14 @@ class ListOffersTest(GetEndpointHelper):
         offers_factories.StockFactory(
             price=15,
             offer=offer_with_multiple_stocks_valid_and_not_valid,
-            beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         )
 
         offers_factories.StockFactory(
             price=16,
             offer=offer_with_multiple_stocks_valid_and_not_valid,
-            beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=2),
-            bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=1),
+            beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=2),
+            bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=1),
         )
 
         query_args = {
@@ -772,7 +773,7 @@ class ListOffersTest(GetEndpointHelper):
         for days_ago in (2, 4, 1, 3):
             offers_factories.OfferFactory(
                 name=f"Offre {days_ago}",
-                dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=days_ago),
+                dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=days_ago),
                 validation=offers_models.OfferValidationStatus.PENDING,
                 venue=validated_venue,
             )
@@ -1195,19 +1196,19 @@ class ListOffersTest(GetEndpointHelper):
             offer=offer,
             quantity=7,
             dnBookedQuantity=2,
-            beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         )
         offers_factories.EventStockFactory(
             offer=offer,
             quantity=9,
             dnBookedQuantity=3,
-            bookingLimitDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            bookingLimitDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         )
         offers_factories.EventStockFactory(
             offer=offer,
             quantity=None,  # unlimited
             dnBookedQuantity=7,
-            bookingLimitDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            bookingLimitDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         )
         query_args = self._get_query_args_by_id(offer.id)
         client = client.with_bo_session_auth(support_pro_n2_admin)
@@ -1336,7 +1337,7 @@ class ListOffersTest(GetEndpointHelper):
         query_args = self._get_query_args_by_id(offer.id)
 
         offers_factories.StockFactory(
-            offer=offer, bookingLimitDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=30)
+            offer=offer, bookingLimitDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=30)
         )
         with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
@@ -1346,7 +1347,7 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Date(s) limite(s) de réservation"] == ""
 
         closest_stock = offers_factories.StockFactory(
-            offer=offer, bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=3)
+            offer=offer, bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
         )
         with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
@@ -1356,7 +1357,7 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Date(s) limite(s) de réservation"] == closest_stock.bookingLimitDatetime.strftime("%d/%m/%Y")
 
         furthest_stock = offers_factories.StockFactory(
-            offer=offer, bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=20)
+            offer=offer, bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=20)
         )
         with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
@@ -1373,7 +1374,7 @@ class ListOffersTest(GetEndpointHelper):
         query_args = self._get_query_args_by_id(offer.id)
 
         offers_factories.StockFactory(
-            offer=offer, bookingLimitDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=30)
+            offer=offer, bookingLimitDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=30)
         )
         with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
@@ -1383,7 +1384,7 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Date(s) limite(s) de réservation"] == ""
 
         closest_stock = offers_factories.StockFactory(
-            offer=offer, bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=3)
+            offer=offer, bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
         )
         with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
@@ -1393,7 +1394,7 @@ class ListOffersTest(GetEndpointHelper):
         assert rows[0]["Date(s) limite(s) de réservation"] == closest_stock.bookingLimitDatetime.strftime("%d/%m/%Y")
 
         furthest_stock = offers_factories.StockFactory(
-            offer=offer, bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=20)
+            offer=offer, bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=20)
         )
         with assert_num_queries(self.expected_num_queries):
             response = authenticated_client.get(url_for(self.endpoint, **query_args))
@@ -2306,7 +2307,9 @@ class MoveOfferVenueButtonTest(button_helpers.ButtonHelper):
         offer = offers_factories.EventOfferFactory(venue=venue)
         offers_factories.EventStockFactory(offer=offer)
         offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=3), isSoftDeleted=True
+            offer=offer,
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=3),
+            isSoftDeleted=True,
         )
         return url_for("backoffice_web.offer.get_offer_details", offer_id=offer.id)
 
@@ -2376,9 +2379,13 @@ class EditOfferVenueTest(PostEndpointHelper):
 
         # other objects to validate queries filters
         offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=7), isSoftDeleted=True
+            offer=offer,
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=7),
+            isSoftDeleted=True,
         )
-        offers_factories.EventStockFactory(beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=7))
+        offers_factories.EventStockFactory(
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=7)
+        )
         bookings_factories.ReimbursedBookingFactory()
 
         response = self.post_to_endpoint(
@@ -2514,10 +2521,10 @@ class EditOfferVenueTest(PostEndpointHelper):
         source_venue, destination_venue, _, _ = venues_in_same_offerer
         offer = offers_factories.EventOfferFactory(venue=source_venue)
         offers_factories.EventStockFactory.create_batch(
-            2, offer=offer, beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            2, offer=offer, beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         )
         offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=1)
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         )
 
         response = self.post_to_endpoint(authenticated_client, offer_id=offer.id, form={"venue": destination_venue.id})
@@ -2868,7 +2875,7 @@ class EditOfferStockTest(PostEndpointHelper):
         later_booking = bookings_factories.UsedBookingFactory(
             stock__offer__venue=venue,
             stock__offer__subcategoryId=subcategories.CONFERENCE.id,
-            stock__beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(hours=2),
+            stock__beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(hours=2),
         )
         later_event = finance_factories.FinanceEventFactory(
             booking=later_booking,
@@ -3809,7 +3816,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert html_parser.count_table_rows(response.data) == 0
 
     def test_get_detail_validated_offer(self, legit_user, authenticated_client):
-        validation_date = datetime.datetime.utcnow()
+        validation_date = date_utils.get_naive_utc_now()
         offer = offers_factories.OfferFactory(
             lastValidationDate=validation_date,
             validation=offers_models.OfferValidationStatus.APPROVED,
@@ -3887,7 +3894,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert "Rejeter" in buttons
 
     def test_get_detail_rejected_offer(self, legit_user, authenticated_client):
-        validation_date = datetime.datetime.utcnow()
+        validation_date = date_utils.get_naive_utc_now()
         offer = offers_factories.OfferFactory(
             lastValidationDate=validation_date,
             validation=offers_models.OfferValidationStatus.REJECTED,
@@ -3943,7 +3950,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         offer = offers_factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
 
         expired_stock = offers_factories.EventStockFactory(
-            offer=offer, beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(hours=1), price=6.66
+            offer=offer, beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(hours=1), price=6.66
         )
 
         query_count = self.expected_num_queries_with_ff
@@ -3972,13 +3979,13 @@ class GetOfferDetailsTest(GetEndpointHelper):
             offer=offer,
             quantity=100,
             dnBookedQuantity=70,
-            beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(hours=2),
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(hours=2),
         )
         expired_stock_2 = offers_factories.EventStockFactory(
             offer=offer,
             quantity=None,
             dnBookedQuantity=25,
-            beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(hours=1),
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(hours=1),
         )
 
         query_count = self.expected_num_queries_with_ff
@@ -4135,7 +4142,7 @@ class GetOfferDetailsTest(GetEndpointHelper):
         assert stocks_rows[3]["Prix"] == expected_price_4
 
     def test_get_offer_details_stocks_sorted_by_event_date_desc(self, authenticated_client):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         offer = offers_factories.EventOfferFactory()
         stock1 = offers_factories.EventStockFactory(offer=offer, beginningDatetime=now + datetime.timedelta(days=5))
         stock2 = offers_factories.EventStockFactory(offer=offer, beginningDatetime=now + datetime.timedelta(days=9))

--- a/api/tests/routes/backoffice/operations_test.py
+++ b/api/tests/routes/backoffice/operations_test.py
@@ -17,6 +17,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.backoffice.filters import format_date
+from pcapi.utils import date as date_utils
 
 from .helpers import button as button_helpers
 from .helpers import html_parser
@@ -240,7 +241,7 @@ class GetEventDetailsTest(GetEndpointHelper):
         event = operations_factories.SpecialEventFactory(
             externalId="fake00001",
             title="Énigme des enchanteurs",
-            eventDate=datetime.datetime.utcnow() + datetime.timedelta(days=2),
+            eventDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=2),
         )
         special_event_id = event.id
         name_question = operations_factories.SpecialEventQuestionFactory(
@@ -311,7 +312,7 @@ class GetEventDetailsTest(GetEndpointHelper):
     def test_filter_event_responses_by_response_status(self, authenticated_client):
         event = operations_factories.SpecialEventFactory(
             externalId="fake00002",
-            eventDate=datetime.datetime.utcnow() + datetime.timedelta(days=2),
+            eventDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=2),
         )
         operations_factories.SpecialEventResponseFactory.create_batch(
             size=2,
@@ -464,7 +465,7 @@ class GetEventDetailsTest(GetEndpointHelper):
     def test_filter_event_responses_by_eligibility(self, authenticated_client):
         event = operations_factories.SpecialEventFactory(
             externalId="fake00002",
-            eventDate=datetime.datetime.utcnow() + datetime.timedelta(days=2),
+            eventDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=2),
         )
         response_pass_18 = operations_factories.SpecialEventResponseFactory(
             event=event, user=users_factories.BeneficiaryFactory()
@@ -524,7 +525,7 @@ class GetEventDetailsTest(GetEndpointHelper):
         event = operations_factories.SpecialEventFactory(
             externalId="fake00001",
             title="A",
-            eventDate=datetime.datetime.utcnow() + datetime.timedelta(days=2),
+            eventDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=2),
         )
         special_event_id = event.id
         name_question = operations_factories.SpecialEventQuestionFactory(
@@ -564,17 +565,17 @@ class GetEventDetailsTest(GetEndpointHelper):
         users_factories.DepositGrantFactory(
             user=user,
             type=finance_models.DepositType.GRANT_15_17,
-            expirationDate=datetime.datetime.utcnow() - datetime.timedelta(days=2),
+            expirationDate=date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
         )
         users_factories.DepositGrantFactory(
             user=user,
             type=finance_models.DepositType.GRANT_18,
-            expirationDate=datetime.datetime.utcnow() + datetime.timedelta(days=300),
+            expirationDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=300),
         )
         event = operations_factories.SpecialEventFactory(
             externalId="fake00001",
             title="Énigme des enchanteurs",
-            eventDate=datetime.datetime.utcnow() + datetime.timedelta(days=2),
+            eventDate=date_utils.get_naive_utc_now() + datetime.timedelta(days=2),
         )
         special_event_id = event.id
         name_question = operations_factories.SpecialEventQuestionFactory(

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -23,6 +23,7 @@ from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.routes.backoffice.pro.forms import TypeOptions
+from pcapi.utils import date as date_utils
 from pcapi.utils import regions as regions_utils
 from pcapi.utils import urls
 from pcapi.utils.human_ids import humanize
@@ -267,7 +268,7 @@ class SearchProUserTest:
         common_name = "Pro"
         users_factories.ProFactory(firstName=common_name)
         suspended_user = users_factories.ProFactory(firstName=common_name, isActive=False)
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         history_factories.ActionHistoryFactory(
             actionType=history_models.ActionType.USER_SUSPENDED,
             actionDate=now - datetime.timedelta(days=4),

--- a/api/tests/routes/backoffice/pro_users_test.py
+++ b/api/tests/routes/backoffice/pro_users_test.py
@@ -19,6 +19,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.backoffice.filters import format_date
+from pcapi.utils import date as date_utils
 from pcapi.utils import email as email_utils
 
 from .helpers import button as button_helpers
@@ -289,10 +290,10 @@ class GetProUserHistoryTest(GetEndpointHelper):
 
     def test_get_history(self, authenticated_client, pro_user):
         action1 = history_factories.ActionHistoryFactory(
-            user=pro_user, actionDate=datetime.datetime.utcnow() - datetime.timedelta(minutes=5)
+            user=pro_user, actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(minutes=5)
         )
         action2 = history_factories.ActionHistoryFactory(
-            actionDate=datetime.datetime.utcnow() - datetime.timedelta(minutes=2),
+            actionDate=date_utils.get_naive_utc_now() - datetime.timedelta(minutes=2),
             actionType=history_models.ActionType.USER_SUSPENDED,
             user=pro_user,
             comment="Test de suspension",
@@ -383,7 +384,7 @@ class GetProUserOfferersTest(GetEndpointHelper):
     def test_get_user_offerers(self, authenticated_client):
         pro_user = users_factories.ProFactory()
         offerer_1 = offerers_factories.UserOffererFactory(
-            user=pro_user, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            user=pro_user, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         ).offerer
         offerer_2 = offerers_factories.NewUserOffererFactory(user=pro_user).offerer
         url = url_for(self.endpoint, user_id=pro_user.id)

--- a/api/tests/routes/backoffice/tags_test.py
+++ b/api/tests/routes/backoffice/tags_test.py
@@ -1,5 +1,4 @@
 from datetime import date
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -11,6 +10,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from .helpers import button as button_helpers
 from .helpers import html_parser
@@ -130,7 +130,7 @@ class ListTagsTest(GetEndpointHelper):
     def test_list_tags(self, authenticated_client):
         categories = criteria_factories.CriterionCategoryFactory.create_batch(2)
 
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         tag_1 = criteria_factories.CriterionFactory(
             description="tag1 description", startDateTime=now, categories=[categories[0]]
         )
@@ -165,10 +165,10 @@ class ListTagsTest(GetEndpointHelper):
     def test_search_list_tags(self, authenticated_client, q, expected_nb_results, expected_results_key):
         tags = {
             "tag1": criteria_factories.CriterionFactory(
-                description="tag1 description", startDateTime=datetime.utcnow()
+                description="tag1 description", startDateTime=date_utils.get_naive_utc_now()
             ),
             "tag2": criteria_factories.CriterionFactory(
-                description="tag2 description", startDateTime=datetime.utcnow()
+                description="tag2 description", startDateTime=date_utils.get_naive_utc_now()
             ),
         }
 

--- a/api/tests/routes/backoffice/titelive_test.py
+++ b/api/tests/routes/backoffice/titelive_test.py
@@ -17,6 +17,7 @@ from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.models.utils import get_or_404
 from pcapi.routes.backoffice.filters import format_titelive_id_lectorat
+from pcapi.utils import date as date_utils
 
 from ...connectors.titelive import fixtures
 from ...connectors.titelive.fixtures import BOOK_BY_SINGLE_EAN_FIXTURE
@@ -103,7 +104,7 @@ class SearchEanTest(GetEndpointHelper):
         card_text = html_parser.extract_cards_text(response.data)
         assert "Inéligible pass Culture :" not in card_text[0]
         assert "EAN white listé : Oui" in card_text[0]
-        assert f"Date d'ajout : {datetime.datetime.utcnow().strftime('%d/%m/%Y')}" in card_text[0]
+        assert f"Date d'ajout : {date_utils.get_naive_utc_now().strftime('%d/%m/%Y')}" in card_text[0]
         assert "Auteur : Frank Columbo" in card_text[0]
         assert "Commentaire : Superbe livre !" in card_text[0]
 

--- a/api/tests/routes/backoffice/update_request_test.py
+++ b/api/tests/routes/backoffice/update_request_test.py
@@ -19,6 +19,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.backoffice.filters import format_date_time
+from pcapi.utils import date as date_utils
 from pcapi.utils import requests
 
 from .helpers import flash
@@ -41,7 +42,7 @@ class ListAccountUpdateRequestsTest(GetEndpointHelper):
     expected_num_queries = 4
 
     def test_list_account_update_requests(self, authenticated_client):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         first_name_update_request = users_factories.FirstNameUpdateRequestFactory(
             user__firstName="Octave",
             user__lastName="César",

--- a/api/tests/routes/external/user_subscription_test.py
+++ b/api/tests/routes/external/user_subscription_test.py
@@ -33,6 +33,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.core.users.api import get_domains_credit
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils import repository
 from pcapi.validation.routes import ubble as ubble_routes
 
@@ -86,7 +87,7 @@ class DmsWebhookApplicationTest:
     )
     def test_dms_request_with_existing_user(self, execute_query, dms_status, fraud_check_status, client):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.utcnow() - relativedelta.relativedelta(years=18),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta.relativedelta(years=18),
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
         )
         subscription_factories.BeneficiaryFraudCheckFactory(
@@ -339,7 +340,7 @@ class DmsWebhookApplicationTest:
         execute_query.return_value = make_single_application(
             12, state=dms_models.GraphQLApplicationStates.draft, email=user.email
         )
-        updated_at = datetime.datetime.utcnow() - datetime.timedelta(days=30)
+        updated_at = date_utils.get_naive_utc_now() - datetime.timedelta(days=30)
         updated_at = updated_at.replace(tzinfo=pytz.timezone("Europe/Paris"))
 
         form_data = {
@@ -373,7 +374,7 @@ class DmsWebhookApplicationTest:
         execute_query.return_value = make_single_application(
             12, state=dms_models.GraphQLApplicationStates.on_going, email=user.email
         )
-        updated_at = datetime.datetime.utcnow() - datetime.timedelta(days=30)
+        updated_at = date_utils.get_naive_utc_now() - datetime.timedelta(days=30)
         updated_at = updated_at.replace(tzinfo=pytz.timezone("Europe/Paris"))
 
         form_data = {
@@ -879,7 +880,7 @@ class DmsWebhookApplicationTest:
     @patch.object(api_dms.DMSGraphQLClient, "execute_query")
     def test_dms_application_on_going(self, execute_query, client):
         user = users_factories.UserFactory(
-            dateOfBirth=datetime.datetime.utcnow() - relativedelta.relativedelta(years=18),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta.relativedelta(years=18),
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
         )
         subscription_factories.BeneficiaryFraudCheckFactory(
@@ -1074,7 +1075,7 @@ class UbbleWebhookTest:
     def _init_test(self, current_identification_state, notified_identification_state):
         user = users_factories.UserFactory(
             phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            dateOfBirth=datetime.datetime.utcnow() - relativedelta.relativedelta(years=18),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta.relativedelta(years=18),
             activity="Lycéen",
         )
         subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
@@ -1572,7 +1573,7 @@ class UbbleWebhookTest:
     def _init_decision_test(
         self,
     ) -> tuple[users_models.User, subscription_models.BeneficiaryFraudCheck, ubble_serializers.WebhookRequest]:
-        birth_date = datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=6)
+        birth_date = date_utils.get_naive_utc_now().date() - relativedelta.relativedelta(years=18, months=6)
         user = users_factories.UserFactory(dateOfBirth=datetime.datetime.combine(birth_date, datetime.time(0, 0)))
         identification_id = str(uuid.uuid4())
         ubble_fraud_check = subscription_models.BeneficiaryFraudCheck(
@@ -1589,7 +1590,7 @@ class UbbleWebhookTest:
                 "identification_id": identification_id,
                 "identification_url": f"https://id.ubble.ai/{identification_id}",
                 "last_name": None,
-                "registration_datetime": datetime.datetime.utcnow().isoformat(),
+                "registration_datetime": date_utils.get_naive_utc_now().isoformat(),
                 "score": None,
                 "status": ubble_schemas.UbbleIdentificationStatus.PROCESSING.value,
                 "supported": None,
@@ -1670,7 +1671,7 @@ class UbbleWebhookTest:
         self, client, ubble_mocker, age, reason_code, reason, in_app_message
     ):
         document_birth_date = (
-            datetime.datetime.utcnow().date()
+            date_utils.get_naive_utc_now().date()
             - relativedelta.relativedelta(years=age)
             - relativedelta.relativedelta(months=1)
         )
@@ -1735,7 +1736,7 @@ class UbbleWebhookTest:
         assert len(mails_testing.outbox) == 0
 
     def test_decision_duplicate_user(self, client, ubble_mocker):
-        birth_date = datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=2)
+        birth_date = date_utils.get_naive_utc_now().date() - relativedelta.relativedelta(years=18, months=2)
         existing_user = users_factories.BeneficiaryGrant18Factory(
             firstName="Duplicate",
             lastName="Fraudster",
@@ -1812,7 +1813,7 @@ class UbbleWebhookTest:
 
     def test_decision_duplicate_id_piece_number(self, client, ubble_mocker):
         users_factories.BeneficiaryGrant18Factory(
-            dateOfBirth=datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=2),
+            dateOfBirth=date_utils.get_naive_utc_now().date() - relativedelta.relativedelta(years=18, months=2),
             idPieceNumber="012345678910",
             email="prems@me.com",
         )
@@ -1825,7 +1826,7 @@ class UbbleWebhookTest:
             included=[
                 test_factories.UbbleIdentificationIncludedDocumentsFactory(
                     attributes__birth_date=(
-                        datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=1)
+                        date_utils.get_naive_utc_now().date() - relativedelta.relativedelta(years=18, months=1)
                     ).isoformat(),
                     attributes__document_number="012345678910",
                     attributes__document_type="CI",
@@ -2258,7 +2259,7 @@ class UbbleWebhookTest:
             included=[
                 test_factories.UbbleIdentificationIncludedDocumentsFactory(
                     attributes__birth_date=(
-                        datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=1)
+                        date_utils.get_naive_utc_now().date() - relativedelta.relativedelta(years=18, months=1)
                     ).isoformat(),
                     attributes__document_number="012345678910",
                     attributes__document_type="CI",
@@ -2363,7 +2364,7 @@ class UbbleWebhookTest:
             included=[
                 test_factories.UbbleIdentificationIncludedDocumentsFactory(
                     attributes__birth_date=(
-                        datetime.datetime.utcnow().date() - relativedelta.relativedelta(years=18, months=1)
+                        date_utils.get_naive_utc_now().date() - relativedelta.relativedelta(years=18, months=1)
                     ).isoformat(),
                     attributes__document_number="012345678910",
                     attributes__document_type="CI",

--- a/api/tests/routes/external/zendesk_test.py
+++ b/api/tests/routes/external/zendesk_test.py
@@ -12,6 +12,7 @@ from pcapi.core.users import constants as user_constants
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import testing as users_testing
 from pcapi.core.users.models import PhoneValidationStatusType
+from pcapi.utils import date as date_utils
 from pcapi.utils import postal_code as postal_code_utils
 
 
@@ -26,7 +27,7 @@ class ZendeskWebhookTest:
         ],
     )
     def test_webhook_update_user_by_email(self, client, caplog, phone_number, postal_code, expected_additional_tags):
-        birth_year = datetime.utcnow().year - user_constants.ELIGIBILITY_AGE_18
+        birth_year = date_utils.get_naive_utc_now().year - user_constants.ELIGIBILITY_AGE_18
 
         user = users_factories.BeneficiaryGrant18Factory(
             dateOfBirth=datetime(birth_year, 1, 2),
@@ -134,7 +135,7 @@ class ZendeskWebhookTest:
         }
 
     def test_webhook_update_user_without_subscription_process(self, client):
-        birth_year = datetime.utcnow().year - user_constants.ELIGIBILITY_AGE_18
+        birth_year = date_utils.get_naive_utc_now().year - user_constants.ELIGIBILITY_AGE_18
 
         # first name, last name and phone number unknown
         user = users_factories.UserFactory(

--- a/api/tests/routes/institutional/playlist_test.py
+++ b/api/tests/routes/institutional/playlist_test.py
@@ -7,6 +7,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.routes.shared.price import convert_to_cent
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -60,7 +61,7 @@ class PlaylistTest:
         assert response.json == []
 
     def test_unbookable_offers_are_not_ignored(self, client):
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         unbookable_offer = offers_factories.EventOfferFactory()
         offers_factories.EventStockFactory(offer=unbookable_offer, isSoftDeleted=True)
         offers_factories.EventStockFactory(offer=unbookable_offer, quantity=0)
@@ -85,7 +86,7 @@ class PlaylistTest:
         ]
 
     def test_unbookable_stocks_are_ignored(self, client):
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         offer = offers_factories.EventOfferFactory()
         offers_factories.EventStockFactory(offer=offer, isSoftDeleted=True)
         offers_factories.EventStockFactory(offer=offer, quantity=0)

--- a/api/tests/routes/native/v1/authentication_test.py
+++ b/api/tests/routes/native/v1/authentication_test.py
@@ -32,6 +32,7 @@ from pcapi.core.users.models import SingleSignOn
 from pcapi.core.users.models import TrustedDevice
 from pcapi.models import db
 from pcapi.utils import crypto
+from pcapi.utils import date as date_utils
 
 from tests.scripts.beneficiary.fixture import make_single_application
 
@@ -1163,7 +1164,7 @@ class EmailValidationTest:
             application_number,
             dms_models.GraphQLApplicationStates.accepted,
             email=email,
-            construction_datetime=datetime.utcnow().isoformat(),
+            construction_datetime=date_utils.get_naive_utc_now().isoformat(),
         )
         response = client.post("/native/v1/validate_email", json={"email_validation_token": token})
 

--- a/api/tests/routes/native/v1/banner_test.py
+++ b/api/tests/routes/native/v1/banner_test.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 import time_machine
 from dateutil.relativedelta import relativedelta
@@ -9,6 +7,7 @@ import pcapi.core.subscription.models as subscription_models
 import pcapi.core.users.factories as users_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import models as users_models
+from pcapi.utils import date as date_utils
 from pcapi.utils.string import u_nbsp
 
 
@@ -68,7 +67,7 @@ class BannerTest:
         assert response.json == self.geolocation_banner
 
     def should_return_activation_banner_when_user_has_phone_validation_to_complete(self, client):
-        dateOfBirth = datetime.datetime.utcnow() - relativedelta(years=18, months=5)
+        dateOfBirth = date_utils.get_naive_utc_now() - relativedelta(years=18, months=5)
         user = users_factories.UserFactory(dateOfBirth=dateOfBirth)
 
         client.with_token(email=user.email)
@@ -79,7 +78,7 @@ class BannerTest:
         assert response.json == self.activation_banner
 
     def should_return_activation_banner_when_user_has_profile_to_complete(self, client):
-        dateOfBirth = datetime.datetime.utcnow() - relativedelta(years=18, months=5)
+        dateOfBirth = date_utils.get_naive_utc_now() - relativedelta(years=18, months=5)
         user = users_factories.UserFactory(
             dateOfBirth=dateOfBirth, phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED
         )
@@ -92,7 +91,7 @@ class BannerTest:
         assert response.json == self.activation_banner
 
     def should_return_activation_banner_when_user_has_identity_check_to_complete(self, client):
-        dateOfBirth = datetime.datetime.utcnow() - relativedelta(years=18, months=5)
+        dateOfBirth = date_utils.get_naive_utc_now() - relativedelta(years=18, months=5)
         user = users_factories.UserFactory(
             dateOfBirth=dateOfBirth, phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED
         )
@@ -111,7 +110,7 @@ class BannerTest:
         assert response.json == self.activation_banner
 
     def should_return_activation_banner_when_user_has_honor_statement_to_complete(self, client):
-        dateOfBirth = datetime.datetime.utcnow() - relativedelta(years=18, months=5)
+        dateOfBirth = date_utils.get_naive_utc_now() - relativedelta(years=18, months=5)
         user = users_factories.UserFactory(
             dateOfBirth=dateOfBirth, phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED
         )
@@ -196,7 +195,7 @@ class BannerTest:
         }
 
     def should_get_17_18_transition_id_check_done_banner(self, client):
-        a_year_ago = datetime.datetime.utcnow() - relativedelta(years=1, months=1)
+        a_year_ago = date_utils.get_naive_utc_now() - relativedelta(years=1, months=1)
         with time_machine.travel(a_year_ago):
             user = users_factories.BeneficiaryFactory(age=17)
 

--- a/api/tests/routes/native/v1/cultural_survey_test.py
+++ b/api/tests/routes/native/v1/cultural_survey_test.py
@@ -12,6 +12,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.core.users import testing
+from pcapi.utils import date as date_utils
 from pcapi.utils.string import u_nbsp
 
 
@@ -318,7 +319,7 @@ class CulturalSurveyQuestionsTest:
         )
 
         assert not user.needsToFillCulturalSurvey
-        assert user.culturalSurveyFilledDate == datetime.datetime.utcnow()
+        assert user.culturalSurveyFilledDate == date_utils.get_naive_utc_now()
 
         assert len(testing.sendinblue_requests) == 1
         assert testing.sendinblue_requests[0]["email"] == user.email

--- a/api/tests/routes/native/v1/favorites_test.py
+++ b/api/tests/routes/native/v1/favorites_test.py
@@ -83,9 +83,9 @@ class GetTest:
             offers_factories.MediationFactory(offer=offer4)
             favorite4 = users_factories.FavoriteFactory(offer=offer4, user=user)
             stock4 = offers_factories.EventStockFactory(
-                offer=offer4, beginningDatetime=datetime.utcnow() + timedelta(minutes=30), price=50
+                offer=offer4, beginningDatetime=date_utils.get_naive_utc_now() + timedelta(minutes=30), price=50
             )
-            assert stock4.bookingLimitDatetime < datetime.utcnow()
+            assert stock4.bookingLimitDatetime < date_utils.get_naive_utc_now()
 
             # Event offer in the past
             offer5 = offers_factories.EventOfferFactory(venue=venue)
@@ -224,7 +224,7 @@ class GetTest:
 
         def test_expired_offer(self, client):
             # Given
-            today = datetime.utcnow() + timedelta(hours=3)  # offset a bit to make sure it's > now()
+            today = date_utils.get_naive_utc_now() + timedelta(hours=3)  # offset a bit to make sure it's > now()
             yesterday = today - timedelta(days=1)
             tomorow = today + timedelta(days=1)
             user = users_factories.BeneficiaryFactory()

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -106,7 +106,7 @@ class OffersTest:
         expired_stock = offers_factories.EventStockFactory(
             offer=offer,
             price=45.67,
-            beginningDatetime=datetime.utcnow() - timedelta(days=1),
+            beginningDatetime=date_utils.get_naive_utc_now() - timedelta(days=1),
             priceCategory__priceCategoryLabel__label="expired",
             features=[
                 cinema_providers_constants.ShowtimeFeatures.VF.value,
@@ -360,7 +360,7 @@ class OffersTest:
 
     @time_machine.travel("2020-01-01")
     def test_get_expired_offer(self, client):
-        stock = offers_factories.EventStockFactory(beginningDatetime=datetime.utcnow() - timedelta(days=1))
+        stock = offers_factories.EventStockFactory(beginningDatetime=date_utils.get_naive_utc_now() - timedelta(days=1))
 
         offer_id = stock.offer.id
 
@@ -586,7 +586,7 @@ class OffersV2Test:
         expired_stock = offers_factories.EventStockFactory(
             offer=offer,
             price=45.67,
-            beginningDatetime=datetime.utcnow() - timedelta(days=1),
+            beginningDatetime=date_utils.get_naive_utc_now() - timedelta(days=1),
             priceCategory__priceCategoryLabel__label="expired",
             features=[
                 cinema_providers_constants.ShowtimeFeatures.VF.value,
@@ -829,7 +829,7 @@ class OffersV2Test:
 
     @time_machine.travel("2020-01-01")
     def test_get_expired_offer(self, client):
-        stock = offers_factories.EventStockFactory(beginningDatetime=datetime.utcnow() - timedelta(days=1))
+        stock = offers_factories.EventStockFactory(beginningDatetime=date_utils.get_naive_utc_now() - timedelta(days=1))
 
         offer_id = stock.offer.id
         with assert_num_queries(self.base_num_queries):
@@ -1457,7 +1457,7 @@ class OffersStocksV2Test:
         expired_stock = offers_factories.EventStockFactory(
             offer=offer,
             price=45.67,
-            beginningDatetime=datetime.utcnow() - timedelta(days=1),
+            beginningDatetime=date_utils.get_naive_utc_now() - timedelta(days=1),
             priceCategory__priceCategoryLabel__label="expired",
             features=[
                 cinema_providers_constants.ShowtimeFeatures.VF.value,

--- a/api/tests/routes/native/v1/reaction_test.py
+++ b/api/tests/routes/native/v1/reaction_test.py
@@ -9,6 +9,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.reactions.models import ReactionTypeEnum
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -42,7 +43,7 @@ class PostReactionTest:
         user = users_factories.BeneficiaryFactory()
         offer = offers_factories.ThingOfferFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id)
         bookings_factories.UsedBookingFactory(
-            user=user, stock__offer=offer, dateUsed=datetime.datetime.utcnow() - datetime.timedelta(hours=25)
+            user=user, stock__offer=offer, dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(hours=25)
         )
         client.with_token(user.email)
 
@@ -59,7 +60,7 @@ class PostReactionTest:
         user = users_factories.BeneficiaryFactory()
         offer = offers_factories.ThingOfferFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id)
         bookings_factories.UsedBookingFactory(
-            user=user, stock__offer=offer, dateUsed=datetime.datetime.utcnow() - datetime.timedelta(hours=25)
+            user=user, stock__offer=offer, dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(hours=25)
         )
         client.with_token(user.email)
 
@@ -72,7 +73,7 @@ class PostReactionTest:
         user = users_factories.BeneficiaryFactory()
         offer = offers_factories.ThingOfferFactory(subcategoryId=subcategories.LIVRE_PAPIER.id)
         bookings_factories.UsedBookingFactory(
-            user=user, stock__offer=offer, dateUsed=datetime.datetime.utcnow() - datetime.timedelta(hours=25)
+            user=user, stock__offer=offer, dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(hours=25)
         )
         client.with_token(user.email)
 
@@ -97,7 +98,7 @@ class PostReactionTest:
         product = offers_factories.ProductFactory()
         offer = offers_factories.OfferFactory(product=product)
         bookings_factories.UsedBookingFactory(
-            user=user, stock__offer=offer, dateUsed=datetime.datetime.utcnow() - datetime.timedelta(hours=25)
+            user=user, stock__offer=offer, dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(hours=25)
         )
         client.with_token(user.email)
 
@@ -120,10 +121,10 @@ class PostReactionTest:
         offer = offers_factories.ThingOfferFactory(subcategoryId=subcategories.LIVRE_PAPIER.id)
         other_offer = offers_factories.ThingOfferFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id)
         bookings_factories.UsedBookingFactory(
-            user=user, stock__offer=offer, dateUsed=datetime.datetime.utcnow() - datetime.timedelta(hours=25)
+            user=user, stock__offer=offer, dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(hours=25)
         )
         bookings_factories.UsedBookingFactory(
-            user=user, stock__offer=other_offer, dateUsed=datetime.datetime.utcnow() - datetime.timedelta(days=25)
+            user=user, stock__offer=other_offer, dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(days=25)
         )
         client.with_token(user.email)
 
@@ -154,7 +155,7 @@ class PostReactionTest:
         bookings_factories.UsedBookingFactory(
             # booking from someone else
             stock__offer=offer,
-            dateUsed=datetime.datetime.utcnow() - datetime.timedelta(hours=25),
+            dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(hours=25),
         )
         client.with_token(user.email)
 
@@ -242,9 +243,9 @@ class GetAvailableReactionTest:
         offer_4 = offers_factories.OfferFactory(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id)
         offer_5 = offers_factories.OfferFactory(subcategoryId=subcategories.ABO_PRESSE_EN_LIGNE.id)
 
-        a_little_more_than_24h_ago = datetime.datetime.utcnow() - datetime.timedelta(hours=25)
-        a_little_more_than_31d_ago = datetime.datetime.utcnow() - datetime.timedelta(days=32)
-        a_lot_more_than_31d_ago = datetime.datetime.utcnow() - datetime.timedelta(days=60)
+        a_little_more_than_24h_ago = date_utils.get_naive_utc_now() - datetime.timedelta(hours=25)
+        a_little_more_than_31d_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=32)
+        a_lot_more_than_31d_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=60)
 
         # Booking eligible to reactions from user
         booking_offer_1 = bookings_factories.UsedBookingFactory(

--- a/api/tests/routes/native/v1/reminder_test.py
+++ b/api/tests/routes/native/v1/reminder_test.py
@@ -6,6 +6,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.reminders import factories as reminders_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.utils import date as date_utils
 
 from tests.conftest import TestClient
 
@@ -26,7 +27,7 @@ class GetRemindersTest:
         user_1 = users_factories.BeneficiaryFactory()
         user_2 = users_factories.BeneficiaryFactory()
 
-        future_publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=30)
+        future_publication_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=30)
         offer_1 = offers_factories.OfferFactory(isActive=False, publicationDatetime=future_publication_date)
         offer_2 = offers_factories.OfferFactory(isActive=False, publicationDatetime=future_publication_date)
 
@@ -83,7 +84,7 @@ class PostReminderTest:
         user_1 = users_factories.BeneficiaryFactory()
         user_2 = users_factories.BeneficiaryFactory()
 
-        future_publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=30)
+        future_publication_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=30)
         offer = offers_factories.OfferFactory(isActive=False, publicationDatetime=future_publication_date)
 
         for user in [user_1, user_2]:
@@ -103,7 +104,7 @@ class PostReminderTest:
     def test_already_existing_reminder(self, client):
         user = users_factories.BeneficiaryFactory()
 
-        future_publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=30)
+        future_publication_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=30)
         offer_1 = offers_factories.OfferFactory(isActive=False, publicationDatetime=future_publication_date)
         offer_2 = offers_factories.OfferFactory(isActive=False, publicationDatetime=future_publication_date)
 
@@ -155,7 +156,7 @@ class DeleteReminderTest:
         user_1 = users_factories.BeneficiaryFactory()
         user_2 = users_factories.BeneficiaryFactory()
 
-        future_publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=30)
+        future_publication_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=30)
         offer_1 = offers_factories.OfferFactory(isActive=False, publicationDatetime=future_publication_date)
         offer_2 = offers_factories.OfferFactory(isActive=False, publicationDatetime=future_publication_date)
 
@@ -182,7 +183,7 @@ class DeleteReminderTest:
     def test_delete_reminder(self, client):
         user = users_factories.BeneficiaryFactory()
 
-        future_publication_date = datetime.datetime.utcnow() + datetime.timedelta(days=30)
+        future_publication_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=30)
         offer_1 = offers_factories.OfferFactory(isActive=False, publicationDatetime=future_publication_date)
         offer_2 = offers_factories.OfferFactory(isActive=False, publicationDatetime=future_publication_date)
 

--- a/api/tests/routes/native/v2/account_test.py
+++ b/api/tests/routes/native/v2/account_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 from unittest.mock import patch
 from urllib.parse import parse_qs
@@ -13,6 +12,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.native.v1.api_errors import account as account_errors
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -226,7 +226,7 @@ class EmailUpdateStatusTest:
         token.expire()
 
     def test_status_returns_new_email_selection_token(self, client):
-        yesterday = datetime.utcnow() + timedelta(days=-1)
+        yesterday = date_utils.get_naive_utc_now() + timedelta(days=-1)
         user = users_factories.BeneficiaryGrant18Factory()
         users_factories.EmailUpdateEntryFactory(
             user=user, creationDate=yesterday, newUserEmail=None, newDomainEmail=None
@@ -252,7 +252,7 @@ class EmailUpdateStatusTest:
         token.expire()
 
     def test_status_returns_reset_password_token(self, client):
-        yesterday = datetime.utcnow() + timedelta(days=-1)
+        yesterday = date_utils.get_naive_utc_now() + timedelta(days=-1)
         user = users_factories.UserFactory(password=None)
         users_factories.EmailUpdateEntryFactory(
             user=user, creationDate=yesterday, newUserEmail=None, newDomainEmail=None
@@ -278,7 +278,7 @@ class EmailUpdateStatusTest:
         reset_password_token.expire()
 
     def test_status_returns_recently_reset_password(self, client):
-        yesterday = datetime.utcnow() + timedelta(days=-1)
+        yesterday = date_utils.get_naive_utc_now() + timedelta(days=-1)
         user = users_factories.UserFactory(password=None)
         users_factories.EmailUpdateEntryFactory(
             user=user, creationDate=yesterday, newUserEmail=None, newDomainEmail=None
@@ -303,7 +303,7 @@ class EmailUpdateStatusTest:
         recently_reset_password_token.expire()
 
     def test_new_email_selection_status(self, client):
-        yesterday = datetime.utcnow() + timedelta(days=-1)
+        yesterday = date_utils.get_naive_utc_now() + timedelta(days=-1)
         two_days_ago = yesterday + timedelta(days=-1)
         user = users_factories.BeneficiaryGrant18Factory()
         users_factories.EmailUpdateEntryFactory(

--- a/api/tests/routes/native/v2/bookings_test.py
+++ b/api/tests/routes/native/v2/bookings_test.py
@@ -17,6 +17,7 @@ from pcapi.core.reactions.factories import ReactionFactory
 from pcapi.core.reactions.models import ReactionTypeEnum
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 
 
@@ -39,7 +40,7 @@ class GetBookingsTest:
         event_booking = booking_factories.BookingFactory(
             user=user,
             stock=offers_factories.EventStockFactory(
-                beginningDatetime=datetime.utcnow() + timedelta(days=2),
+                beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=2),
                 offer__bookingContact="contact@example.net",
             ),
         )
@@ -59,12 +60,12 @@ class GetBookingsTest:
             activationCode=second_activation_code,
         )
         expire_tomorrow = booking_factories.BookingFactory(
-            user=user, dateCreated=datetime.utcnow() - timedelta(days=29)
+            user=user, dateCreated=date_utils.get_naive_utc_now() - timedelta(days=29)
         )
         used_but_in_future = booking_factories.UsedBookingFactory(
             user=user,
-            dateUsed=datetime.utcnow() - timedelta(days=1),
-            stock=offers_factories.StockFactory(beginningDatetime=datetime.utcnow() + timedelta(days=3)),
+            dateUsed=date_utils.get_naive_utc_now() - timedelta(days=1),
+            stock=offers_factories.StockFactory(beginningDatetime=date_utils.get_naive_utc_now() + timedelta(days=3)),
         )
 
         cancelled_permanent_booking = booking_factories.CancelledBookingFactory(
@@ -195,7 +196,7 @@ class GetBookingsTest:
         }
 
     def test_get_bookings_returns_user_reaction(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         stock = offers_factories.EventStockFactory()
         ongoing_booking = booking_factories.BookingFactory(
             stock=stock, user__deposit__expirationDate=now + timedelta(days=180)
@@ -210,7 +211,7 @@ class GetBookingsTest:
         assert response.json["ongoingBookings"][0]["userReaction"] is None
 
     def test_get_bookings_returns_user_reaction_when_one_exists(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         stock = offers_factories.EventStockFactory()
         ongoing_booking = booking_factories.BookingFactory(
             stock=stock, user__deposit__expirationDate=now + timedelta(days=180)
@@ -226,7 +227,7 @@ class GetBookingsTest:
         assert response.json["ongoingBookings"][0]["userReaction"] == "NO_REACTION"
 
     def test_get_bookings_returns_user_reaction_when_reaction_is_on_the_product(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         product = offers_factories.ProductFactory()
         stock = offers_factories.EventStockFactory(offer__product=product)
         ongoing_booking = booking_factories.BookingFactory(
@@ -247,7 +248,7 @@ class GetBookingsTest:
         )
         booking = booking_factories.UsedBookingFactory(
             stock__offer=offer,
-            dateUsed=datetime.utcnow() - timedelta(seconds=60 * 24 * 3600),
+            dateUsed=date_utils.get_naive_utc_now() - timedelta(seconds=60 * 24 * 3600),
         )
         client = client.with_token(booking.user.email)
         with assert_num_queries(2):
@@ -258,7 +259,7 @@ class GetBookingsTest:
         assert response.json["ongoingBookings"][0]["enablePopUpReaction"] is True
 
     def test_get_bookings_returns_stock_price_and_price_category_label(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         stock = offers_factories.EventStockFactory()
         ongoing_booking = booking_factories.BookingFactory(
             stock=stock, user__deposit__expirationDate=now + timedelta(days=180)
@@ -466,7 +467,7 @@ class GetBookingTicketTest:
     )
     def test_get_booking_ticket_by_email(self, client, withdrawal_delay, delta, display):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
-        beginningDatetime = datetime.utcnow() + timedelta(days=delta)
+        beginningDatetime = date_utils.get_naive_utc_now() + timedelta(days=delta)
         booking_factories.BookingFactory(
             user=user,
             stock__offer__subcategoryId=subcategories.CONCERT.id,
@@ -599,7 +600,7 @@ class GetBookingTicketTest:
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
 
         provider = providers_api.get_provider_by_local_class("CDSStocks")
-        beginningDatetime = datetime.utcnow() + timedelta(days=1)
+        beginningDatetime = date_utils.get_naive_utc_now() + timedelta(days=1)
         booking = booking_factories.BookingFactory(
             user=user,
             stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
@@ -632,7 +633,7 @@ class GetBookingTicketTest:
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
 
         provider = providers_api.get_provider_by_local_class("CDSStocks")
-        beginningDatetime = datetime.utcnow() + timedelta(days=2, seconds=200)
+        beginningDatetime = date_utils.get_naive_utc_now() + timedelta(days=2, seconds=200)
         booking = booking_factories.BookingFactory(
             user=user,
             stock__offer__subcategoryId=subcategories.CONFERENCE.id,

--- a/api/tests/routes/pro/delete_filtered_stocks_test.py
+++ b/api/tests/routes/pro/delete_filtered_stocks_test.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import pytest
 import time_machine
 
@@ -8,6 +6,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offer_models
 import pcapi.core.users.factories as users_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -16,7 +15,9 @@ class Returns204Test:
     def test_delete_filtered_stocks(self, client):
         # Given
         offer = offers_factories.OfferFactory()
-        offers_factories.EventStockFactory.create_batch(3, offer=offer, beginningDatetime=datetime.utcnow())
+        offers_factories.EventStockFactory.create_batch(
+            3, offer=offer, beginningDatetime=date_utils.get_naive_utc_now()
+        )
         user = users_factories.UserFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offer.venue.managingOfferer)
 
@@ -63,7 +64,7 @@ class Returns403Test:
         pro = users_factories.ProFactory()
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
-        offers_factories.EventStockFactory(offer=offer, beginningDatetime=datetime.utcnow())
+        offers_factories.EventStockFactory(offer=offer, beginningDatetime=date_utils.get_naive_utc_now())
         data = {
             "offer_id": offer.id,
             "date": "2020-10-15",

--- a/api/tests/routes/pro/delete_headline_offer_test.py
+++ b/api/tests/routes/pro/delete_headline_offer_test.py
@@ -8,6 +8,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offer_models
 import pcapi.core.users.factories as users_factory
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -19,8 +20,8 @@ class Returns204Test:
         offer = offers_factories.OfferFactory()
         offerers_factories.UserOffererFactory(user=pro, offerer=offer.venue.managingOfferer)
         headline_offer = offers_factories.HeadlineOfferFactory(offer=offer)
-        ten_days_ago = datetime.datetime.utcnow() - datetime.timedelta(days=10)
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        ten_days_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=10)
+        yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         old_headline_offer = offers_factories.HeadlineOfferFactory(offer=offer, timespan=(ten_days_ago, yesterday))
 
         data = {"offererId": offer.venue.managingOfferer.id}
@@ -31,7 +32,7 @@ class Returns204Test:
         assert response.status_code == 204
 
         assert not headline_offer.isActive
-        assert headline_offer.timespan.upper.date() == datetime.datetime.utcnow().date()
+        assert headline_offer.timespan.upper.date() == date_utils.get_naive_utc_now().date()
         assert not old_headline_offer.isActive
         assert old_headline_offer.timespan.upper == yesterday
 

--- a/api/tests/routes/pro/get_all_bookings_test.py
+++ b/api/tests/routes/pro/get_all_bookings_test.py
@@ -16,6 +16,7 @@ import pcapi.core.users.factories as users_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.external_bookings.factories import ExternalBookingFactory
 from pcapi.core.testing import assert_num_queries
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import utc_datetime_to_department_timezone
 
 
@@ -262,7 +263,7 @@ class Returns200Test:
         venue1 = offerers_factories.VenueFactory(managingOfferer=offerer1)
         venue2 = offerers_factories.VenueFactory(managingOfferer=offerer2)
 
-        booked_date = datetime.utcnow()
+        booked_date = date_utils.get_naive_utc_now()
 
         booking1 = bookings_factories.BookingFactory(dateCreated=booked_date, stock__offer__venue=venue1)
         bookings_factories.BookingFactory(dateCreated=booked_date, stock__offer__venue=venue2)

--- a/api/tests/routes/pro/get_booking_by_token_v2_test.py
+++ b/api/tests/routes/pro/get_booking_by_token_v2_test.py
@@ -12,6 +12,7 @@ from pcapi.core import testing
 from pcapi.core.bookings import models as bookings_models
 from pcapi.core.categories import subcategories
 from pcapi.utils import date
+from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 
 
@@ -28,11 +29,11 @@ class Returns200Test:
     num_queries += 1  # select user
 
     def test_when_user_has_rights_and_regular_offer(self, client):
-        past = datetime.utcnow() - timedelta(days=2)
+        past = date_utils.get_naive_utc_now() - timedelta(days=2)
         booking = bookings_factories.BookingFactory(
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             stock__beginningDatetime=past,
             stock__offer=offers_factories.EventOfferFactory(
                 extraData={
@@ -80,7 +81,7 @@ class Returns200Test:
 
     def test_when_user_has_rights_and_regular_offer_and_token_in_lower_case(self, client):
         booking = bookings_factories.BookingFactory(
-            stock__beginningDatetime=datetime.utcnow() - timedelta(days=2),
+            stock__beginningDatetime=date_utils.get_naive_utc_now() - timedelta(days=2),
         )
         booking_token = booking.token.lower()
         user_offerer = offerers_factories.UserOffererFactory(offerer=booking.offerer)
@@ -121,7 +122,7 @@ class Returns403Test:
         ]
 
     def test_when_booking_not_confirmed(self, client):
-        next_week = datetime.utcnow() + timedelta(weeks=1)
+        next_week = date_utils.get_naive_utc_now() + timedelta(weeks=1)
         booking = bookings_factories.BookingFactory(stock__beginningDatetime=next_week)
         pro = users_factories.ProFactory()
         offerers_factories.UserOffererFactory(user=pro, offerer=booking.offerer)

--- a/api/tests/routes/pro/get_bookings_csv_test.py
+++ b/api/tests/routes/pro/get_bookings_csv_test.py
@@ -1,5 +1,4 @@
 import csv
-from datetime import datetime
 from datetime import timedelta
 from io import StringIO
 
@@ -10,6 +9,7 @@ from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -24,7 +24,7 @@ class Returns200Test:
         venue1 = offerers_factories.VenueFactory(managingOfferer=offerer1)
         venue2 = offerers_factories.VenueFactory(managingOfferer=offerer2)
 
-        booked_date = datetime.utcnow()
+        booked_date = date_utils.get_naive_utc_now()
 
         booking1 = bookings_factories.BookingFactory(dateCreated=booked_date, stock__offer__venue=venue1)
         bookings_factories.BookingFactory(dateCreated=booked_date, stock__offer__venue=venue2)

--- a/api/tests/routes/pro/get_collective_booking_excel_test.py
+++ b/api/tests/routes/pro/get_collective_booking_excel_test.py
@@ -9,6 +9,7 @@ import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.routes.serialization.collective_bookings_serialize import COLLECTIVE_BOOKING_EXPORT_HEADER
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -32,7 +33,7 @@ class Returns200Test:
         booking = educational_factories.CollectiveBookingFactory(
             dateCreated=datetime(2020, 8, 11, 12, 0, 0),
             collectiveStock__startDatetime=datetime(2020, 8, 13, 12, 0, 0),
-            cancellationLimitDate=datetime.utcnow() + timedelta(days=1),
+            cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=1),
             reimbursementDate=datetime(2021, 8, 11, 12, 0, 0),
             dateUsed=datetime(2020, 8, 15, 12, 0, 0),
             collectiveStock__collectiveOffer__venue__managingOfferer=user_offerer.offerer,
@@ -76,7 +77,7 @@ class Returns200Test:
         booking = educational_factories.CollectiveBookingFactory(
             dateCreated=datetime(2020, 8, 11, 12, 0, 0),
             collectiveStock__startDatetime=datetime(2020, 8, 13, 12, 0, 0),
-            cancellationLimitDate=datetime.utcnow() + timedelta(days=1),
+            cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=1),
             reimbursementDate=None,
             dateUsed=None,
             collectiveStock__collectiveOffer__venue__managingOfferer=user_offerer.offerer,
@@ -119,7 +120,7 @@ class Returns200Test:
         booking = educational_factories.CollectiveBookingFactory(
             dateCreated=datetime(2020, 8, 11, 12, 0, 0),
             collectiveStock__startDatetime=datetime(2020, 8, 13, 12, 0, 0),
-            cancellationLimitDate=datetime.utcnow() + timedelta(days=1),
+            cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=1),
             reimbursementDate=datetime(2021, 8, 11, 12, 0, 0),
             dateUsed=datetime(2020, 8, 15, 12, 0, 0),
             collectiveStock__collectiveOffer__venue__managingOfferer=user_offerer.offerer,
@@ -167,7 +168,7 @@ class Returns200Test:
             dateCreated=datetime(2020, 8, 11, 12, 0, 0),
             collectiveStock__startDatetime=datetime(2020, 8, 13, 12, 0, 0),
             reimbursementDate=datetime(2021, 8, 11, 12, 0, 0),
-            cancellationLimitDate=datetime.utcnow() + timedelta(days=1),
+            cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=1),
             dateUsed=datetime(2020, 8, 15, 12, 0, 0),
             collectiveStock__collectiveOffer__venue__managingOfferer=user_offerer.offerer,
             offerer=user_offerer.offerer,
@@ -205,7 +206,7 @@ class Returns200Test:
             educational_factories.CollectiveBookingFactory(
                 dateCreated=datetime(2020, 8, 11, 12, 0, 0),
                 collectiveStock__startDatetime=datetime(2020, 8, 13, 12, 0, 0),
-                cancellationLimitDate=datetime.utcnow() + timedelta(days=1),
+                cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=1),
                 reimbursementDate=datetime(2021, 8, 11, 12, 0, 0),
                 dateUsed=datetime(2020, 8, 15, 12, 0, 0),
                 collectiveStock__collectiveOffer__venue__managingOfferer=user_offerer.offerer,
@@ -216,7 +217,7 @@ class Returns200Test:
             educational_factories.CollectiveBookingFactory(
                 dateCreated=datetime(2020, 8, 11, 12, 0, 0),
                 collectiveStock__startDatetime=datetime(2020, 8, 13, 12, 0, 0),
-                cancellationLimitDate=datetime.utcnow() + timedelta(days=1),
+                cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=1),
                 reimbursementDate=datetime(2021, 8, 11, 12, 0, 0),
                 dateUsed=datetime(2020, 8, 15, 12, 0, 0),
                 collectiveStock__collectiveOffer__venue__managingOfferer=user_offerer.offerer,
@@ -227,7 +228,7 @@ class Returns200Test:
             educational_factories.CollectiveBookingFactory(
                 dateCreated=datetime(2020, 8, 11, 12, 0, 0),
                 collectiveStock__startDatetime=datetime(2020, 8, 13, 12, 0, 0),
-                cancellationLimitDate=datetime.utcnow() + timedelta(days=1),
+                cancellationLimitDate=date_utils.get_naive_utc_now() + timedelta(days=1),
                 reimbursementDate=datetime(2021, 8, 11, 12, 0, 0),
                 dateUsed=datetime(2020, 8, 15, 12, 0, 0),
                 collectiveStock__collectiveOffer__venue__managingOfferer=user_offerer.offerer,

--- a/api/tests/routes/pro/get_collective_booking_test.py
+++ b/api/tests/routes/pro/get_collective_booking_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -10,6 +9,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import AUTHENTICATION_QUERIES
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -71,7 +71,7 @@ class Returns200Test:
             offerer=user_offerer.offerer, status=finance_models.BankAccountApplicationStatus.ACCEPTED
         )
         offerers_factories.VenueBankAccountLinkFactory(
-            bankAccount=bank_account, venue=venue, timespan=(datetime.utcnow() - timedelta(days=365), None)
+            bankAccount=bank_account, venue=venue, timespan=(date_utils.get_naive_utc_now() - timedelta(days=365), None)
         )
         booking = educational_factories.CollectiveBookingFactory(collectiveStock__collectiveOffer__venue=venue)
         booking_id = booking.id

--- a/api/tests/routes/pro/get_collective_offer_test.py
+++ b/api/tests/routes/pro/get_collective_offer_test.py
@@ -1,5 +1,4 @@
 from datetime import date
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -12,6 +11,7 @@ import pcapi.core.providers.factories as providers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
 from pcapi.core.testing import assert_num_queries
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -368,8 +368,8 @@ class Returns200Test:
         }
 
     def test_dates_on_offer(self, client):
-        beginningDate = datetime.utcnow() + timedelta(days=100)
-        endDate = datetime.utcnow() + timedelta(days=125)
+        beginningDate = date_utils.get_naive_utc_now() + timedelta(days=100)
+        endDate = date_utils.get_naive_utc_now() + timedelta(days=125)
         stock = educational_factories.CollectiveStockFactory(
             startDatetime=beginningDate,
             endDatetime=endDate,

--- a/api/tests/routes/pro/get_collective_offers_test.py
+++ b/api/tests/routes/pro/get_collective_offers_test.py
@@ -12,6 +12,7 @@ from pcapi.core.providers import factories as providers_factories
 from pcapi.core.testing import AUTHENTICATION_QUERIES
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.utils import date as date_utils
 
 
 def _get_serialized_address(
@@ -177,8 +178,8 @@ class Returns200Test:
         offer = educational_factories.CollectiveOfferFactory(
             venue=venue, institution=institution, nationalProgramId=national_program.id
         )
-        next_week = datetime.datetime.utcnow() + datetime.timedelta(days=7)
-        in_two_weeks = datetime.datetime.utcnow() + datetime.timedelta(days=14)
+        next_week = date_utils.get_naive_utc_now() + datetime.timedelta(days=7)
+        in_two_weeks = date_utils.get_naive_utc_now() + datetime.timedelta(days=14)
         educational_factories.CollectiveStockFactory(
             collectiveOffer=offer, startDatetime=next_week, endDatetime=in_two_weeks
         )
@@ -211,8 +212,8 @@ class Returns200Test:
         user = users_factories.UserFactory()
 
         stock = educational_factories.CollectiveStockFactory(
-            startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=125),
-            bookingLimitDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=125),
+            startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=125),
+            bookingLimitDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=125),
         )
         offer = educational_factories.CollectiveOfferFactory(
             collectiveStock=stock,
@@ -237,8 +238,8 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         stock = educational_factories.CollectiveStockFactory(
-            startDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=5),
-            bookingLimitDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=5),
+            startDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=5),
+            bookingLimitDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=5),
             collectiveOffer__venue=venue,
         )
 
@@ -377,13 +378,13 @@ class Returns200Test:
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offer = educational_factories.CollectiveOfferFactory(
             venue=venue,
-            dateCreated=datetime.datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
             imageId="00000125999998",
         )
 
         template = educational_factories.CollectiveOfferTemplateFactory(
             venue=venue,
-            dateCreated=datetime.datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
             imageId="00000125999999",
         )
 
@@ -418,9 +419,9 @@ class Returns200Test:
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
         offer = educational_factories.CollectiveOfferFactory(
             venue=venue,
-            dateCreated=datetime.datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
         )
-        educational_factories.CollectiveOfferTemplateFactory(venue=venue, dateCreated=datetime.datetime.utcnow())
+        educational_factories.CollectiveOfferTemplateFactory(venue=venue, dateCreated=date_utils.get_naive_utc_now())
         educational_factories.CollectiveStockFactory(collectiveOffer=offer)
 
         client = client.with_session_auth(user.email)
@@ -437,15 +438,15 @@ class Returns200Test:
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
-        offer = educational_factories.CollectiveOfferFactory(venue=venue, dateCreated=datetime.datetime.utcnow())
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, dateCreated=date_utils.get_naive_utc_now())
 
-        educational_factories.CollectiveOfferFactory(venue=venue, dateCreated=datetime.datetime.utcnow())
+        educational_factories.CollectiveOfferFactory(venue=venue, dateCreated=date_utils.get_naive_utc_now())
         educational_factories.CollectiveStockFactory(
             collectiveOffer__venue=venue,
-            collectiveOffer__dateCreated=datetime.datetime.utcnow(),
+            collectiveOffer__dateCreated=date_utils.get_naive_utc_now(),
             startDatetime=datetime.datetime(2022, 8, 10),
         )
-        educational_factories.CollectiveOfferTemplateFactory(venue=venue, dateCreated=datetime.datetime.utcnow())
+        educational_factories.CollectiveOfferTemplateFactory(venue=venue, dateCreated=date_utils.get_naive_utc_now())
         educational_factories.CollectiveStockFactory(
             collectiveOffer=offer, startDatetime=datetime.datetime(2022, 10, 10)
         )
@@ -466,30 +467,32 @@ class Returns200Test:
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
 
-        offer_booked = educational_factories.CollectiveOfferFactory(venue=venue, dateCreated=datetime.datetime.utcnow())
+        offer_booked = educational_factories.CollectiveOfferFactory(
+            venue=venue, dateCreated=date_utils.get_naive_utc_now()
+        )
         stock_booked = educational_factories.CollectiveStockFactory(
-            collectiveOffer=offer_booked, dateCreated=datetime.datetime.utcnow()
+            collectiveOffer=offer_booked, dateCreated=date_utils.get_naive_utc_now()
         )
         _booking_confirmed = educational_factories.CollectiveBookingFactory(
             collectiveStock=stock_booked,
-            dateCreated=datetime.datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
             status=educational_models.CollectiveBookingStatus.CONFIRMED,
         )
 
         offer_prebooked = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow()
+            venue=venue, dateCreated=date_utils.get_naive_utc_now()
         )
         stock_prebooked = educational_factories.CollectiveStockFactory(
-            collectiveOffer=offer_prebooked, dateCreated=datetime.datetime.utcnow()
+            collectiveOffer=offer_prebooked, dateCreated=date_utils.get_naive_utc_now()
         )
         _booking_cancelled = educational_factories.CollectiveBookingFactory(
             collectiveStock=stock_prebooked,
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             status=educational_models.CollectiveBookingStatus.CANCELLED,
         )
         _booking_pending = educational_factories.CollectiveBookingFactory(
             collectiveStock=stock_prebooked,
-            dateCreated=datetime.datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
             status=educational_models.CollectiveBookingStatus.PENDING,
         )
 
@@ -518,36 +521,38 @@ class Returns200Test:
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
 
         offer_not_booked = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow()
+            venue=venue, dateCreated=date_utils.get_naive_utc_now()
         )
         _stock_not_booked = educational_factories.CollectiveStockFactory(
-            collectiveOffer=offer_not_booked, dateCreated=datetime.datetime.utcnow()
+            collectiveOffer=offer_not_booked, dateCreated=date_utils.get_naive_utc_now()
         )
 
-        offer_booked = educational_factories.CollectiveOfferFactory(venue=venue, dateCreated=datetime.datetime.utcnow())
+        offer_booked = educational_factories.CollectiveOfferFactory(
+            venue=venue, dateCreated=date_utils.get_naive_utc_now()
+        )
         stock_booked = educational_factories.CollectiveStockFactory(
-            collectiveOffer=offer_booked, dateCreated=datetime.datetime.utcnow()
+            collectiveOffer=offer_booked, dateCreated=date_utils.get_naive_utc_now()
         )
         _booking_confirmed = educational_factories.CollectiveBookingFactory(
             collectiveStock=stock_booked,
-            dateCreated=datetime.datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
             status=educational_models.CollectiveBookingStatus.CONFIRMED,
         )
 
         offer_prebooked = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow()
+            venue=venue, dateCreated=date_utils.get_naive_utc_now()
         )
         stock_prebooked = educational_factories.CollectiveStockFactory(
-            collectiveOffer=offer_prebooked, dateCreated=datetime.datetime.utcnow()
+            collectiveOffer=offer_prebooked, dateCreated=date_utils.get_naive_utc_now()
         )
         _booking_cancelled = educational_factories.CollectiveBookingFactory(
             collectiveStock=stock_prebooked,
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             status=educational_models.CollectiveBookingStatus.CANCELLED,
         )
         _booking_pending = educational_factories.CollectiveBookingFactory(
             collectiveStock=stock_prebooked,
-            dateCreated=datetime.datetime.utcnow(),
+            dateCreated=date_utils.get_naive_utc_now(),
             status=educational_models.CollectiveBookingStatus.PENDING,
         )
 
@@ -589,9 +594,9 @@ class Returns200Test:
         offerer = offerers_factories.OffererFactory()
         offerers_factories.UserOffererFactory(user=user, offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
-        offer = educational_factories.CollectiveOfferFactory(venue=venue, dateCreated=datetime.datetime.utcnow())
+        offer = educational_factories.CollectiveOfferFactory(venue=venue, dateCreated=date_utils.get_naive_utc_now())
         template = educational_factories.CollectiveOfferTemplateFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow()
+            venue=venue, dateCreated=date_utils.get_naive_utc_now()
         )
         educational_factories.CollectiveStockFactory(collectiveOffer=offer)
 
@@ -616,66 +621,66 @@ class Returns200Test:
         venue = offerers_factories.VenueFactory(managingOfferer=offerer)
 
         offer_created_10_days_ago = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=10)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=10)
         )
 
         offer_created_30_days_ago = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=30)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=30)
         )
 
         offer_created_20_days_ago = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=20)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=20)
         )
 
         archived_offer = educational_factories.CollectiveOfferFactory(
-            dateArchived=datetime.datetime.utcnow(),
+            dateArchived=date_utils.get_naive_utc_now(),
             venue=venue,
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=15),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=15),
         )
 
         template_created_14_days_ago = educational_factories.CollectiveOfferTemplateFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=14)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=14)
         )
 
         offer_requiring_attention = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=35)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=35)
         )
-        futur = datetime.datetime.utcnow() + datetime.timedelta(days=5)
+        futur = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
         stock = educational_factories.CollectiveStockFactory(
             bookingLimitDatetime=futur, collectiveOffer=offer_requiring_attention
         )
         _booking = educational_factories.PendingCollectiveBookingFactory(collectiveStock=stock)
 
         published_offer_requiring_urgent_attention = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=35)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=35)
         )
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         stock = educational_factories.CollectiveStockFactory(
             bookingLimitDatetime=tomorrow, collectiveOffer=published_offer_requiring_urgent_attention
         )
 
         offer_requiring_urgent_attention = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=35)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=35)
         )
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         stock = educational_factories.CollectiveStockFactory(
             bookingLimitDatetime=tomorrow, collectiveOffer=offer_requiring_urgent_attention
         )
         _booking = educational_factories.PendingCollectiveBookingFactory(collectiveStock=stock)
 
         offer_booked = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=34)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=34)
         )
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         stock = educational_factories.CollectiveStockFactory(
             bookingLimitDatetime=tomorrow, collectiveOffer=offer_booked
         )
         _booking = educational_factories.ConfirmedCollectiveBookingFactory(collectiveStock=stock)
 
         offer_requiring_not_urgent_confirmation = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=35)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=35)
         )
-        futur_far = datetime.datetime.utcnow() + datetime.timedelta(days=10)
+        futur_far = date_utils.get_naive_utc_now() + datetime.timedelta(days=10)
         stock = educational_factories.CollectiveStockFactory(
             bookingLimitDatetime=futur_far, collectiveOffer=offer_requiring_not_urgent_confirmation
         )
@@ -711,70 +716,72 @@ class Returns200Test:
         # IMPORTANT: When offers have the same urgency score, they are sorted by dateCreated (most recent first)
 
         archived_offer = educational_factories.CollectiveOfferFactory(
-            dateArchived=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            dateArchived=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             venue=venue,
-            dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=15),
+            dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=15),
         )
         educational_factories.CollectiveStockFactory(collectiveOffer=archived_offer)
 
         old_offer = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=30)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=30)
         )
         educational_factories.CollectiveStockFactory(
-            collectiveOffer=old_offer, bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=20)
+            collectiveOffer=old_offer, bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=20)
         )
 
         recent_offer = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=5)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=5)
         )
         educational_factories.CollectiveStockFactory(
-            collectiveOffer=recent_offer, bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=15)
+            collectiveOffer=recent_offer,
+            bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=15),
         )
 
         booked_offer = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=10)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=10)
         )
         stock_booked = educational_factories.CollectiveStockFactory(
-            collectiveOffer=booked_offer, bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=5)
+            collectiveOffer=booked_offer,
+            bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=5),
         )
         educational_factories.ConfirmedCollectiveBookingFactory(collectiveStock=stock_booked)
 
         # Not urgent (booking limit > 7 days)
         pending_not_urgent_offer = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=12)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=12)
         )
         stock_pending_not_urgent = educational_factories.CollectiveStockFactory(
             collectiveOffer=pending_not_urgent_offer,
-            bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=10),
         )
         educational_factories.PendingCollectiveBookingFactory(collectiveStock=stock_pending_not_urgent)
 
         # Medium urgency (booking limit between 2-7 days)
         pending_medium_offer = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=8)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=8)
         )
         stock_pending_medium = educational_factories.CollectiveStockFactory(
             collectiveOffer=pending_medium_offer,
-            bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=4),
+            bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=4),
         )
         educational_factories.PendingCollectiveBookingFactory(collectiveStock=stock_pending_medium)
 
         # Expiring soon, created more recently than pending_urgent_offer
         expiring_soon_offer = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=6)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=6)
         )
         educational_factories.CollectiveStockFactory(
             collectiveOffer=expiring_soon_offer,
-            bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(hours=20),
+            bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(hours=20),
         )
 
         # Urgent, created less recently than expiring_soon_offer
         pending_urgent_offer = educational_factories.CollectiveOfferFactory(
-            venue=venue, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=7)
+            venue=venue, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=7)
         )
         stock_pending_urgent = educational_factories.CollectiveStockFactory(
             collectiveOffer=pending_urgent_offer,
-            bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=1),
+            bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=1),
         )
         educational_factories.PendingCollectiveBookingFactory(collectiveStock=stock_pending_urgent)
 

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -11,6 +11,7 @@ import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.models import WithdrawalTypeEnum
+from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 
 
@@ -382,7 +383,7 @@ class Returns200Test:
 
     @time_machine.travel("2020-10-15 00:00:00")
     def test_future_offer(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         user_offerer = offerers_factories.UserOffererFactory(
             offerer__dateCreated=now,
             offerer__siren="123456789",

--- a/api/tests/routes/pro/get_offerer_stats_test.py
+++ b/api/tests/routes/pro/get_offerer_stats_test.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 import time_machine
 
@@ -9,6 +7,7 @@ import pcapi.core.users.factories as users_factories
 from pcapi.connectors.big_query.queries.offerer_stats import DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE
 from pcapi.connectors.big_query.queries.offerer_stats import TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE
 from pcapi.core import testing
+from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 
 
@@ -28,7 +27,7 @@ class OffererStatsTest:
         mediation = offers_factories.MediationFactory(offer=offer_2)
         offer_3 = offers_factories.OfferFactory(venue__managingOffererId=offerer.id)
         offers_factories.HeadlineOfferFactory(
-            offer=offer_2, venue=offer_2.venue, timespan=(datetime.datetime.utcnow(),), without_mediation=True
+            offer=offer_2, venue=offer_2.venue, timespan=(date_utils.get_naive_utc_now(),), without_mediation=True
         )
 
         offerers_factories.OffererStatsFactory(

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -13,6 +13,7 @@ from pcapi.core import testing
 from pcapi.core.offers import models as offers_models
 from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -41,7 +42,7 @@ class GetOffererTest:
             managingOfferer=offerer,
             withdrawalDetails="More venue withdrawal details",
             adageId="123",
-            adageInscriptionDate=datetime.datetime.utcnow(),
+            adageInscriptionDate=date_utils.get_naive_utc_now(),
         )
         collective_factories.CollectiveDmsApplicationFactory(
             venue=venue,
@@ -402,17 +403,17 @@ class GetOffererTest:
         _up_to_date_link = offerers_factories.VenueBankAccountLinkFactory(
             venue=venue_linked,
             bankAccount=expected_bank_account,
-            timespan=(datetime.datetime.utcnow(), None),
+            timespan=(date_utils.get_naive_utc_now(), None),
         )
         offerers_factories.VenueBankAccountLinkFactory(
-            venue=expected_venue, bankAccount=expected_bank_account, timespan=(datetime.datetime.utcnow(),)
+            venue=expected_venue, bankAccount=expected_bank_account, timespan=(date_utils.get_naive_utc_now(),)
         )
         offerers_factories.VenueBankAccountLinkFactory(
             venue=non_linked_venue,
             bankAccount=expected_bank_account,
             timespan=(
-                datetime.datetime.utcnow() - datetime.timedelta(days=365),
-                datetime.datetime.utcnow() - datetime.timedelta(days=10),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
             ),
         )
 
@@ -511,10 +512,10 @@ class GetOffererTest:
         _up_to_date_link = offerers_factories.VenueBankAccountLinkFactory(
             venue=venue_linked,
             bankAccount=expected_bank_account,
-            timespan=(datetime.datetime.utcnow(), None),
+            timespan=(date_utils.get_naive_utc_now(), None),
         )
         offerers_factories.VenueBankAccountLinkFactory(
-            venue=expected_venue, bankAccount=expected_bank_account, timespan=(datetime.datetime.utcnow(),)
+            venue=expected_venue, bankAccount=expected_bank_account, timespan=(date_utils.get_naive_utc_now(),)
         )
 
         http_client = client.with_session_auth(pro_user.email)
@@ -591,7 +592,7 @@ class GetOffererTest:
         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
 
         bank_account = finance_factories.BankAccountFactory(
-            offerer=offerer, isActive=True, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            offerer=offerer, isActive=True, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         )
 
         first_venue = offerers_factories.VenueFactory(pricing_point="self", managingOfferer=offerer)
@@ -645,8 +646,8 @@ class GetOffererTest:
         offer = offers_factories.OfferFactory(venue__managingOfferer=offerer)
         inactive_offer_on_another_venue = offers_factories.OfferFactory(venue__managingOfferer=offerer, isActive=False)
         inactive_timespan = (
-            datetime.datetime.utcnow() - datetime.timedelta(days=2),
-            datetime.datetime.utcnow() - datetime.timedelta(days=2),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
+            date_utils.get_naive_utc_now() - datetime.timedelta(days=2),
         )
         offers_factories.HeadlineOfferFactory(offer=offer)
         offers_factories.HeadlineOfferFactory(offer=offer, timespan=inactive_timespan)

--- a/api/tests/routes/pro/get_offerers_bank_accounts_test.py
+++ b/api/tests/routes/pro/get_offerers_bank_accounts_test.py
@@ -8,6 +8,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
+from pcapi.utils import date as date_utils
 
 
 class OfferersBankAccountTest:
@@ -118,7 +119,7 @@ class OfferersBankAccountTest:
         offers_factories.StockFactory(offer=offer_bis)
         expected_bank_account = finance_factories.BankAccountFactory(offerer=offerer)
         offerers_factories.VenueBankAccountLinkFactory(
-            venue=expected_venue, bankAccount=expected_bank_account, timespan=(datetime.datetime.utcnow(),)
+            venue=expected_venue, bankAccount=expected_bank_account, timespan=(date_utils.get_naive_utc_now(),)
         )
 
         http_client = client.with_session_auth(pro_user.email)
@@ -205,10 +206,10 @@ class OfferersBankAccountTest:
         offerers_factories.UserOffererFactory(user=pro_user, offerer=offerer)
 
         first_bank_account = finance_factories.BankAccountFactory(
-            offerer=offerer, isActive=True, dateCreated=datetime.datetime.utcnow() - datetime.timedelta(days=1)
+            offerer=offerer, isActive=True, dateCreated=date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         )
         second_bank_account = finance_factories.BankAccountFactory(
-            offerer=offerer, isActive=True, dateCreated=datetime.datetime.utcnow()
+            offerer=offerer, isActive=True, dateCreated=date_utils.get_naive_utc_now()
         )
 
         venue_linked = offerers_factories.VenueFactory(pricing_point="self", managingOfferer=offerer)
@@ -217,12 +218,12 @@ class OfferersBankAccountTest:
             venueId=venue_linked.id,
             bankAccountId=first_bank_account.id,
             timespan=(
-                datetime.datetime.utcnow() - datetime.timedelta(days=365),
-                datetime.datetime.utcnow() - datetime.timedelta(seconds=10),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
+                date_utils.get_naive_utc_now() - datetime.timedelta(seconds=10),
             ),
         )
         offerers_factories.VenueBankAccountLinkFactory(
-            venue=venue_linked, bankAccount=second_bank_account, timespan=(datetime.datetime.utcnow(), None)
+            venue=venue_linked, bankAccount=second_bank_account, timespan=(date_utils.get_naive_utc_now(), None)
         )
 
         venue_not_linked_with_free_offer = offerers_factories.VenueWithoutSiretFactory(managingOfferer=offerer)

--- a/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
+++ b/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
@@ -1,5 +1,4 @@
 import csv
-import datetime
 import string
 from io import StringIO
 
@@ -15,6 +14,7 @@ from pcapi.core.educational import models as educational_models
 from pcapi.core.offers import models as offers_models
 from pcapi.models import db
 from pcapi.routes.serialization.reimbursement_csv_serialize import ReimbursementDetails
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import utc_datetime_to_department_timezone
 
 
@@ -40,13 +40,13 @@ def test_with_pricings(client):
     venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
     bank_account_1 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue1, bankAccount=bank_account_1, timespan=(datetime.datetime.utcnow(),)
+        venue=venue1, bankAccount=bank_account_1, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     venue2 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point=venue1)
     bank_account_2 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue2, bankAccount=bank_account_2, timespan=(datetime.datetime.utcnow(),)
+        venue=venue2, bankAccount=bank_account_2, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     batch = finance_factories.CashflowBatchFactory()
@@ -119,13 +119,13 @@ def test_with_pricings_collective_use_case(client):
     venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
     bank_account_1 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue1, bankAccount=bank_account_1, timespan=(datetime.datetime.utcnow(),)
+        venue=venue1, bankAccount=bank_account_1, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     venue2 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point=venue1)
     bank_account_2 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue2, bankAccount=bank_account_2, timespan=(datetime.datetime.utcnow(),)
+        venue=venue2, bankAccount=bank_account_2, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     batch = finance_factories.CashflowBatchFactory()
@@ -216,13 +216,13 @@ def test_return_only_searched_invoice(client):
     venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
     bank_account_1 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue1, bankAccount=bank_account_1, timespan=(datetime.datetime.utcnow(),)
+        venue=venue1, bankAccount=bank_account_1, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     venue2 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point=venue1)
     bank_account_2 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue2, bankAccount=bank_account_2, timespan=(datetime.datetime.utcnow(),)
+        venue=venue2, bankAccount=bank_account_2, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     batch = finance_factories.CashflowBatchFactory()

--- a/api/tests/routes/pro/get_reimbursements_csv_test.py
+++ b/api/tests/routes/pro/get_reimbursements_csv_test.py
@@ -15,6 +15,7 @@ from pcapi.core.educational import models as educational_models
 from pcapi.core.offers import models as offers_models
 from pcapi.models import db
 from pcapi.routes.serialization.reimbursement_csv_serialize import ReimbursementDetails
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import utc_datetime_to_department_timezone
 
 
@@ -70,13 +71,13 @@ def test_with_venue_filter_with_pricings(client, cutoff, fortnight):
     venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
     bank_account_1 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue1, bankAccount=bank_account_1, timespan=(datetime.datetime.utcnow(),)
+        venue=venue1, bankAccount=bank_account_1, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     venue2 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point=venue1)
     bank_account_2 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue2, bankAccount=bank_account_2, timespan=(datetime.datetime.utcnow(),)
+        venue=venue2, bankAccount=bank_account_2, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     batch = finance_factories.CashflowBatchFactory(cutoff=cutoff)
@@ -275,13 +276,13 @@ def test_with_bank_account_filter_with_pricings_collective_use_case(client, cuto
     venue1 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
     bank_account_1 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue1, bankAccount=bank_account_1, timespan=(datetime.datetime.utcnow(),)
+        venue=venue1, bankAccount=bank_account_1, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     venue2 = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point=venue1)
     bank_account_2 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue2, bankAccount=bank_account_2, timespan=(datetime.datetime.utcnow(),)
+        venue=venue2, bankAccount=bank_account_2, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     batch = finance_factories.CashflowBatchFactory(cutoff=cutoff)
@@ -385,10 +386,10 @@ def test_no_irrelevant_data_collective_offers_use_case(client):
     # create a bank account, link it to the first 2 venues and prepare invoice
     bank_account_1 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue1, bankAccount=bank_account_1, timespan=(datetime.datetime.utcnow(),)
+        venue=venue1, bankAccount=bank_account_1, timespan=(date_utils.get_naive_utc_now(),)
     )
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue2, bankAccount=bank_account_1, timespan=(datetime.datetime.utcnow(),)
+        venue=venue2, bankAccount=bank_account_1, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     batch = finance_factories.CashflowBatchFactory(cutoff=cutoff)
@@ -452,10 +453,10 @@ def test_no_irrelevant_data_individual_offers_use_case(client):
     # create a bank account, link it to the first 2 venues and prepare invoice
     bank_account_1 = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue1, bankAccount=bank_account_1, timespan=(datetime.datetime.utcnow(),)
+        venue=venue1, bankAccount=bank_account_1, timespan=(date_utils.get_naive_utc_now(),)
     )
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue2, bankAccount=bank_account_1, timespan=(datetime.datetime.utcnow(),)
+        venue=venue2, bankAccount=bank_account_1, timespan=(date_utils.get_naive_utc_now(),)
     )
 
     batch = finance_factories.CashflowBatchFactory(cutoff=cutoff)
@@ -648,7 +649,7 @@ def test_with_offer_address_and_venue_address(client, offer_has_oa, len_offerer_
     )
     bank_account = finance_factories.BankAccountFactory(offerer=offerer)
     offerers_factories.VenueBankAccountLinkFactory(
-        venue=venue, bankAccount=bank_account, timespan=(datetime.datetime.utcnow(),)
+        venue=venue, bankAccount=bank_account, timespan=(date_utils.get_naive_utc_now(),)
     )
     batch = finance_factories.CashflowBatchFactory(cutoff=cutoff)
 

--- a/api/tests/routes/pro/get_stocks_stats_test.py
+++ b/api/tests/routes/pro/get_stocks_stats_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -8,6 +7,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -61,7 +61,7 @@ class Returns200Test:
 
     @time_machine.travel("2020-10-15 00:00:00")
     def test_returns_stats(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         user_offerer = offerers_factories.UserOffererFactory()
         offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
         offers_factories.StockFactory(

--- a/api/tests/routes/pro/get_stocks_test.py
+++ b/api/tests/routes/pro/get_stocks_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 
 import pytest
@@ -7,6 +6,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
@@ -50,7 +50,7 @@ class Returns200Test:
     num_queries += 1  # select stocks
 
     def test_returns_an_event_stock(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         booking_datetime = now + timedelta(hours=1)
         booking_datetime_as_isoformat = booking_datetime.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         user_offerer = offerers_factories.UserOffererFactory()
@@ -112,7 +112,7 @@ class Returns200Test:
         }
 
     def test_returns_a_thing_stock(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         user_offerer = offerers_factories.UserOffererFactory()
         thing_offer = offers_factories.ThingOfferFactory(venue__managingOfferer=user_offerer.offerer)
         stock = offers_factories.ThingStockFactory(
@@ -186,8 +186,8 @@ class Returns200Test:
         assert response.json["hasStocks"] == False
 
     def test_returns_true_if_stock_exists_outside_filter(self, client):
-        date_1 = datetime.utcnow()
-        date_2 = datetime.utcnow() + timedelta(days=1)
+        date_1 = date_utils.get_naive_utc_now()
+        date_2 = date_utils.get_naive_utc_now() + timedelta(days=1)
         user_offerer = offerers_factories.UserOffererFactory()
         offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
         offers_factories.StockFactory.create_batch(
@@ -204,8 +204,8 @@ class Returns200Test:
         assert response.json["hasStocks"] == True
 
     def test_should_return_total_stock_count_when_unfiltered(self, client):
-        date_1 = datetime.utcnow()
-        date_2 = datetime.utcnow() + timedelta(days=1)
+        date_1 = date_utils.get_naive_utc_now()
+        date_2 = date_utils.get_naive_utc_now() + timedelta(days=1)
         user_offerer = offerers_factories.UserOffererFactory()
         offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
         offers_factories.StockFactory.create_batch(3, beginningDatetime=date_1, offer=offer)
@@ -221,7 +221,7 @@ class Returns200Test:
         assert len(response.json["stocks"]) == 5
 
     def test_should_return_filtered_stock_count(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         beginning_datetime = now + timedelta(seconds=1)
         booking_limit_datetime = beginning_datetime.replace(hour=23, minute=59) - timedelta(days=3)
         user_offerer = offerers_factories.UserOffererFactory()
@@ -260,8 +260,8 @@ class Returns200Test:
         }
 
     def test_should_return_filtered_stock_count_and_filtered_stock_list(self, client):
-        date_1 = datetime.utcnow()
-        date_2 = datetime.utcnow() + timedelta(days=1)
+        date_1 = date_utils.get_naive_utc_now()
+        date_2 = date_utils.get_naive_utc_now() + timedelta(days=1)
         user_offerer = offerers_factories.UserOffererFactory()
         offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
         offers_factories.StockFactory.create_batch(
@@ -286,8 +286,8 @@ class Returns200Test:
     def test_should_return_filtered_stock_count_and_filtered_stock_list_with_stocks_inferior_to_limit_per_page(
         self, client
     ):
-        date_1 = datetime.utcnow()
-        date_2 = datetime.utcnow() + timedelta(days=1)
+        date_1 = date_utils.get_naive_utc_now()
+        date_2 = date_utils.get_naive_utc_now() + timedelta(days=1)
         user_offerer = offerers_factories.UserOffererFactory()
         offer = offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
         offers_factories.StockFactory.create_batch(

--- a/api/tests/routes/pro/get_user_email_token_test.py
+++ b/api/tests/routes/pro/get_user_email_token_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 from typing import Any
 
@@ -6,6 +5,7 @@ import pytest
 
 from pcapi.core import testing
 from pcapi.core.users import factories as users_factories
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -38,7 +38,7 @@ def test_get_user_email_no_pending_validation(client: Any) -> None:
 
 def test_get_user_email_no_active_pending_validation(client: Any) -> None:
     user = users_factories.ProFactory()
-    now = datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     users_factories.EmailUpdateEntryFactory(user=user, creationDate=now - timedelta(hours=2))
     users_factories.EmailValidationEntryFactory(user=user, creationDate=now - timedelta(hours=1))
 
@@ -52,7 +52,7 @@ def test_get_user_email_no_active_pending_validation(client: Any) -> None:
 
 def test_get_user_email_multiple_validations_with_pending(client: Any) -> None:
     user = users_factories.ProFactory()
-    now = datetime.utcnow()
+    now = date_utils.get_naive_utc_now()
     users_factories.EmailUpdateEntryFactory(user=user, creationDate=now - timedelta(hours=2))
     users_factories.EmailValidationEntryFactory(user=user, creationDate=now - timedelta(hours=1))
     users_factories.EmailUpdateEntryFactory(

--- a/api/tests/routes/pro/get_user_profile_test.py
+++ b/api/tests/routes/pro/get_user_profile_test.py
@@ -1,5 +1,3 @@
-import datetime
-
 import flask
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -7,6 +5,7 @@ from dateutil.relativedelta import relativedelta
 from pcapi.core import testing
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -44,7 +43,7 @@ class Returns200Test:
             email="toto@example.com",
             firstName="Jean",
             lastName="Smisse",
-            dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18),
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
             phoneNumber="0612345678",
             isEmailValidated=True,
         )

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -12,6 +12,7 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.offerers.models import VenueTypeCode
 from pcapi.core.offerers.models import Weekday
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.date import timespan_str_to_numrange
 from pcapi.utils.image_conversion import DO_NOT_CROP
@@ -20,7 +21,7 @@ from pcapi.utils.image_conversion import DO_NOT_CROP
 @pytest.mark.usefixtures("db_session")
 class Returns200Test:
     def when_user_has_rights_on_managing_offerer(self, client, db_session):
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         user_offerer = offerers_factories.UserOffererFactory(user__email="user.pro@test.com")
         venue = offerers_factories.CollectiveVenueFactory(
             name="L'encre et la plume",

--- a/api/tests/routes/pro/patch_all_offers_active_status_test.py
+++ b/api/tests/routes/pro/patch_all_offers_active_status_test.py
@@ -11,6 +11,7 @@ from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.providers import factories as providers_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 now_datetime_with_tz = datetime.now(timezone.utc)
@@ -231,7 +232,7 @@ class Returns204Test:
 @pytest.mark.usefixtures("db_session")
 class ActivateFutureOffersTest:
     def test_activate_future_offers_and_notify_users_with_reminders(self, client):
-        publication_date = datetime.utcnow() + timedelta(days=30)
+        publication_date = date_utils.get_naive_utc_now() + timedelta(days=30)
 
         offer_to_publish_1 = offers_factories.OfferFactory(isActive=False)
         venue = offer_to_publish_1.venue
@@ -252,7 +253,7 @@ class ActivateFutureOffersTest:
         assert not db.session.get(Offer, offer_to_publish_3.id).isActive
 
     def test_deactivate_future_offers(self, client):
-        publication_date = datetime.utcnow() + timedelta(days=30)
+        publication_date = date_utils.get_naive_utc_now() + timedelta(days=30)
 
         offer_published_1 = offers_factories.OfferFactory()
         venue = offer_published_1.venue

--- a/api/tests/routes/pro/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/patch_collective_offer_template_test.py
@@ -12,6 +12,7 @@ from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -53,7 +54,7 @@ class PayloadContext:
 
 
 def build_template_start():
-    return datetime.utcnow() + timedelta(days=1)
+    return date_utils.get_naive_utc_now() + timedelta(days=1)
 
 
 def build_template_end(template_start=None):
@@ -237,7 +238,7 @@ class Returns200Test:
         offer_ctx = build_offer_context()
         pro_client = build_pro_client(client, offer_ctx.user)
         offer = offer_ctx.offer
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
 
         with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
             response = pro_client.patch(
@@ -909,7 +910,7 @@ class InvalidDatesTest:
         pro_client = build_pro_client(client, offer_ctx.user)
         offer_id = offer_ctx.offer.id
 
-        one_week_ago = datetime.utcnow() - timedelta(days=7)
+        one_week_ago = date_utils.get_naive_utc_now() - timedelta(days=7)
         dates = {"start": one_week_ago.isoformat(), "end": build_template_end().isoformat()}
 
         response = self.send_request(pro_client, offer_id, dates)

--- a/api/tests/routes/pro/patch_collective_stock_test.py
+++ b/api/tests/routes/pro/patch_collective_stock_test.py
@@ -17,6 +17,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.providers import factories as providers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -260,7 +261,7 @@ class Return200Test:
         assert edited_collective_booking.educationalYearId == educational_year_2022_2023.adageId
 
     def test_edit_collective_stock_update_booking_limit_date_with_expired_booking(self, client):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         stock = educational_factories.CollectiveStockFactory(
             startDatetime=now + timedelta(days=5), bookingLimitDatetime=now - timedelta(days=2)
         )

--- a/api/tests/routes/pro/patch_offerer_bank_accounts_test.py
+++ b/api/tests/routes/pro/patch_offerer_bank_accounts_test.py
@@ -13,6 +13,7 @@ import pcapi.core.token.serialization as token_serialization
 import pcapi.core.users.factories as users_factories
 from pcapi.core import token
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 ActionOccurred = namedtuple("ActionOccurred", ["type", "authorUserId", "venueId", "offererId", "bankAccountId"])
@@ -225,7 +226,7 @@ class OffererPatchBankAccountsTest:
             .join(finance_models.BankAccount)
             .filter(
                 finance_models.BankAccount.id == bank_account.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             )
             .count()
             == 3
@@ -279,7 +280,7 @@ class OffererPatchBankAccountsTest:
             .join(finance_models.BankAccount)
             .filter(
                 finance_models.BankAccount.id == bank_account.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             )
             .count()
         )
@@ -331,8 +332,8 @@ class OffererPatchBankAccountsTest:
             venue=first_venue,
             bankAccount=bank_account,
             timespan=(
-                datetime.datetime.utcnow() - datetime.timedelta(days=365),
-                datetime.datetime.utcnow() - datetime.timedelta(days=10),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
             ),
         )
         first_timespan = first_history_link.timespan
@@ -340,8 +341,8 @@ class OffererPatchBankAccountsTest:
             venue=second_venue,
             bankAccount=bank_account,
             timespan=(
-                datetime.datetime.utcnow() - datetime.timedelta(days=365),
-                datetime.datetime.utcnow() - datetime.timedelta(days=10),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=365),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
             ),
         )
         second_timespan = second_history_link.timespan
@@ -352,7 +353,7 @@ class OffererPatchBankAccountsTest:
             .join(finance_models.BankAccount)
             .filter(
                 finance_models.BankAccount.id == bank_account.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             )
             .count()
             == 2
@@ -404,7 +405,7 @@ class OffererPatchBankAccountsTest:
             .join(finance_models.BankAccount)
             .filter(
                 finance_models.BankAccount.id == bank_account.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             )
             .count()
             == 2
@@ -446,13 +447,13 @@ class OffererPatchBankAccountsTest:
         first_current_link = offerers_factories.VenueBankAccountLinkFactory(
             venue=first_venue,
             bankAccount=bank_account,
-            timespan=(datetime.datetime.utcnow() - datetime.timedelta(days=365),),
+            timespan=(date_utils.get_naive_utc_now() - datetime.timedelta(days=365),),
         )
         first_timespan = first_current_link.timespan
         second_current_link = offerers_factories.VenueBankAccountLinkFactory(
             venue=second_venue,
             bankAccount=bank_account,
-            timespan=(datetime.datetime.utcnow() - datetime.timedelta(days=365),),
+            timespan=(date_utils.get_naive_utc_now() - datetime.timedelta(days=365),),
         )
         second_timespan = second_current_link.timespan
 
@@ -462,7 +463,7 @@ class OffererPatchBankAccountsTest:
             .join(finance_models.BankAccount)
             .filter(
                 finance_models.BankAccount.id == bank_account.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             )
             .count()
             == 2
@@ -514,7 +515,7 @@ class OffererPatchBankAccountsTest:
             .join(finance_models.BankAccount)
             .filter(
                 finance_models.BankAccount.id == bank_account.id,
-                offerers_models.VenueBankAccountLink.timespan.contains(datetime.datetime.utcnow()),
+                offerers_models.VenueBankAccountLink.timespan.contains(date_utils.get_naive_utc_now()),
             )
             .count()
             == 4
@@ -553,7 +554,7 @@ class OffererPatchBankAccountsTest:
         foreign_bank_account = finance_factories.BankAccountFactory(offerer=foreign_offerer)
         foreign_venue = offerers_factories.VenueFactory(managingOfferer=foreign_offerer, pricing_point="self")
         foreign_link = offerers_factories.VenueBankAccountLinkFactory(
-            venue=foreign_venue, bankAccount=foreign_bank_account, timespan=(datetime.datetime.utcnow(),)
+            venue=foreign_venue, bankAccount=foreign_bank_account, timespan=(date_utils.get_naive_utc_now(),)
         )
 
         assert not bank_account.venueLinks

--- a/api/tests/routes/pro/patch_offers_active_status_test.py
+++ b/api/tests/routes/pro/patch_offers_active_status_test.py
@@ -14,6 +14,7 @@ from pcapi.core import testing
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 now_datetime_with_tz = datetime.now(timezone.utc)
@@ -142,7 +143,7 @@ def is_around_now(dt: datetime) -> bool:
 @pytest.mark.usefixtures("db_session")
 class ActivateFutureOffersTest:
     def test_activate_future_offers_and_notify_users_with_reminders(self, client):
-        publication_date = datetime.utcnow() + timedelta(days=30)
+        publication_date = date_utils.get_naive_utc_now() + timedelta(days=30)
 
         offer_to_publish_1 = offers_factories.OfferFactory(isActive=False, publicationDatetime=publication_date)
         venue = offer_to_publish_1.venue
@@ -172,7 +173,7 @@ class ActivateFutureOffersTest:
         assert not offer3.publicationDatetime
 
     def test_deactivate_future_offers(self, client):
-        publication_date = datetime.utcnow() + timedelta(days=30)
+        publication_date = date_utils.get_naive_utc_now() + timedelta(days=30)
 
         offer_published_1 = offers_factories.OfferFactory(publicationDatetime=publication_date)
         venue = offer_published_1.venue

--- a/api/tests/routes/pro/patch_publish_offer_test.py
+++ b/api/tests/routes/pro/patch_publish_offer_test.py
@@ -14,6 +14,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -330,7 +331,7 @@ class Returns400Test:
         stock = offers_factories.StockFactory(
             offer__isActive=False,
             offer__validation=OfferValidationStatus.DRAFT,
-            beginningDatetime=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            beginningDatetime=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
         )
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
@@ -360,7 +361,7 @@ class Returns400Test:
         )
 
         client = client.with_session_auth("user@example.com")
-        publication_date = datetime.datetime.utcnow().replace(minute=0, second=0) - datetime.timedelta(days=30)
+        publication_date = date_utils.get_naive_utc_now().replace(minute=0, second=0) - datetime.timedelta(days=30)
         response = client.patch(
             "/offers/publish",
             json={

--- a/api/tests/routes/pro/patch_thing_stock_test.py
+++ b/api/tests/routes/pro/patch_thing_stock_test.py
@@ -10,6 +10,7 @@ import pcapi.core.providers.factories as providers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.search.models import IndexationReason
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -23,7 +24,7 @@ class Returns200Test:
                 {
                     "price": 20,
                     "bookingLimitDatetime": format_into_utc_date(
-                        datetime.datetime.utcnow() + datetime.timedelta(days=1)
+                        date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
                     ),
                     "quantity": 10,
                 },
@@ -108,7 +109,7 @@ class Returns400Test:
         "input_json",
         [
             {"price": 20},
-            {"bookingLimitDatetime": format_into_utc_date(datetime.datetime.utcnow() + datetime.timedelta(days=1))},
+            {"bookingLimitDatetime": format_into_utc_date(date_utils.get_naive_utc_now() + datetime.timedelta(days=1))},
         ],
     )
     def test_should_raise_because_you_cannot_update_stock_attribute_except_quantity_for_synchronized_offers(

--- a/api/tests/routes/pro/patch_venue_test.py
+++ b/api/tests/routes/pro/patch_venue_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from decimal import Decimal
 from unittest.mock import patch
 
@@ -15,6 +14,7 @@ from pcapi.core.search.models import IndexationReason
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import testing as external_testing
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import timespan_str_to_numrange
 
 
@@ -51,7 +51,7 @@ class Returns200Test:
     def test_should_update_venue(self, client) -> None:
         # given
         user_offerer = offerers_factories.UserOffererFactory(
-            user__lastConnectionDate=datetime.utcnow(),
+            user__lastConnectionDate=date_utils.get_naive_utc_now(),
         )
         initial_address = geography_factories.AddressFactory(
             street="35 Boulevard de Sébastopol",
@@ -177,7 +177,7 @@ class Returns200Test:
         }
 
     def test_update_venue_is_open_to_public_should_set_is_permanent_to_true_and_sync_acceslibre(self, client) -> None:
-        user_offerer = offerers_factories.UserOffererFactory(user__lastConnectionDate=datetime.utcnow())
+        user_offerer = offerers_factories.UserOffererFactory(user__lastConnectionDate=date_utils.get_naive_utc_now())
         venue = offerers_factories.VenueFactory(
             managingOfferer=user_offerer.offerer,
             isOpenToPublic=False,
@@ -205,7 +205,7 @@ class Returns200Test:
     def test_update_venue_is_close_to_public_should_not_change_is_permanent_but_delete_sync_acceslibre(
         self, client
     ) -> None:
-        user_offerer = offerers_factories.UserOffererFactory(user__lastConnectionDate=datetime.utcnow())
+        user_offerer = offerers_factories.UserOffererFactory(user__lastConnectionDate=date_utils.get_naive_utc_now())
         venue = offerers_factories.VenueFactory(
             venueTypeCode=offerers_models.VenueTypeCode.LIBRARY,
             managingOfferer=user_offerer.offerer,

--- a/api/tests/routes/pro/post_bulk_create_event_stocks_test.py
+++ b/api/tests/routes/pro/post_bulk_create_event_stocks_test.py
@@ -10,6 +10,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -23,7 +24,7 @@ class Returns201Test:
         second_label = offers_factories.PriceCategoryLabelFactory(label="Tarif 2", venue=offer.venue)
         first_price_cat = offers_factories.PriceCategoryFactory(offer=offer, priceCategoryLabel=first_label, price=20)
         second_price_cat = offers_factories.PriceCategoryFactory(offer=offer, priceCategoryLabel=second_label, price=30)
-        beginning = datetime.datetime.utcnow() + relativedelta(days=10)
+        beginning = date_utils.get_naive_utc_now() + relativedelta(days=10)
 
         stock_data = {
             "offerId": offer.id,
@@ -85,8 +86,8 @@ class Returns201Test:
         first_price_cat = offers_factories.PriceCategoryFactory(offer=offer, priceCategoryLabel=shared_label, price=20)
         unique_label = offers_factories.PriceCategoryLabelFactory(label="unique", venue=offer.venue)
         second_price_cat = offers_factories.PriceCategoryFactory(offer=offer, priceCategoryLabel=unique_label, price=30)
-        beginning = datetime.datetime.utcnow() + relativedelta(days=10)
-        beginning_later = datetime.datetime.utcnow() + relativedelta(days=11)
+        beginning = date_utils.get_naive_utc_now() + relativedelta(days=10)
+        beginning_later = date_utils.get_naive_utc_now() + relativedelta(days=11)
 
         stock_data = {
             "offerId": offer.id,
@@ -123,7 +124,7 @@ class Returns201Test:
 
     def test_avoid_duplication_with_different_quantity(self, client):
         offer = offers_factories.EventOfferFactory()
-        beginning = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+        beginning = date_utils.get_naive_utc_now() + datetime.timedelta(hours=1)
         price_cat_label = offers_factories.PriceCategoryLabelFactory(venue=offer.venue, label="Tarif 1")
         price_category = offers_factories.PriceCategoryFactory(
             offer=offer, priceCategoryLabel=price_cat_label, price=10
@@ -156,7 +157,7 @@ class Returns201Test:
 
     def should_not_create_duplicated_stock(self, client):
         offer = offers_factories.EventOfferFactory()
-        beginning = datetime.datetime.utcnow() + relativedelta(hours=4)
+        beginning = date_utils.get_naive_utc_now() + relativedelta(hours=4)
         beginning_later = beginning + relativedelta(days=10)
         price_cat_label_1 = offers_factories.PriceCategoryLabelFactory(venue=offer.venue, label="Tarif 1")
         price_cat_label_2 = offers_factories.PriceCategoryLabelFactory(venue=offer.venue, label="Tarif 2")
@@ -230,7 +231,7 @@ class Returns400Test:
         )
         shared_label = offers_factories.PriceCategoryLabelFactory(label="Shared", venue=offer.venue)
         price_cat = offers_factories.PriceCategoryFactory(offer=offer, priceCategoryLabel=shared_label, price=20)
-        beginning = datetime.datetime.utcnow() + relativedelta(days=10)
+        beginning = date_utils.get_naive_utc_now() + relativedelta(days=10)
 
         stock_data = {
             "offerId": offer.id,
@@ -254,8 +255,8 @@ class Returns400Test:
 
         price_cat_label = offers_factories.PriceCategoryLabelFactory(venue=offer.venue, label="Tarif 1")
         price_cat = offers_factories.PriceCategoryFactory(offer=offer, priceCategoryLabel=price_cat_label, price=10)
-        beginning = datetime.datetime.utcnow() + relativedelta(days=10)
-        bookingLimitDatetime = datetime.datetime.utcnow() + relativedelta(days=10)
+        beginning = date_utils.get_naive_utc_now() + relativedelta(days=10)
+        bookingLimitDatetime = date_utils.get_naive_utc_now() + relativedelta(days=10)
 
         stock_data = {
             "offerId": offer.id,
@@ -282,7 +283,7 @@ class Returns400Test:
         offer = offers_factories.EventOfferFactory(isActive=False, validation=offers_models.OfferValidationStatus.DRAFT)
         offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
         price_category = offers_factories.PriceCategoryFactory(offer=offer)
-        beginning = datetime.datetime.utcnow() + relativedelta(days=10)
+        beginning = date_utils.get_naive_utc_now() + relativedelta(days=10)
         stock_data = {
             "offerId": offer.id,
             "stocks": [
@@ -303,7 +304,7 @@ class Returns400Test:
         too_high_price_category = offers_factories.PriceCategoryFactory(
             offer=offer, priceCategoryLabel__label="too_high_price_category", price=310
         )
-        beginning = datetime.datetime.utcnow() + relativedelta(days=10)
+        beginning = date_utils.get_naive_utc_now() + relativedelta(days=10)
         offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
 
         # When
@@ -331,7 +332,7 @@ class Returns403Test:
         offer = offers_factories.EventOfferFactory()
         price_category = offers_factories.PriceCategoryFactory(offer=offer)
         offerers_factories.UserOffererFactory(user__email="right@example.com", offerer=offer.venue.managingOfferer)
-        beginning = datetime.datetime.utcnow() + relativedelta(days=10)
+        beginning = date_utils.get_naive_utc_now() + relativedelta(days=10)
 
         stock_data = {
             "offerId": offer.id,

--- a/api/tests/routes/pro/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/post_collective_offers_template_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -11,6 +10,7 @@ from pcapi.core.educational import models
 from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -49,12 +49,12 @@ def domains_fixture():
 
 @pytest.fixture(name="template_start", scope="module")
 def template_start_fixture():
-    return datetime.utcnow() + timedelta(days=1)
+    return date_utils.get_naive_utc_now() + timedelta(days=1)
 
 
 @pytest.fixture(name="template_end", scope="module")
 def template_end_fixture():
-    return datetime.utcnow() + timedelta(days=100)
+    return date_utils.get_naive_utc_now() + timedelta(days=100)
 
 
 @pytest.fixture(name="payload")
@@ -168,7 +168,7 @@ class Returns200Test:
         assert response.status_code == 201
 
     def test_with_start_and_end_equal(self, pro_client, payload):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         data = {**payload, "dates": {"start": format_into_utc_date(now), "end": format_into_utc_date(now)}}
 
         with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
@@ -550,7 +550,7 @@ class InvalidDatesTest:
         assert "dates.start" in response.json
 
     def test_start_is_in_the_past(self, pro_client, payload, template_end):
-        one_week_ago = datetime.utcnow() - timedelta(days=7)
+        one_week_ago = date_utils.get_naive_utc_now() - timedelta(days=7)
         dates_extra = {"start": one_week_ago.isoformat(), "end": template_end.isoformat()}
 
         response = self.send_request(pro_client, payload, dates_extra)

--- a/api/tests/routes/pro/post_collective_stock_test.py
+++ b/api/tests/routes/pro/post_collective_stock_test.py
@@ -12,6 +12,7 @@ from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -400,7 +401,7 @@ class Return400Test:
             assert response.json == {"code": "START_AND_END_EDUCATIONAL_YEAR_DIFFERENT"}
 
     def should_not_accept_payload_with_dates_in_the_past(self, client):
-        past = (datetime.datetime.utcnow() - datetime.timedelta(days=1)).isoformat() + "Z"
+        past = (date_utils.get_naive_utc_now() - datetime.timedelta(days=1)).isoformat() + "Z"
         offer = educational_factories.CollectiveOfferFactory()
         offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
 

--- a/api/tests/routes/pro/post_offerer_test.py
+++ b/api/tests/routes/pro/post_offerer_test.py
@@ -1,5 +1,4 @@
 import json
-from datetime import datetime
 
 import pytest
 
@@ -11,6 +10,7 @@ import pcapi.core.users.testing as users_testing
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
+from pcapi.utils import date as date_utils
 
 from tests.connectors import api_entreprise_test_data
 
@@ -131,7 +131,7 @@ def test_user_can_create_offerer(client):
 def test_when_no_address_is_provided(client):
     # given
     pro = users_factories.ProFactory(
-        lastConnectionDate=datetime.utcnow(),
+        lastConnectionDate=date_utils.get_naive_utc_now(),
     )
     body = {
         "name": "Test Offerer",

--- a/api/tests/routes/pro/post_price_categories_test.py
+++ b/api/tests/routes/pro/post_price_categories_test.py
@@ -7,6 +7,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -133,7 +134,7 @@ class Returns200Test:
         expired_stock = offers_factories.EventStockFactory(
             offer=offer,
             priceCategory=price_category,
-            beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=-2),
+            beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=-2),
         )
 
         response = client.with_session_auth("user@example.com").post(

--- a/api/tests/routes/pro/post_thing_stock_test.py
+++ b/api/tests/routes/pro/post_thing_stock_test.py
@@ -10,6 +10,7 @@ import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.search.models import IndexationReason
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -21,7 +22,9 @@ class Returns201Test:
         [
             {
                 "price": 20,
-                "bookingLimitDatetime": format_into_utc_date(datetime.datetime.utcnow() + datetime.timedelta(days=1)),
+                "bookingLimitDatetime": format_into_utc_date(
+                    date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
+                ),
                 "quantity": 10,
             },
             {"price": 0},
@@ -64,8 +67,8 @@ class Returns201Test:
         offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
 
         activation_codes = ["AZ3", "3ZE"]
-        limit_datetime = datetime.datetime.utcnow() + datetime.timedelta(days=1)
-        expiration_datetime = datetime.datetime.utcnow() + datetime.timedelta(days=14)
+        limit_datetime = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
+        expiration_datetime = date_utils.get_naive_utc_now() + datetime.timedelta(days=14)
         stock_data = {
             "offerId": offer.id,
             "price": 20,

--- a/api/tests/routes/pro/post_upsert_headline_offer_test.py
+++ b/api/tests/routes/pro/post_upsert_headline_offer_test.py
@@ -10,6 +10,7 @@ import pcapi.core.users.factories as users_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.search.models import IndexationReason
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -62,8 +63,8 @@ class Returns200Test:
         offers_factories.HeadlineOfferFactory(
             offer=offer,
             timespan=(
-                datetime.datetime.utcnow() - datetime.timedelta(days=20),
-                datetime.datetime.utcnow() - datetime.timedelta(days=10),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=20),
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=10),
             ),
         )
         assert not offer.is_headline_offer

--- a/api/tests/routes/pro/signin_test.py
+++ b/api/tests/routes/pro/signin_test.py
@@ -9,6 +9,7 @@ from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -16,7 +17,7 @@ class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def when_account_is_known(self, client, caplog):
         # given
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         user = users_factories.BeneficiaryGrant18Factory(
             civility=users_models.GenderEnum.M.value,
             city=None,
@@ -122,7 +123,7 @@ class Returns200Test:
     @pytest.mark.usefixtures("db_session")
     def test_with_user_offerer(self, client):
         user_offerer = offerers_factories.UserOffererFactory(
-            user__lastConnectionDate=datetime.datetime.utcnow(),
+            user__lastConnectionDate=date_utils.get_naive_utc_now(),
         )
         data = {
             "identifier": user_offerer.user.email,

--- a/api/tests/routes/pro/upsert_offer_stocks_test.py
+++ b/api/tests/routes/pro/upsert_offer_stocks_test.py
@@ -8,6 +8,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
 import pcapi.core.users.factories as users_factories
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -47,7 +48,7 @@ class Returns204Test:
         stock_to_update = offers_factories.ThingStockFactory(offer=offer, price=decimal.Decimal("5"), quantity=10)
         stock_to_delete = offers_factories.ThingStockFactory(offer=offer, price=decimal.Decimal("7"), quantity=3)
 
-        updated_stock_booking_limit_datetime = datetime.datetime.utcnow() + datetime.timedelta(days=2)
+        updated_stock_booking_limit_datetime = date_utils.get_naive_utc_now() + datetime.timedelta(days=2)
         payload = {
             "stocks": [
                 {

--- a/api/tests/routes/public/collective/endpoints/patch_collective_booking_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_booking_test.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import pytest
 
 import pcapi.core.educational.factories as educational_factories
@@ -7,6 +5,7 @@ import pcapi.core.educational.models as educational_models
 import pcapi.core.offerers.models as offerers_models
 from pcapi.core.educational import testing as educational_testing
 from pcapi.core.mails import testing as mails_testing
+from pcapi.utils import date as date_utils
 
 from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
 from tests.routes.public.helpers import assert_attribute_does_not_change
@@ -44,7 +43,7 @@ class CancelCollectiveBookingTest(PublicAPIVenueEndpointHelper):
         assert response.status_code == 204
 
         assert booking.cancellationReason == educational_models.CollectiveBookingCancellationReasons.PUBLIC_API
-        assert booking.cancellationDate.timestamp() == pytest.approx(datetime.utcnow().timestamp(), rel=1)
+        assert booking.cancellationDate.timestamp() == pytest.approx(date_utils.get_naive_utc_now().timestamp(), rel=1)
         assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
 
         assert len(educational_testing.adage_requests) == 1
@@ -60,7 +59,7 @@ class CancelCollectiveBookingTest(PublicAPIVenueEndpointHelper):
         assert response.status_code == 204
 
         assert booking.cancellationReason == educational_models.CollectiveBookingCancellationReasons.PUBLIC_API
-        assert booking.cancellationDate.timestamp() == pytest.approx(datetime.utcnow().timestamp(), rel=1)
+        assert booking.cancellationDate.timestamp() == pytest.approx(date_utils.get_naive_utc_now().timestamp(), rel=1)
         assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
 
     def test_cancel_offer_ended(self):
@@ -72,7 +71,7 @@ class CancelCollectiveBookingTest(PublicAPIVenueEndpointHelper):
         assert response.status_code == 204
 
         assert booking.cancellationReason == educational_models.CollectiveBookingCancellationReasons.PUBLIC_API
-        assert booking.cancellationDate.timestamp() == pytest.approx(datetime.utcnow().timestamp(), rel=1)
+        assert booking.cancellationDate.timestamp() == pytest.approx(date_utils.get_naive_utc_now().timestamp(), rel=1)
         assert booking.status == educational_models.CollectiveBookingStatus.CANCELLED
 
     @pytest.mark.parametrize(

--- a/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
+++ b/api/tests/routes/public/collective/endpoints/patch_collective_offer_test.py
@@ -251,7 +251,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         )
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer)
 
-        next_month = datetime.utcnow().replace(second=0, microsecond=0) + timedelta(days=30)
+        next_month = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + timedelta(days=30)
         next_month_minus_one_day = next_month - timedelta(days=1)
 
         stringified_next_month = date_utils.utc_datetime_to_department_timezone(next_month, None).isoformat()
@@ -283,7 +283,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         )
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer)
 
-        next_month = datetime.utcnow().replace(second=0, microsecond=0) + timedelta(days=30)
+        next_month = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + timedelta(days=30)
         next_month_minus_one_day = next_month - timedelta(days=1)
 
         payload = {
@@ -304,7 +304,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         offer = educational_factories.CollectiveOfferFactory(venue=venue, provider=venue_provider.provider)
         stock = educational_factories.CollectiveStockFactory(collectiveOffer=offer)
 
-        new_start = datetime.utcnow().replace(second=0, microsecond=0) + timedelta(days=30)
+        new_start = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + timedelta(days=30)
         new_end = new_start + timedelta(days=10)
         new_limit = new_start + timedelta(days=5)
 
@@ -464,7 +464,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         assert not (UPLOAD_FOLDER / offer._get_image_storage_id()).exists()
 
     def test_should_update_expired_booking(self):
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         limit = now - timedelta(days=2)
 
         key, venue_provider = self.setup_active_venue_provider()
@@ -615,7 +615,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         offer = educational_factories.CollectiveOfferFactory(
             venue=venue_provider.venue, provider=venue_provider.provider
         )
-        start = datetime.utcnow() + timedelta(days=5)
+        start = date_utils.get_naive_utc_now() + timedelta(days=5)
         educational_factories.CollectiveStockFactory(collectiveOffer=offer, startDatetime=start)
 
         input_end = start - timedelta(days=1)
@@ -638,7 +638,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         offer = educational_factories.CollectiveOfferFactory(
             venue=venue_provider.venue, provider=venue_provider.provider
         )
-        end = datetime.utcnow() + timedelta(days=5)
+        end = date_utils.get_naive_utc_now() + timedelta(days=5)
         educational_factories.CollectiveStockFactory(
             collectiveOffer=offer, startDatetime=end - timedelta(days=1), endDatetime=end
         )
@@ -663,7 +663,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         offer = educational_factories.CollectiveOfferFactory(
             venue=venue_provider.venue, provider=venue_provider.provider
         )
-        start = datetime.utcnow() + timedelta(days=5)
+        start = date_utils.get_naive_utc_now() + timedelta(days=5)
         educational_factories.CollectiveStockFactory(
             collectiveOffer=offer, startDatetime=start, bookingLimitDatetime=start - timedelta(days=2)
         )
@@ -690,7 +690,7 @@ class CollectiveOffersPublicPatchOfferTest(PublicAPIVenueEndpointHelper):
         offer = educational_factories.CollectiveOfferFactory(
             venue=venue_provider.venue, provider=venue_provider.provider
         )
-        start = datetime.utcnow() + timedelta(days=5)
+        start = date_utils.get_naive_utc_now() + timedelta(days=5)
         educational_factories.CollectiveStockFactory(collectiveOffer=offer, startDatetime=start)
 
         input_limit = start + timedelta(days=3)

--- a/api/tests/routes/public/individual_offers/v1/bookings/get_booking_test.py
+++ b/api/tests/routes/public/individual_offers/v1/bookings/get_booking_test.py
@@ -31,13 +31,13 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
             name="Vieux motard que jamais",
             ean="1234567890123",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
         stock = offers_factories.StockFactory(offer=offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             user__postalCode="75001",
             stock=stock,
         )
@@ -118,13 +118,13 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             user__postalCode="69100",
             stock=event_stock,
         )
@@ -166,7 +166,7 @@ class GetBookingByTokenTest(PublicAPIVenueEndpointHelper):
 
     def test_should_raise_403_when_booking_not_confirmed(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
-        next_week = datetime.datetime.utcnow() + datetime.timedelta(weeks=1)
+        next_week = date_utils.get_naive_utc_now() + datetime.timedelta(weeks=1)
 
         offer = offers_factories.ThingOfferFactory(venue=venue_provider.venue)
         stock = offers_factories.StockFactory(offer=offer, beginningDatetime=next_week)

--- a/api/tests/routes/public/individual_offers/v1/bookings/get_bookings_test.py
+++ b/api/tests/routes/public/individual_offers/v1/bookings/get_bookings_test.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 from pcapi.core import testing
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.offers import factories as offers_factories
+from pcapi.utils import date as date_utils
 
 from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
 
@@ -74,13 +75,13 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
     def test_request_not_existing_page(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         offer = self.setup_base_resource(venue=venue_provider.venue)
-        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             stock=product_stock,
         )
 
@@ -106,13 +107,13 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             name="Vieux motard que jamais",
             ean="1234567890123",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=product_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             stock=product_stock,
         )
 
@@ -160,20 +161,20 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(months=2),
             stock=event_stock,
         )
         booking_2 = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock,
         )
 
@@ -249,7 +250,7 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(weeks=2)
         price_category = offers_factories.PriceCategoryFactory(price=1010, offer=event_offer)
         event_stock = offers_factories.EventStockFactory(
             offer=event_offer,
@@ -259,14 +260,14 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(months=2),
             stock=event_stock,
         )
         booking_2 = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock,
         )
 
@@ -345,7 +346,7 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(
             offer=event_offer,
             beginningDatetime=past,
@@ -358,14 +359,14 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(months=2),
             stock=event_stock,
         )
         bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock_2,
         )
 
@@ -419,7 +420,7 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(
             offer=event_offer,
             beginningDatetime=past,
@@ -432,14 +433,14 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(months=2),
             stock=event_stock,
         )
         bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock_2,
         )
 
@@ -492,7 +493,7 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(
             offer=event_offer,
             beginningDatetime=past,
@@ -506,14 +507,14 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(months=2),
             stock=event_stock,
         )
         bookings_factories.UsedBookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock_2,
         )
 
@@ -566,7 +567,7 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(
             offer=event_offer,
             beginningDatetime=past,
@@ -579,21 +580,21 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(months=2),
             stock=event_stock,
         )
         bookings_factories.UsedBookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock,
         )
         booking = bookings_factories.UsedBookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-3@example.com",
             user__phoneNumber="0698273632",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=2),
             stock=event_stock_2,
         )
 
@@ -651,27 +652,27 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(months=2),
             stock=event_stock,
         )
         booking_2 = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock,
         )
         bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-3@example.com",
             user__phoneNumber="0698890987",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock,
         )
 
@@ -747,27 +748,27 @@ class GetBookingsByOfferTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(weeks=2)
         event_stock = offers_factories.EventStockFactory(offer=event_offer, beginningDatetime=past)
         bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(months=2),
             stock=event_stock,
         )
         booking_2 = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-2@example.com",
             user__phoneNumber="0698271625",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock,
         )
         booking_3 = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=1),
             user__email="beneficiary-3@example.com",
             user__phoneNumber="0698890987",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=1),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=1),
             stock=event_stock,
         )
 

--- a/api/tests/routes/public/individual_offers/v1/bookings/patch_cancel_booking_by_token_test.py
+++ b/api/tests/routes/public/individual_offers/v1/bookings/patch_cancel_booking_by_token_test.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offers import factories as offers_factories
+from pcapi.utils import date as date_utils
 
 from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
 
@@ -26,13 +27,13 @@ class CancelBookingByTokenTest(PublicAPIVenueEndpointHelper):
             name="Vieux motard que jamais",
             ean="1234567890123",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
         product_stock = offers_factories.StockFactory(offer=offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             stock=product_stock,
         )
         return offer, booking
@@ -65,14 +66,14 @@ class CancelBookingByTokenTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        yesterday = datetime.datetime.utcnow() - datetime.timedelta(days=1)
-        in_3_days = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
+        in_3_days = date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
         stock = offers_factories.EventStockFactory(offer=offer, beginningDatetime=in_3_days)
         booking = bookings_factories.BookingFactory(
             dateCreated=yesterday,
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             stock=stock,
         )
 
@@ -86,12 +87,12 @@ class CancelBookingByTokenTest(PublicAPIVenueEndpointHelper):
         [
             (
                 # booking are not cancellable less than 48h before the event
-                datetime.datetime.utcnow() + datetime.timedelta(hours=36),  # less than 48h from now
-                datetime.datetime.utcnow() - datetime.timedelta(days=1),  # yesterday
+                date_utils.get_naive_utc_now() + datetime.timedelta(hours=36),  # less than 48h from now
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=1),  # yesterday
             ),
             (  # after 2 days, event booking are not cancellable
-                datetime.datetime.utcnow() + datetime.timedelta(weeks=1),  # in 1 week
-                datetime.datetime.utcnow() - datetime.timedelta(days=2),  # 2 days ago
+                date_utils.get_naive_utc_now() + datetime.timedelta(weeks=1),  # in 1 week
+                date_utils.get_naive_utc_now() - datetime.timedelta(days=2),  # 2 days ago
             ),
         ],
     )

--- a/api/tests/routes/public/individual_offers/v1/bookings/patch_keep_validated_booking_test.py
+++ b/api/tests/routes/public/individual_offers/v1/bookings/patch_keep_validated_booking_test.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.bookings.models import BookingStatus
 from pcapi.core.offers import factories as offers_factories
+from pcapi.utils import date as date_utils
 
 from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
 
@@ -26,15 +27,15 @@ class PatchKeepBookingByTokenTest(PublicAPIVenueEndpointHelper):
             name="Vieux motard que jamais",
             ean="1234567890123",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
         stock = offers_factories.StockFactory(offer=offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             stock=stock,
-            dateUsed=datetime.datetime.utcnow() - datetime.timedelta(days=1),
+            dateUsed=date_utils.get_naive_utc_now() - datetime.timedelta(days=1),
             status=status or BookingStatus.USED,
         )
         return offer, booking
@@ -84,12 +85,12 @@ class PatchKeepBookingByTokenTest(PublicAPIVenueEndpointHelper):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         offer = offers_factories.EventOfferFactory(venue=venue_provider.venue)
         stock = offers_factories.StockFactory(
-            offer=offer, bookingLimitDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            offer=offer, bookingLimitDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=10)
         )
         booking = bookings_factories.BookingFactory(
             stock=stock,
             status=BookingStatus.CONFIRMED,
-            dateCreated=datetime.datetime.utcnow() + datetime.timedelta(hours=10),
+            dateCreated=date_utils.get_naive_utc_now() + datetime.timedelta(hours=10),
         )
 
         response = self.make_request(plain_api_key, {"token": booking.token})

--- a/api/tests/routes/public/individual_offers/v1/bookings/patch_validate_booking_by_token_test.py
+++ b/api/tests/routes/public/individual_offers/v1/bookings/patch_validate_booking_by_token_test.py
@@ -31,13 +31,13 @@ class ValidateBookingByTokenTest(PublicAPIVenueEndpointHelper):
             name="Vieux motard que jamais",
             ean="1234567890123",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
         stock = offers_factories.StockFactory(offer=offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             stock=stock,
         )
         return offer, booking
@@ -59,13 +59,13 @@ class ValidateBookingByTokenTest(PublicAPIVenueEndpointHelper):
             description="Un livre de contrepèterie",
             name="Vieux motard que jamais",
         )
-        past = datetime.datetime.utcnow() - datetime.timedelta(days=2)
+        past = date_utils.get_naive_utc_now() - datetime.timedelta(days=2)
         stock = offers_factories.EventStockFactory(offer=offer, beginningDatetime=past)
         booking = bookings_factories.BookingFactory(
             dateCreated=past - datetime.timedelta(days=2),
             user__email="beneficiary@example.com",
             user__phoneNumber="0101010101",
-            user__dateOfBirth=datetime.datetime.utcnow() - relativedelta(years=18, months=2),
+            user__dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18, months=2),
             stock=stock,
         )
 
@@ -89,7 +89,7 @@ class ValidateBookingByTokenTest(PublicAPIVenueEndpointHelper):
 
     def test_should_raise_403_when_booking_not_confirmed(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
-        next_week = datetime.datetime.utcnow() + datetime.timedelta(weeks=1)
+        next_week = date_utils.get_naive_utc_now() + datetime.timedelta(weeks=1)
 
         offer = offers_factories.ThingOfferFactory(venue=venue_provider.venue)
         stock = offers_factories.StockFactory(offer=offer, beginningDatetime=next_week)

--- a/api/tests/routes/public/individual_offers/v1/events/delete_event_stock_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/delete_event_stock_test.py
@@ -9,6 +9,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.offers.models import WithdrawalTypeEnum
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from tests.conftest import TestClient
 from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
@@ -26,7 +27,7 @@ class DeleteEventStockTest(PublicAPIVenueEndpointHelper):
         price_category = offers_factories.PriceCategoryFactory(
             offer=event, price=decimal.Decimal("88.99"), priceCategoryLabel=category_label
         )
-        next_year = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=365)
+        next_year = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(days=365)
         stock = offers_factories.EventStockFactory(
             offer=event,
             quantity=10,
@@ -104,7 +105,7 @@ class DeleteEventStockTest(PublicAPIVenueEndpointHelper):
 
         # update
         event.withdrawalType = WithdrawalTypeEnum.IN_APP
-        too_long_ago = datetime.datetime.utcnow() - datetime.timedelta(days=3)
+        too_long_ago = date_utils.get_naive_utc_now() - datetime.timedelta(days=3)
         stock.beginningDatetime = too_long_ago
         stock.bookingLimitDatetime = too_long_ago
         db.session.commit()

--- a/api/tests/routes/public/individual_offers/v1/events/get_event_stocks_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/get_event_stocks_test.py
@@ -33,7 +33,9 @@ class GetEventStocksTest(PublicAPIVenueEndpointHelper):
         price_category = offers_factories.PriceCategoryFactory(
             offer=event, price=12.34, priceCategoryLabel__label="carre or"
         )
-        two_weeks_from_now = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(weeks=2)
+        two_weeks_from_now = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            weeks=2
+        )
         stock = offers_factories.EventStockFactory(
             offer=event,
             priceCategory=price_category,
@@ -84,7 +86,9 @@ class GetEventStocksTest(PublicAPIVenueEndpointHelper):
         price_category = offers_factories.PriceCategoryFactory(
             offer=offer, price=12.34, priceCategoryLabel__label="carre or"
         )
-        two_weeks_from_now = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(weeks=2)
+        two_weeks_from_now = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            weeks=2
+        )
         stock1_id_at_provider = "5edd982915c2a74b9302e443"
         bookable_stock = offers_factories.EventStockFactory(
             offer=offer,

--- a/api/tests/routes/public/individual_offers/v1/events/get_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/get_event_test.py
@@ -9,6 +9,7 @@ from pcapi.core import testing
 from pcapi.core.categories import subcategories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
+from pcapi.utils import date as date_utils
 from pcapi.utils import human_ids
 
 from tests.conftest import TestClient
@@ -108,7 +109,9 @@ class GetEventTest(PublicAPIVenueEndpointHelper):
     def test_get_future_event(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
 
-        publication_date = datetime.utcnow().replace(minute=0, second=0, microsecond=0) + timedelta(days=30)
+        publication_date = date_utils.get_naive_utc_now().replace(minute=0, second=0, microsecond=0) + timedelta(
+            days=30
+        )
         offer = self.setup_base_resource(venue=venue_provider.venue, publicationDatetime=publication_date)
         offer_id = offer.id
 

--- a/api/tests/routes/public/individual_offers/v1/events/patch_date_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/patch_date_test.py
@@ -25,8 +25,10 @@ class PatchEventStockTest(PublicAPIVenueEndpointHelper):
 
     @staticmethod
     def _get_base_payload(price_category_id) -> dict:
-        next_month = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
-        two_weeks_from_now = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(weeks=2)
+        next_month = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
+        two_weeks_from_now = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            weeks=2
+        )
         return {
             "beginningDatetime": date_utils.utc_datetime_to_department_timezone(next_month, None).isoformat(),
             "bookingLimitDatetime": date_utils.utc_datetime_to_department_timezone(
@@ -61,7 +63,7 @@ class PatchEventStockTest(PublicAPIVenueEndpointHelper):
         price_category = offers_factories.PriceCategoryFactory(
             offer=offer, price=decimal.Decimal("88.99"), priceCategoryLabel=category_label
         )
-        next_year = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=365)
+        next_year = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(days=365)
         stock = offers_factories.EventStockFactory(
             offer=offer,
             quantity=10,
@@ -98,8 +100,10 @@ class PatchEventStockTest(PublicAPIVenueEndpointHelper):
         offer, stock = self.setup_base_resource(venue=venue_provider.venue, provider=venue_provider.provider)
         price_category = offers_factories.PriceCategoryFactory(offer=offer)
 
-        one_week_from_now = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(weeks=1)
-        twenty_four_day_from_now = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(
+        one_week_from_now = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            weeks=1
+        )
+        twenty_four_day_from_now = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
             days=24
         )
         with caplog.at_level(logging.INFO):
@@ -143,7 +147,7 @@ class PatchEventStockTest(PublicAPIVenueEndpointHelper):
     def test_sends_email_if_beginning_date_changes_on_edition(self, client):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         event, stock = self.setup_base_resource(venue=venue_provider.venue, provider=venue_provider.provider)
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         two_days_after = now + datetime.timedelta(days=2)
         three_days_after = now + datetime.timedelta(days=3)
 
@@ -179,7 +183,7 @@ class PatchEventStockTest(PublicAPIVenueEndpointHelper):
     def test_update_all_fields_on_date_with_price_category(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         event = offers_factories.EventOfferFactory(venue=venue_provider.venue, lastProvider=venue_provider.provider)
-        now = datetime.datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         tomorrow = now + datetime.timedelta(days=1)
         two_days_after = now + datetime.timedelta(days=2)
         three_days_after = now + datetime.timedelta(days=3)
@@ -219,7 +223,7 @@ class PatchEventStockTest(PublicAPIVenueEndpointHelper):
             lastProvider=venue_provider.provider,
         )
         price_category = offers_factories.PriceCategoryFactory(offer=event)
-        next_year = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=365)
+        next_year = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(days=365)
         stock = offers_factories.EventStockFactory(
             offer=event,
             quantity=10,
@@ -229,7 +233,9 @@ class PatchEventStockTest(PublicAPIVenueEndpointHelper):
             idAtProviders="hoho",
         )
 
-        eight_days_from_now = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=8)
+        eight_days_from_now = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            days=8
+        )
         response = self.make_request(
             plain_api_key,
             path_params={"offer_id": stock.offerId, "stock_id": stock.id},

--- a/api/tests/routes/public/individual_offers/v1/events/patch_price_category_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/patch_price_category_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
+from pcapi.utils import date as date_utils
 
 from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
 
@@ -123,7 +124,7 @@ class PatchPriceCategoryTest(PublicAPIVenueEndpointHelper):
         expired_stock = offers_factories.EventStockFactory(
             offer=offer,
             priceCategory=price_category,
-            beginningDatetime=datetime.datetime.utcnow() + datetime.timedelta(days=-2),
+            beginningDatetime=date_utils.get_naive_utc_now() + datetime.timedelta(days=-2),
         )
 
         response = self.make_request(

--- a/api/tests/routes/public/individual_offers/v1/events/post_event_stocks_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/post_event_stocks_test.py
@@ -20,8 +20,8 @@ class PostEventStocksTest(PublicAPIVenueEndpointHelper):
 
     @staticmethod
     def _get_base_date_dict(price_category_id: int, id_at_provider: str | None = None) -> dict:
-        next_week = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(weeks=1)
-        next_month = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
+        next_week = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(weeks=1)
+        next_month = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
         next_month_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(next_month, "973")
         return {
             "beginningDatetime": next_month_in_non_utc_tz.isoformat(),
@@ -87,8 +87,8 @@ class PostEventStocksTest(PublicAPIVenueEndpointHelper):
             priceCategoryLabel__venue=venue_provider.venue,
         )
 
-        next_week = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(weeks=1)
-        next_month = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
+        next_week = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(weeks=1)
+        next_month = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(days=30)
         next_month_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(next_month, "973")
         two_months_from_now = next_month + datetime.timedelta(days=30)
         two_months_from_now_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(two_months_from_now, "972")

--- a/api/tests/routes/public/individual_offers/v1/events/post_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/post_event_test.py
@@ -127,7 +127,7 @@ class PostEventTest(PublicAPIVenueEndpointHelper):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
 
         payload = self._get_base_payload(venue_provider.venueId)
-        publication_date = datetime.utcnow().replace(minute=0, second=0) + timedelta(days=30)
+        publication_date = date_utils.get_naive_utc_now().replace(minute=0, second=0) + timedelta(days=30)
         payload["publicationDate"] = publication_date.isoformat()
         response = self.make_request(plain_api_key, json_body=payload)
 

--- a/api/tests/routes/public/individual_offers/v1/products/post_product_by_ean_celery_test.py
+++ b/api/tests/routes/public/individual_offers/v1/products/post_product_by_ean_celery_test.py
@@ -43,7 +43,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
     def test_should_raise_404_because_has_no_access_to_venue(self):
         plain_api_key, _ = self.setup_provider()
         venue = self.setup_venue()
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
 
         payload = {
@@ -95,7 +97,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         plain_api_key, venue_provider = self.setup_inactive_venue_provider()
         venue = venue_provider.venue
 
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
 
         payload = {
@@ -127,7 +131,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         )
         unknown_ean = "1234567897123"
 
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
         payload = {
             "location": {"type": "physical", "venueId": venue.id},
@@ -311,7 +317,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         stock = offers_factories.ThingStockFactory(offer=offer, quantity=10, price=100)
         bookings_factories.BookingFactory(stock=stock, quantity=2, user__deposit__amount=300)
 
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         payload = {
             "location": {"type": "physical", "venueId": venue_provider.venue.id},
             "products": [
@@ -407,7 +413,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         book_stock = offers_factories.ThingStockFactory(offer=book_offer, quantity=10, price=100)
         book_stock_id = book_stock.id
 
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
         payload = {
             "location": {"type": "physical", "venueId": venue.id},
@@ -470,7 +478,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         # environments, therefore we cannot rely on its side effects
         update_sib_pro_task_mock.side_effect = None
 
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
         payload = {
             "products": [

--- a/api/tests/routes/public/individual_offers/v1/products/post_product_by_ean_test.py
+++ b/api/tests/routes/public/individual_offers/v1/products/post_product_by_ean_test.py
@@ -42,7 +42,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
     def test_should_raise_404_because_has_no_access_to_venue(self):
         plain_api_key, _ = self.setup_provider()
         venue = self.setup_venue()
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
 
         payload = {
@@ -94,7 +96,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         plain_api_key, venue_provider = self.setup_inactive_venue_provider()
         venue = venue_provider.venue
 
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
 
         payload = {
@@ -126,7 +130,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         )
         unknown_ean = "1234567897123"
 
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
         payload = {
             "location": {"type": "physical", "venueId": venue.id},
@@ -303,7 +309,7 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         stock = offers_factories.ThingStockFactory(offer=offer, quantity=10, price=100)
         bookings_factories.BookingFactory(stock=stock, quantity=2, user__deposit__amount=300)
 
-        tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        tomorrow = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
         payload = {
             "location": {"type": "physical", "venueId": venue_provider.venue.id},
             "products": [
@@ -394,7 +400,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         cd_stock = offers_factories.ThingStockFactory(offer=cd_offer, quantity=10, price=100)
         book_stock = offers_factories.ThingStockFactory(offer=book_offer, quantity=10, price=100)
 
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
         payload = {
             "location": {"type": "physical", "venueId": venue.id},
@@ -451,7 +459,9 @@ class PostProductByEanTest(PublicAPIVenueEndpointHelper):
         # environments, therefore we cannot rely on its side effects
         update_sib_pro_task_mock.side_effect = None
 
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
         payload = {
             "products": [

--- a/api/tests/routes/public/individual_offers/v1/products/post_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/products/post_product_test.py
@@ -166,7 +166,9 @@ class PostProductTest(PublicAPIVenueEndpointHelper):
     def test_product_creation_with_full_body(self, clear_tests_assets_bucket, caplog):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
 
-        in_ten_minutes = datetime.datetime.utcnow().replace(second=0, microsecond=0) + datetime.timedelta(minutes=10)
+        in_ten_minutes = date_utils.get_naive_utc_now().replace(second=0, microsecond=0) + datetime.timedelta(
+            minutes=10
+        )
         in_ten_minutes_in_non_utc_tz = date_utils.utc_datetime_to_department_timezone(in_ten_minutes, "973")
         payload = {
             "location": {"type": "physical", "venueId": venue_provider.venue.id},

--- a/api/tests/routes/serialization/collective_history_test.py
+++ b/api/tests/routes/serialization/collective_history_test.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 
 from pcapi.core.educational import factories
@@ -7,6 +5,7 @@ from pcapi.core.educational import models
 from pcapi.routes.serialization.collective_history_serialize import CollectiveOfferHistory
 from pcapi.routes.serialization.collective_history_serialize import HistoryStep
 from pcapi.routes.serialization.collective_history_serialize import get_collective_offer_history
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -193,7 +192,7 @@ class HistoryCancelledTest:
 
 def _archive_offer(offer: models.CollectiveOffer):
     offer.publicationDatetime = None
-    offer.dateArchived = datetime.datetime.utcnow()
+    offer.dateArchived = date_utils.get_naive_utc_now()
 
 
 class HistoryArchivedTest:

--- a/api/tests/routes/shared/post_reset_password_test.py
+++ b/api/tests/routes/shared/post_reset_password_test.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -8,6 +7,7 @@ from pcapi.connectors.api_recaptcha import InvalidRecaptchaTokenException
 from pcapi.core import token as token_utils
 from pcapi.core.users.models import User
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 class Returns400Test:
@@ -109,7 +109,7 @@ class Returns204Test:
         assert response.status_code == 204
         user = db.session.get(User, user.id)
         assert token_utils.Token.token_exists(token_utils.TokenType.RESET_PASSWORD, user.id)
-        now = datetime.utcnow()
+        now = date_utils.get_naive_utc_now()
         assert (
             (now + timedelta(hours=23))
             < token_utils.Token.get_expiration_date(token_utils.TokenType.RESET_PASSWORD, user.id)

--- a/api/tests/sandboxes/scripts/test_save_sandbox.py
+++ b/api/tests/sandboxes/scripts/test_save_sandbox.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -6,13 +5,14 @@ import pytest
 
 import pcapi.core.offers.factories as offers_factories
 from pcapi.sandboxes.scripts.save_sandbox import _index_all_offers
+from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
 class IndexAllOffersTest:
     def test_index_all_offers(self):
-        publication_date = datetime.utcnow() - timedelta(days=3)
-        booking_allowed_date = datetime.utcnow() + timedelta(days=14)
+        publication_date = date_utils.get_naive_utc_now() - timedelta(days=3)
+        booking_allowed_date = date_utils.get_naive_utc_now() + timedelta(days=14)
 
         # active, published, booking date in the future and active -> should be indexed
         offer_1 = offers_factories.StockFactory(

--- a/api/tests/scripts/beneficiary/fixture.py
+++ b/api/tests/scripts/beneficiary/fixture.py
@@ -9,6 +9,7 @@ from dateutil.relativedelta import relativedelta
 from pcapi import settings
 from pcapi.connectors.dms import models as dms_models
 from pcapi.core.users.constants import ELIGIBILITY_AGE_18
+from pcapi.utils import date as date_utils
 
 
 DEFAULT_MESSAGES = [
@@ -19,7 +20,7 @@ DEFAULT_MESSAGES = [
 ]
 
 
-AGE18_ELIGIBLE_BIRTH_DATE = datetime.datetime.utcnow() - relativedelta(years=ELIGIBILITY_AGE_18)
+AGE18_ELIGIBLE_BIRTH_DATE = date_utils.get_naive_utc_now() - relativedelta(years=ELIGIBILITY_AGE_18)
 
 
 # TODO (thconte: 2023-09-06)

--- a/api/tests/tasks/cultural_survey_task_test.py
+++ b/api/tests/tasks/cultural_survey_task_test.py
@@ -1,16 +1,16 @@
-from datetime import datetime
 from unittest.mock import patch
 
 from pcapi import settings
 from pcapi.tasks.cloud_task import AUTHORIZATION_HEADER_KEY
 from pcapi.tasks.cloud_task import AUTHORIZATION_HEADER_VALUE
+from pcapi.utils import date as date_utils
 
 
 class CulturalSurveyAnswerTest:
     @patch("pcapi.tasks.cultural_survey_tasks.store_public_object")
     def test_cultural_survey_task(self, store_public_object_mock, client, db_session):
-        submit_time = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S")
-        submit_time_short = datetime.utcnow().strftime("%Y%m%d")
+        submit_time = date_utils.get_naive_utc_now().strftime("%Y-%m-%dT%H:%M:%S")
+        submit_time_short = date_utils.get_naive_utc_now().strftime("%Y%m%d")
         data = {
             "user_id": 1,
             "submitted_at": submit_time,

--- a/api/tests/utils/pdf_creation_test.py
+++ b/api/tests/utils/pdf_creation_test.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import pathlib
 import time
@@ -6,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+from pcapi.utils import date as date_utils
 from pcapi.utils import pdf
 
 import tests
@@ -38,7 +38,7 @@ class GeneratePdfFromHtmlTest:
         fetcher = pdf._get_url_fetcher()
         fetcher.delete_cache()
         fetcher.create_cache()
-        metadata = pdf.PdfMetadata(created=datetime.datetime.utcnow())
+        metadata = pdf.PdfMetadata(created=date_utils.get_naive_utc_now())
         out1 = pdf.generate_pdf_from_html(example_html, metadata)
         out2 = pdf.generate_pdf_from_html(example_html, metadata)
         # Do not use `assert out == expected_pdf`: pytest would try to

--- a/api/tests/utils/test_on_commit.py
+++ b/api/tests/utils/test_on_commit.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 from functools import partial
 from unittest.mock import MagicMock
 
 import pytest
 
 from pcapi.core.operations import models as operations_models
+from pcapi.utils import date as date_utils
 from pcapi.utils.transaction_manager import atomic
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
 from pcapi.utils.transaction_manager import on_commit
@@ -14,7 +14,7 @@ from pcapi.utils.transaction_manager import on_commit
 MODEL_INSTANCE = operations_models.SpecialEvent(
     externalId="azerty123",
     title="some_title",
-    eventDate=datetime.utcnow(),
+    eventDate=date_utils.get_naive_utc_now(),
 )
 
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-XXXXX)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

This PR enables the [call-datetime-utcnow (DTZ003)](https://docs.astral.sh/ruff/rules/call-datetime-utcnow/#call-datetime-utcnow-dtz003) rule. A datetime must be timezoned to properly represent a point in time.

For now, all current calls to `datetime.utcnow` will be replaced by `get_naive_utc_now` and the ruff rule will be enabled. Proper timezoning everywhere will be done later.

#### LLM Prompts

This PR was done by AI and proofread by me. Here are the prompts used: 


<details>

<summary>AGENTS.md</summary>

# CLAUDE.md file

> **purpose** – This file is the onboarding manual for every AI assistant (Claude, Cursor, GPT, etc.) and every human who edits this repository.  
> It encodes our coding standards, guard-rails, and workflow tricks so the *human 30 %* (architecture, tests, domain judgment) stays in human hands.[^1]
> Inspired by [julep AGENTS.md file](https://github.com/julep-ai/julep/blob/dev/AGENTS.md). See [diwank's article](https://diwank.space/field-notes-from-shipping-real-code-with-claude).

---

## 0. Project overview

pass Culture is a marketplace that connects cultural actors with teenagers living in France.
Credit is provided to teenagers to book cultural offers such as concerts, museum visits, books, and artistic equipment.

- **src/pcapi/core/**: Core modules
- **src/pcapi/routes/**: Routes exposed to front ends via OpenAPI and Swagger code generation
- **src/pcapi/routes/backoffice**: Has its own Flask app and front end through Jinja templates

**Golden rule**: When unsure about implementation details or requirements, ALWAYS consult the developer rather than making assumptions.

---

## 1. Non-negotiable golden rules

| #: | AI *may* do                                                            | AI *must NOT* do                                                                    |
|---|------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
| G-0 | Whenever unsure about something that's related to the project, ask the developer for clarification before making changes.    |  ❌ Write changes or use tools when you are not sure about something project specific, or if you don't have context for a particular feature/decision. |
| G-1 | Generate code **only inside** relevant source directories or explicitly pointed files.    | ❌ Touch `SPEC.md`, or any `*_spec.py` / `*.ward` files (humans own tests & specs). |
| G-2 | Add/update **`AIDEV-NOTE:` anchor comments** near non-trivial code edits. | ❌ Delete or mangle existing `AIDEV-` comments.                                     |
| G-3 | Follow lint/style configs (`pyproject.toml`, `.ruff.toml`, `.pre-commit-config.yaml`). Use the project's configured linter, if available, instead of manually re-formatting code. | ❌ Re-format code to any other style.                                               |
| G-4 | For changes >300 LOC or >3 files, **ask for confirmation**.            | ❌ Refactor large modules without human guidance.                                     |
| G-5 | Stay within the current task context. Inform the dev if it'd be better to start afresh.                                  | ❌ Continue work from a prior prompt after "new task" – start a fresh session.      |

---

## 2. Build, test & utility commands

If the commands are not available, first activate the virtual environment with `poetry shell`.

```bash
# Format, lint, type-check, test, codegen
ruff check --select I --config pyproject.toml --fix # sort imports
ruff format                                         # format
ruff check                                          # lint
flask shell                                         # spawn a python shell, useful to check that the Flask context loads
python src/pcapi/app.py                             # launch the backend in local dev environment
python src/pcapi/backoffice_app.py                  # launch the back office in local dev environment
pytest -m 'not backoffice'                          # launch the backend tests
pytest -m backoffice                                # launch the back office tests
```

For simple, quick Python script tests: `PYTHONPATH=$PWD python tests/test_file.py` (ensure correct CWD).

---

## 3. Coding standards

- **Python**: 3.11+, Flask, SQLAlchemy
- **Formatting**: `ruff` is configured in `pyproject.toml`
- **Typing**: `mypy` is configured in `pyproject.toml`
- **Naming**: `snake_case` (functions/variables), `PascalCase` (classes), `SCREAMING_SNAKE_CASE` (constants), and `camelCase` for SQLAlchemy model fields (for historic reasons).
- **Error Handling**: Typed exceptions; context managers for resources.
- **Documentation**: Google-style docstrings for public functions/classes.
- **Testing**: Separate test files matching source file patterns.

**Import style**

- The current standard is to import module files and rename them by prefixing with their module name.
- All module functions are called using the prefixed import.

Example:

```python

from pcapi.core.users import models as users_models

def update_user(user: users_models.User) -> None:
  pass

```

## 4. Project layout & Core Components

### Project Layout

| Directory                         | Description                                       |
| --------------------------------- | ------------------------------------------------- |
| `src/pcapi/core/`                   | Core business modules containing domain logic      |
| `src/pcapi/core/users/`             | User management (pro users, beneficiaries, backoffice users) |
| `src/pcapi/core/offers/`            | Cultural offers (products and events)             |
| `src/pcapi/core/offerers/`          | Cultural organizations that provide offers         |
| `src/pcapi/core/bookings/`          | Reservation system for offers                      |
| `src/pcapi/core/finance/`           | Credit management and invoicing system             |
| `src/pcapi/core/educational/`       | Educational offers for schools and institutions    |
| `src/pcapi/core/subscription/`      | Beneficiary registration and identity verification   |
| `src/pcapi/routes/`                 | API endpoints exposed to front-end applications    |
| `src/pcapi/routes/native/`          | Mobile app API endpoints                           |
| `src/pcapi/routes/pro/`             | Professional dashboard API endpoints               |
| `src/pcapi/routes/backoffice/`      | Internal administration interface                  |
| `src/pcapi/connectors/`             | External service integrations (APIs, file systems) |
| `tests/`                            | Test files mirroring source structure             |

### Module Structure

Each core module follows this file structure:

- **api.py**: Public functions for inter-module communication
- **schemas.py**: Pydantic models and dataclasses
- **models.py**: SQLAlchemy models
- **repository.py**: Database access layer using SQLAlchemy
- **factories.py**: FactoryBoy factories to use in tests and sandbox scripts

### Key Domain Models

- **Beneficiary**: Young person (15-18) who receives government cultural credit
- **Offerer**: Cultural organization that provides venues and offers
- **Venue**: Physical or digital location where cultural activities take place
- **Offer**: Cultural product or event available for booking
- **Booking**: Reservation made by a beneficiary for a specific offer
- **Deposit**: Government-allocated credit that beneficiaries can spend on culture
- **Fraud Check**: Identity verification process required for beneficiary activation
- **Subscription Flow**: Multi-step registration process for new beneficiaries

---

## 5. Anchor comments

Add specially formatted comments throughout the codebase, where appropriate, for yourself as inline knowledge that can be easily `grep`ped for.

### Guidelines

- Use `AIDEV-NOTE:`, `AIDEV-TODO:`, or `AIDEV-QUESTION:` (all-caps prefix) for comments aimed at AI and developers.
- Keep them concise (≤ 120 chars).
- **Important:** Before scanning files, always first try to **locate existing anchors** `AIDEV-*` in relevant subdirectories.
- **Update relevant anchors** when modifying associated code.
- **Do not remove `AIDEV-NOTE`s** without explicit human instruction.
- Make sure to add relevant anchor comments, whenever a file or piece of code is:
  - too long, or
  - complex, or
  - critical, or
  - confusing, or
  - could have a bug unrelated to the task you are currently working on.

Example:

```python
# AIDEV-NOTE: perf-hot-path; avoid extra allocations (see ADR-24)
def render_feed(...):
    ...
```

---

## 6. Commit discipline

- **Granular commits**: One logical change per commit.
- **Tag AI-generated commits**: e.g., `feat: optimise feed query [AI]`.
- **Clear commit messages**: Explain the *why*; link to issues/ADRs if architectural.
- **Use `git worktree`** for parallel/long-running AI branches (e.g., `git worktree add ../wip-foo -b wip-foo`).
- **Review AI-generated code**: Never merge code you don't understand.

---

## 7. API models & codegen

- To modify API models, **edit the Pydantic models** in `src/pcapi/routes/**/serializers.py`.
- **Regenerate code** after OpenAPI changes: `bash src/scripts/generate_openapi_code.sh` (from project root).
- **Do NOT manually edit** generated files as they will be overwritten.

**Spectree example**:

```python
from spectree import BaseModel, Tag, Response
from pcapi.routes.serialization import BaseModel as PCBaseModel

class MyRequestModel(PCBaseModel):
    field: str
    
class MyResponseModel(PCBaseModel):  
    result: str

# Use in route with @blueprint.route decorator and spectree validation
```

---

### 8. Pytest testing framework

- Use descriptive test names: `def test_descriptive_scenario():`.
- Use the `db_session` fixture to isolate the tests database.
- Ensure correct working directory (e.g., `api/`) for tests.
- Activate virtual environment: `poetry shell`.
- Limit failures for faster feedback: `pytest --fail-limit 1 module_to_test.py`.

---

## 10. Directory-Specific AGENTS.md Files

- **Always check for `AGENTS.md` files in specific directories** before working on code within them. These files contain targeted context.
- If a directory's `AGENTS.md` is outdated or incorrect, **update it**.
- If you make significant changes to a directory's structure, patterns, or critical implementation details, **document these in its `AGENTS.md`**.
- If a directory lacks a `AGENTS.md` but contains complex logic or patterns worth documenting for AI/humans, **suggest creating one**.

---

## 11. Common pitfalls

- Wrong current working directory (CWD) for commands/tests (e.g., ensure you are in `pass-culture-main/api/`, not in the `pass-culture-main` root folder).
- Forgetting to activate the virtual environment with `poetry shell`.
- Large AI refactors in a single commit (makes `git bisect` difficult).
- Delegating test/spec writing entirely to AI (can lead to false confidence).

---

## 13. Key File & Pattern References

This section provides pointers to important files and common patterns within the codebase.

**API Route Definitions**:

- Location: `src/pcapi/routes/**/*.py` (e.g., `src/pcapi/routes/native/v1/subscription.py`)
- Pattern: Flask blueprints with spectree decorators for OpenAPI generation
- Request/Response models: Pydantic BaseModel classes in `serialization.py` files
- Example: `src/pcapi/routes/native/v1/serialization/subscription.py`

**Serialization Models** (Pydantic):

- Location: `src/pcapi/routes/**/serialization.py` or `serializers.py`
- Pattern: Inherit from `pcapi.routes.serialization.BaseModel`
- Use `alias_generator = to_camel` for camelCase JSON fields
- Configuration: `orm_mode = True` for SQLAlchemy model conversion

**ORM Models** (SQLAlchemy):

- Location: `src/pcapi/core/**/models.py` (e.g., `src/pcapi/core/users/models.py`)
- Pattern: Inherit from `PcObject` or `Model` base classes
- Use `camelCase` for field names (historic reasons)
- Include type hints and relationships

**API Endpoints for Inter-Module Communication**:

- Location: `src/pcapi/core/**/api.py` files
- Pattern: Public functions that other modules can import and use
- Example: `src/pcapi/core/subscription/api.py`

**Database Repositories**:

- Location: `src/pcapi/core/**/repository.py`
- Pattern: Database access layer using SQLAlchemy queries
- Encapsulate complex database operations

**Factory Classes** (For Testing):

- Location: `src/pcapi/core/**/factories.py`
- Pattern: FactoryBoy factories for creating test data
- Used in tests and sandbox scripts

**Schema Definitions** (Data Classes):

- Location: `src/pcapi/core/**/schemas.py`
- Pattern: Pydantic models and dataclasses for business logic
- Example: `src/pcapi/core/subscription/schemas.py`

**External Connectors**:

- Location: `src/pcapi/connectors/**/`
- Pattern: Adapters for external services (APIs, file systems)
- Include serialization models for external API responses

**Test Files**:

- Location: `tests/**/*_test.py`
- Pattern: Mirror source file structure, use descriptive test names
- Use `db_session` fixture for database isolation

---

## 14. Domain-Specific Terminology

**Core Business Entities**:

- **Beneficiary**: Young person (15-18) who receives cultural credit from the French government
- **Offerer**: Cultural actor/organization that provides offers (venues, events, products)
- **Venue**: Physical or digital location where cultural offers are available
- **Offer**: Cultural product or event (concert, book, museum visit, etc.)
- **Booking**: Reservation of an offer by a beneficiary
- **Credit/Deposit**: Government-provided funds for beneficiaries to spend on cultural offers

**User Types**:

- **Pro User**: Professional user representing an offerer/venue
- **Backoffice User**: Internal staff with administrative privileges
- **Underage Beneficiary**: 15-17 year old with limited credit
- **18+ Beneficiary**: 18 year old with full credit access
- **Free Beneficiary**: User with free access to certain offers

**Subscription & Identity Verification**:

- **DMS**: French government document management system for identity verification
- **Ubble**: Third-party identity verification service
- **Educonnect**: French education system identity provider
- **Jouve**: Legacy identity verification provider
- **Fraud Check**: Identity/eligibility verification process
- **Subscription Flow**: Multi-step process for beneficiaries to activate their credit

**Financial Terms**:

- **Deposit**: Financial credit allocated to beneficiaries
- **Reimbursement**: Payment from pass Culture to offerers for bookings
- **Pricing**: Offer cost structure and beneficiary payment rules
- **Finance API**: System for managing payments and reimbursements

**Geographical Terms**:

- **IRIS**: French statistical geographical unit
- **Department**: French administrative division
- **Region**: French administrative region

**Technical Terms**:

- **Feature Toggle**: Runtime configuration flags for enabling/disabling features
- **Spectree**: OpenAPI documentation generation library
- **PCObject**: Base SQLAlchemy model class with common fields
- **Serialization**: Data transformation between API and database models

**Educational Context**:

- **Collective Offer**: Group bookings for schools and educational institutions
- **Educational Institution**: Schools and educational organizations
- **Institutional**: Relating to educational/collective bookings vs individual bookings

**External Integrations**:

- **Provider**: External service that supplies offer data
- **Allocine**: Movie database integration
- **Titelive**: Book database integration
- **CGR**: Cinema chain integration

---

## 15. Meta: Guidelines for updating AGENTS.md files

### Elements that would be helpful to add

1. **Decision flowchart**: A simple decision tree for "when to use X vs Y" for key architectural choices would guide my recommendations.
2. **Reference links**: Links to key files or implementation examples that demonstrate best practices.
3. **Domain-specific terminology**: A small glossary of project-specific terms would help me understand domain language correctly.
4. **Versioning conventions**: How the project handles versioning, both for APIs and internal components.

### Format preferences

1. **Consistent syntax highlighting**: Ensure all code blocks have proper language tags (`python`, `bash`, etc.).
2. **Hierarchical organization**: Consider using hierarchical numbering for subsections to make referencing easier.
3. **Tabular format for key facts**: The tables are very helpful - more structured data in tabular format would be valuable.
4. **Keywords or tags**: Adding semantic markers (like `#performance` or `#security`) to certain sections would help me quickly locate relevant guidance.

[^1]: This principle emphasizes human oversight for critical aspects like architecture, testing, and domain-specific decisions, ensuring AI assists rather than fully dictates development.

---

# AI Assistant Workflow: Step-by-Step Methodology

When responding to user instructions, the AI assistant (Claude, Cursor, GPT, etc.) should follow this process to ensure clarity, correctness, and maintainability:

1. **Consult Relevant Guidance**: When the user gives an instruction, consult the relevant instructions from `AGENTS.md` files (both root and directory-specific) for the request.
2. **Clarify Ambiguities**: Based on what you could gather, see if there's any need for clarifications. If so, ask the user targeted questions before proceeding.
3. **Break Down & Plan**: Break down the task at hand and chalk out a rough plan for carrying it out, referencing project conventions and best practices.
4. **Trivial Tasks**: If the plan/request is trivial, go ahead and get started immediately.
5. **Non-Trivial Tasks**: Otherwise, present the plan to the user for review and iterate based on their feedback.
6. **Track Progress**: Use a to-do list (internally, or optionally in a `TODOS.md` file) to keep track of your progress on multi-step or complex tasks.
7. **If Stuck, Re-plan**: If you get stuck or blocked, return to step 3 to re-evaluate and adjust your plan.
8. **Update Documentation**: Once the user's request is fulfilled, update relevant anchor comments (`AIDEV-NOTE`, etc.) and `AGENTS.md` files in the files and directories you touched.
9. **User Review**: After completing the task, ask the user to review what you've done, and repeat the process as needed.
10. **Session Boundaries**: If the user's request isn't directly related to the current context and can be safely started in a fresh session, suggest starting from scratch to avoid context confusion.

</details>

<details>

<summary>SPECS.md</summary>

# SPEC.md - Deprecate datetime.utcnow in the code base

## Timezone Handling

Currently in the code base, all datetime are timezone naive and `datetime.utcnow` is massively used.

To avoid having to handle timezoned datetimes everywhere in the code base, we need to replace every call
to `datetime.utcnow` with `get_naive_utc_now` defined in `src/pcapi/utils/date.py`.

## `datetime.utcnow` call detection

Add the `DTZ003` call-datetime-utcnow ruff rule in `pyproject.toml` to prevent further calls to that function.
Call `ruff check` and filter warnings that match the `DTZ003` rule.

## Call replacement example

Current state:

```python
import datetime

def do_something_with_now():
  now = datetime.datetime.utcnow()
```

```python
from datetime import datetime

class Venue():
    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=datetime.utcnow)
```

Final state:

```python
from pcapi.utils import date as date_utils

def do_something_with_now():
  now = date_utils.get_naive_utc_now()
```

```python
from datetime import datetime
from pcapi.utils import date as date_utils

class Venue():
    dateCreated: sa_orm.Mapped[datetime] = sa_orm.mapped_column(sa.DateTime, nullable=False, default=date_utils.get_naive_utc_now)
```

## Tests

`ruff check` must succeed.

## Golden rules

You *MUST* scan *only* python files.
You *MUST NOT* edit business logic code.
You *MUST NOT* edit functions signature.
You *MUST NOT* edit test logic.

</details>