### PR TITLE
[PC-38739] fix: yeswehack booking emails limit

### DIFF
--- a/api/src/pcapi/routes/serialization/collective_offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_offers_serialize.py
@@ -520,7 +520,7 @@ def validate_students(students: list[models.StudentLevels]) -> list[models.Stude
 class PostCollectiveOfferBodyModel(HttpBodyModel):
     venue_id: int
     name: str = pydantic_v2.Field(min_length=1, max_length=constants.MAX_COLLECTIVE_NAME_LENGTH)
-    booking_emails: list[pydantic_v2.EmailStr] = pydantic_v2.Field(min_length=1)
+    booking_emails: list[pydantic_v2.EmailStr] = pydantic_v2.Field(min_length=1, max_length=6)
     description: str = pydantic_v2.Field(max_length=constants.MAX_COLLECTIVE_DESCRIPTION_LENGTH)
     domains: list[int] = pydantic_v2.Field(min_length=1)
     duration_minutes: int | None = None
@@ -557,7 +557,7 @@ class PatchCollectiveOfferBodyModel(HttpBodyModel):
     mental_disability_compliant: bool | None = None
     motor_disability_compliant: bool | None = None
     visual_disability_compliant: bool | None = None
-    booking_emails: list[pydantic_v2.EmailStr] | None = pydantic_v2.Field(min_length=1, default=None)
+    booking_emails: list[pydantic_v2.EmailStr] | None = pydantic_v2.Field(min_length=1, max_length=6, default=None)
     description: str | None = pydantic_v2.Field(max_length=constants.MAX_COLLECTIVE_DESCRIPTION_LENGTH, default=None)
     name: str | None = pydantic_v2.Field(min_length=1, max_length=constants.MAX_COLLECTIVE_NAME_LENGTH, default=None)
     students: typing.Annotated[list[models.StudentLevels] | None, pydantic_v2.AfterValidator(validate_students)] = (

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -65,8 +65,8 @@ def before_handler(
         "less_than_equal": "Saisissez un nombre inférieur ou égal à {le}",
         "greater_than": "Saisissez un nombre supérieur à {gt}",
         "less_than": "Saisissez un nombre inférieur à {lt}",
-        "too_short": "Cette liste doit doit avoir une taille minimum de {min_length}",
-        "too_long": "Cette liste doit doit avoir une taille maximum de {max_length}",
+        "too_short": "Cette liste doit avoir une taille minimum de {min_length}",
+        "too_long": "Cette liste doit avoir une taille maximum de {max_length}",
         "model_attributes_type": "Format incorrect",
         "datetime_type": "Format de date invalide",
     }

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -66,6 +66,7 @@ def before_handler(
         "greater_than": "Saisissez un nombre supérieur à {gt}",
         "less_than": "Saisissez un nombre inférieur à {lt}",
         "too_short": "Cette liste doit doit avoir une taille minimum de {min_length}",
+        "too_long": "Cette liste doit doit avoir une taille maximum de {max_length}",
         "model_attributes_type": "Format incorrect",
         "datetime_type": "Format de date invalide",
     }

--- a/api/tests/routes/pro/collective_offers/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/collective_offers/patch_collective_offer_template_test.py
@@ -565,7 +565,7 @@ class Returns400Test:
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"formats": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"formats": ["Cette liste doit avoir une taille minimum de 1"]}
 
     def test_empty_educational_domains(self, client):
         offer_ctx = build_offer_context()
@@ -579,7 +579,7 @@ class Returns400Test:
             response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"domains": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"domains": ["Cette liste doit avoir une taille minimum de 1"]}
 
     def test_unknown_national_program(self, client):
         offer_ctx = build_offer_context()
@@ -729,7 +729,7 @@ class Returns400Test:
 
         assert response.status_code == 400
         assert response.json == {
-            "bookingEmails": ["Cette liste doit doit avoir une taille maximum de 6"],
+            "bookingEmails": ["Cette liste doit avoir une taille maximum de 6"],
         }
 
     def test_update_collective_offer_booking_emails_empty(self, client):
@@ -742,7 +742,7 @@ class Returns400Test:
             response = pro_client.patch(f"/collective/offers/{offer_id}", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"bookingEmails": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"bookingEmails": ["Cette liste doit avoir une taille minimum de 1"]}
 
     def test_description_invalid(self, client):
         offer_ctx = build_offer_context()

--- a/api/tests/routes/pro/collective_offers/patch_collective_offer_template_test.py
+++ b/api/tests/routes/pro/collective_offers/patch_collective_offer_template_test.py
@@ -712,6 +712,26 @@ class Returns400Test:
             "bookingEmails.2": ["Saisissez un email valide"],
         }
 
+    def test_return_error_when_there_is_more_than_6_booking_emails(self, client):
+        offer_ctx = build_offer_context()
+        payload_ctx = build_payload_context()
+
+        pro_client = build_pro_client(client, offer_ctx.user)
+        offer_id = offer_ctx.offer.id
+        payload = payload_ctx.payload
+
+        data = {
+            **payload,
+            "bookingEmails": [f"test{i}@testmail.com" for i in range(1, 8)],
+        }
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.patch(f"/collective/offers-template/{offer_id}", json=data)
+
+        assert response.status_code == 400
+        assert response.json == {
+            "bookingEmails": ["Cette liste doit doit avoir une taille maximum de 6"],
+        }
+
     def test_update_collective_offer_booking_emails_empty(self, client):
         offer_ctx = build_offer_context()
         pro_client = build_pro_client(client, offer_ctx.user)

--- a/api/tests/routes/pro/collective_offers/patch_collective_offer_test.py
+++ b/api/tests/routes/pro/collective_offers/patch_collective_offer_test.py
@@ -467,7 +467,7 @@ class Returns400Test:
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"formats": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"formats": ["Cette liste doit avoir une taille minimum de 1"]}
 
     def test_patch_offer_with_empty_educational_domain(self, client):
         offer = educational_factories.CollectiveOfferFactory(
@@ -628,7 +628,7 @@ class Returns400Test:
             response = client.patch(f"/collective/offers/{offer.id}", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"bookingEmails": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"bookingEmails": ["Cette liste doit avoir une taille minimum de 1"]}
 
     def test_patch_collective_offer_replacing_by_venue_with_no_pricing_point(self, auth_client, venue):
         offer = educational_factories.PublishedCollectiveOfferFactory(venue=venue)

--- a/api/tests/routes/pro/collective_offers/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/collective_offers/post_collective_offers_template_test.py
@@ -399,6 +399,19 @@ class Returns400Test:
             "bookingEmails.2": ["Saisissez un email valide"],
         }
 
+    def test_return_error_when_there_is_more_than_6_booking_emails(self, pro_client, payload):
+        data = {
+            **payload,
+            "bookingEmails": [f"test{i}@testmail.com" for i in range(1, 8)],
+        }
+        with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):
+            response = pro_client.post("/collective/offers-template", json=data)
+
+        assert response.status_code == 400
+        assert response.json == {
+            "bookingEmails": ["Cette liste doit doit avoir une taille maximum de 6"],
+        }
+
     def test_description_invalid(self, pro_client, payload):
         data = {**payload, "description": "too_long" * 200}
         with patch(educational_testing.PATCH_CAN_CREATE_OFFER_PATH):

--- a/api/tests/routes/pro/collective_offers/post_collective_offers_template_test.py
+++ b/api/tests/routes/pro/collective_offers/post_collective_offers_template_test.py
@@ -331,7 +331,7 @@ class Returns400Test:
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"formats": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"formats": ["Cette liste doit avoir une taille minimum de 1"]}
         assert db.session.query(models.CollectiveOffer).count() == 0
 
     def test_empty_domains(self, pro_client, payload):
@@ -341,7 +341,7 @@ class Returns400Test:
             response = pro_client.post("/collective/offers-template", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"domains": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"domains": ["Cette liste doit avoir une taille minimum de 1"]}
 
         assert db.session.query(models.CollectiveOfferTemplate).count() == 0
 
@@ -409,7 +409,7 @@ class Returns400Test:
 
         assert response.status_code == 400
         assert response.json == {
-            "bookingEmails": ["Cette liste doit doit avoir une taille maximum de 6"],
+            "bookingEmails": ["Cette liste doit avoir une taille maximum de 6"],
         }
 
     def test_description_invalid(self, pro_client, payload):

--- a/api/tests/routes/pro/collective_offers/post_collective_offers_test.py
+++ b/api/tests/routes/pro/collective_offers/post_collective_offers_test.py
@@ -408,7 +408,7 @@ class Returns400Test:
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"bookingEmails": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"bookingEmails": ["Cette liste doit avoir une taille minimum de 1"]}
         assert db.session.query(models.CollectiveOffer).count() == 0
 
     def test_create_collective_offer_empty_contact_email(self, client):
@@ -444,7 +444,7 @@ class Returns400Test:
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"formats": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"formats": ["Cette liste doit avoir une taille minimum de 1"]}
         assert db.session.query(models.CollectiveOffer).count() == 0
 
     def test_create_collective_offer_no_domains(self, client):
@@ -456,7 +456,7 @@ class Returns400Test:
             response = client.with_session_auth("user@example.com").post("/collective/offers", json=data)
 
         assert response.status_code == 400
-        assert response.json == {"domains": ["Cette liste doit doit avoir une taille minimum de 1"]}
+        assert response.json == {"domains": ["Cette liste doit avoir une taille minimum de 1"]}
         assert db.session.query(models.CollectiveOffer).count() == 0
 
     def test_create_collective_offer_description_invalid(self, client):

--- a/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
+++ b/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
@@ -270,7 +270,7 @@ def test_too_many_invoices_searched_returns_an_error(client):
     response = client.get(f"/v2/reimbursements/csv?{references}")
 
     assert response.status_code == 400
-    assert response.json == {"invoicesReferences": ["Cette liste doit doit avoir une taille maximum de 75"]}
+    assert response.json == {"invoicesReferences": ["Cette liste doit avoir une taille maximum de 75"]}
 
 
 def test_booking_with_empty_use_date_should_be_ok(client):

--- a/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
+++ b/api/tests/routes/pro/get_reimbursements_csv_by_invoices_test.py
@@ -270,7 +270,7 @@ def test_too_many_invoices_searched_returns_an_error(client):
     response = client.get(f"/v2/reimbursements/csv?{references}")
 
     assert response.status_code == 400
-    assert response.json == {"invoicesReferences": ["Set should have at most 75 items after validation, not more"]}
+    assert response.json == {"invoicesReferences": ["Cette liste doit doit avoir une taille maximum de 75"]}
 
 
 def test_booking_with_empty_use_date_should_be_ok(client):


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-38739)

En front, on affiche le bouton pour ajouter un email tant que la liste d'email (`bookingEmails`) a moins de 5 éléments (`bookingEmails.lenght <= 5`). Ce qui fait qu'on peut en ajouter un 6e. 
La limite (`max_length`) dans le back **doit donc être de 6.**

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
