### PR TITLE
(PC-41696)[API] feat: create v2 routes for native oauth

### DIFF
--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
     on_success_status=200,
     on_error_statuses=[400, 401],
     api=blueprint.api,
+    deprecated=True,
 )
 def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
     if FeatureToggle.ENABLE_NATIVE_APP_RECAPTCHA.is_active():
@@ -99,7 +100,9 @@ def signout() -> None:
 @blueprint.native_route("/refresh_access_token", methods=["POST"])
 @atomic()
 @authenticated_with_refresh_token
-@spectree_serialize(response_model=authentication.RefreshResponse, api=blueprint.api, on_error_statuses=[401])
+@spectree_serialize(
+    response_model=authentication.RefreshResponse, api=blueprint.api, on_error_statuses=[401], deprecated=True
+)
 def refresh() -> authentication.RefreshResponse:
     users_api.update_last_connection_date(current_user)
     try:
@@ -205,7 +208,9 @@ def validate_email(body: ValidateEmailRequest) -> ValidateEmailResponse:
 
 
 @blueprint.native_route("/oauth/state", methods=["GET"])
-@spectree_serialize(response_model=authentication.OauthStateResponse, on_success_status=200, api=blueprint.api)
+@spectree_serialize(
+    response_model=authentication.OauthStateResponse, on_success_status=200, api=blueprint.api, deprecated=True
+)
 def sso_oauth_state() -> authentication.OauthStateResponse:
     encoded_oauth_state_token = users_api.create_oauth_state_token()
     return authentication.OauthStateResponse(oauth_state_token=encoded_oauth_state_token)
@@ -223,6 +228,7 @@ _SSO_ACCESS_DENIED_ERROR = {
     on_success_status=200,
     on_error_statuses=[400, 401],
     api=blueprint.api,
+    deprecated=True,
 )
 def sso_authorize(sso_provider: str, body: authentication.OAuthSigninRequest) -> authentication.SigninResponse:
     if sso_provider not in authentication.SSOProvider:

--- a/api/src/pcapi/routes/native/v2/authentication.py
+++ b/api/src/pcapi/routes/native/v2/authentication.py
@@ -1,13 +1,20 @@
+import logging
+
 from flask import g
+from flask import request
 from flask_login import current_user
 
+import pcapi.core.token as token_utils
 from pcapi.connectors import api_recaptcha
+from pcapi.connectors import apple_oauth
+from pcapi.connectors import google_oauth
 from pcapi.core.users import api as users_api
 from pcapi.core.users import exceptions as users_exceptions
 from pcapi.core.users import models as user_models
 from pcapi.core.users import repository as users_repo
 from pcapi.core.users.sessions import create_user_jwt_tokens
 from pcapi.core.users.sessions import refresh_user_jwt_tokens
+from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
 from pcapi.models.feature import FeatureToggle
@@ -15,9 +22,13 @@ from pcapi.routes.native.security import _raise_forbidden
 from pcapi.routes.native.security import authenticated_with_refresh_token
 from pcapi.routes.native.v2.serialization import authentication
 from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils.repository import transaction
 from pcapi.utils.transaction_manager import atomic
 
 from .. import blueprint
+
+
+logger = logging.getLogger(__name__)
 
 
 @blueprint.native_route("/signin", version="v2", methods=["POST"])
@@ -83,3 +94,129 @@ def refresh(body: authentication.RefreshRequestV2) -> authentication.RefreshResp
         device_info=body.device_info,
     )
     return authentication.RefreshResponseV2(access_token=tokens.access, refresh_token=tokens.refresh)
+
+
+@blueprint.native_route("/oauth/state", version="v2", methods=["GET"])
+@spectree_serialize(response_model=authentication.OauthStateResponseV2, on_success_status=200, api=blueprint.api)
+def sso_oauth_state() -> authentication.OauthStateResponseV2:
+    encoded_oauth_state_token = users_api.create_oauth_state_token()
+    return authentication.OauthStateResponseV2(oauth_state_token=encoded_oauth_state_token)
+
+
+_SSO_ACCESS_DENIED_ERROR = {
+    "code": "SSO_ERROR",
+    "general": ["La connexion avec ce compte SSO est refusée. Contacte le support pour plus d'informations."],
+}
+
+
+@blueprint.native_route("/oauth/<string:sso_provider>/authorize", version="v2", methods=["POST"])
+@spectree_serialize(
+    response_model=authentication.SigninResponseV2,
+    on_success_status=200,
+    on_error_statuses=[400, 401],
+    api=blueprint.api,
+)
+def sso_authorize(sso_provider: str, body: authentication.OAuthSigninRequestV2) -> authentication.SigninResponseV2:
+    if sso_provider not in authentication.SSOProvider:
+        raise api_errors.ApiErrors({"error": "Unknown SSO provider"})
+
+    try:
+        oauth_state_token = token_utils.UUIDToken.load_and_check(
+            body.oauth_state_token, token_utils.TokenType.OAUTH_STATE
+        )
+    except (users_exceptions.ExpiredToken, users_exceptions.InvalidToken) as e:
+        raise ApiErrors(
+            {
+                "code": "SSO_LOGIN_TIMEOUT",
+                "general": ["La demande de connexion a mis trop de temps."],
+            },
+            status_code=400,
+        ) from e
+    oauth_state_token.expire()
+
+    is_web = request.headers.get("platform") == "web"
+    if sso_provider == "apple":
+        try:
+            sso_user = apple_oauth.get_apple_user(body.authorization_code, is_web)
+        except apple_oauth.AppleSignInException:
+            raise ApiErrors({"code": "SSO_ERROR", "general": "L'authentification a échoué"}, status_code=401)
+    elif sso_provider == "google":
+        sso_user = google_oauth.get_google_user(body.authorization_code, is_web)
+
+    if not sso_user.email_verified:
+        logger.warning(
+            "SSO access denied: email not verified",
+            extra={"sso_provider": sso_provider},
+        )
+        raise ApiErrors(_SSO_ACCESS_DENIED_ERROR)
+
+    if not sso_user.email:
+        raise api_errors.ApiErrors(
+            {"code": "EMAIL_MISSING", "general": ["L'email n'a pas pu être récupéré auprès du fournisseur SSO."]}
+        )
+
+    email = sso_user.email
+    sso_user_id = sso_user.sub
+    single_sign_on = users_repo.get_single_sign_on(sso_provider, sso_user_id)
+    if not single_sign_on:
+        user = users_repo.find_user_by_email(email)
+    else:
+        user = single_sign_on.user
+
+    if not user:
+        logger.info(
+            "Successful SSO authentication but no matching email found, sending account creation token",
+            extra={"sso_provider": sso_provider, "avoid_current_user": True},
+            technical_message_id=f"users.login.sso.{sso_provider}",
+        )
+        encoded_account_creation_token = users_api.create_account_creation_token(sso_user)
+        # the frontends (web, ios & android app) will handle this error and redirect to the account creation form
+        raise ApiErrors(
+            {
+                "code": "SSO_EMAIL_NOT_FOUND",
+                "accountCreationToken": encoded_account_creation_token,
+                "email": email,
+                "general": [f"Aucun compte pass Culture lié à {email} n'a été trouvé"],
+            },
+            status_code=401,
+        )
+
+    if user.account_state.is_deleted or user.account_state == user_models.AccountState.ANONYMIZED:
+        logger.warning(
+            "SSO access denied: account state is not allowed",
+            extra={"sso_provider": sso_provider, "account_state": user.account_state},
+        )
+        raise ApiErrors(_SSO_ACCESS_DENIED_ERROR)
+
+    sso_user_id = sso_user.sub
+    with transaction():
+        if not user.isEmailValidated:
+            # An account registered with a password and with its email not validated is a symptom
+            # of an account pre-hijacking attack waiting for an email validation. To prevent this
+            # we disable the email + password login when a SSO is enabled.
+            user.password = None
+            user.isEmailValidated = True
+
+        current_provider_sso = None
+        user_ssos_for_provider = [sso for sso in user.single_sign_ons if sso.ssoProvider == sso_provider]
+        if user_ssos_for_provider:
+            current_provider_sso = user_ssos_for_provider[0]
+            current_provider_sso.ssoUserId = sso_user.sub
+        else:
+            current_provider_sso = users_repo.create_single_sign_on(user, sso_provider, sso_user_id)
+            db.session.add(current_provider_sso)
+
+    users_api.save_device_info_and_notify_user(user, body.device_info)
+
+    users_api.update_last_connection_date(user)
+    logger.info(
+        "Successful authentication attempt",
+        extra={"sso_provider": sso_provider, "avoid_current_user": True},
+        technical_message_id=f"users.login.sso.{sso_provider}",
+    )
+    tokens = create_user_jwt_tokens(user=user, device_info=body.device_info)
+    return authentication.SigninResponseV2(
+        access_token=tokens.access,
+        refresh_token=tokens.refresh,
+        account_state=user.account_state,
+    )

--- a/api/src/pcapi/routes/native/v2/serialization/authentication.py
+++ b/api/src/pcapi/routes/native/v2/serialization/authentication.py
@@ -1,7 +1,14 @@
+from enum import Enum
+
 from pcapi.core.users.models import AccountState
 from pcapi.routes.native.v2.serialization.common_models import DeviceInfoV2
 from pcapi.routes.serialization import HttpBodyModel
 from pcapi.routes.serialization import HttpQueryParamsModel
+
+
+class SSOProvider(Enum):
+    APPLE = "apple"
+    GOOGLE = "google"
 
 
 class SigninRequestV2(HttpQueryParamsModel):
@@ -23,4 +30,14 @@ class RefreshResponseV2(HttpBodyModel):
 
 
 class RefreshRequestV2(HttpBodyModel):
+    device_info: DeviceInfoV2
+
+
+class OauthStateResponseV2(HttpBodyModel):
+    oauth_state_token: str
+
+
+class OAuthSigninRequestV2(HttpQueryParamsModel):
+    authorization_code: str
+    oauth_state_token: str
     device_info: DeviceInfoV2

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -10873,6 +10873,7 @@
         },
         "/native/v1/oauth/state": {
             "get": {
+                "deprecated": true,
                 "description": "",
                 "operationId": "get__native_v1_oauth_state",
                 "parameters": [],
@@ -10964,6 +10965,7 @@
         },
         "/native/v1/oauth/{sso_provider}/authorize": {
             "post": {
+                "deprecated": true,
                 "description": "",
                 "operationId": "post__native_v1_oauth_{sso_provider}_authorize",
                 "parameters": [
@@ -11800,6 +11802,7 @@
         },
         "/native/v1/refresh_access_token": {
             "post": {
+                "deprecated": true,
                 "description": "",
                 "operationId": "post__native_v1_refresh_access_token",
                 "parameters": [],
@@ -12126,6 +12129,7 @@
         },
         "/native/v1/signin": {
             "post": {
+                "deprecated": true,
                 "description": "",
                 "operationId": "post__native_v1_signin",
                 "parameters": [],

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -4225,6 +4225,29 @@
                 "title": "OAuthSigninRequest",
                 "type": "object"
             },
+            "OAuthSigninRequestV2": {
+                "additionalProperties": false,
+                "properties": {
+                    "authorizationCode": {
+                        "title": "Authorizationcode",
+                        "type": "string"
+                    },
+                    "deviceInfo": {
+                        "$ref": "#/components/schemas/DeviceInfoV2"
+                    },
+                    "oauthStateToken": {
+                        "title": "Oauthstatetoken",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "authorizationCode",
+                    "oauthStateToken",
+                    "deviceInfo"
+                ],
+                "title": "OAuthSigninRequestV2",
+                "type": "object"
+            },
             "OauthStateResponse": {
                 "additionalProperties": false,
                 "properties": {
@@ -4237,6 +4260,20 @@
                     "oauthStateToken"
                 ],
                 "title": "OauthStateResponse",
+                "type": "object"
+            },
+            "OauthStateResponseV2": {
+                "additionalProperties": false,
+                "properties": {
+                    "oauthStateToken": {
+                        "title": "Oauthstatetoken",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "oauthStateToken"
+                ],
+                "title": "OauthStateResponseV2",
                 "type": "object"
             },
             "OfferAccessibilityResponse": {
@@ -12879,6 +12916,100 @@
                     }
                 ],
                 "summary": "get_bookings_list <GET>",
+                "tags": []
+            }
+        },
+        "/native/v2/oauth/state": {
+            "get": {
+                "description": "",
+                "operationId": "get__native_v2_oauth_state",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/OauthStateResponseV2"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Content"
+                    }
+                },
+                "summary": "sso_oauth_state <GET>",
+                "tags": []
+            }
+        },
+        "/native/v2/oauth/{sso_provider}/authorize": {
+            "post": {
+                "description": "",
+                "operationId": "post__native_v2_oauth_{sso_provider}_authorize",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "sso_provider",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OAuthSigninRequestV2"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SigninResponseV2"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Content"
+                    }
+                },
+                "summary": "sso_authorize <POST>",
                 "tags": []
             }
         },

--- a/api/tests/routes/native/v2/authentication_test.py
+++ b/api/tests/routes/native/v2/authentication_test.py
@@ -1,4 +1,6 @@
+import copy
 import logging
+import uuid
 from datetime import datetime
 from unittest.mock import patch
 
@@ -8,13 +10,18 @@ from flask_jwt_extended import decode_token
 from flask_jwt_extended.utils import create_refresh_token
 
 from pcapi import settings
+from pcapi.connectors import apple_oauth
+from pcapi.core import token as token_utils
 from pcapi.core.history import factories as history_factories
+from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
+from pcapi.core.users import schemas as users_schemas
 from pcapi.core.users import testing as brevo_testing
 from pcapi.core.users.models import AccountState
 from pcapi.core.users.models import NativeUserSession
+from pcapi.core.users.models import SingleSignOn
 from pcapi.models import db
 
 
@@ -490,3 +497,389 @@ class RefreshAccessTokenTest:
             )
             .count()
         )
+
+
+class SSOSigninTest:
+    valid_sso_user = users_schemas.SSOUser(
+        sub="100428144463745704968",
+        email="docteur.cuesta@passkoultour.app",
+        email_verified=True,
+    )
+    device_info = {
+        "os": "iOS",
+        "deviceId": "ID",
+        "source": "app",
+    }
+
+    def test_fails_if_unknown_provider(self, client):
+        response = client.post(
+            "/native/v2/oauth/unknown_sso/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": "wontbechecked",
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 400
+
+    @patch("pcapi.connectors.apple_oauth.get_apple_user")
+    def test_cant_fetch_apple_user(self, mocked_apple_oauth, client):
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_apple_oauth.side_effect = apple_oauth.AppleSignInException
+
+        response = client.post(
+            "/native/v2/oauth/apple/authorize",
+            json={
+                "authorizationCode": "4/apple_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 401
+        assert response.json["code"] == "SSO_ERROR"
+        assert response.json["general"] == "L'authentification a échoué"
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_account_is_active(self, mocked_google_oauth, client, caplog):
+        users_factories.SingleSignOnFactory(
+            ssoUserId=self.valid_sso_user.sub, user__email=self.valid_sso_user.email, user__isActive=True
+        )
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        with caplog.at_level(logging.INFO):
+            response = client.post(
+                "/native/v2/oauth/google/authorize",
+                json={
+                    "authorizationCode": "4/google_code",
+                    "oauthStateToken": oauth_state_token.encoded_token,
+                    "device_info": self.device_info,
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.json["accountState"] == AccountState.ACTIVE.value
+        assert "Successful authentication attempt" in caplog.messages
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_account_is_deleted(self, mocked_google_oauth, client):
+        user = users_factories.UserFactory(email=self.valid_sso_user.email, isActive=False)
+        users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_sso_user.sub)
+        history_factories.SuspendedUserActionHistoryFactory(user=user, reason=users_constants.SuspensionReason.DELETED)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json["code"] == "SSO_ERROR"
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_account_is_anonymized(self, mocked_google_oauth, client):
+        user = users_factories.AnonymizedUserFactory(email=self.valid_sso_user.email)
+        users_factories.SingleSignOnFactory(user=user, ssoUserId=self.valid_sso_user.sub)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json["code"] == "SSO_ERROR"
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_account_creation_token_if_account_does_not_exist(self, mocked_google_oauth, client, caplog):
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        with caplog.at_level(logging.INFO):
+            response = client.post(
+                "/native/v2/oauth/google/authorize",
+                json={
+                    "authorizationCode": "4/google_code",
+                    "oauthStateToken": oauth_state_token.encoded_token,
+                    "device_info": self.device_info,
+                },
+            )
+
+        assert response.status_code == 401
+        assert set(["code", "accountCreationToken", "general", "email"]) == response.json.keys()
+        assert response.json["code"] == "SSO_EMAIL_NOT_FOUND"
+        assert response.json["email"] == self.valid_sso_user.email
+
+        decoded_account_creation_token = token_utils.UUIDToken.load_without_checking(
+            response.json["accountCreationToken"]
+        )
+        assert uuid.UUID(decoded_account_creation_token.key_suffix)
+        assert users_schemas.SSOUser.model_validate(decoded_account_creation_token.data)
+        assert not decoded_account_creation_token.check(
+            token_utils.TokenType.ACCOUNT_CREATION, decoded_account_creation_token.key_suffix
+        )
+
+    @pytest.mark.parametrize("sso_provider", ("apple", "google"))
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    @patch("pcapi.connectors.apple_oauth.get_apple_user")
+    def test_updates_single_sign_on_email_change(self, mocked_apple_oauth, mocked_google_oauth, sso_provider, client):
+        user = users_factories.UserFactory(isActive=True)
+        google_sso = users_factories.SingleSignOnFactory(user=user, ssoUserId="old id", ssoProvider=sso_provider)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_apple_oauth.return_value = self.valid_sso_user
+        mocked_google_oauth.return_value = self.valid_sso_user
+        user.email = self.valid_sso_user.email
+
+        response = client.post(
+            f"/native/v2/oauth/{sso_provider}/authorize",
+            json={
+                "authorizationCode": "fakeAuthCode",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 200
+        assert google_sso.ssoUserId == self.valid_sso_user.sub
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_single_sign_on_inserts_sso_method_if_email_found(self, mocked_google_oauth, client):
+        user = users_factories.UserFactory(email=self.valid_sso_user.email, isActive=True)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 200
+
+        created_sso = (
+            db.session.query(SingleSignOn).filter(SingleSignOn.user == user, SingleSignOn.ssoProvider == "google").one()
+        )
+        assert created_sso.ssoUserId == self.valid_sso_user.sub
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_single_sign_on_raises_if_email_not_validated(self, mocked_google_oauth, client):
+        users_factories.UserFactory(email=self.valid_sso_user.email, isActive=True)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        unvalidated_email_google_user = copy.deepcopy(self.valid_sso_user)
+        unvalidated_email_google_user.email_verified = False
+        mocked_google_oauth.return_value = unvalidated_email_google_user
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 400
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_single_sign_on_validates_email_and_deletes_password(self, mocked_google_oauth, client, caplog):
+        user = users_factories.UserFactory(email=self.valid_sso_user.email, isEmailValidated=False)
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 200, response.json
+        assert user.isEmailValidated
+        assert user.password is None
+
+    @pytest.mark.parametrize("sso_provider", ("apple", "google"))
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    @patch("pcapi.connectors.apple_oauth.get_apple_user")
+    def test_single_sign_on_does_not_duplicate_ssos(
+        self, mocked_apple_oauth, mocked_google_oauth, sso_provider, client
+    ):
+        single_sign_on = users_factories.SingleSignOnFactory(
+            user__email=self.valid_sso_user.email, ssoUserId=self.valid_sso_user.sub, ssoProvider=sso_provider
+        )
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_apple_oauth.return_value = self.valid_sso_user
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        response = client.post(
+            f"/native/v2/oauth/{sso_provider}/authorize",
+            json={
+                "authorizationCode": "fakeAuthCode",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 200
+        assert db.session.query(SingleSignOn).filter(SingleSignOn.user == single_sign_on.user).count() == 1
+
+    def test_oauth_state_token_past_expiration_date(self, client):
+        with time_machine.travel("2022-01-01"):
+            oauth_state_token = token_utils.UUIDToken.create(
+                token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+            )
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 400, response.json
+        assert response.json["code"] == "SSO_LOGIN_TIMEOUT"
+
+    def test_oauth_state_token_expired(self, client):
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        oauth_state_token.expire()
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 400, response.json
+        assert response.json["code"] == "SSO_LOGIN_TIMEOUT"
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_authorization_expires_oauth_state_token(self, mocked_google_oauth, client):
+        users_factories.SingleSignOnFactory(
+            ssoUserId=self.valid_sso_user.sub, user__email=self.valid_sso_user.email, user__isActive=True
+        )
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+        )
+
+        assert response.status_code == 200, response.json
+        assert not token_utils.UUIDToken.token_exists(token_utils.TokenType.OAUTH_STATE, oauth_state_token.key_suffix)
+
+    def test_oauth_state_token_creation(self, client):
+        with assert_num_queries(0):
+            response = client.get("/native/v2/oauth/state")
+            assert response.status_code == 200, response.json
+
+        oauth_state_token = token_utils.UUIDToken.load_without_checking(response.json["oauthStateToken"])
+        assert uuid.UUID(oauth_state_token.key_suffix)
+        assert not oauth_state_token.check(token_utils.TokenType.OAUTH_STATE, oauth_state_token.key_suffix)
+
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_oauth_state_token_roundtrip(self, mocked_google_oauth, client):
+        users_factories.SingleSignOnFactory(
+            ssoUserId=self.valid_sso_user.sub, user__email=self.valid_sso_user.email, user__isActive=True
+        )
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        oauth_state_token_response = client.get("/native/v2/oauth/state")
+        authorization_response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token_response.json["oauthStateToken"],
+                "device_info": self.device_info,
+            },
+        )
+
+        assert authorization_response.status_code == 200, authorization_response.json
+
+    @pytest.mark.parametrize("header,is_web", [("web", True), ("", False), ("other", False)])
+    @patch("pcapi.connectors.google_oauth.get_google_user")
+    def test_get_platform_from_request_headers(self, mocked_google_oauth, client, header, is_web):
+        users_factories.SingleSignOnFactory(
+            ssoUserId=self.valid_sso_user.sub, user__email=self.valid_sso_user.email, user__isActive=True
+        )
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+        mocked_google_oauth.return_value = self.valid_sso_user
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={
+                "authorizationCode": "4/google_code",
+                "oauthStateToken": oauth_state_token.encoded_token,
+                "device_info": self.device_info,
+            },
+            headers={"platform": header},
+        )
+
+        assert response.status_code == 200, response.json
+        mocked_google_oauth.assert_called_with("4/google_code", is_web)
+
+    def test_single_sign_on_fail_when_missing_device_info(self, client):
+        users_factories.SingleSignOnFactory(
+            ssoUserId=self.valid_sso_user.sub, user__email=self.valid_sso_user.email, user__isActive=True
+        )
+        oauth_state_token = token_utils.UUIDToken.create(
+            token_utils.TokenType.OAUTH_STATE, users_constants.ACCOUNT_CREATION_TOKEN_LIFE_TIME
+        )
+
+        response = client.post(
+            "/native/v2/oauth/google/authorize",
+            json={"authorizationCode": "4/google_code", "oauthStateToken": oauth_state_token.encoded_token},
+        )
+
+        assert response.status_code == 400

--- a/api/tests/test_flask_app.py
+++ b/api/tests/test_flask_app.py
@@ -61,6 +61,7 @@ KNOWN_PUBLIC_ENDPOINTS = [
     "native.native_v1.similar_offers",  # → response.status_code = 200
     "native.native_v2.get_offer_v2",  # → response.status_code = 404
     "native.native_v2.get_venue_v2",  # → response.status_code = 404
+    "native.native_v2.sso_oauth_state",  # → response.status_code = 200
     "native.native_v3.get_offer_v3",  # → response.status_code = 404
     "Private API.clear_email_list",  # → response.status_code = 200
     "Private API.testing_route_with_common_errors",


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41696)

## Context
The new way of handling sessions forces the `deviceInfo` to be present when connecting user. Oauth endpoints do not enforce that param in the body for login.

## Tasks
 - add v2 endpoint for oauth login
 - enforce `deviceInfo` in the POST for login
 - add v2 endpoint for `oauth/state`, so that all routes for oauth are in v2