### PR TITLE
(PC-37873)[PRO] feat: always display postal code in offer bookable list

### DIFF
--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/Cells.module.scss
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/Cells.module.scss
@@ -279,9 +279,10 @@
   color: var(--color-text-subtle);
 }
 
-.text-overflow-ellipsis {
+.institution-label-ellipsis {
   display: -webkit-box;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-  -webkit-line-clamp: 3;
   overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveOfferRow.spec.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/CollectiveOfferRow.spec.tsx
@@ -198,7 +198,8 @@ describe('CollectiveOfferRow', () => {
         }),
       })
 
-      expect(screen.queryByText('Collège Bellevue - 30100')).toBeInTheDocument()
+      expect(screen.getByText('Collège Bellevue')).toBeInTheDocument()
+      expect(screen.getByText('30100')).toBeInTheDocument()
     })
 
     it('should display institution cell when offer is bookable', () => {
@@ -218,7 +219,8 @@ describe('CollectiveOfferRow', () => {
         }),
       })
 
-      expect(screen.getByText('Lycée Jean Moulin - 30100')).toBeInTheDocument()
+      expect(screen.getByText('Lycée Jean Moulin')).toBeInTheDocument()
+      expect(screen.getByText('30100')).toBeInTheDocument()
     })
 
     it('should not display institution cell when isTemplateTable is true', () => {

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/OfferInstitutionCell/OfferInstitutionCell.spec.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/OfferInstitutionCell/OfferInstitutionCell.spec.tsx
@@ -43,12 +43,10 @@ describe('OfferInstitutionCell', () => {
       },
     })
 
-    expect(screen.getByRole('cell')).toHaveTextContent(
-      'Collège Bellevue - 76000'
-    )
+    expect(screen.getByRole('cell')).toHaveTextContent('Collège Bellevue 76000')
   })
 
-  it('should display institutionType and city when name is not provided', () => {
+  it('should display institutionType, city and postalCode when name is not provided', () => {
     renderOfferInstitutionCell({
       ...props,
       educationalInstitution: {
@@ -57,7 +55,7 @@ describe('OfferInstitutionCell', () => {
       },
     })
 
-    expect(screen.getByRole('cell')).toHaveTextContent('COLLEGE Rouen')
+    expect(screen.getByRole('cell')).toHaveTextContent('COLLEGE Rouen 76000')
   })
 
   it('should display "Tous les établissements" for OfferTemplate when institution name and postal code are empty', () => {

--- a/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/OfferInstitutionCell/OfferInstitutionCell.tsx
+++ b/pro/src/components/CollectiveOffersTable/CollectiveOfferRow/OfferInstitutionCell/OfferInstitutionCell.tsx
@@ -21,20 +21,10 @@ export const OfferInstitutionCell = ({
   const { name, postalCode, institutionType, city } =
     educationalInstitution || {}
 
-  const getInstitutionLabel = () => {
-    if (name && postalCode) {
-      return `${name} - ${postalCode}`
-    }
-    if (institutionType || city) {
-      return `${institutionType} ${city}`
-    }
-
-    if (isTemplate) {
-      return 'Tous les établissements'
-    }
-
-    return '-'
-  }
+  const institutionLabel =
+    name ||
+    [institutionType, city].filter(Boolean).join(' ') ||
+    (isTemplate ? 'Tous les établissements' : '-')
 
   return (
     <td
@@ -48,8 +38,11 @@ export const OfferInstitutionCell = ({
       )}
       headers={`${rowId} ${getCellsDefinition().INSTITUTION.id}`}
     >
-      <div className={styles['text-overflow-ellipsis']}>
-        {getInstitutionLabel()}
+      <div>
+        <div className={styles['institution-label-ellipsis']}>
+          {institutionLabel}
+        </div>
+        {postalCode && <div> {postalCode}</div>}
       </div>
     </td>
   )


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-37873)

Si le nom de l'établissement est trop long, on veut toujours voir le code postal, donc on limite le nom de l'établissement à 2 lignes, et on affiche toujours le code postal en dessous

<img width="1131" height="580" alt="Capture d’écran 2025-10-08 à 17 35 42" src="https://github.com/user-attachments/assets/ba1d8e19-38d1-4356-8a09-cbdf6c895531" />
