### PR TITLE
(PC-41050)[PRO] feat: allow to create new artist in ArtistFields

### DIFF
--- a/pro/src/commons/custom_types/form.ts
+++ b/pro/src/commons/custom_types/form.ts
@@ -3,3 +3,5 @@ export type SelectOption<T extends string | number = string> = {
   label: string
   thumbUrl?: string | null
 }
+
+export type ApiOption = SelectOption & Record<string, unknown>

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/DetailsSubForm/components/ArtistField/ArtistField.module.scss
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/DetailsSubForm/components/ArtistField/ArtistField.module.scss
@@ -2,7 +2,7 @@
 
 .row {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: var(--size-spacing-s);
 
   .select {

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/DetailsSubForm/components/ArtistField/ArtistField.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/DetailsSubForm/components/ArtistField/ArtistField.spec.tsx
@@ -106,6 +106,7 @@ describe('ArtistField', () => {
     expect(props.disabled).toBe(false)
     expect(props.required).toBe(false)
     expect(props.thumbPlaceholder).toBeDefined()
+    expect(props.value).toBe('any-name')
   })
 
   it('should not render ApiSelect', () => {
@@ -178,11 +179,11 @@ describe('ArtistField', () => {
     })
   })
 
-  it('onSearch should update form value with search text', async () => {
+  it('onCreate should update form value with search text', async () => {
     const { getValues } = renderArtistField()
     const props = apiSelectSpy.mock.calls[0][0]
 
-    props.onSearch?.('John')
+    props.onCreate('John')
 
     await waitFor(() => {
       const artistOfferLinks = getValues().artistOfferLinks
@@ -205,6 +206,22 @@ describe('ArtistField', () => {
       expect(artistOfferLinks[0]).toEqual({
         artistId: '42',
         artistName: 'John Doe',
+        artistType: ArtistType.AUTHOR,
+      })
+    })
+  })
+
+  it('onReset should update form value with empty string', async () => {
+    const { getValues } = renderArtistField()
+    const props = apiSelectSpy.mock.calls[0][0]
+
+    props.onReset?.()
+
+    await waitFor(() => {
+      const artistOfferLinks = getValues().artistOfferLinks
+      expect(artistOfferLinks[0]).toEqual({
+        artistId: null,
+        artistName: '',
         artistType: ArtistType.AUTHOR,
       })
     })

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/DetailsSubForm/components/ArtistField/ArtistField.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/DetailsSubForm/components/ArtistField/ArtistField.tsx
@@ -38,7 +38,6 @@ export function ArtistField({
   fieldArray,
 }: Readonly<ArtistFieldProps>) {
   const {
-    register,
     setValue,
     watch,
     setFocus,
@@ -75,7 +74,6 @@ export function ArtistField({
   return (
     <>
       {fieldsForType.map(({ field, index }) => {
-        const { ref } = register(`artistOfferLinks.${index}.artistName`)
         const name = `artistOfferLinks.${index}`
         const artistName = watch(`artistOfferLinks.${index}.artistName`)
         const isTrashDisabled =
@@ -100,14 +98,21 @@ export function ArtistField({
                     )
                   }
                 }}
-                onSearch={(searchText) => {
+                onCreate={(artistName) => {
                   setValue(
                     `artistOfferLinks.${index}`,
                     {
                       artistId: null,
-                      artistName: searchText,
+                      artistName: artistName,
                       artistType,
                     },
+                    { shouldValidate: true }
+                  )
+                }}
+                onReset={() => {
+                  setValue(
+                    `artistOfferLinks.${index}`,
+                    { artistId: null, artistName: '', artistType },
                     { shouldValidate: true }
                   )
                 }}
@@ -131,7 +136,7 @@ export function ArtistField({
                 disabled={readOnly}
                 required={false}
                 thumbPlaceholder={avatarPlaceholder}
-                ref={ref}
+                value={artistName}
               />
             </div>
 

--- a/pro/src/ui-kit/form/AddressSelect/AddressSelect.tsx
+++ b/pro/src/ui-kit/form/AddressSelect/AddressSelect.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import { useFormContext } from 'react-hook-form'
 import { useDebouncedCallback } from 'use-debounce'
 
 import type {
@@ -73,6 +74,8 @@ export const AddressSelect = forwardRef(
     }: AddressSelectProps,
     ref: Ref<HTMLInputElement>
   ) => {
+    const formContext = useFormContext()
+
     const [addressOptions, setAddressOptions] = useState<SelectOption[]>([])
     const addressesMap = useRef<Map<string, AdresseData>>(new Map())
     const inputRef = useRef<HTMLInputElement>(null) // Ref to pass to <SelectAutoComplete />
@@ -144,6 +147,7 @@ export const AddressSelect = forwardRef(
         }}
         onChange={(event) => {
           onChange?.(event)
+          void formContext?.trigger(name)
           const addressData = addressesMap.current.get(event.target.value)
           if (addressData) {
             onAddressChosen?.(addressData)

--- a/pro/src/ui-kit/form/ApiSelect/ApiSelect.spec.tsx
+++ b/pro/src/ui-kit/form/ApiSelect/ApiSelect.spec.tsx
@@ -2,7 +2,9 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
 
-import { type ApiOption, ApiSelect, type ApiSelectProps } from './ApiSelect'
+import type { ApiOption } from '@/commons/custom_types/form'
+
+import { ApiSelect, type ApiSelectProps } from './ApiSelect'
 
 const name = 'any-name'
 const apiSelectLabel = 'any-label'

--- a/pro/src/ui-kit/form/ApiSelect/ApiSelect.spec.tsx
+++ b/pro/src/ui-kit/form/ApiSelect/ApiSelect.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
 
@@ -7,9 +7,11 @@ import { type ApiOption, ApiSelect, type ApiSelectProps } from './ApiSelect'
 const name = 'any-name'
 const apiSelectLabel = 'any-label'
 
+const mockValue = 'option-value'
 const mockOnSelect = vi.fn()
 const mockSearchApi = vi.fn()
-const mockOnSearch = vi.fn()
+const mockOnCreate = vi.fn()
+const mockOnReset = vi.fn()
 
 const renderApiSelect = (props?: Partial<ApiSelectProps<ApiOption>>) => {
   return render(
@@ -18,7 +20,8 @@ const renderApiSelect = (props?: Partial<ApiSelectProps<ApiOption>>) => {
       label={apiSelectLabel}
       onSelect={mockOnSelect}
       searchApi={mockSearchApi}
-      onSearch={mockOnSearch}
+      onCreate={mockOnCreate}
+      onReset={mockOnReset}
       {...props}
     />
   )
@@ -47,7 +50,6 @@ describe('ApiSelect', () => {
     await waitFor(() => {
       expect(mockSearchApi).toHaveBeenCalledWith('option')
     })
-    expect(mockOnSearch).toHaveBeenCalledWith('option')
     expect(screen.getByText('option-label')).toBeInTheDocument()
   })
 
@@ -59,6 +61,22 @@ describe('ApiSelect', () => {
     expect(mockSearchApi).not.toHaveBeenCalled()
 
     expect(screen.getByText('Aucun résultat')).toBeInTheDocument()
+  })
+
+  it('should add creatable option', async () => {
+    renderApiSelect()
+
+    await userEvent.type(screen.getByLabelText(/any-label/), 'creatable')
+
+    expect(screen.getByText('Ajouter "creatable"')).toBeInTheDocument()
+  })
+
+  it('should not add creatable option if value is too short', async () => {
+    renderApiSelect()
+
+    await userEvent.type(screen.getByLabelText(/any-label/), 'cr')
+
+    expect(screen.queryByText(/Ajouter/)).not.toBeInTheDocument()
   })
 
   it('should select options', async () => {
@@ -88,19 +106,62 @@ describe('ApiSelect', () => {
     })
   })
 
+  it('should create new option', async () => {
+    renderApiSelect()
+
+    await userEvent.type(screen.getByLabelText(/any-label/), 'creatable')
+
+    const creatableOption = await screen.findByRole('option', {
+      name: /Ajouter creatable/,
+    })
+    await userEvent.click(creatableOption)
+
+    expect(mockOnCreate).toHaveBeenCalledWith('creatable')
+  })
+
   it('should not fail when api fail', async () => {
     mockSearchApi.mockRejectedValueOnce([])
 
     renderApiSelect()
     await userEvent.type(screen.getByLabelText(/any-label/), 'Lucie Aubrac')
-    expect(await screen.findByText('Aucun résultat')).toBeInTheDocument()
+    expect(
+      await screen.findByText('Ajouter "Lucie Aubrac"')
+    ).toBeInTheDocument()
   })
 
   it('should search options on mount', async () => {
-    renderApiSelect({ value: 'option-value' })
+    renderApiSelect({ value: mockValue })
 
     await waitFor(() => {
-      expect(mockSearchApi).toHaveBeenCalledWith('option-value')
+      expect(mockSearchApi).toHaveBeenCalledWith(mockValue)
     })
+  })
+
+  it('should reset form value when value is empty', async () => {
+    renderApiSelect({ value: mockValue })
+
+    const input = screen.getByLabelText(/any-label/)
+    await userEvent.clear(input)
+
+    expect(mockOnReset).toHaveBeenCalled()
+  })
+
+  it('should fallback on current form value on blur event when value is not empty', async () => {
+    mockSearchApi.mockResolvedValueOnce([
+      {
+        value: 'option-value',
+        label: 'option-label',
+        thumbUrl: 'option-thumbUrl',
+      },
+    ])
+    renderApiSelect({ value: mockValue })
+
+    await waitFor(() => expect(mockSearchApi).toHaveBeenCalledWith(mockValue))
+
+    const input = screen.getByLabelText(/any-label/)
+    await userEvent.type(input, 'new-option-label')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(input).toHaveValue('option-label'))
   })
 })

--- a/pro/src/ui-kit/form/ApiSelect/ApiSelect.stories.tsx
+++ b/pro/src/ui-kit/form/ApiSelect/ApiSelect.stories.tsx
@@ -1,6 +1,8 @@
 import type { StoryObj } from '@storybook/react-vite'
 
-import { ApiSelect, ApiOption } from './ApiSelect'
+import { ApiSelect } from './ApiSelect'
+
+import type { ApiOption } from '@/commons/custom_types/form'
 
 export default {
   title: '@/ui-kit/forms/ApiSelect',

--- a/pro/src/ui-kit/form/ApiSelect/ApiSelect.tsx
+++ b/pro/src/ui-kit/form/ApiSelect/ApiSelect.tsx
@@ -1,16 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
-import type { SelectOption } from '@/commons/custom_types/form'
+import type { ApiOption, SelectOption } from '@/commons/custom_types/form'
 import { SelectAutocomplete } from '@/ui-kit/form/SelectAutoComplete/SelectAutocomplete'
 
 const DEBOUNCE_TIME_BEFORE_REQUEST = 400
 
-export interface ApiOption extends SelectOption {
-  [key: string]: unknown
-}
-
-export type ApiSelectProps<T extends ApiOption> = {
+export type ApiSelectProps<T extends ApiOption> = Readonly<{
   name: string
   label: string | JSX.Element
   disabled?: boolean
@@ -25,9 +21,9 @@ export type ApiSelectProps<T extends ApiOption> = {
   searchApi: (searchText: string) => Promise<T[]>
   value?: string
   thumbPlaceholder?: string
-}
+}>
 
-export const ApiSelect = function ApiSelect<T extends ApiOption>({
+export function ApiSelect<T extends ApiOption>({
   name,
   label,
   disabled = false,

--- a/pro/src/ui-kit/form/ApiSelect/ApiSelect.tsx
+++ b/pro/src/ui-kit/form/ApiSelect/ApiSelect.tsx
@@ -1,22 +1,10 @@
-import {
-  forwardRef,
-  type Ref,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import type { SelectOption } from '@/commons/custom_types/form'
 import { SelectAutocomplete } from '@/ui-kit/form/SelectAutoComplete/SelectAutocomplete'
 
 const DEBOUNCE_TIME_BEFORE_REQUEST = 400
-
-type ApiSelectComponent = <T extends ApiOption>(
-  props: ApiSelectProps<T> & { ref?: Ref<HTMLInputElement> }
-) => JSX.Element | null
 
 export interface ApiOption extends SelectOption {
   [key: string]: unknown
@@ -32,32 +20,31 @@ export type ApiSelectProps<T extends ApiOption> = {
   required?: boolean
   minSearchLength?: number
   onSelect(option: T | undefined): void
-  onSearch?(searchText: string): void
+  onCreate(value: string): void
+  onReset(): void
   searchApi: (searchText: string) => Promise<T[]>
   value?: string
   thumbPlaceholder?: string
 }
 
-export const ApiSelect = forwardRef(function ApiSelect<T extends ApiOption>(
-  {
-    name,
-    label,
-    disabled = false,
-    className,
-    description,
-    error,
-    required = true,
-    minSearchLength = 3,
-    onSelect,
-    onSearch,
-    searchApi,
-    value,
-    thumbPlaceholder,
-  }: ApiSelectProps<T>,
-  ref: Ref<HTMLInputElement>
-) {
+export const ApiSelect = function ApiSelect<T extends ApiOption>({
+  name,
+  label,
+  disabled = false,
+  className,
+  description,
+  error,
+  required = true,
+  minSearchLength = 3,
+  onSelect,
+  onCreate,
+  onReset,
+  searchApi,
+  value: currentValue,
+  thumbPlaceholder,
+}: ApiSelectProps<T>) {
   const [options, setOptions] = useState<SelectOption[]>([])
-  const inputRef = useRef<HTMLInputElement>(null)
+  const [value, setValue] = useState<string>(currentValue ?? '')
   const optionsMap = useRef<Map<string, T>>(new Map())
 
   const fetchOptions = useCallback(
@@ -88,15 +75,14 @@ export const ApiSelect = forwardRef(function ApiSelect<T extends ApiOption>(
 
   const debouncedOnSearch = useDebouncedCallback((searchText: string) => {
     fetchOptions(searchText)
-    onSearch?.(searchText)
   }, DEBOUNCE_TIME_BEFORE_REQUEST)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: only run on mount
   useEffect(() => {
-    fetchOptions(value ?? inputRef.current?.value ?? '')
+    value && fetchOptions(value)
   }, [])
 
-  useImperativeHandle(ref, () => inputRef.current as HTMLInputElement)
+  const creatableOption = value.length >= minSearchLength ? value : undefined
 
   return (
     <SelectAutocomplete
@@ -106,18 +92,30 @@ export const ApiSelect = forwardRef(function ApiSelect<T extends ApiOption>(
       thumbPlaceholder={thumbPlaceholder}
       description={description}
       onSearch={(searchText) => {
+        if (searchText === '') {
+          onReset()
+        }
+        setValue(searchText)
         debouncedOnSearch(searchText)
       }}
       onChange={(event) => {
         const selectedOption = optionsMap.current.get(event.target.value)
-        onSelect(selectedOption)
+        if (selectedOption) {
+          onSelect(selectedOption)
+        } else {
+          onCreate(event.target.value)
+        }
       }}
+      onBlur={() => {
+        setValue(currentValue ?? '')
+        debouncedOnSearch(currentValue ?? '')
+      }}
+      creatableOption={creatableOption}
       disabled={disabled}
       className={className}
-      ref={inputRef}
       error={error}
       required={required}
       value={value}
     />
   )
-}) as ApiSelectComponent
+}

--- a/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.module.scss
+++ b/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.module.scss
@@ -1,4 +1,5 @@
 @use "styles/variables/_z-index.scss" as zIndex;
+@use "styles/mixins/_fonts.scss" as fonts;
 @use "styles/mixins/_forms.scss" as forms;
 @use "styles/mixins/_rem.scss" as rem;
 
@@ -19,21 +20,34 @@
     padding: var(--size-spacing-s);
   }
 
+  .option-item-wrapper {
+    padding: var(--size-spacing-m) var(--size-spacing-l) 0;
+  }
+
   .options-item {
     display: flex;
-    padding: rem.torem(11.2px) rem.torem(16px);
     gap: rem.torem(8px);
     align-items: center;
     cursor: pointer;
+    padding-bottom: var(--size-spacing-m);
+
+    &--separator {
+      border-bottom: rem.torem(1px) solid var(--color-border-subtle);
+    }
   }
 
   .option-hovered {
     background: var(--color-background-subtle);
+    outline: rem.torem(2px) solid var(--color-border-focused);
+    outline-offset: rem.torem(-2px);
+  }
 
-    .options-item {
-      border: rem.torem(2px) solid var(--color-border-focused);
-      padding: rem.torem(9.2px) rem.torem(14px);
-    }
+  .option-creatable-icon {
+    flex-shrink: 0;
+  }
+
+  .option-creatable-label {
+    @include fonts.body-accent;
   }
 }
 

--- a/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.spec.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { createEvent, fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createRef } from 'react'
 
@@ -35,6 +35,7 @@ const DEFAULT_PROPS: OptionsListProps = {
   hoveredOptionIndex: 0,
   listRef: createRef(),
   selectOption: vi.fn(),
+  createOption: vi.fn(),
 }
 
 const renderOptionsList = (
@@ -57,7 +58,7 @@ describe('<OptionsList />', () => {
   })
 
   it('should render options with correct data attributes', () => {
-    renderOptionsList(DEFAULT_PROPS)
+    renderOptionsList()
 
     const options = screen.getAllByRole('option')
     expect(options[0]).toHaveAttribute('data-value', '01')
@@ -78,7 +79,7 @@ describe('<OptionsList />', () => {
     expect(DEFAULT_PROPS.setHoveredOptionIndex).toHaveBeenCalledWith(3)
   })
 
-  it('should call selectOption with options on click', async () => {
+  it('should call selectOption on click', async () => {
     const user = userEvent.setup()
     renderOptionsList()
 
@@ -90,62 +91,107 @@ describe('<OptionsList />', () => {
     })
   })
 
-  it('should render option thumbnails when thumbPlaceholder is provided', () => {
-    renderOptionsList({
-      ...DEFAULT_PROPS,
-      thumbPlaceholder: '/placeholder.png',
-    })
+  it('should call createOption on click', async () => {
+    const user = userEvent.setup()
+    renderOptionsList({ ...DEFAULT_PROPS, creatableOption: 'Paris' })
 
-    const imgs = screen.getAllByRole('presentation', { hidden: true })
-    expect(imgs).toHaveLength(15)
-    expect(imgs[0]).toHaveAttribute('src', '/placeholder.png')
+    const creatableOption = screen.getByText('Ajouter "Paris"')
+    await user.click(creatableOption)
+    expect(DEFAULT_PROPS.createOption).toHaveBeenCalledWith('Paris')
   })
 
-  it('should render both placeholder and thumbUrl', () => {
-    renderOptionsList({
-      ...DEFAULT_PROPS,
-      filteredOptions: [
-        { value: '01', label: 'Ain', thumbUrl: 'https://example.com/ain.jpg' },
-      ],
-      thumbPlaceholder: '/placeholder.png',
-    })
-
-    const imgs = screen.getAllByRole('presentation', { hidden: true })
-    expect(imgs).toHaveLength(2)
-    expect(imgs[0]).toHaveAttribute('src', '/placeholder.png')
-    expect(imgs[1]).toHaveAttribute('src', 'https://example.com/ain.jpg')
+  it('should prevent default on mousedown', () => {
+    renderOptionsList()
+    const option = screen.getAllByRole('option')[0]
+    const event = createEvent.mouseDown(option)
+    fireEvent(option, event)
+    expect(event.defaultPrevented).toBe(true)
   })
 
-  it('should make thumbUrl visible after it loads', () => {
-    renderOptionsList({
-      ...DEFAULT_PROPS,
-      filteredOptions: [
-        { value: '01', label: 'Ain', thumbUrl: 'https://example.com/ain.jpg' },
-      ],
-      thumbPlaceholder: '/placeholder.png',
+  describe('option items', () => {
+    it('should render option thumbnails when thumbPlaceholder is provided', () => {
+      renderOptionsList({
+        ...DEFAULT_PROPS,
+        thumbPlaceholder: '/placeholder.png',
+      })
+
+      const imgs = screen.getAllByRole('presentation', { hidden: true })
+      expect(imgs).toHaveLength(15)
+      expect(imgs[0]).toHaveAttribute('src', '/placeholder.png')
     })
 
-    const imgs = screen.getAllByRole('presentation', { hidden: true })
-    const realImg = imgs[1]
+    it('should render both placeholder and thumbUrl', () => {
+      renderOptionsList({
+        ...DEFAULT_PROPS,
+        filteredOptions: [
+          {
+            value: '01',
+            label: 'Ain',
+            thumbUrl: 'https://example.com/ain.jpg',
+          },
+        ],
+        thumbPlaceholder: '/placeholder.png',
+      })
 
-    expect(realImg).not.toHaveClass('options-img-visible')
-    fireEvent.load(realImg)
-    expect(realImg).toHaveClass('options-img-visible')
+      const imgs = screen.getAllByRole('presentation', { hidden: true })
+      expect(imgs).toHaveLength(2)
+      expect(imgs[0]).toHaveAttribute('src', '/placeholder.png')
+      expect(imgs[1]).toHaveAttribute('src', 'https://example.com/ain.jpg')
+    })
+
+    it('should make thumbUrl visible after it loads', () => {
+      renderOptionsList({
+        ...DEFAULT_PROPS,
+        filteredOptions: [
+          {
+            value: '01',
+            label: 'Ain',
+            thumbUrl: 'https://example.com/ain.jpg',
+          },
+        ],
+        thumbPlaceholder: '/placeholder.png',
+      })
+
+      const imgs = screen.getAllByRole('presentation', { hidden: true })
+      const realImg = imgs[1]
+
+      expect(realImg).not.toHaveClass('options-img-visible')
+      fireEvent.load(realImg)
+      expect(realImg).toHaveClass('options-img-visible')
+    })
+
+    it('should keep thumbUrl hidden when thumbUrl fails to load', () => {
+      renderOptionsList({
+        ...DEFAULT_PROPS,
+        filteredOptions: [
+          {
+            value: '01',
+            label: 'Ain',
+            thumbUrl: 'https://example.com/ain.jpg',
+          },
+        ],
+        thumbPlaceholder: '/placeholder.png',
+      })
+
+      const imgs = screen.getAllByRole('presentation', { hidden: true })
+      const realImg = imgs[1]
+
+      fireEvent.error(realImg)
+      expect(realImg).not.toHaveClass('options-img-visible')
+    })
   })
 
-  it('should keep thumbUrl hidden when thumbUrl fails to load', () => {
-    renderOptionsList({
-      ...DEFAULT_PROPS,
-      filteredOptions: [
-        { value: '01', label: 'Ain', thumbUrl: 'https://example.com/ain.jpg' },
-      ],
-      thumbPlaceholder: '/placeholder.png',
+  describe('creatable option items', () => {
+    it('should render creatable option', () => {
+      renderOptionsList({
+        ...DEFAULT_PROPS,
+        creatableOption: 'Paris',
+      })
+
+      expect(screen.getByText('Ajouter "Paris"')).toBeInTheDocument()
+      expect(
+        screen.getByRole('img', { name: 'Ajouter Paris' })
+      ).toBeInTheDocument()
     })
-
-    const imgs = screen.getAllByRole('presentation', { hidden: true })
-    const realImg = imgs[1]
-
-    fireEvent.error(realImg)
-    expect(realImg).not.toHaveClass('options-img-visible')
   })
 })

--- a/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/OptionsList/OptionsList.tsx
@@ -1,7 +1,9 @@
 import cx from 'classnames'
-import { type Ref, useState } from 'react'
+import fullMoreIcon from 'icons/full-more.svg'
+import { type ReactNode, type Ref, useState } from 'react'
 
 import type { SelectOption } from '@/commons/custom_types/form'
+import { SvgIcon } from '@/ui-kit/SvgIcon/SvgIcon'
 
 import styles from './OptionsList.module.scss'
 
@@ -14,6 +16,8 @@ export interface OptionsListProps {
   listRef: Ref<HTMLUListElement>
   hoveredOptionIndex: number | null
   selectOption: (option: SelectOption) => void
+  createOption: (option: string) => void
+  creatableOption?: string
 }
 
 export const OptionsList = ({
@@ -25,57 +29,150 @@ export const OptionsList = ({
   listRef,
   hoveredOptionIndex,
   selectOption,
-}: OptionsListProps): JSX.Element => (
-  <ul
-    className={cx(styles['menu'], className)}
-    data-testid="list"
-    id={`list-${fieldName}`}
-    ref={listRef}
-    // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: Seems to be the only solution for combobox pattern
-    role="listbox"
-    aria-label="options"
-  >
-    {filteredOptions.length > 0 ? (
-      filteredOptions.map((option: SelectOption, index: number) => {
-        const isSelected = hoveredOptionIndex === index
+  createOption,
+  creatableOption,
+}: OptionsListProps): JSX.Element => {
+  const optionListSize = filteredOptions.length + (creatableOption ? 1 : 0)
+  return (
+    <ul
+      className={cx(styles['menu'], className)}
+      data-testid="list"
+      id={`list-${fieldName}`}
+      ref={listRef}
+      // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: Seems to be the only solution for combobox pattern
+      role="listbox"
+      aria-label="options"
+      onMouseDown={(e) => e.preventDefault()}
+    >
+      {creatableOption && (
+        <OptionListItem
+          key={creatableOption}
+          fieldName={fieldName}
+          index={0}
+          optionListSize={optionListSize}
+          isHovered={hoveredOptionIndex === 0}
+          dataValue={creatableOption}
+          setHoveredOptionIndex={setHoveredOptionIndex}
+          onClick={() => createOption(creatableOption)}
+        >
+          <CreatableOptionItem
+            label={creatableOption}
+            withSeparator={optionListSize > 1}
+          />
+        </OptionListItem>
+      )}
+      {filteredOptions.map((option: SelectOption, index: number) => {
+        const realIndex = creatableOption ? index + 1 : index
         return (
-          // biome-ignore lint/a11y/useKeyWithClickEvents: the onKeyDown is handled in the parent component
-          <li
-            aria-selected={isSelected}
-            aria-posinset={index + 1}
-            aria-setsize={filteredOptions.length}
-            className={
-              hoveredOptionIndex === index ? styles['option-hovered'] : ''
-            }
-            data-value={option.value}
-            data-selected={isSelected}
-            id={`option-${fieldName}-${index}`}
+          <OptionListItem
             key={option.value}
-            onMouseEnter={() => setHoveredOptionIndex(index)}
-            onFocus={() => setHoveredOptionIndex(index)}
-            onClick={() => {
-              selectOption(option)
-            }}
-            // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: Seems to be the only solution for combobox pattern
-            role="option"
-            tabIndex={-1}
+            fieldName={fieldName}
+            index={realIndex}
+            optionListSize={optionListSize}
+            isHovered={hoveredOptionIndex === realIndex}
+            dataValue={option.value}
+            setHoveredOptionIndex={setHoveredOptionIndex}
+            onClick={() => selectOption(option)}
           >
-            <span className={styles['options-item']}>
-              {(option.thumbUrl || thumbPlaceholder) && (
-                <ThumbWithPlaceholder
-                  thumbUrl={option.thumbUrl}
-                  thumbPlaceholder={thumbPlaceholder}
-                />
-              )}
-              <span>{option.label}</span>
-            </span>
-          </li>
+            <OptionItem
+              label={option.label}
+              thumbUrl={option.thumbUrl}
+              thumbPlaceholder={thumbPlaceholder}
+            />
+          </OptionListItem>
         )
-      })
-    ) : (
-      <li className={styles['menu--no-results']}>Aucun résultat</li>
+      })}
+      {optionListSize === 0 && (
+        <li className={styles['menu--no-results']}>Aucun résultat</li>
+      )}
+    </ul>
+  )
+}
+
+interface OptionListItemProps {
+  fieldName: string
+  index: number
+  optionListSize: number
+  isHovered: boolean
+  dataValue: string | number
+  setHoveredOptionIndex: (value: number | null) => void
+  onClick: () => void
+  children: ReactNode
+}
+
+const OptionListItem = ({
+  fieldName,
+  index,
+  optionListSize,
+  isHovered,
+  dataValue,
+  setHoveredOptionIndex,
+  onClick,
+  children,
+}: OptionListItemProps) => (
+  // biome-ignore lint/a11y/useKeyWithClickEvents: the onKeyDown is handled in the parent component
+  <li
+    aria-selected={isHovered}
+    aria-posinset={index + 1}
+    aria-setsize={optionListSize}
+    className={isHovered ? styles['option-hovered'] : ''}
+    data-value={dataValue}
+    data-selected={isHovered}
+    id={`option-${fieldName}-${index}`}
+    onMouseEnter={() => setHoveredOptionIndex(index)}
+    onFocus={() => setHoveredOptionIndex(index)}
+    onClick={onClick}
+    // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: Seems to be the only solution for combobox pattern
+    role="option"
+    tabIndex={-1}
+  >
+    <div className={styles['option-item-wrapper']}>{children}</div>
+  </li>
+)
+
+const CreatableOptionItem = ({
+  label,
+  withSeparator,
+}: {
+  label: string
+  withSeparator: boolean
+}) => (
+  <span
+    className={cx(
+      styles['options-item'],
+      withSeparator && styles['options-item--separator']
     )}
-  </ul>
+  >
+    <SvgIcon
+      src={fullMoreIcon}
+      alt={`Ajouter ${label}`}
+      width="20"
+      className={styles['option-creatable-icon']}
+    />
+    <span className={styles['option-creatable-label']} aria-hidden="true">
+      Ajouter &quot;{label}&quot;
+    </span>
+  </span>
+)
+
+const OptionItem = ({
+  label,
+  thumbUrl,
+  thumbPlaceholder,
+}: {
+  label: string
+  thumbUrl?: string | null
+  thumbPlaceholder?: string
+}) => (
+  <span className={styles['options-item']}>
+    {(thumbUrl || thumbPlaceholder) && (
+      <ThumbWithPlaceholder
+        thumbUrl={thumbUrl}
+        thumbPlaceholder={thumbPlaceholder}
+      />
+    )}
+    <span>{label}</span>
+  </span>
 )
 
 const ThumbWithPlaceholder = ({

--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.spec.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.spec.tsx
@@ -194,13 +194,10 @@ describe('SelectAutocomplete', () => {
     })
   })
 
-  it('should call "onChange" and "onBlur" when user selects a valid option', async () => {
-    const onBlur = vi.fn()
+  it('should call "onChange" when user selects a valid option', async () => {
     const onChange = vi.fn()
 
-    render(
-      <SelectAutocomplete {...props} onChange={onChange} onBlur={onBlur} />
-    )
+    render(<SelectAutocomplete {...props} onChange={onChange} />)
     const user = userEvent.setup()
 
     const input = screen.getByRole('combobox')
@@ -215,9 +212,24 @@ describe('SelectAutocomplete', () => {
       type: 'change',
       target: { name: 'departement', value: '02' },
     })
-    expect(onBlur).toHaveBeenCalledWith({
-      type: 'blur',
-      target: { name: 'departement', value: '02' },
+  })
+
+  it('should call "onChange" when user creates a new option', async () => {
+    const onChange = vi.fn()
+
+    render(
+      <SelectAutocomplete
+        {...props}
+        onChange={onChange}
+        creatableOption="Paris"
+      />
+    )
+    const user = userEvent.setup()
+    await user.type(screen.getByRole('combobox'), 'Paris')
+    await user.click(screen.getByText('Ajouter "Paris"'))
+    expect(onChange).toHaveBeenCalledWith({
+      type: 'change',
+      target: { name: 'departement', value: 'Paris' },
     })
   })
 

--- a/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
+++ b/pro/src/ui-kit/form/SelectAutoComplete/SelectAutocomplete.tsx
@@ -61,6 +61,8 @@ export type SelectAutocompleteProps = {
   searchInOptions?(options: SelectOption[], pattern: string): SelectOption[]
   /** Called when the dropdown opens */
   shouldResetOnOpen?: boolean
+  /** Value of the creatable option */
+  creatableOption?: string
 }
 
 export const SelectAutocomplete = forwardRef(
@@ -84,6 +86,7 @@ export const SelectAutocomplete = forwardRef(
         options.filter((opt) =>
           opt.label.toLowerCase().includes(pattern.trim().toLowerCase())
         ),
+      creatableOption,
       shouldResetOnOpen = false,
     }: SelectAutocompleteProps,
     ref: ForwardedRef<HTMLInputElement>
@@ -127,6 +130,8 @@ export const SelectAutocomplete = forwardRef(
 
     const filteredOptions = searchInOptions(options, searchField)
 
+    const optionsListSize = filteredOptions.length + (creatableOption ? 1 : 0)
+
     const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
       switch (event.key) {
         case 'ArrowUp':
@@ -134,8 +139,7 @@ export const SelectAutocomplete = forwardRef(
             event.preventDefault()
 
             const newIndex =
-              (hoveredOptionIndex - 1 + filteredOptions.length) %
-              filteredOptions.length
+              (hoveredOptionIndex - 1 + optionsListSize) % optionsListSize
 
             setHoveredOptionIndex(newIndex)
             const nextHoveredElement =
@@ -146,11 +150,11 @@ export const SelectAutocomplete = forwardRef(
         case 'ArrowDown':
           openDropdown()
           if (hoveredOptionIndex === null) {
-            if (filteredOptions.length > 0) {
+            if (optionsListSize > 0) {
               setHoveredOptionIndex(0)
             }
           } else {
-            const newIndex = (hoveredOptionIndex + 1) % filteredOptions.length
+            const newIndex = (hoveredOptionIndex + 1) % optionsListSize
 
             setHoveredOptionIndex(newIndex)
             const nextHoveredElement =
@@ -159,14 +163,17 @@ export const SelectAutocomplete = forwardRef(
           }
           break
         case 'Enter':
-          if (
-            isDropdownOpen &&
-            hoveredOptionIndex !== null &&
-            filteredOptions[hoveredOptionIndex]
-          ) {
+          if (isDropdownOpen && hoveredOptionIndex !== null) {
             event.preventDefault()
-            if (filteredOptions[hoveredOptionIndex]) {
-              selectOption(filteredOptions[hoveredOptionIndex])
+            if (creatableOption) {
+              if (hoveredOptionIndex === 0) {
+                createOption(creatableOption)
+              } else {
+                selectOption(filteredOptions[hoveredOptionIndex - 1])
+              }
+            } else {
+              filteredOptions[hoveredOptionIndex] &&
+                selectOption(filteredOptions[hoveredOptionIndex])
             }
           }
           break
@@ -195,9 +202,15 @@ export const SelectAutocomplete = forwardRef(
         type: 'change',
         target: { name, value: option.value },
       })
-      onBlur({
-        type: 'blur',
-        target: { name, value: option.value },
+
+      setIsDropdownOpen(false)
+      setHoveredOptionIndex(null)
+    }
+
+    const createOption = (creatableOption: string) => {
+      onChange({
+        type: 'change',
+        target: { name, value: creatableOption },
       })
 
       setIsDropdownOpen(false)
@@ -315,7 +328,9 @@ export const SelectAutocomplete = forwardRef(
                 listRef={listRef}
                 hoveredOptionIndex={hoveredOptionIndex}
                 selectOption={selectOption}
+                createOption={createOption}
                 thumbPlaceholder={thumbPlaceholder}
+                creatableOption={creatableOption}
               />
             )}
           </div>


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/jira/software/c/projects/PC/boards/66?selectedIssue=PC-41050)

**L'équipe design/produit souhaite introduire un nouveau comportement au `selectAutocomplete` : l'ajout d'une valeur n'appartenant pas à la liste des options.**

💡 Nous proposons dans cette PR la solution technique la moins coûteuse pour intégrer ce comportement avec l'existant. Le ticket est en effet urgent côté produit car l'expérience actuelle génère de la dette produit/data.

⚠️ Mais le composant `selectAutocomplete` est de plus en plus compliqué à maintenir à cause de : 
- la diversité des usages : comportement très différent entre le `AddressSelect`, le `ApiSelect`, et la `sélection des institutions/enseignant`.
- l'intégration legacy de ce composant au sein des différents formulaires.

Conscient d'ajouter encore de la dette, la squad Engagement propose un **plan en 3 étapes pour simplifier et refacto le composant `SelectAutocomplete` :** 

1. Nous avons initié une reflexion avec l'équipe design system afin de réfléchir à une potentielle harmonisation des comportements du `selectAutocomplete`.

2. Une fois aligné, la squad Engagement sera owner de refacto l'intégration du composant au sein des différents formulaires afin de faciliter le développement futur du composant design system.

3.  L'ajout du composant au design system sera priorisé dans les trimestres prochains.

## 🖼️ Before & After Images

| avant | après |
|--------|--------|
|  <img width="574" height="361" alt="Screenshot 2026-05-11 at 12 02 48" src="https://github.com/user-attachments/assets/18bba3b9-7fbc-4d2e-abc5-0508dea60bde" /> | <img width="557" height="407" alt="Screenshot 2026-05-11 at 11 44 01" src="https://github.com/user-attachments/assets/a36e04cb-73eb-4f1d-8f06-73684b348746" />  |





