### PR TITLE
(BSR)[API] fix: pc generate_public_api_openapi_json

### DIFF
--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -27,18 +27,6 @@ services:
     networks:
       - db_nw
 
-  pcapi-tests:
-    build:
-      context: ./api
-      target: pcapi-tests
-      args:
-        network_mode: ${DOCKER_NETWORK_MODE:-default}
-    profiles: ["test"]  # don't start with compose up
-    env_file:
-      - env_file
-    networks:
-      - db_nw
-
   flask:
     build:
       context: ./api
@@ -48,6 +36,9 @@ services:
     working_dir: /usr/src/app
     container_name: pc-api
     command: ["./start-api-when-database-is-ready.sh"]
+    volumes:
+      - ./api/documentation/static/openapi.json:/usr/src/app/documentation/static/openapi.json
+      - ./api/tests:/usr/src/app/tests
     develop:
       watch:
         - action: sync
@@ -83,6 +74,8 @@ services:
     working_dir: /usr/src/app
     container_name: pc-backoffice
     command: ["./start-backoffice-when-api-is-ready.sh"]
+    volumes:
+      - ./api/tests:/usr/src/app/tests
     develop:
       watch:
         - action: sync

--- a/infra/pc_scripts/test_backend.sh
+++ b/infra/pc_scripts/test_backend.sh
@@ -5,7 +5,7 @@ function test_backend {
   docker stop pc-postgres-pytest
   docker rm -v pc-postgres-pytest
   docker compose -f "$ROOT_PATH/docker-compose-backend.yml" up -d postgres-test
-  docker compose -f "$ROOT_PATH/docker-compose-backend.yml" build pcapi-tests --build-arg="network_mode=${DOCKER_NETWORK_MODE:-default}" --build-arg="uid=$UID"
+  docker compose -f "$ROOT_PATH/docker-compose-backend.yml" build flask --build-arg="network_mode=${DOCKER_NETWORK_MODE:-default}" --build-arg="uid=$UID"
 
   until docker compose -f "$ROOT_PATH/docker-compose-backend.yml" logs postgres-test 2>/dev/null | grep -q "PostgreSQL init process complete; ready for start up."; do
     echo "waiting for test-database"
@@ -14,7 +14,7 @@ function test_backend {
 
   docker compose -f "$ROOT_PATH/docker-compose-backend.yml" run --rm \
     -e RUN_ENV=tests -e SQLALCHEMY_WARN_20=1 \
-    pcapi-tests \
+    flask \
     bash -c "rm -rf static/object_store_data/thumbs* && \
              pytest -m 'not backoffice' --durations=5 --color=yes -rsx -v $pytest_args"
 }
@@ -24,7 +24,7 @@ function test_backoffice {
   docker stop pc-postgres-pytest
   docker rm -v pc-postgres-pytest
   docker compose -f "$ROOT_PATH/docker-compose-backend.yml" up -d postgres-test
-  docker compose -f "$ROOT_PATH/docker-compose-backend.yml" build pcapi-tests --build-arg="network_mode=${DOCKER_NETWORK_MODE:-default}" --build-arg="uid=$UID"
+  docker compose -f "$ROOT_PATH/docker-compose-backend.yml" build backoffice --build-arg="network_mode=${DOCKER_NETWORK_MODE:-default}" --build-arg="uid=$UID"
 
   until docker compose -f "$ROOT_PATH/docker-compose-backend.yml" logs postgres-test 2>/dev/null | grep -q "PostgreSQL init process complete; ready for start up."; do
     echo "waiting for test-database"
@@ -32,7 +32,7 @@ function test_backoffice {
   done
 
   docker compose -f "$ROOT_PATH/docker-compose-backend.yml" run --rm -e RUN_ENV=tests -e SQLALCHEMY_WARN_20=1 \
-    pcapi-tests \
+    backoffice \
     bash -c "rm -rf static/object_store_data/thumbs* && \
              pytest -m backoffice --durations=5 --color=yes -rsx -v $pytest_args"
 }


### PR DESCRIPTION
Docker Compose develop.watch only syncs the files from the host to the container and not the other way around. To reenable pc generate_{public,native}_api_openapi_json, we need to add the openapi.json files to the services volumes.

The pcapi-tests build target is removed in favor of mounting the test files in the dev images. This prevents rebuilding the image when the tests change.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-XXXXX)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
