### PR TITLE
Pc 41265/script fill venue validation status

### DIFF
--- a/api/src/pcapi/alembic/versions/20260415T232939_5566d8393bb3_add_nullable_validation_status_to_venue.py
+++ b/api/src/pcapi/alembic/versions/20260415T232939_5566d8393bb3_add_nullable_validation_status_to_venue.py
@@ -1,0 +1,23 @@
+"""add nullable validationStatus to venue"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from pcapi.core.offerers.models import ValidationStatus
+from pcapi.utils.db import MagicEnum
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "5566d8393bb3"
+down_revision = "4c0c60c2ab7d"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("venue", sa.Column("validationStatus", MagicEnum(ValidationStatus), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("venue", "validationStatus")

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -467,6 +467,14 @@ def create_venue(
 
     data = venue_data.model_dump(by_alias=True)
     data["dmsToken"] = dms_token
+    data["validationStatus"] = (
+        db.session.query(models.Offerer)
+        .filter(models.Offerer.id == venue_data.managing_offerer_id)
+        .options(sa_orm.load_only(models.Offerer.validationStatus))
+        .one()
+        .validationStatus
+    )
+
     if not data["publicName"]:
         data["publicName"] = data["name"]
     if venue.is_soft_deleted():

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -44,6 +44,7 @@ from pcapi.models.deactivable_mixin import DeactivableMixin
 from pcapi.models.has_thumb_mixin import HasThumbMixin
 from pcapi.models.pc_object import PcObject
 from pcapi.models.soft_deletable_mixin import SoftDeletableMixin
+from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.models.validation_status_mixin import ValidationStatusMixin
 from pcapi.utils import crypto
 from pcapi.utils import date as date_utils
@@ -292,9 +293,16 @@ DisplayableActivity: enum.EnumType = enum.Enum(  # type: ignore[misc]
 )
 
 
-class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMixin):
+class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMixin, ValidationStatusMixin):
     __tablename__ = "venue"
     thumb_path_component = "venues"
+
+    # TODO(jbaudet - 04/2026): this overrides `ValidationStatusMixin`
+    # column definition: column is now nullable, and should be removed
+    # once the column has been filled with expected values.
+    validationStatus: sa_orm.Mapped[ValidationStatus | None] = sa_orm.mapped_column(  # type: ignore[assignment]
+        sa.Enum(ValidationStatus, create_constraint=False), nullable=True
+    )
 
     name: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.String(140), nullable=False)
 

--- a/api/src/pcapi/scripts/fill_venue_validation_status/main.py
+++ b/api/src/pcapi/scripts/fill_venue_validation_status/main.py
@@ -1,0 +1,65 @@
+"""
+Job console documentation here: https://www.notion.so/passcultureapp/Documentation-Job-Console-769beeacd5a146de9c97b6f8ee544276
+
+You can start the job from the infra repository with github cli :
+
+gh workflow run on_dispatch_pcapi_console_job.yaml \
+  -f ENVIRONMENT_SHORT_NAME=tst \
+  -f RESOURCES="512Mi/.5" \
+  -f BRANCH_NAME=PC-41265/script_fill_venue_validation_status \
+  -f NAMESPACE=fill_venue_validation_status \
+  -f SCRIPT_ARGUMENTS="";
+
+"""
+
+import argparse
+import logging
+
+import sqlalchemy.orm as sa_orm
+
+from pcapi.app import app
+from pcapi.core.offerers import models
+from pcapi.models import db
+from pcapi.utils.chunks import get_chunks
+
+
+logger = logging.getLogger(__name__)
+
+
+def main(apply: bool = False) -> None:
+    query = (
+        db.session.query(models.Venue)
+        .filter(models.Venue.validationStatus == None)
+        .with_entities(models.Venue.id)
+        .yield_per(10_000)
+    )
+
+    venue_ids = {row[0] for row in query}
+
+    for ids in get_chunks(venue_ids, chunk_size=100):
+        venues = (
+            db.session.query(models.Venue)
+            .filter(models.Venue.id.in_(ids))
+            .options(sa_orm.joinedload(models.Venue.managingOfferer).load_only(models.Offerer.validationStatus))
+        )
+
+        for venue in venues:
+            venue.validationStatus = venue.managingOfferer.validationStatus
+            db.session.add(venue)
+
+        if apply:
+            logger.info("script: fill venue validation status, updating venues...", extra={"venues": ids})
+            db.session.commit()
+        else:
+            logger.info("script: fill venue validation status, rollback", extra={"venues": ids})
+            db.session.rollback()
+
+
+if __name__ == "__main__":
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    main(args.apply)

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -210,6 +210,7 @@ class CreateVenueTest:
         assert venue.bookingEmail == "venue@example.com"
         assert venue.dmsToken
         assert venue.current_pricing_point_id == venue.id
+        assert venue.validationStatus == user_offerer.offerer.validationStatus
 
         offerer_address = db.session.query(offerers_models.OffererAddress).one()
         assert offerer_address.label is None

--- a/api/tests/scripts/fill_venue_validation_status/test_main.py
+++ b/api/tests/scripts/fill_venue_validation_status/test_main.py
@@ -1,0 +1,45 @@
+import pytest
+
+from pcapi.core.offerers import factories
+from pcapi.models import db
+from pcapi.models.validation_status_mixin import ValidationStatus
+from pcapi.scripts.fill_venue_validation_status.main import main
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def test_one_venue_without_validation_status():
+    venue = factories.VenueFactory(validationStatus=None)
+    main(apply=True)
+
+    db.session.refresh(venue)
+    assert venue.validationStatus == venue.managingOfferer.validationStatus
+
+
+def test_only_updates_venues_without_validation_status():
+    venue_to_update = factories.VenueFactory(validationStatus=None)
+    venue_to_ignore = factories.VenueFactory(
+        managingOfferer__validationStatus=ValidationStatus.NEW, validationStatus=ValidationStatus.VALIDATED
+    )
+
+    main(apply=True)
+
+    db.session.refresh(venue_to_update)
+    db.session.refresh(venue_to_ignore)
+
+    assert venue_to_update.validationStatus == venue_to_update.managingOfferer.validationStatus
+    assert venue_to_ignore.validationStatus == ValidationStatus.VALIDATED
+
+
+def test_nothing_is_updated_when_apply_is_fals():
+    venue_to_update = factories.VenueFactory(validationStatus=None)
+    venue_to_ignore = factories.VenueFactory(validationStatus=ValidationStatus.VALIDATED)
+
+    main(apply=False)
+
+    db.session.refresh(venue_to_update)
+    db.session.refresh(venue_to_ignore)
+
+    assert not venue_to_update.validationStatus
+    assert venue_to_ignore.validationStatus == ValidationStatus.VALIDATED


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41265)

Script dont le but est de remplir la colonne `validationStatus` de venue avec une valeur par défaut : celle de son `offerer`. Cela permettra ensuite d'interdire une valeur nulle dans cette colonne.

Ce script dépend de la migration qui ajoute cette nouvelle colonne à `venue` : https://github.com/pass-culture/pass-culture-main/pull/22296