### PR TITLE
(PC-38082)[PRO] feat: no adage preview if offer status is archived

### DIFF
--- a/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveEditionOfferNavigation/CollectiveEditionOfferNavigation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveEditionOfferNavigation/CollectiveEditionOfferNavigation.tsx
@@ -106,7 +106,10 @@ export const CollectiveEditionOfferNavigation = ({
     location.pathname.includes('edition')
 
   const canPreviewOffer = () => {
-    return isTemplate
+    return (
+      isTemplate &&
+      offer?.displayedStatus !== CollectiveOfferDisplayedStatus.ARCHIVED
+    )
   }
 
   const canArchiveOffer = () => {

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveEditionOfferNavigation/__specs__/CollectiveEditionOfferNavigation.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveEditionOfferNavigation/__specs__/CollectiveEditionOfferNavigation.spec.tsx
@@ -396,10 +396,24 @@ describe('CollectiveEditionOfferNavigation', () => {
     const duplicateOfferButton = screen.queryByRole('button', {
       name: 'Dupliquer',
     })
-    const previewButton = screen.queryByText('Aperçu dans ADAGE')
 
     expect(archiveButton).not.toBeInTheDocument()
     expect(duplicateOfferButton).not.toBeInTheDocument()
+  })
+
+  it('should not show preview button when offer is template and status is archived', () => {
+    renderCollectiveEditingOfferNavigation({
+      ...props,
+      isTemplate: true,
+      offer: getCollectiveOfferFactory({
+        displayedStatus: CollectiveOfferDisplayedStatus.ARCHIVED,
+      }),
+    })
+
+    const previewButton = screen.queryByRole('button', {
+      name: 'Aperçu dans ADAGE',
+    })
+
     expect(previewButton).not.toBeInTheDocument()
   })
 })

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.spec.tsx
@@ -235,7 +235,7 @@ describe('BookableOfferSummary', () => {
     expect(previewButton).toBeInTheDocument()
   })
 
-  it('should render the "Aperçu" action for an archived offer', () => {
+  it('should not render the "Aperçu" action for an archived offer', () => {
     const testProps = {
       offer: getCollectiveOfferFactory({
         displayedStatus: CollectiveOfferDisplayedStatus.ARCHIVED,
@@ -243,8 +243,8 @@ describe('BookableOfferSummary', () => {
     }
 
     renderBookableOfferSummary(testProps)
-    const previewButton = screen.getByText('Aperçu')
-    expect(previewButton).toBeInTheDocument()
+    const previewButton = screen.queryByText('Aperçu')
+    expect(previewButton).not.toBeInTheDocument()
   })
 
   it('should not render the "Aperçu" action for a draft offer', () => {

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.tsx
@@ -170,6 +170,10 @@ export const BookableOfferSummary = ({ offer }: BookableOfferSummaryProps) => {
     CollectiveOfferAllowedAction.CAN_DUPLICATE
   )
 
+  const canPreviewOffer =
+    offer.displayedStatus !== CollectiveOfferDisplayedStatus.DRAFT &&
+    offer.displayedStatus !== CollectiveOfferDisplayedStatus.ARCHIVED
+
   const isBookingCancellable = isActionAllowedOnCollectiveOffer(
     offer,
     CollectiveOfferAllowedAction.CAN_CANCEL
@@ -271,8 +275,7 @@ export const BookableOfferSummary = ({ offer }: BookableOfferSummaryProps) => {
                 </li>
               )}
 
-              {offer.displayedStatus !==
-                CollectiveOfferDisplayedStatus.DRAFT && (
+              {canPreviewOffer && (
                 <li>
                   <ButtonLink
                     to={`/offre/${offer.id}/collectif/apercu`}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-38082)

Ne pas afficher l'action "Aperçu sur ADAGE" si l'offre est au statut archivée