### PR TITLE
(PC-41533)[PRO] style: set <Card> padding to xl

### DIFF
--- a/pro/src/ui-kit/Card/Card.module.scss
+++ b/pro/src/ui-kit/Card/Card.module.scss
@@ -7,7 +7,7 @@
   gap: var(--size-spacing-l);
   border: rem.torem(1px) solid var(--color-border-subtle);
   border-radius: var(--size-border-radius-m);
-  padding: var(--size-spacing-xl) var(--size-spacing-l);
+  padding: var(--size-spacing-xl);
   background-color: var(--color-background);
 
   &-info {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41533)

- Tous les paddings internes du composant UKit `<Card>` passent à 24px (haut, bas, gauche, droite), soit `--size-spacing-xl`
- Cette modification s'applique à **toutes les instances** du composant `<Card>` sur la plateforme, y compris les instances présentes sur la page d'accueil

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

Before | After
:---: | :---:
<img width="345" height="505" alt="image" src="https://github.com/user-attachments/assets/72240f8f-24f0-4dc3-96b8-55a4d16c747e" /> | <img width="345" height="505" alt="image" src="https://github.com/user-attachments/assets/3c70e9d1-9d7e-4955-a032-1e5a2d0b0e90" />
<img width="498" height="326" alt="image" src="https://github.com/user-attachments/assets/0777bdf9-c688-42de-8bc0-8b7a49827a9b" /> | <img width="498" height="326" alt="image" src="https://github.com/user-attachments/assets/ab6a0f0b-071b-4519-86e4-ecc31a17bbd8" />

