### PR TITLE
(PC-40176)[PRO] fix: (wip) Fix <StepContent/>’s label display

### DIFF
--- a/pro/src/components/Stepper/Stepper.module.scss
+++ b/pro/src/components/Stepper/Stepper.module.scss
@@ -49,6 +49,15 @@ $number-size: rem.torem(30px);
       }
     }
 
+    .label {
+      .inner > span {
+        position: absolute;
+        left: 0;
+        transform: translateX(calc(-50% + ($number-size / 2)));
+        white-space: nowrap;
+      }
+    }
+
     &.selectionnable {
       .step {
         color: var(--color-text-default);


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-40176)

- Bug suite à cette discussion : https://passcultureteam.slack.com/archives/C07KPU96FUK/p1770306495049839
- Tentative de résolution via un `white-space: nowrap;` + calcul et positionnement absolu --> à peaufiner voir si c'est faisable proprement comme ça où s'il faut partir sur une autre solution.

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
