### PR TITLE
(PC-41644)[API] feat: pro: venues lite: order venues

### DIFF
--- a/api/src/pcapi/routes/serialization/venue_serialize.py
+++ b/api/src/pcapi/routes/serialization/venue_serialize.py
@@ -332,6 +332,9 @@ class GetVenueListLiteResponseModel(HttpBodyModel):
         venues: typing.Collection[offerers_models.Venue],
         with_pending_validation: typing.Collection[offerers_models.Venue],
     ) -> "GetVenueListLiteResponseModel":
+        venues = sorted(venues, key=lambda v: v.publicName)
+        with_pending_validation = sorted(with_pending_validation, key=lambda v: v.publicName)
+
         return cls(
             venues=[VenueListItemLiteResponseModel.build(venue) for venue in venues],
             venues_with_pending_validation=[

--- a/api/tests/routes/pro/get_venues_lite_test.py
+++ b/api/tests/routes/pro/get_venues_lite_test.py
@@ -17,7 +17,8 @@ def test_loads_all_venues_ids_and_names(client):
     venues = [first_venue, second_venue]
 
     pending_offerer = offerers_factories.PendingUserOffererFactory(user=user_offerer.user).offerer
-    with_pending_validation = offerers_factories.VenueFactory(managingOfferer=pending_offerer)
+    first_with_pending_validation = offerers_factories.VenueFactory(managingOfferer=pending_offerer, publicName="PV1")
+    second_with_pending_validation = offerers_factories.VenueFactory(managingOfferer=pending_offerer, publicName="PV2")
 
     client = client.with_session_auth(user_offerer.user.email)
 
@@ -32,7 +33,7 @@ def test_loads_all_venues_ids_and_names(client):
     assert "venues" in response.json
     assert len(response.json["venues"]) == len(venues)
 
-    expected = [
+    assert response.json["venues"] == [
         {
             "id": venue.id,
             "managingOffererId": venue.managingOffererId,
@@ -52,10 +53,10 @@ def test_loads_all_venues_ids_and_names(client):
                 "street": venue.offererAddress.address.street,
             },
         }
-        for venue in sorted(venues, key=lambda v: v.id)
+        for venue in sorted(venues, key=lambda v: v.publicName)
     ]
 
-    assert sorted(response.json["venues"], key=lambda v: v["id"]) == expected
+    with_pending_validations = [first_with_pending_validation, second_with_pending_validation]
     assert response.json["venuesWithPendingValidation"] == [
         {
             "id": with_pending_validation.id,
@@ -76,6 +77,7 @@ def test_loads_all_venues_ids_and_names(client):
                 "street": with_pending_validation.offererAddress.address.street,
             },
         }
+        for with_pending_validation in with_pending_validations
     ]
 
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41644)

Trier les lieux renvoyés par la route `GET /lite/venues`, par nom. Cela servira pour le hub d'accueil du portail pro.