### PR TITLE
(PC-37994)[API] feat: validate foreign key offerer_address_venueId_fkey

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
 d5f66de2af3d (pre) (head)
-5ed5e8472e25 (post) (head)
+ae9151369f8d (post) (head)

--- a/api/src/pcapi/alembic/versions/20251013T114953_ae9151369f8d_validate_offerer_address_venueId_fkey.py
+++ b/api/src/pcapi/alembic/versions/20251013T114953_ae9151369f8d_validate_offerer_address_venueId_fkey.py
@@ -1,0 +1,23 @@
+"""Validate foreign key on offerer_address: offerer_address_venueId_fkey"""
+
+from alembic import op
+
+from pcapi import settings
+
+
+# pre/post deployment: post
+# revision identifiers, used by Alembic.
+revision = "ae9151369f8d"
+down_revision = "5ed5e8472e25"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("SET SESSION statement_timeout='300s'")  # or more if needed
+    op.execute("""ALTER TABLE offerer_address VALIDATE CONSTRAINT "offerer_address_venueId_fkey" """)
+    op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Index invalide détecté par Sentry.
J'avais oublié la validation de la clé étrangère dans la PR du ticket Jira https://passculture.atlassian.net/browse/PC-37994
À reporter sur staging avant la MEP du 14 octobre.