### PR TITLE
(PC-41512)[API] fix: ignore offerer_id when venue_id is set

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -686,10 +686,17 @@ def get_offers_by_filters(
             offerers_models.UserOfferer.isValidated,
         )
     )
-    if offerer_id is not None:
-        query = query.filter(offerers_models.Venue.managingOffererId == offerer_id)
+    # ignore offerer_id if venue_id is set:
+    # -> the offerer filter makes no sense since a venue belongs to an
+    # offerer
+    # -> /!\ for some unknown reasons, this could lead to a strange
+    # query that is insanely slow (venue_id + offerer_id
+    # + period_beginning_date + period_ending_date + .limit())
     if venue_id is not None:
         query = query.filter(models.Offer.venueId == venue_id)
+    elif offerer_id is not None:
+        query = query.filter(offerers_models.Venue.managingOffererId == offerer_id)
+
     if offerer_address_id is not None:
         query = query.filter(models.Offer.offererAddressId == offerer_address_id)
     if creation_mode is not None:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41512)

Pour une raison encore inexpliquée, la fonction de filtre utilisée sur le portail pro peut produire une requête qui semble sans fin avec cette combinaison : dates de début et de fin, _venue_ et _offerer_. Le problème semble se déclencher avec l'ajout d'une limite.

En attendant d'y trouver une explication, cette PR propose un fix simple : retirer le filtre sur l'_offerer_ s'il y a déjà un filtre sur la _venue_ (puisqu'avoir les deux est par définition redondant). Les premiers essais semblent concluants.