### PR TITLE
(PC-41093)[API] fix: implement bookings order for v2 route

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -180,6 +180,22 @@ def get_individual_bookings(user: users_models.User) -> list[models.Booking]:
     return (db.session.query(models.Booking).filter_by(userId=user.id).options(*_get_booking_options())).all()
 
 
+def _sort_ended_bookings(bookings: list[models.Booking]) -> list[models.Booking]:
+    return sorted(
+        bookings,
+        key=lambda b: b.stock.beginningDatetime or b.dateUsed or b.cancellationDate or datetime.datetime.min,
+        reverse=True,
+    )
+
+
+def _sort_ongoing_bookings(bookings: list[models.Booking]) -> list[models.Booking]:
+    # put permanent bookings at the end with datetime.max
+    return sorted(
+        bookings,
+        key=lambda b: (b.expirationDate or b.stock.beginningDatetime or datetime.datetime.max, -b.id),
+    )
+
+
 def classify_and_sort_bookings(
     individual_bookings: list[models.Booking],
 ) -> tuple[list[models.Booking], list[models.Booking]]:
@@ -195,20 +211,7 @@ def classify_and_sort_bookings(
             ongoing_bookings.append(booking)
             booking.qrCodeData = utils.get_qr_code_data(booking.token)  # type: ignore [attr-defined]
 
-    sorted_ended_bookings = sorted(
-        ended_bookings,
-        key=lambda b: b.stock.beginningDatetime or b.dateUsed or b.cancellationDate or datetime.datetime.min,
-        reverse=True,
-    )
-    # put permanent bookings at the end with datetime.max
-    sorted_ongoing_bookings = sorted(
-        ongoing_bookings,
-        key=lambda b: (
-            b.expirationDate or b.stock.beginningDatetime or datetime.datetime.max,
-            -b.id,
-        ),
-    )
-    return (sorted_ended_bookings, sorted_ongoing_bookings)
+    return (_sort_ended_bookings(ended_bookings), _sort_ongoing_bookings(ongoing_bookings))
 
 
 def get_user_bookings_by_status(user: users_models.User, status: str) -> list[models.Booking]:
@@ -269,7 +272,7 @@ def get_user_bookings_by_status(user: users_models.User, status: str) -> list[mo
         )
     )
 
-    query_filter = sa.or_(
+    is_ended = sa.or_(
         models.Booking.displayAsEnded.is_(True),
         models.Booking.status.in_(
             [
@@ -282,8 +285,11 @@ def get_user_bookings_by_status(user: users_models.User, status: str) -> list[mo
     )
 
     if status == models.BookingsListStatus.ENDED.value:
-        return query.filter(query_filter).all()
-    return query.filter(sa.not_(query_filter)).all()
+        bookings = query.filter(is_ended).all()
+        return _sort_ended_bookings(bookings)
+
+    bookings = query.filter(sa.not_(is_ended)).all()
+    return _sort_ongoing_bookings(bookings)
 
 
 def _book_offer(

--- a/api/tests/routes/native/v2/bookings_test.py
+++ b/api/tests/routes/native/v2/bookings_test.py
@@ -196,6 +196,109 @@ class GetBookingsTest:
             "totalAmount": 1010,
         }
 
+    def test_get_bookings_sorts_ended_bookings_by_date_desc(self, client):
+        user = users_factories.BeneficiaryFactory(email=self.identifier, age=18)
+
+        base_dt = datetime(2023, 3, 2)
+        older_ended = booking_factories.UsedBookingFactory(
+            user=user,
+            displayAsEnded=True,
+            dateUsed=base_dt,
+            stock__beginningDatetime=base_dt,
+        )
+        newer_ended = booking_factories.UsedBookingFactory(
+            user=user,
+            displayAsEnded=True,
+            dateUsed=base_dt + timedelta(days=1),
+            stock__beginningDatetime=base_dt + timedelta(days=1),
+        )
+
+        client.with_token(user)
+        with assert_num_queries(2):  # user, booking
+            response = client.get("/native/v2/bookings")
+
+        assert response.status_code == 200
+        ended_ids = [b["id"] for b in response.json["endedBookings"]]
+        assert ended_ids == [newer_ended.id, older_ended.id]
+
+    def test_get_bookings_list_sorts_ended_bookings(self, client):
+        user = users_factories.BeneficiaryFactory(email=self.identifier, age=18)
+
+        base_dt = datetime(2023, 3, 2)
+        booking_with_beginning_date = booking_factories.UsedBookingFactory(
+            user=user,
+            cancellation_date=None,
+            dateUsed=None,
+            stock__beginningDatetime=base_dt,
+        )
+        booking_with_date_used = booking_factories.UsedBookingFactory(
+            user=user,
+            cancellation_date=None,
+            dateUsed=base_dt + timedelta(days=1),
+            stock__beginningDatetime=None,
+        )
+        booking_with_cancellation_date = booking_factories.CancelledBookingFactory(
+            user=user,
+            cancellation_date=base_dt + timedelta(days=2),
+            dateUsed=None,
+            stock__beginningDatetime=None,
+        )
+
+        client.with_token(user)
+        with assert_num_queries(2):  # user, booking
+            response = client.get("/native/v2/bookings")
+
+        assert response.status_code == 200
+        booking_ids = [b["id"] for b in response.json["endedBookings"]]
+        assert booking_ids == [
+            booking_with_cancellation_date.id,
+            booking_with_date_used.id,
+            booking_with_beginning_date.id,
+        ]
+
+    def test_get_bookings_list_sorts_ongoing_bookings(self, client):
+        user = users_factories.BeneficiaryFactory(email=self.identifier, age=18)
+
+        base_dt = datetime(2023, 3, 2)
+        booking_with_expiration_date = booking_factories.BookingFactory(
+            user=user,
+            dateCreated=base_dt,
+            stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,  # SUPPORT_PHYSIQUE_FILM bookings can expire => expirationDate is not None and expirationDate is dateCreated + BOOKINGS_AUTO_EXPIRY_DELAY
+        )
+        booking_with_beginning_date = booking_factories.BookingFactory(
+            user=user,
+            stock__beginningDatetime=base_dt,
+            stock__offer__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,  # LIVRE_NUMERIQUE bookings can't expire => expirationDate is None
+        )
+        booking_without_date = booking_factories.BookingFactory(
+            user=user,
+            stock__beginningDatetime=None,
+            stock__offer__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
+        )
+        booking_without_date_with_higher_id = booking_factories.BookingFactory(
+            user=user,
+            stock__beginningDatetime=None,
+            stock__offer__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
+        )
+
+        assert booking_with_expiration_date.expirationDate is not None
+        assert booking_with_expiration_date.expirationDate > base_dt
+        assert booking_with_beginning_date.expirationDate is None
+        assert booking_without_date_with_higher_id.id > booking_without_date.id
+
+        client.with_token(user)
+        with assert_num_queries(2):  # user + booking
+            response = client.get("/native/v2/bookings")
+
+        assert response.status_code == 200
+        booking_ids = [b["id"] for b in response.json["ongoingBookings"]]
+        assert booking_ids == [
+            booking_with_beginning_date.id,
+            booking_with_expiration_date.id,
+            booking_without_date_with_higher_id.id,
+            booking_without_date.id,
+        ]
+
     def test_get_bookings_returns_user_reaction(self, client):
         now = date_utils.get_naive_utc_now()
         stock = offers_factories.EventStockFactory()
@@ -517,6 +620,49 @@ class GetBookingsListTest:
             "totalAmount": int(ongoing_booking.total_amount * 100),
         }
 
+    def test_get_bookings_list_sorts_ongoing_bookings(self, client):
+        user = users_factories.BeneficiaryFactory(email=self.identifier, age=18)
+
+        base_dt = datetime(2023, 3, 2)
+        booking_with_expiration_date = booking_factories.BookingFactory(
+            user=user,
+            dateCreated=base_dt,
+            stock__offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,  # SUPPORT_PHYSIQUE_FILM bookings can expire => expirationDate is not None and expirationDate is dateCreated + BOOKINGS_AUTO_EXPIRY_DELAY
+        )
+        booking_with_beginning_date = booking_factories.BookingFactory(
+            user=user,
+            stock__beginningDatetime=base_dt,
+            stock__offer__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,  # LIVRE_NUMERIQUE bookings can't expire => expirationDate is None
+        )
+        booking_without_date = booking_factories.BookingFactory(
+            user=user,
+            stock__beginningDatetime=None,
+            stock__offer__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
+        )
+        booking_without_date_with_higher_id = booking_factories.BookingFactory(
+            user=user,
+            stock__beginningDatetime=None,
+            stock__offer__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
+        )
+
+        assert booking_with_expiration_date.expirationDate is not None
+        assert booking_with_expiration_date.expirationDate > base_dt
+        assert booking_with_beginning_date.expirationDate is None
+        assert booking_without_date_with_higher_id.id > booking_without_date.id
+
+        client.with_token(user)
+        with assert_num_queries(2):  # user + booking
+            response = client.get("/native/v2/bookings/ongoing")
+
+        assert response.status_code == 200
+        booking_ids = [b["id"] for b in response.json["bookings"]]
+        assert booking_ids == [
+            booking_with_beginning_date.id,
+            booking_with_expiration_date.id,
+            booking_without_date_with_higher_id.id,
+            booking_without_date.id,
+        ]
+
     def test_get_bookings_list_returns_ended_bookings(self, client):
         user = users_factories.BeneficiaryFactory(email=self.identifier, age=18)
 
@@ -622,6 +768,49 @@ class GetBookingsListTest:
             "userReaction": ended_booking.userReaction.value,
             "totalAmount": int(ended_booking.total_amount * 100),
         }
+
+    def test_get_bookings_list_sorts_ended_bookings(self, client):
+        user = users_factories.BeneficiaryFactory(email=self.identifier, age=18)
+
+        base_dt = datetime(2023, 3, 2)
+        booking_with_beginning_date = booking_factories.UsedBookingFactory(
+            user=user,
+            cancellation_date=None,
+            dateUsed=None,
+            stock__beginningDatetime=base_dt,
+        )
+        booking_with_date_used = booking_factories.UsedBookingFactory(
+            user=user,
+            cancellation_date=None,
+            dateUsed=base_dt + timedelta(days=1),
+            stock__beginningDatetime=None,
+        )
+        booking_with_cancellation_date = booking_factories.CancelledBookingFactory(
+            user=user,
+            cancellation_date=base_dt + timedelta(days=2),
+            dateUsed=None,
+            stock__beginningDatetime=None,
+        )
+        booking_without_date = booking_factories.BookingFactory(
+            user=user,
+            displayAsEnded=True,
+            cancellation_date=None,
+            dateUsed=None,
+            stock__beginningDatetime=None,
+        )
+
+        client.with_token(user)
+        with assert_num_queries(2):  # user, booking
+            response = client.get("/native/v2/bookings/ended")
+
+        assert response.status_code == 200
+        booking_ids = [b["id"] for b in response.json["bookings"]]
+        assert booking_ids == [
+            booking_with_cancellation_date.id,
+            booking_with_date_used.id,
+            booking_with_beginning_date.id,
+            booking_without_date.id,
+        ]
 
     booking_start_date = datetime(2023, 3, 2)
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41093)

- Utilisation dans la route `GET /native/v2/bookings/<status>` du tri qui était implémenté dans la fonction `classify_and_sort_bookings`, utilisée dans `GET /native/v1/bookings`
- Les mêmes tests sont écrits pour `GET /native/v2/bookings` puis pour `GET /native/v2/bookings/ended` et `GET /native/v2/bookings/ongoing`
