### PR TITLE
(PC-41751)[API] fix: Brevo can't create contact [email]: code=invalid…

### DIFF
--- a/api/src/pcapi/core/mails/backends/sendinblue.py
+++ b/api/src/pcapi/core/mails/backends/sendinblue.py
@@ -175,7 +175,10 @@ class SendinblueBackend(BaseBackend):
             #     "message": "Unable to update contact, email is already associated with another Contact",
             #     "metadata":{"duplicate_identifiers":["email"]}
             # }
-            if code == "duplicate_parameter" and data.get("metadata", {}).get("duplicate_identifiers") == ["email"]:
+            # Same body with "code": "invalid_parameter".
+            if code in ("duplicate_parameter", "invalid_parameter") and data.get("metadata", {}).get(
+                "duplicate_identifiers"
+            ) == ["email"]:
                 return self.delete_contact(payload.email)
 
             if code:

--- a/api/tests/core/mails/mails_test.py
+++ b/api/tests/core/mails/mails_test.py
@@ -128,9 +128,10 @@ class SendinblueBackendTest:
         )
         mock_delete_contact.assert_not_called()
 
+    @pytest.mark.parametrize("code", ["duplicate_parameter", "invalid_parameter"])
     @patch("brevo.contacts.client.ContactsClient.delete_contact")
     @patch("brevo.contacts.client.ContactsClient.create_contact")
-    def test_create_contact_duplicate_email(self, mock_create_contact, mock_delete_contact):
+    def test_create_contact_duplicate_email(self, mock_create_contact, mock_delete_contact, code):
         payload = serialization.UpdateBrevoContactRequest(
             email="old.email@example.com",
             use_pro_subaccount=True,
@@ -143,7 +144,7 @@ class SendinblueBackendTest:
             status_code=400,
             headers={"Content-Type": "application/json"},
             body={
-                "code": "duplicate_parameter",
+                "code": code,
                 "message": "Unable to update contact, email is already associated with another Contact",
                 "metadata": {"duplicate_identifiers": ["email"]},
             },


### PR DESCRIPTION
…_parameter, message=Unable to update contact, email is already associated with another Contact

Ticket Jira : https://passculture.atlassian.net/browse/PC-41751
Sentry : https://pass-culture.sentry.io/issues/110362878/