### PR TITLE
(PC-41286)[PRO] feat: update UI and wording for onboarding screen

### DIFF
--- a/pro/e2e/didacticOnboarding.e2e.ts
+++ b/pro/e2e/didacticOnboarding.e2e.ts
@@ -13,8 +13,14 @@ test.describe('Didactic Onboarding feature', () => {
   test.beforeEach(async ({ authenticatedPage: page }) => {
     await page.goto('/accueil')
     await expect(
-      page.getByText('Bienvenue sur le pass Culture Pro !')
+      page.getByText('Bienvenue sur pass Culture Pro !')
     ).toBeVisible()
+    await expect(
+      page.getByText(
+        /Notre équipe vous contactera par email pour vous demander vos justificatifs d’inscription./
+      )
+    ).toBeVisible()
+    await expect(page.getByText(/Pensez à vérifier vos spams./)).toBeVisible()
     await expect(
       page.getByText('Où souhaitez-vous diffuser votre première offre ?')
     ).toBeVisible()

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.spec.tsx
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.spec.tsx
@@ -33,27 +33,33 @@ describe('OnboardingOffersChoice Component', () => {
   })
 
   it('renders the first card with correct title, description, and button', () => {
-    // Check for the first card's title
-    const firstCardTitle = screen.getByText(
-      'Sur l’application mobile à destination des jeunes'
-    )
-    expect(firstCardTitle).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        level: 3,
+        name: 'Sur l’application mobile à destination des jeunes',
+      })
+    ).toBeInTheDocument()
 
-    // Check for the first card's button
-    const firstCardButton = screen.getAllByText('Commencer')[0]
-    expect(firstCardButton).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', {
+        name: 'Commencer la création d’offre sur l’application mobile',
+      })
+    ).toHaveTextContent('Créer une offre individuelle')
   })
 
   it('renders the second card with correct title, description, and button', () => {
-    // Check for the second card's title
-    const secondCardTitle = screen.getByText(
-      'Sur ADAGE à destination des enseignants'
-    )
-    expect(secondCardTitle).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', {
+        level: 3,
+        name: 'Sur ADAGE à destination des enseignants',
+      })
+    ).toBeInTheDocument()
 
-    // Check for the second card's button
-    const secondCardButton = screen.getAllByText('Commencer')[1]
-    expect(secondCardButton).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: 'Commencer la création d’offre sur ADAGE',
+      })
+    ).toHaveTextContent('Déposer un dossier ADAGE')
   })
 
   it('displays the onboarding collective modal when the second button is clicked', async () => {

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
@@ -42,14 +42,17 @@ export const OnboardingOffersChoice = () => {
             to="/onboarding/individuel"
             aria-label="Commencer la création d’offre sur l’application mobile"
             fullWidth
-            label="Commencer"
+            label="Créer une offre individuelle"
           />
         </Card.Footer>
       </Card>
 
       <Card>
         <Card.Image src={collective} alt="" />
-        <Card.Header title="Sur ADAGE à destination des enseignants" />
+        <Card.Header
+          title="Sur ADAGE à destination des enseignants"
+          titleTag="h3"
+        />
         <Card.Content>
           <span>
             Vos offres seront visibles{' '}
@@ -75,7 +78,7 @@ export const OnboardingOffersChoice = () => {
                   setShowModal(true)
                 }}
                 fullWidth
-                label="Commencer"
+                label="Déposer un dossier ADAGE"
               />
             }
             open={showModal}

--- a/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.module.scss
+++ b/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.module.scss
@@ -1,14 +1,18 @@
 @use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/size.scss" as size;
+@use "styles/mixins/_rem.scss" as rem;
 
 .onboarding-offer-container {
   display: flex;
   flex-direction: column;
-  gap: var(--size-spacing-xxl);
   align-items: flex-start;
   justify-content: flex-start;
+  max-width: rem.torem(721px);
 }
 
 .onboarding-offer-header-subtitle {
   @include fonts.title3;
+
+  margin-top: var(--size-border-radius-xxl);
+  margin-bottom: var(--size-border-radius-l);
 }

--- a/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.spec.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.spec.tsx
@@ -11,8 +11,15 @@ describe('OnboardingOffersChoice Component', () => {
     renderWithProviders(<OnboardingOffersTypeChoice />)
 
     expect(
-      screen.getByText('Bienvenue sur le pass Culture Pro !')
+      screen.getByText('Bienvenue sur pass Culture Pro !')
     ).toBeInTheDocument()
+
+    expect(
+      screen.getByText(
+        /Notre équipe vous contactera par email pour vous demander vos justificatifs d’inscription./
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByText(/Pensez à vérifier vos spams./)).toBeInTheDocument()
 
     expect(
       screen.getByText('Où souhaitez-vous diffuser votre première offre ?')

--- a/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOffersTypeChoice/OnboardingOffersTypeChoice.tsx
@@ -1,16 +1,18 @@
 import { OnboardingLayout } from '@/app/App/layouts/funnels/OnboardingLayout/OnboardingLayout'
 import { OnboardingOffersChoice } from '@/components/OnboardingOffersChoice/OnboardingOffersChoice'
+import { Banner } from '@/design-system/Banner/Banner'
 
 import styles from './OnboardingOffersTypeChoice.module.scss'
 
 export const OnboardingOffersTypeChoice = () => {
   return (
     <OnboardingLayout
-      mainHeading="Bienvenue sur le pass Culture Pro !"
+      mainHeading="Bienvenue sur pass Culture Pro !"
       verticallyCentered
       isEntryScreen
     >
       <div className={styles['onboarding-offer-container']}>
+        <Banner title="Notre équipe vous contactera par email pour vous demander vos justificatifs d’inscription. Pensez à vérifier vos spams." />
         <h2 className={styles['onboarding-offer-header-subtitle']}>
           Où souhaitez-vous diffuser votre première offre ?
         </h2>


### PR DESCRIPTION
## 🎯 Related Ticket

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41286)

Mise à jour de l'UI et des wordings de l'écran d'onboarding des offres :

- **Wording** : remplacement de « Bienvenue sur **le** pass Culture Pro ! » par « Bienvenue sur pass Culture Pro ! » (page d'onboarding + test e2e associé).
- **Nouvelle bannière d'information** ajoutée sur l'écran `OnboardingOffersTypeChoice` pour prévenir l'utilisateur qu'il sera recontacté par email pour fournir ses justificatifs d'inscription, avec un rappel de vérifier les spams.
- **Labels des CTA** de `OnboardingOffersChoice` plus explicites :
  - « Commencer » → « Créer une offre individuelle »
  - « Commencer » → « Déposer un dossier ADAGE »
- **Accessibilité/sémantique** : le titre de la carte ADAGE est corrigé en `h3` (via `titleTag="h3"` qui avait été oublié lors d'une migration vers le composant `<Card>` du ui-kit), les specs utilisent `getByRole('heading' | 'link' | 'button')` plutôt que `getByText`.
- **Layout** : ajustement du SCSS de `OnboardingOffersTypeChoice` (suppression du `gap`, ajout d'un `max-width: 721px`, marges verticales sur le sous-titre).
- **Tests** : mise à jour des specs unitaires (`OnboardingOffersTypeChoice`, `OnboardingOffersChoice`) et du test e2e `didacticOnboarding.e2e.ts` pour couvrir les nouveaux textes.

## 🖼️ Before & After Images

Before | After
:---: | :---:
<img width="980" height="855" alt="image" src="https://github.com/user-attachments/assets/7c1a0ce7-f7a5-4a68-8a7d-b59dd76eb291" /> | <img width="980" height="855" alt="image" src="https://github.com/user-attachments/assets/943b1ab2-3782-4648-97b1-5bc40feb3620" />