### PR TITLE
Revert "(PC-41119)[PRO] feat: Give the ability to skip the onboarding (only for the session)"

### DIFF
--- a/pro/e2e/didacticOnboarding.e2e.ts
+++ b/pro/e2e/didacticOnboarding.e2e.ts
@@ -30,28 +30,6 @@ test.describe('Didactic Onboarding feature', () => {
     ).toBeVisible()
   })
 
-  test('I should be able to skip the onboarding', async ({
-    authenticatedPage: page,
-  }) => {
-    // Should not be able to go to home page
-    await page.goto('/accueil')
-    await expect(
-      page.getByText('Où souhaitez-vous diffuser votre première offre ?')
-    ).toBeVisible()
-
-    await page.pause()
-    await page.getByRole('button', { name: 'Je le ferai plus tard' }).click()
-    await expect(
-      page.getByText('Bienvenue sur votre espace partenaire')
-    ).toBeVisible()
-
-    // I should be able to navigate without being redirected to onboarding
-    await page.getByRole('link', { name: 'Réservations' }).click()
-    await expect(
-      page.getByRole('heading', { name: 'Réservations individuelles' })
-    ).toBeVisible()
-  })
-
   test('I should not be able to onboard me by submitting an Adage referencing file if I don’t have an Adage ID', async ({
     authenticatedPage: page,
   }) => {

--- a/pro/src/app/AppRouter/AppRouterGuard.tsx
+++ b/pro/src/app/AppRouter/AppRouterGuard.tsx
@@ -3,7 +3,6 @@ import { Navigate, useLocation, useSearchParams } from 'react-router'
 
 import { findCurrentRoute } from '@/app/AppRouter/findCurrentRoute'
 import { useAppSelector } from '@/commons/hooks/useAppSelector'
-import { COOKIES } from '@/commons/utils/localStorageManager'
 
 type AppRouterGuardProps = {
   children: ReactNode
@@ -54,7 +53,6 @@ export const AppRouterGuard = memo(({ children }: AppRouterGuardProps) => {
       return <Navigate to="/rattachement-en-cours" replace />
     } else if (
       userAccess === 'no-onboarding' &&
-      !document.cookie.includes(COOKIES.DID_SKIP_ONBOARDING) &&
       !currentRoute?.meta?.onboardingOnly &&
       !currentRoute?.meta?.canBeOnboarding &&
       !location.pathname.startsWith('/inscription')

--- a/pro/src/app/AppRouter/__specs__/utils.spec.ts
+++ b/pro/src/app/AppRouter/__specs__/utils.spec.ts
@@ -2,13 +2,11 @@ import type { FeatureResponseModel } from '@/apiClient/v1'
 import type { UserPermissions } from '@/commons/auth/types'
 import * as storeModule from '@/commons/store/store'
 import { configureTestStore } from '@/commons/store/testUtils'
-import { COOKIES } from '@/commons/utils/localStorageManager'
 
 import {
   isNewHomepageEnabled,
   isSwitchVenueEnabled,
   mustBeAuthenticated,
-  mustBeOnboardedOrSkipped,
   mustBeOnboardedWithSelectedPartnerVenue,
   mustBeUnauthenticated,
   mustHaveSelectedAdminOfferer,
@@ -26,9 +24,6 @@ const makeUserPermissions = (
   ...overrides,
 })
 
-function mockCookie(value: string) {
-  Object.defineProperty(document, 'cookie', { writable: true, value })
-}
 describe('utils', () => {
   describe('mustBeAuthenticated', () => {
     it('should return true when user is authenticated', () => {
@@ -58,37 +53,6 @@ describe('utils', () => {
     })
   })
 
-  describe('mustBeOnboardedOrSkipped', () => {
-    it('should return true when user is onboarded whatever the sessions storage value is', () => {
-      mockCookie('')
-      const permissions = makeUserPermissions({
-        isOnboarded: true,
-      })
-      expect(mustBeOnboardedOrSkipped(permissions)).toBe(true)
-
-      mockCookie(`${COOKIES.DID_SKIP_ONBOARDING}=true`)
-      expect(mustBeOnboardedOrSkipped(permissions)).toBe(true)
-    })
-
-    it('should return false when user is not onboarded with no cookie', () => {
-      mockCookie('')
-      const permissions = makeUserPermissions({
-        isOnboarded: false,
-      })
-
-      expect(mustBeOnboardedOrSkipped(permissions)).toBe(false)
-    })
-
-    it('should return true when user is not onboarded with the cookie set', () => {
-      mockCookie(`${COOKIES.DID_SKIP_ONBOARDING}=true`)
-      const permissions = makeUserPermissions({
-        isOnboarded: false,
-      })
-
-      expect(mustBeOnboardedOrSkipped(permissions)).toBe(true)
-    })
-  })
-
   describe('mustBeOnboardedWithSelectedPartnerVenue', () => {
     it('should return true when user is authenticated, onboarded, and has associated venue', () => {
       const permissions = makeUserPermissions({
@@ -111,7 +75,6 @@ describe('utils', () => {
     })
 
     it('should return false when user is not onboarded', () => {
-      mockCookie('')
       const permissions = makeUserPermissions({
         isAuthenticated: true,
         isOnboarded: false,

--- a/pro/src/app/AppRouter/utils.ts
+++ b/pro/src/app/AppRouter/utils.ts
@@ -1,7 +1,6 @@
 import type { UserPermissions } from '@/commons/auth/types'
 import { isFeatureActive } from '@/commons/store/features/selectors'
 import { rootStore } from '@/commons/store/store'
-import { COOKIES } from '@/commons/utils/localStorageManager'
 
 export const mustBeAuthenticated = (userPermissions: UserPermissions) =>
   userPermissions.isAuthenticated
@@ -9,15 +8,10 @@ export const mustBeAuthenticated = (userPermissions: UserPermissions) =>
 export const mustBeUnauthenticated = (userPermissions: UserPermissions) =>
   !userPermissions.isAuthenticated
 
-export const mustBeOnboardedOrSkipped = (userPermissions: UserPermissions) =>
-  userPermissions.isOnboarded ||
-  document.cookie.includes(COOKIES.DID_SKIP_ONBOARDING)
-
 export const mustBeOnboardedWithSelectedPartnerVenue = (
   userPermissions: UserPermissions
 ) =>
-  mustHaveSelectedPartnerVenue(userPermissions) &&
-  mustBeOnboardedOrSkipped(userPermissions)
+  mustHaveSelectedPartnerVenue(userPermissions) && userPermissions.isOnboarded
 
 export const mustHaveSelectedPartnerVenue = (
   userPermissions: UserPermissions

--- a/pro/src/commons/utils/localStorageManager.ts
+++ b/pro/src/commons/utils/localStorageManager.ts
@@ -18,10 +18,6 @@ export enum LOCAL_STORAGE_KEY {
   SELECTED_OFFERER_ID = 'homepageSelectedOffererId',
 }
 
-export enum COOKIES {
-  DID_SKIP_ONBOARDING = 'DID_SKIP_ONBOARDING',
-}
-
 export const PASS_CULTURE_PREFIX = 'PASS_CULTURE_'
 
 /**

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.module.scss
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.module.scss
@@ -10,9 +10,3 @@
 .card-description-highlight {
   color: var(--color-text-brand-primary);
 }
-
-.skip-link-wrapper {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-}

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.spec.tsx
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.spec.tsx
@@ -10,11 +10,6 @@ import { renderWithProviders } from '@/commons/utils/renderWithProviders'
 import { OnboardingOffersChoice } from './OnboardingOffersChoice'
 
 const mockLogEvent = vi.fn()
-const mockNavigate = vi.fn()
-vi.mock('react-router', async () => ({
-  ...(await vi.importActual('react-router')),
-  useNavigate: () => mockNavigate,
-}))
 
 describe('OnboardingOffersChoice Component', () => {
   beforeEach(() => {
@@ -87,12 +82,5 @@ describe('OnboardingOffersChoice Component', () => {
         )
       })
     })
-  })
-
-  it('should handle skip link', async () => {
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Je le ferai plus tard' })
-    )
-    expect(mockNavigate).toHaveBeenCalledWith('/accueil')
   })
 })

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
@@ -1,18 +1,10 @@
-import { addDays } from 'date-fns'
 import { useState } from 'react'
-import { useNavigate } from 'react-router'
 
 import { useAnalytics } from '@/app/App/analytics/firebase'
 import { OnboardingDidacticEvents } from '@/commons/core/FirebaseEvents/constants'
 import { NBSP } from '@/commons/core/shared/constants'
-import { COOKIES } from '@/commons/utils/localStorageManager'
 import { Button } from '@/design-system/Button/Button'
-import {
-  ButtonColor,
-  ButtonVariant,
-  IconPositionEnum,
-} from '@/design-system/Button/types'
-import fullNextIcon from '@/icons/full-next.svg'
+import { ButtonVariant } from '@/design-system/Button/types'
 import { Card } from '@/ui-kit/Card/Card'
 import { Dialog } from '@/ui-kit/Dialog/Dialog'
 
@@ -24,95 +16,74 @@ import styles from './OnboardingOffersChoice.module.scss'
 export const OnboardingOffersChoice = () => {
   const [showModal, setShowModal] = useState(false)
   const { logEvent } = useAnalytics()
-  const navigate = useNavigate()
 
   return (
-    <>
-      <div className={styles['card-container']}>
-        <Card>
-          <Card.Image src={individuelle} alt="" />
-          <Card.Header
-            title="Sur l’application mobile à destination des jeunes"
-            titleTag="h3"
-          />
-          <Card.Content>
-            <span>
-              Vos offres seront visibles par{' '}
-              <strong className={styles['card-description-highlight']}>
-                + de 4 millions de jeunes
-              </strong>
-              {NBSP}
-              inscrits sur l’application mobile pass Culture.
-            </span>
-          </Card.Content>
-          <Card.Footer>
-            <Button
-              as="a"
-              variant={ButtonVariant.PRIMARY}
-              to="/onboarding/individuel"
-              aria-label="Commencer la création d’offre sur l’application mobile"
-              fullWidth
-              label="Commencer"
-            />
-          </Card.Footer>
-        </Card>
-
-        <Card>
-          <Card.Image src={collective} alt="" />
-          <Card.Header title="Sur ADAGE à destination des enseignants" />
-          <Card.Content>
-            <span>
-              Vos offres seront visibles{' '}
-              <strong className={styles['card-description-highlight']}>
-                par tous les enseignants
-              </strong>{' '}
-              des collèges et lycées publics et privés sous contrat.
-            </span>
-          </Card.Content>
-          <Card.Footer>
-            <Dialog
-              title=""
-              onCancel={() => setShowModal(false)}
-              hideIcon={true}
-              trigger={
-                <Button
-                  type="submit"
-                  aria-label="Commencer la création d’offre sur ADAGE"
-                  onClick={() => {
-                    logEvent(
-                      OnboardingDidacticEvents.HAS_CLICKED_START_COLLECTIVE_DIDACTIC_ONBOARDING
-                    )
-                    setShowModal(true)
-                  }}
-                  fullWidth
-                  label="Commencer"
-                />
-              }
-              open={showModal}
-            >
-              <OnboardingCollectiveModal />
-            </Dialog>
-          </Card.Footer>
-        </Card>
-      </div>
-      <div className={styles['skip-link-wrapper']}>
-        <Button
-          variant={ButtonVariant.TERTIARY}
-          color={ButtonColor.NEUTRAL}
-          icon={fullNextIcon}
-          iconPosition={IconPositionEnum.RIGHT}
-          label="Je le ferai plus tard"
-          onClick={() => {
-            const tomorrow = addDays(new Date(), 1)
-            // biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API is only available on firefox as of 2025-06-24
-            document.cookie = `${COOKIES.DID_SKIP_ONBOARDING}=true; expires=${tomorrow.toUTCString()}; path=/;`
-
-            setTimeout(() => {
-              navigate('/accueil')
-            })
-          }}
+    <div className={styles['card-container']}>
+      <Card>
+        <Card.Image src={individuelle} alt="" />
+        <Card.Header
+          title="Sur l’application mobile à destination des jeunes"
+          titleTag="h3"
         />
-      </div>
-    </>
+        <Card.Content>
+          <span>
+            Vos offres seront visibles par{' '}
+            <strong className={styles['card-description-highlight']}>
+              + de 4 millions de jeunes
+            </strong>
+            {NBSP}
+            inscrits sur l’application mobile pass Culture.
+          </span>
+        </Card.Content>
+        <Card.Footer>
+          <Button
+            as="a"
+            variant={ButtonVariant.PRIMARY}
+            to="/onboarding/individuel"
+            aria-label="Commencer la création d’offre sur l’application mobile"
+            fullWidth
+            label="Commencer"
+          />
+        </Card.Footer>
+      </Card>
+
+      <Card>
+        <Card.Image src={collective} alt="" />
+        <Card.Header title="Sur ADAGE à destination des enseignants" />
+        <Card.Content>
+          <span>
+            Vos offres seront visibles{' '}
+            <strong className={styles['card-description-highlight']}>
+              par tous les enseignants
+            </strong>{' '}
+            des collèges et lycées publics et privés sous contrat.
+          </span>
+        </Card.Content>
+        <Card.Footer>
+          <Dialog
+            title=""
+            onCancel={() => setShowModal(false)}
+            hideIcon={true}
+            trigger={
+              <Button
+                type="submit"
+                aria-label="Commencer la création d’offre sur ADAGE"
+                onClick={() => {
+                  logEvent(
+                    OnboardingDidacticEvents.HAS_CLICKED_START_COLLECTIVE_DIDACTIC_ONBOARDING
+                  )
+                  setShowModal(true)
+                }}
+                fullWidth
+                label="Commencer"
+              />
+            }
+            open={showModal}
+          >
+            <OnboardingCollectiveModal />
+          </Dialog>
+        </Card.Footer>
+      </Card>
+    </div>
   )
 }


### PR DESCRIPTION
Revert de efd61bcda8c2ee8baf8127bc0635cfed70a562ce pour faciliter des déploiements côté EAC et réappliquer le fonctionnalité après activation de la nouvelle page d'accueil