### PR TITLE
(PC-41288)[PRO] feat: better data display on validation screen

### DIFF
--- a/pro/src/components/SignupJourneyForm/Validation/Validation.module.scss
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.module.scss
@@ -1,25 +1,53 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_size.scss" as size;
 
 .subtitle {
   @include fonts.title4;
 }
 
 .data-displaying {
+  @include fonts.body-accent-s;
+
   margin-top: var(--size-spacing-s);
   padding: var(--size-spacing-l);
   background: var(--color-background-subtle);
   color: var(--color-text-default);
   border-radius: var(--size-border-radius-m);
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto;
 
-  .data-line {
-    @include fonts.body;
+  @media (min-width: size.$tablet) {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto;
+    row-gap: var(--size-spacing-s);
+  }
 
-    margin-bottom: var(--size-spacing-s);
-    overflow-wrap: break-word;
+  .data-term {
+    margin-bottom: var(--size-spacing-xs);
 
-    &:last-child {
-      margin-bottom: 0;
+    @media (min-width: size.$tablet) {
+      margin-bottom: initial;
+    }
+  }
+
+  .data-definition {
+    color: var(--color-text-subtle);
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-spacing-xs);
+
+    &:not(:last-child) {
+      margin-bottom: var(--size-spacing-l);
+
+      @media (min-width: size.$tablet) {
+        margin-bottom: initial;
+      }
+    }
+
+    @media (min-width: size.$tablet) {
+      text-align: right;
     }
   }
 }

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.spec.tsx
@@ -69,12 +69,6 @@ vi.mock('@/apiClient/api', () => ({
   },
 }))
 
-const selectCurrentOffererId = vi.hoisted(() => vi.fn())
-vi.mock('@/commons/store/offerer/selectors', async (importOriginal) => ({
-  ...(await importOriginal()),
-  selectCurrentOffererId,
-}))
-
 const setSelectedOffererByIdMock = vi.hoisted(() => vi.fn())
 vi.mock('@/commons/store/user/dispatchers/setSelectedOffererById', () => ({
   setSelectedOffererById: (args: unknown) => {
@@ -129,6 +123,10 @@ const renderValidationScreen = (
           />
           <Route path="/accueil" element={<div>accueil</div>} />
           <Route path="/onboarding" element={<div>onboarding</div>} />
+          <Route
+            path="/rattachement-en-cours"
+            element={<div>rattachement</div>}
+          />
         </Routes>
       </SignupJourneyContext.Provider>
       <SnackBarContainer />
@@ -213,10 +211,51 @@ describe('ValidationScreen', () => {
     expect(await screen.findByText('Musée')).toBeInTheDocument()
     expect(screen.getByText('url1')).toBeInTheDocument()
     expect(screen.getByText('url2')).toBeInTheDocument()
+    expect(screen.getByText('nom')).toBeInTheDocument()
     expect(screen.getByText('nom public')).toBeInTheDocument()
-    expect(screen.getByText('123123123')).toBeInTheDocument()
+    expect(screen.getByText('123 123 123')).toBeInTheDocument()
     expect(screen.getByText('3 Rue de Valois, 75001 Paris')).toBeInTheDocument()
-    expect(screen.getByText('À des groupes scolaires')).toBeInTheDocument()
+    expect(
+      screen.getByText('Aux groupes scolaires via ADAGE')
+    ).toBeInTheDocument()
+  })
+
+  it('should display "non diffusée" if the offerer is not diffusible', async () => {
+    renderValidationScreen({
+      ...contextValue,
+      activity: {
+        activity: 'MUSEUM',
+        socialUrls: ['url1', 'url2'],
+        targetCustomer: Target.EDUCATIONAL,
+        phoneNumber: '',
+        culturalDomains: ['Domaine 1', 'Domaine 2', 'Domaine 3'],
+      },
+      offerer: {
+        name: '',
+        publicName: 'nom public',
+        siret: '123123123',
+        hasVenueWithSiret: false,
+        isDiffusible: false,
+        ...addressInformations,
+        street: 'Adresse non diffusée',
+      },
+    })
+    expect(await screen.findByText('Musée')).toBeInTheDocument()
+    expect(screen.getByText('url1')).toBeInTheDocument()
+    expect(screen.getByText('url2')).toBeInTheDocument()
+    expect(screen.getByText('Domaines d’activité')).toBeInTheDocument()
+    expect(screen.getByText('Domaine 1')).toBeInTheDocument()
+    expect(screen.getByText('Domaine 2')).toBeInTheDocument()
+    expect(screen.getByText('Domaine 3')).toBeInTheDocument()
+    expect(screen.getByText('Non diffusée')).toBeInTheDocument()
+    expect(screen.getByText('nom public')).toBeInTheDocument()
+    expect(screen.getByText('123 123 123')).toBeInTheDocument()
+    expect(
+      screen.getByText('Adresse non diffusée, 75001 Paris')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText('Aux groupes scolaires via ADAGE')
+    ).toBeInTheDocument()
   })
 
   describe('user actions', () => {
@@ -242,13 +281,12 @@ describe('ValidationScreen', () => {
         initialAddress,
         setInitialAddress: noop,
       }
-      selectCurrentOffererId.mockReturnValue(null)
     })
 
     it('should navigate to activity page with the previous step button', async () => {
       renderValidationScreen(contextValue)
 
-      await userEvent.click(screen.getByText('Étape précédente'))
+      await userEvent.click(screen.getByText('Retour'))
       expect(screen.getByText('Activite')).toBeInTheDocument()
     })
 
@@ -259,7 +297,7 @@ describe('ValidationScreen', () => {
       expect(screen.getByText('Authentification')).toBeInTheDocument()
     })
 
-    it('should navigate to activite page when clicking the second update button', async () => {
+    it('should navigate to activity page when clicking the second update button', async () => {
       renderValidationScreen(contextValue)
       await userEvent.click(screen.getAllByText('Modifier')[1])
 
@@ -407,12 +445,6 @@ describe('ValidationScreen', () => {
       expect(payload.activity).toBe('MUSEUM')
     })
 
-    it('should see the data from the previous forms for validation without public name', async () => {
-      renderValidationScreen(contextValue)
-      expect(await screen.findByText('Musée')).toBeInTheDocument()
-      expect(screen.getByText('nom')).toBeInTheDocument()
-    })
-
     it('should send cultural domains', async () => {
       if (contextValue.activity) {
         contextValue.activity.culturalDomains = [
@@ -435,9 +467,10 @@ describe('ValidationScreen', () => {
       vi.spyOn(utils, 'getReCaptchaToken').mockResolvedValue('token')
 
       renderValidationScreen(contextValue)
-      expect(
-        screen.getByText('Domaine 1, Domaine II, Domaine C')
-      ).toBeInTheDocument()
+      expect(screen.getByText('Domaines d’activité')).toBeInTheDocument()
+      expect(screen.getByText('Domaine 1')).toBeInTheDocument()
+      expect(screen.getByText('Domaine II')).toBeInTheDocument()
+      expect(screen.getByText('Domaine C')).toBeInTheDocument()
       await userEvent.click(screen.getByText('Valider et créer ma structure'))
       expect(saveNewOnboardingDataMock).toHaveBeenCalledTimes(1)
       const [[payload]] = saveNewOnboardingDataMock.mock.calls
@@ -489,6 +522,54 @@ describe('ValidationScreen', () => {
         token: 'token',
         isOpenToPublic: false,
         phoneNumber: '',
+      })
+    })
+
+    describe('newAccess', () => {
+      beforeEach(() => {
+        vi.spyOn(api, 'listOfferersNames').mockResolvedValue({
+          offerersNames: [],
+          offerersNamesWithPendingValidation: [],
+        })
+        vi.spyOn(api, 'getVenues').mockResolvedValue({ venues: [] })
+        vi.spyOn(api, 'saveNewOnboardingData').mockResolvedValue(
+          {} as PostOffererResponseModel
+        )
+        vi.spyOn(utils, 'initReCaptchaScript').mockReturnValue({
+          remove: vi.fn(),
+        } as unknown as HTMLScriptElement)
+        vi.spyOn(utils, 'getReCaptchaToken').mockResolvedValue('token')
+      })
+
+      it('should navigate to home page if newAccess is full', async () => {
+        setSelectedOffererByIdMock.mockReturnValue(createMockPromise('full'))
+        renderValidationScreen(contextValue, {
+          storeOverrides: {
+            user: {
+              access: 'full',
+            },
+          },
+        })
+        await userEvent.click(screen.getByText('Valider et créer ma structure'))
+        expect(screen.getByText('accueil')).toBeInTheDocument()
+      })
+
+      it('should navigate to onboarding page if newAccess is no-onboarding', async () => {
+        setSelectedOffererByIdMock.mockReturnValue(
+          createMockPromise('no-onboarding')
+        )
+        renderValidationScreen(contextValue)
+        await userEvent.click(screen.getByText('Valider et créer ma structure'))
+        expect(screen.getByText('onboarding')).toBeInTheDocument()
+      })
+
+      it('should navigate to rattachement page if newAccess is unattached', async () => {
+        setSelectedOffererByIdMock.mockReturnValue(
+          createMockPromise('unattached')
+        )
+        renderValidationScreen(contextValue)
+        await userEvent.click(screen.getByText('Valider et créer ma structure'))
+        expect(screen.getByText('rattachement')).toBeInTheDocument()
       })
     })
   })

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
@@ -33,7 +33,9 @@ import { initializeUser } from '@/commons/store/user/dispatchers/initializeUser'
 import { setSelectedOffererById } from '@/commons/store/user/dispatchers/setSelectedOffererById'
 import { updateUser } from '@/commons/store/user/reducer'
 import { ensureCurrentUser } from '@/commons/store/user/selectors'
+import { pluralizeFr } from '@/commons/utils/pluralize'
 import { getReCaptchaToken } from '@/commons/utils/recaptcha'
+import { humanizeSiret } from '@/commons/utils/siren'
 import {
   DEFAULT_ADDRESS_FORM_VALUES,
   DEFAULT_OFFERER_FORM_VALUES,
@@ -49,6 +51,7 @@ import {
 } from '@/design-system/Button/types'
 import fullEditIcon from '@/icons/full-edit.svg'
 import { SignupJourneyAction } from '@/pages/SignupJourneyRoutes/constants'
+import { formatPhoneNumber } from '@/pages/User/UserProfile/UserPhone/UserPhone'
 
 import { ActionBar } from '../ActionBar/ActionBar'
 import styles from './Validation.module.scss'
@@ -76,10 +79,9 @@ export const Validation = (): JSX.Element | undefined => {
   const dispatch = useAppDispatch()
 
   const targetCustomerLabel = {
-    [Target.INDIVIDUAL]: 'Au grand public',
-    [Target.EDUCATIONAL]: 'À des groupes scolaires',
-    [Target.INDIVIDUAL_AND_EDUCATIONAL]:
-      'Au grand public et à des groupes scolaires',
+    [Target.INDIVIDUAL]: 'Aux jeunes via l’application pass Culture',
+    [Target.EDUCATIONAL]: 'Aux groupes scolaires via ADAGE',
+    [Target.INDIVIDUAL_AND_EDUCATIONAL]: 'Aux jeunes et aux groupes scolaires',
   }[activity?.targetCustomer ?? Target.INDIVIDUAL]
 
   useEffect(() => {
@@ -177,6 +179,7 @@ export const Validation = (): JSX.Element | undefined => {
           shouldRefetch: true,
         })
       ).unwrap()
+
       // if the new access is full, we redirect to the home page
       if (userAccess === newAccess && newAccess === 'full') {
         navigate('/accueil')
@@ -223,15 +226,32 @@ export const Validation = (): JSX.Element | undefined => {
           />
         </div>
 
-        <div className={styles['data-displaying']}>
-          <div className={styles['data-line']}>
+        <dl className={styles['data-displaying']}>
+          <dt className={styles['data-term']}>Numéro de SIRET</dt>
+          <dd className={styles['data-definition']}>
+            {humanizeSiret(offerer.siret)}
+          </dd>
+
+          <dt className={styles['data-term']}>Raison sociale</dt>
+          <dd className={styles['data-definition']}>
+            {offerer.name || 'Non diffusée'}
+          </dd>
+
+          <dt className={styles['data-term']}>Nom public</dt>
+          <dd className={styles['data-definition']}>
             {offerer.publicName || offerer.name}
-          </div>
-          <div className={styles['data-line']}>{offerer.siret}</div>
-          <div className={styles['data-line']}>
+          </dd>
+
+          <dt className={styles['data-term']}>Accueil du public</dt>
+          <dd className={styles['data-definition']}>
+            {offerer.isOpenToPublic === 'true' ? 'Oui' : 'Non'}
+          </dd>
+
+          <dt className={styles['data-term']}>Adresse</dt>
+          <dd className={styles['data-definition']}>
             {offerer.street}, {offerer.postalCode} {offerer.city}
-          </div>
-        </div>
+          </dd>
+        </dl>
       </section>
       <section className={styles['validation-screen']}>
         <div className={styles['validation-screen-subtitle']}>
@@ -254,29 +274,55 @@ export const Validation = (): JSX.Element | undefined => {
             label="Modifier"
           />
         </div>
-        <div className={styles['data-displaying']}>
-          <div className={styles['data-line']}>
-            {activityLabel}
-            {activity.activity === 'OTHER' &&
-              ` : ${activity.otherActivityComment}`}
-          </div>
+
+        <dl className={styles['data-displaying']}>
+          <dt className={styles['data-term']}>Activité principale</dt>
+          <dd className={styles['data-definition']}>{activityLabel}</dd>
+
           {(activity.culturalDomains ?? []).length > 0 && (
-            <div className={styles['data-line']}>
-              {activity.culturalDomains?.join(', ')}
-            </div>
+            <>
+              <dt className={styles['data-term']}>
+                {pluralizeFr(
+                  activity.culturalDomains?.length ?? 0,
+                  'Domaine d’activité',
+                  'Domaines d’activité'
+                )}
+              </dt>
+              <dd className={styles['data-definition']}>
+                {(activity.culturalDomains ?? []).map((domain) => (
+                  <div key={domain}>{domain}</div>
+                ))}
+              </dd>
+            </>
           )}
-          {activity.socialUrls.map((url) => (
-            <div className={styles['data-line']} key={url}>
-              {url}
-            </div>
-          ))}
-          <div className={styles['data-line']}>{targetCustomerLabel}</div>
-        </div>
+
+          <dt className={styles['data-term']}>Téléphone</dt>
+          <dd className={styles['data-definition']}>
+            {formatPhoneNumber(activity.phoneNumber)}
+          </dd>
+
+          {activity.socialUrls.length > 0 && (
+            <>
+              <dt className={styles['data-term']}>
+                {pluralizeFr(
+                  activity.socialUrls.length,
+                  'Site internet',
+                  'Sites internet'
+                )}
+              </dt>
+              <dd className={styles['data-definition']}>
+                {activity.socialUrls.map((url) => (
+                  <div key={url}>{url}</div>
+                ))}
+              </dd>
+            </>
+          )}
+
+          <dt className={styles['data-term']}>Public cible</dt>
+          <dd className={styles['data-definition']}>{targetCustomerLabel}</dd>
+        </dl>
       </section>
-      <Banner
-        title="Modification possible"
-        description="Ces informations pourront être modifiées dans la page dédiée de votre espace."
-      />
+      <Banner title="Vous pourrez modifier ces informations à tout moment depuis votre espace partenaire." />
 
       <ActionBar
         onClickPrevious={handlePreviousStep}
@@ -285,6 +331,7 @@ export const Validation = (): JSX.Element | undefined => {
         onClickNext={onSubmit}
         isDisabled={loading}
         withRightIcon={false}
+        previousStepTitle="Retour"
         nextStepTitle="Valider et créer ma structure"
       />
     </div>


### PR DESCRIPTION
## 🎯 Related Ticket

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41288)

Refonte UI de l’écran récapitulatif (page de validation) du parcours de création de structure, afin d’améliorer la lisibilité des données saisies aux étapes précédentes.

- Remplacement de la structure `div` par une liste de description sémantique (`<dl>` / `<dt>` / `<dd>`) pour afficher chaque donnée avec son libellé
- Ajout d’un libellé explicite devant chaque valeur (auparavant, seules les valeurs brutes étaient affichées).
- Formatage des données pour une meilleure lisibilité :
  - SIRET humanisé via `humanizeSiret` (`123 123 123 ...`).
  - Numéro de téléphone formaté via `formatPhoneNumber`.
  - Domaines d’activité affichés sous forme de liste plutôt qu’en chaîne concaténée.
  - Pluralisation des libellés via `pluralizeFr`.
- Mise à jour des libellés de public cible :
  - `Au grand public` → `Aux jeunes via l’application pass Culture`
  - `À des groupes scolaires` → `Aux groupes scolaires via ADAGE`
  - `Au grand public et à des groupes scolaires` → `Aux jeunes et aux groupes scolaires`
- Mise à jour du style SCSS (`Validation.module.scss`) : typographie `body-accent-s`, utilisation du mixin `size`, styles adaptés à la structure `<dl>`.
- Mise à jour des tests unitaires en conséquence (nouveaux libellés, formatage SIRET, libellé `Retour` en remplacement de `Étape précédente`, suppression du cas de test obsolète sur l’absence de nom public).

## 🖼️ Before & After Images

Before | After
:---: | :---:
<img width="604" height="928" alt="image" src="https://github.com/user-attachments/assets/85a32935-c64f-4432-8ce8-b7b8bc4eec9d" /> | <img width="604" height="928" alt="image" src="https://github.com/user-attachments/assets/a691c392-2aa3-4c4c-9306-432c1a5f477a" />