### PR TITLE
PC 41154 Ajouter une entrée libre au choix de l'activité "Autre"

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2247,6 +2247,19 @@ def create_from_onboarding_data(
         venue = create_venue(venue_creation_info, user)
         create_venue_registration(venue.id, new_onboarding_info.target, new_onboarding_info.webPresence)
 
+    # Log the other activity comment if activity is OTHER
+    if onboarding_data.activity.value == offerers_models.Activity.OTHER.value:
+        logger.info(
+            "Other activity comment",
+            extra={
+                "user_id": user.id,
+                "venue_id": venue.id,
+                "is_open_to_public": onboarding_data.is_open_to_public,
+                "user_input": onboarding_data.otherActivityComment,
+            },
+            technical_message_id="venue_creation_with_other_activity",
+        )
+
     # Send welcome email only in the case of offerer creation
     if user_offerer.validationStatus == ValidationStatus.VALIDATED:
         transactional_mails.send_welcome_to_pro_email(user, venue)

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -278,6 +278,7 @@ class CreateOffererBodyModel(HttpBodyModel):
 
 class SaveNewOnboardingDataQueryModel(HttpBodyModel):
     activity: offerers_models.ActivityOpenToPublic | offerers_models.ActivityNotOpenToPublic
+    otherActivityComment: str | None
     address: address_serialize.LocationBodyModelV2
     cultural_domains: list[str] | None = pydantic_v2.Field(min_length=1, default=None)
     create_venue_without_siret: bool = False

--- a/api/src/pcapi/routes/serialization/offerers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offerers_serialize.py
@@ -278,7 +278,7 @@ class CreateOffererBodyModel(HttpBodyModel):
 
 class SaveNewOnboardingDataQueryModel(HttpBodyModel):
     activity: offerers_models.ActivityOpenToPublic | offerers_models.ActivityNotOpenToPublic
-    otherActivityComment: str | None
+    otherActivityComment: str | None = None
     address: address_serialize.LocationBodyModelV2
     cultural_domains: list[str] | None = pydantic_v2.Field(min_length=1, default=None)
     create_venue_without_siret: bool = False

--- a/pro/e2e/signupJourneyCreateNotDiffusibleOfferer.e2e.ts
+++ b/pro/e2e/signupJourneyCreateNotDiffusibleOfferer.e2e.ts
@@ -61,7 +61,7 @@ test.describe('Signup journey with not diffusible offerer siret', () => {
       .click()
     await page.getByText('Théatre').click()
 
-    await page.getByLabel(/Activité principale/).selectOption('Autre')
+    await page.getByLabel(/Activité principale/).selectOption('Festival')
     await page.getByLabel('Numéro de téléphone').fill('612345678')
     await page.getByText('Au grand public').click()
     await page.getByText('Étape suivante').click()

--- a/pro/package.json
+++ b/pro/package.json
@@ -12,6 +12,7 @@
     "build:integration": "VITE_APP_VERSION=$(node -pe 'require(\"./package.json\").version') vite build --mode integration",
     "build:production": "VITE_APP_VERSION=$(node -pe 'require(\"./package.json\").version') vite build --mode production",
     "generate:api:client:local": "./scripts/generate_api_client_local.sh",
+    "generate:api:client:local:next": "./scripts/generate_api_client_local_next.sh",
     "generate:api:client:local:no:docker": "PCAPI_HOST=localhost:5001 ./scripts/generate_api_client_local.sh",
     "generate:api:client:local:no:docker:next": "PCAPI_HOST=localhost:5001 ./scripts/generate_api_client_local_next.sh",
     "lint:js": "biome check --no-errors-on-unmatched",

--- a/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
+++ b/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
@@ -12,6 +12,7 @@ export type SaveNewOnboardingDataQueryModel = {
   createVenueWithoutSiret?: boolean;
   culturalDomains?: (Array<string> | null);
   isOpenToPublic: boolean;
+  otherActivityComment: (string | null);
   phoneNumber?: (string | null);
   publicName?: (string | null);
   siret: string;

--- a/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
+++ b/pro/src/apiClient/v1/models/SaveNewOnboardingDataQueryModel.ts
@@ -12,7 +12,7 @@ export type SaveNewOnboardingDataQueryModel = {
   createVenueWithoutSiret?: boolean;
   culturalDomains?: (Array<string> | null);
   isOpenToPublic: boolean;
-  otherActivityComment: (string | null);
+  otherActivityComment?: (string | null);
   phoneNumber?: (string | null);
   publicName?: (string | null);
   siret: string;

--- a/pro/src/apiClient/v1/new/types.gen.ts
+++ b/pro/src/apiClient/v1/new/types.gen.ts
@@ -5765,6 +5765,10 @@ export type SaveNewOnboardingDataQueryModel = {
      */
     isOpenToPublic: boolean;
     /**
+     * Otheractivitycomment
+     */
+    otherActivityComment: string | null;
+    /**
      * Phonenumber
      */
     phoneNumber?: string | null;

--- a/pro/src/apiClient/v1/new/types.gen.ts
+++ b/pro/src/apiClient/v1/new/types.gen.ts
@@ -5767,7 +5767,7 @@ export type SaveNewOnboardingDataQueryModel = {
     /**
      * Otheractivitycomment
      */
-    otherActivityComment: string | null;
+    otherActivityComment?: string | null;
     /**
      * Phonenumber
      */

--- a/pro/src/commons/context/SignupJourneyContext/constants.ts
+++ b/pro/src/commons/context/SignupJourneyContext/constants.ts
@@ -2,6 +2,7 @@ import type { ActivityContext } from './SignupJourneyContext'
 
 export const DEFAULT_ACTIVITY_VALUES: ActivityContext = {
   activity: undefined,
+  otherActivityComment: undefined,
   socialUrls: [''],
   targetCustomer: undefined,
   phoneNumber: '',

--- a/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -28,6 +28,7 @@ interface SocialUrl {
 
 export interface ActivityFormValues {
   activity?: ActivityOpenToPublicType | ActivityNotOpenToPublicType
+  otherActivityComment: string | undefined
   socialUrls: SocialUrl[]
   targetCustomer: {
     individual: boolean
@@ -92,6 +93,18 @@ export const ActivityForm = (): JSX.Element => {
             required
           />
         </FormLayout.Row>
+
+        {watch('activity') === 'OTHER' && (
+          <FormLayout.Row mdSpaceAfter>
+            <TextInput
+              {...register(`otherActivityComment`)}
+              label="Précisez votre activité"
+              error={formState.errors.otherActivityComment?.message}
+              maxCharactersCount={100}
+              required
+            />
+          </FormLayout.Row>
+        )}
 
         {!isLoadingEducationalDomains && (
           <FormLayout.Row mdSpaceAfter>

--- a/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -28,7 +28,7 @@ interface SocialUrl {
 
 export interface ActivityFormValues {
   activity?: ActivityOpenToPublicType | ActivityNotOpenToPublicType
-  otherActivityComment: string | undefined
+  otherActivityComment?: string
   socialUrls: SocialUrl[]
   targetCustomer: {
     individual: boolean

--- a/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
@@ -245,4 +245,21 @@ describe('screens:SignupJourney::ActivityForm', () => {
     await userEvent.click(screen.getByText(/domaine III/))
     expect(screen.getByLabelText('domaines sélectionnés')).toBeInTheDocument()
   })
+
+  it('should display other activity comment input when activity is OTHER', async () => {
+    renderActivityForm(initialValues, contextValue)
+
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', {
+        name: /Activité principale/,
+      }),
+      'Autre'
+    )
+    const otherActivityCommentInput = screen.queryByLabelText(
+      /Précisez votre activité/
+    )
+    expect(otherActivityCommentInput).toBeInTheDocument()
+    expect(otherActivityCommentInput).toBeRequired()
+    expect(otherActivityCommentInput).toHaveAttribute('maxlength', '100')
+  })
 })

--- a/pro/src/components/SignupJourneyForm/Activity/constants.ts
+++ b/pro/src/components/SignupJourneyForm/Activity/constants.ts
@@ -2,6 +2,7 @@ import type { ActivityFormValues } from '@/components/SignupJourneyForm/Activity
 
 export const defaultActivityFormValues: ActivityFormValues = {
   activity: undefined,
+  otherActivityComment: undefined,
   socialUrls: [{ url: '' }],
   targetCustomer: {
     individual: false,

--- a/pro/src/components/SignupJourneyForm/Activity/validationSchema.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/validationSchema.tsx
@@ -30,6 +30,12 @@ export const validationSchema = (
     activity: activityValidator.required(
       'Veuillez sélectionner une activité principale'
     ),
+    otherActivityComment: yup.string().when('activity', {
+      is: (activity: ActivityOpenToPublicType | ActivityNotOpenToPublicType) =>
+        activity === 'OTHER',
+      then: (schema) =>
+        schema.required('Veuillez préciser votre type d’activité'),
+    }),
     culturalDomains: yup
       .array()
       .of(yup.string().required())

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.spec.tsx
@@ -315,6 +315,7 @@ describe('ValidationScreen', () => {
       await userEvent.click(screen.getByText('Valider et créer ma structure'))
       expect(api.saveNewOnboardingData).toHaveBeenCalledWith({
         activity: 'MUSEUM',
+        otherActivityComment: null,
         culturalDomains: undefined,
         publicName: 'nom public',
         siret: '123123123',
@@ -358,6 +359,7 @@ describe('ValidationScreen', () => {
       expect(api.saveNewOnboardingData).toHaveBeenCalledWith({
         culturalDomains: undefined,
         activity: 'MUSEUM',
+        otherActivityComment: null,
         publicName: null,
         siret: '123123123',
         webPresence: 'url1, url2',
@@ -444,6 +446,50 @@ describe('ValidationScreen', () => {
         'Domaine II',
         'Domaine C',
       ])
+    })
+
+    it('should send other activity comment if activity is OTHER', async () => {
+      if (contextValue.activity) {
+        contextValue.activity.activity = 'OTHER'
+        contextValue.activity.otherActivityComment = 'urbex en pleine nature'
+      }
+      vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
+        offerersNames: [],
+        offerersNamesWithPendingValidation: [],
+      })
+      vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: [] })
+      vi.spyOn(api, 'saveNewOnboardingData').mockResolvedValue(
+        {} as PostOffererResponseModel
+      )
+      vi.spyOn(utils, 'initReCaptchaScript').mockReturnValue({
+        remove: vi.fn(),
+      } as unknown as HTMLScriptElement)
+      vi.spyOn(utils, 'getReCaptchaToken').mockResolvedValue('token')
+      renderValidationScreen(contextValue)
+      await userEvent.click(screen.getByText('Valider et créer ma structure'))
+      expect(api.saveNewOnboardingData).toHaveBeenCalledWith({
+        culturalDomains: undefined,
+        activity: 'OTHER',
+        otherActivityComment: 'urbex en pleine nature',
+        publicName: null,
+        siret: '123123123',
+        webPresence: 'url1, url2',
+        target: Target.EDUCATIONAL,
+        createVenueWithoutSiret: false,
+        address: {
+          street: '3 Rue de Valois',
+          banId: '75118_5995_00043',
+          city: 'Paris',
+          latitude: 0,
+          longitude: 0,
+          postalCode: '75001',
+          inseeCode: '75111',
+          isManualEdition: false,
+        },
+        token: 'token',
+        isOpenToPublic: false,
+        phoneNumber: '',
+      })
     })
   })
 

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
@@ -131,6 +131,7 @@ export const Validation = (): JSX.Element | undefined => {
         activity: activity.activity as
           | ActivityOpenToPublic
           | ActivityNotOpenToPublic,
+        otherActivityComment: activity.otherActivityComment || null,
         webPresence: activity.socialUrls.join(', '),
         target:
           /* istanbul ignore next: the form validation already handles this */
@@ -254,7 +255,11 @@ export const Validation = (): JSX.Element | undefined => {
           />
         </div>
         <div className={styles['data-displaying']}>
-          <div className={styles['data-line']}>{activityLabel}</div>
+          <div className={styles['data-line']}>
+            {activityLabel}
+            {activity.activity === 'OTHER' &&
+              ` : ${activity.otherActivityComment}`}
+          </div>
           {(activity.culturalDomains ?? []).length > 0 && (
             <div className={styles['data-line']}>
               {activity.culturalDomains?.join(', ')}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41154)

Lorsqu'on choisit "Autre" pour l'activité principale, un champs texte libre apparaît.

<img width="420"  alt="image" src="https://github.com/user-attachments/assets/34060828-efb7-46fd-9774-bd5eab3394c2" />

----
**Règles de gestion :**
- Champ libre de type texte, limité à 100 caractères
- Obligatoire lorsque l’activité est “Autre”
- Envoyé au backend sous le nom de `otherActivityComment` à la validation de l’inscription de structure
- Champ non obligatoire au niveau de l’API
- Valeur non enregistrée en base de données, logguée en backend lors de la création de la Venue dans une trace destinée à la data (`technical_message_id` = `venue_creation_with_other_activity`)