### PR TITLE
(PC-41709)[BO] revert: Semgrep Finding: python.flask.security.audit.f…

### DIFF
--- a/api/src/pcapi/routes/backoffice/auth.py
+++ b/api/src/pcapi/routes/backoffice/auth.py
@@ -50,7 +50,7 @@ def login() -> response_utils.BackofficeResponse:
         login_user(local_admin, remember=True)
         return werkzeug.utils.redirect(url_for(".home"))
 
-    redirect_uri = url_for(".authorize")
+    redirect_uri = url_for(".authorize", _external=True)
     return backoffice_oauth.google.authorize_redirect(redirect_uri)
 
 


### PR DESCRIPTION
…lask-url-for-external-true.flask-url-for-external-true #389

This reverts commit 15bc47500321612a450bbf1eed41b3e99b73d4cf.

BO staging cassé : 
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/1f54f30d-e3b0-4dfb-a60e-9547779633ef" />
