### PR TITLE
(PC-41265)[API] feat: add nullable status column to venue

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-de0fbd846d9f (pre) (head)
+734b78b841f2 (pre) (head)
 1356ff1cc2fc (post) (head)

--- a/api/src/pcapi/alembic/versions/20260507T084121_734b78b841f2_add_nullable_state_to_venue.py
+++ b/api/src/pcapi/alembic/versions/20260507T084121_734b78b841f2_add_nullable_state_to_venue.py
@@ -1,0 +1,23 @@
+"""add nullable state to venue"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from pcapi.core.offerers.models import VenueState
+from pcapi.utils.db import MagicEnum
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "734b78b841f2"
+down_revision = "de0fbd846d9f"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("venue", sa.Column("state", MagicEnum(VenueState), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("venue", "state")

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -301,6 +301,10 @@ DisplayableActivity: enum.EnumType = enum.Enum(  # type: ignore[misc]
 )
 
 
+class VenueState(enum.Enum):
+    CLOSED = "CLOSED"
+
+
 class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMixin):
     __tablename__ = "venue"
     thumb_path_component = "venues"
@@ -519,6 +523,10 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
 
     activity: sa_orm.Mapped[Activity | None] = sa_orm.mapped_column(
         db_utils.MagicEnum(Activity, use_values=False), nullable=True
+    )
+
+    state: sa_orm.Mapped[VenueState | None] = sa_orm.mapped_column(
+        db_utils.MagicEnum(VenueState), nullable=True, default=None
     )
 
     __table_args__ = (


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41265)

Ajout d'une nouvelle colonne `state` à `venue`. Il s'agit d'un enum avec, pour l'instant, une seule option : `CLOSED`. La colonne peut être nulle pour faciliter la migration et les changements à venir à ce niveau-là.

Le ticket mentionne une colonne `status`... j'ai préféré `state` parce que cela devrait éviter quelques soucis actuels et à venir : il arrive, notamment dans le BO, que des requêtes ajoutent des colonnes nommées `status`, ce qui peut générer des erreurs. On pourrait dans chacun de ces cas renommer explicitement `venue.status` en `venue.venue_status` mais cela risque de nous faire perdre un peu de temps pour rien.