### PR TITLE
Bsr e2e quickfixes

### DIFF
--- a/pro/e2e/createAccount.e2e.ts
+++ b/pro/e2e/createAccount.e2e.ts
@@ -75,10 +75,7 @@ test.describe('Account creation', () => {
       page.getByText('Dites-nous pour quelle structure vous travaillez')
     ).toBeVisible()
     await expectNoErrorSnackbar(page)
-    // Press tab to focus on the top of the page
-    await page.keyboard.press('Tab')
-    expect(page.getByRole('link', { name: 'Aller au contenu' })).toBeFocused()
-
+    
     await checkAccessibility(page)
   })
 })

--- a/pro/e2e/createAccount.e2e.ts
+++ b/pro/e2e/createAccount.e2e.ts
@@ -75,7 +75,7 @@ test.describe('Account creation', () => {
       page.getByText('Dites-nous pour quelle structure vous travaillez')
     ).toBeVisible()
     await expectNoErrorSnackbar(page)
-    
+
     await checkAccessibility(page)
   })
 })

--- a/pro/e2e/didacticOnboarding.e2e.ts
+++ b/pro/e2e/didacticOnboarding.e2e.ts
@@ -189,10 +189,10 @@ test.describe('Didactic Onboarding feature', () => {
     await page.getByLabel(/Non accessible/).check()
     await page.getByText('Enregistrer et continuer').click()
 
-    await page.goto('/onboarding/individuel')
     await Promise.all([
-      page.waitForResponse(isGetOffersResponse),
+      page.goto('/onboarding/individuel'),
       page.waitForResponse(isGetCategoriesResponse),
+      page.waitForResponse(isGetOffersResponse),
     ])
 
     await expect(

--- a/pro/e2e/didacticOnboarding.e2e.ts
+++ b/pro/e2e/didacticOnboarding.e2e.ts
@@ -28,10 +28,6 @@ test.describe('Didactic Onboarding feature', () => {
     await expect(
       page.getByText('Sur ADAGE à destination des enseignants')
     ).toBeVisible()
-
-    // Press tab to focus on the top of the page
-    await page.keyboard.press('Tab')
-    await page.getByRole('link', { name: 'Aller au contenu' }).click()
   })
 
   test('I should be able to skip the onboarding', async ({

--- a/pro/e2e/signupJourneyCreateOfferer.e2e.ts
+++ b/pro/e2e/signupJourneyCreateOfferer.e2e.ts
@@ -243,9 +243,6 @@ test.describe('Signup journey with known offerer...', () => {
       await venuesSiretPromise
 
       await expect(page).toHaveURL(/\/inscription\/structure\/rattachement/)
-      // Hack because "aller au contenu" is focused by `useFocus`
-      await page.getByRole('link', { name: 'Aller au contenu' }).focus()
-      await page.getByRole('link', { name: 'Aller au contenu' }).click()
 
       const addressSearchPromise = page.waitForResponse((response) =>
         response.url().includes('data.geopf.fr/geocodage/search')
@@ -328,10 +325,6 @@ test.describe('Signup journey with known offerer...', () => {
       )
       await page.getByText('Continuer').click()
       await venuesSiretPromise
-
-      // Hack because "aller au contenu" is focused by `useFocus`
-      await page.getByRole('link', { name: 'Aller au contenu' }).focus()
-      await page.getByRole('link', { name: 'Aller au contenu' }).click()
 
       await page.getByText('Rejoindre cet espace').click()
 


### PR DESCRIPTION
Corrections de tests flaky:
- Retrait du "hack" du skiplink qui faisait sauter l'écran.
- Amélioration d'un test de navigation dans l'onboarding didactique.