### PR TITLE
(PC-40802)[API] feat: add input validation for subscription QF

### DIFF
--- a/api/src/pcapi/core/subscription/utils.py
+++ b/api/src/pcapi/core/subscription/utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import unicodedata
 
 import sqlalchemy as sa
@@ -6,12 +7,15 @@ from sqlalchemy import orm as sa_orm
 from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.sql.functions import Function
 
+from pcapi.utils.countries import INSEE_COUNTRIES
+
 
 logger = logging.getLogger(__name__)
 
 ACCEPTED_CHARS_FOR_NAMES = [" ", "-", ".", ",", "'", "’"]
 ACCEPTED_CHARS_FOR_CITY = [" ", "-", "'", "(", ")"]
 ACCEPTED_CHARS_FOR_ADDRESS = ACCEPTED_CHARS_FOR_CITY + [".", ",", "’", "°"]
+INSEE_COUNTRIES_CODE_SET = {c for c, _ in INSEE_COUNTRIES}
 
 
 def is_latin(s: str, accepted_chars: list[str]) -> bool:
@@ -29,21 +33,21 @@ def is_latin(s: str, accepted_chars: list[str]) -> bool:
     return True
 
 
-def validate_not_empty(value: str) -> None:
-    if not value:
-        logger.info("Empty value for field")
-        raise ValueError("This field cannot be empty")
+def validate_not_empty(value: str, field_name: str) -> None:
+    if not value.strip():
+        logger.info("Empty value for field %s", field_name)
+        raise ValueError("le champ ne doit pas être vide")
 
 
 def validate_name(name: str) -> None:
-    validate_not_empty(name)
+    validate_not_empty(name, "name")
     if not is_latin(name, accepted_chars=ACCEPTED_CHARS_FOR_NAMES):
         logger.info("Invalid value for field name: %s", name)
         raise ValueError("Les champs textuels doivent contenir des caractères latins")
 
 
 def validate_address(address: str) -> None:
-    validate_not_empty(address)
+    validate_not_empty(address, "address")
     for char in address:
         if not is_latin(char, accepted_chars=ACCEPTED_CHARS_FOR_ADDRESS) and not char.isnumeric():
             logger.info("Invalid value for field address: %s", address)
@@ -51,10 +55,28 @@ def validate_address(address: str) -> None:
 
 
 def validate_city(city: str) -> None:
-    validate_not_empty(city)
+    validate_not_empty(city, "city")
     if not is_latin(city, accepted_chars=ACCEPTED_CHARS_FOR_CITY):
         logger.info("Invalid value for field city: %s", city)
         raise ValueError("Le champ city doit contenir des caractères latins")
+
+
+def validate_postal_code(postal_code: str) -> None:
+    if not re.match(r"^\d{5}$", postal_code):
+        logger.info("Invalid value for field postal_code: %s", postal_code)
+        raise ValueError("Le code postal doit contenir 5 caractères numériques")
+
+
+def validate_country_cog_code(country_cog_code: str) -> None:
+    if country_cog_code not in INSEE_COUNTRIES_CODE_SET:
+        logger.info("Invalid value for field country_cog_code: %s", country_cog_code)
+        raise ValueError("Le code cog du pays n'existe pas")
+
+
+def validate_city_cog_code(city_cog_code: str) -> None:
+    if not re.match(r"^(?:\d{5}|2[AB]\d{3})$", city_cog_code):
+        logger.info("Invalid value for field city_cog_code: %s", city_cog_code)
+        raise ValueError("Le code cog de la commune n'est pas valide")
 
 
 def matching(column: str | sa_orm.Mapped[str | None], search_value: str) -> ColumnElement[bool]:

--- a/api/src/pcapi/routes/native/v1/serialization/subscription.py
+++ b/api/src/pcapi/routes/native/v1/serialization/subscription.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 
 import pydantic as pydantic_v2
 
@@ -7,7 +8,9 @@ from pcapi.core.subscription import utils as subscription_utils
 from pcapi.core.users import models as users_models
 from pcapi.routes.serialization import HttpBodyModel
 from pcapi.routes.serialization import HttpQueryParamsModel
-from pcapi.serialization.exceptions import PydanticError
+
+
+logger = logging.getLogger(__name__)
 
 
 class ProfileContent(HttpBodyModel):
@@ -39,17 +42,9 @@ class ProfileUpdateRequest(HttpQueryParamsModel):
     phone_number: str | None = None
     school_type_id: profile_options.SchoolTypeIdEnum | None = None
 
-    @pydantic_v2.field_validator("first_name", "last_name", "address", "city", "postal_code", mode="after")
-    @classmethod
-    def mandatory_string_fields_cannot_be_empty(cls, v: str) -> str:
-        v = v.strip()
-        if not v:
-            raise PydanticError("This field cannot be empty")
-        return v
-
     @pydantic_v2.field_validator("first_name", "last_name", mode="after")
     @classmethod
-    def string_must_contain_latin_characters(cls, v: str) -> str:
+    def name_must_be_valid(cls, v: str) -> str:
         subscription_utils.validate_name(v)
         return v
 
@@ -63,6 +58,12 @@ class ProfileUpdateRequest(HttpQueryParamsModel):
     @classmethod
     def address_must_be_valid(cls, v: str) -> str:
         subscription_utils.validate_address(v)
+        return v
+
+    @pydantic_v2.field_validator("postal_code", mode="after")
+    @classmethod
+    def postal_code_must_be_valid(cls, v: str) -> str:
+        subscription_utils.validate_postal_code(v)
         return v
 
 
@@ -92,3 +93,39 @@ class BonusCreditRequest(HttpQueryParamsModel):
     gender: users_models.GenderEnum
     birth_country_cog_code: str
     birth_city_cog_code: str | None = None
+
+    @pydantic_v2.field_validator("last_name", mode="after")
+    @classmethod
+    def last_name_must_be_valid(cls, v: str) -> str:
+        subscription_utils.validate_name(v)
+        return v
+
+    @pydantic_v2.field_validator("first_names", mode="after")
+    @classmethod
+    def first_names_must_be_valid(cls, v: str) -> str:
+        if not v:
+            logger.info("Empty value for field: first_names")
+            raise ValueError("le champ first_names ne doit pas être vide")
+        for name in v:
+            subscription_utils.validate_name(name)
+        return v
+
+    @pydantic_v2.field_validator("common_name", mode="after")
+    @classmethod
+    def common_name_must_be_valid(cls, v: str) -> str:
+        if v:
+            subscription_utils.validate_name(v)
+        return v
+
+    @pydantic_v2.field_validator("birth_country_cog_code", mode="after")
+    @classmethod
+    def birth_country_cog_code_must_be_valid(cls, v: str) -> str:
+        subscription_utils.validate_country_cog_code(v)
+        return v
+
+    @pydantic_v2.field_validator("birth_city_cog_code", mode="after")
+    @classmethod
+    def birth_city_cog_code_must_be_valid(cls, v: str) -> str:
+        if v:
+            subscription_utils.validate_city_cog_code(v)
+        return v

--- a/api/tests/core/subscription/test_utils.py
+++ b/api/tests/core/subscription/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 import pcapi.core.subscription.utils as subscription_utils
+from pcapi.utils.countries import INSEE_COUNTRIES
 
 
 class UtilsUnitTest:
@@ -37,6 +38,8 @@ class UtilsUnitTest:
     @pytest.mark.parametrize(
         "test_input",
         [
+            "",
+            "  ",
             "მარიამ",
             "&",
             "25 & 26 rue Duhesme",
@@ -47,43 +50,131 @@ class UtilsUnitTest:
             subscription_utils.validate_address(test_input)
 
     @pytest.mark.parametrize(
-        "test_input,expected",
+        "test_input",
         [
-            ("a", True),
-            ("მარიამ", False),
-            ("Château-Chinon (Ville)", True),
-            ("Trucy-l'Orgueilleux", True),
-            ("", False),
-            (None, False),
+            "a",
+            "Château-Chinon (Ville)",
+            "Trucy-l'Orgueilleux",
         ],
     )
-    def test_is_city_valid(self, test_input, expected):
-        if expected:
-            subscription_utils.validate_city(test_input)
-        else:
-            with pytest.raises(ValueError):
-                subscription_utils.validate_city(test_input)
+    def test_valid_city(self, test_input):
+        subscription_utils.validate_city(test_input)
 
     @pytest.mark.parametrize(
-        "test_input,expected",
+        "test_input",
         [
-            ("", False),
-            ("a", True),
-            ("Verona", True),
-            ("Charles-Apollon", True),
-            ("John O'Wick", True),
-            ("John O’Wick", True),
-            ("Martin king, Jr.", True),
-            ("მარიამ", False),
-            ("aé", True),
-            ("&", False),
-            ("a&", False),
-            ("1", False),
+            "მარიამ",
+            "",
+            "  ",
         ],
     )
-    def test_is_name_valid(self, test_input, expected):
-        if expected:
+    def test_invalid_city(self, test_input):
+        with pytest.raises(ValueError):
+            subscription_utils.validate_city(test_input)
+
+    def test_valid_postal_code(self):
+        subscription_utils.validate_postal_code("75000")
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            "750001",
+            "7A000",
+            "7500",
+            "",
+            "  ",
+            "75 000",
+            "75000 ",
+            " 75000",
+            "(75000)",
+            "7500.",
+            "750.0",
+        ],
+    )
+    def test_invalid_postal_code(self, test_input):
+        with pytest.raises(ValueError):
+            subscription_utils.validate_postal_code(test_input)
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            "75000",
+            "2A000",
+            "2B000",
+        ],
+    )
+    def test_valid_city_cog_code(self, test_input):
+        subscription_utils.validate_city_cog_code(test_input)
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            "3A000",
+            "750001",
+            "7A000",
+            "7500",
+            "",
+            "  ",
+            "75 000",
+            "75000 ",
+            " 75000",
+            "(75000)",
+            "7500.",
+            "750.0",
+        ],
+    )
+    def test_invalid_city_cog_code(self, test_input):
+        with pytest.raises(ValueError):
+            subscription_utils.validate_city_cog_code(test_input)
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [country for country, _ in INSEE_COUNTRIES],
+    )
+    def test_valid_country_cog_code(self, test_input):
+        subscription_utils.validate_country_cog_code(test_input)
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            "",
+            " ",
+            "99100 ",
+            " 99100",
+            "99 100",
+            "991000",
+        ],
+    )
+    def test_invalid_country_cog_code(self, test_input):
+        with pytest.raises(ValueError):
+            subscription_utils.validate_country_cog_code(test_input)
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            "a",
+            "Verona",
+            "Charles-Apollon",
+            "John O'Wick",
+            "John O’Wick",
+            "Martin king, Jr.",
+            "aé",
+        ],
+    )
+    def test_is_name_valid(self, test_input):
+        subscription_utils.validate_name(test_input)
+
+    @pytest.mark.parametrize(
+        "test_input",
+        [
+            "",
+            "  ",
+            "მარიამ",
+            "&",
+            "a&",
+            "1",
+        ],
+    )
+    def test_invalid_name(self, test_input):
+        with pytest.raises(ValueError):
             subscription_utils.validate_name(test_input)
-        else:
-            with pytest.raises(ValueError):
-                subscription_utils.validate_name(test_input)

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -924,17 +924,24 @@ class BonusTest:
     def test_create_bonus_fraud_check(self, mocked_task, client):
         user = users_factories.BeneficiaryFactory()
 
-        response = client.with_token(user).post(
-            "/native/v1/subscription/bonus/quotient_familial",
-            json={
-                "lastName": "Lefebvre",
-                "firstNames": ["Alexis"],
-                "birthDate": "1982-12-27",
-                "gender": "Mme",
-                "birthCountryCogCode": "91100",
-                "birthCityCogCode": "08480",
-            },
-        )
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # recredit
+        expected_num_queries += 1  # beneficiary_fraud_check
+        expected_num_queries += 1  # beneficiary_fraud_check (insert)
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.post(
+                "/native/v1/subscription/bonus/quotient_familial",
+                json={
+                    "lastName": "Lefebvre",
+                    "firstNames": ["Alexis"],
+                    "birthDate": "1982-12-27",
+                    "gender": "Mme",
+                    "birthCountryCogCode": "99100",
+                    "birthCityCogCode": "08480",
+                },
+            )
 
         assert response.status_code == 204, response.json
 
@@ -951,7 +958,7 @@ class BonusTest:
                 "first_names": ["Alexis"],
                 "birth_date": "1982-12-27",
                 "gender": "Mme",
-                "birth_country_cog_code": "91100",
+                "birth_country_cog_code": "99100",
                 "birth_city_cog_code": "08480",
             },
         }
@@ -978,7 +985,7 @@ class BonusTest:
                 "firstNames": ["Alexis"],
                 "birthDate": "1982-12-27",
                 "gender": "Mme",
-                "birthCountryCogCode": "91100",
+                "birthCountryCogCode": "99100",
                 "birthCityCogCode": "08480",
             },
         )
@@ -999,7 +1006,7 @@ class BonusTest:
                 "firstNames": ["Alexis"],
                 "birthDate": "1982-12-27",
                 "gender": "Mme",
-                "birthCountryCogCode": "91100",
+                "birthCountryCogCode": "99100",
                 "birthCityCogCode": "08480",
             },
         )
@@ -1019,7 +1026,7 @@ class BonusTest:
                 "firstNames": ["Alexis"],
                 "birthDate": "1982-12-27",
                 "gender": "Mme",
-                "birthCountryCogCode": "91100",
+                "birthCountryCogCode": "99100",
                 "birthCityCogCode": "08480",
             },
         )
@@ -1033,3 +1040,105 @@ class BonusTest:
             subscription_models.FraudCheckStatus.STARTED,
             subscription_models.FraudCheckStatus.KO,
         }
+
+    def test_bonus_qf_invalid_character(self, client):
+        user = users_factories.BeneficiaryFactory()
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/bonus/quotient_familial",
+            json={
+                "lastName": "Lefebvre",
+                "firstNames": ["Alexis", "ჯონ"],
+                "birthDate": "1982-12-27",
+                "gender": "Mme",
+                "birthCountryCogCode": "99100",
+                "birthCityCogCode": "08480",
+            },
+        )
+
+        assert response.status_code == 400
+
+    def test_bonus_qf_empty_first_names(self, client):
+        user = users_factories.BeneficiaryFactory()
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/bonus/quotient_familial",
+            json={
+                "lastName": "Lefebvre",
+                "firstNames": [],
+                "birthDate": "1982-12-27",
+                "gender": "Mme",
+                "birthCountryCogCode": "99100",
+                "birthCityCogCode": "08480",
+            },
+        )
+
+        assert response.status_code == 400
+
+    def test_bonus_qf_empty_field(self, client):
+        user = users_factories.BeneficiaryFactory()
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/bonus/quotient_familial",
+            json={
+                "lastName": "  ",
+                "firstNames": ["Alexis"],
+                "birthDate": "1982-12-27",
+                "gender": "Mme",
+                "birthCountryCogCode": "99100",
+                "birthCityCogCode": "08480",
+            },
+        )
+
+        assert response.status_code == 400
+
+    def test_bonus_qf_missing_field(self, client):
+        user = users_factories.BeneficiaryFactory()
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/bonus/quotient_familial",
+            json={
+                "lastName": "Lefebvre",
+                "firstNames": ["Alexis", "ჯონ"],
+                "birthDate": "1982-12-27",
+                "gender": "Mme",
+                "birthCountryCogCode": "99100",
+                "birthCityCogCode": "08480",
+            },
+        )
+
+        assert response.status_code == 400
+
+    def test_bonus_qf_invalid_country_cog_code(self, client):
+        user = users_factories.BeneficiaryFactory()
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/bonus/quotient_familial",
+            json={
+                "lastName": "Lefebvre",
+                "firstNames": ["Alexis", "ჯონ"],
+                "birthDate": "1982-12-27",
+                "gender": "Mme",
+                "birthCountryCogCode": "91100",
+                "birthCityCogCode": "08480",
+            },
+        )
+
+        assert response.status_code == 400
+
+    def test_bonus_qf_invalid_city_cog_code(self, client):
+        user = users_factories.BeneficiaryFactory()
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/bonus/quotient_familial",
+            json={
+                "lastName": "Lefebvre",
+                "firstNames": ["Alexis", "ჯონ"],
+                "birthDate": "1982-12-27",
+                "gender": "Mme",
+                "birthCountryCogCode": "91100",
+                "birthCityCogCode": "08E80",
+            },
+        )
+
+        assert response.status_code == 400


### PR DESCRIPTION
[Ticket Jira](https://passculture.atlassian.net/browse/PC-40802)

Je suis aller à l'essentiel sans refacto mais il y a des questions un peu plus générales qui pourraient se poser sur le fait de factoriser la validation de la subscription et du profile de account


Je suis sûr à 98% de la condition pour `validate_city_cog_code` mais je ne sais pas si je mettrai ma main à couper dessus donc à voir si on la simplifie. 


Est-ce qu'on veut une vérif de date sur `birthDate` ? Je ne suis pas sûr que ce soit nécessaire 



Donner suite à cette réflexion : https://github.com/pass-culture/pass-culture-main/pull/22341#discussion_r3109703847
=> Je préfère laisse comme ça pour le moment pour que subscription et [le profile de account](https://github.com/pass-culture/pass-culture-main/blob/6211269edb8c28ae1f6e98f341f9a37fb9168b8c/api/src/pcapi/routes/native/v1/account.py#L83) soit alignés et faire une PR propre de refacto le moment venu pour factoriser tout bien. On a aussi une question d'indiquer mieux les erreurs en front par rapport au numéro de téléphone et vu que ça retourne des codes métier aujourd'hui je préfère aussi attendre que la question soit réglée en front. 



