### PR TITLE
(BSR)[API] fix: attempt to prevent duplicate offerer name in tests

### DIFF
--- a/api/tests/core/external/external_users_test.py
+++ b/api/tests/core/external/external_users_test.py
@@ -622,7 +622,7 @@ def test_get_most_favorite_subcategories_two_equal():
     }
 
 
-def test_get_user_attributes_with_achievements():
+def test_get_user_attributes_with_achievements(db_session):
     user = BeneficiaryFactory()
     booking = BookingFactory(user=user)
     AchievementFactory(


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Attempt to fix failing `test_check_active_offerers ` test  