### PR TITLE
(PC-41300)[API] fix: recredit users for 17 yo in an edge case

### DIFF
--- a/api/src/pcapi/core/finance/deposit_api.py
+++ b/api/src/pcapi/core/finance/deposit_api.py
@@ -185,9 +185,7 @@ def _recredit_grant_17_18_deposit_using_age(user: users_models.User) -> models.R
     if not current_age or not user.deposit:
         return None
 
-    age_at_first_registration = eligibility_api.get_age_at_first_registration(
-        user, users_models.EligibilityType.AGE17_18
-    )
+    age_at_first_registration = eligibility_api.get_age_at_first_registration(user, eligibility=None)
     latest_age_related_recredit: models.Recredit | None = None
     starting_age, end_age = sorted([age_at_first_registration or current_age, current_age])
     for age_to_recredit in range(starting_age, end_age + 1):

--- a/api/src/pcapi/core/users/eligibility_api.py
+++ b/api/src/pcapi/core/users/eligibility_api.py
@@ -82,7 +82,9 @@ def get_pre_decree_eligibility(
     return None
 
 
-def get_age_at_first_registration(user: users_models.User, eligibility: users_models.EligibilityType) -> int | None:
+def get_age_at_first_registration(
+    user: users_models.User, eligibility: users_models.EligibilityType | None
+) -> int | None:
     if not user.birth_date:
         return None
 

--- a/api/tests/core/finance/test_deposit_api.py
+++ b/api/tests/core/finance/test_deposit_api.py
@@ -587,6 +587,7 @@ class UserRecreditTest:
                 age=16, phoneNumber="+33600000000", deposit__amount=12, deposit__expirationDate=next_week
             )
             user_2 = users_factories.BeneficiaryFactory(age=17, deposit__expirationDate=next_week)
+            factories.RecreditFactory(deposit=user_2.deposit, recreditType=models.RecreditType.RECREDIT_17)
 
         with time_machine.travel(pcapi_settings.CREDIT_V3_DECREE_DATETIME):
             # finish steps for user 2

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -14,6 +14,7 @@ from pcapi.connectors.dms import api as api_dms
 from pcapi.connectors.dms import factories as dms_factories
 from pcapi.connectors.dms import models as dms_models
 from pcapi.connectors.dms import serializer as dms_serializer
+from pcapi.core.finance import factories as finance_factories
 from pcapi.core.finance import models as finance_models
 from pcapi.core.mails.transactional.brevo_template_ids import TransactionalEmail
 from pcapi.core.subscription import factories as subscription_factories
@@ -1321,6 +1322,16 @@ class RunIntegrationTest:
                 phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
                 deposit__expirationDate=date_utils.get_naive_utc_now() + relativedelta(years=2),
             )
+            finance_factories.RecreditFactory(
+                deposit=user.deposit, recreditType=finance_models.RecreditType.RECREDIT_15
+            )
+            finance_factories.RecreditFactory(
+                deposit=user.deposit, recreditType=finance_models.RecreditType.RECREDIT_16
+            )
+            finance_factories.RecreditFactory(
+                deposit=user.deposit, recreditType=finance_models.RecreditType.RECREDIT_17
+            )
+
         subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
         details = fixtures.make_parsed_graphql_application(application_number=123, state="accepte", email=user.email)
         details.draft_date = date_utils.get_naive_utc_now().isoformat()

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -2270,11 +2270,18 @@ class ActivateBeneficiaryIfNoMissingStepTest:
     @time_machine.travel("2025-03-03")
     def test_underage_transition_to_18_after_decree(self):
         before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(days=1)
-        user = users_factories.Transition1718Factory(_phoneNumber="0123456789", dateCreated=before_decree)
-        subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
-        subscription_factories.HonorStatementFraudCheckFactory(user=user)
+        with time_machine.travel(before_decree):
+            user = users_factories.BeneficiaryFactory(age=17, _phoneNumber="0123456789")
+            finance_factories.RecreditFactory(
+                deposit=user.deposit, recreditType=finance_models.RecreditType.RECREDIT_17
+            )
 
-        is_user_activated = subscription_api.activate_beneficiary_if_no_missing_step(user)
+        year_when_user_reached_eighteen = before_decree + relativedelta(years=1)
+        with time_machine.travel(year_when_user_reached_eighteen):
+            subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
+            subscription_factories.HonorStatementFraudCheckFactory(user=user)
+
+            is_user_activated = subscription_api.activate_beneficiary_if_no_missing_step(user)
 
         assert is_user_activated
         assert user.is_beneficiary
@@ -2297,8 +2304,29 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert recredit.recreditType == finance_models.RecreditType.RECREDIT_18
         assert user.recreditAmountToShow == 150
 
+    def test_post_decree_when_registration_started_at_16_before_decree(self):
+        before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(weeks=1)
+        with time_machine.travel(before_decree):
+            user = users_factories.HonorStatementValidatedUserFactory(age=16, _phoneNumber="0123456789")
+
+        year_when_user_reached_eighteen = before_decree + relativedelta(years=2)
+        with time_machine.travel(year_when_user_reached_eighteen):
+            subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
+            subscription_factories.HonorStatementFraudCheckFactory(user=user)
+
+            is_user_activated = subscription_api.activate_beneficiary_if_no_missing_step(user)
+
+        assert is_user_activated
+        assert user.is_beneficiary
+        assert user.deposit.type == finance_models.DepositType.GRANT_17_18
+
+        recredit_types = [recredit.recreditType for recredit in user.deposit.recredits]
+        assert set(recredit_types) == {finance_models.RecreditType.RECREDIT_17, finance_models.RecreditType.RECREDIT_18}
+        assert user.deposit.amount == 50 + 150
+        assert user.recreditAmountToShow == 50 + 150
+
     @pytest.mark.parametrize("age", [18, 19, 20])
-    def test_post_decree_when_registration_started_at_17(self, age):
+    def test_post_decree_when_registration_started_at_17_after_decree(self, age):
         starting_age = 17
         user = users_factories.HonorStatementValidatedUserFactory(age=starting_age, _phoneNumber="0123456789")
 


### PR DESCRIPTION
During the credit process, we also need to credit retroactively. If a user starts their subscription process at 17 and finishes it at 18, we recredit for both years.

But their subscription can start at 15 year old through the UNDERAGE eligibility type : we have to include them to be able to accurately give the 17 and 18 credits.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41300)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
