### PR TITLE
(PC-38644)[API] feat: return 404 when checking user access to offerer/venue

### DIFF
--- a/api/src/pcapi/models/api_errors.py
+++ b/api/src/pcapi/models/api_errors.py
@@ -5,6 +5,9 @@ from pcapi.core.core_exception import ClientError
 from pcapi.core.core_exception import CoreException
 
 
+OBJECT_NOT_FOUND_ERROR_MESSAGE = "L'objet n'existe pas, ou vous n'avez pas les droits nécessaires pour y accéder."
+
+
 class ApiErrors(Exception):
     status_code: int = 400
 
@@ -71,3 +74,7 @@ class UuidCastError(ApiErrors):
 
 class InternalError(ApiErrors):
     status_code = 500
+
+
+def resource_not_found_error() -> ResourceNotFoundError:
+    return ResourceNotFoundError(errors={"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]})

--- a/api/src/pcapi/models/utils.py
+++ b/api/src/pcapi/models/utils.py
@@ -1,10 +1,10 @@
 import typing
 
 import sqlalchemy.orm as sa_orm
-from werkzeug.exceptions import NotFound
 
 from pcapi import models
 from pcapi.models import db
+from pcapi.models.api_errors import resource_not_found_error
 
 
 T = typing.TypeVar("T", bound=models.Model)
@@ -13,7 +13,7 @@ T = typing.TypeVar("T", bound=models.Model)
 def get_or_404_from_query(query: "sa_orm.Query[T]", obj_id: int | str) -> T:
     obj = query.filter_by(id=obj_id).one_or_none()
     if not obj:
-        raise NotFound()
+        raise resource_not_found_error()
     return obj
 
 
@@ -24,5 +24,5 @@ def get_or_404(model: typing.Type[T], obj_id: int | str) -> T:
 def first_or_404(query: "sa_orm.Query[T]") -> T:
     obj = query.first()
     if not obj:
-        raise NotFound()
+        raise resource_not_found_error()
     return obj

--- a/api/src/pcapi/routes/pro/bookings.py
+++ b/api/src/pcapi/routes/pro/bookings.py
@@ -18,7 +18,6 @@ from pcapi.core.bookings import validation as bookings_validation
 from pcapi.core.bookings.models import BookingExportType
 from pcapi.core.offers.models import Offer
 from pcapi.core.offers.models import Stock
-from pcapi.core.users import repository as users_repository
 from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.models.utils import get_or_404
@@ -36,6 +35,7 @@ from pcapi.routes.serialization.bookings_recap_serialize import UserHasBookingRe
 from pcapi.routes.serialization.bookings_recap_serialize import serialize_bookings
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse
+from pcapi.utils.rest import check_user_has_access_to_offerer
 from pcapi.utils.transaction_manager import atomic
 
 from . import blueprint
@@ -47,8 +47,7 @@ from . import blueprint
 @spectree_serialize(response_model=ListBookingsResponseModel, api=blueprint.pro_private_schema)
 def get_bookings_pro(query: ListBookingsQueryModel) -> ListBookingsResponseModel:
     user = current_user._get_current_object()
-    if not users_repository.has_access(user, query.offerer_id):
-        raise api_errors.ResourceNotFoundError()
+    check_user_has_access_to_offerer(user, query.offerer_id)
 
     venue_ids = _resolve_venue_ids_for_offerer(offerer_id=query.offerer_id, venue_id=query.venue_id)
 
@@ -105,8 +104,7 @@ def export_bookings_for_offer_as_csv(offer_id: int, query: BookingsExportQueryMo
     user = current_user._get_current_object()
     offer = get_or_404(Offer, offer_id)
 
-    if not users_repository.has_access(user, offer.venue.managingOffererId):
-        raise api_errors.ForbiddenError({"global": "You are not allowed to access this offer"})
+    check_user_has_access_to_offerer(user, offer.venue.managingOffererId)
 
     if query.status == BookingsExportStatusFilter.VALIDATED:
         return cast(
@@ -138,8 +136,7 @@ def export_bookings_for_offer_as_excel(offer_id: int, query: BookingsExportQuery
     user = current_user._get_current_object()
     offer = get_or_404(Offer, offer_id)
 
-    if not users_repository.has_access(user, offer.venue.managingOffererId):
-        raise api_errors.ForbiddenError({"global": "You are not allowed to access this offer"})
+    check_user_has_access_to_offerer(user, offer.venue.managingOffererId)
 
     if query.status == BookingsExportStatusFilter.VALIDATED:
         return cast(
@@ -194,8 +191,7 @@ def get_offer_price_categories_and_schedules_by_dates(offer_id: int) -> EventDat
     user = current_user._get_current_object()
     offer = get_or_404(Offer, offer_id)
 
-    if not users_repository.has_access(user, offer.venue.managingOffererId):
-        raise api_errors.ForbiddenError({"global": "You are not allowed to access this offer"})
+    check_user_has_access_to_offerer(user, offer.venue.managingOffererId)
 
     stocks = (
         db.session.query(Stock)
@@ -243,8 +239,7 @@ def get_offer_price_categories_and_schedules_by_dates(offer_id: int) -> EventDat
 
 def _create_booking_export_file(query: ListBookingsQueryModel, export_type: BookingExportType) -> bytes:
     user = current_user._get_current_object()
-    if not users_repository.has_access(user, query.offerer_id):
-        raise api_errors.ResourceNotFoundError()
+    check_user_has_access_to_offerer(user, query.offerer_id)
 
     venue_ids = _resolve_venue_ids_for_offerer(offerer_id=query.offerer_id, venue_id=query.venue_id)
 
@@ -275,7 +270,7 @@ def _resolve_venue_ids_for_offerer(*, offerer_id: int, venue_id: int | None) -> 
     if venue_id is not None:
         venue = get_or_404(offerers_models.Venue, venue_id)
         if venue.managingOffererId != offerer_id:
-            raise api_errors.ResourceNotFoundError()
+            raise api_errors.resource_not_found_error()
         return [venue_id]
     return offerers_repository.get_venue_ids_by_offerer_ids([offerer_id])
 
@@ -283,7 +278,7 @@ def _resolve_venue_ids_for_offerer(*, offerer_id: int, venue_id: int | None) -> 
 def _get_booking_by_token_or_404(token: str) -> bookings_models.Booking:
     booking = bookings_repository.get_booking_by_token(token, load_options=["offerer", "venue", "offer", "address"])
     if not booking:
-        raise api_errors.ResourceNotFoundError({"global": [TOKEN_NOT_FOUND_ERROR_MESSAGE]})
+        raise api_errors.ResourceNotFoundError(errors={"global": [TOKEN_NOT_FOUND_ERROR_MESSAGE]})
 
     return booking
 

--- a/api/src/pcapi/routes/pro/collective_bookings.py
+++ b/api/src/pcapi/routes/pro/collective_bookings.py
@@ -8,6 +8,7 @@ from pcapi.core.educational.api import booking as educational_api_booking
 from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import exceptions as offerers_exceptions
 from pcapi.models.api_errors import ApiErrors
+from pcapi.models.api_errors import resource_not_found_error
 from pcapi.routes.apis import private_api
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils.rest import check_user_has_access_to_offerer
@@ -31,9 +32,7 @@ def cancel_collective_offer_booking(offer_id: int) -> None:
     try:
         offerer = offerers_api.get_offerer_by_collective_offer_id(offer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors(
-            {"code": "NO_COLLECTIVE_OFFER_FOUND", "message": "No collective offer has been found with this id"}, 404
-        )
+        raise resource_not_found_error()
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     try:
@@ -45,9 +44,7 @@ def cancel_collective_offer_booking(offer_id: int) -> None:
             {"code": "NO_ACTIVE_STOCK_FOUND", "message": "No active stock has been found with this id"}, 404
         )
     except collective_exceptions.CollectiveOfferNotFound:
-        raise ApiErrors(
-            {"code": "NO_COLLECTIVE_OFFER_FOUND", "message": "No collective offer has been found with this id"}, 404
-        )
+        raise resource_not_found_error()
     except collective_exceptions.NoCollectiveBookingToCancel:
         raise ApiErrors({"code": "NO_BOOKING", "message": "This collective offer has no booking to cancel"}, 400)
     except collective_exceptions.CollectiveOfferForbiddenAction:

--- a/api/src/pcapi/routes/pro/collective_offers.py
+++ b/api/src/pcapi/routes/pro/collective_offers.py
@@ -17,6 +17,7 @@ from pcapi.core.offers import constants as offers_constants
 from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.core.offers import validation as offers_validation
 from pcapi.models.api_errors import ApiErrors
+from pcapi.models.api_errors import resource_not_found_error
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import collective_offers_serialize
 from pcapi.routes.serialization import educational_redactors
@@ -190,16 +191,13 @@ def get_collective_offer(offer_id: int) -> collective_offers_serialize.GetCollec
     try:
         offerer = offerers_api.get_offerer_by_collective_offer_id(offer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
+        raise resource_not_found_error()
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     try:
         offer = repository.get_collective_offer_by_id(offer_id)
     except exceptions.CollectiveOfferNotFound:
-        raise ApiErrors(
-            errors={"global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"]},
-            status_code=404,
-        )
+        raise resource_not_found_error()
     return collective_offers_serialize.GetCollectiveOfferResponseModel.build(offer)
 
 
@@ -214,15 +212,12 @@ def get_collective_offer_template(offer_id: int) -> collective_offers_serialize.
     try:
         offerer = offerers_api.get_offerer_by_collective_offer_template_id(offer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
+        raise resource_not_found_error()
     check_user_has_access_to_offerer(current_user, offerer.id)
     try:
         offer = repository.get_collective_offer_template_by_id(offer_id)
     except exceptions.CollectiveOfferTemplateNotFound:
-        raise ApiErrors(
-            errors={"global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"]},
-            status_code=404,
-        )
+        raise resource_not_found_error()
     return collective_offers_serialize.GetCollectiveOfferTemplateResponseModel.build(offer)
 
 
@@ -237,7 +232,7 @@ def get_collective_offer_request(request_id: int) -> collective_offers_serialize
     try:
         collective_offer_request = repository.get_collective_offer_request_by_id(request_id)
     except exceptions.CollectiveOfferRequestNotFound:
-        raise ApiErrors(errors={"global": ["Le formulaire demandé n'existe pas"]}, status_code=404)
+        raise resource_not_found_error()
 
     offerer_id = collective_offer_request.collectiveOfferTemplate.venue.managingOffererId
     check_user_has_access_to_offerer(current_user, offerer_id)
@@ -261,9 +256,9 @@ def create_collective_offer(
 
     # venue / offerer errors
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
+        raise resource_not_found_error()
     except exceptions.VenueIdDoesNotExist:
-        raise ApiErrors({"venueId": "The venue does not exist."}, 404)
+        raise resource_not_found_error()
 
     # adage errors
     except exceptions.CulturalPartnerNotFoundException:
@@ -285,7 +280,7 @@ def create_collective_offer(
     except exceptions.CollectiveOfferTemplateForbiddenAction:
         raise ApiErrors({"code": "COLLECTIVE_OFFER_TEMPLATE_FORBIDDEN_ACTION"}, status_code=403)
     except exceptions.CollectiveOfferTemplateNotFound:
-        raise ApiErrors({"code": "COLLECTIVE_OFFER_TEMPLATE_NOT_FOUND"}, status_code=404)
+        raise resource_not_found_error()
 
     return collective_offers_serialize.CollectiveOfferResponseIdModel(id=offer.id)
 
@@ -303,7 +298,7 @@ def edit_collective_offer(
     try:
         offerer = offerers_api.get_offerer_by_collective_offer_id(offer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
+        raise resource_not_found_error()
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     if not offerers_api.can_offerer_create_educational_offer(offerer.id):
@@ -324,7 +319,7 @@ def edit_collective_offer(
     except exceptions.OffererOfVenueDontMatchOfferer:
         raise ApiErrors({"venueId": "New venue needs to have the same offerer"}, 403)
     except exceptions.VenueIdDoesNotExist:
-        raise ApiErrors({"venueId": "The venue does not exist."}, 404)
+        raise resource_not_found_error()
 
     # domains / national_program errors
     except exceptions.NationalProgramNotFound:
@@ -363,7 +358,7 @@ def edit_collective_offer_template(
     try:
         offerer = offerers_api.get_offerer_by_collective_offer_template_id(offer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
+        raise resource_not_found_error()
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     if not offerers_api.can_offerer_create_educational_offer(offerer.id):
@@ -374,7 +369,7 @@ def edit_collective_offer_template(
 
     # venue / offerer errors
     except exceptions.VenueIdDoesNotExist:
-        raise ApiErrors({"venueId": "The venue does not exist."}, 404)
+        raise resource_not_found_error()
     except exceptions.OffererOfVenueDontMatchOfferer:
         raise ApiErrors({"venueId": "New venue needs to have the same offerer"}, 403)
 
@@ -487,7 +482,7 @@ def patch_collective_offers_educational_institution(
     try:
         offerer = offerers_api.get_offerer_by_collective_offer_id(offer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
+        raise resource_not_found_error()
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     try:
@@ -513,14 +508,14 @@ def patch_collective_offers_educational_institution(
 @login_required
 @spectree_serialize(
     on_success_status=200,
-    on_error_statuses=[403, 404],
+    on_error_statuses=[404],
     api=blueprint.pro_private_schema,
     response_model=collective_offers_serialize.GetCollectiveOfferResponseModel,
 )
 def patch_collective_offer_publication(offer_id: int) -> collective_offers_serialize.GetCollectiveOfferResponseModel:
     offer = repository.get_collective_offer_and_confidence_rules(offer_id)
     if offer is None:
-        raise ApiErrors({"offerer": ["Aucune offre trouvée pour cet id"]}, status_code=404)
+        raise resource_not_found_error()
 
     check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
@@ -534,7 +529,7 @@ def patch_collective_offer_publication(offer_id: int) -> collective_offers_seria
 @login_required
 @spectree_serialize(
     on_success_status=200,
-    on_error_statuses=[403, 404],
+    on_error_statuses=[404],
     api=blueprint.pro_private_schema,
     response_model=collective_offers_serialize.GetCollectiveOfferTemplateResponseModel,
 )
@@ -543,8 +538,8 @@ def patch_collective_offer_template_publication(
 ) -> collective_offers_serialize.GetCollectiveOfferTemplateResponseModel:
     try:
         offer = repository.get_collective_offer_template_by_id(offer_id)
-    except exceptions.CollectiveOfferNotFound:
-        raise ApiErrors({"offerer": ["Aucune offre trouvée pour cet id"]}, status_code=404)
+    except exceptions.CollectiveOfferTemplateNotFound:
+        raise resource_not_found_error()
 
     check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
@@ -569,9 +564,9 @@ def create_collective_offer_template(
 
     # venue / offerer errors
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
+        raise resource_not_found_error()
     except exceptions.VenueIdDoesNotExist:
-        raise ApiErrors({"venueId": "The venue does not exist."}, 404)
+        raise resource_not_found_error()
 
     # adage errors
     except exceptions.CulturalPartnerNotFoundException:
@@ -655,7 +650,7 @@ def attach_offer_image(
     try:
         offer = repository.get_collective_offer_by_id(offer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune offre trouvée pour cet id."]}, status_code=404)
+        raise resource_not_found_error()
 
     check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
@@ -695,7 +690,7 @@ def attach_offer_template_image(
     try:
         offer = repository.get_collective_offer_template_by_id(offer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune offre trouvée pour cet id."]}, status_code=404)
+        raise resource_not_found_error()
 
     check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
@@ -727,7 +722,7 @@ def delete_offer_image(offer_id: int) -> None:
     try:
         offer = repository.get_collective_offer_by_id(offer_id)
     except exceptions.CollectiveOfferNotFound:
-        raise ApiErrors({"offerer": ["Aucune offre trouvée pour cet id."]}, status_code=404)
+        raise resource_not_found_error()
 
     check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
@@ -750,7 +745,7 @@ def delete_offer_template_image(offer_id: int) -> None:
     try:
         offer = repository.get_collective_offer_template_by_id(offer_id)
     except exceptions.CollectiveOfferTemplateNotFound:
-        raise ApiErrors({"offerer": ["Aucune offre trouvée pour cet id."]}, status_code=404)
+        raise resource_not_found_error()
 
     check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
@@ -798,13 +793,13 @@ def duplicate_collective_offer(
     try:
         offerer = offerers_api.get_offerer_by_collective_offer_id(offer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
+        raise resource_not_found_error()
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     try:
         original_offer = repository.get_collective_offer_by_id(offer_id)
     except exceptions.CollectiveOfferNotFound:
-        raise ApiErrors({"offerer": ["Aucune offre trouvée pour cet id"]}, status_code=404)
+        raise resource_not_found_error()
 
     try:
         offer = api_offer.duplicate_offer_and_stock(original_offer=original_offer)

--- a/api/src/pcapi/routes/pro/collective_stocks.py
+++ b/api/src/pcapi/routes/pro/collective_stocks.py
@@ -11,7 +11,7 @@ from pcapi.core.offerers import repository as offerers_repository
 from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ForbiddenError
-from pcapi.models.api_errors import ResourceNotFoundError
+from pcapi.models.api_errors import resource_not_found_error
 from pcapi.routes.apis import private_api
 from pcapi.routes.pro import blueprint
 from pcapi.routes.serialization import collective_stock_serialize
@@ -38,7 +38,7 @@ def create_collective_stock(
     try:
         offerer = offerers_repository.get_by_collective_offer_id(body.offerId)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ResourceNotFoundError({"offerer": ["Aucune structure trouvée à partir de cette offre"]})
+        raise resource_not_found_error()
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     try:
@@ -71,12 +71,12 @@ def edit_collective_stock(
 ) -> collective_stock_serialize.CollectiveStockResponseModel:
     collective_stock = repository.get_collective_stock(collective_stock_id)
     if collective_stock is None:
-        raise ResourceNotFoundError({"code": "COLLECTIVE_STOCK_NOT_FOUND"})
+        raise resource_not_found_error()
 
     try:
         offerer = offerers_repository.get_by_collective_stock_id(collective_stock.id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ResourceNotFoundError({"offerer": ["Aucune structure trouvée à partir de cette offre"]})
+        raise resource_not_found_error()
     check_user_has_access_to_offerer(current_user, offerer.id)
 
     try:

--- a/api/src/pcapi/routes/pro/headline_offer.py
+++ b/api/src/pcapi/routes/pro/headline_offer.py
@@ -33,7 +33,7 @@ def upsert_headline_offer(
     offer = offers_repository.get_offer_by_id(body.offer_id, load_options=["headline_offer", "venue"])
 
     if not offer:
-        raise api_errors.ResourceNotFoundError
+        raise api_errors.resource_not_found_error()
     offerer_id = offer.venue.managingOffererId
 
     rest.check_user_has_access_to_offerer(current_user, offerer_id)

--- a/api/src/pcapi/routes/pro/offerers.py
+++ b/api/src/pcapi/routes/pro/offerers.py
@@ -23,7 +23,7 @@ from pcapi.core.offerers import api
 from pcapi.core.offerers import repository
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
-from pcapi.models.api_errors import ResourceNotFoundError
+from pcapi.models.api_errors import resource_not_found_error
 from pcapi.models.utils import get_or_404
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import finance_serialize
@@ -85,7 +85,7 @@ def get_offerer(offerer_id: int) -> offerers_serialize.GetOffererResponseModel:
     check_user_has_access_to_offerer(current_user, offerer_id)
     row = repository.get_offerer_and_extradata(offerer_id)
     if not row:
-        raise ResourceNotFoundError()
+        raise resource_not_found_error()
     ids_of_venues_with_offers = offerers_repository.get_ids_of_venues_with_offers([row.Offerer.id])
     has_digital_venue_at_least_one_offer = offerers_repository.has_digital_venue_with_at_least_one_offer(row.Offerer.id)
     venues_with_non_free_offers_without_bank_accounts = (
@@ -217,7 +217,7 @@ def get_offerer_bank_accounts_and_attached_venues(
     check_user_has_access_to_offerer(current_user, offerer_id)
     offerer = repository.get_offerer_with_bank_accounts(offerer_id)
     if not offerer:
-        raise ResourceNotFoundError()
+        raise resource_not_found_error()
 
     return offerers_serialize.GetOffererBankAccountsResponseModel(
         id=offerer.id,
@@ -249,7 +249,7 @@ def link_venue_to_bank_account(
     check_user_has_access_to_offerer(current_user, offerer_id)
     bank_account = finance_repository.get_bank_account_with_current_venues_links(offerer_id, bank_account_id)
     if bank_account is None:
-        raise ResourceNotFoundError()
+        raise resource_not_found_error()
     try:
         finance_api.update_bank_account_venues_links(current_user, bank_account, body.venues_ids)
     except finance_exceptions.VenueAlreadyLinkedToAnotherBankAccount as exc:
@@ -349,7 +349,8 @@ def get_offerer_v2_stats(offerer_id: int) -> offerers_serialize.GetOffererV2Stat
     try:
         stats = api.get_offerer_v2_stats(offerer_id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise ResourceNotFoundError()
+        raise resource_not_found_error()
+
     return offerers_serialize.GetOffererV2StatsResponseModel.model_validate(stats)
 
 
@@ -392,7 +393,7 @@ def get_venue_headline_offer(
     try:
         venue_headline_offer = repository.get_venue_headline_offer(venue_id)
     except sa_orm.exc.NoResultFound:
-        raise ResourceNotFoundError()
+        raise resource_not_found_error()
 
     return headline_offer_serialize.HeadLineOfferResponseModel.model_validate(venue_headline_offer)
 

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -23,7 +23,6 @@ from pcapi.core.offers import schemas as offers_schemas
 from pcapi.core.offers import tasks
 from pcapi.core.offers import validation
 from pcapi.core.providers.constants import TITELIVE_MUSIC_TYPES
-from pcapi.core.users import repository as users_repository
 from pcapi.core.videos import api as videos_api
 from pcapi.core.videos import exceptions as videos_exceptions
 from pcapi.models import api_errors
@@ -118,12 +117,7 @@ def get_offer(offer_id: int) -> offers_serialize.GetIndividualOfferWithAddressRe
     try:
         offer = offers_repository.get_offer_by_id(offer_id, load_options=load_all)
     except exceptions.OfferNotFound:
-        raise api_errors.ApiErrors(
-            errors={
-                "global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"],
-            },
-            status_code=404,
-        )
+        raise api_errors.resource_not_found_error()
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
     return offers_serialize.GetIndividualOfferWithAddressResponseModel.from_orm(offer)
@@ -140,12 +134,7 @@ def get_stocks(offer_id: int, query: offers_serialize.StocksQueryModel) -> offer
     try:
         offer = offers_repository.get_offer_by_id(offer_id, load_options=["offerer_address"])
     except exceptions.OfferNotFound:
-        raise api_errors.ApiErrors(
-            errors={
-                "global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"],
-            },
-            status_code=404,
-        )
+        raise api_errors.resource_not_found_error()
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
     filtered_stocks = offers_repository.get_filtered_stocks(
@@ -188,12 +177,7 @@ def upsert_offer_stocks(
     try:
         offer = offers_repository.get_offer_by_id(offer_id)
     except exceptions.OfferNotFound:
-        raise api_errors.ApiErrors(
-            errors={
-                "global": "No offer found for this id",
-            },
-            status_code=404,
-        )
+        raise api_errors.resource_not_found_error()
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
     stock_inputs: list[offers_schemas.ThingStockUpsertInput] = []
@@ -223,12 +207,7 @@ def delete_stocks(offer_id: int, body: offers_serialize.DeleteStockListBody) -> 
     try:
         offer = offers_repository.get_offer_by_id(offer_id)
     except exceptions.OfferNotFound:
-        raise api_errors.ApiErrors(
-            errors={
-                "global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"],
-            },
-            status_code=404,
-        )
+        raise api_errors.resource_not_found_error()
 
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
     stocks_to_delete = [stock for stock in offer.stocks if stock.id in body.ids_to_delete]
@@ -252,12 +231,7 @@ def get_stocks_stats(offer_id: int) -> offers_serialize.StockStatsResponseModel:
     try:
         offer = offers_repository.get_offer_by_id(offer_id)
     except exceptions.OfferNotFound:
-        raise api_errors.ApiErrors(
-            errors={
-                "global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"],
-            },
-            status_code=404,
-        )
+        raise api_errors.resource_not_found_error()
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
     try:
         stocks_stats = offers_api.get_stocks_stats(offer_id=offer_id)
@@ -284,9 +258,7 @@ def get_stocks_stats(offer_id: int) -> offers_serialize.StockStatsResponseModel:
 @atomic()
 def delete_draft_offers(body: offers_serialize.DeleteOfferRequestBody) -> None:
     if not body.ids:
-        raise api_errors.ResourceNotFoundError(
-            {"global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"]}
-        )
+        raise api_errors.resource_not_found_error()
     query = offers_repository.get_offers_by_ids(current_user, body.ids)  # type: ignore[arg-type]
     offers_api.batch_delete_draft_offers(query)
 
@@ -397,7 +369,7 @@ def post_offer(
 @login_required
 @spectree_serialize(
     on_success_status=200,
-    on_error_statuses=[404, 403],
+    on_error_statuses=[404],
     api=blueprint.pro_private_schema,
     response_model=offers_serialize.GetIndividualOfferResponseModel,
 )
@@ -408,13 +380,13 @@ def patch_publish_offer(
     try:
         offerer = offerers_repository.get_by_offer_id(body.id)
     except offerers_exceptions.CannotFindOffererForOfferId:
-        raise api_errors.ApiErrors({"offerer": ["Aucune structure trouvée à partir de cette offre"]}, status_code=404)
+        raise api_errors.resource_not_found_error()
 
     rest.check_user_has_access_to_offerer(current_user, offerer.id)
 
     offer = offers_repository.get_offer_and_extradata(body.id)
     if offer is None:
-        raise api_errors.ApiErrors({"offer": ["Cette offre n’existe pas"]}, status_code=404)
+        raise api_errors.resource_not_found_error()
     if not offers_repository.offer_has_bookable_stocks(offer.id):
         raise api_errors.ApiErrors({"offer": "Cette offre n’a pas de stock réservable"}, 400)
 
@@ -500,7 +472,7 @@ def patch_offer(
             ],
         )
     except exceptions.OfferNotFound:
-        raise api_errors.ResourceNotFoundError()
+        raise api_errors.resource_not_found_error()
 
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
@@ -544,9 +516,7 @@ def create_thumbnail(form: CreateThumbnailBodyModel) -> CreateThumbnailResponseM
     try:
         offer = offers_repository.get_offer_by_id(form.offer_id)
     except exceptions.OfferNotFound:
-        raise api_errors.ResourceNotFoundError(
-            errors={"global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"]}
-        )
+        raise api_errors.resource_not_found_error()
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
     if "thumb" not in request.files:
@@ -635,7 +605,7 @@ def replace_offer_price_categories(
     try:
         offer = offers_repository.get_offer_by_id(offer_id)
     except exceptions.OfferNotFound:
-        raise api_errors.ResourceNotFoundError(errors={"offer_id": "Offer not found"})
+        raise api_errors.resource_not_found_error()
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
     price_category_inputs: list[offers_schemas.PriceCategoryInput] = []
@@ -673,12 +643,11 @@ def replace_offer_price_categories(
 def get_active_venue_offer_by_ean(venue_id: int, ean: str) -> offers_serialize.GetActiveEANOfferResponseModel:
     try:
         venue = get_or_404(offerers_models.Venue, venue_id)
-        rest.check_user_has_access_to_offerer(current_user, venue.managingOffererId)
         offer = offers_repository.get_active_offer_by_venue_id_and_ean(venue_id, ean)
     except exceptions.OfferNotFound:
-        raise api_errors.ResourceNotFoundError(
-            errors={"global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"]}
-        )
+        raise api_errors.resource_not_found_error()
+
+    rest.check_user_has_access_to_offerer(current_user, venue.managingOffererId)
 
     return offers_serialize.GetActiveEANOfferResponseModel.from_orm(offer)
 
@@ -775,10 +744,7 @@ def post_highlight_request_offer(
     try:
         offer = offers_repository.get_offer_by_id(offer_id, load_options={"venue"})
     except exceptions.OfferNotFound:
-        raise api_errors.ApiErrors(
-            errors={"global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"]},
-            status_code=404,
-        )
+        raise api_errors.resource_not_found_error()
     rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
     validation.check_offer_can_ask_for_highlight_request(offer)
 
@@ -825,10 +791,9 @@ def get_offer_pro_advice(offer_id: int) -> offers_serialize.GetProAdviceResponse
     try:
         offer = offers_repository.get_offer_by_id(offer_id, load_options=["venue", "pro_advice"])
     except exceptions.OfferNotFound:
-        raise api_errors.ResourceNotFoundError()
+        raise api_errors.resource_not_found_error()
 
-    if not users_repository.has_access(current_user, offer.venue.managingOffererId):
-        raise api_errors.ResourceNotFoundError()
+    rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
     pro_advice = offers_serialize.ProAdviceModel.model_validate(offer.proAdvice) if offer.proAdvice else None
     return offers_serialize.GetProAdviceResponseModel(pro_advice=pro_advice)
@@ -848,10 +813,9 @@ def create_offer_pro_advice(
     try:
         offer = offers_repository.get_offer_by_id(offer_id, load_options=["venue", "pro_advice"])
     except exceptions.OfferNotFound:
-        raise api_errors.ResourceNotFoundError()
+        raise api_errors.resource_not_found_error()
 
-    if not users_repository.has_access(current_user, offer.venue.managingOffererId):
-        raise api_errors.ResourceNotFoundError()
+    rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
     user = current_user._get_current_object()
     pro_advice = pro_advice_api.create_pro_advice(offer, body.content, body.author, user.id)
@@ -871,10 +835,9 @@ def update_offer_pro_advice(
     try:
         offer = offers_repository.get_offer_by_id(offer_id, load_options=["venue", "pro_advice"])
     except exceptions.OfferNotFound:
-        raise api_errors.ResourceNotFoundError()
+        raise api_errors.resource_not_found_error()
 
-    if not users_repository.has_access(current_user, offer.venue.managingOffererId):
-        raise api_errors.ResourceNotFoundError()
+    rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
     user = current_user._get_current_object()
     pro_advice = pro_advice_api.update_pro_advice(offer, body.content, body.author, user.id)
@@ -892,10 +855,9 @@ def delete_offer_pro_advice(offer_id: int) -> None:
     try:
         offer = offers_repository.get_offer_by_id(offer_id, load_options=["venue", "pro_advice"])
     except exceptions.OfferNotFound:
-        raise api_errors.ResourceNotFoundError()
+        raise api_errors.resource_not_found_error()
 
-    if not users_repository.has_access(current_user, offer.venue.managingOffererId):
-        raise api_errors.ResourceNotFoundError()
+    rest.check_user_has_access_to_offerer(current_user, offer.venue.managingOffererId)
 
     user = current_user._get_current_object()
     pro_advice_api.delete_pro_advice(offer, user.id)

--- a/api/src/pcapi/routes/pro/venue_providers.py
+++ b/api/src/pcapi/routes/pro/venue_providers.py
@@ -4,7 +4,6 @@ import functools
 from flask_login import current_user
 from flask_login import login_required
 from sqlalchemy.orm import exc as orm_exc
-from werkzeug.exceptions import NotFound
 
 import pcapi.core.offerers.models as offerers_models
 from pcapi.core.providers import api
@@ -17,6 +16,7 @@ from pcapi.core.providers.models import VenueProviderCreationPayload
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.api_errors import ResourceNotFoundError
+from pcapi.models.api_errors import resource_not_found_error
 from pcapi.routes.apis import private_api
 from pcapi.routes.serialization import venue_provider_serialize
 from pcapi.serialization.decorator import spectree_serialize
@@ -30,14 +30,14 @@ from . import blueprint
 def _get_venue_or_404(venue_id: int) -> offerers_models.Venue:
     venue = db.session.query(offerers_models.Venue).filter_by(id=venue_id).one_or_none()
     if not venue:
-        raise NotFound
+        raise resource_not_found_error()
     return venue
 
 
 def _get_provider_or_404(provider_id: int) -> providers_models.Provider:
     provider = db.session.query(providers_models.Provider).filter_by(id=provider_id).one_or_none()
     if not provider:
-        raise NotFound
+        raise resource_not_found_error()
     return provider
 
 
@@ -156,7 +156,7 @@ def update_venue_provider(
     try:
         venue_provider = providers_repository.get_venue_provider_by_id(venue_provider_id)
     except orm_exc.NoResultFound:
-        raise NotFound()
+        raise resource_not_found_error()
 
     rest.check_user_has_access_to_offerer(current_user, venue_provider.venue.managingOffererId)
 
@@ -172,7 +172,7 @@ def delete_venue_provider(venue_provider_id: int) -> None:
     try:
         venue_provider = providers_repository.get_venue_provider_by_id(venue_provider_id)
     except orm_exc.NoResultFound:
-        raise NotFound()
+        raise resource_not_found_error()
 
     rest.check_user_has_access_to_offerer(current_user, venue_provider.venue.managingOffererId)
 

--- a/api/src/pcapi/routes/pro/venues.py
+++ b/api/src/pcapi/routes/pro/venues.py
@@ -1,6 +1,5 @@
 from functools import partial
 
-import flask
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 from flask import request
@@ -24,6 +23,7 @@ from pcapi.core.offers import models as offers_models
 from pcapi.core.offers import tasks as offers_tasks
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
+from pcapi.models.api_errors import resource_not_found_error
 from pcapi.models.feature import FeatureToggle
 from pcapi.models.utils import get_or_404
 from pcapi.routes.apis import private_api
@@ -80,7 +80,7 @@ def get_venue(venue_id: int) -> venue_serialize.GetVenueResponseModel:
         .options(sa_orm.joinedload(models.Venue.offererAddress).joinedload(models.OffererAddress.address))
     ).one_or_none()
     if not venue:
-        flask.abort(404)
+        raise resource_not_found_error()
 
     check_user_has_access_to_offerer(current_user, venue.managingOffererId)
 

--- a/api/src/pcapi/utils/rest.py
+++ b/api/src/pcapi/utils/rest.py
@@ -1,23 +1,13 @@
 from pcapi.core.users import repository as users_repository
 from pcapi.core.users.models import User
-from pcapi.models.api_errors import ApiErrors
+from pcapi.models.api_errors import resource_not_found_error
 
 
 def check_user_has_access_to_offerer(user: User, offerer_id: int) -> None:
     if not users_repository.has_access(user, offerer_id):
-        raise ApiErrors(
-            errors={
-                "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."],
-            },
-            status_code=403,
-        )
+        raise resource_not_found_error()
 
 
 def check_user_has_access_to_venues(user: User, venue_ids: list[int]) -> None:
     if not users_repository.has_access_to_venues(user, venue_ids):
-        raise ApiErrors(
-            errors={
-                "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."],
-            },
-            status_code=403,
-        )
+        raise resource_not_found_error()

--- a/api/tests/models/utils_test.py
+++ b/api/tests/models/utils_test.py
@@ -1,9 +1,9 @@
 import pytest
-from werkzeug.exceptions import NotFound
 
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.models.api_errors import ApiErrors
 from pcapi.models.utils import first_or_404
 
 
@@ -22,5 +22,5 @@ class FirstOr404Test:
         obj = users_factories.UserFactory(firstName="Alice")
         db.session.add(obj)
 
-        with pytest.raises(NotFound):
+        with pytest.raises(ApiErrors):
             first_or_404(db.session.query(users_models.User).filter(users_models.User.firstName == "Bob"))

--- a/api/tests/routes/pro/bookings/get_booking_by_token_v2_test.py
+++ b/api/tests/routes/pro/bookings/get_booking_by_token_v2_test.py
@@ -98,25 +98,6 @@ class Returns401Test:
 
 
 class Returns403Test:
-    def test_when_user_doesnt_have_rights_and_token_exists(self, client):
-        booking = bookings_factories.BookingFactory()
-        another_pro_user = users_factories.ProFactory()
-
-        url = f"/bookings/token/{booking.token}"
-        client = client.with_session_auth(another_pro_user.email)
-        num_queries = 1  # select user_session + user
-        num_queries += 1  # select booking
-        num_queries += 1  # check user has rights on offerer
-        num_queries += 1  # rollback atomic
-        num_queries += 1  # rollback atomic
-        with testing.assert_num_queries(num_queries):
-            response = client.get(url)
-            assert response.status_code == 404
-
-        assert response.json["global"] == [
-            "La contremarque n'existe pas, ou vous n'avez pas les droits nécessaires pour y accéder."
-        ]
-
     def test_when_booking_not_confirmed(self, client):
         next_week = date_utils.get_naive_utc_now() + timedelta(weeks=1)
         booking = bookings_factories.BookingFactory(stock__beginningDatetime=next_week)
@@ -205,6 +186,25 @@ class Returns403Test:
 
 
 class Returns404Test:
+    def test_when_user_doesnt_have_rights_and_token_exists(self, client):
+        booking = bookings_factories.BookingFactory()
+        another_pro_user = users_factories.ProFactory()
+
+        url = f"/bookings/token/{booking.token}"
+        client = client.with_session_auth(another_pro_user.email)
+        num_queries = 1  # select user_session + user
+        num_queries += 1  # select booking
+        num_queries += 1  # check user has rights on offerer
+        num_queries += 1  # rollback atomic
+        num_queries += 1  # rollback atomic
+        with testing.assert_num_queries(num_queries):
+            response = client.get(url)
+            assert response.status_code == 404
+
+        assert response.json["global"] == [
+            "La contremarque n'existe pas, ou vous n'avez pas les droits nécessaires pour y accéder."
+        ]
+
     def test_missing_token(self, client):
         with testing.assert_num_queries(0):
             response = client.get("/bookings/token/")

--- a/api/tests/routes/pro/bookings/get_bookings_csv_test.py
+++ b/api/tests/routes/pro/bookings/get_bookings_csv_test.py
@@ -9,6 +9,7 @@ from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 
 
@@ -46,8 +47,8 @@ class Returns200Test:
             )
 
 
-class Returns401Test:
-    def test_return_403_if_user_is_not_authorized(self, client):
+class Returns404Test:
+    def test_return_404_if_user_is_not_authorized(self, client):
         user_offerer = offerers_factories.UserOffererFactory()
         # authorized offer
         offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
@@ -57,6 +58,5 @@ class Returns401Test:
         expected_num_queries = 7  # offer + session + offer + venue + SELECT EXISTS user_offerer + rollback + rollback
         with assert_num_queries(expected_num_queries):
             response = client.get(f"/bookings/offer/{offer_unauthorized.id}/csv?event_date=2021-01-01&status=all")
-            assert response.status_code == 403
-
-        assert response.json == {"global": "You are not allowed to access this offer"}
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/bookings/get_bookings_excel_test.py
+++ b/api/tests/routes/pro/bookings/get_bookings_excel_test.py
@@ -3,13 +3,14 @@ import pytest
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.testing import assert_num_queries
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-class Returns401Test:
-    def test_return_403_if_user_is_not_authorized(self, client):
+class Returns404Test:
+    def test_return_404_if_user_is_not_authorized(self, client):
         user_offerer = offerers_factories.UserOffererFactory()
         # authorized offer
         offers_factories.OfferFactory(venue__managingOfferer=user_offerer.offerer)
@@ -19,6 +20,5 @@ class Returns401Test:
         expected_num_queries = 7  #  offer +  session + offer + venue + SELECT EXISTS user_offerer + rollback + rollback
         with assert_num_queries(expected_num_queries):
             response = client.get(f"/bookings/offer/{offer_unauthorized.id}/excel?event_date=2021-01-01&status=all")
-            assert response.status_code == 403
-
-        assert response.json == {"global": "You are not allowed to access this offer"}
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/collective_bookings/patch_cancel_collective_offer_booking_test.py
+++ b/api/tests/routes/pro/collective_bookings/patch_cancel_collective_offer_booking_test.py
@@ -8,6 +8,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.token import SecureToken
 from pcapi.core.token.serialization import ConnectAsInternalModel
 from pcapi.core.users import factories as user_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -118,14 +119,9 @@ class Returns404Test:
         response = client.patch(f"/collective/offers/{offer_id}/cancel_booking")
 
         assert response.status_code == 404
-        assert response.json == {
-            "code": "NO_COLLECTIVE_OFFER_FOUND",
-            "message": "No collective offer has been found with this id",
-        }
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
         assert len(testing.adage_requests) == 0
 
-
-class Returns403Test:
     def test_user_does_not_have_access_to_offerer(self, client):
         user = user_factories.UserFactory()
         offerer = offerers_factories.OffererFactory()
@@ -137,12 +133,12 @@ class Returns403Test:
         client = client.with_session_auth(user.email)
         response = client.patch(f"/collective/offers/{offer_id}/cancel_booking")
 
-        assert response.status_code == 403
-        assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
-        }
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
         assert len(testing.adage_requests) == 0
 
+
+class Returns403Test:
     @pytest.mark.parametrize("status", testing.STATUSES_NOT_ALLOWING_CANCEL)
     def test_cancel_unallowed_action(self, client, status):
         offer = factories.create_collective_offer_by_status(status)

--- a/api/tests/routes/pro/collective_offers/get_collective_offer_request_test.py
+++ b/api/tests/routes/pro/collective_offers/get_collective_offer_request_test.py
@@ -9,6 +9,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
 from pcapi.core.testing import assert_num_queries
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("db_session")
@@ -91,7 +92,8 @@ class GetCollectiveOfferRequestTest:
         # rollback
         with assert_num_queries(expected_num_queries):
             response = client.get(dst)
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_offer_request_does_not_exist(self, client):
         pro_user = users_factories.ProFactory()
@@ -110,3 +112,4 @@ class GetCollectiveOfferRequestTest:
         with assert_num_queries(4):  #  session + collective_offer_request + rollback + rollback
             response = client.get(dst)
             assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/collective_offers/get_collective_offer_template_test.py
+++ b/api/tests/routes/pro/collective_offers/get_collective_offer_template_test.py
@@ -7,6 +7,7 @@ from pcapi.core.geography import factories as geography_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -214,7 +215,7 @@ class Returns200Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def test_access_by_unauthorized_pro_user(self, client):
         pro_user = users_factories.ProFactory()
         offer = educational_factories.CollectiveOfferTemplateFactory()
@@ -230,4 +231,5 @@ class Returns403Test:
         # rollback
         with assert_num_queries(expected_num_queries):
             response = client.get(f"/collective/offers-template/{offer_id}")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/collective_offers/get_collective_offer_test.py
+++ b/api/tests/routes/pro/collective_offers/get_collective_offer_test.py
@@ -9,6 +9,7 @@ import pcapi.core.providers.factories as providers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
 from pcapi.core.testing import assert_num_queries
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
@@ -320,7 +321,7 @@ class Returns200Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def test_access_by_unauthorized_pro_user(self, client):
         pro_user = users_factories.ProFactory()
         offer = educational_factories.CollectiveOfferFactory()
@@ -336,4 +337,13 @@ class Returns403Test:
         # rollback
         with assert_num_queries(expected_num_queries):
             response = client.get(f"/collective/offers/{offer_id}")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_offer_not_found(self, client):
+        pro_user = users_factories.ProFactory()
+        client = client.with_session_auth(email=pro_user.email)
+        response = client.get("/collective/offers/123456789")
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/collective_offers/patch_collective_offer_publication_test.py
+++ b/api/tests/routes/pro/collective_offers/patch_collective_offer_publication_test.py
@@ -7,6 +7,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.offer_mixin import OfferValidationStatus
 
 
@@ -72,7 +73,7 @@ class Returns204Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def expect_offer_to_be_approved(self, client):
         offer = educational_factories.CollectiveOfferFactory(validation=OfferValidationStatus.DRAFT)
         user_offerer = offerers_factories.UserOffererFactory()
@@ -81,10 +82,19 @@ class Returns403Test:
 
         response = client.with_session_auth(user_offerer.user.email).patch(url)
 
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
         offer = db.session.query(educational_models.CollectiveOffer).filter_by(id=offer.id).one()
         assert offer.validation == OfferValidationStatus.DRAFT
         assert not offer.lastValidationAuthor
+
+    def test_offer_not_found(self, client):
+        user_offerer = offerers_factories.UserOffererFactory()
+        client_auth = client.with_session_auth(user_offerer.user.email)
+        response = client_auth.patch("/collective/offers/123456789/publish")
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/collective_offers/patch_collective_offer_template_publication_test.py
+++ b/api/tests/routes/pro/collective_offers/patch_collective_offer_template_publication_test.py
@@ -6,6 +6,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.offer_mixin import OfferValidationStatus
 
 
@@ -48,7 +49,7 @@ class Returns204Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def expect_offer_to_be_approved(self, client):
         offer = educational_factories.CollectiveOfferTemplateFactory(validation=OfferValidationStatus.DRAFT)
         user_offerer = offerers_factories.UserOffererFactory()
@@ -57,10 +58,19 @@ class Returns403Test:
 
         response = client.with_session_auth(user_offerer.user.email).patch(url)
 
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
         offer = db.session.query(educational_models.CollectiveOfferTemplate).filter_by(id=offer.id).one()
         assert offer.validation == OfferValidationStatus.DRAFT
         assert not offer.lastValidationAuthor
+
+    def test_offer_not_found(self, client):
+        user_offerer = offerers_factories.UserOffererFactory()
+        client_auth = client.with_session_auth(user_offerer.user.email)
+        response = client_auth.patch("/collective/offers-template/123456789/publish")
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/collective_offers/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/collective_offers/patch_collective_offer_template_test.py
@@ -12,6 +12,7 @@ from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.routes.serialization.collective_offers_serialize import PatchCollectiveOfferTemplateBodyModel
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
@@ -1025,21 +1026,6 @@ class Returns403Test:
         assert offer.name == previous_name
         assert offer.description == previous_description
 
-    def test_user_is_not_attached_to_offerer(self, client):
-        offer = educational_factories.CollectiveOfferTemplateFactory(name="Old name")
-        offer_ctx = build_offer_context(offer=offer)
-
-        pro_client = build_pro_client(client, offer_ctx.user)
-
-        data = {"name": "New name"}
-        response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
-
-        assert response.status_code == 403
-        assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
-        ]
-        assert db.session.get(models.CollectiveOfferTemplate, offer.id).name == "Old name"
-
     def test_replacing_venue_with_different_offerer(self, client):
         offer_ctx = build_offer_context()
 
@@ -1071,12 +1057,26 @@ class Returns403Test:
 
 
 class Returns404Test:
+    def test_user_is_not_attached_to_offerer(self, client):
+        offer = educational_factories.CollectiveOfferTemplateFactory(name="Old name")
+        offer_ctx = build_offer_context(offer=offer)
+
+        pro_client = build_pro_client(client, offer_ctx.user)
+
+        data = {"name": "New name"}
+        response = pro_client.patch(f"/collective/offers-template/{offer.id}", json=data)
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+        assert db.session.get(models.CollectiveOfferTemplate, offer.id).name == "Old name"
+
     def test_offer_does_not_exist(self, client):
         user = offerers_factories.UserOffererFactory().user
         pro_client = build_pro_client(client, user)
 
         response = pro_client.patch("/collective/offers-template/12", json={})
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_unknown_educational_domain(self, client):
         offer_ctx = build_offer_context()
@@ -1104,4 +1104,4 @@ class Returns404Test:
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 404
-        assert response.json == {"venueId": "The venue does not exist."}
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/collective_offers/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/collective_offers/patch_collective_offer_test.py
@@ -16,6 +16,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users import factories as users_factories
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.routes.serialization.collective_offers_serialize import PatchCollectiveOfferBodyModel
 
 
@@ -839,21 +840,6 @@ class Returns400Test:
 
 
 class Returns403Test:
-    def when_user_is_not_attached_to_offerer(self, app, client):
-        offer = educational_factories.CollectiveOfferFactory(name="Old name")
-        offerers_factories.UserOffererFactory(user__email="user@example.com")
-
-        data = {"name": "New name"}
-        client = client.with_session_auth("user@example.com")
-        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
-            response = client.patch(f"/collective/offers/{offer.id}", json=data)
-
-        assert response.status_code == 403
-        assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
-        ]
-        assert db.session.get(models.CollectiveOffer, offer.id).name == "Old name"
-
     def test_patch_collective_offer_replacing_venue_with_different_offerer(self, client):
         offerer = offerers_factories.OffererFactory()
         offerer2 = offerers_factories.OffererFactory()
@@ -955,12 +941,26 @@ class Returns403Test:
 
 
 class Returns404Test:
+    def when_user_is_not_attached_to_offerer(self, app, client):
+        offer = educational_factories.CollectiveOfferFactory(name="Old name")
+        offerers_factories.UserOffererFactory(user__email="user@example.com")
+
+        data = {"name": "New name"}
+        client = client.with_session_auth("user@example.com")
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
+            response = client.patch(f"/collective/offers/{offer.id}", json=data)
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+        assert db.session.get(models.CollectiveOffer, offer.id).name == "Old name"
+
     def test_returns_404_if_offer_does_not_exist(self, app, client):
         users_factories.UserFactory(email="user@example.com")
 
-        response = client.with_session_auth("user@example.com").patch("/collective/offers/ADFGA", json={})
+        response = client.with_session_auth("user@example.com").patch("/collective/offers/123456789", json={})
 
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_patch_offer_with_unknown_educational_domain(self, app, client):
         offer = educational_factories.CollectiveOfferFactory(educational_domains=None)
@@ -997,4 +997,4 @@ class Returns404Test:
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 404
-        assert response.json == {"venueId": "The venue does not exist."}
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/collective_offers/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/collective_offers/post_collective_offers_template_test.py
@@ -11,6 +11,7 @@ from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
@@ -304,15 +305,6 @@ class Returns200Test:
 
 
 class Returns403Test:
-    def test_random_user(self, client, payload):
-        user = offerers_factories.UserOffererFactory().user
-
-        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
-            response = client.with_session_auth(user.email).post("/collective/offers-template", json=payload)
-
-        assert response.status_code == 403
-        assert db.session.query(models.CollectiveOfferTemplate).count() == 0
-
     def test_no_adage_offerer(self, pro_client, payload):
         def raise_ac(*args, **kwargs):
             raise educational_exceptions.CulturalPartnerNotFoundException("pouet")
@@ -627,6 +619,16 @@ class InvalidDatesTest:
 
 
 class Returns404Test:
+    def test_random_user(self, client, payload):
+        user = offerers_factories.UserOffererFactory().user
+
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
+            response = client.with_session_auth(user.email).post("/collective/offers-template", json=payload)
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+        assert db.session.query(models.CollectiveOfferTemplate).count() == 0
+
     def test_unknown_domain(self, pro_client, payload):
         data = {**payload, "domains": [0]}
 
@@ -652,3 +654,4 @@ class Returns404Test:
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/collective_offers/post_collective_offers_test.py
+++ b/api/tests/routes/pro/collective_offers/post_collective_offers_test.py
@@ -12,6 +12,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import testing as brevo_testing
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -339,19 +340,6 @@ class Returns200Test:
 
 
 class Returns403Test:
-    def test_create_collective_offer_random_user(self, client):
-        user = users_factories.UserFactory()
-        venue = offerers_factories.VenueFactory()
-        offerer = venue.managingOfferer
-        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
-
-        data = base_offer_payload(venue=venue)
-        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
-            response = client.with_session_auth(user.email).post("/collective/offers", json=data)
-
-        assert response.status_code == 403
-        assert db.session.query(models.CollectiveOffer).count() == 0
-
     def test_create_collective_offer_cannot_create_educational(self, client):
         def raise_ac(*args, **kwargs):
             raise educational_exceptions.CulturalPartnerNotFoundException("pouet")
@@ -649,6 +637,20 @@ class Returns400Test:
 
 
 class Returns404Test:
+    def test_create_collective_offer_random_user(self, client):
+        user = users_factories.UserFactory()
+        venue = offerers_factories.VenueFactory()
+        offerer = venue.managingOfferer
+        offerers_factories.UserOffererFactory(offerer=offerer, user__email="user@example.com")
+
+        data = base_offer_payload(venue=venue)
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
+            response = client.with_session_auth(user.email).post("/collective/offers", json=data)
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+        assert db.session.query(models.CollectiveOffer).count() == 0
+
     def test_create_collective_offer_with_unknown_domain(self, client):
         # Given
         venue = offerers_factories.VenueFactory()
@@ -725,7 +727,7 @@ class Returns404Test:
 
         # Then
         assert response.status_code == 404
-        assert response.json == {"code": "COLLECTIVE_OFFER_TEMPLATE_NOT_FOUND"}
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     @pytest.mark.parametrize("status", educational_testing.STATUSES_NOT_ALLOWING_CREATE_BOOKABLE_OFFER)
     def test_create_collective_offer_with_not_allowed_collective_offer_template(self, client, status):
@@ -756,3 +758,4 @@ class Returns404Test:
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/collective_stocks/patch_collective_stock_test.py
+++ b/api/tests/routes/pro/collective_stocks/patch_collective_stock_test.py
@@ -18,6 +18,7 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.providers import factories as providers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 
 
@@ -294,6 +295,24 @@ class Return200Test:
 
 
 class Return403Test:
+    def test_edit_collective_stocks_should_not_be_possible_when_offer_created_by_public_api(self, client):
+        stock = educational_factories.CollectiveStockFactory(
+            collectiveOffer__provider=providers_factories.ProviderFactory()
+        )
+        offerers_factories.UserOffererFactory(
+            user__email="user@example.com", offerer=stock.collectiveOffer.venue.managingOfferer
+        )
+
+        stock_edition_payload = {"totalPrice": 1500}
+
+        client.with_session_auth("user@example.com")
+        response = client.patch(f"/collective/stocks/{stock.id}", json=stock_edition_payload)
+
+        assert response.status_code == 403
+        assert response.json == {"global": ["Cette action n'est pas autorisée sur l'offre collective liée à ce stock."]}
+
+
+class Return404Test:
     @time_machine.travel("2020-11-17 15:00:00")
     def test_edit_collective_stocks_should_not_be_possible_when_user_not_linked_to_offerer(self, client):
         stock = educational_factories.CollectiveStockFactory(
@@ -314,26 +333,19 @@ class Return403Test:
         response = client.patch(f"/collective/stocks/{stock.id}", json=stock_edition_payload)
 
         # Then
-        assert response.status_code == 403
-        assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
-        }
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
-    def test_edit_collective_stocks_should_not_be_possible_when_offer_created_by_public_api(self, client):
-        stock = educational_factories.CollectiveStockFactory(
-            collectiveOffer__provider=providers_factories.ProviderFactory()
-        )
+    def test_edit_collective_stocks_should_not_be_possible_when_stock_does_not_exist(self, client):
         offerers_factories.UserOffererFactory(
-            user__email="user@example.com", offerer=stock.collectiveOffer.venue.managingOfferer
+            user__email="user@example.com",
         )
-
-        stock_edition_payload = {"totalPrice": 1500}
 
         client.with_session_auth("user@example.com")
-        response = client.patch(f"/collective/stocks/{stock.id}", json=stock_edition_payload)
+        response = client.patch("/collective/stocks/123456789", json={})
 
-        assert response.status_code == 403
-        assert response.json == {"global": ["Cette action n'est pas autorisée sur l'offre collective liée à ce stock."]}
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 class Return400Test:

--- a/api/tests/routes/pro/collective_stocks/post_collective_stock_test.py
+++ b/api/tests/routes/pro/collective_stocks/post_collective_stock_test.py
@@ -11,6 +11,7 @@ from pcapi.core.educational.models import CollectiveStock
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.utils import date as date_utils
 
@@ -88,7 +89,7 @@ class Return200Test:
         assert created_stock.endDatetime == datetime.datetime(2022, 1, 18, 18, 0, 0)
 
 
-class Return400Test:
+class Return404Test:
     @time_machine.travel("2020-11-17 15:00:00")
     def test_create_collective_stocks_should_not_be_available_if_user_not_linked_to_offerer(self, client):
         offer = factories.CollectiveOfferFactory()
@@ -107,11 +108,31 @@ class Return400Test:
         client.with_session_auth("user@example.com")
         response = client.post("/collective/stocks/", json=stock_payload)
 
-        assert response.status_code == 403
-        assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    @time_machine.travel("2020-11-17 15:00:00")
+    def test_create_collective_stocks_should_not_be_available_if_offer_not_found(self, client):
+        offerers_factories.UserOffererFactory(user__email="user@example.com")
+
+        stock_payload = {
+            "offerId": 123456789,
+            "startDatetime": "2022-01-17T22:00:00Z",
+            "endDatetime": "2022-01-17T22:00:00Z",
+            "bookingLimitDatetime": "2021-12-31T20:00:00Z",
+            "totalPrice": 1500,
+            "numberOfTickets": 38,
+            "educationalPriceDetail": "Détail du prix",
         }
 
+        client.with_session_auth("user@example.com")
+        response = client.post("/collective/stocks/", json=stock_payload)
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+
+class Return400Test:
     @time_machine.travel("2020-11-17 15:00:00")
     def test_missing_end_datetime(self, client):
         offer = factories.CollectiveOfferFactory()

--- a/api/tests/routes/pro/delete_image_collective_offers_template_test.py
+++ b/api/tests/routes/pro/delete_image_collective_offers_template_test.py
@@ -7,6 +7,7 @@ from pcapi import settings
 from pcapi.core.educational.factories import CollectiveOfferTemplateFactory
 from pcapi.core.educational.models import CollectiveOfferTemplate
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 import tests
 
@@ -68,7 +69,8 @@ class DeleteImageFromFileTest:
         )
 
         # then
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_not_authentified(self, client):
         # when
@@ -88,3 +90,4 @@ class DeleteImageFromFileTest:
 
         # then
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/delete_image_collective_offers_test.py
+++ b/api/tests/routes/pro/delete_image_collective_offers_test.py
@@ -8,6 +8,7 @@ from pcapi.core.educational import factories
 from pcapi.core.educational import models
 from pcapi.core.educational import testing as educational_testing
 from pcapi.core.offerers import factories as offerers_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 import tests
 
@@ -74,7 +75,8 @@ class DeleteImageFromFileTest:
         response = client.with_session_auth(email="user@example.com").delete(f"/collective/offers/{offer2.id}/image")
 
         # then
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     @pytest.mark.parametrize("status", educational_testing.STATUSES_NOT_ALLOWING_EDIT_DETAILS)
     def test_delete_image_unallowed_action(self, client, status):
@@ -113,3 +115,4 @@ class DeleteImageFromFileTest:
 
         # then
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/delete_stocks_test.py
+++ b/api/tests/routes/pro/delete_stocks_test.py
@@ -8,6 +8,7 @@ from pcapi.core.bookings import factories as booking_factory
 from pcapi.core.token import SecureToken
 from pcapi.core.token.serialization import ConnectAsInternalModel
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("db_session")
@@ -102,7 +103,7 @@ class Returns401Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def test_delete_stocks_when_current_user_has_no_rights_on_offer(self, client):
         # given
         offer = offers_factories.OfferFactory()
@@ -116,4 +117,13 @@ class Returns403Test:
         response = client.with_session_auth(pro.email).post(f"/offers/{offer.id}/stocks/delete", json=data)
 
         # then
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_delete_stocks_when_offer_not_found(self, client):
+        pro = users_factories.ProFactory()
+        response = client.with_session_auth(pro.email).post(
+            "/offers/123456789/stocks/delete", json={"ids_to_delete": []}
+        )
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/delete_venue_banner_test.py
+++ b/api/tests/routes/pro/delete_venue_banner_test.py
@@ -5,6 +5,7 @@ import pytest
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi import settings
 from pcapi.core.search.models import IndexationReason
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils.human_ids import humanize
 
 
@@ -82,6 +83,7 @@ class VenueBannerTest:
 
         response = client.delete("/venues/1234/banner")
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     @patch("pcapi.core.offerers.api.delete_venue_banner")
     def test_no_access_rights(self, mock_delete_venue_banner, client):
@@ -91,6 +93,7 @@ class VenueBannerTest:
         client = client.with_session_auth(email=user.user.email)
 
         response = client.delete(f"/venues/{venue.id}/banner")
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
         mock_delete_venue_banner.assert_not_called()

--- a/api/tests/routes/pro/finance/get_invoices_v2_test.py
+++ b/api/tests/routes/pro/finance/get_invoices_v2_test.py
@@ -6,6 +6,7 @@ import pcapi.core.finance.factories as finance_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -236,8 +237,5 @@ class GetInvoicesTest:
         queries += 1  # rollback
         with testing.assert_num_queries(queries):
             response = client.get("/v2/finance/has-invoice", params=params)
-            assert response.status_code == 403
-
-        assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
-        }
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_number_of_event_price_categories_and_schedules_by_date_test.py
+++ b/api/tests/routes/pro/get_number_of_event_price_categories_and_schedules_by_date_test.py
@@ -7,6 +7,7 @@ import pcapi.core.bookings.models as bookings_models
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core import testing
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("db_session")
@@ -133,4 +134,5 @@ def test_user_is_forbidden(client):
     queries += 1  # rollback
     with testing.assert_num_queries(queries):
         response = client.get(f"/bookings/dates/{offer_id}")
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_offer_test.py
+++ b/api/tests/routes/pro/get_offer_test.py
@@ -16,13 +16,14 @@ from pcapi.core.artist import factories as artist_factories
 from pcapi.core.artist import models as artist_models
 from pcapi.core.categories import subcategories
 from pcapi.core.offers.models import WithdrawalTypeEnum
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 from pcapi.utils.human_ids import humanize
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     # get user_session + user
     # get offer
     # get artist
@@ -39,7 +40,8 @@ class Returns403Test:
         offer_id = offer.id
         with testing.assert_num_queries(self.num_queries):
             response = auth_client.get(f"/offers/{offer_id}")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_access_by_unauthorized_pro_user(self, client):
         pro_user = users_factories.ProFactory()
@@ -49,7 +51,15 @@ class Returns403Test:
         offer_id = offer.id
         with testing.assert_num_queries(self.num_queries):
             response = auth_client.get(f"/offers/{offer_id}")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_offer_not_found(self, client):
+        pro_user = users_factories.ProFactory()
+        auth_client = client.with_session_auth(email=pro_user.email)
+        response = auth_client.get("/offers/123456789")
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/get_offerer_addresses_test.py
+++ b/api/tests/routes/pro/get_offerer_addresses_test.py
@@ -7,6 +7,7 @@ from pcapi.core.offerers import schemas
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -230,7 +231,7 @@ class Return200Test:
             ]
 
 
-class Return400Test:
+class Return404Test:
     def test_access_by_unauthorized_pro_user(self, client):
         pro = users_factories.ProFactory()
         offerer = offerers_factories.OffererFactory()
@@ -238,4 +239,12 @@ class Return400Test:
         offerer_id = offerer.id
         with assert_num_queries(4):
             response = client.get(f"/offerers/{offerer_id}/offerer_addresses")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_offerer_not_found(self, client):
+        pro = users_factories.ProFactory()
+        client = client.with_session_auth(email=pro.email)
+        response = client.get("/offerers/123456789/offerer_addresses")
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_offerer_eligibility_test.py
+++ b/api/tests/routes/pro/get_offerer_eligibility_test.py
@@ -5,6 +5,7 @@ from pcapi.core import testing
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -45,7 +46,7 @@ class Return200Test:
                 assert collective_ds_application is None or response.json.get("hasDsApplication")
 
 
-class Return400Test:
+class Return404Test:
     num_queries = testing.AUTHENTICATION_QUERIES
     num_queries += 1  # check user_offerer
     num_queries += 1  # rollback (atomic)
@@ -57,4 +58,5 @@ class Return400Test:
         offerer_id = 0
         with assert_num_queries(self.num_queries):
             response = client.get(f"/offerers/{offerer_id}/eligibility")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_offerer_members_test.py
+++ b/api/tests/routes/pro/get_offerer_members_test.py
@@ -5,6 +5,7 @@ import pcapi.core.offerers.models as offerers_models
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("db_session")
@@ -42,7 +43,7 @@ class Returns200Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns400Test:
+class Returns404Test:
     def test_access_by_unauthorized_pro_user(self, client):
         pro = users_factories.ProFactory()
         offerer = offerers_factories.OffererFactory()
@@ -55,4 +56,12 @@ class Returns400Test:
         queries += 1  # rollback
         with testing.assert_num_queries(queries):
             response = client.get(f"/offerers/{offerer_id}/members")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_offerer_not_found(self, client):
+        pro = users_factories.ProFactory()
+        client = client.with_session_auth(email=pro.email)
+        response = client.get("/offerers/123456789/members")
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_offerer_stats_v2_test.py
+++ b/api/tests/routes/pro/get_offerer_stats_v2_test.py
@@ -1,14 +1,12 @@
-from unittest.mock import patch
-
 import pytest
 
 import pcapi.core.educational.factories as educational_factories
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
-import pcapi.core.users.models as users_models
 from pcapi.core import testing
 from pcapi.core.educational.models import CollectiveBookingStatus
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.offer_mixin import OfferValidationStatus
 
 
@@ -159,11 +157,13 @@ class Return200Test:
         }
 
 
-class TestReturn400:
+class Return404Test:
     num_queries = testing.AUTHENTICATION_QUERIES
     num_queries += 1  # check user_offerer exists
+    num_queries += 1  # rollback (atomic)
+    num_queries += 1  # rollback (atomic)
 
-    def test_get_offerer_stats_returns_403_if_user_has_no_rights_on_offerer(self, client):
+    def test_get_offerer_stats_returns_404_if_user_has_no_rights_on_offerer(self, client):
         pro_user = users_factories.ProFactory()
         user_offerer = offerers_factories.UserOffererFactory()
 
@@ -171,20 +171,14 @@ class TestReturn400:
         offerer_id = user_offerer.offerer.id
         with testing.assert_num_queries(self.num_queries):
             response = client.get(f"/offerers/{offerer_id}/v2/stats")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
-        assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
-        }
-
-    @patch("pcapi.utils.rest.check_user_has_access_to_offerer")
-    def test_get_offerer_stats_returns_404_if_offerer_is_not_found(self, check_user_has_access_to_offerer, client):
-        pro_user = users_factories.ProFactory(roles=[users_models.UserRole.PRO, users_models.UserRole.ADMIN])
-
-        check_user_has_access_to_offerer.return_value = True
+    def test_get_offerer_stats_returns_404_if_offerer_is_not_found(self, client):
+        pro_user = users_factories.ProFactory()
 
         client = client.with_session_auth(pro_user.email)
         with testing.assert_num_queries(self.num_queries):
             response = client.get("/offerers/1/v2/stats")
-
-        assert response.status_code == 404
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_offerer_test.py
+++ b/api/tests/routes/pro/get_offerer_test.py
@@ -14,6 +14,7 @@ import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
 from pcapi.core.offers import models as offers_models
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.validation_status_mixin import ValidationStatus
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
@@ -130,13 +131,26 @@ class GetOffererTest:
         db.session.refresh(offerer)
         assert len(offerer.managedVenues) == 3
 
-    def test_unknown_offerer(self, client):
+    def test_wrong_offerer_id_format(self, client):
         pro = users_factories.ProFactory()
 
         client = client.with_session_auth(pro.email)
         with testing.assert_num_queries(testing.AUTHENTICATION_QUERIES):
             response = client.get("/offerers/ABC1234")
             assert response.status_code == 404
+
+    def test_unknown_offerer(self, client):
+        pro = users_factories.ProFactory()
+
+        client = client.with_session_auth(pro.email)
+        num_queries = testing.AUTHENTICATION_QUERIES
+        num_queries += 1  # get_offerer_and_extradata
+        num_queries += 1  # rollback
+        num_queries += 1  # rollback
+        with testing.assert_num_queries(num_queries):
+            response = client.get("/offerers/1234")
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_unauthorized_offerer(self, client):
         pro = users_factories.ProFactory()
@@ -150,7 +164,8 @@ class GetOffererTest:
         num_queries += 1  # rollback
         with testing.assert_num_queries(num_queries):
             response = client.get(f"/offerers/{offerer_id}")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_serialize_venue_offer_created_flag(self, client):
         pro = users_factories.ProFactory()

--- a/api/tests/routes/pro/get_offerers_bank_accounts_test.py
+++ b/api/tests/routes/pro/get_offerers_bank_accounts_test.py
@@ -8,6 +8,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 
 
@@ -28,9 +29,8 @@ class OfferersBankAccountTest:
         num_queries += 2  # rollbacks
         with testing.assert_num_queries(num_queries):
             response = http_client.get(f"/offerers/{offerer_2_id}/bank-accounts")
-            assert response.status_code == 403
-
-        assert "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information." in str(response.json)
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     @pytest.mark.usefixtures("db_session")
     def test_user_can_access_bank_accounts_page_even_if_it_doesnt_have_any(self, client):

--- a/api/tests/routes/pro/get_statistics_test.py
+++ b/api/tests/routes/pro/get_statistics_test.py
@@ -9,6 +9,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.connectors.clickhouse import query_mock as clickhouse_query_mock
 from pcapi.core import testing
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.validation_status_mixin import ValidationStatus
 
 
@@ -254,7 +255,7 @@ class Returns422Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def test_get_statistics_for_not_owned_venue_should_fail(self, client):
         user = users_factories.UserFactory()
         offerer = offerers_factories.OffererFactory()
@@ -271,10 +272,8 @@ class Returns403Test:
         num_queries += 1  # rollback
         with testing.assert_num_queries(num_queries):
             response = test_client.get(f"/get-statistics/?venueIds={venue_id}&venueIds={foreign_venue}")
-            assert response.status_code == 403
-        assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
-        ]
+            assert response.status_code == 404
+            assert response.json["global"] == [OBJECT_NOT_FOUND_ERROR_MESSAGE]
 
     def test_get_statistics_with_unvalidated_userofferer_should_fail(self, client):
         user = users_factories.UserFactory()
@@ -292,7 +291,5 @@ class Returns403Test:
         num_queries += 1  # rollback
         with testing.assert_num_queries(num_queries):
             response = test_client.get(f"/get-statistics/?venueIds={venue_id}")
-            assert response.status_code == 403
-        assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
-        ]
+            assert response.status_code == 404
+            assert response.json["global"] == [OBJECT_NOT_FOUND_ERROR_MESSAGE]

--- a/api/tests/routes/pro/get_stocks_stats_test.py
+++ b/api/tests/routes/pro/get_stocks_stats_test.py
@@ -7,11 +7,12 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     num_queries = testing.AUTHENTICATION_QUERIES
     num_queries += 1  # select offer
     num_queries += 1  # select venue
@@ -27,7 +28,8 @@ class Returns403Test:
         offer_id = offer.id
         with testing.assert_num_queries(self.num_queries):
             response = client.get(f"/offers/{offer_id}/stocks-stats")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_access_by_unauthorized_pro_user(self, client):
         pro_user = users_factories.ProFactory()
@@ -37,7 +39,15 @@ class Returns403Test:
         offer_id = offer.id
         with testing.assert_num_queries(self.num_queries):
             response = client.get(f"/offers/{offer_id}/stocks-stats")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_offer_not_found(self, client):
+        pro_user = users_factories.ProFactory()
+        client = client.with_session_auth(email=pro_user.email)
+        response = client.get("/offers/123456789/stocks-stats")
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/get_stocks_test.py
+++ b/api/tests/routes/pro/get_stocks_test.py
@@ -6,11 +6,12 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     num_queries = testing.AUTHENTICATION_QUERIES
     num_queries += 1  # select offer
     num_queries += 1  # select venue
@@ -26,7 +27,8 @@ class Returns403Test:
         offer_id = offer.id
         with testing.assert_num_queries(self.num_queries):
             response = client.get(f"/offers/{offer_id}/stocks")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_access_by_unauthorized_pro_user(self, client):
         pro_user = users_factories.ProFactory()
@@ -36,7 +38,15 @@ class Returns403Test:
         offer_id = offer.id
         with testing.assert_num_queries(self.num_queries):
             response = client.get(f"/offers/{offer_id}/stocks")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_offer_not_found(self, client):
+        pro_user = users_factories.ProFactory()
+        client = client.with_session_auth(pro_user.email)
+        response = client.get("/offers/123456789/stocks")
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/routes/pro/get_venue_headline_offer_test.py
+++ b/api/tests/routes/pro/get_venue_headline_offer_test.py
@@ -8,6 +8,7 @@ from pcapi.core.offers.models import GcuCompatibilityType
 from pcapi.core.offers.models import ImageType
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -62,7 +63,7 @@ class Return200Test:
             assert response.status_code == 200
 
 
-class Return400Test:
+class Return404Test:
     num_queries = testing.AUTHENTICATION_QUERIES
     num_queries += 1  # check user_offerer
     num_queries += 1  # get headline offer
@@ -76,7 +77,8 @@ class Return400Test:
         venue_id = venue.id
         with assert_num_queries(self.num_queries - 1):  # unauthorized, so no query to headline offer made
             response = client.get(f"/venues/{venue_id}/headline-offer")
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_get_venue_headline_offer_not_found(self, client):
         user_offerer = offerers_factories.UserOffererFactory()
@@ -87,3 +89,4 @@ class Return400Test:
         with assert_num_queries(self.num_queries):
             response = client.get(f"/venues/{venue_id}/headline-offer")
             assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_venue_locations_test.py
+++ b/api/tests/routes/pro/get_venue_locations_test.py
@@ -4,6 +4,7 @@ import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -95,7 +96,7 @@ class Return200Test:
         ]
 
 
-class Return400Test:
+class Return404Test:
     def test_access_by_unauthorized_pro_user(self, client):
         pro = users_factories.ProFactory()
         offerer = offerers_factories.OffererFactory()
@@ -106,10 +107,12 @@ class Return400Test:
             response = client.get(
                 f"/venues/{venue_id}/locations", params={"withOffersOption": "INDIVIDUAL_OFFERS_ONLY"}
             )
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_get_offerer_addresses_unexistent_venue(self, client):
         pro = users_factories.ProFactory()
         client = client.with_session_auth(email=pro.email)
         response = client.get("/venues/1/locations", params={"withOffersOption": "INDIVIDUAL_OFFERS_ONLY"})
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_venue_offer_by_ean_test.py
+++ b/api/tests/routes/pro/get_venue_offer_by_ean_test.py
@@ -4,37 +4,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core import testing
-
-
-@pytest.mark.usefixtures("db_session")
-class Returns403Test:
-    num_queries = 1  # get user_session + user
-    num_queries += 1  # get venue
-    num_queries += 1  # check user_offerer exists
-    num_queries += 1  # rollback
-    num_queries += 1  # rollback
-
-    def test_access_by_beneficiary(self, client):
-        beneficiary = users_factories.BeneficiaryGrant18Factory()
-        offer = offers_factories.ThingOfferFactory(ean="0123456789123")
-
-        auth_client = client.with_session_auth(email=beneficiary.email)
-        venue_id = offer.venueId
-        ean = offer.ean
-        with testing.assert_num_queries(self.num_queries):
-            response = auth_client.get(f"/offers/{venue_id}/ean/{ean}")
-            assert response.status_code == 403
-
-    def test_access_by_unauthorized_pro_user(self, client):
-        pro_user = users_factories.ProFactory()
-        offer = offers_factories.ThingOfferFactory(ean="0123456789123")
-
-        auth_client = client.with_session_auth(email=pro_user.email)
-        venue_id = offer.venueId
-        ean = offer.ean
-        with testing.assert_num_queries(self.num_queries):
-            response = auth_client.get(f"/offers/{venue_id}/ean/{ean}")
-            assert response.status_code == 403
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("db_session")
@@ -68,7 +38,6 @@ class Returns200Test:
 class Returns404Test:
     num_queries = 1  # session + user
     num_queries += 1  # venue
-    num_queries += 1  # user offerer
     num_queries += 1  # payload (joined query)
     num_queries += 1  # rollback
     num_queries += 1  # rollback
@@ -85,9 +54,7 @@ class Returns404Test:
         with testing.assert_num_queries(self.num_queries):
             response = auth_client.get(f"/offers/{venue_id}/ean/2323456789123")
             assert response.status_code == 404
-
-        response_json = response.json
-        assert response_json == {"global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"]}
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_access_to_not_active_offer(self, client):
         user_offerer = offerers_factories.UserOffererFactory()
@@ -103,6 +70,32 @@ class Returns404Test:
         with testing.assert_num_queries(self.num_queries):
             response = auth_client.get(f"/offers/{venue_id}/ean/{ean}")
             assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
-        response_json = response.json
-        assert response_json == {"global": ["Aucun objet ne correspond à cet identifiant dans notre base de données"]}
+    def test_access_by_beneficiary(self, client):
+        self.num_queries += 1  # check user_offerer exists
+
+        beneficiary = users_factories.BeneficiaryGrant18Factory()
+        offer = offers_factories.ThingOfferFactory(ean="0123456789123")
+
+        auth_client = client.with_session_auth(email=beneficiary.email)
+        venue_id = offer.venueId
+        ean = offer.ean
+        with testing.assert_num_queries(self.num_queries):
+            response = auth_client.get(f"/offers/{venue_id}/ean/{ean}")
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_access_by_unauthorized_pro_user(self, client):
+        self.num_queries += 1  # check user_offerer exists
+
+        pro_user = users_factories.ProFactory()
+        offer = offers_factories.ThingOfferFactory(ean="0123456789123")
+
+        auth_client = client.with_session_auth(email=pro_user.email)
+        venue_id = offer.venueId
+        ean = offer.ean
+        with testing.assert_num_queries(self.num_queries):
+            response = auth_client.get(f"/offers/{venue_id}/ean/{ean}")
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_venue_offers_statistics_test.py
+++ b/api/tests/routes/pro/get_venue_offers_statistics_test.py
@@ -12,6 +12,7 @@ import pcapi.core.users.models as users_models
 from pcapi.core import testing
 from pcapi.core.educational.models import CollectiveOfferDisplayedStatus
 from pcapi.core.testing import assert_num_queries
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.routes.pro import offerers as routes
 
@@ -114,13 +115,15 @@ class GetVenueOfferStatisticsTest:
 
         client = client.with_session_auth(user_offerer.user.email)
         response = client.get(f"/venues/{another_venue.id}/offers-statistics")
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_cannot_view_venue_stats_if_venue_does_not_exist(self, client):
         user_offerer = offerers_factories.UserOffererFactory()
         client = client.with_session_auth(user_offerer.user.email)
         response = client.get("/venues/1/offers-statistics")
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 class GetOffersWithHeadlinesAndMediationsTest:
@@ -211,7 +214,7 @@ class Return200Test:
         }
 
 
-class Return400Test:
+class Return404Test:
     num_queries = testing.AUTHENTICATION_QUERIES
     num_queries += 1  # check user_offerer exists
     num_queries += 2  # rollback transactions
@@ -225,17 +228,15 @@ class Return400Test:
 
         with testing.assert_num_queries(self.num_queries + 2):  # +2 for the authorization check
             response = client.get(f"/venue/{venue.id}/offers-statistics")
-            assert response.status_code == 403
-
-        assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
-        }
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_get_offers_stats_returns_404_if_venue_is_not_found(self, client):
         pro_user = users_factories.ProFactory(roles=[users_models.UserRole.PRO])
 
         client = client.with_session_auth(pro_user.email)
+
         with testing.assert_num_queries(self.num_queries):
             response = client.get("/venue/888/offers-statistics")
-
-        assert response.status_code == 404
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -14,6 +14,7 @@ from pcapi.core.educational import factories as educational_factories
 from pcapi.core.offerers.models import VenueTypeCode
 from pcapi.core.offerers.models import Weekday
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 from pcapi.utils.date import timespan_str_to_numrange
@@ -721,7 +722,8 @@ class Returns200Test:
         assert response.json["hasNonDraftOffers"] is True
 
 
-class Returns403Test:
+@pytest.mark.usefixtures("db_session")
+class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def when_current_user_doesnt_have_rights(self, client):
         pro = users_factories.ProFactory(email="user.pro@example.com")
@@ -737,8 +739,13 @@ class Returns403Test:
         venue_id = venue.id
         with testing.assert_num_queries(num_queries):
             response = auth_request.get("/venues/%s" % venue_id)
-            assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
-        assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
-        ]
+    @pytest.mark.usefixtures("db_session")
+    def test_venue_not_found(self, client):
+        pro = users_factories.ProFactory()
+        auth_request = client.with_session_auth(email=pro.email)
+        response = auth_request.get("/venues/123456789")
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/offers/get_offers_home_test.py
+++ b/api/tests/routes/pro/offers/get_offers_home_test.py
@@ -9,6 +9,7 @@ from pcapi.core.testing import AUTHENTICATION_QUERIES
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
 from pcapi.models import offer_mixin
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils.date import format_into_utc_date
 
 from tests.conftest import TestClient
@@ -302,7 +303,7 @@ class Returns200Test:
         ]
 
 
-class Return400Test:
+class Return404Test:
     def test_user_has_no_access(self, client: TestClient):
         user = users_factories.UserFactory()
         venue = offerers_factories.VenueFactory()
@@ -316,8 +317,8 @@ class Return400Test:
         num_queries += 1  # rollback
         with assert_num_queries(num_queries):
             response = client.get(f"{URL}?venueId={venue_id}")
-
-        assert response.status_code == 403
+            assert response.status_code == 404
+            assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_return_error_when_no_venue_given(self, client: TestClient):
         user_offerer = offerers_factories.UserOffererFactory()

--- a/api/tests/routes/pro/offers/thumbnail/delete_thumbnail_test.py
+++ b/api/tests/routes/pro/offers/thumbnail/delete_thumbnail_test.py
@@ -7,6 +7,7 @@ import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers.models import Mediation
 from pcapi.core.search.models import IndexationReason
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils.human_ids import humanize
 
 
@@ -55,7 +56,8 @@ class OfferMediationTest:
         client = client.with_session_auth(email="user@example.com")
         response = client.delete(f"/offers/thumbnails/{offer.id}")
 
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_number_id_offer(self, client):
         offerers_factories.UserOffererFactory(user__email="user@example.com")
@@ -64,6 +66,7 @@ class OfferMediationTest:
         response = client.delete("/offers/thumbnails/123445678")
 
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     def test_unkown_offer(self, client):
         offer = offerers_factories.UserOffererFactory(user__email="user@example.com")
@@ -72,4 +75,4 @@ class OfferMediationTest:
         response = client.delete(f"/offers/thumbnails/{offer.id + 1}")
 
         assert response.status_code == 404
-        assert response.json == {}
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/offers/thumbnail/post_thumbnail_test.py
+++ b/api/tests/routes/pro/offers/thumbnail/post_thumbnail_test.py
@@ -9,6 +9,7 @@ import pcapi.core.offers.factories as offers_factories
 from pcapi.core.offers import exceptions
 from pcapi.core.offers.models import Mediation
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils.human_ids import humanize
 
 import tests
@@ -121,4 +122,4 @@ class CreateThumbnailFromFileTest:
         response = client.post("/offers/thumbnails", form=data)
 
         assert response.status_code == 404
-        assert response.json["global"] == ["Aucun objet ne correspond à cet identifiant dans notre base de données"]
+        assert response.json["global"] == [OBJECT_NOT_FOUND_ERROR_MESSAGE]

--- a/api/tests/routes/pro/patch_booking_keep_by_token_test.py
+++ b/api/tests/routes/pro/patch_booking_keep_by_token_test.py
@@ -41,7 +41,7 @@ class Returns401Test:
         assert response.status_code == 401
 
 
-class Returns403Test:
+class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def test_when_user_is_not_attached_to_linked_offerer(self, client):
         booking = bookings_factories.UsedBookingFactory()
@@ -58,8 +58,6 @@ class Returns403Test:
         ]
         assert booking.status == BookingStatus.USED
 
-
-class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def test_missing_token(self, client):
         user = users_factories.ProFactory()

--- a/api/tests/routes/pro/patch_booking_use_by_token_test.py
+++ b/api/tests/routes/pro/patch_booking_use_by_token_test.py
@@ -42,19 +42,6 @@ class Returns401Test:
 
 
 class Returns403Test:
-    def test_when_user_is_not_attached_to_linked_offerer(self, client):
-        booking = bookings_factories.BookingFactory()
-        another_pro_user = offerers_factories.UserOffererFactory().user
-
-        response = client.with_session_auth(another_pro_user.email).patch(f"/bookings/use/token/{booking.token}")
-
-        assert response.status_code == 404
-        assert response.json["global"] == [
-            "La contremarque n'existe pas, ou vous n'avez pas les droits nécessaires pour y accéder."
-        ]
-        booking = db.session.get(Booking, booking.id)
-        assert booking.status == BookingStatus.CONFIRMED
-
     def test_when_offerer_is_closed(self, client):
         offerer = offerers_factories.ClosedOffererFactory()
         booking = bookings_factories.BookingFactory(stock__offer__venue__managingOfferer=offerer)
@@ -69,6 +56,19 @@ class Returns403Test:
 
 
 class Returns404Test:
+    def test_when_user_is_not_attached_to_linked_offerer(self, client):
+        booking = bookings_factories.BookingFactory()
+        another_pro_user = offerers_factories.UserOffererFactory().user
+
+        response = client.with_session_auth(another_pro_user.email).patch(f"/bookings/use/token/{booking.token}")
+
+        assert response.status_code == 404
+        assert response.json["global"] == [
+            "La contremarque n'existe pas, ou vous n'avez pas les droits nécessaires pour y accéder."
+        ]
+        booking = db.session.get(Booking, booking.id)
+        assert booking.status == BookingStatus.CONFIRMED
+
     def test_missing_token(self, client):
         response = client.patch("/bookings/use/token/")
         assert response.status_code == 404

--- a/api/tests/routes/pro/patch_offer_test.py
+++ b/api/tests/routes/pro/patch_offer_test.py
@@ -23,6 +23,7 @@ from pcapi.core.offers.models import WithdrawalTypeEnum
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils.date import format_into_utc_date
 
 
@@ -1177,7 +1178,7 @@ class Returns400Test:
         assert response.json["global"] == ["Les extraData des offres avec produit ne sont pas modifiables"]
 
 
-class Returns403Test:
+class Returns404Test:
     endpoint = "/offers/{offer_id}"
 
     def when_user_is_not_attached_to_offerer(self, app, client):
@@ -1197,15 +1198,9 @@ class Returns403Test:
         )
 
         # Then
-        assert response.status_code == 403
-        assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
-        ]
+        assert response.status_code == 404
+        assert response.json["global"] == [OBJECT_NOT_FOUND_ERROR_MESSAGE]
         assert db.session.get(Offer, offer.id).name == "Old name"
-
-
-class Returns404Test:
-    endpoint = "/offers/{offer_id}"
 
     def test_returns_404_if_offer_does_not_exist(self, app, client):
         # given
@@ -1216,6 +1211,7 @@ class Returns404Test:
 
         # then
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 @pytest.fixture(name="user_offerer")

--- a/api/tests/routes/pro/patch_publish_offer_test.py
+++ b/api/tests/routes/pro/patch_publish_offer_test.py
@@ -13,6 +13,7 @@ from pcapi.core.categories import subcategories
 from pcapi.core.offerers.schemas import VenueTypeCode
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.utils import date as date_utils
@@ -32,7 +33,14 @@ class Returns404Test:
         response = client.with_session_auth("user@example.com").patch(
             "/offers/publish", json={"id": other_stock.offer.id}
         )
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_patch_publish_offer_not_found(self, client):
+        offerers_factories.UserOffererFactory(user__email="user@example.com")
+        response = client.with_session_auth("user@example.com").patch("/offers/publish", json={"id": 123456789})
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 now_datetime_with_tz = datetime.datetime.now(datetime.timezone.utc)

--- a/api/tests/routes/pro/post_offer_test.py
+++ b/api/tests/routes/pro/post_offer_test.py
@@ -13,6 +13,7 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers.models import Offer
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.offer_mixin import OfferValidationStatus
 
 
@@ -835,6 +836,7 @@ class Returns400Test:
         response = client.with_session_auth("user@example.com").post("/offers", json=data)
 
         assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
     @pytest.mark.parametrize(
         "input_json,expected_json",
@@ -869,7 +871,7 @@ class Returns400Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def test_when_user_is_not_attached_to_offerer(self, client):
         users_factories.ProFactory(email="user@example.com")
         venue = offerers_factories.VenueFactory()
@@ -885,7 +887,5 @@ class Returns403Test:
         }
         response = client.with_session_auth("user@example.com").post("/offers", json=data)
 
-        assert response.status_code == 403
-        assert response.json["global"] == [
-            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
-        ]
+        assert response.status_code == 404
+        assert response.json["global"] == [OBJECT_NOT_FOUND_ERROR_MESSAGE]

--- a/api/tests/routes/pro/post_offerer_invite_member_again_test.py
+++ b/api/tests/routes/pro/post_offerer_invite_member_again_test.py
@@ -4,6 +4,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.users.factories as users_factories
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("db_session")
@@ -76,6 +77,9 @@ class Returns400Test:
         assert response.status_code == 400
         assert response.json == {"email": "Impossible de renvoyer une invitation pour ce collaborateur"}
 
+
+@pytest.mark.usefixtures("db_session")
+class Returns404Test:
     def test_user_has_not_access_to_offerer(self, client):
         pro_user = users_factories.ProFactory(email="pro.user@example.com")
         offerer = offerers_factories.OffererFactory(id=1)
@@ -84,6 +88,7 @@ class Returns400Test:
 
         data = {"email": "new.user@example.com"}
 
-        response = client.with_session_auth("pro.user@example.com").post("/offerers/2/invite", json=data)
+        response = client.with_session_auth("pro.user@example.com").post("/offerers/2/invite-again", json=data)
 
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/post_offerer_invite_member_test.py
+++ b/api/tests/routes/pro/post_offerer_invite_member_test.py
@@ -4,6 +4,7 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.users.factories as users_factories
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("db_session")
@@ -39,6 +40,9 @@ class Returns400Test:
         assert response.status_code == 400
         assert response.json == {"email": "Une invitation a déjà été envoyée à ce collaborateur"}
 
+
+@pytest.mark.usefixtures("db_session")
+class Returns404Test:
     def test_user_has_not_access_to_offerer(self, client):
         pro_user = users_factories.ProFactory(email="pro.user@example.com")
         offerer = offerers_factories.OffererFactory(id=1)
@@ -48,4 +52,5 @@ class Returns400Test:
 
         response = client.with_session_auth("pro.user@example.com").post("/offerers/2/invite", json=data)
 
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/stocks/patch_bulk_update_event_stocks_test.py
+++ b/api/tests/routes/pro/stocks/patch_bulk_update_event_stocks_test.py
@@ -15,6 +15,7 @@ from pcapi.core.bookings import models as bookings_models
 from pcapi.core.mails.transactional import brevo_template_ids
 from pcapi.core.offers import models as offers_models
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
@@ -564,7 +565,7 @@ class Returns400Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def when_user_has_no_rights_and_creating_stock_from_offer_id(self, client, db_session):
         users_factories.ProFactory(email="wrong@example.com")
         offer = offers_factories.EventOfferFactory()
@@ -585,7 +586,27 @@ class Returns403Test:
             },
         )
 
-        assert response.status_code == 403
-        assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
-        }
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_offer_not_found(self, client):
+        users_factories.ProFactory(email="user@example.com")
+        booking_datetime = date_utils.get_naive_utc_now() + relativedelta(hours=4)
+
+        response = client.with_session_auth("user@example.com").patch(
+            "/stocks/bulk",
+            json={
+                "offerId": 123456789,
+                "stocks": [
+                    {
+                        "id": 10,
+                        "priceCategoryId": 10,
+                        "quantity": 10,
+                        "beginningDatetime": format_into_utc_date(booking_datetime),
+                    },
+                ],
+            },
+        )
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/stocks/post_bulk_create_event_stocks_test.py
+++ b/api/tests/routes/pro/stocks/post_bulk_create_event_stocks_test.py
@@ -10,6 +10,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
@@ -332,7 +333,7 @@ class Returns400Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def when_user_has_no_rights_and_creating_stock_from_offer_id(self, client, db_session):
         user = users_factories.ProFactory(email="wrong@example.com")
         offer = offers_factories.EventOfferFactory()
@@ -352,7 +353,24 @@ class Returns403Test:
         }
         response = client.with_session_auth(user.email).post("/stocks/bulk", json=stock_data)
 
-        assert response.status_code == 403
-        assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    def test_when_offer_id_not_found(self, client):
+        user = users_factories.ProFactory()
+        beginning = date_utils.get_naive_utc_now() + relativedelta(days=10)
+
+        stock_data = {
+            "offerId": 123456789,
+            "stocks": [
+                {
+                    "beginningDatetime": format_into_utc_date(beginning),
+                    "bookingLimitDatetime": format_into_utc_date(beginning),
+                    "priceCategoryId": 1,
+                },
+            ],
         }
+        response = client.with_session_auth(user.email).post("/stocks/bulk", json=stock_data)
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/upsert_offer_stocks_test.py
+++ b/api/tests/routes/pro/upsert_offer_stocks_test.py
@@ -8,6 +8,7 @@ import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offers_models
 import pcapi.core.users.factories as users_factories
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
@@ -165,7 +166,7 @@ class Returns401Test:
 
 
 @pytest.mark.usefixtures("db_session")
-class Returns403Test:
+class Returns404Test:
     def test_user_without_rights(self, client):
         offer = offers_factories.ThingOfferFactory()
         unauthorized_pro = users_factories.ProFactory()
@@ -174,14 +175,9 @@ class Returns403Test:
         payload = {"stocks": []}
         response = client.with_session_auth(unauthorized_pro.email).patch(f"/offers/{offer.id}/stocks/", json=payload)
 
-        assert response.status_code == 403
-        assert response.json == {
-            "global": ["Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."]
-        }
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
-
-@pytest.mark.usefixtures("db_session")
-class Returns404Test:
     def test_offer_not_found(self, client):
         user = users_factories.UserFactory()
         offerers_factories.UserOffererFactory(user=user)
@@ -190,4 +186,4 @@ class Returns404Test:
         response = client.with_session_auth(user.email).patch("/offers/999999/stocks/", json=payload)
 
         assert response.status_code == 404
-        assert response.json == {"global": "No offer found for this id"}
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/users/post_user_review_test.py
+++ b/api/tests/routes/pro/users/post_user_review_test.py
@@ -6,6 +6,7 @@ import pytest
 from pcapi.connectors.harvestr import HaverstrRequester
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.users import factories as users_factories
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -98,7 +99,8 @@ class PostUserReviewTest:
         with caplog.at_level(logging.INFO):
             response = client.post("/users/log-user-review", json=data)
 
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
         assert "User submitting review" not in caplog.messages
         harvestr_create_message.assert_not_called()
 

--- a/api/tests/routes/pro/users/validate_user_test.py
+++ b/api/tests/routes/pro/users/validate_user_test.py
@@ -65,7 +65,7 @@ class Returns204Tests:
             assert session_["user_id"] == user.id
 
 
-class Returns400Test:
+class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     @pytest.mark.usefixtures("rsa_keys")
     @mock.patch("pcapi.flask_app.redis.client.Pipeline.execute")

--- a/api/tests/routes/pro/venue_providers/delete_venue_provider_test.py
+++ b/api/tests/routes/pro/venue_providers/delete_venue_provider_test.py
@@ -3,6 +3,7 @@ import pytest
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.providers import api as providers_api
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 @pytest.mark.usefixtures("db_session")
@@ -20,17 +21,18 @@ def test_delete_venue_provider(client):
 
 
 @pytest.mark.usefixtures("db_session")
-def test_delete_venue_provider_should_return_404(client):
+def test_delete_invalid_venue_provider_should_return_404(client):
     user_offerer = offerers_factories.UserOffererFactory()
     offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
 
     response = client.with_session_auth(email=user_offerer.user.email).delete("/venue-providers/12345")
 
     assert response.status_code == 404
+    assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
 
 
 @pytest.mark.usefixtures("db_session")
-def test_delete_venue_provider_should_return_403(client):
+def test_delete_venue_provider_should_return_404_when_user_has_no_rights(client):
     user_offerer = offerers_factories.UserOffererFactory()
     venue = offerers_factories.VenueFactory()
     provider = providers_factories.PublicApiProviderFactory()
@@ -38,4 +40,5 @@ def test_delete_venue_provider_should_return_403(client):
 
     response = client.with_session_auth(email=user_offerer.user.email).delete(f"/venue-providers/{venue_provider.id}")
 
-    assert response.status_code == 403
+    assert response.status_code == 404
+    assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/routes/pro/venue_providers/put_venue_provider_test.py
+++ b/api/tests/routes/pro/venue_providers/put_venue_provider_test.py
@@ -5,6 +5,7 @@ import pcapi.core.providers.factories as providers_factories
 import pcapi.core.providers.models as provider_models
 import pcapi.core.users.factories as user_factories
 from pcapi.models import db
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 
 
 class Returns200Test:
@@ -123,7 +124,7 @@ class Returns401Test:
         assert response.status_code == 401
 
 
-class Returns403Test:
+class Returns404Test:
     @pytest.mark.usefixtures("db_session")
     def test_user_has_right_on_venue(self, client):
         user = user_factories.ProFactory()
@@ -146,4 +147,14 @@ class Returns403Test:
             },
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}
+
+    @pytest.mark.usefixtures("db_session")
+    def test_venue_provider_not_found(self, client):
+        user = user_factories.ProFactory()
+        auth_request = client.with_session_auth(email=user.email)
+        response = auth_request.put("/venue-providers/123456789", json={})
+
+        assert response.status_code == 404
+        assert response.json == {"global": [OBJECT_NOT_FOUND_ERROR_MESSAGE]}

--- a/api/tests/utils/rest_test.py
+++ b/api/tests/utils/rest_test.py
@@ -3,6 +3,7 @@ import pytest
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.users.factories as users_factories
 from pcapi.core.testing import assert_no_duplicated_queries
+from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
 from pcapi.models.api_errors import ApiErrors
 from pcapi.utils.rest import check_user_has_access_to_offerer
 
@@ -25,7 +26,5 @@ class CheckUserHasAccessToOffererTest:
         with pytest.raises(ApiErrors) as error:
             check_user_has_access_to_offerer(user, offerer.id)
 
-        assert error.value.errors["global"] == [
-            "Vous n'avez pas les droits d'accès suffisants pour accéder à cette information."
-        ]
-        assert error.value.status_code == 403
+        assert error.value.errors["global"] == [OBJECT_NOT_FOUND_ERROR_MESSAGE]
+        assert error.value.status_code == 404


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/jira/software/c/projects/PC/boards/66?selectedIssue=PC-38644)

On ne s'intéresse dans cette PR qu'aux routes `/pro`

- commit 1 : retourner une 404 lors des check d'accès
- commit 2 : uniformiser les messages d'erreurs des 404
- commit 3 : corriger les tests unitaires



**NB: Cas particulier sur les offres collectives :** nous n'avons pas supprimé les 403 qui ne posent pas de problème d'énumération, et avons seulement uniformisés les messages des 404 suivantes :
- CannotFindOffererForOfferId
- CollectiveOfferNotFound
- CollectiveOfferTemplateNotFound
- VenueIdDoesNotExist
- CollectiveOfferRequestNotFound
- CollectiveStockNotFound