### PR TITLE
(PC-40019)[API] feat: add similar artists v2 native endpoint

### DIFF
--- a/api/src/pcapi/connectors/recommendation.py
+++ b/api/src/pcapi/connectors/recommendation.py
@@ -38,6 +38,12 @@ def get_similar_offers(offer_id: int, user: users_models.User | None = None, par
     return backend.get_similar_offers(offer_id, user, params)
 
 
+def get_similar_artists(artist_id: str, params: dict | None = None) -> bytes:
+    backend = _get_backend()
+    params = params or {}
+    return backend.get_similar_artists(artist_id, params)
+
+
 def get_playlist(user: users_models.User, params: dict | None = None, body: dict | None = None) -> bytes:
     backend = _get_backend()
     params = params or {}
@@ -47,6 +53,9 @@ def get_playlist(user: users_models.User, params: dict | None = None, body: dict
 
 class BaseBackend:
     def get_similar_offers(self, offer_id: int, user: users_models.User | None, params: dict) -> bytes:
+        raise NotImplementedError()
+
+    def get_similar_artists(self, artist_id: str, params: dict) -> bytes:
         raise NotImplementedError()
 
     def get_playlist(self, user: users_models.User, params: dict, body: dict) -> bytes:
@@ -62,6 +71,16 @@ class TestingBackend:
                 "reco_origin": "unknown",
                 "model_origin": "default",
                 "call_id": "956bd070-cbb1-42d3-bea4-89855bf3b11c",
+            },
+        }
+        return bytes(json.dumps(response), encoding="utf-8")
+
+    def get_similar_artists(self, artist_id: str, params: dict) -> bytes:
+        response = {
+            "similar_artists": [],
+            "params": {
+                "artist_id": artist_id,
+                "call_id": "00000000-0000-0000-0000-000000000000",
             },
         }
         return bytes(json.dumps(response), encoding="utf-8")
@@ -112,6 +131,10 @@ class HttpBackend:
         # the Recommendation API, but let's be defensive.
         params.pop("user_id", None)
         params["userId"] = str(user.id) if user else None
+        return self._request("get", path, params=params)
+
+    def get_similar_artists(self, artist_id: str, params: dict) -> bytes:
+        path = f"/similar_artists/{artist_id}"
         return self._request("get", path, params=params)
 
     def get_playlist(self, user: users_models.User, params: dict, body: dict) -> bytes:

--- a/api/src/pcapi/core/artist/repository.py
+++ b/api/src/pcapi/core/artist/repository.py
@@ -41,3 +41,15 @@ def get_filtered_artists_for_search(search_value: str) -> list[models.Artist]:
         .limit(5)
         .all()
     )
+
+
+def get_artists_by_ids(artist_ids: list[str]) -> list[models.Artist]:
+    """Fetch eligible artists by IDs, preserving no particular order (caller is responsible for ordering)."""
+    return (
+        db.session.query(models.Artist)
+        .filter(
+            models.Artist.id.in_(artist_ids),
+            get_artist_search_eligibility_subquery(),
+        )
+        .all()
+    )

--- a/api/src/pcapi/routes/native/v1/artists.py
+++ b/api/src/pcapi/routes/native/v1/artists.py
@@ -1,7 +1,11 @@
+import json
 import logging
+import uuid
 
 from flask import abort
 
+from pcapi.connectors import recommendation as recommendation_connector
+from pcapi.core.artist import repository as artist_repository
 from pcapi.core.artist.models import Artist
 from pcapi.models import db
 from pcapi.serialization.decorator import spectree_serialize
@@ -27,4 +31,38 @@ def get_artist(artist_id: str) -> serializers.ArtistResponse:
         description_credit="© Contenu généré par IA \u2728" if artist.biography else None,
         description_source=artist.wikipedia_url if artist.biography else None,
         image=artist.thumbUrl,
+    )
+
+
+@blueprint.native_route("/artists/<string:artist_id>/similar", methods=["GET"])
+@spectree_serialize(response_model=serializers.SimilarArtistsResponse, api=blueprint.api, on_error_statuses=[400])
+def get_similar_artists(artist_id: str) -> serializers.SimilarArtistsResponse:
+    try:
+        uuid.UUID(artist_id)
+    except ValueError:
+        abort(400)
+
+    try:
+        raw = recommendation_connector.get_similar_artists(artist_id)
+    except recommendation_connector.RecommendationApiTimeoutException:
+        logger.warning("Recommendation API timeout for similar_artists", extra={"artist_id": artist_id})
+        return serializers.SimilarArtistsResponse(artists=[])
+    except recommendation_connector.RecommendationApiException:
+        logger.warning("Recommendation API error for similar_artists", extra={"artist_id": artist_id})
+        return serializers.SimilarArtistsResponse(artists=[])
+
+    ds_response = json.loads(raw)
+    artist_ids = [item["artist_id_match"] for item in ds_response.get("similar_artists", [])]
+
+    if not artist_ids:
+        return serializers.SimilarArtistsResponse(artists=[])
+
+    artists_by_id = {artist.id: artist for artist in artist_repository.get_artists_by_ids(artist_ids)}
+
+    return serializers.SimilarArtistsResponse(
+        artists=[
+            serializers.SimilarArtistItem(id=artist.id, name=artist.name, image=artist.thumbUrl)
+            for aid in artist_ids
+            if (artist := artists_by_id.get(aid))
+        ]
     )

--- a/api/src/pcapi/routes/native/v1/serialization/artists.py
+++ b/api/src/pcapi/routes/native/v1/serialization/artists.py
@@ -8,3 +8,13 @@ class ArtistResponse(HttpBodyModel):
     description_credit: str | None = None
     description_source: str | None = None
     image: str | None = None
+
+
+class SimilarArtistItem(HttpBodyModel):
+    id: str
+    name: str
+    image: str | None = None
+
+
+class SimilarArtistsResponse(HttpBodyModel):
+    artists: list[SimilarArtistItem]

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -7382,6 +7382,54 @@
                 "title": "SigninResponseV2",
                 "type": "object"
             },
+            "SimilarArtistItem": {
+                "additionalProperties": false,
+                "properties": {
+                    "id": {
+                        "title": "Id",
+                        "type": "string"
+                    },
+                    "image": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "default": null,
+                        "title": "Image"
+                    },
+                    "name": {
+                        "title": "Name",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "title": "SimilarArtistItem",
+                "type": "object"
+            },
+            "SimilarArtistsResponse": {
+                "additionalProperties": false,
+                "properties": {
+                    "artists": {
+                        "items": {
+                            "$ref": "#/components/schemas/SimilarArtistItem"
+                        },
+                        "title": "Artists",
+                        "type": "array"
+                    }
+                },
+                "required": [
+                    "artists"
+                ],
+                "title": "SimilarArtistsResponse",
+                "type": "object"
+            },
             "SimilarOffersRequestQuery": {
                 "additionalProperties": false,
                 "properties": {
@@ -9874,6 +9922,53 @@
                     }
                 },
                 "summary": "get_artist <GET>",
+                "tags": []
+            }
+        },
+        "/native/v1/artists/{artist_id}/similar": {
+            "get": {
+                "description": "",
+                "operationId": "get__native_v1_artists_{artist_id}_similar",
+                "parameters": [
+                    {
+                        "description": "",
+                        "in": "path",
+                        "name": "artist_id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimilarArtistsResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Content"
+                    }
+                },
+                "summary": "get_similar_artists <GET>",
                 "tags": []
             }
         },

--- a/api/tests/routes/native/v1/similar_artists_test.py
+++ b/api/tests/routes/native/v1/similar_artists_test.py
@@ -1,0 +1,145 @@
+import json
+
+import pytest
+
+import pcapi.core.artist.factories as artist_factories
+import pcapi.core.offers.factories as offers_factories
+from pcapi.core.testing import assert_num_queries
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+DS_URL = "https://example.com/recommendation"
+DS_SIMILAR_ARTISTS_URL = DS_URL + "/similar_artists/{artist_id}"
+
+
+def _ds_response(artist_ids: list[str]) -> bytes:
+    return json.dumps(
+        {
+            "similar_artists": [{"artist_id_match": aid, "rank": i + 1} for i, aid in enumerate(artist_ids)],
+            "params": {"artist_id": "irrelevant", "call_id": "test-call-id"},
+        }
+    ).encode()
+
+
+def _link_artist_to_bookable_offer(artist):
+    product = offers_factories.ProductFactory()
+    artist_factories.ArtistProductLinkFactory(artist_id=artist.id, product_id=product.id)
+    offer = offers_factories.ThingOfferFactory(product=product)
+    offers_factories.StockFactory(offer=offer)
+
+
+@pytest.mark.settings(
+    RECOMMENDATION_BACKEND="pcapi.connectors.recommendation.HttpBackend",
+    RECOMMENDATION_API_URL=DS_URL,
+)
+class GetSimilarArtistsTest:
+    def test_returns_similar_artists_in_ds_order(self, client, requests_mock):
+        first = artist_factories.ArtistFactory(name="First similar")
+        second = artist_factories.ArtistFactory(name="Second similar")
+        _link_artist_to_bookable_offer(first)
+        _link_artist_to_bookable_offer(second)
+        source_id = "00000000-0000-0000-0000-000000000001"
+
+        requests_mock.get(
+            DS_SIMILAR_ARTISTS_URL.format(artist_id=source_id),
+            content=_ds_response([first.id, second.id]),
+        )
+
+        with assert_num_queries(1):
+            response = client.get(f"/native/v1/artists/{source_id}/similar")
+
+        assert response.status_code == 200
+        assert response.json == {
+            "artists": [
+                {"id": first.id, "name": first.name, "image": first.thumbUrl},
+                {"id": second.id, "name": second.name, "image": second.thumbUrl},
+            ]
+        }
+
+    def test_skips_blacklisted_similar(self, client, requests_mock):
+        blacklisted = artist_factories.ArtistFactory(is_blacklisted=True)
+        ok_artist = artist_factories.ArtistFactory()
+        _link_artist_to_bookable_offer(ok_artist)
+        source_id = "00000000-0000-0000-0000-000000000001"
+
+        requests_mock.get(
+            DS_SIMILAR_ARTISTS_URL.format(artist_id=source_id),
+            content=_ds_response([blacklisted.id, ok_artist.id]),
+        )
+
+        with assert_num_queries(1):
+            response = client.get(f"/native/v1/artists/{source_id}/similar")
+
+        assert response.status_code == 200
+        assert len(response.json["artists"]) == 1
+        assert response.json["artists"][0]["id"] == ok_artist.id
+
+    def test_skips_similar_without_eligible_offer(self, client, requests_mock):
+        no_offer = artist_factories.ArtistFactory()
+        ok_artist = artist_factories.ArtistFactory()
+        _link_artist_to_bookable_offer(ok_artist)
+        source_id = "00000000-0000-0000-0000-000000000001"
+
+        requests_mock.get(
+            DS_SIMILAR_ARTISTS_URL.format(artist_id=source_id),
+            content=_ds_response([no_offer.id, ok_artist.id]),
+        )
+
+        with assert_num_queries(1):
+            response = client.get(f"/native/v1/artists/{source_id}/similar")
+
+        assert response.status_code == 200
+        assert len(response.json["artists"]) == 1
+        assert response.json["artists"][0]["id"] == ok_artist.id
+
+    def test_empty_when_ds_returns_empty_list(self, client, requests_mock):
+        source_id = "00000000-0000-0000-0000-000000000001"
+
+        requests_mock.get(
+            DS_SIMILAR_ARTISTS_URL.format(artist_id=source_id),
+            content=_ds_response([]),
+        )
+
+        with assert_num_queries(0):
+            response = client.get(f"/native/v1/artists/{source_id}/similar")
+
+        assert response.status_code == 200
+        assert response.json == {"artists": []}
+
+    def test_empty_on_recommendation_api_timeout(self, client, requests_mock):
+        from pcapi.utils import requests as pcapi_requests
+
+        source_id = "00000000-0000-0000-0000-000000000001"
+        requests_mock.get(
+            DS_SIMILAR_ARTISTS_URL.format(artist_id=source_id),
+            exc=pcapi_requests.exceptions.Timeout,
+        )
+
+        with assert_num_queries(0):
+            response = client.get(f"/native/v1/artists/{source_id}/similar")
+
+        assert response.status_code == 200
+        assert response.json == {"artists": []}
+
+    def test_empty_on_recommendation_api_error(self, client, requests_mock):
+        from pcapi.utils import requests as pcapi_requests
+
+        source_id = "00000000-0000-0000-0000-000000000001"
+        requests_mock.get(
+            DS_SIMILAR_ARTISTS_URL.format(artist_id=source_id),
+            exc=pcapi_requests.exceptions.ConnectionError,
+        )
+
+        with assert_num_queries(0):
+            response = client.get(f"/native/v1/artists/{source_id}/similar")
+
+        assert response.status_code == 200
+        assert response.json == {"artists": []}
+
+
+def test_returns_400_when_artist_id_is_not_a_uuid(client):
+    with assert_num_queries(0):
+        response = client.get("/native/v1/artists/not-a-uuid/similar")
+
+    assert response.status_code == 400

--- a/api/tests/test_flask_app.py
+++ b/api/tests/test_flask_app.py
@@ -48,6 +48,7 @@ KNOWN_PUBLIC_ENDPOINTS = [
     "native.native_v1.email_validation_remaining_resends",  # → response.status_code = 200
     "native.native_v1.empty_email_validation_remaining_resends",  # → response.status_code = 200
     "native.native_v1.get_artist",  # → response.status_code = 404
+    "native.native_v1.get_similar_artists",  # → response.status_code = 200
     "native.native_v1.get_categories",  # → response.status_code = 200
     "native.native_v1.get_movie_screenings_by_venue",  # → response.status_code = 200
     "native.native_v1.get_offer",  # → response.status_code = 404


### PR DESCRIPTION
## Contexte

Ticket [PC-40019](https://passculture.atlassian.net/browse/PC-40019)

## Changements

- Nouvelle route GET /native/v1/artists/<artist_id>/similar → jusqu'à NATIVE_SIMILAR_ARTISTS_MAX_COUNT (10) artistes similaires (id, name, image). 200 + [] si la source est inexistante ou blacklistée.
- Nouvelle table artist_similar_artist (artist_id, similar_artist_id, similarity_rank), alimentée par l'équipe DS.
- Migrations séparées : pre = CREATE TABLE, post = CREATE INDEX CONCURRENTLY.
- Repository get_similar_artists_for_native en une seule query (filtre éligibilité + EXISTS sur la source).
- Factory ArtistSimilarArtistFactory + tests route (ordre, filtres, num queries).


## Hors scope

- Le champ `category` mentionné dans le ticket est mis de côté en accord avec le PO, à préciser dans un futur ticket.


[PC-40019]: https://passculture.atlassian.net/browse/PC-40019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ