### PR TITLE
(PC-40936)[API] feat: add auth to e2e routes without

### DIFF
--- a/.github/workflows/ci_sub_test_e2e.yml
+++ b/.github/workflows/ci_sub_test_e2e.yml
@@ -138,6 +138,7 @@ jobs:
         env:
           IMAGE: ${{ inputs.image }}
           TAG: ${{ inputs.tag }}
+          E2E_API_KEY: DummyToken
         run: |
           if [ "$TAG" != "latest" ]; then
             docker load --input "${{ runner.temp }}/$IMAGE-$TAG.tar"
@@ -152,6 +153,7 @@ jobs:
             --publish 5001:5001 \
             --publish 10002:10002 \
             --entrypoint bash \
+            --env E2E_API_KEY=DummyToken \
             "${{ steps.compute-image-name.outputs.image_name }}" \
             -c "set -e ; flask install_postgres_extensions ; alembic upgrade pre@head ; alembic upgrade post@head ; flask install_data ; FLASK_USE_RELOADER=0 python src/pcapi/app.py"
 
@@ -176,7 +178,9 @@ jobs:
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:3001)" != "200" ]]; do sleep 5; done' || false
 
       - name: "Playwright run"
-        run: yarn test:e2e:ci --reporter=blob --shard="${{ matrix.shardIndex }}/${{matrix.shardTotal }}"
+        run: E2E_API_KEY=DummyToken yarn test:e2e:ci --reporter=blob --shard="${{ matrix.shardIndex }}/${{matrix.shardTotal }}"
+        env:
+          E2E_API_KEY: DummyToken
 
       - name: "Upload Playwright report"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/api/src/pcapi/routes/internal/e2e.py
+++ b/api/src/pcapi/routes/internal/e2e.py
@@ -10,8 +10,11 @@ from pcapi.models.api_errors import ApiErrors
 from pcapi.routes.apis import private_api
 from pcapi.sandboxes.scripts import getters
 
+from .e2e_account import api_key_required
+
 
 @private_api.route("/sandboxes/<module_name>/<getter_name>", methods=["GET"])
+@api_key_required
 def get_sandbox(module_name: str, getter_name: str) -> Response:
     if not hasattr(getters, module_name):
         errors = ApiErrors()
@@ -49,6 +52,7 @@ def get_sandbox(module_name: str, getter_name: str) -> Response:
 # otherwise the outbox will be empty
 # The next endpoints is only available if ENABLE_TEST_ROUTES is set to 1
 @private_api.route("/sandboxes/clear_email_list", methods=["GET"])
+@api_key_required
 def clear_email_list() -> str:
     if len(mails_testing.outbox) != 0:
         mails_testing.outbox.clear()
@@ -56,6 +60,7 @@ def clear_email_list() -> str:
 
 
 @private_api.route("/sandboxes/get_unique_email", methods=["GET"])
+@api_key_required
 def get_unique_email() -> dict:
     delay = 0
     while len(mails_testing.outbox) == 0 and delay <= 60:

--- a/api/src/pcapi/routes/internal/e2e_account.py
+++ b/api/src/pcapi/routes/internal/e2e_account.py
@@ -20,16 +20,17 @@ from pcapi.routes.backoffice.dev.blueprint import get_token_expiration_timestamp
 from pcapi.utils import transaction_manager
 
 
-API_KEY_HEADER_NAME = "X-API-KEY"
+API_KEY_HEADER_NAME = "x-api-key"
 
 
 def api_key_required(route_function: typing.Callable) -> typing.Callable:
     @functools.wraps(route_function)
     def wrapper(*args: typing.Any, **kwargs: typing.Any) -> flask.Response:
-        if not (request.headers.get(API_KEY_HEADER_NAME) or "").strip():
+        token = request.headers.get(API_KEY_HEADER_NAME)
+        if not token:
             raise api_errors.UnauthorizedError(errors={"auth": "API key required"})
 
-        if request.headers[API_KEY_HEADER_NAME] != settings.E2E_API_KEY:
+        if token != settings.E2E_API_KEY:
             raise api_errors.ForbiddenError(errors={"auth": "Invalid API key"})
 
         return route_function(*args, **kwargs)

--- a/api/src/pcapi/routes/internal/storage.py
+++ b/api/src/pcapi/routes/internal/storage.py
@@ -6,8 +6,11 @@ from flask import send_file
 from pcapi.core.object_storage.backends.local import LocalBackend
 from pcapi.routes.apis import public_api
 
+from .e2e_account import api_key_required
+
 
 @public_api.route("/storage/<bucket_id>/<path:object_id>")
+@api_key_required
 def send_storage_file(bucket_id: str, object_id: str) -> Response:
     path = LocalBackend().local_path(bucket_id, object_id)
     type_path = path.parent / (path.name + ".type")

--- a/api/src/pcapi/routes/internal/testing.py
+++ b/api/src/pcapi/routes/internal/testing.py
@@ -12,12 +12,14 @@ from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils.transaction_manager import atomic
 
 from . import serializers
+from .e2e_account import api_key_required
 
 
 logger = logging.getLogger(__name__)
 
 
 @public_api.route("/testing/features", methods=["PATCH"])
+@api_key_required
 @atomic()
 @spectree_serialize(on_success_status=204)
 def set_features(body: serializers.FeaturesToggleRequest) -> None:
@@ -33,6 +35,7 @@ class AdageFakeToken(HttpBodyModel):
 
 
 @blueprint.adage_iframe.route("/testing/token", methods=["GET"])
+@api_key_required
 @atomic()
 @spectree_serialize(api=blueprint.api, on_error_statuses=[404])
 def create_adage_jwt_fake_token() -> AdageFakeToken:

--- a/api/tests/routes/internal/testing_test.py
+++ b/api/tests/routes/internal/testing_test.py
@@ -8,10 +8,17 @@ from pcapi.models.feature import Feature
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
+@pytest.fixture(name="auth_client")
+def auth_client_fixture(client, settings):
+    settings.E2E_API_KEY = "secret"
+    client.auth_header = {"x-api-key": settings.E2E_API_KEY}
+    return client
+
+
 class FeaturesToggleTest:
     @pytest.mark.features(ENABLE_NATIVE_APP_RECAPTCHA=False)
-    def test_set_features(self, client):
-        response = client.patch(
+    def test_set_features(self, auth_client):
+        response = auth_client.patch(
             "/testing/features",
             json={
                 "features": [
@@ -28,16 +35,16 @@ class FeaturesToggleTest:
         assert feature.isActive
 
 
-def test_create_adage_jwt_fake_token(client):
+def test_create_adage_jwt_fake_token(auth_client):
     dst = url_for("adage_iframe.create_adage_jwt_fake_token")
-    response = client.get(dst)
+    response = auth_client.get(dst)
 
     assert response.status_code == 200
     assert response.json["token"]
 
 
 @pytest.mark.settings(ENABLE_TEST_ROUTES=False)
-def test_route_unreachable(client):
+def test_route_unreachable(auth_client):
     dst = url_for("adage_iframe.create_adage_jwt_fake_token")
-    response = client.get(dst)
+    response = auth_client.get(dst)
     assert response.status_code == 404

--- a/pro/e2e/adageConfirmation.e2e.ts
+++ b/pro/e2e/adageConfirmation.e2e.ts
@@ -47,7 +47,8 @@ test.describe('Adage confirmation', () => {
     const providerApiKey = userData.providerApiKey
 
     const clearEmailResponse = await requestContext.get(
-      `${BASE_API_URL}/sandboxes/clear_email_list`
+      `${BASE_API_URL}/sandboxes/clear_email_list`,
+      { headers: { 'x-api-key': process.env.E2E_API_KEY } }
     )
     expect(clearEmailResponse.status()).toBe(200)
 
@@ -134,7 +135,8 @@ test.describe('Adage confirmation', () => {
     ).toBeVisible()
 
     const clearEmailResponse2 = await requestContext.get(
-      `${BASE_API_URL}/sandboxes/clear_email_list`
+      `${BASE_API_URL}/sandboxes/clear_email_list`,
+      { headers: { 'x-api-key': process.env.E2E_API_KEY } }
     )
     expect(clearEmailResponse2.status()).toBe(200)
 
@@ -200,7 +202,8 @@ test.describe('Adage confirmation', () => {
     await expect(page.getByRole('button', { name: 'Statut' })).toBeVisible()
 
     const clearEmailResponse3 = await requestContext.get(
-      `${BASE_API_URL}/sandboxes/clear_email_list`
+      `${BASE_API_URL}/sandboxes/clear_email_list`,
+      { headers: { 'x-api-key': process.env.E2E_API_KEY } }
     )
     expect(clearEmailResponse3.status()).toBe(200)
 

--- a/pro/e2e/collaborator.e2e.ts
+++ b/pro/e2e/collaborator.e2e.ts
@@ -36,7 +36,7 @@ test.describe('Collaborator list feature', () => {
 
     const clearResponse = await requestContext.fetch(
       `${BASE_API_URL}/sandboxes/clear_email_list`,
-      { method: 'GET' }
+      { method: 'GET', headers: { 'x-api-key': process.env.E2E_API_KEY } }
     )
     expect(clearResponse.status()).toBe(200)
 

--- a/pro/e2e/createAccount.e2e.ts
+++ b/pro/e2e/createAccount.e2e.ts
@@ -20,7 +20,7 @@ test.describe('Account creation', () => {
 
     const clearResponse = await requestContext.fetch(
       `${BASE_API_URL}/sandboxes/clear_email_list`,
-      { method: 'GET' }
+      { method: 'GET', headers: { 'x-api-key': process.env.E2E_API_KEY } }
     )
     expect(clearResponse.status()).toBe(200)
 

--- a/pro/e2e/fixtures/adage.ts
+++ b/pro/e2e/fixtures/adage.ts
@@ -43,6 +43,7 @@ export const test = base.extend<{
       'http://localhost:5001/adage-iframe/testing/token',
       {
         method: 'GET',
+        headers: { 'x-api-key': process.env.E2E_API_KEY },
       }
     )
     const body = await response.json()

--- a/pro/e2e/helpers/features.ts
+++ b/pro/e2e/helpers/features.ts
@@ -17,6 +17,7 @@ export async function setFeatureFlags(
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',
+        'x-api-key': process.env.E2E_API_KEY,
       },
       data: { features },
     }

--- a/pro/e2e/helpers/sandbox.ts
+++ b/pro/e2e/helpers/sandbox.ts
@@ -13,6 +13,9 @@ export async function sandboxCall<T = unknown>(
     method,
     timeout: SANDBOX_TIMEOUT,
     failOnStatusCode: false,
+    headers: {
+      'x-api-key': process.env.E2E_API_KEY,
+    },
   })
 
   if (response.status() === 200) {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-40936)

Ne pas permettre l'accès à certaines routes e2e sans être authentifié. Il semblerait que les éléments essentiels étaient déjà présents mais que le décorateur n'avait pas été appliqué partout.