### PR TITLE
(PC-41567)[API] fix: order cumulated views by date to fix display

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -2109,11 +2109,12 @@ class VenueOffersStatisticsModel:
 
 def get_venue_offers_statistics(venue_id: int) -> VenueOffersStatisticsModel:
     daily_views = clickhouse_queries.OfferConsultationCountQuery().execute({"venue_id": str(venue_id)})
+    sorted_daily_views = sorted(daily_views, key=lambda x: x.day)
     views_count = clickhouse_queries.VenueOffersMonthlyViewsQuery().execute({"venue_id": str(venue_id)})
     top_offers = clickhouse_queries.TopOffersByViewsQuery().execute({"venue_id": str(venue_id)})
 
     return VenueOffersStatisticsModel(
-        daily_views=[DailyViewsModel(day=row.day, views=row.views) for row in daily_views],
+        daily_views=[DailyViewsModel(day=row.day, views=row.views) for row in sorted_daily_views],
         total_views_last_30_days=views_count[0].total if len(views_count) > 0 else 0,
         top_offers=[OfferViewsModel(offer_id=row.id, views=row.views, rank=row.rank) for row in top_offers],
     )

--- a/pro/src/pages/Homepage/components/StatisticsDashboard/__specs__/CumulatedViews.spec.tsx
+++ b/pro/src/pages/Homepage/components/StatisticsDashboard/__specs__/CumulatedViews.spec.tsx
@@ -93,6 +93,21 @@ describe('CumulatedViews', () => {
     expect(rows).toHaveLength(11)
   })
 
+  it('should sort daily views by ascendent date', () => {
+    const end = new Date('2026-04-28')
+
+    const dailyViews = Array.from({ length: 10 }, (_, index) => ({
+      views: 100 + index,
+      day: format(add(end, { days: -index }), FORMAT_ISO_DATE_ONLY),
+    }))
+
+    renderCumulatedViews({ dailyViews, totalViewsLast30Days: 0 })
+
+    const rows = screen.getAllByRole('row')
+
+    expect(rows[1]).toHaveTextContent('2026-04-19')
+  })
+
   it('should render chart when all views have the same value', () => {
     const today = new Date()
     const start = subMonths(today, 2)

--- a/pro/src/pages/Homepage/components/StatisticsDashboard/components/CumulatedViews.tsx
+++ b/pro/src/pages/Homepage/components/StatisticsDashboard/components/CumulatedViews.tsx
@@ -48,10 +48,15 @@ export const CumulatedViews = ({
   totalViewsLast30Days,
   showTitle = true,
 }: CumulatedViewsProps) => {
+  const sortedDailyViews = dailyViews.toSorted(
+    (a, b) => new Date(a.day).getTime() - new Date(b.day).getTime()
+  )
+
   const chartRef = useRef<ChartJS<'line', XYPoint[], unknown> | null>(null)
 
   const hasNoViews =
-    dailyViews.length < 2 || dailyViews.every((view) => view.views === 0)
+    sortedDailyViews.length < 2 ||
+    sortedDailyViews.every((view) => view.views === 0)
 
   const { recentViews, minViews, maxViews, firstMonth } = useMemo(() => {
     const cutoff = startOfMonth(subMonths(new Date(), 5))
@@ -62,7 +67,7 @@ export const CumulatedViews = ({
     let min = Infinity
     let max = -Infinity
 
-    for (const view of dailyViews) {
+    for (const view of sortedDailyViews) {
       const date = new Date(view.day)
       if (date >= cutoff) {
         const views = view.views
@@ -99,7 +104,7 @@ export const CumulatedViews = ({
         month: 'long',
       }),
     }
-  }, [dailyViews])
+  }, [sortedDailyViews])
 
   const data = useMemo(() => buildDatasets(recentViews), [recentViews])
 
@@ -154,7 +159,7 @@ export const CumulatedViews = ({
                 </tr>
               </thead>
               <tbody>
-                {dailyViews.map((dailyView) => (
+                {sortedDailyViews.map((dailyView) => (
                   <tr key={dailyView.day}>
                     <td>{dailyView.day}</td>
                     <td>{dailyView.views}</td>


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41567)

### Revue fonctionnelle ok ✅ 

ont été testé : 
- le correctif backend tout seul en appelant clickhouse en local
- le correctif front tout seul en envoyant des données mockées via [cet outil incroyable](https://tweak-extension.com/onboarding) S/O @cmoinier-pass  💯 
- les deux ensemble


<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

### Changements effectués

Les données récupérées depuis clickhouse n'étaient pas toujours ordonnées dans le temps, ce qui a créé des soucis d'affichage pour certaines venues. 

Cette PR est un double fix : 
- côté back : on va ordonner les données qu'on récupère depuis clickhouse : comme on mock les données de clickhouse dans nos tests, ce n'est pas possible d'écrire un test unitaire qui valide cette modification. Cependant cela à été testé en pair-test. Côté perf, la requête est 2 à 3 fois plus longue. On passe d'une moyenne de 60ms à 150ms environ. C'est acceptable car l'affichage de cette carte ne bloque pas le reste de la page

AVANT / APRÈS : 
<img width="838" height="64" alt="Capture d’écran 2026-04-28 à 16 30 50" src="https://github.com/user-attachments/assets/0cca217f-515d-459b-9727-a04db6104888" />
<img width="838" height="63" alt="Capture d’écran 2026-04-28 à 16 31 02" src="https://github.com/user-attachments/assets/301afb9e-ea7a-481e-b5ca-7cfa57d8045e" />

- côté front : 
on ajoute le triage "au cas où"

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images


<img width="513" height="421" alt="Capture d’écran 2026-04-28 à 16 34 10" src="https://github.com/user-attachments/assets/e23172cc-a98d-429c-bcfc-dbc896e5fd62" />


<img width="656" height="695" alt="Capture d’écran 2026-04-28 à 16 40 46" src="https://github.com/user-attachments/assets/19099e20-9916-48a8-bce1-4a8c4b89cf5a" />
