### PR TITLE
(PC-40908)[API] fix: do not allow extra fields in AddressLocation serializer

### DIFF
--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -866,6 +866,7 @@
                 "type": "object"
             },
             "AddressLocation": {
+                "additionalProperties": false,
                 "description": "If your offer location is different from the venue location",
                 "properties": {
                     "addressId": {

--- a/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serialization.py
@@ -153,6 +153,9 @@ class AddressLocation(serialization.ConfiguredBaseModel):
             address_label=offer.offererAddress.label,  # type: ignore[arg-type]
         )
 
+    class Config:
+        extra = "forbid"
+
 
 class PhysicalLocation(serialization.ConfiguredBaseModel):
     """

--- a/api/tests/routes/public/individual_offers/v1/events/post_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/post_event_test.py
@@ -609,6 +609,21 @@ class PostEventTest(PublicAPIVenueEndpointHelper):
             "location.AddressLocation.addressId": [f"There is no address with id {not_existing_address_id}"]
         }
 
+    def test_event_with_address_extra_field_are_not_allowed(self):
+        plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=False)
+        payload = self._get_base_payload(venue_provider.venueId)
+        address = geography_factories.AddressFactory()
+        payload["location"] = {
+            "type": "address",
+            "venueId": venue_provider.venueId,
+            "addressId": address.id,
+            "adressLabel": "adressLabel should be addressLabel",
+        }
+
+        response = self.make_request(plain_api_key, json_body=payload)
+        assert response.status_code == 400
+        assert response.json["location.AddressLocation.adressLabel"] == ["extra fields not permitted"]
+
     def test_event_without_ticket(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=False)
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-40908)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [x] Travail pair testé en environnement de preview: 

On a vérifié la non régression sur :

- créa / modif d'offre collective avec localisation :white_check_mark:  
- post / patch product (avec et sans EAN) via api publique :white_check_mark:
- post/patch event offer sur API publique :white_check_mark:
- qu'on a pas cassé le GET Offer sur API publique et App native :white_check_mark:
