### PR TITLE
(BSR) ci: fix on: push trigger syntax

### DIFF
--- a/.github/workflows/cd_deploy_staging.yml
+++ b/.github/workflows/cd_deploy_staging.yml
@@ -2,7 +2,8 @@ name: 1 [CD] Deploy staging
 
 on:
   push:
-    tags: "v[0-9]+.0.0"
+    tags:
+      - "v[0-9]+.0.0"
   workflow_dispatch:
 
 permissions: write-all


### PR DESCRIPTION
`tags` requires an array, not a string
