### PR TITLE
(BSR)[API] fix: image creation without crop params

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -1744,6 +1744,9 @@ def save_venue_banner(
         "image_credit": image_credit,
         "author_id": user.id,
         "original_image_url": f"{venue.thumbUrl}_{original_image_timestamp}",
+        "updated_at": updated_at.isoformat(),
+    }
+    if crop_params:
         # NOTE(jbaudet - 02/2026): the asdict has been added because of
         # the pydantic migration which leads to some models using
         # CropParams or CropParamsV2. For example some response models
@@ -1751,9 +1754,7 @@ def save_venue_banner(
         # mess.
         # Feel free to remove this explicit serialization once
         # the whole pydantic migration is done.
-        "crop_params": dataclasses.asdict(crop_params) if crop_params else None,
-        "updated_at": updated_at.isoformat(),
-    }
+        venue.bannerMeta["crop_params"] = dataclasses.asdict(crop_params)
 
     db.session.add(venue)
     db.session.flush()

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -2363,7 +2363,6 @@ class VenueBannerTest:
             "author_id": user.id,
             "image_credit": "none",
             "original_image_url": str(directory / f"{humanize(venue.id)}_1602720001"),
-            "crop_params": None,
             "updated_at": "2020-10-15T00:00:00",
         }
 
@@ -2393,7 +2392,6 @@ class VenueBannerTest:
             "author_id": user.id,
             "image_credit": "none",
             "original_image_url": str(directory / f"{humanize(venue.id)}_1602720001"),
-            "crop_params": None,
             "updated_at": "2020-10-15T00:00:00",
         }
 

--- a/api/tests/routes/public/individual_offers/v1/products/patch_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/products/patch_product_test.py
@@ -72,9 +72,9 @@ class PatchProductTest(PublicAPIVenueEndpointHelper):
 
         response = self.make_request(
             plain_api_key,
-            {"offer_id": offer.id, "location": {"venue_id": venue.id}},
+            json_body={"offerId": offer.id, "location": {"type": "physical", "venue_id": venue.id}},
         )
-        assert response.status_code == 404
+        assert response.status_code == 404, response.json
 
     def test_deactivate_offer(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Correction de la création d'image sans crop params.
Il n'est pas attendu d'avoir `cropParams` dans `bannerMeta` qui soit à `None`.
Dans le cas où `cropParams` serait vide, on n'ajoute pas la clef dans `bannerMeta`