### PR TITLE
(PC-40309)[API] feat: add phone number to /subscription/profile/

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -31,6 +31,7 @@ from pcapi.core.users import young_status as young_status_module
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.utils import date as date_utils
+from pcapi.utils import phone_number as phone_number_utils
 from pcapi.utils.decorators import retry
 
 from . import exceptions
@@ -524,10 +525,17 @@ def complete_profile(
     activity: users_models.ActivityEnum,
     first_name: str,
     last_name: str,
+    phone_number: str | None = None,
     school_type: users_models.SchoolTypeEnum | None = None,
 ) -> None:
     if postal_code in postal_code_utils.INELIGIBLE_POSTAL_CODES:
         raise exceptions.IneligiblePostalCodeException()
+
+    new_phone_number = phone_number
+    if phone_number:
+        phone_data = phone_number_utils.ParsedPhoneNumber(phone_number)
+        phone_number_utils.check_phone_number_is_legit(phone_data.phone_number, phone_data.country_code)
+        new_phone_number = phone_data.phone_number
 
     update_payload: dict = {
         "address": address,
@@ -535,6 +543,7 @@ def complete_profile(
         "postalCode": postal_code,
         "departementCode": postal_code_utils.PostalCode(postal_code).get_departement_code(),
         "activity": activity.value,
+        "phoneNumber": new_phone_number,
         "schoolType": school_type,
     }
 
@@ -558,6 +567,7 @@ def complete_profile(
             last_name=last_name,
             origin="Completed in application step",
             postal_code=postal_code,
+            phone_number=new_phone_number,
             school_type=school_type,
         ),
     )

--- a/api/src/pcapi/core/subscription/dms/api.py
+++ b/api/src/pcapi/core/subscription/dms/api.py
@@ -425,6 +425,7 @@ def _create_profile_completion_fraud_check_from_dms(
             last_name=last_name,
             origin=f"Completed in DMS application {application_id}",
             postal_code=postal_code,
+            phone_number=None,
             school_type=None,
         ),
     )

--- a/api/src/pcapi/core/subscription/factories.py
+++ b/api/src/pcapi/core/subscription/factories.py
@@ -143,6 +143,7 @@ class ProfileCompletionContentFactory(factory.Factory):
     last_name = factory.Faker("last_name")
     origin = "In app"
     postal_code = factory.Faker("postcode", locale="fr_FR")
+    phone_number: str | None = None
     school_type: users_models.SchoolTypeEnum | None = None
 
 

--- a/api/src/pcapi/core/subscription/schemas.py
+++ b/api/src/pcapi/core/subscription/schemas.py
@@ -176,6 +176,7 @@ class ProfileCompletionContent(pydantic_v2.BaseModel):
     postal_code: str | None = pydantic_v2.Field(
         None, validation_alias="postalCode"
     )  # Optional because it was not saved up until now
+    phone_number: str | None = None
     school_type: users_models.SchoolTypeEnum | None = None
 
     @pydantic_v2.field_validator("activity", mode="before")

--- a/api/src/pcapi/routes/native/v1/account.py
+++ b/api/src/pcapi/routes/native/v1/account.py
@@ -65,7 +65,9 @@ def patch_user_profile(body: serializers.UserProfilePatchRequest) -> serializers
     if "postal_code" in profile_update_dict:
         postal_code = profile_update_dict["postal_code"]
         if postal_code in postal_code_utils.INELIGIBLE_POSTAL_CODES:
-            raise api_errors.ApiErrors({"code": "INELIGIBLE_POSTAL_CODE"})
+            error = {"code": "INELIGIBLE_POSTAL_CODE"}
+            logger.warning("Failed to update postal code", extra={"code postal": postal_code, "code": error["code"]})
+            raise api_errors.ApiErrors(error, status_code=400)
         if not re.match(r"^\d{5}$", postal_code):
             raise api_errors.ApiErrors({"code": "INVALID_POSTAL_CODE"})
 

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -17,6 +17,7 @@ class ProfileContent(HttpBodyModel):
     first_name: str
     last_name: str
     postal_code: str
+    phone_number: str | None = None
     school_type: profile_options.SchoolTypeValueEnum | None = None
 
     model_config = pydantic_v2.ConfigDict(
@@ -35,6 +36,7 @@ class ProfileUpdateRequest(HttpQueryParamsModel):
     first_name: str
     last_name: str
     postal_code: str
+    phone_number: str | None = None
     school_type_id: profile_options.SchoolTypeIdEnum | None = None
 
     @pydantic_v2.field_validator("first_name", "last_name", "address", "city", "postal_code", mode="after")

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -22,6 +22,7 @@ from pcapi.core.users import models as users_models
 from pcapi.models import api_errors
 from pcapi.routes.native.security import authenticated_and_active_user_required
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils import phone_number as phone_number_utils
 from pcapi.utils.transaction_manager import atomic
 from pcapi.utils.transaction_manager import on_commit
 
@@ -33,8 +34,8 @@ logger = logging.getLogger(__name__)
 
 
 @blueprint.native_route("/subscription/profile", methods=["GET"])
-@spectree_serialize(on_success_status=200, on_error_statuses=[404], api=blueprint.api)
 @authenticated_and_active_user_required
+@spectree_serialize(on_success_status=200, on_error_statuses=[404], api=blueprint.api)
 def get_profile() -> serializers.ProfileResponse | None:
     if (profile_data := subscription_api.get_profile_data(current_user)) is not None:
         profile_data_dict = profile_data.dict()
@@ -49,9 +50,9 @@ def get_profile() -> serializers.ProfileResponse | None:
 
 
 @blueprint.native_route("/subscription/profile", methods=["POST"])
-@spectree_serialize(on_success_status=204, api=blueprint.api)
-@authenticated_and_active_user_required
 @atomic()
+@authenticated_and_active_user_required
+@spectree_serialize(on_success_status=204, api=blueprint.api)
 def complete_profile(body: serializers.ProfileUpdateRequest) -> None:
     try:
         subscription_api.complete_profile(
@@ -62,12 +63,23 @@ def complete_profile(body: serializers.ProfileUpdateRequest) -> None:
             city=body.city,
             postal_code=body.postal_code,
             activity=users_models.ActivityEnum[body.activity_id.value],
+            phone_number=body.phone_number,
             school_type=(
                 users_models.SchoolTypeEnum[body.school_type_id.value] if body.school_type_id is not None else None
             ),
         )
     except exceptions.IneligiblePostalCodeException:
-        raise api_errors.ApiErrors({"code": "INELIGIBLE_POSTAL_CODE"})
+        error = {"code": "INELIGIBLE_POSTAL_CODE"}
+        logger.warning("Failed to define postal code", extra={"code postal": body.postal_code, "code": error["code"]})
+        raise api_errors.ApiErrors(error, status_code=400)
+    except phone_number_utils.InvalidCountryCode:
+        error = {"code": "INVALID_COUNTRY_CODE", "message": "L'indicatif téléphonique n'est pas accepté"}
+        logger.warning("Failed to define phone number", extra={"number": body.phone_number, "code": error["code"]})
+        raise api_errors.ApiErrors(error, status_code=400)
+    except phone_number_utils.InvalidPhoneNumber:
+        error = {"code": "INVALID_PHONE_NUMBER", "message": "Le numéro de téléphone est invalide"}
+        logger.warning("Failed to define phone number", extra={"number": body.phone_number, "code": error["code"]})
+        raise api_errors.ApiErrors(error, status_code=400)
 
     is_activated = subscription_api.activate_beneficiary_if_no_missing_step(current_user)
     if not is_activated:
@@ -75,12 +87,12 @@ def complete_profile(body: serializers.ProfileUpdateRequest) -> None:
 
 
 @blueprint.native_route("/subscription/activity_types", methods=["GET"])
+@authenticated_and_active_user_required
 @spectree_serialize(
     response_model=serializers.ActivityTypesResponse,
     on_success_status=200,
     api=blueprint.api,
 )
-@authenticated_and_active_user_required
 def get_activity_types() -> serializers.ActivityTypesResponse:
     activities = [
         serializers.ActivityResponseModel.model_validate(activity) for activity in profile_options.ALL_ACTIVITIES
@@ -93,9 +105,9 @@ def get_activity_types() -> serializers.ActivityTypesResponse:
 
 
 @blueprint.native_route("/subscription/honor_statement", methods=["POST"])
-@spectree_serialize(on_success_status=204, api=blueprint.api)
-@authenticated_and_active_user_required
 @atomic()
+@authenticated_and_active_user_required
+@spectree_serialize(on_success_status=204, api=blueprint.api)
 def create_honor_statement_fraud_check() -> None:
     fraud_api.create_honor_statement_fraud_check(current_user, "statement from /subscription/honor_statement endpoint")
 
@@ -106,9 +118,9 @@ def create_honor_statement_fraud_check() -> None:
 
 
 @blueprint.native_route("/ubble_identification", methods=["POST"])
-@spectree_serialize(api=blueprint.api, response_model=serializers.IdentificationSessionResponse)
-@authenticated_and_active_user_required
 @atomic()
+@authenticated_and_active_user_required
+@spectree_serialize(api=blueprint.api, response_model=serializers.IdentificationSessionResponse)
 def start_identification_session(
     body: serializers.IdentificationSessionRequest,
 ) -> serializers.IdentificationSessionResponse:
@@ -158,9 +170,9 @@ def start_identification_session(
 
 
 @blueprint.native_route("/subscription/bonus/quotient_familial", methods=["POST"])
-@spectree_serialize(on_success_status=204, api=blueprint.api)
-@authenticated_and_active_user_required
 @atomic()
+@authenticated_and_active_user_required
+@spectree_serialize(on_success_status=204, api=blueprint.api)
 def create_quotient_familial_bonus_credit_fraud_check(body: serializers.BonusCreditRequest) -> None:
     if not users_api.get_user_is_eligible_for_bonification(current_user):
         raise api_errors.ApiErrors(

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -6514,6 +6514,18 @@
                         "title": "Lastname",
                         "type": "string"
                     },
+                    "phoneNumber": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "default": null,
+                        "title": "Phonenumber"
+                    },
                     "postalCode": {
                         "title": "Postalcode",
                         "type": "string"

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -53,6 +53,7 @@ class GetProfileTest:
         assert profile_content["postalCode"] == content.postal_code
         assert profile_content["activity"] == content.activity
         assert profile_content["schoolType"] == content.school_type
+        assert profile_content["phoneNumber"] == content.phone_number
 
     def test_get_profile_with_no_fraud_check(self, client):
         user = users_factories.BeneficiaryGrant18Factory()
@@ -125,6 +126,7 @@ class GetProfileTest:
             "postalCode": "77000",
             "activityId": "HIGH_SCHOOL_STUDENT",
             "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+            "phoneNumber": "+33609080706",
         }
 
         with time_machine.travel(date_utils.get_naive_utc_now() - datetime.timedelta(days=365)):
@@ -142,6 +144,7 @@ class GetProfileTest:
         assert response.json["profile"]["postalCode"] == profile_data["postalCode"]
         assert response.json["profile"]["activity"] == users_models.ActivityEnum.HIGH_SCHOOL_STUDENT.value
         assert response.json["profile"]["schoolType"] == users_models.SchoolTypeEnum.PUBLIC_HIGH_SCHOOL.value
+        assert response.json["profile"]["phoneNumber"] == profile_data["phoneNumber"]
 
     def test_get_profile_with_legacy_profile_completion_fraud_check(self, client):
         user = users_factories.BeneficiaryGrant18Factory()
@@ -175,8 +178,6 @@ class UpdateProfileTest:
             activity=None,
             firstName=None,
             lastName=None,
-            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            phoneNumber="+33609080706",
             dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
         )
 
@@ -188,12 +189,24 @@ class UpdateProfileTest:
             "postalCode": "77000",
             "activityId": "HIGH_SCHOOL_STUDENT",
             "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+            "phoneNumber": "+33609080706",
         }
 
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # user (update)
+        expected_num_queries += 1  # beneficiary_fraud_check (insert)
+        expected_num_queries += 1  # user
+        expected_num_queries += 1  # beneficiary_fraud_review
+        expected_num_queries += 1  # beneficiary_fraud_check
+        expected_num_queries += 1  # action history
+        expected_num_queries += 1  # booking
+        expected_num_queries += 1  # favorite
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # achievement
         client.with_token(user)
-        response = client.post("/native/v1/subscription/profile", profile_data)
-
-        assert response.status_code == 204
+        with assert_num_queries(expected_num_queries):
+            response = client.post("/native/v1/subscription/profile", profile_data)
+            assert response.status_code == 204
 
         user = db.session.get(users_models.User, user.id)
         assert not user.is_beneficiary
@@ -225,150 +238,12 @@ class UpdateProfileTest:
         assert profile_completion_fraud_check.reason == "Completed in application step"
 
     @pytest.mark.features(ENABLE_UBBLE=True)
-    def test_fulfill_profile_invalid_character(self, client):
-        user = users_factories.UserFactory(
-            address=None,
-            city=None,
-            postalCode=None,
-            activity=None,
-            firstName=None,
-            lastName=None,
-            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            phoneNumber="+33609080706",
-            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
-        )
-
-        profile_data = {
-            "firstName": "ჯონ",
-            "lastName": "Doe",
-            "address": "1 rue des rues",
-            "city": "Uneville",
-            "postalCode": "77000",
-            "activityId": "HIGH_SCHOOL_STUDENT",
-            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
-        }
-
-        client.with_token(user)
-        response = client.post("/native/v1/subscription/profile", profile_data)
-
-        assert response.status_code == 400
-
-    @pytest.mark.features(ENABLE_UBBLE=True)
-    def test_fulfill_profile_empty_field(self, client):
-        user = users_factories.UserFactory(
-            address=None,
-            city=None,
-            postalCode=None,
-            activity=None,
-            firstName=None,
-            lastName=None,
-            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            phoneNumber="+33609080706",
-            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
-        )
-
-        profile_data = {
-            "firstName": " ",
-            "lastName": "Doe",
-            "address": "1 rue des rues",
-            "city": "Uneville",
-            "postalCode": "77000",
-            "activityId": "HIGH_SCHOOL_STUDENT",
-            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
-        }
-
-        client.with_token(user)
-        response = client.post("/native/v1/subscription/profile", profile_data)
-
-        assert response.status_code == 400
-
-    @pytest.mark.features(ENABLE_UBBLE=True)
-    def test_fulfill_profile_missing_mandatory_field(self, client):
-        user = users_factories.UserFactory(
-            address=None,
-            city=None,
-            postalCode=None,
-            activity=None,
-            firstName=None,
-            lastName=None,
-            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            phoneNumber="+33609080706",
-            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
-        )
-
-        profile_data = {
-            "firstName": " ",
-            "lastName": "Doe",
-            "address": "1 rue des rues",
-            "city": "Uneville",
-            "postalCode": "77000",
-            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
-        }
-
-        client.with_token(user)
-        response = client.post("/native/v1/subscription/profile", profile_data)
-
-        assert response.status_code == 400
-
-    @pytest.mark.parametrize("postal_code", INELIGIBLE_POSTAL_CODES)
-    @pytest.mark.features(ENABLE_UBBLE=True)
-    def test_fulfill_profile_ineligible_postal_code(self, client, postal_code):
-        user = users_factories.UserFactory()
-
-        response = client.with_token(user).post(
-            "/native/v1/subscription/profile",
-            {
-                "firstName": "John",
-                "lastName": "Doe",
-                "address": "1 rue des rues",
-                "city": "Uneville",
-                "postalCode": postal_code,
-                "activityId": "HIGH_SCHOOL_STUDENT",
-                "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
-            },
-        )
-
-        assert response.status_code == 400
-        assert response.json["code"] == "INELIGIBLE_POSTAL_CODE"
-
-    @pytest.mark.features(ENABLE_UBBLE=True)
-    def test_fulfill_profile_valid_character(self, client):
-        user = users_factories.UserFactory(
-            address=None,
-            city=None,
-            postalCode=None,
-            activity=None,
-            firstName=None,
-            lastName=None,
-            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            phoneNumber="+33609080706",
-            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
-        )
-
-        profile_data = {
-            "firstName": "John",
-            "lastName": "àâçéèêîôœùûÀÂÇÉÈÊÎÔŒÙÛ-' ",
-            "address": "1 rue des rues",
-            "city": "Uneville",
-            "postalCode": "77000",
-            "activityId": "HIGH_SCHOOL_STUDENT",
-            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
-        }
-
-        client.with_token(user)
-        response = client.post("/native/v1/subscription/profile", profile_data)
-
-        assert response.status_code == 204
-
-    @pytest.mark.features(ENABLE_UBBLE=True)
     def test_fulfill_profile_activation(self, client):
         user = users_factories.UserFactory(
             address=None,
             city=None,
             postalCode=None,
             activity=None,
-            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
-            phoneNumber="+33609080706",
             dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
         )
 
@@ -396,12 +271,33 @@ class UpdateProfileTest:
             "postalCode": "77000",
             "activityId": "HIGH_SCHOOL_STUDENT",
             "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+            "phoneNumber": "+33609080706",
         }
 
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # user (update)
+        expected_num_queries += 1  # beneficiary_fraud_check (insert)
+        expected_num_queries += 1  # user
+        expected_num_queries += 1  # beneficiary_fraud_review
+        expected_num_queries += 1  # beneficiary_fraud_check
+        expected_num_queries += 1  # action history
+        expected_num_queries += 1  # user
+        expected_num_queries += 1  # user
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # deposit (exists)
+        expected_num_queries += 1  # user (update)
+        expected_num_queries += 1  # deposit (insert)
+        expected_num_queries += 1  # recredit
+        expected_num_queries += 1  # deposit (update)
+        expected_num_queries += 1  # recredit (insert)
+        expected_num_queries += 1  # booking
+        expected_num_queries += 1  # favorite
+        expected_num_queries += 1  # achievement
+        expected_num_queries += 1  # user (update)
         client.with_token(user)
-        response = client.post("/native/v1/subscription/profile", profile_data)
-
-        assert response.status_code == 204
+        with assert_num_queries(expected_num_queries):
+            response = client.post("/native/v1/subscription/profile", profile_data)
+            assert response.status_code == 204
 
         user = db.session.get(users_models.User, user.id)
         assert user.firstName == "Alexandra"
@@ -413,6 +309,227 @@ class UpdateProfileTest:
         assert notification["user_id"] == user.id
         assert notification["attribute_values"]["u.is_beneficiary"]
         assert notification["attribute_values"]["u.postal_code"] == "75008"
+
+    @pytest.mark.features(ENABLE_UBBLE=True)
+    def test_fulfill_profile_without_optional_fields(self, client):
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            firstName=None,
+            lastName=None,
+            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
+        )
+
+        profile_data = {
+            "firstName": "John",
+            "lastName": "Doe",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activityId": "HIGH_SCHOOL_STUDENT",
+        }
+
+        client.with_token(user)
+        response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 204
+
+        assert user.firstName == "John"
+        assert user.lastName == "Doe"
+        assert user.address == "1 rue des rues"
+        assert user.city == "Uneville"
+        assert user.postalCode == "77000"
+        assert user.activity == "Lycéen"
+        assert user.schoolType is None
+        assert user.phoneNumber is None
+
+        # Check that a PROFILE_COMPLETION fraud check is created
+        profile_completion_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type == subscription_models.FraudCheckType.PROFILE_COMPLETION
+        ]
+        assert len(profile_completion_fraud_checks) == 1
+        profile_completion_fraud_check = profile_completion_fraud_checks[0]
+        assert profile_completion_fraud_check.status == subscription_models.FraudCheckStatus.OK
+        assert profile_completion_fraud_check.reason == "Completed in application step"
+
+    @pytest.mark.features(ENABLE_UBBLE=True)
+    def test_fulfill_profile_invalid_character(self, client):
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            firstName=None,
+            lastName=None,
+            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
+        )
+
+        profile_data = {
+            "firstName": "ჯონ",
+            "lastName": "Doe",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activityId": "HIGH_SCHOOL_STUDENT",
+            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+            "phoneNumber": "+33609080706",
+        }
+
+        client.with_token(user)
+        response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 400
+
+    @pytest.mark.features(ENABLE_UBBLE=True)
+    def test_fulfill_profile_empty_field(self, client):
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            firstName=None,
+            lastName=None,
+            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
+        )
+
+        profile_data = {
+            "firstName": " ",
+            "lastName": "Doe",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activityId": "HIGH_SCHOOL_STUDENT",
+            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+            "phoneNumber": "+33609080706",
+        }
+
+        client.with_token(user)
+        response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 400
+
+    @pytest.mark.features(ENABLE_UBBLE=True)
+    def test_fulfill_profile_missing_mandatory_field(self, client):
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            firstName=None,
+            lastName=None,
+            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
+        )
+
+        profile_data = {
+            "firstName": " ",
+            "lastName": "Doe",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+            "phoneNumber": "+33609080706",
+        }
+
+        client.with_token(user)
+        response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize("postal_code", INELIGIBLE_POSTAL_CODES)
+    @pytest.mark.features(ENABLE_UBBLE=True)
+    def test_fulfill_profile_ineligible_postal_code(self, client, postal_code):
+        user = users_factories.UserFactory()
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/profile",
+            {
+                "firstName": "John",
+                "lastName": "Doe",
+                "address": "1 rue des rues",
+                "city": "Uneville",
+                "postalCode": postal_code,
+                "activityId": "HIGH_SCHOOL_STUDENT",
+                "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+                "phoneNumber": "+33609080706",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json["code"] == "INELIGIBLE_POSTAL_CODE"
+
+    @pytest.mark.features(ENABLE_UBBLE=True)
+    def test_fulfill_profile_invalid_phone_number(self, client):
+        user = users_factories.UserFactory()
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/profile",
+            {
+                "firstName": "John",
+                "lastName": "Doe",
+                "address": "1 rue des rues",
+                "city": "Uneville",
+                "postalCode": "77000",
+                "activityId": "HIGH_SCHOOL_STUDENT",
+                "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+                "phoneNumber": "+336090807060",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json["code"] == "INVALID_PHONE_NUMBER"
+
+    @pytest.mark.features(ENABLE_UBBLE=True)
+    def test_fulfill_profile_invalid_phone_number_country_code(self, client):
+        user = users_factories.UserFactory()
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/profile",
+            {
+                "firstName": "John",
+                "lastName": "Doe",
+                "address": "1 rue des rues",
+                "city": "Uneville",
+                "postalCode": "77000",
+                "activityId": "HIGH_SCHOOL_STUDENT",
+                "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+                "phoneNumber": "+46609080706",
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json["code"] == "INVALID_COUNTRY_CODE"
+
+    @pytest.mark.features(ENABLE_UBBLE=True)
+    def test_fulfill_profile_valid_character(self, client):
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            firstName=None,
+            lastName=None,
+            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
+        )
+
+        profile_data = {
+            "firstName": "John",
+            "lastName": "àâçéèêîôœùûÀÂÇÉÈÊÎÔŒÙÛ-' ",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activityId": "HIGH_SCHOOL_STUDENT",
+            "schoolTypeId": "PUBLIC_HIGH_SCHOOL",
+            "phoneNumber": "+33609080706",
+        }
+
+        client.with_token(user)
+        response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 204
 
 
 class ActivityTypesTest:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-40309)

- Pour l’ajout du phone_number j’ai repris ce qui est fait dans [ce endpoint](https://github.com/pass-culture/pass-culture-main/blob/23f13490e8d7e31859aa1537c2236fb0c5fdc29f/api/src/pcapi/routes/native/v1/account.py#L62). Je n’ai pas repris les log de warning mais dites moi si vous pensez que c’est utile. Je n’ai pas repris la maj de `phone_validation_status` parce qu’on ne l’utilise plus et c’est qqch que j’aimerai dégager aussi.
- Le endpoint get on l'appel encore mais on n’utilise plus son résultat dans l’app, et on va supprimer l'appel dans un prochain ticket. Et du coup il y a aussi un ticket back pour le supprimer le endpoint en temps voulu. J’ai quand même mis à jour le serializer car le endpoint retourne automatiquement le numéro de téléphone une fois qu’il est ajouté au contenu du fraud check

