### PR TITLE
(PC-40497) ci: add tag to pro and api when building docker image

### DIFF
--- a/.github/workflows/dev_on_workflow_build_docker_image.yml
+++ b/.github/workflows/dev_on_workflow_build_docker_image.yml
@@ -29,6 +29,12 @@ jobs:
           echo "$TAG" > version.txt
           git add version.txt
 
+      - name: Add version to pro
+        working-directory: pro
+        run: |
+          yarn version
+          git add package.json
+
       - name: Build docker image and save as github artifact
         uses: ./.github/actions/build-docker-image
         with:


### PR DESCRIPTION
CI

Suite à un mismatch entre la version de pro et d'api après un hotfix, je propose ce petit changement dans la CI