### PR TITLE
(PC-39126)[API] feat: get cultural domains

### DIFF
--- a/api/src/pcapi/core/offerers/repository.py
+++ b/api/src/pcapi/core/offerers/repository.py
@@ -234,6 +234,11 @@ def get_active_venue_page_data(venue_id: int) -> models.Venue | None:
                 )
             )
             .options(
+                sa_orm.selectinload(models.Venue.collectiveDomains).load_only(
+                    educational_models.EducationalDomain.name,
+                )
+            )
+            .options(
                 sa_orm.joinedload(models.Venue.offererAddress)
                 .load_only()
                 .joinedload(models.OffererAddress.address)

--- a/api/src/pcapi/routes/native/v2/serialization/offerers.py
+++ b/api/src/pcapi/routes/native/v2/serialization/offerers.py
@@ -6,6 +6,27 @@ from pcapi.core.offerers.schemas import SocialMedia
 from pcapi.routes.serialization import HttpBodyModel
 
 
+EDUCATIONAL_DOMAIN_LABELS_FOR_NATIVE: dict[str, str] = {
+    "Architecture": "Architecture",
+    "Arts du cirque et arts de la rue": "Cirque et arts de la rue",
+    "Arts numériques": "Arts numériques",
+    "Arts visuels, arts plastiques, arts appliqués": "Arts visuels et plastiques",
+    "Cinéma, audiovisuel": "Cinéma",
+    "Culture scientifique, technique et industrielle": "Culture scientifique",
+    "Danse": "Danse",
+    "Design": "Design",
+    "Développement durable": "Développement durable",
+    "Univers du livre, de la lecture et des écritures": "Lecture et écriture",
+    "Musique": "Musique",
+    "Patrimoine": "Patrimoine",
+    "Photographie": "Photographie",
+    "Théâtre, expression dramatique, marionnettes": "Spectacle vivant",
+    "Bande dessinée": "Bande dessinée",
+    "Média et information": "Média et information",
+    "Mémoire": "Mémoire",
+}
+
+
 class VenueContact(HttpBodyModel):
     email: str | None = None
     phone_number: str | None = None
@@ -44,6 +65,11 @@ class AccessibilityData(HttpBodyModel):
     visual_disability: VisualDisability | None = None
 
 
+class CulturalDomainItem(HttpBodyModel):
+    id: int
+    name: str
+
+
 class VenueResponse(HttpBodyModel):
     id: int
     accessibility_data: AccessibilityData
@@ -53,6 +79,7 @@ class VenueResponse(HttpBodyModel):
     banner_url: pydantic_v2.HttpUrl | None = None
     contact: VenueContact | None = None
     city: str | None = None
+    cultural_domains: list[CulturalDomainItem] | None = None
     description: str | None = None
     external_accessibility_data: AccessibilityData | None = None
     external_accessibility_id: str | None = None
@@ -122,4 +149,13 @@ class VenueResponse(HttpBodyModel):
             timezone=venue.offererAddress.address.timezone,
             volunteering_url=venue.volunteeringUrl,
             withdrawal_details=venue.withdrawalDetails,
+            cultural_domains=[
+                CulturalDomainItem(
+                    id=domain.id,
+                    name=EDUCATIONAL_DOMAIN_LABELS_FOR_NATIVE.get(domain.name, domain.name),
+                )
+                for domain in sorted(venue.collectiveDomains, key=lambda d: d.id)
+            ]
+            if not venue.isOpenToPublic
+            else None,
         )

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -2641,6 +2641,25 @@
                 "title": "Credit",
                 "type": "object"
             },
+            "CulturalDomainItem": {
+                "additionalProperties": false,
+                "properties": {
+                    "id": {
+                        "title": "Id",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "title": "CulturalDomainItem",
+                "type": "object"
+            },
             "CulturalSurveyAnswer": {
                 "properties": {
                     "id": {
@@ -8992,6 +9011,21 @@
                             }
                         ],
                         "default": null
+                    },
+                    "culturalDomains": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/CulturalDomainItem"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "default": null,
+                        "title": "Culturaldomains"
                     },
                     "description": {
                         "anyOf": [

--- a/api/tests/routes/native/v2/offerers_test.py
+++ b/api/tests/routes/native/v2/offerers_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pcapi.connectors.acceslibre import ExpectedFieldsEnum as acceslibre_enum
+from pcapi.core.educational import factories as educational_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers.schemas import VenueTypeCode
 from pcapi.core.testing import assert_num_queries
@@ -12,6 +13,7 @@ pytestmark = pytest.mark.usefixtures("db_session")
 class GetVenueTest:
     expected_num_queries = 1  # venue with joined tables
     expected_num_queries += 1  # opening hours (selectinload)
+    expected_num_queries += 1  # collectiveDomains / educational domains (selectinload)
 
     def test_get_venue(self, client):
         venue = offerers_factories.VenueFactory(
@@ -69,6 +71,7 @@ class GetVenueTest:
             "bannerIsFromGoogle": False,
             "bannerUrl": venue.bannerUrl,
             "city": venue.offererAddress.address.city,
+            "culturalDomains": None,
             "contact": {
                 "email": venue.contact.email,
                 "phoneNumber": venue.contact.phone_number,
@@ -164,6 +167,53 @@ class GetVenueTest:
         assert response.json["bannerCredit"] == "Henri"
         assert response.json["bannerIsFromGoogle"] is False
         assert response.json["bannerUrl"] == venue.bannerUrl
+
+    def test_get_venue_not_open_to_public_returns_cultural_domains(self, client):
+        domain_b = educational_factories.EducationalDomainFactory(name="Musique")
+        domain_a = educational_factories.EducationalDomainFactory(name="Architecture")
+        venue = offerers_factories.VenueFactory(
+            isPermanent=True,
+            isOpenToPublic=False,
+            collectiveDomains=[domain_a, domain_b],
+        )
+        venue_id = venue.id
+        with assert_num_queries(self.expected_num_queries, expire_session=False):
+            response = client.get(f"/native/v2/venue/{venue_id}")
+            assert response.status_code == 200
+
+        assert response.json["isOpenToPublic"] is False
+        assert response.json["culturalDomains"] == sorted(
+            [
+                {"id": domain_a.id, "name": domain_a.name},
+                {"id": domain_b.id, "name": domain_b.name},
+            ],
+            key=lambda item: item["id"],
+        )
+
+    def test_get_venue_not_open_to_public_shortens_mapped_cultural_domain_labels(self, client):
+        long_label = "Arts du cirque et arts de la rue"
+        short_label = "Cirque et arts de la rue"
+        domain = educational_factories.EducationalDomainFactory(name=long_label)
+        venue = offerers_factories.VenueFactory(
+            isPermanent=True,
+            isOpenToPublic=False,
+            collectiveDomains=[domain],
+        )
+        response = client.get(f"/native/v2/venue/{venue.id}")
+        assert response.status_code == 200
+        assert response.json["culturalDomains"] == [{"id": domain.id, "name": short_label}]
+
+    def test_get_venue_not_open_to_public_unknown_domain_label_unchanged(self, client):
+        label = "Nouveau domaine sans mapping dédié"
+        domain = educational_factories.EducationalDomainFactory(name=label)
+        venue = offerers_factories.VenueFactory(
+            isPermanent=True,
+            isOpenToPublic=False,
+            collectiveDomains=[domain],
+        )
+        response = client.get(f"/native/v2/venue/{venue.id}")
+        assert response.status_code == 200
+        assert response.json["culturalDomains"] == [{"id": domain.id, "name": label}]
 
     def test_get_non_permanent_venue(self, client):
         venue = offerers_factories.VenueFactory(isPermanent=False)


### PR DESCRIPTION
This PR attemps to solve:

- https://passculture.atlassian.net/browse/PC-39126
- https://passculture.atlassian.net/browse/PC-39317

Shotly, the frontend needs the cultural domains info for Venue entities where the field `is_open_to_public` is False