### PR TITLE
(PC-41290)[PRO] feat: make socialUrls required (at least 1) and update labels

### DIFF
--- a/pro/e2e/signupJourneyCreateNotDiffusibleOfferer.e2e.ts
+++ b/pro/e2e/signupJourneyCreateNotDiffusibleOfferer.e2e.ts
@@ -51,7 +51,7 @@ test.describe('Signup journey with not diffusible offerer siret', () => {
     await expect(page.getByLabel(/Adresse postale/)).toHaveCount(0)
 
     await page.getByText('Étape suivante').click()
-    await page.getByText('Étape précédente').click()
+    await page.getByText('Retour').click()
     await expect(page.getByLabel('Non')).toBeChecked()
     await page.getByText('Étape suivante').click()
 
@@ -63,8 +63,11 @@ test.describe('Signup journey with not diffusible offerer siret', () => {
 
     await page.getByLabel(/Activité principale/).selectOption('Festival')
     await page.getByLabel('Numéro de téléphone').fill('612345678')
-    await page.getByText('Au grand public').click()
-    await page.getByText('Étape suivante').click()
+    await page
+      .getByLabel('Site internet, réseau social')
+      .fill('http://example.com')
+    await page.getByText('Aux jeunes via l’application pass Culture').click()
+    await page.getByText('Continuer').click()
 
     await expect(page).toHaveURL(/\/inscription\/structure\/confirmation/)
 
@@ -108,15 +111,18 @@ test.describe('Signup journey with not diffusible offerer siret', () => {
     await page.getByTestId('list').getByText(MOCKED_BACK_ADDRESS_LABEL).click()
 
     await page.getByText('Étape suivante').click()
-    await page.getByText('Étape précédente').click()
+    await page.getByText('Retour').click()
     await page.getByLabel('Oui').click()
     await page.getByText('Étape suivante').click()
 
     await expect(page).toHaveURL(/\/inscription\/structure\/activite/)
     await page.getByLabel(/Activité principale/).selectOption('Galerie d’art')
     await page.getByLabel('Numéro de téléphone').fill('612345678')
-    await page.getByText('Au grand public').click()
-    await page.getByText('Étape suivante').click()
+    await page
+      .getByLabel('Site internet, réseau social')
+      .fill('http://example.com')
+    await page.getByText('Aux jeunes via l’application pass Culture').click()
+    await page.getByText('Continuer').click()
 
     await expect(page).toHaveURL(/\/inscription\/structure\/confirmation/)
 

--- a/pro/e2e/signupJourneyCreateOfferer.e2e.ts
+++ b/pro/e2e/signupJourneyCreateOfferer.e2e.ts
@@ -54,15 +54,18 @@ test.describe('Signup journey with unknown offerer and unknown venue', () => {
     await expect(page).toHaveURL(/\/inscription\/structure\/activite/)
     await page.getByLabel(/Activité principale/).selectOption('Galerie d’art')
     await page.getByLabel('Numéro de téléphone').fill('612345678')
-    await page.getByText('Étape suivante').click()
+    await page
+      .getByLabel('Site internet, réseau social')
+      .fill('http://example.com')
+    await page.getByText('Continuer').click()
     await expect(
       page.getByText('Veuillez sélectionner au moins une option')
     ).toBeVisible()
 
     await expect(page).toHaveURL(/\/inscription\/structure\/activite/)
-    await page.getByText('Au grand public').click()
+    await page.getByText('Aux jeunes via l’application pass Culture').click()
     await checkAccessibility(page)
-    await page.getByText('Étape suivante').click()
+    await page.getByText('Continuer').click()
 
     await expect(page).toHaveURL(/\/inscription\/structure\/confirmation/)
     await expect(page.getByText('5 Rue Curial, 75019 Paris')).toBeVisible()
@@ -127,8 +130,11 @@ test.describe('Signup journey with unknown offerer and unknown venue', () => {
     await expect(page).toHaveURL(/\/inscription\/structure\/activite/)
     await page.getByLabel(/Activité principale/).selectOption('Galerie d’art')
     await page.getByLabel('Numéro de téléphone').fill('612345678')
-    await page.getByText('Au grand public').click()
-    await page.getByText('Étape suivante').click()
+    await page
+      .getByLabel('Site internet, réseau social')
+      .fill('http://example.com')
+    await page.getByText('Aux jeunes via l’application pass Culture').click()
+    await page.getByText('Continuer').click()
 
     await expect(page).toHaveURL(/\/inscription\/structure\/confirmation/)
     await expect(page.getByText('10 Rue du test, 75002 Paris')).toBeVisible()
@@ -187,8 +193,11 @@ test.describe('Signup journey with known offerer...', () => {
       await expect(page).toHaveURL(/\/inscription\/structure\/activite/)
       await page.getByLabel(/Activité principale/).selectOption('Galerie d’art')
       await page.getByLabel('Numéro de téléphone').fill('612345678')
-      await page.getByText('Au grand public').click()
-      await page.getByText('Étape suivante').click()
+      await page
+        .getByLabel('Site internet, réseau social')
+        .fill('http://example.com')
+      await page.getByText('Aux jeunes via l’application pass Culture').click()
+      await page.getByText('Continuer').click()
 
       await expect(page).toHaveURL(/\/inscription\/structure\/confirmation/)
 
@@ -267,13 +276,16 @@ test.describe('Signup journey with known offerer...', () => {
         .getByLabel(/Activité principale/)
         .selectOption('Sélectionnez votre activité principale')
       await page.getByLabel('Numéro de téléphone').fill('612345678')
-      await page.getByText('Au grand public').click()
-      await page.getByText('Étape suivante').click()
+      await page
+        .getByLabel('Site internet, réseau social')
+        .fill('http://example.com')
+      await page.getByText('Aux jeunes via l’application pass Culture').click()
+      await page.getByText('Continuer').click()
       await expect(page.getByText('Activité non valide')).toBeVisible()
 
       await expect(page).toHaveURL(/\/inscription\/structure\/activite/)
       await page.getByLabel(/Activité principale/).selectOption('Galerie d’art')
-      await page.getByText('Étape suivante').click()
+      await page.getByText('Continuer').click()
 
       await expect(page).toHaveURL(/\/inscription\/structure\/confirmation$/)
 

--- a/pro/src/components/SignupJourneyForm/Activity/Activity.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/Activity.tsx
@@ -167,6 +167,8 @@ export const Activity = () => {
             isDisabled={methods.formState.isSubmitting}
             previousTo={SIGNUP_JOURNEY_STEP_IDS.AUTHENTICATION}
             nextTo={SIGNUP_JOURNEY_STEP_IDS.CONFIRMATION}
+            nextStepTitle="Continuer"
+            previousStepTitle="Retour"
           />
         </form>
       </FormProvider>

--- a/pro/src/components/SignupJourneyForm/Activity/ActivityForm.module.scss
+++ b/pro/src/components/SignupJourneyForm/Activity/ActivityForm.module.scss
@@ -7,3 +7,7 @@
   flex-direction: column;
   gap: var(--size-spacing-m);
 }
+
+.banner-container {
+  margin-top: var(--size-spacing-m);
+}

--- a/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -10,6 +10,7 @@ import { buildSelectOptions } from '@/commons/utils/buildSelectOptions'
 import { pluralizeFr } from '@/commons/utils/pluralize'
 import { FormLayout } from '@/components/FormLayout/FormLayout'
 import { ScrollToFirstHookFormErrorAfterSubmit } from '@/components/ScrollToFirstErrorAfterSubmit/ScrollToFirstErrorAfterSubmit'
+import { Banner } from '@/design-system/Banner/Banner'
 import { Button } from '@/design-system/Button/Button'
 import { ButtonColor, ButtonVariant } from '@/design-system/Button/types'
 import { CheckboxGroup } from '@/design-system/CheckboxGroup/CheckboxGroup'
@@ -156,6 +157,7 @@ export const ActivityForm = (): JSX.Element => {
                 label="Site internet, réseau social"
                 description="Format : https://www.siteinternet.com"
                 type="url"
+                required
                 error={formState.errors.socialUrls?.[index]?.url?.message}
                 extension={
                   watchSocialUrls.length > 1 && (
@@ -194,11 +196,11 @@ export const ActivityForm = (): JSX.Element => {
 
         <FormLayout.Row className={styles['target-customer-row']}>
           <CheckboxGroup
-            label="À qui souhaitez-vous destiner vos offres sur le pass Culture ? Cette information est collectée à titre informatif."
+            label="À qui souhaitez-vous destiner vos offres sur le pass Culture ? *"
             description="Sélectionnez au moins une option"
             options={[
               {
-                label: 'Au grand public',
+                label: 'Aux jeunes via l’application pass Culture',
                 sizing: 'fill',
                 checked: watch('targetCustomer.individual'),
                 onChange: async (e) => {
@@ -207,7 +209,7 @@ export const ActivityForm = (): JSX.Element => {
                 },
               },
               {
-                label: 'À des groupes scolaires',
+                label: 'Aux groupes scolaires via ADAGE',
                 sizing: 'fill',
                 checked: watch('targetCustomer.educational'),
                 onChange: async (e) => {
@@ -221,6 +223,8 @@ export const ActivityForm = (): JSX.Element => {
           />
         </FormLayout.Row>
       </FormLayout.Section>
+
+      <Banner title="Vous pourrez cumuler les deux types d'offres avec un seul compte pass Culture Pro." />
     </>
   )
 }

--- a/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/ActivityForm.tsx
@@ -158,7 +158,12 @@ export const ActivityForm = (): JSX.Element => {
                 description="Format : https://www.siteinternet.com"
                 type="url"
                 required
-                error={formState.errors.socialUrls?.[index]?.url?.message}
+                error={
+                  formState.errors.socialUrls?.[index]?.url?.message ??
+                  (index === 0
+                    ? formState.errors.socialUrls?.root?.message
+                    : undefined)
+                }
                 extension={
                   watchSocialUrls.length > 1 && (
                     <div
@@ -221,10 +226,11 @@ export const ActivityForm = (): JSX.Element => {
             variant="detailed"
             error={formState.errors.targetCustomer?.message}
           />
+          <div className={styles['banner-container']}>
+            <Banner title="Vous pourrez cumuler les deux types d'offres avec un seul compte pass Culture Pro." />
+          </div>
         </FormLayout.Row>
       </FormLayout.Section>
-
-      <Banner title="Vous pourrez cumuler les deux types d'offres avec un seul compte pass Culture Pro." />
     </>
   )
 }

--- a/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityForm.spec.tsx
@@ -98,12 +98,12 @@ describe('screens:SignupJourney::ActivityForm', () => {
       await screen.findByRole('button', { name: 'Ajouter un lien' })
     ).toBeInTheDocument()
     expect(
-      screen.getByLabelText('Au grand public', {
+      screen.getByLabelText('Aux jeunes via l’application pass Culture', {
         exact: false,
       })
     ).not.toBeChecked()
     expect(
-      screen.getByLabelText('À des groupes scolaires', {
+      screen.getByLabelText('Aux groupes scolaires via ADAGE', {
         exact: false,
       })
     ).not.toBeChecked()
@@ -138,12 +138,12 @@ describe('screens:SignupJourney::ActivityForm', () => {
     expect(screen.getByText('Musée')).toBeInTheDocument()
     expect(screen.getAllByText('Site internet, réseau social')).toHaveLength(2)
     expect(
-      screen.getByLabelText('Au grand public', {
+      screen.getByLabelText('Aux jeunes via l’application pass Culture', {
         exact: false,
       })
     ).not.toBeChecked()
     expect(
-      screen.getByLabelText('À des groupes scolaires', {
+      screen.getByLabelText('Aux groupes scolaires via ADAGE', {
         exact: false,
       })
     ).not.toBeChecked()
@@ -197,8 +197,12 @@ describe('screens:SignupJourney::ActivityForm', () => {
   it('should change targetCustomer value on click', async () => {
     renderActivityForm(initialValues, contextValue)
 
-    const publicTarget = screen.getByLabelText('Au grand public')
-    const schoolTarget = screen.getByLabelText('À des groupes scolaires')
+    const publicTarget = screen.getByLabelText(
+      'Aux jeunes via l’application pass Culture'
+    )
+    const schoolTarget = screen.getByLabelText(
+      'Aux groupes scolaires via ADAGE'
+    )
 
     expect(publicTarget).not.toBeChecked()
     expect(schoolTarget).not.toBeChecked()

--- a/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/__specs__/ActivityScreen.spec.tsx
@@ -166,20 +166,20 @@ describe('screens:SignupJourney::Activity', () => {
       await screen.findByRole('button', { name: 'Ajouter un lien' })
     ).toBeInTheDocument()
     expect(
-      screen.getByLabelText('Au grand public', {
+      screen.getByLabelText('Aux jeunes via l’application pass Culture', {
         exact: false,
       })
     ).not.toBeChecked()
     expect(
-      screen.getByLabelText('À des groupes scolaires', {
+      screen.getByLabelText('Aux groupes scolaires via ADAGE', {
         exact: false,
       })
     ).not.toBeChecked()
     expect(
-      await screen.findByRole('button', { name: 'Étape suivante' })
+      await screen.findByRole('button', { name: 'Continuer' })
     ).toBeInTheDocument()
     expect(
-      await screen.findByRole('button', { name: 'Étape précédente' })
+      await screen.findByRole('button', { name: 'Retour' })
     ).toBeInTheDocument()
   })
 
@@ -251,7 +251,7 @@ describe('screens:SignupJourney::Activity', () => {
   it('should display validation screen on click next step button', async () => {
     contextValue.activity = {
       activity: 'MUSEUM',
-      socialUrls: [],
+      socialUrls: ['http://example.com'],
       targetCustomer: Target.INDIVIDUAL_AND_EDUCATIONAL,
       phoneNumber: '0605120510',
       culturalDomains: undefined,
@@ -266,9 +266,7 @@ describe('screens:SignupJourney::Activity', () => {
       })
     ).toBeInTheDocument()
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Étape suivante' })
-    )
+    await userEvent.click(screen.getByRole('button', { name: 'Continuer' }))
 
     await waitFor(() => {
       expect(screen.getByText('Validation screen')).toBeInTheDocument()
@@ -278,7 +276,7 @@ describe('screens:SignupJourney::Activity', () => {
   it('should go next step with individual target customer', async () => {
     contextValue.activity = {
       activity: 'MUSEUM',
-      socialUrls: [],
+      socialUrls: ['http://example.com'],
       targetCustomer: Target.INDIVIDUAL,
       phoneNumber: '0605120510',
       culturalDomains: undefined,
@@ -292,12 +290,14 @@ describe('screens:SignupJourney::Activity', () => {
         name: 'Et enfin, définissez l’activité de votre structure',
       })
     ).toBeInTheDocument()
-    expect(screen.getByLabelText('Au grand public')).toBeChecked()
-    expect(screen.getByLabelText('À des groupes scolaires')).not.toBeChecked()
+    expect(
+      screen.getByLabelText('Aux jeunes via l’application pass Culture')
+    ).toBeChecked()
+    expect(
+      screen.getByLabelText('Aux groupes scolaires via ADAGE')
+    ).not.toBeChecked()
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Étape suivante' })
-    )
+    await userEvent.click(screen.getByRole('button', { name: 'Continuer' }))
 
     expect(screen.getByText('Validation screen')).toBeInTheDocument()
   })
@@ -305,7 +305,7 @@ describe('screens:SignupJourney::Activity', () => {
   it('should go next step with educational target customer', async () => {
     contextValue.activity = {
       activity: 'MUSEUM',
-      socialUrls: [],
+      socialUrls: ['http://example.com'],
       targetCustomer: Target.EDUCATIONAL,
       phoneNumber: '0605120510',
       culturalDomains: undefined,
@@ -319,12 +319,14 @@ describe('screens:SignupJourney::Activity', () => {
         name: 'Et enfin, définissez l’activité de votre structure',
       })
     ).toBeInTheDocument()
-    expect(screen.getByLabelText('Au grand public')).not.toBeChecked()
-    expect(screen.getByLabelText('À des groupes scolaires')).toBeChecked()
+    expect(
+      screen.getByLabelText('Aux jeunes via l’application pass Culture')
+    ).not.toBeChecked()
+    expect(
+      screen.getByLabelText('Aux groupes scolaires via ADAGE')
+    ).toBeChecked()
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Étape suivante' })
-    )
+    await userEvent.click(screen.getByRole('button', { name: 'Continuer' }))
 
     expect(screen.getByText('Validation screen')).toBeInTheDocument()
   })
@@ -339,9 +341,7 @@ describe('screens:SignupJourney::Activity', () => {
       })
     ).toBeInTheDocument()
 
-    await userEvent.click(
-      screen.getByRole('button', { name: 'Étape précédente' })
-    )
+    await userEvent.click(screen.getByRole('button', { name: 'Retour' }))
 
     expect(screen.getByText('Authentication screen')).toBeInTheDocument()
   })

--- a/pro/src/components/SignupJourneyForm/Activity/validationSchema.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/validationSchema.tsx
@@ -59,8 +59,13 @@ export const validationSchema = (
           url: yup
             .string()
             .url('Veuillez renseigner une URL valide. Ex : https://exemple.com')
-            .required('Veuillez renseigner au moins une URL'),
+            .defined(),
         })
+      )
+      .test(
+        'at-least-one-url',
+        'Veuillez renseigner au moins une URL',
+        (value) => (value ?? []).some((item) => Boolean(item.url.trim()))
       )
       .required(),
 

--- a/pro/src/components/SignupJourneyForm/Activity/validationSchema.tsx
+++ b/pro/src/components/SignupJourneyForm/Activity/validationSchema.tsx
@@ -30,12 +30,14 @@ export const validationSchema = (
     activity: activityValidator.required(
       'Veuillez sélectionner une activité principale'
     ),
+
     otherActivityComment: yup.string().when('activity', {
       is: (activity: ActivityOpenToPublicType | ActivityNotOpenToPublicType) =>
         activity === 'OTHER',
       then: (schema) =>
         schema.required('Veuillez préciser votre type d’activité'),
     }),
+
     culturalDomains: yup
       .array()
       .of(yup.string().required())
@@ -49,19 +51,19 @@ export const validationSchema = (
         }
         return schema
       }),
+
     socialUrls: yup
       .array()
       .of(
-        yup.object().shape({
+        yup.object({
           url: yup
             .string()
-            .default('')
-            .url(
-              'Veuillez renseigner une URL valide. Ex : https://exemple.com'
-            ),
+            .url('Veuillez renseigner une URL valide. Ex : https://exemple.com')
+            .required('Veuillez renseigner au moins une URL'),
         })
       )
       .required(),
+
     targetCustomer: yup
       .object()
       .test({
@@ -75,6 +77,7 @@ export const validationSchema = (
         educational: yup.boolean().required(),
       })
       .required('Veuillez sélectionner au moins une option'),
+
     phoneNumber: yup
       .string()
       .min(10, 'Veuillez renseigner au moins 10 chiffres')


### PR DESCRIPTION
## 🎯 Related Ticket

[Ticket Jira : PC-41290](https://passculture.atlassian.net/browse/PC-41290)

### Résumé
- **URLs site / réseaux sociaux** : le champ (via le schéma Yup) exige une URL valide et au moins une URL renseignée sur les lignes du formulaire ; le champ `TextInput` est marqué `required` côté UI.
- **Cible des offres** : libellés des cases à cocher mis à jour (« Aux jeunes via l’application pass Culture », « Aux groupes scolaires via ADAGE ») ; le libellé de la question inclut un astérisque `*` ; le sous-texte de sélection reste explicite.
- **Bannière** : ajout d’une bannière d’information expliquant qu’on peut cumuler les deux types d’offres avec un seul compte pass Culture Pro.
- **Navigation de l’étape Activité** : libellés des boutons d’en-tête d’étape personnalisés — « Continuer » / « Retour » à la place de « Étape suivante » / « Étape précédente ».
- **Tests** : specs `ActivityForm` et `Activity` alignés sur les nouveaux textes, les boutons et des données de test incluant une URL valide quand le flux exige d’avancer à l’étape suivante.

## 🖼️ Before & After Images

Modifications UI (libellés, bannière, intitulés de boutons, indicateur requis sur le champ URL).  
Merci d’ajouter des captures de l’écran Activité **avant** (branche de base) et **après** cette branche, par exemple :

| Avant | Après |
|:---:|:---:|
<img width="1118" height="1263" alt="image" src="https://github.com/user-attachments/assets/9383a554-2d7a-42db-b0ec-a8c3a936edd4" /> | <img width="1118" height="1263" alt="image" src="https://github.com/user-attachments/assets/794d7c07-4cff-40b4-9aa6-1becf0c8c356" />
<img width="1118" height="1263" alt="image" src="https://github.com/user-attachments/assets/6562429f-6727-41b0-b69d-e4f70952410e" /> | <img width="1118" height="1263" alt="image" src="https://github.com/user-attachments/assets/2d84f047-b536-4a25-940f-907416b75fd4" />

