### PR TITLE
(BSR)[PRO] feat: focus dialog title on open

### DIFF
--- a/pro/src/ui-kit/Dialog/Dialog.spec.tsx
+++ b/pro/src/ui-kit/Dialog/Dialog.spec.tsx
@@ -27,4 +27,10 @@ describe('Dialog', () => {
     expect(onCancel).not.toHaveBeenCalled()
     expect(onClose).toHaveBeenCalledTimes(1)
   })
+
+  it('should focus the title heading when the dialog opens', () => {
+    renderDialog()
+
+    expect(screen.getByText('dialog')).toHaveFocus()
+  })
 })

--- a/pro/src/ui-kit/Dialog/Dialog.tsx
+++ b/pro/src/ui-kit/Dialog/Dialog.tsx
@@ -1,6 +1,6 @@
 import * as RadixDialog from '@radix-ui/react-dialog'
 import type React from 'react'
-import { useId } from 'react'
+import { useRef } from 'react'
 
 import strokeErrorIcon from '@/icons/stroke-error.svg'
 import {
@@ -41,15 +41,15 @@ export const Dialog = ({
   open,
   refToFocusOnClose,
 }: DialogProps): JSX.Element => {
-  const titleId = useId()
+  const titleRef = useRef<HTMLDivElement>(null)
 
   return (
     <DialogBuilder
-      ariaLabelledby={titleId}
       open={open}
       onOpenChange={(open) => !open && (onClose ? onClose() : onCancel())}
       trigger={trigger}
       refToFocusOnClose={refToFocusOnClose}
+      refToFocusOnOpen={titleRef}
     >
       <div className={`${styles['dialog']} ${extraClassNames}`}>
         {!hideIcon && (
@@ -60,7 +60,7 @@ export const Dialog = ({
           />
         )}
         <RadixDialog.Title>
-          <div className={styles['dialog-title']} id={titleId}>
+          <div className={styles['dialog-title']} ref={titleRef} tabIndex={-1}>
             {title}
             <span className={styles['dialog-title-span']}>{secondTitle}</span>
           </div>

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.spec.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.spec.tsx
@@ -214,6 +214,16 @@ describe('DialogBuilder', () => {
     expect(overlay).toHaveClass('dialog-builder-overlay-drawer')
   })
 
+  it('should focus the title heading when the dialog opens', async () => {
+    renderDialogBuilder()
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Open the dialog' })
+    )
+
+    expect(screen.getByRole('heading', { name: 'Dialog title' })).toHaveFocus()
+  })
+
   it('should focus external element on close when refToFocusOnClose is provided', async () => {
     const externalFocusRef = createRef<HTMLButtonElement>()
     renderDialogBuilder(

--- a/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
+++ b/pro/src/ui-kit/DialogBuilder/DialogBuilder.tsx
@@ -8,8 +8,6 @@ import { DialogBuilderCloseButton } from './DialogBuilderCloseButton'
 type DialogVariant = 'default' | 'drawer'
 
 export interface DialogBuilderProps {
-  /** `<dialog>` aria label element ID (usually the title). */
-  ariaLabelledby?: string
   /**
    * The trigger element that opens the dialog.
    */
@@ -59,6 +57,11 @@ export interface DialogBuilderProps {
    * If refToFocusOnClose.current is null, the trigger element will be focused as a fallback.
    */
   refToFocusOnClose?: React.RefObject<HTMLElement | null>
+  /**
+   * Ref of the element to focus on when the dialog opens.
+   * Falls back to the title heading when not provided.
+   */
+  refToFocusOnOpen?: React.RefObject<HTMLElement | null>
 }
 
 /**
@@ -81,7 +84,6 @@ export interface DialogBuilderProps {
 const DialogBuilderBase = ({
   trigger,
   title,
-  ariaLabelledby,
   isTitleHidden = false,
   imageTitle = null,
   children,
@@ -92,8 +94,10 @@ const DialogBuilderBase = ({
   className,
   variant = 'default',
   refToFocusOnClose,
+  refToFocusOnOpen,
 }: Readonly<DialogBuilderProps>) => {
   const contentRef = useRef<HTMLDivElement>(null)
+  const titleRef = useRef<HTMLHeadingElement>(null)
 
   return (
     <Dialog.Root
@@ -113,7 +117,6 @@ const DialogBuilderBase = ({
           <Dialog.Content
             className={cn(styles['dialog-builder-content'], className)}
             aria-describedby={undefined}
-            aria-labelledby={ariaLabelledby}
             ref={contentRef}
             onPointerDownOutside={(e) => {
               if (!contentRef.current) {
@@ -135,6 +138,13 @@ const DialogBuilderBase = ({
                 e.preventDefault()
               }
             }}
+            onOpenAutoFocus={(ev) => {
+              const target = refToFocusOnOpen?.current ?? titleRef.current
+              if (target) {
+                ev.preventDefault()
+                target.focus()
+              }
+            }}
             onCloseAutoFocus={(ev: Event) => {
               if (!refToFocusOnClose) {
                 return
@@ -144,9 +154,6 @@ const DialogBuilderBase = ({
               refToFocusOnClose.current?.focus()
             }}
           >
-            <DialogBuilderCloseButton
-              closeButtonClassName={closeButtonClassName}
-            />
             <section className={styles['dialog-builder-section']}>
               {title && (
                 <Dialog.Title asChild>
@@ -157,12 +164,21 @@ const DialogBuilderBase = ({
                       ]]: isTitleHidden,
                     })}
                   >
-                    <h1 className={styles['dialog-builder-title']}>{title}</h1>
+                    <h1
+                      ref={titleRef}
+                      tabIndex={-1}
+                      className={styles['dialog-builder-title']}
+                    >
+                      {title}
+                    </h1>
                     {imageTitle}
                   </div>
                 </Dialog.Title>
               )}
               {children}
+              <DialogBuilderCloseButton
+                closeButtonClassName={closeButtonClassName}
+              />
             </section>
           </Dialog.Content>
         </Dialog.Overlay>


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Lors de l'ouverture d'un dialog, le focus arrivait sur le premier élément focusable : par exemple l'icone de fermeture de la modale pour les drawer

Cette PR permet de focus sur le titre (pour les composants ui-kit `DialogBuilder` et `Dialog`)

- [x] testé au VO chrome et safari