### PR TITLE
(IC-1133) refactor: push only into old artifact registry when image is for preview environment

### DIFF
--- a/.github/workflows/dev_on_dispatch_deploy_pullrequests.yml
+++ b/.github/workflows/dev_on_dispatch_deploy_pullrequests.yml
@@ -139,6 +139,7 @@ jobs:
       image: pcapi
       tag: ${{ github.sha }}
       tag_latest: true
+      is_for_preview: true
     secrets:
       WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
       SERVICE_ACCOUNT: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}

--- a/.github/workflows/dev_on_workflow_push_docker_image.yml
+++ b/.github/workflows/dev_on_workflow_push_docker_image.yml
@@ -16,6 +16,11 @@ on:
         type: boolean
         default: false
 
+      is_for_preview:
+        required: false
+        type: boolean
+        default: false
+
     secrets:
       WORKLOAD_IDENTITY_PROVIDER:
         description: 'Workload Identity Provider for fetching secrets in Secret Manager'
@@ -35,15 +40,18 @@ jobs:
             project_id: passculture-infra-prod
             repository: pass-culture-artifact-registry
             cosign_kms_key_secret_name: passculture-metier-ehp/cosign_kms_key
+            allow_preview_image: true
           - registry: europe-docker.pkg.dev
             project_id: pc-infra-prd
             repository: pass-culture-artifact-registry
             cosign_kms_key_secret_name: pc-infra-prd/cosign_kms_key
+            allow_preview_image: false
     steps:
       - name: Checkout new tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Push built docker image to Artifact Registry ${{ matrix.registry }}
+        if: ${{ !inputs.is_for_preview || matrix.allow_preview_image }}
         uses: ./.github/actions/push-docker-image
         with:
           image: ${{ inputs.image }}


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

- [Front](?expand=1&template=template_front.md)
- [Back](?expand=1&template=template_back.md)
- [Script](?expand=1&template=template_script.md)
- [DS](?expand=1&template=template_DS.md)
