### PR TITLE
(PC-40520)[PRO] feat: add new stats card to the new homepage

### DIFF
--- a/api/src/pcapi/connectors/clickhouse/query_mock.py
+++ b/api/src/pcapi/connectors/clickhouse/query_mock.py
@@ -130,6 +130,7 @@ class MockOfferConsultationCountQueryResult:
 
 OFFER_CONSULTATION_COUNT = [
     MockOfferConsultationCountQueryResult(day=datetime.date(2026, 1, 1), views=3456),
+    MockOfferConsultationCountQueryResult(day=datetime.date(2026, 1, 2), views=4567),
 ]
 
 

--- a/api/tests/connectors/clickhouse/clickhouse_test.py
+++ b/api/tests/connectors/clickhouse/clickhouse_test.py
@@ -51,6 +51,8 @@ class GetOfferConsultationCountTest:
     def test_get_offer_consultation_count(self):
         results = clickhouse_queries.OfferConsultationCountQuery().execute({"venue_id": 1})
 
-        assert len(results) == 1
+        assert len(results) == 2
         assert results[0].day == datetime.date(2026, 1, 1)
         assert results[0].views == 3456
+        assert results[1].day == datetime.date(2026, 1, 2)
+        assert results[1].views == 4567

--- a/pro/e2e/fixtures/newHomepage.ts
+++ b/pro/e2e/fixtures/newHomepage.ts
@@ -68,7 +68,10 @@ export async function expectIndividualModules(
     visibleModules.includes('OFFERS_CARD')
   )
   await expectModuleVisibility(
-    page.getByText('Module statistiques'),
+    page.getByRole('heading', {
+      level: 2,
+      name: "Les statistiques sur l'individuel",
+    }),
     visibleModules.includes('STATS_CARD')
   )
   await expectModuleVisibility(

--- a/pro/src/pages/Homepage/NewHomepage.spec.tsx
+++ b/pro/src/pages/Homepage/NewHomepage.spec.tsx
@@ -46,6 +46,10 @@ vi.mock('./components/NewsletterCard/NewsletterCard', () => ({
   NewsletterCard: () => <div>Newsletter</div>,
 }))
 
+vi.mock('./components/StatsCard/StatsCard', () => ({
+  StatsCard: () => <div>Les statistiques sur l'individuel</div>,
+}))
+
 vi.mock('./components/OffersEmptyStateCard/OffersEmptyStateCard', () => ({
   OffersEmptyStateCard: ({ variant }: { variant: OffersCardVariant }) => {
     const variantText = variant === 'INDIVIDUAL' ? 'individuelle' : 'collective'
@@ -401,7 +405,7 @@ describe('NewHomepage', () => {
 
       expect(
         screen.getByRole('tabpanel', { description: /indiv/ })
-      ).toHaveTextContent(/Evolution de consultation de vos offres/)
+      ).toHaveTextContent(/Les statistiques sur l'individuel/)
 
       expect(
         screen.getByRole('tabpanel', { description: /indiv/ })

--- a/pro/src/pages/Homepage/NewHomepage.tsx
+++ b/pro/src/pages/Homepage/NewHomepage.tsx
@@ -34,6 +34,7 @@ import { IndividualOffersCard } from './components/IndividualOffersCard/Individu
 import { NewsletterCard } from './components/NewsletterCard/NewsletterCard'
 import { OffersEmptyStateCard } from './components/OffersEmptyStateCard/OffersEmptyStateCard'
 import { PartnerPageCard } from './components/PartnerPageCard/PartnerPageCard'
+import { StatsCard } from './components/StatsCard/StatsCard'
 import { HomepageVariant } from './components/types'
 import { VenueValidationBanner } from './components/VenueValidationBanner/VenueValidationBanner'
 import { WebinarCard } from './components/WebinarCard/WebinarCard'
@@ -153,11 +154,7 @@ export const NewHomepage = (): JSX.Element => {
                 selectedPartnerVenue.location?.departmentCode
               }
             />
-            <div>
-              Evolution de consultation de vos offres
-              <br />
-              <b>Module statistiques</b>
-            </div>
+            <StatsCard venue={selectedPartnerVenue} />
             <EditoCard
               canDisplayHighlights={selectedPartnerVenue.canDisplayHighlights}
               venueId={selectedPartnerVenue.id}

--- a/pro/src/pages/Homepage/components/StatisticsDashboard/StatisticsDashboard.module.scss
+++ b/pro/src/pages/Homepage/components/StatisticsDashboard/StatisticsDashboard.module.scss
@@ -24,7 +24,7 @@
   grid-template-columns: 1fr;
 
   &.has-top-offers {
-    @media (min-width: size.$tablet) {
+    @media (min-width: size.$laptop) {
       grid-template-columns: 1fr rem.torem(230px);
     }
   }

--- a/pro/src/pages/Homepage/components/StatisticsDashboard/__specs__/StatisticsDashboard.spec.tsx
+++ b/pro/src/pages/Homepage/components/StatisticsDashboard/__specs__/StatisticsDashboard.spec.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 
 import { api } from '@/apiClient/api'
 import { defaultGetVenue } from '@/commons/utils/factories/collectiveApiFactories'
@@ -58,7 +58,10 @@ describe('StatisticsDashboard', () => {
   it('should not render most viewed offers if there are none', async () => {
     vi.spyOn(api, 'getVenueOffersStats').mockResolvedValue({
       jsonData: {
-        dailyViews: [{ day: '2020-10-10', views: 10 }],
+        dailyViews: [
+          { day: '2020-10-10', views: 10 },
+          { day: '2020-10-11', views: 20 },
+        ],
         topOffers: [],
         totalViewsLast30Days: 0,
       },
@@ -67,11 +70,13 @@ describe('StatisticsDashboard', () => {
 
     renderStatisticsDashboard()
 
-    expect(
-      await screen.findByRole('heading', {
-        name: /Les statistiques sur l’individuel/,
-      })
-    ).toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', {
+          name: /Les statistiques sur l'individuel/,
+        })
+      ).toBeInTheDocument()
+    })
     expect(
       screen.queryByText('Vos offres les plus consultées')
     ).not.toBeInTheDocument()

--- a/pro/src/pages/Homepage/components/StatisticsDashboard/components/CumulatedViews.tsx
+++ b/pro/src/pages/Homepage/components/StatisticsDashboard/components/CumulatedViews.tsx
@@ -28,6 +28,7 @@ import { CumulatedViewsEmptyState } from './CumulatedViewsEmptyState'
 export interface CumulatedViewsProps {
   dailyViews: VenueDailyViewModel[]
   totalViewsLast30Days: number
+  showTitle?: boolean
 }
 
 type XYPoint = { x: string; y: number }
@@ -45,6 +46,7 @@ Chart.register(
 export const CumulatedViews = ({
   dailyViews,
   totalViewsLast30Days,
+  showTitle = true,
 }: CumulatedViewsProps) => {
   const chartRef = useRef<ChartJS<'line', XYPoint[], unknown> | null>(null)
 
@@ -113,9 +115,11 @@ export const CumulatedViews = ({
   return (
     <div className={styles['cumulated-views']}>
       <div className={styles['header']}>
-        <h3 className={styles['block-title']}>
-          Les statistiques sur l’individuel
-        </h3>
+        {showTitle && (
+          <h3 className={styles['block-title']}>
+            Les statistiques sur l'individuel
+          </h3>
+        )}
         <span className={styles['total-views']}>
           Vos offres individuelles ont été vues{' '}
           {totalViewsLast30Days.toLocaleString('fr-FR')} fois ces 30 derniers

--- a/pro/src/pages/Homepage/components/StatsCard/StatsCard.spec.tsx
+++ b/pro/src/pages/Homepage/components/StatsCard/StatsCard.spec.tsx
@@ -1,0 +1,85 @@
+import { screen, waitFor } from '@testing-library/react'
+
+import { api } from '@/apiClient/api'
+import { defaultGetVenue } from '@/commons/utils/factories/collectiveApiFactories'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { StatsCard } from './StatsCard'
+
+vi.mock('@/apiClient/api', () => ({
+  api: {
+    getVenueOffersStats: vi.fn(),
+  },
+}))
+
+const renderStatsCard = (hasOffers = true) =>
+  renderWithProviders(
+    <StatsCard
+      venue={{
+        ...defaultGetVenue,
+        hasNonDraftOffers: hasOffers,
+      }}
+    />,
+    {
+      user: sharedCurrentUserFactory(),
+    }
+  )
+
+describe('StatsCard', () => {
+  it('should not render the card when there is less than 2 days of data', async () => {
+    vi.spyOn(api, 'getVenueOffersStats').mockResolvedValue({
+      jsonData: { dailyViews: [], topOffers: [], totalViewsLast30Days: 0 },
+      venueId: 1,
+    })
+
+    const { container } = renderStatsCard()
+
+    await waitFor(() => {
+      expect(api.getVenueOffersStats).toHaveBeenCalled()
+    })
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('should not render the card when there is only 1 day of data', async () => {
+    vi.spyOn(api, 'getVenueOffersStats').mockResolvedValue({
+      jsonData: {
+        dailyViews: [{ day: '2020-10-10', views: 10 }],
+        topOffers: [],
+        totalViewsLast30Days: 10,
+      },
+      venueId: 1,
+    })
+
+    const { container } = renderStatsCard()
+
+    await waitFor(() => {
+      expect(api.getVenueOffersStats).toHaveBeenCalled()
+    })
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('should render the card with stats when there are at least 2 days of data', async () => {
+    vi.spyOn(api, 'getVenueOffersStats').mockResolvedValue({
+      jsonData: {
+        dailyViews: [
+          { day: '2020-10-10', views: 10 },
+          { day: '2020-10-11', views: 20 },
+        ],
+        topOffers: [],
+        totalViewsLast30Days: 30,
+      },
+      venueId: 1,
+    })
+
+    renderStatsCard()
+
+    expect(
+      await screen.findByRole('heading', {
+        name: /Les statistiques sur l'individuel/,
+      })
+    ).toBeVisible()
+  })
+})

--- a/pro/src/pages/Homepage/components/StatsCard/StatsCard.tsx
+++ b/pro/src/pages/Homepage/components/StatsCard/StatsCard.tsx
@@ -1,0 +1,50 @@
+import cn from 'classnames'
+import useSWR from 'swr'
+
+import { api } from '@/apiClient/api'
+import type { GetVenueResponseModel } from '@/apiClient/v1'
+import { GET_VENUES_STATS_QUERY_KEY } from '@/commons/config/swrQueryKeys'
+import { Card } from '@/ui-kit/Card/Card'
+
+import { CumulatedViews } from '../StatisticsDashboard/components/CumulatedViews'
+import { MostViewedOffers } from '../StatisticsDashboard/components/MostViewedOffers'
+import styles from '../StatisticsDashboard/StatisticsDashboard.module.scss'
+
+interface StatsCardProps {
+  venue: GetVenueResponseModel
+}
+
+export const StatsCard = ({ venue }: StatsCardProps) => {
+  const { data: stats } = useSWR(
+    [GET_VENUES_STATS_QUERY_KEY, venue.id],
+    ([, venueId]) => api.getVenueOffersStats(venueId)
+  )
+
+  const dailyViews = stats?.jsonData.dailyViews ?? []
+
+  if (!stats || dailyViews.length < 2) {
+    return null
+  }
+
+  const { topOffers, totalViewsLast30Days } = stats.jsonData
+
+  return (
+    <Card>
+      <Card.Header title="Les statistiques sur l'individuel" />
+      <Card.Content>
+        <div
+          className={cn(styles['data-container'], {
+            [styles['has-top-offers']]: topOffers.length > 0,
+          })}
+        >
+          <CumulatedViews
+            dailyViews={dailyViews}
+            totalViewsLast30Days={totalViewsLast30Days}
+            showTitle={false}
+          />
+          {topOffers.length > 0 && <MostViewedOffers topOffers={topOffers} />}
+        </div>
+      </Card.Content>
+    </Card>
+  )
+}


### PR DESCRIPTION
Ticket jira : https://passculture.atlassian.net/browse/PC-40520

Ajouter le module des statistiques à la nouvelle home

Rendu : 
<img width="862" height="573" alt="Capture d’écran 2026-04-13 à 11 03 20" src="https://github.com/user-attachments/assets/f9456a26-6e58-44cd-876a-16d15a96a9f5" />

Responsive : 
<img width="645" height="595" alt="Capture d’écran 2026-04-13 à 11 03 43" src="https://github.com/user-attachments/assets/4b6937ae-2596-4e12-9a26-be0332c6ffe6" />

<img width="242" height="626" alt="Capture d’écran 2026-04-13 à 14 30 02" src="https://github.com/user-attachments/assets/5c554f27-0085-4a59-9f0f-f93319cdd9db" />



