### PR TITLE
(PC-41395)[API] fix: finance event not saved as cancelled

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -258,6 +258,7 @@ def cancel_latest_event(
         return None
     pricing = _cancel_event_pricing(event, models.PricingLogReason.MARK_AS_UNUSED)
     event.status = models.FinanceEventStatus.CANCELLED
+    db.session.add(event)
     db.session.flush()
     logger.info(
         "Cancelled finance event and its pricing",


### PR DESCRIPTION
Ticket Jira : https://passculture.atlassian.net/browse/PC-41395

```
Not the first time, and I don't know why...
Log "Cancelled finance event and its pricing" was printed. Log "Booking was marked as unused" was printed.
Contact update tasks were initiated on commit.
But the finance event was kept "ready"!

=> TypeError: '<' not supported between instances of 'NoneType' and 'datetime.datetime' (1 additional frame(s) were not displayed)
...
  File "pcapi/core/finance/api.py", line 502, in price_event
    pricing = _price_event(event)
  File "pcapi/core/finance/api.py", line 584, in _price_event
    rule = reimbursement_rules.get_reimbursement_rule(booking, rule_finder, new_revenue)
  File "pcapi/core/finance/reimbursement_rules.py", line 254, in get_reimbursement_rule
    custom_rule = custom_rule_finder.get_rule(booking)
  File "pcapi/core/finance/reimbursement_rules.py", line 237, in get_rule
    for rule in self.rules_by_venue.get(finance_api.get_pricing_point_link(booking).pricingPointId, ()):
  File "pcapi/core/finance/api.py", line 362, in get_pricing_point_link
    if timestamp < link.timespan.lower:

Maybe this can help if sometimes the ORM does not add it properly to the session.
```