### PR TITLE
(PC-40335)[API] script: create artist mini thumb for existing artists

### DIFF
--- a/api/src/pcapi/scripts/create_artist_mini_thumbs/main.py
+++ b/api/src/pcapi/scripts/create_artist_mini_thumbs/main.py
@@ -1,0 +1,97 @@
+"""
+Job console documentation here: https://www.notion.so/passcultureapp/Documentation-Job-Console-769beeacd5a146de9c97b6f8ee544276
+
+You can start the job from the infra repository with github cli :
+
+gh workflow run on_dispatch_pcapi_console_job.yaml \
+  -f ENVIRONMENT_SHORT_NAME=tst \
+  -f RESOURCES="512Mi/.5" \
+  -f BRANCH_NAME=PC-40335 \
+  -f NAMESPACE=create_artist_mini_thumbs \
+  -f SCRIPT_ARGUMENTS="";
+
+"""
+
+import argparse
+import gc
+import logging
+
+from pcapi import settings
+from pcapi.app import app
+from pcapi.core import object_storage
+from pcapi.core.artist import api as artist_api
+from pcapi.core.artist.models import Artist
+from pcapi.models import db
+
+
+logger = logging.getLogger(__name__)
+
+
+def main(not_dry: bool, limit: int | None = None, offset: int | None = None) -> None:
+    logger.info("Starting artist mini thumb backfill (dry=%s, limit=%s, offset=%s)", not not_dry, limit, offset)
+
+    # List existing mini thumbs to skip artists that already have them
+    mini_thumbs_folder = f"{settings.ARTIST_MINI_THUMBS_FOLDER_NAME}"
+    logger.info("Listing existing mini thumbs from folder: %s", mini_thumbs_folder)
+
+    existing_files = object_storage.list_files(mini_thumbs_folder, max_results=100000)
+    mediation_uuids_with_mini_thumbs = {
+        file_path.split("/")[-1] for file_path in existing_files if not file_path.endswith(".type")
+    }
+    del existing_files
+    logger.info("Found %d existing mini thumbs", len(mediation_uuids_with_mini_thumbs))
+
+    # select artists that don't have mini thumbs and have a mediation uuid
+    query = (
+        db.session.query(Artist.id, Artist.mediation_uuid)
+        .filter(Artist.mediation_uuid.is_not(None))
+        .filter(Artist.mediation_uuid.notin_(mediation_uuids_with_mini_thumbs))
+        .order_by(Artist.name)
+    )
+    if offset:
+        query = query.offset(offset)
+    if limit is not None:
+        query = query.limit(limit)
+
+    artists = query.all()
+
+    total = len(artists)
+    logger.info("Found %d artists to process", total)
+
+    processed = 0
+
+    for artist_id, mediation_uuid in artists:
+        try:
+            image_list = object_storage.get_public_object(
+                folder=settings.ARTIST_THUMBS_FOLDER_NAME,
+                object_id=mediation_uuid,
+            )
+
+            if not_dry:
+                artist_api.store_mini_thumb(image_list[0], mediation_uuid)
+            else:
+                logger.info("Dry run, would create mini thumb for artist %s", artist_id)
+
+            processed += 1
+
+        except Exception as e:
+            logger.warning(
+                "Error processing artist %s with mediation uuid %s", artist_id, mediation_uuid, extra={"exc": e}
+            )
+        finally:
+            del image_list
+            gc.collect()
+
+    logger.info("Finished mini thumb backfill: %d processed", processed)
+
+
+if __name__ == "__main__":
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--not-dry", action="store_true")
+    parser.add_argument("--offset", type=int, default=0, help="Number of artists to skip before processing")
+    parser.add_argument("--limit", type=int, default=None, help="Maximum number of artists to process")
+    args = parser.parse_args()
+
+    main(not_dry=args.not_dry, limit=args.limit, offset=args.offset)

--- a/api/tests/scripts/create_artist_mini_thumbs/test_main.py
+++ b/api/tests/scripts/create_artist_mini_thumbs/test_main.py
@@ -1,0 +1,95 @@
+from unittest import mock
+
+import pytest
+
+from pcapi.core.artist import factories as artist_factories
+from pcapi.scripts.create_artist_mini_thumbs.main import main
+
+
+FAKE_IMAGE_BYTES = b"fake-image"
+
+
+@pytest.mark.usefixtures("db_session")
+class CreateArtistMiniThumbsTest:
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.artist_api.store_mini_thumb")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.get_public_object")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.list_files")
+    def test_creates_mini_thumb_for_artist_with_mediation_uuid(
+        self, mock_list_files, mock_get_public_object, mock_store_mini_thumb
+    ):
+        artist = artist_factories.ArtistFactory(mediation_uuid="some-uuid")
+        mock_list_files.return_value = []
+        mock_get_public_object.return_value = [FAKE_IMAGE_BYTES]
+
+        main(not_dry=True)
+
+        mock_get_public_object.assert_called_once_with(folder="thumbs/artist", object_id="some-uuid")
+        mock_store_mini_thumb.assert_called_once_with(FAKE_IMAGE_BYTES, artist.mediation_uuid)
+
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.artist_api.store_mini_thumb")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.get_public_object")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.list_files")
+    def test_skips_artist_that_already_has_mini_thumb(
+        self, mock_list_files, mock_get_public_object, mock_store_mini_thumb
+    ):
+        artist_factories.ArtistFactory(mediation_uuid="already-done-uuid")
+        mock_list_files.return_value = ["thumbs/artist/72x72/already-done-uuid"]
+
+        main(not_dry=True)
+
+        mock_get_public_object.assert_not_called()
+        mock_store_mini_thumb.assert_not_called()
+
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.artist_api.store_mini_thumb")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.get_public_object")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.list_files")
+    def test_skips_artist_without_mediation_uuid(self, mock_list_files, mock_get_public_object, mock_store_mini_thumb):
+        artist_factories.ArtistFactory(mediation_uuid=None)
+        mock_list_files.return_value = []
+
+        main(not_dry=True)
+
+        mock_get_public_object.assert_not_called()
+        mock_store_mini_thumb.assert_not_called()
+
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.artist_api.store_mini_thumb")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.get_public_object")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.list_files")
+    def test_dry_run_does_not_store(self, mock_list_files, mock_get_public_object, mock_store_mini_thumb):
+        artist_factories.ArtistFactory(mediation_uuid="some-uuid")
+        mock_list_files.return_value = []
+        mock_get_public_object.return_value = [FAKE_IMAGE_BYTES]
+
+        main(not_dry=False)
+
+        mock_store_mini_thumb.assert_not_called()
+
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.artist_api.store_mini_thumb")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.get_public_object")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.list_files")
+    def test_limit_restricts_number_of_artists_processed(
+        self, mock_list_files, mock_get_public_object, mock_store_mini_thumb
+    ):
+        artist_factories.ArtistFactory(mediation_uuid="uuid-1")
+        artist_factories.ArtistFactory(mediation_uuid="uuid-2")
+        artist_factories.ArtistFactory(mediation_uuid="uuid-3")
+        mock_list_files.return_value = []
+        mock_get_public_object.return_value = [FAKE_IMAGE_BYTES]
+
+        main(not_dry=True, limit=1)
+
+        assert mock_store_mini_thumb.call_count == 1
+
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.artist_api.store_mini_thumb")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.get_public_object")
+    @mock.patch("pcapi.scripts.create_artist_mini_thumbs.main.object_storage.list_files")
+    def test_offset_skips_artists(self, mock_list_files, mock_get_public_object, mock_store_mini_thumb):
+        artist_factories.ArtistFactory(mediation_uuid="uuid-1")
+        artist_factories.ArtistFactory(mediation_uuid="uuid-2")
+        artist_factories.ArtistFactory(mediation_uuid="uuid-3")
+        mock_list_files.return_value = []
+        mock_get_public_object.return_value = [FAKE_IMAGE_BYTES]
+
+        main(not_dry=True, offset=1)
+
+        assert mock_store_mini_thumb.call_count == 2


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/jira/software/c/projects/PC/boards/66?selectedIssue=PC-40356)

**:warning: Ne pas merger dans `master`!**

<!-- Ajouter le label `do-not-merge` pour que la CI bloque le merge -->

Mon script a tourné sur :

- Testing :
  - [X] Dry run : [lien vers le job](https://github.com/pass-culture/infra/actions/runs/22104908149/job/63884902212)
  - [ ] ~~Actual run : lien vers le job~~ AUCUN ARTISTE AVEC DES MEDIATION_UUID
- Staging :
  - [x] Dry run : lien vers le job
  - [x] Actual run : [lien vers le job](https://github.com/pass-culture/infra/actions/runs/22227204965/job/64297020777) 
- Production :
  - [ ] ~~Dry run : lien vers le job~~
  - [ ] ~~Actual run : lien vers le job~~
- Intégration (**:warning: ne pas oublier cet environnement**) :
  - [ ] ~~Dry run : lien vers le job~~
  - [ ] ~~Actual run : lien vers le job~~
