### PR TITLE
(PC-41603)[API] script: replace artist ids that haven't been created by user with artist custom name

### DIFF
--- a/api/src/pcapi/scripts/clean_artist_again/main.py
+++ b/api/src/pcapi/scripts/clean_artist_again/main.py
@@ -4,7 +4,7 @@ Job console documentation here: https://www.notion.so/passcultureapp/Documentati
 You can start the job from the infra repository with github cli :
 
 gh workflow run on_dispatch_pcapi_console_job.yaml \
-  -f ENVIRONMENT_SHORT_NAME=tst \
+  -f ENVIRONMENT_SHORT_NAME=stg \
   -f RESOURCES="512Mi/.5" \
   -f BRANCH_NAME=ogeber/pc-41603-rattrapage-artistes-encore \
   -f NAMESPACE=clean_artist_again \
@@ -21,19 +21,17 @@ import typing
 import unicodedata
 
 import sqlalchemy as sa
-import sqlalchemy.exc as sa_exc
+from sqlalchemy.orm import joinedload
 
 from pcapi.core.artist import models as artist_models
+from pcapi.core.offers import models as offers_models
 from pcapi.models import db
-from pcapi.utils.transaction_manager import atomic
 
 
 logger = logging.getLogger(__name__)
 
 BATCH_SIZE = 1000
 OFFER_ID_HEADER = "offer_id"
-CUSTOM_NAME_HEADER = "custom_name"
-ARTIST_ID_HEADER = "artist_id"
 ARTIST_TYPE_HEADER = "artist_type"
 
 
@@ -54,97 +52,123 @@ def slugify_name(name: str) -> str:
     return "".join(c for c in normalized if unicodedata.category(c) != "Mn").lower().strip()
 
 
-def process_batch(batch_rows: tuple, commit: bool) -> None:
-    artist_ids_to_fetch = set()
-    rows_to_process = []
-
-    for row in batch_rows:
-        offer_id = int(row.get(OFFER_ID_HEADER))
-        artist_id = str(row.get(ARTIST_ID_HEADER)) if row.get(ARTIST_ID_HEADER) else None
-        artist_type = row.get(ARTIST_TYPE_HEADER)
-
-        if artist_id:
-            rows_to_process.append({"offer_id": offer_id, "artist_id": artist_id, "artist_type": artist_type})
-            artist_ids_to_fetch.add(artist_id)
-
-    if not rows_to_process:
-        return
-
-    # Récupération des artist_name depuis la table Artist
-    stmt = sa.select(artist_models.Artist.id, artist_models.Artist.name).where(
-        artist_models.Artist.id.in_(artist_ids_to_fetch)
-    )
-    artist_names_mapping = {str(r.id): r.name for r in db.session.execute(stmt).all()}
-
-    # Offres mises à jour, pour supprimer les doublons ensuite
+def _update_artist_offer_links(rows_to_process: dict, offers_mapping: dict, links_mapping: dict) -> set:
     modified_offers = set()
 
-    # 1/2 : Remplacer les ArtistOfferLink ayant un artist_id par le artist.name dans le custom_name
-    for item in rows_to_process:
-        offer_id = item["offer_id"]
-        artist_id = item["artist_id"]
-        artist_type = item["artist_type"]
+    for o_id, a_type in rows_to_process.keys():
+        offer = offers_mapping.get(o_id)
+        extra_data = offer.extraData if offer else None
+        name_to_keep = extra_data.get(a_type) if extra_data else None
 
-        resolved_name = artist_names_mapping.get(artist_id)
-        if not resolved_name:
-            logger.warning(f"Nom introuvable pour l'artiste {artist_id} (offre {offer_id})")
+        if not name_to_keep:
             continue
 
-        try:
-            with atomic():
-                update_stmt = (
-                    sa.update(artist_models.ArtistOfferLink)
-                    .filter_by(offer_id=offer_id, artist_id=artist_id, artist_type=artist_type)
-                    .values(artist_id=None, custom_name=resolved_name)
-                )
-                db.session.execute(update_stmt)
-                modified_offers.add(offer_id)
+        existing_links = [link for link in links_mapping.get(o_id, []) if link.artist_type.value == a_type]
 
-        except sa_exc.IntegrityError:
-            # On a déjà un ArtistOfferLink avec ce tuple (offer_id, custom_name, artist_type) sans artist_id
-            logger.info(f"Doublon détecté : suppression du lien pour l'offre {offer_id}, artiste {artist_id}")
-            delete_stmt = sa.delete(artist_models.ArtistOfferLink).filter_by(
-                offer_id=offer_id, artist_id=artist_id, artist_type=artist_type
+        if not existing_links:
+            continue
+
+        existing_link_to_keep = next(
+            (link for link in existing_links if link.artist_id is None and link.custom_name == name_to_keep), None
+        )
+
+        if existing_link_to_keep:
+            duplicates = [link for link in existing_links if link.id != existing_link_to_keep.id]
+        else:
+            existing_link_to_update = existing_links[0]
+            duplicates = existing_links[1:]
+
+            update_stmt = (
+                sa.update(artist_models.ArtistOfferLink)
+                .where(artist_models.ArtistOfferLink.id == existing_link_to_update.id)
+                .values(custom_name=name_to_keep, artist_id=None)
+            )
+            db.session.execute(update_stmt)
+
+        modified_offers.add(o_id)
+
+        for duplicate in duplicates:
+            delete_stmt = sa.delete(artist_models.ArtistOfferLink).where(
+                artist_models.ArtistOfferLink.id == duplicate.id
             )
             db.session.execute(delete_stmt)
+            logger.info(f"Offre {o_id} ({a_type}) : Suppression du lien doublon ID {duplicate.id}")
+
+    return modified_offers
+
+
+def _clean_duplicates(modified_offers: set) -> None:
+    cleanup_stmt = sa.select(
+        artist_models.ArtistOfferLink.id,
+        artist_models.ArtistOfferLink.offer_id,
+        artist_models.ArtistOfferLink.artist_type,
+        artist_models.ArtistOfferLink.custom_name,
+    ).where(
+        artist_models.ArtistOfferLink.offer_id.in_(list(modified_offers)),
+        artist_models.ArtistOfferLink.artist_id.is_(None),
+    )
+
+    existing_links = db.session.execute(cleanup_stmt).all()
+
+    # Si on a le même tuple (offer_id, artist_type, slug_name) -> On ne garde que la première ligne
+    seen_combinations = {}
+    links_ids_to_delete = []
+
+    for link in existing_links:
+        slug = slugify_name(link.custom_name)
+        key = (link.offer_id, link.artist_type, slug)
+
+        if key in seen_combinations:
+            # le tuple (offer_id, artist_type, slug_name) à déjà été vu : on marque cet ArtistOfferLink pour être supprimé
+            links_ids_to_delete.append(link.id)
+            logger.info(
+                f"Doublon détecté pour l'ArtistOfferLink {link.id}) sur l'offre {link.offer_id} avec le nom {link.custom_name}."
+            )
+        else:
+            seen_combinations[key] = link.id
+
+    if links_ids_to_delete:
+        delete_duplicates_stmt = sa.delete(artist_models.ArtistOfferLink).where(
+            artist_models.ArtistOfferLink.id.in_(links_ids_to_delete)
+        )
+        db.session.execute(delete_duplicates_stmt)
+        logger.info(f"{len(links_ids_to_delete)} liens en doublon supprimés de la table ArtistOfferLink.")
+
+
+def process_batch(batch_rows: tuple, commit: bool) -> None:
+    offer_ids_to_fetch = []
+    rows = []
+
+    for row in batch_rows:
+        o_id = int(row.get(OFFER_ID_HEADER))
+        a_type = row.get(ARTIST_TYPE_HEADER)
+        offer_ids_to_fetch.append(o_id)
+        rows.append({"offer_id": o_id, "artist_type": a_type})
+
+    rows_to_process = {(r["offer_id"], r["artist_type"]): r for r in rows}
+    offer_stmt = (
+        sa.select(offers_models.Offer)
+        .where(offers_models.Offer.id.in_(list(offer_ids_to_fetch)))
+        .options(joinedload(offers_models.Offer.product))
+    )
+    offers_mapping = {offer.id: offer for offer in db.session.scalars(offer_stmt).all()}
+
+    links_stmt = sa.select(artist_models.ArtistOfferLink).where(
+        artist_models.ArtistOfferLink.offer_id.in_(list(offer_ids_to_fetch))
+    )
+
+    links_mapping: dict[int, list] = dict()
+    for link in db.session.scalars(links_stmt).all():
+        if link.offer_id not in links_mapping:
+            links_mapping[link.offer_id] = []
+        links_mapping[link.offer_id].append(link)
+
+    # 1/2 : Remplacer les ArtistOfferLink ayant un custom_name uniquement par la bonne valeur dans les extraData
+    modified_offers = _update_artist_offer_links(rows_to_process, offers_mapping, links_mapping)
 
     # 2/2 on supprime les doublons (cf ticket JIRA)
     if modified_offers:
-        cleanup_stmt = sa.select(
-            artist_models.ArtistOfferLink.id,
-            artist_models.ArtistOfferLink.offer_id,
-            artist_models.ArtistOfferLink.artist_type,
-            artist_models.ArtistOfferLink.custom_name,
-        ).where(
-            artist_models.ArtistOfferLink.offer_id.in_(list(modified_offers)),
-            artist_models.ArtistOfferLink.artist_id.is_(None),
-        )
-
-        existing_links = db.session.execute(cleanup_stmt).all()
-
-        # Si on a le même tuple (offer_id, artist_type, slug_name) -> On ne garde que la première ligne
-        seen_combinations = {}
-        links_ids_to_delete = []
-
-        for link in existing_links:
-            slug = slugify_name(link.custom_name)
-            key = (link.offer_id, link.artist_type, slug)
-
-            if key in seen_combinations:
-                # le tuple (offer_id, artist_type, slug_name) à déjà été vu : on marque cet ArtistOfferLink pour être supprimé
-                links_ids_to_delete.append(link.id)
-                logger.info(
-                    f"Doublon détecté pour l'ArtistOfferLink {link.id}) sur l'offre {link.offer_id} avec le nom {link.custom_name}."
-                )
-            else:
-                seen_combinations[key] = link.id
-
-        if links_ids_to_delete:
-            delete_duplicates_stmt = sa.delete(artist_models.ArtistOfferLink).where(
-                artist_models.ArtistOfferLink.id.in_(links_ids_to_delete)
-            )
-            db.session.execute(delete_duplicates_stmt)
-            logger.info(f"{len(links_ids_to_delete)} liens en doublon supprimés de la table ArtistOfferLink.")
+        _clean_duplicates(modified_offers)
 
     if commit:
         db.session.commit()

--- a/api/src/pcapi/scripts/clean_artist_again/main.py
+++ b/api/src/pcapi/scripts/clean_artist_again/main.py
@@ -10,190 +10,104 @@ gh workflow run on_dispatch_pcapi_console_job.yaml \
   -f NAMESPACE=clean_artist_again \
   -f SCRIPT_ARGUMENTS="";
 
+Rebuilds ArtistOfferLink rows for every offer created before CUTOFF_DATE:
+
+  1. Deletes all ArtistOfferLink rows for those offers (including offers linked to a product).
+  2. Re-creates one ArtistOfferLink per relevant artist_type present in the offer's extraData, with `(artist_id=None, custom_name=<exact extraData value>)`.
+     The raw extraData value is copied into custom_name. Offers linked to a product are NOT re-created.
 """
 
 import argparse
-import csv
-import itertools
 import logging
-import os
 import typing
-import unicodedata
 
 import sqlalchemy as sa
-from sqlalchemy.orm import joinedload
 
-from pcapi.core.artist import models as artist_models
-from pcapi.core.offers import models as offers_models
 from pcapi.models import db
 
 
 logger = logging.getLogger(__name__)
 
-BATCH_SIZE = 1000
-OFFER_ID_HEADER = "offer_id"
-ARTIST_TYPE_HEADER = "artist_type"
+BATCH_SIZE = 50_000
+DEFAULT_MIN_ID = 0
+DEFAULT_MAX_ID = 50000
 
 
-def read_csv_file(filename: str) -> typing.Iterator[dict[str, str]]:
-    namespace_dir = os.path.dirname(os.path.abspath(__file__))
-    with open(f"{namespace_dir}/{filename}.csv", "r", encoding="utf-8") as csv_file:
-        csv_rows = csv.DictReader(csv_file, delimiter=",")
-        yield from csv_rows
-
-
-def slugify_name(name: str) -> str:
+_DELETE_SQL = sa.text(
     """
-    Retourne le nom en minuscule et sans accents
+    DELETE FROM artist_offer_link
+    WHERE offer_id BETWEEN :low AND :high
     """
-    if not name:
-        return ""
-    normalized = unicodedata.normalize("NFD", name)
-    return "".join(c for c in normalized if unicodedata.category(c) != "Mn").lower().strip()
+)
+
+_INSERT_SQL = sa.text(
+    """
+    INSERT INTO artist_offer_link (offer_id, artist_type, custom_name)
+    SELECT DISTINCT sub.offer_id,
+        CASE kv.key WHEN 'stageDirector' THEN 'stage_director' ELSE kv.key END,
+        kv.value
+    FROM (
+        SELECT
+            o.id AS offer_id,
+            o."jsonData" AS extra_data
+        FROM offer o
+        WHERE o.id BETWEEN :low AND :high
+          AND o."productId" IS NULL
+    ) sub
+    CROSS JOIN LATERAL jsonb_each_text(
+        CASE WHEN jsonb_typeof(sub.extra_data) = 'object' THEN sub.extra_data ELSE '{}'::jsonb END
+    ) AS kv
+    WHERE kv.key IN ('author', 'performer', 'stageDirector')
+      AND kv.value IS NOT NULL
+      AND btrim(kv.value) <> ''
+    ON CONFLICT DO NOTHING
+    """
+)
+
+_INSERT_SQL_WITH_RETURN = sa.text(_INSERT_SQL.text + " RETURNING offer_id, artist_type, custom_name")
 
 
-def _update_artist_offer_links(rows_to_process: dict, offers_mapping: dict, links_mapping: dict) -> set:
-    modified_offers = set()
+def _process_range(low: int, high: int, verbose: bool) -> int:
+    params = {"low": low, "high": high}
+    db.session.execute(_DELETE_SQL, params)
+    if verbose:
+        rows = db.session.execute(_INSERT_SQL_WITH_RETURN, params).all()
+        for offer_id, artist_type, custom_name in rows:
+            logger.info("  offre %s : %s = %r", offer_id, artist_type, custom_name)
+        return len(rows)
+    else:
+        result = typing.cast(sa.CursorResult, db.session.execute(_INSERT_SQL, params))
+        return result.rowcount or 0
 
-    for o_id, a_type in rows_to_process.keys():
-        offer = offers_mapping.get(o_id)
-        extra_data = offer.extraData if offer else None
-        name_to_keep = extra_data.get(a_type) if extra_data else None
 
-        if not name_to_keep:
-            continue
+def main(
+    commit: bool,
+    min_offer_id: int = DEFAULT_MIN_ID,
+    max_offer_id: int = DEFAULT_MAX_ID,
+    batch_size: int = BATCH_SIZE,
+    verbose: bool = False,
+) -> None:
+    logger.info("Traitement des offres %s..%s (commit=%s)", min_offer_id, max_offer_id, commit)
+    low = min_offer_id
 
-        existing_links = [link for link in links_mapping.get(o_id, []) if link.artist_type.value == a_type]
+    total_created = 0
+    while low <= max_offer_id:
+        high = min(low + batch_size - 1, max_offer_id)
+        created = _process_range(low, high, verbose)
+        total_created += created
+        logger.info("Batch %s..%s : %s liens créés", low, high, created)
 
-        if not existing_links:
-            continue
-
-        existing_link_to_keep = next(
-            (link for link in existing_links if link.artist_id is None and link.custom_name == name_to_keep), None
-        )
-
-        if existing_link_to_keep:
-            duplicates = [link for link in existing_links if link.id != existing_link_to_keep.id]
+        if commit:
+            db.session.commit()
         else:
-            existing_link_to_update = existing_links[0]
-            duplicates = existing_links[1:]
-
-            update_stmt = (
-                sa.update(artist_models.ArtistOfferLink)
-                .where(artist_models.ArtistOfferLink.id == existing_link_to_update.id)
-                .values(custom_name=name_to_keep, artist_id=None)
-            )
-            db.session.execute(update_stmt)
-
-        modified_offers.add(o_id)
-
-        for duplicate in duplicates:
-            delete_stmt = sa.delete(artist_models.ArtistOfferLink).where(
-                artist_models.ArtistOfferLink.id == duplicate.id
-            )
-            db.session.execute(delete_stmt)
-            logger.info(f"Offre {o_id} ({a_type}) : Suppression du lien doublon ID {duplicate.id}")
-
-    return modified_offers
-
-
-def _clean_duplicates(modified_offers: set) -> None:
-    cleanup_stmt = sa.select(
-        artist_models.ArtistOfferLink.id,
-        artist_models.ArtistOfferLink.offer_id,
-        artist_models.ArtistOfferLink.artist_type,
-        artist_models.ArtistOfferLink.custom_name,
-    ).where(
-        artist_models.ArtistOfferLink.offer_id.in_(list(modified_offers)),
-        artist_models.ArtistOfferLink.artist_id.is_(None),
-    )
-
-    existing_links = db.session.execute(cleanup_stmt).all()
-
-    # Si on a le même tuple (offer_id, artist_type, slug_name) -> On ne garde que la première ligne
-    seen_combinations = {}
-    links_ids_to_delete = []
-
-    for link in existing_links:
-        slug = slugify_name(link.custom_name)
-        key = (link.offer_id, link.artist_type, slug)
-
-        if key in seen_combinations:
-            # le tuple (offer_id, artist_type, slug_name) à déjà été vu : on marque cet ArtistOfferLink pour être supprimé
-            links_ids_to_delete.append(link.id)
-            logger.info(
-                f"Doublon détecté pour l'ArtistOfferLink {link.id}) sur l'offre {link.offer_id} avec le nom {link.custom_name}."
-            )
-        else:
-            seen_combinations[key] = link.id
-
-    if links_ids_to_delete:
-        delete_duplicates_stmt = sa.delete(artist_models.ArtistOfferLink).where(
-            artist_models.ArtistOfferLink.id.in_(links_ids_to_delete)
-        )
-        db.session.execute(delete_duplicates_stmt)
-        logger.info(f"{len(links_ids_to_delete)} liens en doublon supprimés de la table ArtistOfferLink.")
-
-
-def process_batch(batch_rows: tuple, commit: bool) -> None:
-    offer_ids_to_fetch = []
-    rows = []
-
-    for row in batch_rows:
-        o_id = int(row.get(OFFER_ID_HEADER))
-        a_type = row.get(ARTIST_TYPE_HEADER)
-        offer_ids_to_fetch.append(o_id)
-        rows.append({"offer_id": o_id, "artist_type": a_type})
-
-    rows_to_process = {(r["offer_id"], r["artist_type"]): r for r in rows}
-    offer_stmt = (
-        sa.select(offers_models.Offer)
-        .where(offers_models.Offer.id.in_(list(offer_ids_to_fetch)))
-        .options(joinedload(offers_models.Offer.product))
-    )
-    offers_mapping = {offer.id: offer for offer in db.session.scalars(offer_stmt).all()}
-
-    links_stmt = sa.select(artist_models.ArtistOfferLink).where(
-        artist_models.ArtistOfferLink.offer_id.in_(list(offer_ids_to_fetch))
-    )
-
-    links_mapping: dict[int, list] = dict()
-    for link in db.session.scalars(links_stmt).all():
-        if link.offer_id not in links_mapping:
-            links_mapping[link.offer_id] = []
-        links_mapping[link.offer_id].append(link)
-
-    # 1/2 : Remplacer les ArtistOfferLink ayant un custom_name uniquement par la bonne valeur dans les extraData
-    modified_offers = _update_artist_offer_links(rows_to_process, offers_mapping, links_mapping)
-
-    # 2/2 on supprime les doublons (cf ticket JIRA)
-    if modified_offers:
-        _clean_duplicates(modified_offers)
+            db.session.flush()
+        low = high + 1
 
     if commit:
-        db.session.commit()
+        logger.info("Script terminé avec succès — %s liens créés au total", total_created)
     else:
-        db.session.flush()
-
-    logger.info("Fin du batch")
-    db.session.expunge_all()
-
-
-def main(commit: bool, filename: str, start_from_batch: int = 1) -> None:
-    rows = read_csv_file(filename)
-
-    for batch_idx, batch_rows in enumerate(itertools.batched(rows, BATCH_SIZE), start=1):
-        if batch_idx < start_from_batch:
-            continue
-
-        logger.info(f"Traitement du batch {batch_idx}")
-        process_batch(batch_rows, commit)
-
-    if not commit:
         db.session.rollback()
-        logger.info("Dry run terminé, rollback des données")
-    else:
-        logger.info("Script terminé avec succès")
+        logger.info("Dry run terminé (%s liens auraient été créés), rollback des données", total_created)
 
 
 if __name__ == "__main__":
@@ -203,8 +117,37 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--commit", action="store_true")
-    parser.add_argument("--start-from-batch", type=int, default=1)
+    parser.add_argument(
+        "--min-offer-id",
+        type=int,
+        default=DEFAULT_MIN_ID,
+        help="Resume from this offer id (inclusive).",
+    )
+    parser.add_argument(
+        "--max-offer-id",
+        type=int,
+        default=DEFAULT_MAX_ID,
+        help="Stop at this offer id (inclusive).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=BATCH_SIZE,
+        help="Offer id range processed per batch.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Log every created artist_offer_link (offer id, artist type, custom name).",
+    )
     args = parser.parse_args()
-    filename = "artist_cleanup"
 
-    main(commit=args.commit, start_from_batch=args.start_from_batch, filename=filename)
+    db.session.execute(sa.text("SET SESSION statement_timeout = '1200s'"))  # 20 minutes
+
+    main(
+        commit=args.commit,
+        min_offer_id=args.min_offer_id,
+        max_offer_id=args.max_offer_id,
+        batch_size=args.batch_size,
+        verbose=args.verbose,
+    )

--- a/api/src/pcapi/scripts/clean_artist_again/main.py
+++ b/api/src/pcapi/scripts/clean_artist_again/main.py
@@ -1,0 +1,186 @@
+"""
+Job console documentation here: https://www.notion.so/passcultureapp/Documentation-Job-Console-769beeacd5a146de9c97b6f8ee544276
+
+You can start the job from the infra repository with github cli :
+
+gh workflow run on_dispatch_pcapi_console_job.yaml \
+  -f ENVIRONMENT_SHORT_NAME=tst \
+  -f RESOURCES="512Mi/.5" \
+  -f BRANCH_NAME=ogeber/pc-41603-rattrapage-artistes-encore \
+  -f NAMESPACE=clean_artist_again \
+  -f SCRIPT_ARGUMENTS="";
+
+"""
+
+import argparse
+import csv
+import itertools
+import logging
+import os
+import typing
+import unicodedata
+
+import sqlalchemy as sa
+import sqlalchemy.exc as sa_exc
+
+from pcapi.core.artist import models as artist_models
+from pcapi.models import db
+from pcapi.utils.transaction_manager import atomic
+
+
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 1000
+OFFER_ID_HEADER = "offer_id"
+CUSTOM_NAME_HEADER = "custom_name"
+ARTIST_ID_HEADER = "artist_id"
+ARTIST_TYPE_HEADER = "artist_type"
+
+
+def read_csv_file(filename: str) -> typing.Iterator[dict[str, str]]:
+    namespace_dir = os.path.dirname(os.path.abspath(__file__))
+    with open(f"{namespace_dir}/{filename}.csv", "r", encoding="utf-8") as csv_file:
+        csv_rows = csv.DictReader(csv_file, delimiter=",")
+        yield from csv_rows
+
+
+def slugify_name(name: str) -> str:
+    """
+    Retourne le nom en minuscule et sans accents
+    """
+    if not name:
+        return ""
+    normalized = unicodedata.normalize("NFD", name)
+    return "".join(c for c in normalized if unicodedata.category(c) != "Mn").lower().strip()
+
+
+def process_batch(batch_rows: tuple, commit: bool) -> None:
+    artist_ids_to_fetch = set()
+    rows_to_process = []
+
+    for row in batch_rows:
+        offer_id = int(row.get(OFFER_ID_HEADER))
+        artist_id = str(row.get(ARTIST_ID_HEADER)) if row.get(ARTIST_ID_HEADER) else None
+        artist_type = row.get(ARTIST_TYPE_HEADER)
+
+        if artist_id:
+            rows_to_process.append({"offer_id": offer_id, "artist_id": artist_id, "artist_type": artist_type})
+            artist_ids_to_fetch.add(artist_id)
+
+    if not rows_to_process:
+        return
+
+    # Récupération des artist_name depuis la table Artist
+    stmt = sa.select(artist_models.Artist.id, artist_models.Artist.name).where(
+        artist_models.Artist.id.in_(artist_ids_to_fetch)
+    )
+    artist_names_mapping = {str(r.id): r.name for r in db.session.execute(stmt).all()}
+
+    # Offres mises à jour, pour supprimer les doublons ensuite
+    modified_offers = set()
+
+    # 1/2 : Remplacer les ArtistOfferLink ayant un artist_id par le artist.name dans le custom_name
+    for item in rows_to_process:
+        offer_id = item["offer_id"]
+        artist_id = item["artist_id"]
+        artist_type = item["artist_type"]
+
+        resolved_name = artist_names_mapping.get(artist_id)
+        if not resolved_name:
+            logger.warning(f"Nom introuvable pour l'artiste {artist_id} (offre {offer_id})")
+            continue
+
+        try:
+            with atomic():
+                update_stmt = (
+                    sa.update(artist_models.ArtistOfferLink)
+                    .filter_by(offer_id=offer_id, artist_id=artist_id, artist_type=artist_type)
+                    .values(artist_id=None, custom_name=resolved_name)
+                )
+                db.session.execute(update_stmt)
+                modified_offers.add(offer_id)
+
+        except sa_exc.IntegrityError:
+            # On a déjà un ArtistOfferLink avec ce tuple (offer_id, custom_name, artist_type) sans artist_id
+            logger.info(f"Doublon détecté : suppression du lien pour l'offre {offer_id}, artiste {artist_id}")
+            delete_stmt = sa.delete(artist_models.ArtistOfferLink).filter_by(
+                offer_id=offer_id, artist_id=artist_id, artist_type=artist_type
+            )
+            db.session.execute(delete_stmt)
+
+    # 2/2 on supprime les doublons (cf ticket JIRA)
+    if modified_offers:
+        cleanup_stmt = sa.select(
+            artist_models.ArtistOfferLink.id,
+            artist_models.ArtistOfferLink.offer_id,
+            artist_models.ArtistOfferLink.artist_type,
+            artist_models.ArtistOfferLink.custom_name,
+        ).where(
+            artist_models.ArtistOfferLink.offer_id.in_(list(modified_offers)),
+            artist_models.ArtistOfferLink.artist_id.is_(None),
+        )
+
+        existing_links = db.session.execute(cleanup_stmt).all()
+
+        # Si on a le même tuple (offer_id, artist_type, slug_name) -> On ne garde que la première ligne
+        seen_combinations = {}
+        links_ids_to_delete = []
+
+        for link in existing_links:
+            slug = slugify_name(link.custom_name)
+            key = (link.offer_id, link.artist_type, slug)
+
+            if key in seen_combinations:
+                # le tuple (offer_id, artist_type, slug_name) à déjà été vu : on marque cet ArtistOfferLink pour être supprimé
+                links_ids_to_delete.append(link.id)
+                logger.info(
+                    f"Doublon détecté pour l'ArtistOfferLink {link.id}) sur l'offre {link.offer_id} avec le nom {link.custom_name}."
+                )
+            else:
+                seen_combinations[key] = link.id
+
+        if links_ids_to_delete:
+            delete_duplicates_stmt = sa.delete(artist_models.ArtistOfferLink).where(
+                artist_models.ArtistOfferLink.id.in_(links_ids_to_delete)
+            )
+            db.session.execute(delete_duplicates_stmt)
+            logger.info(f"{len(links_ids_to_delete)} liens en doublon supprimés de la table ArtistOfferLink.")
+
+    if commit:
+        db.session.commit()
+    else:
+        db.session.flush()
+
+    logger.info("Fin du batch")
+    db.session.expunge_all()
+
+
+def main(commit: bool, filename: str, start_from_batch: int = 1) -> None:
+    rows = read_csv_file(filename)
+
+    for batch_idx, batch_rows in enumerate(itertools.batched(rows, BATCH_SIZE), start=1):
+        if batch_idx < start_from_batch:
+            continue
+
+        logger.info(f"Traitement du batch {batch_idx}")
+        process_batch(batch_rows, commit)
+
+    if not commit:
+        db.session.rollback()
+        logger.info("Dry run terminé, rollback des données")
+    else:
+        logger.info("Script terminé avec succès")
+
+
+if __name__ == "__main__":
+    from pcapi.app import app
+
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--commit", action="store_true")
+    parser.add_argument("--start-from-batch", type=int, default=1)
+    args = parser.parse_args()
+    filename = "artist_cleanup"
+
+    main(commit=args.commit, start_from_batch=args.start_from_batch, filename=filename)

--- a/api/tests/scripts/clean_artist_again/test_main.py
+++ b/api/tests/scripts/clean_artist_again/test_main.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+import logging
 
 import pytest
 
@@ -7,245 +7,180 @@ from pcapi.core.artist import models as artist_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.models import db
 from pcapi.scripts.clean_artist_again.main import main
-from pcapi.scripts.clean_artist_again.main import slugify_name
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-def test_slugify():
-    name = "Lucía Sánchez Saornil"
-    assert slugify_name(name) == "lucia sanchez saornil"
-
-
-@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
-def test_with_custom_name_and_artist_id(mock_read_csv):
-    offer = offers_factories.OfferFactory(extraData={"author": "Ursula K. Le Guin"})
-    offer_id = offer.id
-    artist = artist_factories.ArtistFactory(name="ursula k. le guin")
-    artist_id = artist.id
-    artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id,
-        artist_id=artist_id,
-        custom_name="ursula k. le guin",
-        artist_type=artist_models.ArtistType.AUTHOR,
+def _links_for(offer_id: int) -> list[artist_models.ArtistOfferLink]:
+    return (
+        db.session.query(artist_models.ArtistOfferLink)
+        .filter_by(offer_id=offer_id)
+        .order_by(artist_models.ArtistOfferLink.artist_type, artist_models.ArtistOfferLink.custom_name)
+        .all()
     )
 
-    mock_read_csv.return_value = [
-        {
-            "offer_id": str(offer_id),
-            "custom_name": "ursula k. le guin",
-            "artist_id": str(artist_id),
-            "artist_type": artist_models.ArtistType.AUTHOR.value,
-        }
-    ]
 
-    main(commit=True, filename="mock_filename")
+def test_creates_link_from_extra_data():
+    offer = offers_factories.OfferFactory(extraData={"author": "Author Name"})
 
-    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
-    assert link is not None
-    assert link.offer_id == offer_id
-    assert link.artist_id == None
-    assert link.custom_name == "Ursula K. Le Guin"
-    assert link.artist_name == "Ursula K. Le Guin"
+    main(commit=True, min_offer_id=offer.id, max_offer_id=offer.id)
+
+    links = _links_for(offer.id)
+    assert len(links) == 1
+    assert links[0].artist_id is None
+    assert links[0].custom_name == "Author Name"
+    assert links[0].artist_type == artist_models.ArtistType.AUTHOR
 
 
-@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
-def test_with_custom_name_and_no_artist_id(mock_read_csv):
+def test_empty_values_produce_no_links():
     offer = offers_factories.OfferFactory(
-        extraData={"author": "Ursula K. Le Guin"},
+        extraData={"author": "", "performer": "   ", "stageDirector": None},
     )
-    offer_id = offer.id
+
+    main(commit=True, min_offer_id=offer.id, max_offer_id=offer.id)
+
+    assert _links_for(offer.id) == []
+
+
+def test_only_relevant_artist_types_are_kept():
+    offer = offers_factories.OfferFactory(
+        extraData={
+            "author": "Author Name",
+            "performer": "Performer Name",
+            "stageDirector": "Stage Director Name",
+            "musicSubType": "Music Sub Type",
+        },
+    )
+
+    main(commit=True, min_offer_id=offer.id, max_offer_id=offer.id)
+
+    links = _links_for(offer.id)
+    assert {(link.artist_type, link.custom_name) for link in links} == {
+        (artist_models.ArtistType.AUTHOR, "Author Name"),
+        (artist_models.ArtistType.PERFORMER, "Performer Name"),
+        (artist_models.ArtistType.STAGE_DIRECTOR, "Stage Director Name"),
+    }
+
+
+def test_delete_existing_links():
+    offer = offers_factories.OfferFactory(extraData=None)
+    any_artist = artist_factories.ArtistFactory(name="Artist Name")
     artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id,
-        artist_id=None,
-        custom_name="ursula k. le guin",
+        offer_id=offer.id,
+        artist_id=any_artist.id,
+        custom_name=None,
         artist_type=artist_models.ArtistType.AUTHOR,
     )
-
-    mock_read_csv.return_value = [
-        {
-            "offer_id": str(offer_id),
-            "custom_name": "ursula k. le guin",
-            "artist_id": "",
-            "artist_type": artist_models.ArtistType.AUTHOR.value,
-        }
-    ]
-
-    main(commit=True, filename="mock_filename")
-
-    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
-    assert link is not None
-    assert link.offer_id == offer_id
-    assert link.artist_id == None
-    assert link.custom_name == "Ursula K. Le Guin"
-    assert link.artist_name == "Ursula K. Le Guin"
-
-
-@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
-def test_with_custom_name_and_no_artist_id_and_product(mock_read_csv):
-    product = offers_factories.ProductFactory(extraData={"author": "Ursula K. Le Guin"})
-    product_id = product.id
-    offer = offers_factories.OfferFactory(productId=product_id)
-    offer_id = offer.id
     artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id,
+        offer_id=offer.id,
         artist_id=None,
-        custom_name="ursula k. le guin",
+        custom_name="Custom Name",
         artist_type=artist_models.ArtistType.AUTHOR,
     )
 
-    mock_read_csv.return_value = [
-        {
-            "offer_id": str(offer_id),
-            "custom_name": "ursula k. le guin",
-            "artist_id": "",
-            "artist_type": artist_models.ArtistType.AUTHOR.value,
-        }
-    ]
+    main(commit=True, min_offer_id=offer.id, max_offer_id=offer.id)
 
-    main(commit=True, filename="mock_filename")
-
-    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
-    assert link is not None
-    assert link.offer_id == offer_id
-    assert link.artist_id == None
-    assert link.custom_name == "Ursula K. Le Guin"
-    assert link.artist_name == "Ursula K. Le Guin"
+    assert _links_for(offer.id) == []
 
 
-@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
-def test_without_artist_id_should_update(mock_read_csv):
-    offer = offers_factories.OfferFactory(extraData={"author": "Mariana Enriquez"})
-    offer_id = offer.id
-    artist = artist_factories.ArtistFactory(name="mariana enriquez")
-    artist_id = artist.id
+def test_offer_with_product_links_are_not_recreated():
+    product = offers_factories.ProductFactory(extraData={"author": "Product Author"})
+    offer = offers_factories.OfferFactory(
+        product=product,
+        extraData={"author": "Product Author"},
+    )
     artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id,
-        custom_name="mariana enriquez",
-        artist=None,
+        offer_id=offer.id,
+        artist_id=None,
+        custom_name="Custom Name",
         artist_type=artist_models.ArtistType.AUTHOR,
     )
 
-    mock_read_csv.return_value = [
-        {
-            "offer_id": str(offer_id),
-            "custom_name": "mariana enriquez",
-            "artist_id": str(artist_id),
-            "artist_type": artist_models.ArtistType.AUTHOR.value,
-        }
-    ]
+    main(commit=True, min_offer_id=offer.id, max_offer_id=offer.id)
 
-    main(commit=True, filename="mock_filename")
-
-    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
-    assert link is not None
-    assert link.offer_id == offer_id
-    assert link.artist_id == None
-    assert link.custom_name == "Mariana Enriquez"
-    assert link.artist_name == "Mariana Enriquez"
+    assert _links_for(offer.id) == []
 
 
-@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
-def test_handle_duplicates(mock_read_csv):
-    offer = offers_factories.OfferFactory(extraData={"author": "Lena Dunham", "performer": "Lena Dunham"})
-    another_offer = offers_factories.OfferFactory(extraData={"author": "Lena dunham"})
-    offer_id = offer.id
-    another_offer_id = another_offer.id
-
-    artist = artist_factories.ArtistFactory(name="lena dunham")
-    another_artist = artist_factories.ArtistFactory(name="lena dunham")
-    artist_id = artist.id
-    another_artist_id = another_artist.id
-
-    link_to_update = artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id, custom_name=None, artist_id=artist_id, artist_type=artist_models.ArtistType.AUTHOR
-    )  # a garder
-    link_to_delete = artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id,
-        custom_name=None,
-        artist_id=another_artist_id,
-        artist_type=artist_models.ArtistType.AUTHOR,
-    )  # a supprimer : doublon car artist_id est différent
-    link_different_type = artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id,
-        custom_name=None,
-        artist_id=artist_id,
-        artist_type=artist_models.ArtistType.PERFORMER,
-    )  # à garder: l'artist type est différent
-    link_different_offer = artist_factories.ArtistOfferLinkFactory(
-        offer_id=another_offer_id,
-        custom_name=None,
-        artist_id=another_artist_id,
-        artist_type=artist_models.ArtistType.AUTHOR,
-    )  # à garder: l'offre est différente
-    link_with_custom_name = artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id,
-        custom_name="Lena dunham",
+def test_dry_run_does_not_persist_changes():
+    offer = offers_factories.OfferFactory(extraData={"author": "Author Name"})
+    pre_existing = artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer.id,
         artist_id=None,
+        custom_name="Custom Name",
         artist_type=artist_models.ArtistType.AUTHOR,
-    )  # à supprimer : doublon avec link_to_update lorsqu'il sera mis à jour
+    )
+    pre_existing_id = pre_existing.id
+    db.session.commit()
 
-    link_to_update_id = link_to_update.id
-    link_to_delete_id = link_to_delete.id
-    link_different_type_id = link_different_type.id
-    link_different_offer_id = link_different_offer.id
-    link_with_custom_name_id = link_with_custom_name.id
-
-    mock_read_csv.return_value = [
-        {
-            "offer_id": str(offer_id),
-            "custom_name": "lena dunham",
-            "artist_id": str(artist.id),
-            "artist_type": artist_models.ArtistType.AUTHOR.value,
-        },  # on garde le link_to_update
-        {
-            "offer_id": str(offer_id),
-            "custom_name": "lena dunham",
-            "artist_id": str(another_artist.id),
-            "artist_type": artist_models.ArtistType.AUTHOR.value,
-        },  # cette ligne doit supprimer le link_to_delete
-        {
-            "offer_id": str(offer_id),
-            "custom_name": "lena dunham",
-            "artist_id": str(artist.id),
-            "artist_type": artist_models.ArtistType.PERFORMER.value,
-        },  # on garde également le link_different_type
-        {
-            "offer_id": str(another_offer_id),
-            "custom_name": "lena dunham",
-            "artist_id": str(another_artist.id),
-            "artist_type": artist_models.ArtistType.AUTHOR.value,
-        },  # on garde car c'est une autre offre
-        {
-            "offer_id": str(offer_id),
-            "custom_name": "lena dunham",
-            "artist_id": None,
-            "artist_type": artist_models.ArtistType.AUTHOR.value,
-        },  # on supprime car doublon avec link_to_update
-    ]
-
-    main(commit=True, filename="mock_filename")
+    main(commit=False, min_offer_id=offer.id, max_offer_id=offer.id)
 
     db.session.expire_all()
+    links = _links_for(offer.id)
+    assert len(links) == 1
+    assert links[0].id == pre_existing_id
+    assert links[0].custom_name == "Custom Name"
 
-    offer_links = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).all()
-    another_offer_links = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=another_offer_id).all()
 
-    assert len(offer_links) == 2
-    assert len(another_offer_links) == 1
+def test_processes_all_offers_in_range():
+    offer_a = offers_factories.OfferFactory(extraData={"author": "Author A"})
+    offer_b = offers_factories.OfferFactory(extraData={"performer": "Performer B"})
 
-    assert db.session.get(artist_models.ArtistOfferLink, link_to_update_id) is not None
-    assert db.session.get(artist_models.ArtistOfferLink, link_different_type_id) is not None
-    assert db.session.get(artist_models.ArtistOfferLink, link_different_offer_id) is not None
+    main(commit=True, min_offer_id=offer_a.id, max_offer_id=offer_b.id)
 
-    assert db.session.get(artist_models.ArtistOfferLink, link_to_delete_id) is None
-    assert db.session.get(artist_models.ArtistOfferLink, link_with_custom_name_id) is None
+    assert {link.custom_name for link in _links_for(offer_a.id)} == {"Author A"}
+    assert {link.custom_name for link in _links_for(offer_b.id)} == {"Performer B"}
 
-    for link in offer_links:
-        assert link.artist_id is None
-        assert link.custom_name == "Lena Dunham"
 
-    for link in another_offer_links:
-        assert link.artist_id is None
-        assert link.custom_name == "Lena dunham"
+def test_min_offer_id_skips_earlier_offers():
+    offer_a = offers_factories.OfferFactory(extraData={"author": "Author A"})
+    offer_b = offers_factories.OfferFactory(extraData={"author": "Author B"})
+    skipped_link = artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_a.id,
+        artist_id=None,
+        custom_name="Custom Name",
+        artist_type=artist_models.ArtistType.PERFORMER,
+    )
+    skipped_link_id = skipped_link.id
+
+    main(commit=True, min_offer_id=offer_b.id, max_offer_id=offer_b.id)
+
+    links_a = _links_for(offer_a.id)
+    assert len(links_a) == 1
+    assert links_a[0].id == skipped_link_id
+    assert {link.custom_name for link in _links_for(offer_b.id)} == {"Author B"}
+
+
+def test_max_offer_id_skips_later_offers():
+    offer_a = offers_factories.OfferFactory(extraData={"author": "Author A"})
+    offer_b = offers_factories.OfferFactory(extraData={"author": "Author B"})
+    skipped_link = artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_b.id,
+        artist_id=None,
+        custom_name="Custom Name",
+        artist_type=artist_models.ArtistType.PERFORMER,
+    )
+    skipped_link_id = skipped_link.id
+
+    main(commit=True, min_offer_id=offer_a.id, max_offer_id=offer_a.id)
+
+    assert {link.custom_name for link in _links_for(offer_a.id)} == {"Author A"}
+    links_b = _links_for(offer_b.id)
+    assert len(links_b) == 1
+    assert links_b[0].id == skipped_link_id
+
+
+def test_verbose_logs_each_created_link(caplog):
+    offer = offers_factories.OfferFactory(
+        extraData={"author": "Author Name", "performer": "Performer Name"},
+    )
+
+    with caplog.at_level(logging.INFO):
+        main(commit=True, min_offer_id=offer.id, max_offer_id=offer.id, verbose=True)
+
+    assert {link.custom_name for link in _links_for(offer.id)} == {"Author Name", "Performer Name"}
+    link_logs = [record.message for record in caplog.records if f"offre {offer.id} :" in record.message]
+    assert sorted(link_logs) == [
+        f"  offre {offer.id} : author = 'Author Name'",
+        f"  offre {offer.id} : performer = 'Performer Name'",
+    ]

--- a/api/tests/scripts/clean_artist_again/test_main.py
+++ b/api/tests/scripts/clean_artist_again/test_main.py
@@ -19,72 +19,15 @@ def test_slugify():
 
 
 @patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
-def test_with_artist_id(mock_read_csv):
-    offer = offers_factories.OfferFactory()
-    offer_id = offer.id
-    artist = artist_factories.ArtistFactory(name="Goliarda Sapienza")
-    artist_id = artist.id
-    artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id, artist_id=artist_id, custom_name=None, artist_type=artist_models.ArtistType.AUTHOR
-    )
-    mock_read_csv.return_value = [
-        {
-            "offer_id": str(offer_id),
-            "artist_id": str(artist_id),
-            "artist_type": artist_models.ArtistType.AUTHOR,
-            "custom_name": "",
-        },
-    ]
-
-    main(commit=True, filename="mock_filename")
-
-    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
-    assert link is not None
-    assert link.offer_id == offer_id
-    assert link.artist_id == None
-    assert link.custom_name == "Goliarda Sapienza"
-    assert link.artist_name == "Goliarda Sapienza"
-
-
-@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
-def test_with_custom_name(mock_read_csv):
-    offer = offers_factories.OfferFactory()
-    offer_id = offer.id
-    artist = artist_factories.ArtistFactory(name="Goliarda Sapienza")
-    artist_id = artist.id
-    artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id, artist_id=artist_id, custom_name="Naomi Novik", artist_type=artist_models.ArtistType.AUTHOR
-    )
-
-    mock_read_csv.return_value = [
-        {
-            "offer_id": str(offer.id),
-            "custom_name": "naomi novik",
-            "artist_id": str(artist_id),
-            "artist_type": artist_models.ArtistType.AUTHOR,
-        }
-    ]
-
-    main(commit=True, filename="mock_filename")
-
-    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
-    assert link is not None
-    assert link.offer_id == offer_id
-    assert link.custom_name == "Goliarda Sapienza"
-    assert link.artist_id is None
-    assert link.artist_name == "Goliarda Sapienza"
-
-
-@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
 def test_with_custom_name_and_artist_id(mock_read_csv):
-    offer = offers_factories.OfferFactory()
+    offer = offers_factories.OfferFactory(extraData={"author": "Ursula K. Le Guin"})
     offer_id = offer.id
-    artist = artist_factories.ArtistFactory(name="Ursula K. Le Guin")
+    artist = artist_factories.ArtistFactory(name="ursula k. le guin")
     artist_id = artist.id
     artist_factories.ArtistOfferLinkFactory(
         offer_id=offer_id,
         artist_id=artist_id,
-        custom_name="Ursula K. Le Guin",
+        custom_name="ursula k. le guin",
         artist_type=artist_models.ArtistType.AUTHOR,
     )
 
@@ -93,7 +36,7 @@ def test_with_custom_name_and_artist_id(mock_read_csv):
             "offer_id": str(offer_id),
             "custom_name": "ursula k. le guin",
             "artist_id": str(artist_id),
-            "artist_type": artist_models.ArtistType.AUTHOR,
+            "artist_type": artist_models.ArtistType.AUTHOR.value,
         }
     ]
 
@@ -108,24 +51,24 @@ def test_with_custom_name_and_artist_id(mock_read_csv):
 
 
 @patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
-def test_without_artist_id_should_not_update(mock_read_csv):
-    offer = offers_factories.OfferFactory()
+def test_with_custom_name_and_no_artist_id(mock_read_csv):
+    offer = offers_factories.OfferFactory(
+        extraData={"author": "Ursula K. Le Guin"},
+    )
     offer_id = offer.id
-    artist = artist_factories.ArtistFactory(name="Mariana Enriquez")
-    artist_id = artist.id
     artist_factories.ArtistOfferLinkFactory(
         offer_id=offer_id,
-        custom_name="Ursula K. Le Guin",
-        artist=None,
+        artist_id=None,
+        custom_name="ursula k. le guin",
         artist_type=artist_models.ArtistType.AUTHOR,
-    )  # should not change
+    )
 
     mock_read_csv.return_value = [
         {
             "offer_id": str(offer_id),
-            "custom_name": "Mariana Enriquez",
-            "artist_id": str(artist_id),
-            "artist_type": artist_models.ArtistType.AUTHOR,
+            "custom_name": "ursula k. le guin",
+            "artist_id": "",
+            "artist_type": artist_models.ArtistType.AUTHOR.value,
         }
     ]
 
@@ -140,14 +83,78 @@ def test_without_artist_id_should_not_update(mock_read_csv):
 
 
 @patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
+def test_with_custom_name_and_no_artist_id_and_product(mock_read_csv):
+    product = offers_factories.ProductFactory(extraData={"author": "Ursula K. Le Guin"})
+    product_id = product.id
+    offer = offers_factories.OfferFactory(productId=product_id)
+    offer_id = offer.id
+    artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id,
+        artist_id=None,
+        custom_name="ursula k. le guin",
+        artist_type=artist_models.ArtistType.AUTHOR,
+    )
+
+    mock_read_csv.return_value = [
+        {
+            "offer_id": str(offer_id),
+            "custom_name": "ursula k. le guin",
+            "artist_id": "",
+            "artist_type": artist_models.ArtistType.AUTHOR.value,
+        }
+    ]
+
+    main(commit=True, filename="mock_filename")
+
+    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
+    assert link is not None
+    assert link.offer_id == offer_id
+    assert link.artist_id == None
+    assert link.custom_name == "Ursula K. Le Guin"
+    assert link.artist_name == "Ursula K. Le Guin"
+
+
+@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
+def test_without_artist_id_should_update(mock_read_csv):
+    offer = offers_factories.OfferFactory(extraData={"author": "Mariana Enriquez"})
+    offer_id = offer.id
+    artist = artist_factories.ArtistFactory(name="mariana enriquez")
+    artist_id = artist.id
+    artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id,
+        custom_name="mariana enriquez",
+        artist=None,
+        artist_type=artist_models.ArtistType.AUTHOR,
+    )
+
+    mock_read_csv.return_value = [
+        {
+            "offer_id": str(offer_id),
+            "custom_name": "mariana enriquez",
+            "artist_id": str(artist_id),
+            "artist_type": artist_models.ArtistType.AUTHOR.value,
+        }
+    ]
+
+    main(commit=True, filename="mock_filename")
+
+    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
+    assert link is not None
+    assert link.offer_id == offer_id
+    assert link.artist_id == None
+    assert link.custom_name == "Mariana Enriquez"
+    assert link.artist_name == "Mariana Enriquez"
+
+
+@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
 def test_handle_duplicates(mock_read_csv):
-    offer = offers_factories.OfferFactory()
-    another_offer = offers_factories.OfferFactory()
+    offer = offers_factories.OfferFactory(extraData={"author": "Lena Dunham", "performer": "Lena Dunham"})
+    another_offer = offers_factories.OfferFactory(extraData={"author": "Lena dunham"})
     offer_id = offer.id
     another_offer_id = another_offer.id
 
-    artist = artist_factories.ArtistFactory(name="Lena Dunham")
-    another_artist = artist_factories.ArtistFactory(name="Lena dunham")
+    artist = artist_factories.ArtistFactory(name="lena dunham")
+    another_artist = artist_factories.ArtistFactory(name="lena dunham")
     artist_id = artist.id
     another_artist_id = another_artist.id
 
@@ -155,11 +162,14 @@ def test_handle_duplicates(mock_read_csv):
         offer_id=offer_id, custom_name=None, artist_id=artist_id, artist_type=artist_models.ArtistType.AUTHOR
     )  # a garder
     link_to_delete = artist_factories.ArtistOfferLinkFactory(
-        offer_id=offer_id, custom_name=None, artist_id=another_artist_id, artist_type=artist_models.ArtistType.AUTHOR
-    )  # a supprimer : même artist type, mais artist_id différent
+        offer_id=offer_id,
+        custom_name=None,
+        artist_id=another_artist_id,
+        artist_type=artist_models.ArtistType.AUTHOR,
+    )  # a supprimer : doublon car artist_id est différent
     link_different_type = artist_factories.ArtistOfferLinkFactory(
         offer_id=offer_id,
-        custom_name="lena dunham",
+        custom_name=None,
         artist_id=artist_id,
         artist_type=artist_models.ArtistType.PERFORMER,
     )  # à garder: l'artist type est différent
@@ -169,37 +179,50 @@ def test_handle_duplicates(mock_read_csv):
         artist_id=another_artist_id,
         artist_type=artist_models.ArtistType.AUTHOR,
     )  # à garder: l'offre est différente
+    link_with_custom_name = artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id,
+        custom_name="Lena dunham",
+        artist_id=None,
+        artist_type=artist_models.ArtistType.AUTHOR,
+    )  # à supprimer : doublon avec link_to_update lorsqu'il sera mis à jour
 
     link_to_update_id = link_to_update.id
     link_to_delete_id = link_to_delete.id
     link_different_type_id = link_different_type.id
     link_different_offer_id = link_different_offer.id
+    link_with_custom_name_id = link_with_custom_name.id
 
     mock_read_csv.return_value = [
         {
             "offer_id": str(offer_id),
             "custom_name": "lena dunham",
             "artist_id": str(artist.id),
-            "artist_type": artist_models.ArtistType.AUTHOR,
+            "artist_type": artist_models.ArtistType.AUTHOR.value,
         },  # on garde le link_to_update
         {
             "offer_id": str(offer_id),
             "custom_name": "lena dunham",
             "artist_id": str(another_artist.id),
-            "artist_type": artist_models.ArtistType.AUTHOR,
+            "artist_type": artist_models.ArtistType.AUTHOR.value,
         },  # cette ligne doit supprimer le link_to_delete
         {
             "offer_id": str(offer_id),
             "custom_name": "lena dunham",
             "artist_id": str(artist.id),
-            "artist_type": artist_models.ArtistType.PERFORMER,
+            "artist_type": artist_models.ArtistType.PERFORMER.value,
         },  # on garde également le link_different_type
         {
             "offer_id": str(another_offer_id),
             "custom_name": "lena dunham",
             "artist_id": str(another_artist.id),
-            "artist_type": artist_models.ArtistType.AUTHOR,
+            "artist_type": artist_models.ArtistType.AUTHOR.value,
         },  # on garde car c'est une autre offre
+        {
+            "offer_id": str(offer_id),
+            "custom_name": "lena dunham",
+            "artist_id": None,
+            "artist_type": artist_models.ArtistType.AUTHOR.value,
+        },  # on supprime car doublon avec link_to_update
     ]
 
     main(commit=True, filename="mock_filename")
@@ -217,6 +240,7 @@ def test_handle_duplicates(mock_read_csv):
     assert db.session.get(artist_models.ArtistOfferLink, link_different_offer_id) is not None
 
     assert db.session.get(artist_models.ArtistOfferLink, link_to_delete_id) is None
+    assert db.session.get(artist_models.ArtistOfferLink, link_with_custom_name_id) is None
 
     for link in offer_links:
         assert link.artist_id is None

--- a/api/tests/scripts/clean_artist_again/test_main.py
+++ b/api/tests/scripts/clean_artist_again/test_main.py
@@ -1,0 +1,227 @@
+from unittest.mock import patch
+
+import pytest
+
+from pcapi.core.artist import factories as artist_factories
+from pcapi.core.artist import models as artist_models
+from pcapi.core.offers import factories as offers_factories
+from pcapi.models import db
+from pcapi.scripts.clean_artist_again.main import main
+from pcapi.scripts.clean_artist_again.main import slugify_name
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+def test_slugify():
+    name = "Lucía Sánchez Saornil"
+    assert slugify_name(name) == "lucia sanchez saornil"
+
+
+@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
+def test_with_artist_id(mock_read_csv):
+    offer = offers_factories.OfferFactory()
+    offer_id = offer.id
+    artist = artist_factories.ArtistFactory(name="Goliarda Sapienza")
+    artist_id = artist.id
+    artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id, artist_id=artist_id, custom_name=None, artist_type=artist_models.ArtistType.AUTHOR
+    )
+    mock_read_csv.return_value = [
+        {
+            "offer_id": str(offer_id),
+            "artist_id": str(artist_id),
+            "artist_type": artist_models.ArtistType.AUTHOR,
+            "custom_name": "",
+        },
+    ]
+
+    main(commit=True, filename="mock_filename")
+
+    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
+    assert link is not None
+    assert link.offer_id == offer_id
+    assert link.artist_id == None
+    assert link.custom_name == "Goliarda Sapienza"
+    assert link.artist_name == "Goliarda Sapienza"
+
+
+@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
+def test_with_custom_name(mock_read_csv):
+    offer = offers_factories.OfferFactory()
+    offer_id = offer.id
+    artist = artist_factories.ArtistFactory(name="Goliarda Sapienza")
+    artist_id = artist.id
+    artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id, artist_id=artist_id, custom_name="Naomi Novik", artist_type=artist_models.ArtistType.AUTHOR
+    )
+
+    mock_read_csv.return_value = [
+        {
+            "offer_id": str(offer.id),
+            "custom_name": "naomi novik",
+            "artist_id": str(artist_id),
+            "artist_type": artist_models.ArtistType.AUTHOR,
+        }
+    ]
+
+    main(commit=True, filename="mock_filename")
+
+    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
+    assert link is not None
+    assert link.offer_id == offer_id
+    assert link.custom_name == "Goliarda Sapienza"
+    assert link.artist_id is None
+    assert link.artist_name == "Goliarda Sapienza"
+
+
+@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
+def test_with_custom_name_and_artist_id(mock_read_csv):
+    offer = offers_factories.OfferFactory()
+    offer_id = offer.id
+    artist = artist_factories.ArtistFactory(name="Ursula K. Le Guin")
+    artist_id = artist.id
+    artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id,
+        artist_id=artist_id,
+        custom_name="Ursula K. Le Guin",
+        artist_type=artist_models.ArtistType.AUTHOR,
+    )
+
+    mock_read_csv.return_value = [
+        {
+            "offer_id": str(offer_id),
+            "custom_name": "ursula k. le guin",
+            "artist_id": str(artist_id),
+            "artist_type": artist_models.ArtistType.AUTHOR,
+        }
+    ]
+
+    main(commit=True, filename="mock_filename")
+
+    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
+    assert link is not None
+    assert link.offer_id == offer_id
+    assert link.artist_id == None
+    assert link.custom_name == "Ursula K. Le Guin"
+    assert link.artist_name == "Ursula K. Le Guin"
+
+
+@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
+def test_without_artist_id_should_not_update(mock_read_csv):
+    offer = offers_factories.OfferFactory()
+    offer_id = offer.id
+    artist = artist_factories.ArtistFactory(name="Mariana Enriquez")
+    artist_id = artist.id
+    artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id,
+        custom_name="Ursula K. Le Guin",
+        artist=None,
+        artist_type=artist_models.ArtistType.AUTHOR,
+    )  # should not change
+
+    mock_read_csv.return_value = [
+        {
+            "offer_id": str(offer_id),
+            "custom_name": "Mariana Enriquez",
+            "artist_id": str(artist_id),
+            "artist_type": artist_models.ArtistType.AUTHOR,
+        }
+    ]
+
+    main(commit=True, filename="mock_filename")
+
+    link = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).first()
+    assert link is not None
+    assert link.offer_id == offer_id
+    assert link.artist_id == None
+    assert link.custom_name == "Ursula K. Le Guin"
+    assert link.artist_name == "Ursula K. Le Guin"
+
+
+@patch("pcapi.scripts.clean_artist_again.main.read_csv_file")
+def test_handle_duplicates(mock_read_csv):
+    offer = offers_factories.OfferFactory()
+    another_offer = offers_factories.OfferFactory()
+    offer_id = offer.id
+    another_offer_id = another_offer.id
+
+    artist = artist_factories.ArtistFactory(name="Lena Dunham")
+    another_artist = artist_factories.ArtistFactory(name="Lena dunham")
+    artist_id = artist.id
+    another_artist_id = another_artist.id
+
+    link_to_update = artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id, custom_name=None, artist_id=artist_id, artist_type=artist_models.ArtistType.AUTHOR
+    )  # a garder
+    link_to_delete = artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id, custom_name=None, artist_id=another_artist_id, artist_type=artist_models.ArtistType.AUTHOR
+    )  # a supprimer : même artist type, mais artist_id différent
+    link_different_type = artist_factories.ArtistOfferLinkFactory(
+        offer_id=offer_id,
+        custom_name="lena dunham",
+        artist_id=artist_id,
+        artist_type=artist_models.ArtistType.PERFORMER,
+    )  # à garder: l'artist type est différent
+    link_different_offer = artist_factories.ArtistOfferLinkFactory(
+        offer_id=another_offer_id,
+        custom_name=None,
+        artist_id=another_artist_id,
+        artist_type=artist_models.ArtistType.AUTHOR,
+    )  # à garder: l'offre est différente
+
+    link_to_update_id = link_to_update.id
+    link_to_delete_id = link_to_delete.id
+    link_different_type_id = link_different_type.id
+    link_different_offer_id = link_different_offer.id
+
+    mock_read_csv.return_value = [
+        {
+            "offer_id": str(offer_id),
+            "custom_name": "lena dunham",
+            "artist_id": str(artist.id),
+            "artist_type": artist_models.ArtistType.AUTHOR,
+        },  # on garde le link_to_update
+        {
+            "offer_id": str(offer_id),
+            "custom_name": "lena dunham",
+            "artist_id": str(another_artist.id),
+            "artist_type": artist_models.ArtistType.AUTHOR,
+        },  # cette ligne doit supprimer le link_to_delete
+        {
+            "offer_id": str(offer_id),
+            "custom_name": "lena dunham",
+            "artist_id": str(artist.id),
+            "artist_type": artist_models.ArtistType.PERFORMER,
+        },  # on garde également le link_different_type
+        {
+            "offer_id": str(another_offer_id),
+            "custom_name": "lena dunham",
+            "artist_id": str(another_artist.id),
+            "artist_type": artist_models.ArtistType.AUTHOR,
+        },  # on garde car c'est une autre offre
+    ]
+
+    main(commit=True, filename="mock_filename")
+
+    db.session.expire_all()
+
+    offer_links = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=offer_id).all()
+    another_offer_links = db.session.query(artist_models.ArtistOfferLink).filter_by(offer_id=another_offer_id).all()
+
+    assert len(offer_links) == 2
+    assert len(another_offer_links) == 1
+
+    assert db.session.get(artist_models.ArtistOfferLink, link_to_update_id) is not None
+    assert db.session.get(artist_models.ArtistOfferLink, link_different_type_id) is not None
+    assert db.session.get(artist_models.ArtistOfferLink, link_different_offer_id) is not None
+
+    assert db.session.get(artist_models.ArtistOfferLink, link_to_delete_id) is None
+
+    for link in offer_links:
+        assert link.artist_id is None
+        assert link.custom_name == "Lena Dunham"
+
+    for link in another_offer_links:
+        assert link.artist_id is None
+        assert link.custom_name == "Lena dunham"


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41603)

pseudo-revert de ce script : https://github.com/pass-culture/pass-culture-main/pull/21255

- On supprime les ArtistOfferLinks sur TOUTES les offres créées avant le 23 février 2026 
- On re-créé UN SEUL lien par offre ET par type d'artiste (author, performer, stage_director) en copiant la valeur des extradata dans le custom name 

**:warning: Ne pas merger dans `master`!**

<!-- Ajouter le label `do-not-merge` pour que la CI bloque le merge -->

Mon script a tourné sur :

- Testing :
  - [ ] Dry run : lien vers le job
  - [ ] Actual run : lien vers le job
- Staging :
  - [x] Dry run : [lien vers le job](https://github.com/pass-culture/infra/actions/runs/27348867813/job/80805174831) : lancé en verbose pour valider les liens créés. Sur un petit échantillon seulement (394565242 -> 394627504)
  - [x] Actual run : [lien vers le job](https://github.com/pass-culture/infra/actions/runs/27358234743/job/80839185387)
- Production :
  - [x] Dry run : [lien vers le job](https://github.com/pass-culture/infra/actions/runs/27561327703/job/81474139842)
  - [x] Actual run : [lien vers le job](https://console.cloud.google.com/logs/query;query=labels.%22k8s-pod%2Fjob-name%22%3D%22pcapi-console-075848-clean-artist-again%22;cursorTimestamp=2026-06-16T08:59:40.343985687Z;duration=PT45M?project=pc-backend-prd&rapt=AEjHL4N3XTbDRoPp78oZN1F731hi5BgJAmQ2vPJ9Xj_oOiVeOinCCbgGIKyBwul_BTgqsV5cLAIw7L74TOgwCJlSxnJ2zldlMcN1ueInlZNhzUf8Daaghgc)
- Intégration (**:warning: ne pas oublier cet environnement**) :
  - [ ] Dry run : lien vers le job
  - [ ] Actual run : lien vers le job
