### PR TITLE
(PC-41386)[API] fix: phone_number deletion during profil completion

### DIFF
--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -531,11 +531,11 @@ def complete_profile(
     if postal_code in postal_code_utils.INELIGIBLE_POSTAL_CODES:
         raise exceptions.IneligiblePostalCodeException()
 
-    new_phone_number = phone_number
+    parsed_phone_number = phone_number
     if phone_number:
         phone_data = phone_number_utils.ParsedPhoneNumber(phone_number)
         phone_number_utils.check_phone_number_is_legit(phone_data.phone_number, phone_data.country_code)
-        new_phone_number = phone_data.phone_number
+        parsed_phone_number = phone_data.phone_number
 
     update_payload: dict = {
         "address": address,
@@ -543,9 +543,11 @@ def complete_profile(
         "postalCode": postal_code,
         "departementCode": postal_code_utils.PostalCode(postal_code).get_departement_code(),
         "activity": activity.value,
-        "phoneNumber": new_phone_number,
         "schoolType": school_type,
     }
+
+    if parsed_phone_number:
+        update_payload["phoneNumber"] = parsed_phone_number
 
     if not user.firstName:
         update_payload["firstName"] = first_name
@@ -567,7 +569,7 @@ def complete_profile(
             last_name=last_name,
             origin="Completed in application step",
             postal_code=postal_code,
-            phone_number=new_phone_number,
+            phone_number=parsed_phone_number,
             school_type=school_type,
         ),
     )

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -357,6 +357,35 @@ class UpdateProfileTest:
         assert profile_completion_fraud_check.reason == "Completed in application step"
 
     @pytest.mark.features(ENABLE_UBBLE=True)
+    def test_phone_number_not_deleted_if_missing_but_previously_filled(self, client):
+        user = users_factories.UserFactory(
+            address=None,
+            city=None,
+            postalCode=None,
+            activity=None,
+            firstName=None,
+            lastName=None,
+            phoneNumber="+33609080706",
+            dateOfBirth=datetime.date.today() - relativedelta(years=18, months=6),
+        )
+
+        profile_data = {
+            "firstName": "John",
+            "lastName": "Doe",
+            "address": "1 rue des rues",
+            "city": "Uneville",
+            "postalCode": "77000",
+            "activityId": "HIGH_SCHOOL_STUDENT",
+        }
+
+        client.with_token(user)
+        response = client.post("/native/v1/subscription/profile", profile_data)
+
+        assert response.status_code == 204
+
+        assert user.phoneNumber == "+33609080706"
+
+    @pytest.mark.features(ENABLE_UBBLE=True)
     def test_fulfill_profile_invalid_character(self, client):
         user = users_factories.UserFactory(
             address=None,


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41386)


On peut se poser la question de faire la même chose pour `schoolType` sur lequel je me suis basé quand j'ai ajouté le `phoneNumber` mais qui lui ne pose pas problème . Mais je pense que ce n'est pas nécessaire parce qu'en fait c'est un POST mais qui a quand même des champs optionnel parce qu'il est utilisé pour plusieurs parcours. Et au final si on n'avait plus que le nouveau parcours on pourrait retirer la condition que j'ajoute ici pour le `phoneNumber` 


