### PR TITLE
(PC-41265)[API] feat:migrate: add new venue.validationStatus column

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-4c0c60c2ab7d (pre) (head)
+5566d8393bb3 (pre) (head)
 b69574766fe3 (post) (head)

--- a/api/src/pcapi/alembic/versions/20260415T232939_5566d8393bb3_add_nullable_validation_status_to_venue.py
+++ b/api/src/pcapi/alembic/versions/20260415T232939_5566d8393bb3_add_nullable_validation_status_to_venue.py
@@ -1,0 +1,23 @@
+"""add nullable validationStatus to venue"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from pcapi.core.offerers.models import ValidationStatus
+from pcapi.utils.db import MagicEnum
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "5566d8393bb3"
+down_revision = "4c0c60c2ab7d"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("venue", sa.Column("validationStatus", MagicEnum(ValidationStatus), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("venue", "validationStatus")

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -467,6 +467,14 @@ def create_venue(
 
     data = venue_data.model_dump(by_alias=True)
     data["dmsToken"] = dms_token
+    data["validationStatus"] = (
+        db.session.query(models.Offerer)
+        .filter(models.Offerer.id == venue_data.managing_offerer_id)
+        .options(sa_orm.load_only(models.Offerer.validationStatus))
+        .one()
+        .validationStatus
+    )
+
     if not data["publicName"]:
         data["publicName"] = data["name"]
     if venue.is_soft_deleted():

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -44,6 +44,7 @@ from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.has_thumb_mixin import HasThumbMixin
 from pcapi.models.pc_object import PcObject
 from pcapi.models.soft_deletable_mixin import SoftDeletableMixin
+from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.models.validation_status_mixin import ValidationStatusMixin
 from pcapi.utils import crypto
 from pcapi.utils import date as date_utils
@@ -301,9 +302,16 @@ DisplayableActivity: enum.EnumType = enum.Enum(  # type: ignore[misc]
 )
 
 
-class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMixin):
+class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMixin, ValidationStatusMixin):
     __tablename__ = "venue"
     thumb_path_component = "venues"
+
+    # TODO(jbaudet - 04/2026): this overrides `ValidationStatusMixin`
+    # column definition: column is now nullable, and should be removed
+    # once the column has been filled with expected values.
+    validationStatus: sa_orm.Mapped[ValidationStatus | None] = sa_orm.mapped_column(  # type: ignore[assignment]
+        sa.Enum(ValidationStatus, create_constraint=False), nullable=True
+    )
 
     name: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.String(140), nullable=False)
 

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -210,6 +210,7 @@ class CreateVenueTest:
         assert venue.bookingEmail == "venue@example.com"
         assert venue.dmsToken
         assert venue.current_pricing_point_id == venue.id
+        assert venue.validationStatus == user_offerer.offerer.validationStatus
 
         offerer_address = db.session.query(offerers_models.OffererAddress).one()
         assert offerer_address.label is None


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41265)

Ajout d'une colonne `validationStatus` à `venue`, qui sera utilisée pour gérer sa fermeture, à l'image de ce qui se fait côté `offerer` : aujourd'hui, elle peut être nulle, le temps de remplir la table. La contrainte sera ensuite la même que sur la table `offerer`.

Pour une raison étrange, la migration n'a pas pu être générée automatiquement (_alembic_ n'a pas identifié la nouvelle colonne).