### PR TITLE
(PC-41246)[PRO] fix: `document.body` may be null.

### DIFF
--- a/pro/src/ui-kit/Tooltip/Tooltip.tsx
+++ b/pro/src/ui-kit/Tooltip/Tooltip.tsx
@@ -55,13 +55,15 @@ export function Tooltip({ children, content, className }: TooltipProps) {
   const tooltipContentRect = panelRef.current?.getBoundingClientRect()
 
   //  Prevent the panel from being outlide the screen
-  const offsetLeft = tooltipContentRect
-    ? tooltipContentWidth + tooltipContentRect.x > document.body.clientWidth
-      ? document.body.clientWidth - tooltipContentWidth - tooltipContentRect.x
-      : tooltipContentRect.x < 0
-        ? -tooltipContentRect.x
-        : 0
-    : 0
+  const offsetLeft =
+    // document.body may be null in some rare cases.
+    tooltipContentRect && document.body
+      ? tooltipContentWidth + tooltipContentRect.x > document.body.clientWidth
+        ? document.body.clientWidth - tooltipContentWidth - tooltipContentRect.x
+        : tooltipContentRect.x < 0
+          ? -tooltipContentRect.x
+          : 0
+      : 0
 
   //  Position the tooltip above its trigger
   const offsetTop = tooltipContentRect ? -tooltipContentRect.height : 0


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41246)

Correction d'une erreur sentry où `document.body` est `null`.