### PR TITLE
(PC-41229)[API] fix: allow 18 yo id check when 17 yo

### DIFF
--- a/api/src/pcapi/core/subscription/models.py
+++ b/api/src/pcapi/core/subscription/models.py
@@ -6,7 +6,6 @@ import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 from sqlalchemy.dialects import postgresql
 
-from pcapi.core.users import constants as users_constants
 from pcapi.core.users import models as users_models
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
@@ -308,10 +307,6 @@ class BeneficiaryFraudCheck(PcObject, Model):
             self.type in (FraudCheckType.UBBLE, FraudCheckType.DMS)
             and self.status == FraudCheckStatus.OK
             and self.eligibilityType in [users_models.EligibilityType.UNDERAGE, users_models.EligibilityType.AGE17_18]
-            and (
-                self.user.has_beneficiary_role
-                or (self.user.age is not None and self.user.age >= users_constants.ELIGIBILITY_AGE_18)
-            )
         )
 
 

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -2496,6 +2496,28 @@ class ActivateBeneficiaryIfNoMissingStepTest:
 
         assert len(mock_activate_beneficiary.mock_calls) == 3
 
+    def test_activation_on_getting_younger_at_id_check(self):
+        last_year = datetime.now(tz=None) - relativedelta(years=1)
+        with time_machine.travel(last_year):
+            # user first completed their profile at 17, declaring they were 18
+            user = users_factories.ProfileCompletedUserFactory(age=17)
+        # user starts the second subscription process
+        subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
+        # but user is actually 17
+        seventeen_years_ago = datetime.now(tz=None) - relativedelta(years=17, months=1)
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            user=user,
+            type=subscription_models.FraudCheckType.UBBLE,
+            status=subscription_models.FraudCheckStatus.OK,
+            resultContent=subscription_factories.UbbleContentFactory(birth_date=seventeen_years_ago.date().isoformat()),
+        )
+        user.validatedBirthDate = seventeen_years_ago.date()
+        subscription_factories.HonorStatementFraudCheckFactory(user=user)
+
+        is_user_activated = subscription_api.activate_beneficiary_if_no_missing_step(user)
+
+        assert is_user_activated
+
 
 @pytest.mark.usefixtures("db_session")
 class HasCompletedProfileTest:


### PR DESCRIPTION
Sometimes the user (or Educonnect) get their birth date wrong by a year in the past, making us think that they are 18 yo instead of 17 yo. In such cases, we must be able to tell that the id check they "did at 18" is also valid for the 17 yo subscription process.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41229)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
