### PR TITLE
(PC-41273)[API] refactor: improve booking ticket logic

### DIFF
--- a/api/src/pcapi/routes/native/v2/serialization/bookings.py
+++ b/api/src/pcapi/routes/native/v2/serialization/bookings.py
@@ -32,13 +32,15 @@ class OfferImageV2(HttpBodyModel):
 
 
 class TicketDisplayEnum(enum.Enum):
+    CINEMA_VOUCHER = "cinema_voucher"
     EMAIL_SENT = "email_sent"
     EMAIL_WILL_BE_SENT = "email_will_be_sent"
+    EXTERNAL_TICKET = "external_ticket"
+    HIDDEN_EXTERNAL_TICKET = "hidden_external_ticket"
+    NO_TICKET = "no_ticket"
     ONLINE_CODE = "online_code"
-    NOT_VISIBLE = "not_visible"
-    QR_CODE = "qr_code"
-    VOUCHER = "voucher"
     TICKET = "ticket"
+    VOUCHER = "voucher"
 
 
 class BookingVenueAddressResponseV2(HttpBodyModel):
@@ -220,6 +222,16 @@ def get_ticket_infos(booking: bookings_models.Booking) -> TicketResponse:
         delay=offer.withdrawalDelay,
     )
 
+    if offer.withdrawalType == WithdrawalTypeEnum.NO_TICKET:
+        return TicketResponse(
+            activation_code=None,
+            external_booking=None,
+            display=TicketDisplayEnum.NO_TICKET,
+            token=None,
+            voucher=None,
+            withdrawal=withdrawal,
+        )
+
     if offer.withdrawalType == WithdrawalTypeEnum.BY_EMAIL:
         return TicketResponse(
             activation_code=None,
@@ -254,7 +266,7 @@ def get_ticket_infos(booking: bookings_models.Booking) -> TicketResponse:
                 if booking_visible
                 else None
             ),
-            display=TicketDisplayEnum.QR_CODE if booking_visible else TicketDisplayEnum.NOT_VISIBLE,
+            display=TicketDisplayEnum.EXTERNAL_TICKET if booking_visible else TicketDisplayEnum.HIDDEN_EXTERNAL_TICKET,
             token=None,
             voucher=None,
             withdrawal=withdrawal,
@@ -269,7 +281,7 @@ def get_ticket_infos(booking: bookings_models.Booking) -> TicketResponse:
     token = TokenResponse(data=booking.token) if not booking.isExternal else None
     display = TicketDisplayEnum.VOUCHER if voucher else TicketDisplayEnum.TICKET
     if offer.subcategoryId == SEANCE_CINE.id:
-        display = TicketDisplayEnum.QR_CODE
+        display = TicketDisplayEnum.CINEMA_VOUCHER
 
     return TicketResponse(
         activation_code=None,

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -8007,13 +8007,15 @@
             },
             "TicketDisplayEnum": {
                 "enum": [
+                    "cinema_voucher",
                     "email_sent",
                     "email_will_be_sent",
+                    "external_ticket",
+                    "hidden_external_ticket",
+                    "no_ticket",
                     "online_code",
-                    "not_visible",
-                    "qr_code",
-                    "voucher",
-                    "ticket"
+                    "ticket",
+                    "voucher"
                 ],
                 "title": "TicketDisplayEnum",
                 "type": "string"

--- a/api/tests/routes/native/v2/bookings_test.py
+++ b/api/tests/routes/native/v2/bookings_test.py
@@ -993,45 +993,21 @@ class GetBookingTicketTest:
         assert ticket["withdrawal"]["type"] == "on_site"
         assert ticket["withdrawal"]["delay"] == 60 * 30
 
-    def test_get_booking_no_ticket(self, client):
-        user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
-        booking = booking_factories.BookingFactory(
-            user=user,
-            stock__offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
-            stock__offer__withdrawalType=offer_models.WithdrawalTypeEnum.NO_TICKET,
-        )
-
-        client.with_token(user)
-        with assert_num_queries(2):  # user + booking
-            response = client.get("/native/v2/bookings")
-            assert response.status_code == 200
-
-        ticket = response.json["ongoingBookings"][0]["ticket"]
-        assert ticket["display"] == "voucher"
-        assert ticket["voucher"] == {"data": f"PASSCULTURE:v3;TOKEN:{booking.token}"}
-        assert ticket["token"] == {
-            "data": booking.token,
-        }
-        assert ticket["activationCode"] is None
-
     def test_get_booking_event_no_ticket(self, client):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
         booking = booking_factories.BookingFactory(
             user=user,
-            stock__offer__subcategoryId=subcategories.VISITE_GUIDEE.id,
+            stock__offer__subcategoryId=subcategories.CONCERT.id,
             stock__offer__withdrawalType=offer_models.WithdrawalTypeEnum.NO_TICKET,
         )
 
         client.with_token(user)
-        with assert_num_queries(2):  # user + booking
-            response = client.get("/native/v2/bookings")
-            assert response.status_code == 200
+        response = client.get(f"/native/v2/bookings/{booking.id}")
+        assert response.status_code == 200
 
-        ticket = response.json["ongoingBookings"][0]["ticket"]
-        assert ticket["display"] == "ticket"
-        assert ticket["token"] == {
-            "data": booking.token,
-        }
+        ticket = response.json["ticket"]
+        assert ticket["display"] == "no_ticket"
+        assert ticket["token"] is None
         assert ticket["voucher"] is None
         assert ticket["activationCode"] is None
 
@@ -1043,8 +1019,9 @@ class GetBookingTicketTest:
         )
 
         client.with_token(user)
-        response = client.get(f"/native/v2/bookings/{booking.id}")
-        assert response.status_code == 200
+        with assert_num_queries(3):  # user + bookings + booking
+            response = client.get(f"/native/v2/bookings/{booking.id}")
+            assert response.status_code == 200
 
         ticket = response.json["ticket"]
         assert ticket["display"] == "voucher"
@@ -1150,30 +1127,16 @@ class GetBookingTicketTest:
         assert ticket["display"] == "voucher"
 
     @pytest.mark.parametrize(
-        "subcategory,withdrawal_type,voucher,display",
+        "subcategory,withdrawal_type",
         [
-            (subcategories.CONCERT.id, offer_models.WithdrawalTypeEnum.ON_SITE, False, "ticket"),
+            (subcategories.CONCERT.id, offer_models.WithdrawalTypeEnum.ON_SITE),
             (
                 subcategories.EVENEMENT_CINE.id,
                 offer_models.WithdrawalTypeEnum.ON_SITE,
-                False,
-                "ticket",
-            ),
-            (
-                subcategories.SEANCE_CINE.id,
-                offer_models.WithdrawalTypeEnum.ON_SITE,
-                True,
-                "qr_code",
-            ),
-            (
-                subcategories.FESTIVAL_MUSIQUE.id,
-                offer_models.WithdrawalTypeEnum.ON_SITE,
-                False,
-                "ticket",
             ),
         ],
     )
-    def test_get_internal_event_ticket(self, client, subcategory, withdrawal_type, voucher, display):
+    def test_get_internal_event_ticket(self, client, subcategory, withdrawal_type):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
         booking = booking_factories.BookingFactory(
             user=user,
@@ -1182,19 +1145,35 @@ class GetBookingTicketTest:
         )
 
         client.with_token(user)
-        with assert_num_queries(2):  # user + booking
-            response = client.get("/native/v2/bookings")
+        with assert_num_queries(3):  # user + bookings + booking
+            response = client.get(f"/native/v2/bookings/{booking.id}")
             assert response.status_code == 200
 
-        ticket = response.json["ongoingBookings"][0]["ticket"]
-        if voucher:
-            assert ticket["voucher"] == {"data": f"PASSCULTURE:v3;TOKEN:{booking.token}"}
-        else:
-            assert ticket["voucher"] == None
+        ticket = response.json["ticket"]
+
+        assert ticket["voucher"] is None
         assert ticket["token"] == {
             "data": booking.token,
         }
-        assert ticket["display"] == display
+        assert ticket["display"] == "ticket"
+
+    def test_get_physical_event_no_ticket(self, client):
+        user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
+        booking = booking_factories.BookingFactory(
+            user=user,
+            stock__offer__subcategoryId=subcategories.CONCERT.id,
+            stock__offer__withdrawalType=offer_models.WithdrawalTypeEnum.NO_TICKET,
+        )
+
+        client.with_token(user)
+        with assert_num_queries(3):  # user + bookings + booking
+            response = client.get(f"/native/v2/bookings/{booking.id}")
+            assert response.status_code == 200
+
+        ticket = response.json["ticket"]
+        assert ticket["token"] == None
+        assert ticket["voucher"] == None
+        assert ticket["display"] == "no_ticket"
 
     @pytest.mark.features(ENABLE_CDS_IMPLEMENTATION=True)
     def test_get_external_event_ticket_visible(self, client):
@@ -1215,11 +1194,11 @@ class GetBookingTicketTest:
         ExternalBookingFactory(booking=booking, barcode="111111112", seat="A_2")
 
         client.with_token(user)
-        with assert_num_queries(2):  # user + booking
-            response = client.get("/native/v2/bookings")
+        with assert_num_queries(3):  # user + bookings + booking
+            response = client.get(f"/native/v2/bookings/{booking.id}")
             assert response.status_code == 200
 
-        ticket = response.json["ongoingBookings"][0]["ticket"]
+        ticket = response.json["ticket"]
         response_data = sorted(ticket["externalBooking"]["data"], key=lambda x: x["seat"])
         assert response_data == [
             {"barcode": "111111111", "seat": "A_1"},
@@ -1228,7 +1207,7 @@ class GetBookingTicketTest:
 
         assert ticket["token"] is None
         assert ticket["voucher"] is None
-        assert ticket["display"] == "qr_code"
+        assert ticket["display"] == "external_ticket"
 
     @pytest.mark.features(ENABLE_CDS_IMPLEMENTATION=True)
     def test_get_external_event_ticket_hidden(self, client):
@@ -1249,15 +1228,34 @@ class GetBookingTicketTest:
         ExternalBookingFactory(booking=booking, barcode="111111112", seat="A_2")
 
         client.with_token(user)
-        with assert_num_queries(2):  # user + booking
-            response = client.get("/native/v2/bookings")
+        with assert_num_queries(3):  # user + bookings + booking
+            response = client.get(f"/native/v2/bookings/{booking.id}")
             assert response.status_code == 200
 
-        ticket = response.json["ongoingBookings"][0]["ticket"]
+        ticket = response.json["ticket"]
         assert ticket["externalBooking"] == {
             "data": None,
         }
 
         assert ticket["token"] is None
         assert ticket["voucher"] is None
-        assert ticket["display"] == "not_visible"
+        assert ticket["display"] == "hidden_external_ticket"
+
+    def test_get_cinema_voucher(self, client):
+        user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
+        booking = booking_factories.BookingFactory(
+            user=user,
+            stock__offer__subcategoryId=subcategories.SEANCE_CINE.id,
+        )
+
+        client.with_token(user)
+        with assert_num_queries(3):  # user + bookings + booking
+            response = client.get(f"/native/v2/bookings/{booking.id}")
+            assert response.status_code == 200
+
+        ticket = response.json["ticket"]
+        assert ticket["token"] == {
+            "data": booking.token,
+        }
+        assert ticket["voucher"] == {"data": f"PASSCULTURE:v3;TOKEN:{booking.token}"}
+        assert ticket["display"] == "cinema_voucher"

--- a/api/tests/routes/native/v2/bookings_test.py
+++ b/api/tests/routes/native/v2/bookings_test.py
@@ -1002,8 +1002,9 @@ class GetBookingTicketTest:
         )
 
         client.with_token(user)
-        response = client.get(f"/native/v2/bookings/{booking.id}")
-        assert response.status_code == 200
+        with assert_num_queries(3):  # user + bookings + booking
+            response = client.get(f"/native/v2/bookings/{booking.id}")
+            assert response.status_code == 200
 
         ticket = response.json["ticket"]
         assert ticket["display"] == "no_ticket"
@@ -1041,7 +1042,7 @@ class GetBookingTicketTest:
     def test_get_booking_ticket_by_email(self, client, withdrawal_delay, delta, display):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
         beginningDatetime = date_utils.get_naive_utc_now() + timedelta(days=delta)
-        booking_factories.BookingFactory(
+        booking = booking_factories.BookingFactory(
             user=user,
             stock__offer__subcategoryId=subcategories.CONCERT.id,
             stock__offer__withdrawalType=offer_models.WithdrawalTypeEnum.BY_EMAIL,
@@ -1050,11 +1051,11 @@ class GetBookingTicketTest:
         )
 
         client.with_token(user)
-        with assert_num_queries(2):  # user + booking
-            response = client.get("/native/v2/bookings")
+        with assert_num_queries(3):  # user + bookings + booking
+            response = client.get(f"/native/v2/bookings/{booking.id}")
             assert response.status_code == 200
 
-        ticket = response.json["ongoingBookings"][0]["ticket"]
+        ticket = response.json["ticket"]
         assert ticket["token"] is None
         assert ticket["voucher"] is None
         assert ticket["display"] == display
@@ -1063,22 +1064,21 @@ class GetBookingTicketTest:
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
 
         digital_stock = offers_factories.StockWithActivationCodesFactory()
-        booking_factories.BookingFactory(
+        booking = booking_factories.BookingFactory(
             user=user,
             stock=digital_stock,
             activationCode=digital_stock.activationCodes[0],
         )
 
         client.with_token(user)
-        with assert_num_queries(2):  # user + booking
-            response = client.get("/native/v2/bookings")
+        with assert_num_queries(3):  # user + bookings + booking
+            response = client.get(f"/native/v2/bookings/{booking.id}")
             assert response.status_code == 200
 
-        ticket = response.json["ongoingBookings"][0]["ticket"]
+        ticket = response.json["ticket"]
         assert ticket["token"] is None
         assert ticket["voucher"] is None
-        booking_id = response.json["ongoingBookings"][0]["id"]
-        booking_activation_code = next(code for code in digital_stock.activationCodes if code.bookingId == booking_id)
+        booking_activation_code = next(code for code in digital_stock.activationCodes if code.bookingId == booking.id)
         assert ticket["activationCode"] == {
             "code": booking_activation_code.code,
             "expirationDate": None,
@@ -1126,22 +1126,12 @@ class GetBookingTicketTest:
         assert ticket["voucher"] == {"data": f"PASSCULTURE:v3;TOKEN:{booking.token}"}
         assert ticket["display"] == "voucher"
 
-    @pytest.mark.parametrize(
-        "subcategory,withdrawal_type",
-        [
-            (subcategories.CONCERT.id, offer_models.WithdrawalTypeEnum.ON_SITE),
-            (
-                subcategories.EVENEMENT_CINE.id,
-                offer_models.WithdrawalTypeEnum.ON_SITE,
-            ),
-        ],
-    )
-    def test_get_internal_event_ticket(self, client, subcategory, withdrawal_type):
+    def test_get_internal_event_ticket(self, client):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
         booking = booking_factories.BookingFactory(
             user=user,
-            stock__offer__subcategoryId=subcategory,
-            stock__offer__withdrawalType=withdrawal_type,
+            stock__offer__subcategoryId=subcategories.CONCERT.id,
+            stock__offer__withdrawalType=offer_models.WithdrawalTypeEnum.ON_SITE,
         )
 
         client.with_token(user)
@@ -1171,8 +1161,8 @@ class GetBookingTicketTest:
             assert response.status_code == 200
 
         ticket = response.json["ticket"]
-        assert ticket["token"] == None
-        assert ticket["voucher"] == None
+        assert ticket["token"] is None
+        assert ticket["voucher"] is None
         assert ticket["display"] == "no_ticket"
 
     @pytest.mark.features(ENABLE_CDS_IMPLEMENTATION=True)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41273)

Modification de l'enum `TicketDisplayEnum` pour passer plus de logique d'affichage des tickets d'une resa dans le back
A part `EMAIL_SENT` / `EMAIL_SENT_WILL_BE_SENT` et `NO_TICKET`, aucune valeur de cette enum n'était utilisé jusqu'à présent dans le front natif.

Testé sans modification dans le front et avec les modifications prenant en compte ces ajustements

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
