### PR TITLE
(PC-41212)[API] feat: update Ubble logging level to reduce noise in Sentry

### DIFF
--- a/api/src/pcapi/connectors/beneficiaries/ubble.py
+++ b/api/src/pcapi/connectors/beneficiaries/ubble.py
@@ -56,9 +56,8 @@ def log_and_handle_ubble_response(
                 return ubble_function(*args, **kwargs)
             except requests.exceptions.HTTPError as e:
                 response = e.response
-                logger.error(
-                    f"Ubble %s error: {response.status_code}",
-                    request_type,
+                logger.warning(
+                    "Ubble error",
                     extra={
                         "alert": "Ubble error",
                         "error_type": "http",
@@ -286,16 +285,16 @@ def download_ubble_picture(http_url: pydantic_networks.HttpUrl) -> tuple[str | N
         raise requests.ExternalAPIException(is_retryable=True)
 
     if response.status_code == 403:
-        logger.error(
+        logger.warning(
             "Ubble picture-download: request has expired",
             extra={"url": str(http_url), "status_code": response.status_code},
         )
         raise UbbleAssetExpiredError("Asset has expired. It needs to be refetched before archiving.")
 
     if response.status_code != 200:
-        logger.error(
-            f"Ubble picture-download: unexpected error: {response.status_code}",
-            extra={"url": str(http_url)},
+        logger.warning(
+            "Ubble picture-download: unexpected error",
+            extra={"url": str(http_url), "status_code": response.status_code},
         )
         raise requests.ExternalAPIException(is_retryable=False)
 

--- a/api/src/pcapi/core/subscription/messages.py
+++ b/api/src/pcapi/core/subscription/messages.py
@@ -205,7 +205,7 @@ def get_stepper_title_and_subtitle(
         return subscription_schemas.SubscriptionStepperDetails(title=subscription_schemas.STEPPER_HAS_ISSUES_TITLE)
 
     if not user.age:
-        logger.error("Eligible user has no age", extra={"user": user.id})
+        logger.warning("Eligible user has no age", extra={"user": user.id})
         return subscription_schemas.SubscriptionStepperDetails(title=subscription_schemas.STEPPER_DEFAULT_TITLE)
 
     eligibility_to_activate = eligibility_api.get_pre_decree_or_current_eligibility(user)

--- a/api/src/pcapi/core/subscription/ubble/tasks.py
+++ b/api/src/pcapi/core/subscription/ubble/tasks.py
@@ -45,7 +45,7 @@ def update_ubble_workflow_task(payload: ubble_schemas.UpdateWorkflowPayload) -> 
         ubble_api.update_ubble_workflow(fraud_check)
 
     if fraud_check.status == subscription_models.FraudCheckStatus.PENDING:
-        logger.error(
+        logger.warning(
             "Pending ubble application still pending after 12 hours. This is a problem on the Ubble side.",
             extra={"fraud_check_id": fraud_check.id, "ubble_id": fraud_check.thirdPartyId},
         )

--- a/api/tests/core/subscription/ubble/test_api.py
+++ b/api/tests/core/subscription/ubble/test_api.py
@@ -1053,7 +1053,7 @@ class DownloadUbbleDocumentPictureTest:
 
         # Then
         record = caplog.records[0]
-        assert record.levelname == "ERROR"
+        assert record.levelname == "WARNING"
         assert record.message == "Ubble picture-download: request has expired"
         assert self.picture_path in record.extra["url"]
 


### PR DESCRIPTION
Reduce level from `error` to `warning` to drop the following issues :

 - https://pass-culture.sentry.io/issues/78270795
 - https://pass-culture.sentry.io/issues/30818826
 - https://pass-culture.sentry.io/issues/82293555
 - https://pass-culture.sentry.io/issues/51169576

