### PR TITLE
 (PC-41797)[API] refactor: rename CDS resources to CineOffice

### DIFF
--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -20,8 +20,8 @@ from pcapi.core.bookings.utils import generate_hmac_signature
 from pcapi.core.providers import tasks as providers_tasks
 from pcapi.core.providers.clients import cinema_client
 from pcapi.core.providers.clients.boost_client import BoostAPIClient
-from pcapi.core.providers.clients.cds_client import CineDigitalServiceAPIClient
 from pcapi.core.providers.clients.cgr_client import CGRAPIClient
+from pcapi.core.providers.clients.cine_office_client import CineOfficeAPIClient
 from pcapi.core.providers.clients.ems_client import EMSAPIClient
 from pcapi.models import db
 from pcapi.models import feature
@@ -124,7 +124,7 @@ def _check_cinema_booking_is_enabled(local_class: str) -> None:
 
 def _instantiate_cinema_api_client(
     venue_id: int,
-) -> CineDigitalServiceAPIClient | BoostAPIClient | CGRAPIClient | EMSAPIClient:
+) -> CineOfficeAPIClient | BoostAPIClient | CGRAPIClient | EMSAPIClient:
     local_class, cinema_id = _get_cinema_local_class_and_id(venue_id)
     sentry_sdk.set_tag("cinema-provider-local-class", local_class)
 
@@ -135,7 +135,7 @@ def _instantiate_cinema_api_client(
             cds_cinema_details = providers_repository.get_cds_cinema_details(cinema_id)
             cinema_api_token = cds_cinema_details.cinemaApiToken
             account_id = cds_cinema_details.accountId
-            return CineDigitalServiceAPIClient(
+            return CineOfficeAPIClient(
                 cinema_id, account_id, cinema_api_token, request_timeout=EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS
             )
         case "BoostStocks":

--- a/api/src/pcapi/core/logging.py
+++ b/api/src/pcapi/core/logging.py
@@ -291,7 +291,7 @@ def install_logging() -> None:
 def _enable_cinema_provider_debug_logging() -> None:
     logging.getLogger("pcapi.connectors.api_allocine").setLevel(logging.DEBUG)
     logging.getLogger("pcapi.core.providers.clients.boost_client").setLevel(logging.DEBUG)
-    logging.getLogger("pcapi.core.providers.clients.cds_client").setLevel(logging.DEBUG)
+    logging.getLogger("pcapi.core.providers.clients.cine_office_client").setLevel(logging.DEBUG)
     logging.getLogger("pcapi.core.providers.clients.cgr_client").setLevel(logging.DEBUG)
     logging.getLogger("pcapi.connectors.ems").setLevel(logging.DEBUG)
 

--- a/api/src/pcapi/core/providers/clients/cine_office_client.py
+++ b/api/src/pcapi/core/providers/clients/cine_office_client.py
@@ -19,7 +19,7 @@ from pcapi.utils import date as date_utils
 from pcapi.utils import requests
 from pcapi.utils.queue import add_to_queue
 
-from . import cds_serializers
+from . import cine_office_serializers
 
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ SEATMAP_HARDCODED_LABELS_SCREENID = "SEATMAP_HARDCODED_LABELS_SCREENID_"
 CDS_TICKET_ALREADY_CANCELED_ERROR_MESSAGE = "TICKET_ALREADY_CANCELED"
 
 
-class CineDigitalServiceAPIException(external_bookings_exceptions.ExternalBookingException):
+class CineOfficeAPIException(external_bookings_exceptions.ExternalBookingException):
     pass
 
 
@@ -63,16 +63,17 @@ def _extract_reason_from_response(response: requests.Response) -> str:
 
 def _raise_for_status(response: requests.Response, cinema_api_token: str | None, request_detail: str) -> None:
     """
-    Raise `CineDigitalServiceAPIException` is status >= 400
+    Raise `CineOfficeAPIException` is status >= 400
     """
     if response.status_code >= 400:
         reason = _extract_reason_from_response(response)
         if cinema_api_token:
             reason = reason.replace(cinema_api_token, "")  # filter out token
-        raise CineDigitalServiceAPIException(f"Error on CDS API on {request_detail} : {reason}")
+        raise CineOfficeAPIException(f"Error on CineOffice API on {request_detail} : {reason}")
 
 
-class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
+# INFO: The old name of CineOffice was CineDigitalService or CDS
+class CineOfficeAPIClient(cinema_client.CinemaAPIClient):
     def __init__(
         self,
         cinema_id: str,
@@ -93,7 +94,7 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
 
         This method logs response at debug level.
 
-        :raise: CineDigitalServiceAPIException
+        :raise: CineOfficeAPIException
         """
         response = requests.get(url, params={"api_token": self.token}, timeout=self.request_timeout)
         _raise_for_status(response, self.token, f"GET {url}")
@@ -110,7 +111,7 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
         If an error occurred, it returns the JSON body explaining the error.
 
         :payload: Must be a stringified JSON
-        :raise: CineDigitalServiceAPIException
+        :raise: CineOfficeAPIException
         """
         response = requests.put(
             url,
@@ -133,7 +134,7 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
         """
         Make an authenticated POST by adding an `api_token` in query params.
 
-        :raise: CineDigitalServiceAPIException
+        :raise: CineOfficeAPIException
         """
         response = requests.post(
             url,
@@ -157,79 +158,79 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
         by caching their results based on their input arguments, thus avoiding costly recomputations.
         """
         data = self._authenticated_get(f"{self.base_url}cinemas")
-        cinemas = TypeAdapter(list[cds_serializers.CinemaCDS]).validate_python(data)
+        cinemas = TypeAdapter(list[cine_office_serializers.Cinema]).validate_python(data)
         for cinema in cinemas:
             if cinema.id == self.cinema_id:
                 return cinema.is_internet_sale_gauge_active
-        raise CineDigitalServiceAPIException(
+        raise CineOfficeAPIException(
             f"Cinema internet_sale_gauge_active not found in Cine Digital Service API "
             f"for cinemaId={self.cinema_id} & url={self.base_url}"
         )
 
-    def get_shows(self) -> list[cds_serializers.ShowCDS]:
+    def get_shows(self) -> list[cine_office_serializers.Show]:
         data = self._authenticated_get(f"{self.base_url}shows")
-        shows = TypeAdapter(list[cds_serializers.ShowCDS]).validate_python(data)
+        shows = TypeAdapter(list[cine_office_serializers.Show]).validate_python(data)
 
         if not shows:
             logger.warning("[CDS] Api call returned no show", extra={"cinemaId": self.cinema_id, "url": self.base_url})
 
         return shows
 
-    def get_show(self, show_id: int) -> cds_serializers.ShowCDS:
+    def get_show(self, show_id: int) -> cine_office_serializers.Show:
         """
         Fetch all shows and filter them using `show_id`
 
         :raise: `ExternalBookingShowDoesNotExistError` if no show has the given `show_id`
         """
         data = self._authenticated_get(f"{self.base_url}shows")
-        shows = TypeAdapter(list[cds_serializers.ShowCDS]).validate_python(data)
+        shows = TypeAdapter(list[cine_office_serializers.Show]).validate_python(data)
         for show in shows:
             if show.id == show_id:
                 return show
         raise external_bookings_exceptions.ExternalBookingShowDoesNotExistError()
 
-    def get_venue_movies(self) -> list[cds_serializers.MediaCDS]:
+    def get_venue_movies(self) -> list[cine_office_serializers.Media]:
         data = self._authenticated_get(f"{self.base_url}media")
-        return TypeAdapter(list[cds_serializers.MediaCDS]).validate_python(data)
+        return TypeAdapter(list[cine_office_serializers.Media]).validate_python(data)
 
     def get_rating(self) -> dict:  # method used by BO to check authentication is working
         return self._authenticated_get(f"{self.base_url}rating")
 
-    def get_voucher_payment_type(self) -> cds_serializers.PaymentTypeCDS:
+    def get_voucher_payment_type(self) -> cine_office_serializers.PaymentTypeCDS:
         data = self._authenticated_get(f"{self.base_url}paiementtype")
-        payment_types = TypeAdapter(list[cds_serializers.PaymentTypeCDS]).validate_python(data)
+        payment_types = TypeAdapter(list[cine_office_serializers.PaymentTypeCDS]).validate_python(data)
         for payment_type in payment_types:
             if payment_type.internal_code == VOUCHER_PAYMENT_TYPE_CDS:
                 return payment_type
 
-        raise CineDigitalServiceAPIException(
+        raise CineOfficeAPIException(
             f"Pass Culture payment type not found in Cine Digital Service API for cinemaId={self.cinema_id}"
             f" & url={self.base_url}"
         )
 
     @lru_cache
-    def get_pc_voucher_types(self) -> list[cds_serializers.VoucherTypeCDS]:
+    def get_pc_voucher_types(self) -> list[cine_office_serializers.VoucherType]:
         data = self._authenticated_get(f"{self.base_url}vouchertype")
-        voucher_types = TypeAdapter(list[cds_serializers.VoucherTypeCDS]).validate_python(data)
+        voucher_types = TypeAdapter(list[cine_office_serializers.VoucherType]).validate_python(data)
         return [
             voucher_type
             for voucher_type in voucher_types
             if voucher_type.code == PASS_CULTURE_VOUCHER_CODE and voucher_type.tariff
         ]
 
-    def get_screen(self, screen_id: int) -> cds_serializers.ScreenCDS:
+    def get_screen(self, screen_id: int) -> cine_office_serializers.Screen:
         data = self._authenticated_get(f"{self.base_url}screens")
-        screens = TypeAdapter(list[cds_serializers.ScreenCDS]).validate_python(data)
+        screens = TypeAdapter(list[cine_office_serializers.Screen]).validate_python(data)
         for screen in screens:
             if screen.id == screen_id:
                 return screen
-        raise CineDigitalServiceAPIException(
+        raise CineOfficeAPIException(
             f"Screen #{screen_id} not found in Cine Digital Service API for cinemaId={self.cinema_id} & url={self.base_url}"
         )
 
     def get_hardcoded_seatmap(
         self,
-        show: cds_serializers.ShowCDS,
+        show: cine_office_serializers.Show,
     ) -> list[list[str | typing.Literal[0]]]:
         """Return a matrix (a list of lists) of values, where each
         value is a seat number as a string (e.g. "A7" or "123"), or
@@ -247,8 +248,8 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
         return seatmap
 
     def get_available_seat(
-        self, show: cds_serializers.ShowCDS, screen: cds_serializers.ScreenCDS
-    ) -> list[cds_serializers.SeatCDS]:
+        self, show: cine_office_serializers.Show, screen: cine_office_serializers.Screen
+    ) -> list[cine_office_serializers.Seat]:
         seatmap = self.get_seatmap(show.id)
         available_seats_index = [
             (i, j) for i in range(0, seatmap.nb_row) for j in range(0, seatmap.nb_col) if seatmap.map[i][j] == 1
@@ -258,11 +259,11 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
         best_seat = self._get_closest_seat_to_center((seatmap.nb_row // 2, seatmap.nb_col // 2), available_seats_index)
 
         hardcoded_seatmap = self.get_hardcoded_seatmap(show)
-        return [cds_serializers.SeatCDS(best_seat, screen, seatmap, hardcoded_seatmap)]
+        return [cine_office_serializers.Seat(best_seat, screen, seatmap, hardcoded_seatmap)]
 
     def get_available_duo_seat(
-        self, show: cds_serializers.ShowCDS, screen: cds_serializers.ScreenCDS
-    ) -> list[cds_serializers.SeatCDS]:
+        self, show: cine_office_serializers.Show, screen: cine_office_serializers.Screen
+    ) -> list[cine_office_serializers.Seat]:
         seatmap = self.get_seatmap(show.id)
         seatmap_center = ((seatmap.nb_row - 1) / 2, (seatmap.nb_col - 1) / 2)
 
@@ -287,13 +288,13 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
         hardcoded_seatmap = self.get_hardcoded_seatmap(show)
 
         return [
-            cds_serializers.SeatCDS(first_seat, screen, seatmap, hardcoded_seatmap),
-            cds_serializers.SeatCDS(second_seat, screen, seatmap, hardcoded_seatmap),
+            cine_office_serializers.Seat(first_seat, screen, seatmap, hardcoded_seatmap),
+            cine_office_serializers.Seat(second_seat, screen, seatmap, hardcoded_seatmap),
         ]
 
-    def get_seatmap(self, show_id: int) -> cds_serializers.SeatmapCDS:
+    def get_seatmap(self, show_id: int) -> cine_office_serializers.Seatmap:
         data = self._authenticated_get(f"{self.base_url}shows/{show_id}/seatmap")
-        seatmap_cds = cds_serializers.SeatmapCDS.model_validate(data)
+        seatmap_cds = cine_office_serializers.Seatmap.model_validate(data)
         return seatmap_cds
 
     def _get_closest_seat_to_center(
@@ -321,11 +322,11 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
         )
 
         if api_response:
-            cancel_errors = cds_serializers.CancelBookingsErrorsCDS.model_validate(api_response)
+            cancel_errors = cine_office_serializers.CancelBookingsErrors.model_validate(api_response)
             if {CDS_TICKET_ALREADY_CANCELED_ERROR_MESSAGE} == set(cancel_errors.root.values()):
                 return  # We don't raise if the tickets have already been cancelled
             sep = "\n"
-            raise CineDigitalServiceAPIException(
+            raise CineOfficeAPIException(
                 f"Error while canceling bookings :{sep}{sep.join([f'{barcode} : {error_msg}' for barcode, error_msg in cancel_errors.root.items()])}"
             )
 
@@ -335,18 +336,18 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
     ) -> list[cinema_client.Ticket]:
         quantity = booking.quantity
         if quantity < 0 or quantity > 2:
-            raise CineDigitalServiceAPIException(f"Booking quantity={quantity} should be 1 or 2")
+            raise CineOfficeAPIException(f"Booking quantity={quantity} should be 1 or 2")
 
         show = self.get_show(show_id)
         screen = self.get_screen(show.screen.id)
         show_voucher_type = self.get_voucher_type_for_show(show)
         if not show_voucher_type:
-            raise CineDigitalServiceAPIException(f"Unavailable pass culture tariff for show={show.id}")
+            raise CineOfficeAPIException(f"Unavailable pass culture tariff for show={show.id}")
 
         ticket_sale_collection = self._create_ticket_sale_dict(show, quantity, screen, show_voucher_type)
         payement_collection = self._create_transaction_payment(quantity, show_voucher_type)
 
-        create_transaction_body = cds_serializers.CreateTransactionBodyCDS(
+        create_transaction_body = cine_office_serializers.CreateTransactionBody(
             cinema_id=self.cinema_id,
             is_cancelled=False,
             transaction_date=date_utils.get_naive_utc_now().strftime(CDS_DATE_FORMAT),
@@ -356,7 +357,7 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
 
         json_response = self._authenticated_post(f"{self.base_url}transaction/create", payload=create_transaction_body)
 
-        create_transaction_response = cds_serializers.CreateTransactionResponseCDS.model_validate(json_response)
+        create_transaction_response = cine_office_serializers.CreateTransactionResponse.model_validate(json_response)
 
         for ticket in create_transaction_response.tickets:
             add_to_queue(
@@ -377,11 +378,11 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
 
     def _create_ticket_sale_dict(
         self,
-        show: cds_serializers.ShowCDS,
+        show: cine_office_serializers.Show,
         booking_quantity: int,
-        screen: cds_serializers.ScreenCDS,
-        show_voucher_type: cds_serializers.VoucherTypeCDS,
-    ) -> list[cds_serializers.TicketSaleCDS]:
+        screen: cine_office_serializers.Screen,
+        show_voucher_type: cine_office_serializers.VoucherType,
+    ) -> list[cine_office_serializers.TicketSale]:
         seats_to_book = []
         if not show.is_disabled_seatmap and not show.is_empty_seatmap:
             seats_to_book = (
@@ -397,7 +398,7 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
 
         ticket_sale_list = []
         for i in range(booking_quantity):
-            ticket_sale = cds_serializers.TicketSaleCDS(
+            ticket_sale = cine_office_serializers.TicketSale(
                 id=(i + 1) * -1,
                 cinema_id=self.cinema_id,
                 operation_date=date_utils.get_naive_utc_now().strftime(CDS_DATE_FORMAT),
@@ -405,8 +406,8 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
                 seat_col=seats_to_book[i].seatCol if bool(seats_to_book) else None,
                 seat_row=seats_to_book[i].seatRow if bool(seats_to_book) else None,
                 seat_number=seats_to_book[i].seatNumber if bool(seats_to_book) else None,
-                tariff=cds_serializers.IdObjectCDS(id=show_voucher_type.tariff.id),
-                show=cds_serializers.IdObjectCDS(id=show.id),
+                tariff=cine_office_serializers.IdObject(id=show_voucher_type.tariff.id),
+                show=cine_office_serializers.IdObject(id=show.id),
                 voucher_type=PASS_CULTURE_VOUCHER_CODE,
                 disabled_person=False,
             )
@@ -415,18 +416,18 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
         return ticket_sale_list
 
     def _create_transaction_payment(
-        self, booking_quantity: int, show_voucher_type: cds_serializers.VoucherTypeCDS
-    ) -> list[cds_serializers.TransactionPayementCDS]:
+        self, booking_quantity: int, show_voucher_type: cine_office_serializers.VoucherType
+    ) -> list[cine_office_serializers.TransactionPayement]:
         payment_type = self.get_voucher_payment_type()
 
         assert show_voucher_type.tariff
         payement_collection = []
         for i in range(booking_quantity):
-            payment = cds_serializers.TransactionPayementCDS(
+            payment = cine_office_serializers.TransactionPayement(
                 id=(i + 1) * -1,
                 amount=show_voucher_type.tariff.price,
-                payement_type=cds_serializers.IdObjectCDS(id=payment_type.id),
-                voucher_type=cds_serializers.IdObjectCDS(id=show_voucher_type.id),
+                payement_type=cine_office_serializers.IdObject(id=payment_type.id),
+                voucher_type=cine_office_serializers.IdObject(id=show_voucher_type.id),
             )
             payement_collection.append(payment)
 
@@ -436,9 +437,9 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
     # when `CDSStocks` is removed
     def get_voucher_type_for_show(
         self,
-        show: cds_serializers.ShowCDS,
-        pc_voucher_types: list[cds_serializers.VoucherTypeCDS] | None = None,
-    ) -> cds_serializers.VoucherTypeCDS | None:
+        show: cine_office_serializers.Show,
+        pc_voucher_types: list[cine_office_serializers.VoucherType] | None = None,
+    ) -> cine_office_serializers.VoucherType | None:
         pc_voucher_types = pc_voucher_types or self.get_pc_voucher_types()
 
         show_pc_vouchers = []
@@ -455,18 +456,18 @@ class CineDigitalServiceAPIClient(cinema_client.CinemaAPIClient):
         min_price_voucher = min(show_pc_vouchers, key=attrgetter("tariff.price"))
         return min_price_voucher
 
-    def get_cinema_infos(self) -> cds_serializers.CinemaCDS:
+    def get_cinema_infos(self) -> cine_office_serializers.Cinema:
         data = self._authenticated_get(f"{self.base_url}cinemas")
-        cinemas = TypeAdapter(list[cds_serializers.CinemaCDS]).validate_python(data)
+        cinemas = TypeAdapter(list[cine_office_serializers.Cinema]).validate_python(data)
         for cinema in cinemas:
             if cinema.id == self.cinema_id:
                 return cinema
-        raise CineDigitalServiceAPIException(
+        raise CineOfficeAPIException(
             f"Cinema not found in Cine Digital Service API for cinemaId={self.cinema_id} & url={self.base_url}"
         )
 
     @lru_cache
     def get_media_options(self) -> dict[int, str]:
         data = self._authenticated_get(f"{self.base_url}mediaoptions")
-        media_options = TypeAdapter(list[cds_serializers.MediaOptionCDS]).validate_python(data)
+        media_options = TypeAdapter(list[cine_office_serializers.MediaOption]).validate_python(data)
         return {media_option.id: media_option.ticketlabel for media_option in media_options if media_option.ticketlabel}

--- a/api/src/pcapi/core/providers/clients/cine_office_serializers.py
+++ b/api/src/pcapi/core/providers/clients/cine_office_serializers.py
@@ -7,41 +7,41 @@ from pydantic import Field
 import pcapi.core.offers.models as offers_models
 
 
-class CDSBaseModel(pydantic.BaseModel):
+class CineOfficeBaseModel(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(validate_by_name=True)
 
 
-class IdObjectCDS(CDSBaseModel):
+class IdObject(CineOfficeBaseModel):
     id: int
 
 
-class ShowTariffCDS(CDSBaseModel):
-    tariff: IdObjectCDS = Field(alias="tariffid")
+class ShowTariff(CineOfficeBaseModel):
+    tariff: IdObject = Field(alias="tariffid")
 
 
-class ShowsMediaoptionsCDS(CDSBaseModel):
-    media_options_id: IdObjectCDS = Field(alias="mediaoptionsid")
+class ShowsMediaOptions(CineOfficeBaseModel):
+    media_options_id: IdObject = Field(alias="mediaoptionsid")
 
 
-class CinemaParameterCDS(CDSBaseModel):
+class CinemaParameter(CineOfficeBaseModel):
     id: int
     key: str
     value: str | None = None
 
 
-class CinemaCDS(CDSBaseModel):
+class Cinema(CineOfficeBaseModel):
     id: str
     is_internet_sale_gauge_active: bool = Field(alias="internetsalegaugeactive")
-    cinema_parameters: list[CinemaParameterCDS] = Field(alias="cinemaParameters", default_factory=list)
+    cinema_parameters: list[CinemaParameter] = Field(alias="cinemaParameters", default_factory=list)
 
 
-class MediaOptionCDS(CDSBaseModel):
+class MediaOption(CineOfficeBaseModel):
     id: int
     ticketlabel: str | None = None
     label: str
 
 
-class ShowCDS(CDSBaseModel):
+class Show(CineOfficeBaseModel):
     id: int
     is_cancelled: bool = Field(alias="canceled")
     is_deleted: bool = Field(alias="deleted")
@@ -50,10 +50,10 @@ class ShowCDS(CDSBaseModel):
     remaining_place: int = Field(alias="remainingplace")
     internet_remaining_place: int = Field(alias="internetremainingplace")
     showtime: datetime.datetime
-    shows_tariff_pos_type_collection: list[ShowTariffCDS] = Field(alias="showsTariffPostypeCollection")
-    screen: IdObjectCDS = Field(alias="screenid")
-    media: IdObjectCDS = Field(alias="mediaid")
-    shows_mediaoptions_collection: list[ShowsMediaoptionsCDS] = Field(alias="showsMediaoptionsCollection")
+    shows_tariff_pos_type_collection: list[ShowTariff] = Field(alias="showsTariffPostypeCollection")
+    screen: IdObject = Field(alias="screenid")
+    media: IdObject = Field(alias="mediaid")
+    shows_mediaoptions_collection: list[ShowsMediaOptions] = Field(alias="showsMediaoptionsCollection")
 
     @pydantic.field_validator("is_empty_seatmap")
     def string_with_no_digit_to_true(cls, value: str | bool) -> bool:
@@ -69,10 +69,10 @@ class ShowCDS(CDSBaseModel):
         return False
 
 
-class MediaCDS(CDSBaseModel):
+class Media(CineOfficeBaseModel):
     id: int
     title: str
-    duration: int | None = None  # CDS api returns duration in seconds
+    duration: int | None = None  # CineOffice api returns duration in seconds
     posterpath: str | None = None
     storyline: str | None = None
     visanumber: str | None = None
@@ -90,33 +90,33 @@ class MediaCDS(CDSBaseModel):
         )
 
 
-class PaymentTypeCDS(CDSBaseModel):
+class PaymentTypeCDS(CineOfficeBaseModel):
     id: int
     internal_code: str = Field(alias="internalcode")
     is_active: bool = Field(alias="active")
 
 
-class TariffCDS(CDSBaseModel):
+class Tariff(CineOfficeBaseModel):
     id: int
     price: float
     is_active: bool = Field(alias="active")
     label: str = Field(alias="labeltariff")
 
 
-class VoucherTypeCDS(CDSBaseModel):
+class VoucherType(CineOfficeBaseModel):
     id: int
     code: str | None = None
-    tariff: TariffCDS | None = Field(alias="tariffid", default=None)
+    tariff: Tariff | None = Field(alias="tariffid", default=None)
 
 
-class ScreenCDS(CDSBaseModel):
+class Screen(CineOfficeBaseModel):
     id: int
     seatmap_front_to_back: bool = Field(alias="seatmapfronttoback")
     seatmap_left_to_right: bool = Field(alias="seatmaplefttoright")
     seatmap_skip_missing_seats: bool = Field(alias="seatmapskipmissingseats")
 
 
-class SeatmapCDS(pydantic.RootModel, CDSBaseModel):
+class Seatmap(pydantic.RootModel, CineOfficeBaseModel):
     root: list[list[int]]
 
     @property
@@ -132,16 +132,16 @@ class SeatmapCDS(pydantic.RootModel, CDSBaseModel):
         return len(self.map[0]) if len(self.map[0]) > 0 else 0
 
 
-class CancelBookingCDS(CDSBaseModel):
+class CancelBooking(CineOfficeBaseModel):
     barcodes: list[int]
     paiement_type_id: int = Field(alias="paiementtypeid")
 
 
-class CancelBookingsErrorsCDS(pydantic.RootModel, CDSBaseModel):
+class CancelBookingsErrors(pydantic.RootModel, CineOfficeBaseModel):
     root: dict[str, str]
 
 
-class TicketSaleCDS(CDSBaseModel):
+class TicketSale(CineOfficeBaseModel):
     id: int
     cinema_id: str = Field(alias="cinemaid")
     operation_date: str = Field(alias="operationdate")
@@ -149,44 +149,44 @@ class TicketSaleCDS(CDSBaseModel):
     seat_col: int | None = Field(alias="seatcol", default=None)
     seat_row: int | None = Field(alias="seatrow", default=None)
     seat_number: str | None = Field(alias="seatnumber", default=None)
-    tariff: IdObjectCDS = Field(alias="tariffid")
+    tariff: IdObject = Field(alias="tariffid")
     voucher_type: str = Field(alias="vouchertype")
-    show: IdObjectCDS = Field(alias="showid")
+    show: IdObject = Field(alias="showid")
     disabled_person: bool = Field(alias="disabledperson")
 
 
-class TransactionPayementCDS(CDSBaseModel):
+class TransactionPayement(CineOfficeBaseModel):
     id: int
     amount: float
-    payement_type: IdObjectCDS = Field(alias="paiementtypeid")
-    voucher_type: IdObjectCDS = Field(alias="vouchertypeid")
+    payement_type: IdObject = Field(alias="paiementtypeid")
+    voucher_type: IdObject = Field(alias="vouchertypeid")
 
 
-class CreateTransactionBodyCDS(CDSBaseModel):
+class CreateTransactionBody(CineOfficeBaseModel):
     cinema_id: str = Field(alias="cinemaid")
     transaction_date: str = Field(alias="transactiondate")
     is_cancelled: bool = Field(alias="canceled")
-    ticket_sale_collection: list[TicketSaleCDS] = Field(alias="ticketsaleCollection")
-    payement_collection: list[TransactionPayementCDS] = Field(alias="paiementCollection")
+    ticket_sale_collection: list[TicketSale] = Field(alias="ticketsaleCollection")
+    payement_collection: list[TransactionPayement] = Field(alias="paiementCollection")
 
 
-class TicketResponseCDS(CDSBaseModel):
+class TicketResponse(CineOfficeBaseModel):
     barcode: str
     seat_number: str | None = Field(alias="seatnumber", default=None)
 
 
-class CreateTransactionResponseCDS(CDSBaseModel):
+class CreateTransactionResponse(CineOfficeBaseModel):
     id: int
     invoice_id: str = Field(alias="invoiceid")
-    tickets: list[TicketResponseCDS]
+    tickets: list[TicketResponse]
 
 
-class SeatCDS:
+class Seat:
     def __init__(
         self,
         seat_location_indices: tuple[int, int],
-        screen_infos: ScreenCDS,
-        seat_map: SeatmapCDS,
+        screen_infos: Screen,
+        seat_map: Seatmap,
         hardcoded_seatmap: list[list[str | typing.Literal[0]]],
     ):
         self.seatRow = seat_location_indices[0]

--- a/api/src/pcapi/core/providers/commands.py
+++ b/api/src/pcapi/core/providers/commands.py
@@ -15,8 +15,8 @@ from pcapi.utils import logging as logging_utils
 from pcapi.utils.blueprint import Blueprint
 
 from .etls.boost_etl import BoostExtractTransformLoadProcess
-from .etls.cds_etl import CDSExtractTransformLoadProcess
 from .etls.cgr_etl import CGRExtractTransformLoadProcess
+from .etls.cine_office_etl import CineOfficeExtractTransformLoadProcess
 from .etls.ems_etl import EMSExtractTransformLoadProcess
 from .titelive_utils import generate_titelive_gtl_from_file
 
@@ -52,12 +52,13 @@ def test_etl_integration(venue_provider_id: int) -> None:
     local_class_to_etl_mapping: dict[
         str,
         Type[BoostExtractTransformLoadProcess]
-        | Type[CDSExtractTransformLoadProcess]
+        | Type[CineOfficeExtractTransformLoadProcess]
         | Type[CGRExtractTransformLoadProcess]
         | Type[EMSExtractTransformLoadProcess],
     ] = {
         "BoostStocks": BoostExtractTransformLoadProcess,
-        "CDSStocks": CDSExtractTransformLoadProcess,
+        # INFO: CDS is the old name of CineOffice
+        "CDSStocks": CineOfficeExtractTransformLoadProcess,
         "CGRStocks": CGRExtractTransformLoadProcess,
         "EMSStocks": EMSExtractTransformLoadProcess,
     }
@@ -157,7 +158,7 @@ def synchronize_allocine_stocks() -> None:
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_RECURRENT_CRON)
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_CDS_IMPLEMENTATION)
 def synchronize_cine_office_stocks() -> None:
-    """Launch Cine Office synchronization."""
+    """Launch Ciné Office synchronization."""
     cine_office_stocks_provider = providers_repository.get_provider_by_local_class("CDSStocks")
     assert cine_office_stocks_provider  # helps mypy
     venue_providers = providers_repository.get_active_venue_providers_by_provider(cine_office_stocks_provider.id)

--- a/api/src/pcapi/core/providers/etls/cine_office_etl.py
+++ b/api/src/pcapi/core/providers/etls/cine_office_etl.py
@@ -5,8 +5,8 @@ import typing
 from pcapi import settings
 from pcapi.core.providers import models
 from pcapi.core.providers import repository
-from pcapi.core.providers.clients import cds_serializers
-from pcapi.core.providers.clients.cds_client import CineDigitalServiceAPIClient
+from pcapi.core.providers.clients import cine_office_serializers
+from pcapi.core.providers.clients.cine_office_client import CineOfficeAPIClient
 from pcapi.utils import date as date_utils
 
 from .cinema_etl_template import CinemaETLProcessTemplate
@@ -18,20 +18,19 @@ from .cinema_etl_template import ShowStockData
 logger = logging.getLogger(__name__)
 
 
-class CineDigitalServiceExtractResult(typing.TypedDict):
-    movies: list[cds_serializers.MediaCDS]
+class CineOfficeExtractResult(typing.TypedDict):
+    movies: list[cine_office_serializers.Media]
     media_options: dict[int, str]
-    shows: list[cds_serializers.ShowCDS]
-    voucher_types: list[cds_serializers.VoucherTypeCDS]
+    shows: list[cine_office_serializers.Show]
+    voucher_types: list[cine_office_serializers.VoucherType]
     is_internet_sale_gauge_active: bool
 
 
-class CDSExtractTransformLoadProcess(
-    CinemaETLProcessTemplate[CineDigitalServiceAPIClient, CineDigitalServiceExtractResult]
-):
+# INFO: The old name of CineOffice was CineDigitalService or CDS
+class CineOfficeExtractTransformLoadProcess(CinemaETLProcessTemplate[CineOfficeAPIClient, CineOfficeExtractResult]):
     """
     Integration to import products, offers, stocks & price_categories for a `Venue`
-    linked to `CDS`.
+    linked to `Ciné Office`.
     """
 
     def __init__(self, venue_provider: models.VenueProvider):
@@ -42,7 +41,7 @@ class CDSExtractTransformLoadProcess(
         cinema_details = repository.get_cds_cinema_details(venue_provider.venueIdAtOfferProvider)
         super().__init__(
             venue_provider=venue_provider,
-            api_client=CineDigitalServiceAPIClient(
+            api_client=CineOfficeAPIClient(
                 cinema_id=venue_provider.venueIdAtOfferProvider,
                 account_id=cinema_details.accountId,
                 cinema_api_token=cinema_details.cinemaApiToken,
@@ -50,7 +49,7 @@ class CDSExtractTransformLoadProcess(
             ),
         )
 
-    def _extract(self) -> CineDigitalServiceExtractResult:
+    def _extract(self) -> CineOfficeExtractResult:
         """
         Step 1: Fetch data from CDS API
         """
@@ -62,7 +61,7 @@ class CDSExtractTransformLoadProcess(
             "is_internet_sale_gauge_active": self.api_client.get_internet_sale_gauge_active(),
         }
 
-    def _transform(self, extract_result: CineDigitalServiceExtractResult) -> list[LoadableMovie]:
+    def _transform(self, extract_result: CineOfficeExtractResult) -> list[LoadableMovie]:
         loadable_data_by_movie_uuid: dict[str, LoadableMovie] = {}
         is_internet_sale_gauge_active = extract_result["is_internet_sale_gauge_active"]
         for movie in extract_result["movies"]:
@@ -151,7 +150,7 @@ class CDSExtractTransformLoadProcess(
 
         return loadable_movies
 
-    def _extract_result_to_log_dict(self, extract_result: CineDigitalServiceExtractResult) -> dict:
+    def _extract_result_to_log_dict(self, extract_result: CineOfficeExtractResult) -> dict:
         """Helper method to easily log result from extract step"""
         return {
             "movies": [movie.model_dump_json() for movie in extract_result["movies"]],

--- a/api/src/pcapi/core/providers/models.py
+++ b/api/src/pcapi/core/providers/models.py
@@ -266,7 +266,7 @@ class CinemaProviderPivot(PcObject, Model):
 
 
 class CDSCinemaDetails(PcObject, Model):
-    """Stores info on the specific login details of a cinema synced with CDS"""
+    """Stores info on the specific login details of a cinema synced with CineOffice (CDS is the old name)"""
 
     __tablename__ = "cds_cinema_details"
 

--- a/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
+++ b/api/src/pcapi/local_providers/cinema_providers/cds/cds_stocks.py
@@ -16,9 +16,9 @@ import pcapi.utils.date as utils_date
 from pcapi import settings
 from pcapi.core.categories import subcategories
 from pcapi.core.offerers.models import Venue
-from pcapi.core.providers.clients.cds_client import CineDigitalServiceAPIClient
-from pcapi.core.providers.clients.cds_serializers import MediaCDS
-from pcapi.core.providers.clients.cds_serializers import ShowCDS
+from pcapi.core.providers.clients.cine_office_client import CineOfficeAPIClient
+from pcapi.core.providers.clients.cine_office_serializers import Media
+from pcapi.core.providers.clients.cine_office_serializers import Show
 from pcapi.core.providers.models import VenueProvider
 from pcapi.core.providers.repository import get_cds_cinema_details
 from pcapi.local_providers.chunk_manager import get_last_update_for_provider
@@ -54,13 +54,13 @@ class CDSStocks(LocalProvider):
         self.apiToken = cinema_details.cinemaApiToken
         self.accountId = cinema_details.accountId
         self.isDuo = venue_provider.isDuoOffers if venue_provider.isDuoOffers else False
-        self.client_cds = CineDigitalServiceAPIClient(
+        self.client_cds = CineOfficeAPIClient(
             cinema_id=self.cinema_id,
             account_id=self.accountId,
             cinema_api_token=self.apiToken,
             request_timeout=settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS,
         )
-        self.movies: Iterator[MediaCDS] = iter(self.client_cds.get_venue_movies())
+        self.movies: Iterator[Media] = iter(self.client_cds.get_venue_movies())
         self.media_options = self.client_cds.get_media_options()
         self.shows = self._get_cds_shows()
         self.filtered_movie_showtimes = None
@@ -194,7 +194,7 @@ class CDSStocks(LocalProvider):
                 % (showtime_uuid, self.movie_information.allocineid, self.venue.id)
             )
 
-        show: ShowCDS = showtime["show_information"]
+        show: Show = showtime["show_information"]
         local_tz = utils_date.get_department_timezone(self.venue.offererAddress.address.departmentCode)
         datetime_in_utc = utils_date.local_datetime_to_default_timezone(show.showtime, local_tz)
 
@@ -298,7 +298,7 @@ class CDSStocks(LocalProvider):
 
         return shows_with_pass_culture_tariff
 
-    def get_or_create_movie_product(self, movie: MediaCDS) -> offers_models.Product | None:
+    def get_or_create_movie_product(self, movie: Media) -> offers_models.Product | None:
         assert self.provider  # helps mypy
         generic_movie = movie.to_generic_movie()
         product = offers_api.upsert_movie_product_from_provider(generic_movie, self.provider)
@@ -331,9 +331,9 @@ def _build_movie_uuid(movie_information_id: int, venue: Venue) -> str:
     return f"{movie_information_id}%{venue.id}%CDS"
 
 
-def _build_showtime_uuid(showtime_details: ShowCDS) -> str:
+def _build_showtime_uuid(showtime_details: Show) -> str:
     return str(showtime_details.id)
 
 
-def _build_stock_uuid(movie_information_id: int, venue: Venue, showtime_details: ShowCDS) -> str:
+def _build_stock_uuid(movie_information_id: int, venue: Venue, showtime_details: Show) -> str:
     return f"{_build_movie_uuid(movie_information_id, venue)}#{_build_showtime_uuid(showtime_details)}"

--- a/api/src/pcapi/local_providers/provider_manager.py
+++ b/api/src/pcapi/local_providers/provider_manager.py
@@ -7,8 +7,8 @@ import pcapi.connectors.ems as ems_connectors
 from pcapi.core.providers import models as provider_models
 from pcapi.core.providers import repository as providers_repository
 from pcapi.core.providers.etls.boost_etl import BoostExtractTransformLoadProcess
-from pcapi.core.providers.etls.cds_etl import CDSExtractTransformLoadProcess
 from pcapi.core.providers.etls.cgr_etl import CGRExtractTransformLoadProcess
+from pcapi.core.providers.etls.cine_office_etl import CineOfficeExtractTransformLoadProcess
 from pcapi.local_providers.allocine.allocine_stocks import AllocineStocks
 from pcapi.local_providers.cinema_providers.boost.boost_stocks import BoostStocks
 from pcapi.local_providers.cinema_providers.cds.cds_stocks import CDSStocks
@@ -27,18 +27,18 @@ logger = logging.getLogger(__name__)
 _NAME_TO_LOCAL_PROVIDER_CLASS: dict[str, Type[LocalProvider]] = {
     "AllocineStocks": AllocineStocks,
     "BoostStocks": BoostStocks,
-    "CDSStocks": CDSStocks,
+    "CDSStocks": CDSStocks,  # INFO: CDS is the old name of CineOffice
     "CGRStocks": CGRStocks,
 }
 
 _LOCAL_CLASS_NAME_TO_ETL_CLASS: dict[
     str,
     Type[BoostExtractTransformLoadProcess]
-    | Type[CDSExtractTransformLoadProcess]
+    | Type[CineOfficeExtractTransformLoadProcess]
     | Type[CGRExtractTransformLoadProcess],
 ] = {
     "BoostStocks": BoostExtractTransformLoadProcess,
-    "CDSStocks": CDSExtractTransformLoadProcess,
+    "CDSStocks": CineOfficeExtractTransformLoadProcess,  # INFO: CDS is the old name of CineOffice
     "CGRStocks": CGRExtractTransformLoadProcess,
 }
 

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -38,7 +38,7 @@ class FeatureToggle(enum.Enum):
     APP_ENABLE_AUTOCOMPLETE = "Active l'autocomplete sur la barre de recherche relative au rework de la homepage"
     BENEFICIARY_VALIDATION_AFTER_FRAUD_CHECKS = "Active la validation d'un bénéficiaire via les contrôles de sécurité"
     DISABLE_BOOST_EXTERNAL_BOOKINGS = "Désactiver les réservations externes Boost"
-    DISABLE_CDS_EXTERNAL_BOOKINGS = "Désactiver les réservations externes CDS"
+    DISABLE_CDS_EXTERNAL_BOOKINGS = "Désactiver les réservations externes Ciné Office (ex-CDS)"
     DISABLE_CGR_EXTERNAL_BOOKINGS = "Désactiver les réservations externes CGR"
     DISABLE_EMS_EXTERNAL_BOOKINGS = "Désactiver les réservations externes EMS"
     DISCORD_ENABLE_NEW_ACCESS = "Activer/Désactiver l'accès au serveur Discord à des nouveaux utilisateurs"
@@ -56,7 +56,7 @@ class FeatureToggle(enum.Enum):
         "Active la synchronisation des comptes bancaires avec l'outil finance externe (Cegid XRP Flex)"
     )
     ENABLE_BEAMER = "Active Beamer, le système de notifs du portail pro"
-    ENABLE_CDS_IMPLEMENTATION = "Permet la réservation de place de cinéma avec l'API CDS"
+    ENABLE_CDS_IMPLEMENTATION = "Permet la réservation de place de cinéma avec l'API Ciné Office (ex-CDS)"
     ENABLE_CRON_TO_UPDATE_OFFERER_STATS = "Active la mise à jour des statistiques des entités juridiques avec un cron"
     ENABLE_CHRONICLES_SYNC = "Activer la synchronisation des chroniques"
     ENABLE_CULTURAL_SURVEY = "Activer l'affichage du questionnaire des pratiques initiales pour les bénéficiaires"

--- a/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/individual_bookings_blueprint.py
@@ -31,8 +31,8 @@ from pcapi.core.geography import models as geography_models
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
-from pcapi.core.providers.clients import cds_client
 from pcapi.core.providers.clients import cgr_client
+from pcapi.core.providers.clients import cine_office_client
 from pcapi.core.users import models as users_models
 from pcapi.models import db
 from pcapi.routes.backoffice import autocomplete
@@ -516,7 +516,7 @@ def _batch_cancel_bookings(
                 mark_transaction_as_invalid()
             except (
                 cgr_client.CGRAPIException,
-                cds_client.CineDigitalServiceAPIException,
+                cine_office_client.CineOfficeAPIException,
                 ems.EMSAPIException,
             ) as exc:
                 logger.info(

--- a/api/src/pcapi/routes/backoffice/pivots/contexts/cineoffice.py
+++ b/api/src/pcapi/routes/backoffice/pivots/contexts/cineoffice.py
@@ -8,8 +8,8 @@ from werkzeug.exceptions import NotFound
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.providers import models as providers_models
 from pcapi.core.providers import repository as providers_repository
-from pcapi.core.providers.clients.cds_client import CineDigitalServiceAPIClient
-from pcapi.core.providers.clients.cds_client import CineDigitalServiceAPIException
+from pcapi.core.providers.clients.cine_office_client import CineOfficeAPIClient
+from pcapi.core.providers.clients.cine_office_client import CineOfficeAPIException
 from pcapi.models import db
 from pcapi.utils import requests
 
@@ -109,11 +109,11 @@ class CineofficeContext(PivotContext):
     @classmethod
     def check_if_api_call_is_ok(cls, account_id: str, api_token: str) -> None:
         try:
-            client = CineDigitalServiceAPIClient(cinema_id="", account_id=account_id, cinema_api_token=api_token)
+            client = CineOfficeAPIClient(cinema_id="", account_id=account_id, cinema_api_token=api_token)
             client.get_rating()
             flash("Connexion à l'API OK.", "success")
-        except (requests.exceptions.RequestException, CineDigitalServiceAPIException) as exc:
+        except (requests.exceptions.RequestException, CineOfficeAPIException) as exc:
             logger.warning(
-                "Network error on checking CDS API information", extra={"exc": exc, "account_id": account_id}
+                "Network error on checking CineOffice API information", extra={"exc": exc, "account_id": account_id}
             )
             flash(Markup("Connexion à l'API KO : {error}").format(error=exc), "warning")

--- a/api/src/pcapi/routes/backoffice/pivots/forms.py
+++ b/api/src/pcapi/routes/backoffice/pivots/forms.py
@@ -94,9 +94,9 @@ class EditCGRForm(EditPivotForm):
 
 
 class EditCineOfficeForm(EditPivotForm):
-    cinema_id = fields.PCStringField("Identifiant cinéma (CDS)")
-    account_id = fields.PCStringField("Nom de compte (CDS)")
-    api_token = fields.PCStringField("Clé API (CDS)")
+    cinema_id = fields.PCStringField("Identifiant cinéma (Ciné Office)")
+    account_id = fields.PCStringField("Nom de compte (Ciné Office)")
+    api_token = fields.PCStringField("Clé API (Ciné Office)")
 
     def validate_account_id(self, account_id: fields.PCStringField) -> fields.PCStringField:
         # account_id is used to build a url; only some specific characters are allowed

--- a/api/src/pcapi/routes/backoffice/templates/pivots/get/cineoffice.html
+++ b/api/src/pcapi/routes/backoffice/templates/pivots/get/cineoffice.html
@@ -7,8 +7,8 @@
       <th scope="col"></th>
       <th scope="col">Id du partenaire culturel</th>
       <th scope="col">Partenaire culturel</th>
-      <th scope="col">Identifiant cinéma (CDS)</th>
-      <th scope="col">Nom de l'utilisateur (CDS)</th>
+      <th scope="col">Identifiant cinéma (Ciné Office)</th>
+      <th scope="col">Nom de l'utilisateur (Ciné Office)</th>
     </tr>
   </thead>
   <tbody>

--- a/api/src/pcapi/utils/requests.py
+++ b/api/src/pcapi/utils/requests.py
@@ -75,9 +75,9 @@ def _redact_url(url: str | None) -> str | None:
             "codeCogInseeCommuneNaissance",
             "annee",
             "mois",
-            # Allociné and Cine Digital Service (CDS) want authentication token to appear in GET
+            # Allociné and Ciné Office (ex-CDS) want authentication token to appear in GET
             # requests. We don't want to log them.
-            # For Allociné, the query param name is 'token'. For CDS, the name is 'api_token'
+            # For Allociné, the query param name is 'token'. For Ciné Office, the name is 'api_token'
             "token",
         ]
     )

--- a/api/tests/core/bookings/test_api_race_condition.py
+++ b/api/tests/core/bookings/test_api_race_condition.py
@@ -119,7 +119,7 @@ class BookingRaceConditionTest:
             Session.remove()
 
     @pytest.mark.usefixtures("clean_database")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     @patch("pcapi.settings.CDS_API_URL", "fakeUrl/")
     def test_stock_race_condition_between_booking_and_synchronization(self, mock_get_venue_movies, requests_mock, app):
         # Given

--- a/api/tests/core/external_bookings/test_api.py
+++ b/api/tests/core/external_bookings/test_api.py
@@ -20,7 +20,7 @@ from pcapi.core.external_bookings.api import book_event_ticket
 from pcapi.core.external_bookings.api import cancel_event_ticket
 from pcapi.core.external_bookings.api import get_active_cinema_venue_provider
 from pcapi.core.external_bookings.api import send_booking_notification_to_external_service
-from pcapi.core.providers.clients.cds_client import CineDigitalServiceAPIClient
+from pcapi.core.providers.clients.cine_office_client import CineOfficeAPIClient
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.tasks.serialization.external_api_booking_notification_tasks import BookingAction
 
@@ -69,7 +69,7 @@ class InstantiateCinemaApiClientTest:
         venue_id = venue_provider.venueId
         client_api = _instantiate_cinema_api_client(venue_id)
 
-        assert isinstance(client_api, CineDigitalServiceAPIClient)
+        assert isinstance(client_api, CineOfficeAPIClient)
         assert client_api.cinema_id == "test_id"
         assert client_api.token == "test_token"
         assert client_api.base_url == "https://test_account.test_cds_url/vad/"

--- a/api/tests/core/providers/clients/test_cine_office_client.py
+++ b/api/tests/core/providers/clients/test_cine_office_client.py
@@ -10,13 +10,13 @@ import time_machine
 import pcapi.core.bookings.factories as bookings_factories
 import pcapi.core.external_bookings.exceptions as external_bookings_exceptions
 import pcapi.core.users.factories as users_factories
-from pcapi.core.providers.clients import cds_client
-from pcapi.core.providers.clients import cds_serializers
-from pcapi.core.providers.clients.cds_client import CineDigitalServiceAPIClient
+from pcapi.core.providers.clients import cine_office_client
+from pcapi.core.providers.clients import cine_office_serializers
+from pcapi.core.providers.clients.cine_office_client import CineOfficeAPIClient
 from pcapi.utils import date as date_utils
 
 
-def create_show_cds(
+def create_show(
     id_: int = 1,
     is_cancelled: bool = False,
     is_deleted: bool = False,
@@ -29,8 +29,8 @@ def create_show_cds(
     screen_id: int = 50,
     media_id: int = 52,
     mediaoptions_ids=(),
-) -> cds_serializers.ShowCDS:
-    return cds_serializers.ShowCDS(
+) -> cine_office_serializers.Show:
+    return cine_office_serializers.Show(
         id=id_,
         is_cancelled=is_cancelled,
         is_deleted=is_deleted,
@@ -40,25 +40,27 @@ def create_show_cds(
         internet_remaining_place=internet_remaining_place,
         showtime=showtime,
         shows_tariff_pos_type_collection=[
-            cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=show_tariff_id))
+            cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=show_tariff_id))
             for show_tariff_id in shows_tariff_pos_type_ids
         ],
-        screen=cds_serializers.IdObjectCDS(id=screen_id),
-        media=cds_serializers.IdObjectCDS(id=media_id),
+        screen=cine_office_serializers.IdObject(id=screen_id),
+        media=cine_office_serializers.IdObject(id=media_id),
         shows_mediaoptions_collection=[
-            cds_serializers.ShowsMediaoptionsCDS(media_options_id=cds_serializers.IdObjectCDS(id=media_option_id))
+            cine_office_serializers.ShowsMediaOptions(
+                media_options_id=cine_office_serializers.IdObject(id=media_option_id)
+            )
             for media_option_id in mediaoptions_ids
         ],
     )
 
 
-def create_screen_cds(
+def create_screen(
     id_: int = 50,
     seatmap_front_to_back: bool = True,
     seatmap_left_to_right: bool = True,
     seatmap_skip_missing_seats: bool = False,
-) -> cds_serializers.ScreenCDS:
-    return cds_serializers.ScreenCDS(
+) -> cine_office_serializers.Screen:
+    return cine_office_serializers.Screen(
         id=id_,
         seatmap_front_to_back=seatmap_front_to_back,
         seatmap_left_to_right=seatmap_left_to_right,
@@ -144,26 +146,26 @@ ONE_SHOW_RESPONSE_JSON = [
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceGetShowTest:
+class CineOfficeGetShowTest:
     def test_should_return_show_corresponding_to_show_id(self, caplog, requests_mock):
         requests_mock.get(
             "https://accountid_test.apiUrl_test/shows?api_token=token_test",
             json=MANY_SHOWS_RESPONSE_JSON,
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="cinemaid_test",
             account_id="accountid_test",
             cinema_api_token="token_test",
             request_timeout=14,
         )
-        with caplog.at_level(logging.DEBUG, logger="pcapi.core.providers.clients.cds_client"):
+        with caplog.at_level(logging.DEBUG, logger="pcapi.core.providers.clients.cine_office_client"):
             show = cine_digital_service.get_show(2)
 
         assert len(caplog.records) == 1
         assert caplog.records[0].message == "[CINEMA] Call to external API"
         assert caplog.records[0].extra == {
-            "api_client": "CineDigitalServiceAPIClient",
+            "api_client": "CineOfficeAPIClient",
             "method": "GET https://accountid_test.apiUrl_test/shows",
             "cinema_id": "cinemaid_test",
             "response": MANY_SHOWS_RESPONSE_JSON,
@@ -177,7 +179,7 @@ class CineDigitalServiceGetShowTest:
             "https://accountid_test.apiUrl_test/shows?api_token=token_test",
             json=response_json,
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id",
             account_id="accountid_test",
             cinema_api_token="token_test",
@@ -195,7 +197,7 @@ class CineDigitalServiceGetShowTest:
         show.update(seatmap=seatmap)
         requests_mock.get("https://account_test.apiUrl_test/shows?api_token=token_test", json=[show])
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="account_test", cinema_api_token="token_test"
         )
 
@@ -204,7 +206,7 @@ class CineDigitalServiceGetShowTest:
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceGetPaymentTypeTest:
+class CineOfficeGetPaymentTypeTest:
     def test_should_return_voucher_payment_type(self, caplog, requests_mock):
         requests_mock.get(
             "https://accountid_test.apiUrl_test/paiementtype?api_token=token_test",
@@ -214,7 +216,7 @@ class CineDigitalServiceGetPaymentTypeTest:
             ],
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="cinemaid_test",
             account_id="accountid_test",
             cinema_api_token="token_test",
@@ -222,13 +224,13 @@ class CineDigitalServiceGetPaymentTypeTest:
 
         payment_type = cine_digital_service.get_voucher_payment_type()
 
-        with caplog.at_level(logging.DEBUG, logger="pcapi.core.providers.clients.cds_client"):
+        with caplog.at_level(logging.DEBUG, logger="pcapi.core.providers.clients.cine_office_client"):
             payment_type = cine_digital_service.get_voucher_payment_type()
 
         assert len(caplog.records) == 1
         assert caplog.records[0].message == "[CINEMA] Call to external API"
         assert caplog.records[0].extra == {
-            "api_client": "CineDigitalServiceAPIClient",
+            "api_client": "CineOfficeAPIClient",
             "method": "GET https://accountid_test.apiUrl_test/paiementtype",
             "cinema_id": "cinemaid_test",
             "response": [
@@ -249,10 +251,10 @@ class CineDigitalServiceGetPaymentTypeTest:
             ],
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
-        with pytest.raises(cds_client.CineDigitalServiceAPIException) as cds_exception:
+        with pytest.raises(cine_office_client.CineOfficeAPIException) as cds_exception:
             cine_digital_service.get_voucher_payment_type()
         assert (
             str(cds_exception.value)
@@ -261,7 +263,7 @@ class CineDigitalServiceGetPaymentTypeTest:
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceGetPCVoucherTypesTest:
+class CineOfficeGetPCVoucherTypesTest:
     def test_should_return_only_voucher_types_with_pass_culture_code_and_tariff(self, requests_mock, caplog):
         requests_mock.get(
             "https://accountid_test.apiUrl_test/vouchertype?api_token=token_test",
@@ -273,19 +275,19 @@ class CineDigitalServiceGetPCVoucherTypesTest:
                 {"id": 5, "code": None},
             ],
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="cinemaid_test",
             account_id="accountid_test",
             cinema_api_token="token_test",
         )
 
-        with caplog.at_level(logging.DEBUG, logger="pcapi.core.providers.clients.cds_client"):
+        with caplog.at_level(logging.DEBUG, logger="pcapi.core.providers.clients.cine_office_client"):
             pc_voucher_types = cine_digital_service.get_pc_voucher_types()
 
         assert len(caplog.records) == 1
         assert caplog.records[0].message == "[CINEMA] Call to external API"
         assert caplog.records[0].extra == {
-            "api_client": "CineDigitalServiceAPIClient",
+            "api_client": "CineOfficeAPIClient",
             "method": "GET https://accountid_test.apiUrl_test/vouchertype",
             "cinema_id": "cinemaid_test",
             "response": [
@@ -319,7 +321,7 @@ class CineDigitalServiceGetPCVoucherTypesTest:
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceGetScreenTest:
+class CineOfficeGetScreenTest:
     def test_should_return_screen_corresponding_to_screen_id(self, requests_mock):
         requests_mock.get(
             "https://accountid_test.apiUrl_test/screens?api_token=token_test",
@@ -329,7 +331,7 @@ class CineDigitalServiceGetScreenTest:
                 {"id": 3, "seatmapfronttoback": True, "seatmaplefttoright": True, "seatmapskipmissingseats": True},
             ],
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         show = cine_digital_service.get_screen(2)
@@ -360,10 +362,10 @@ class CineDigitalServiceGetScreenTest:
                 },
             ],
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
-        with pytest.raises(cds_client.CineDigitalServiceAPIException) as cds_exception:
+        with pytest.raises(cine_office_client.CineOfficeAPIException) as cds_exception:
             cine_digital_service.get_screen(4)
         assert (
             str(cds_exception.value)
@@ -372,17 +374,17 @@ class CineDigitalServiceGetScreenTest:
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceGetAvailableSingleSeatTest:
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_hardcoded_seatmap", return_value=[])
+class CineOfficeGetAvailableSingleSeatTest:
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_hardcoded_seatmap", return_value=[])
     def test_should_return_seat_available(self, mocked_get_hardcoded_seatmap, requests_mock):
-        screen = cds_serializers.ScreenCDS(
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=True,
             seatmaplefttoright=True,
             seatmapskipmissingseats=False,
         )
 
-        show = create_show_cds(id_=1)
+        show = create_show(id_=1)
 
         requests_mock.get(
             "https://accountid_test.apiUrl_test/shows/1/seatmap?api_token=token_test",
@@ -399,7 +401,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
             ],
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
 
@@ -409,7 +411,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert best_seat[0].seatCol == 5
         assert best_seat[0].seatNumber == "E_6"
 
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_hardcoded_seatmap")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_hardcoded_seatmap")
     def test_should_return_seat_available_when_seatmap_is_hardcoded(self, mocked_get_hardcoded_seatmap, requests_mock):
         mocked_hardcoded_seatmap = [
             ["P_17", "P_15", "P_13", "P_11", "P_9", "P_7", "P_5", "P_3", "P_1"],
@@ -419,14 +421,14 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
 
         mocked_get_hardcoded_seatmap.return_value = mocked_hardcoded_seatmap
 
-        screen = cds_serializers.ScreenCDS(
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=True,
             seatmaplefttoright=True,
             seatmapskipmissingseats=False,
         )
 
-        show = create_show_cds(id_=1)
+        show = create_show(id_=1)
 
         requests_mock.get(
             "https://accountid_test.apiUrl_test/shows/1/seatmap?api_token=token_test",
@@ -436,7 +438,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
                 [1, 1, 1, 1, 1, 1, 0, 1, 1],
             ],
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
 
@@ -446,7 +448,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert best_seat[0].seatCol == 4
         assert best_seat[0].seatNumber == "M_9"
 
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_hardcoded_seatmap", return_value=[])
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_hardcoded_seatmap", return_value=[])
     def test_should_not_return_prm_seat(self, mocked_get_hardcoded_seatmap, requests_mock):
         seatmap_json = [
             [1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1],
@@ -460,18 +462,18 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
             [0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 1],
         ]
 
-        screen = cds_serializers.ScreenCDS(
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=True,
             seatmaplefttoright=True,
             seatmapskipmissingseats=False,
         )
-        show = create_show_cds(id_=1, screen_id=1)
+        show = create_show(id_=1, screen_id=1)
         requests_mock.get(
             "https://accountid_test.apiUrl_test/shows/1/seatmap?api_token=token_test",
             json=seatmap_json,
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         best_seat = cine_digital_service.get_available_seat(show, screen)
@@ -480,7 +482,7 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         assert best_seat[0].seatCol == 5
         assert best_seat[0].seatNumber == "D_6"
 
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_hardcoded_seatmap", return_value=[])
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_hardcoded_seatmap", return_value=[])
     def test_should_return_seat_infos_according_to_screen(self, mocked_get_hardcoded_seatmap, requests_mock):
         seatmap_json = [
             [3, 3, 3, 3, 0, 0, 3, 3],
@@ -491,20 +493,20 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
             [3, 3, 3, 3, 0, 0, 3, 3],
         ]
 
-        screen = cds_serializers.ScreenCDS(
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=False,
             seatmaplefttoright=False,
             seatmapskipmissingseats=True,
         )
 
-        show = create_show_cds(id_=1, screen_id=1)
+        show = create_show(id_=1, screen_id=1)
 
         requests_mock.get(
             "https://accountid_test.apiUrl_test/shows/1/seatmap?api_token=token_test",
             json=seatmap_json,
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         best_seat = cine_digital_service.get_available_seat(show, screen)
@@ -522,25 +524,25 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
             [3, 3, 3, 3, 0, 3],
         ]
 
-        screen = cds_serializers.ScreenCDS(
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=True,
             seatmaplefttoright=True,
             seatmapskipmissingseats=False,
         )
-        show = create_show_cds(id_=1, screen_id=1)
+        show = create_show(id_=1, screen_id=1)
 
         requests_mock.get(
             "https://accountid_test.apiUrl_test/shows/1/seatmap?api_token=token_test",
             json=seatmap_json,
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         best_seat = cine_digital_service.get_available_seat(show, screen)
         assert not best_seat
 
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_hardcoded_seatmap", return_value=[])
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_hardcoded_seatmap", return_value=[])
     def test_should_return_correct_seat_number(self, mocked_get_hardcoded_seatmap, requests_mock):
         # fmt: off
         seatmap_json = [
@@ -561,19 +563,19 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
         ]
         # fmt: on
 
-        screen = cds_serializers.ScreenCDS(
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=True,
             seatmaplefttoright=False,
             seatmapskipmissingseats=False,
         )
-        show = create_show_cds(id_=1, screen_id=1)
+        show = create_show(id_=1, screen_id=1)
 
         requests_mock.get(
             "https://accountid_test.apiUrl_test/shows/1/seatmap?api_token=token_test",
             json=seatmap_json,
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         best_seat = cine_digital_service.get_available_seat(show, screen)
@@ -583,11 +585,11 @@ class CineDigitalServiceGetAvailableSingleSeatTest:
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceGetAvailableDuoSeatTest:
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_cinema_infos")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_seatmap")
+class CineOfficeGetAvailableDuoSeatTest:
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_cinema_infos")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_seatmap")
     def test_should_return_duo_seat_if_available(self, mocked_get_seatmap, mocked_get_cinema_infos):
-        seatmap = cds_serializers.SeatmapCDS(
+        seatmap = cine_office_serializers.Seatmap(
             [
                 [1, 1, 1, 1, 0, 1],
                 [1, 1, 1, 3, 0, 1],
@@ -597,18 +599,18 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
             ]
         )
 
-        cinema = cds_serializers.CinemaCDS(id="1", is_internet_sale_gauge_active=True)
-        screen = cds_serializers.ScreenCDS(
+        cinema = cine_office_serializers.Cinema(id="1", is_internet_sale_gauge_active=True)
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=True,
             seatmaplefttoright=True,
             seatmapskipmissingseats=False,
         )
-        show = create_show_cds(id_=1, screen_id=1)
+        show = create_show(id_=1, screen_id=1)
 
         mocked_get_seatmap.return_value = seatmap
         mocked_get_cinema_infos.return_value = cinema
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         duo_seats = cine_digital_service.get_available_duo_seat(show, screen)
@@ -616,12 +618,12 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
         assert duo_seats[0].seatNumber == "B_2"
         assert duo_seats[1].seatNumber == "B_3"
 
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_hardcoded_seatmap")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_seatmap")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_hardcoded_seatmap")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_seatmap")
     def test_should_return_duo_seat_if_available_when_seatmap_is_hardcoded(
         self, mocked_get_seatmap, mocked_get_hardcoded_seatmap
     ):
-        seatmap = cds_serializers.SeatmapCDS(
+        seatmap = cine_office_serializers.Seatmap(
             [
                 [1, 1, 1, 1, 0, 1],
                 [1, 1, 1, 3, 0, 1],
@@ -631,17 +633,17 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
             ["P_17", "P_15", "P_13", "P_11", "P_9", "P_7"],
             ["M_17", "M_15", "M_13", "M_11", "M_9", "M_7"],
         ]
-        screen = cds_serializers.ScreenCDS(
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=True,
             seatmaplefttoright=True,
             seatmapskipmissingseats=False,
         )
-        show = create_show_cds(id_=1, screen_id=1)
+        show = create_show(id_=1, screen_id=1)
 
         mocked_get_seatmap.return_value = seatmap
         mocked_get_hardcoded_seatmap.return_value = mocked_hardcoded_seatmap
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         duo_seats = cine_digital_service.get_available_duo_seat(show, screen)
@@ -658,29 +660,29 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
             [3, 3, 3, 3, 0, 3],
         ]
 
-        screen = cds_serializers.ScreenCDS(
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=True,
             seatmaplefttoright=True,
             seatmapskipmissingseats=False,
         )
-        show = create_show_cds(id_=1, screen_id=1)
+        show = create_show(id_=1, screen_id=1)
 
         requests_mock.get(
             "https://accountid_test.apiUrl_test/shows/1/seatmap?api_token=token_test",
             json=seatmap_json,
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         duo_seats = cine_digital_service.get_available_duo_seat(show, screen)
         assert len(duo_seats) == 0
 
     @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_cinema_infos")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_seatmap")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_cinema_infos")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_seatmap")
     def test_should_return_two_separate_seats_if_no_duo_available(self, mocked_get_seatmap, mocked_get_cinema_infos):
-        seatmap = cds_serializers.SeatmapCDS(
+        seatmap = cine_office_serializers.Seatmap(
             [
                 [1, 3, 1, 3, 0, 1],
                 [3, 3, 3, 3, 0, 3],
@@ -690,18 +692,18 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
             ]
         )
 
-        screen = cds_serializers.ScreenCDS(
+        screen = cine_office_serializers.Screen(
             id=1,
             seatmapfronttoback=True,
             seatmaplefttoright=True,
             seatmapskipmissingseats=False,
         )
-        show = create_show_cds(id_=1, screen_id=1)
-        cinema = cds_serializers.CinemaCDS(id="1", is_internet_sale_gauge_active=True)
+        show = create_show(id_=1, screen_id=1)
+        cinema = cine_office_serializers.Cinema(id="1", is_internet_sale_gauge_active=True)
 
         mocked_get_seatmap.return_value = seatmap
         mocked_get_cinema_infos.return_value = cinema
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         duo_seats = cine_digital_service.get_available_duo_seat(show, screen)
@@ -711,7 +713,7 @@ class CineDigitalServiceGetAvailableDuoSeatTest:
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceCancelBookingTest:
+class CineOfficeCancelBookingTest:
     def test_should_cancel_booking_with_success(self, requests_mock):
         requests_mock.put(
             "https://accountid_test.apiUrl_test/transaction/cancel?api_token=token_test",
@@ -722,7 +724,7 @@ class CineDigitalServiceCancelBookingTest:
             "https://accountid_test.apiUrl_test/paiementtype?api_token=token_test",
             json=[{"id": 12, "active": True, "internalcode": "VCH"}],
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id",
             account_id="accountid_test",
             cinema_api_token="token_test",
@@ -748,13 +750,13 @@ class CineDigitalServiceCancelBookingTest:
             json=[{"id": 12, "active": True, "internalcode": "VCH"}],
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id",
             account_id="accountid_test",
             cinema_api_token="token_test",
         )
 
-        with pytest.raises(cds_client.CineDigitalServiceAPIException) as exception:
+        with pytest.raises(cine_office_client.CineOfficeAPIException) as exception:
             cine_digital_service.cancel_booking(
                 ["111111111111", "222222222222", "333333333333", "444444444444", "555555555555"]
             )
@@ -778,7 +780,7 @@ class CineDigitalServiceCancelBookingTest:
             "https://accountid_test.apiUrl_test/paiementtype?api_token=token_test",
             json=[{"id": 12, "active": True, "internalcode": "VCH"}],
         )
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
 
@@ -786,9 +788,9 @@ class CineDigitalServiceCancelBookingTest:
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceGetVoucherForShowTest:
+class CineOfficeGetVoucherForShowTest:
     def test_should_return_none_when_show_does_not_have_pass_culture_tariff(self, requests_mock):
-        show = cds_serializers.ShowCDS(
+        show = cine_office_serializers.Show(
             id=1,
             is_cancelled=False,
             is_deleted=False,
@@ -797,11 +799,13 @@ class CineDigitalServiceGetVoucherForShowTest:
             remaining_place=88,
             internet_remaining_place=20,
             showtime=date_utils.get_naive_utc_now(),
-            shows_tariff_pos_type_collection=[cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=5))],
-            screen=cds_serializers.IdObjectCDS(id=1),
-            media=cds_serializers.IdObjectCDS(id=52),
+            shows_tariff_pos_type_collection=[
+                cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=5))
+            ],
+            screen=cine_office_serializers.IdObject(id=1),
+            media=cine_office_serializers.IdObject(id=52),
             shows_mediaoptions_collection=[
-                cds_serializers.ShowsMediaoptionsCDS(media_options_id=cds_serializers.IdObjectCDS(id=12))
+                cine_office_serializers.ShowsMediaOptions(media_options_id=cine_office_serializers.IdObject(id=12))
             ],
         )
 
@@ -813,7 +817,7 @@ class CineDigitalServiceGetVoucherForShowTest:
             ],
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
 
@@ -822,7 +826,7 @@ class CineDigitalServiceGetVoucherForShowTest:
         assert not voucher_type
 
     def test_should_return_psculture_voucher_with_the_lower_price(self, requests_mock):
-        show = cds_serializers.ShowCDS(
+        show = cine_office_serializers.Show(
             id=1,
             is_cancelled=False,
             is_deleted=False,
@@ -832,13 +836,13 @@ class CineDigitalServiceGetVoucherForShowTest:
             internet_remaining_place=20,
             showtime=date_utils.get_naive_utc_now(),
             shows_tariff_pos_type_collection=[
-                cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=3)),
-                cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=2)),
+                cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=3)),
+                cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=2)),
             ],
-            screen=cds_serializers.IdObjectCDS(id=1),
-            media=cds_serializers.IdObjectCDS(id=52),
+            screen=cine_office_serializers.IdObject(id=1),
+            media=cine_office_serializers.IdObject(id=52),
             shows_mediaoptions_collection=[
-                cds_serializers.ShowsMediaoptionsCDS(media_options_id=cds_serializers.IdObjectCDS(id=12))
+                cine_office_serializers.ShowsMediaOptions(media_options_id=cine_office_serializers.IdObject(id=12))
             ],
         )
 
@@ -850,7 +854,7 @@ class CineDigitalServiceGetVoucherForShowTest:
             ],
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
 
@@ -862,13 +866,13 @@ class CineDigitalServiceGetVoucherForShowTest:
 
 @pytest.mark.usefixtures("db_session")
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceBookTicketTest:
+class CineOfficeBookTicketTest:
     @time_machine.travel("2025-09-22T09:23:40.464832", tick=False)
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_show")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_screen")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_available_seat")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_pc_voucher_types")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_voucher_payment_type")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_show")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_screen")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_available_seat")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_pc_voucher_types")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_voucher_payment_type")
     def test_should_call_connector_with_correct_args_and_return_barcode_and_seat_number(
         self,
         mocked_get_voucher_payment_type,
@@ -880,32 +884,32 @@ class CineDigitalServiceBookTicketTest:
     ):
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         booking = bookings_factories.BookingFactory(user=beneficiary, quantity=1)
-        mocked_get_voucher_payment_type.return_value = cds_serializers.PaymentTypeCDS(
+        mocked_get_voucher_payment_type.return_value = cine_office_serializers.PaymentTypeCDS(
             id=12, internal_code="VCH", is_active=True
         )
         mocked_get_pc_voucher_types.return_value = [
-            cds_serializers.VoucherTypeCDS(
+            cine_office_serializers.VoucherType(
                 id=3,
                 code="PSCULTURE",
-                tariff=cds_serializers.TariffCDS(id=42, price=5, is_active=True, label="pass Culture"),
+                tariff=cine_office_serializers.Tariff(id=42, price=5, is_active=True, label="pass Culture"),
             )
         ]
 
         mocked_get_available_seat.return_value = [
-            cds_serializers.SeatCDS(
+            cine_office_serializers.Seat(
                 (0, 0),
-                create_screen_cds(),
-                seat_map=cds_serializers.SeatmapCDS([[1, 1, 1], [1, 1, 1], [1, 1, 1]]),
+                create_screen(),
+                seat_map=cine_office_serializers.Seatmap([[1, 1, 1], [1, 1, 1], [1, 1, 1]]),
                 hardcoded_seatmap=[],
             ),
         ]
 
-        mocked_get_show.return_value = create_show_cds(
+        mocked_get_show.return_value = create_show(
             id_=181,
             shows_tariff_pos_type_ids=[42],
             is_empty_seatmap='["1", "1", "1"], ["1", "1", "1"], ["1", "1", "1"]]',
         )
-        mocked_get_screen.return_value = create_screen_cds()
+        mocked_get_screen.return_value = create_screen()
 
         requests_mock.post(
             "https://accountid_test.apiUrl_test/transaction/create?api_token=token_test",
@@ -926,7 +930,7 @@ class CineDigitalServiceBookTicketTest:
             },
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id",
             account_id="accountid_test",
             cinema_api_token="token_test",
@@ -967,12 +971,12 @@ class CineDigitalServiceBookTicketTest:
         assert tickets[0].seat_number == "A_1"
 
     @time_machine.travel("2025-09-22T09:23:40.464832", tick=False)
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_available_seat")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_show")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_screen")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_available_duo_seat")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_pc_voucher_types")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_voucher_payment_type")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_available_seat")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_show")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_screen")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_available_duo_seat")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_pc_voucher_types")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_voucher_payment_type")
     @pytest.mark.parametrize("booking_quantity", [0, 1])
     def test_should_raise_not_enough_seats_error(
         self,
@@ -987,28 +991,28 @@ class CineDigitalServiceBookTicketTest:
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         booking = bookings_factories.BookingFactory(user=beneficiary, quantity=booking_quantity)
 
-        mocked_get_voucher_payment_type.return_value = cds_serializers.PaymentTypeCDS(
+        mocked_get_voucher_payment_type.return_value = cine_office_serializers.PaymentTypeCDS(
             id=12, internal_code="VCH", is_active=True
         )
         mocked_get_pc_voucher_types.return_value = [
-            cds_serializers.VoucherTypeCDS(
+            cine_office_serializers.VoucherType(
                 id=3,
                 code="PSCULTURE",
-                tariff=cds_serializers.TariffCDS(id=42, price=5, is_active=True, label="pass Culture"),
+                tariff=cine_office_serializers.Tariff(id=42, price=5, is_active=True, label="pass Culture"),
             )
         ]
 
         mocked_get_available_seat.return_value = []
         mocked_get_available_duo_seat.return_value = []
 
-        mocked_get_show.return_value = create_show_cds(
+        mocked_get_show.return_value = create_show(
             id_=181,
             shows_tariff_pos_type_ids=[42],
             is_empty_seatmap='["0", "0", "0"], ["0", "0", "0"], ["0", "0", "0"]]',
         )
-        mocked_get_screen.return_value = create_screen_cds()
+        mocked_get_screen.return_value = create_screen()
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
         with pytest.raises(external_bookings_exceptions.ExternalBookingNotEnoughSeatsError) as exc:
@@ -1017,11 +1021,11 @@ class CineDigitalServiceBookTicketTest:
         assert exc.value.remainingQuantity == 0
 
     @time_machine.travel("2025-09-22T09:23:40.464832", tick=False)
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_show")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_screen")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_available_duo_seat")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_pc_voucher_types")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_voucher_payment_type")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_show")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_screen")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_available_duo_seat")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_pc_voucher_types")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_voucher_payment_type")
     def test_should_call_connector_with_correct_args_and_return_barcodes_and_seat_numbers_for_duo(
         self,
         mocked_get_voucher_payment_type,
@@ -1035,28 +1039,28 @@ class CineDigitalServiceBookTicketTest:
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         booking = bookings_factories.BookingFactory(user=beneficiary, quantity=2)
         venue_id = booking.venueId
-        mocked_get_voucher_payment_type.return_value = cds_serializers.PaymentTypeCDS(
+        mocked_get_voucher_payment_type.return_value = cine_office_serializers.PaymentTypeCDS(
             id=12, internal_code="VCH", is_active=True
         )
         mocked_get_pc_voucher_types.return_value = [
-            cds_serializers.VoucherTypeCDS(
+            cine_office_serializers.VoucherType(
                 id=3,
                 code="PSCULTURE",
-                tariff=cds_serializers.TariffCDS(id=42, price=5, is_active=True, label="pass Culture"),
+                tariff=cine_office_serializers.Tariff(id=42, price=5, is_active=True, label="pass Culture"),
             )
         ]
-        mocked_seatmap = cds_serializers.SeatmapCDS([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+        mocked_seatmap = cine_office_serializers.Seatmap([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
         mocked_get_available_duo_seat.return_value = [
-            cds_serializers.SeatCDS((0, 0), create_screen_cds(), mocked_seatmap, hardcoded_seatmap=[]),
-            cds_serializers.SeatCDS((0, 1), create_screen_cds(), mocked_seatmap, hardcoded_seatmap=[]),
+            cine_office_serializers.Seat((0, 0), create_screen(), mocked_seatmap, hardcoded_seatmap=[]),
+            cine_office_serializers.Seat((0, 1), create_screen(), mocked_seatmap, hardcoded_seatmap=[]),
         ]
 
-        mocked_get_show.return_value = create_show_cds(
+        mocked_get_show.return_value = create_show(
             id_=181,
             shows_tariff_pos_type_ids=[42],
             is_empty_seatmap='["1", "1", "1"], ["1", "1", "1"], ["1", "1", "1"]]',
         )
-        mocked_get_screen.return_value = create_screen_cds()
+        mocked_get_screen.return_value = create_screen()
 
         requests_mock.post(
             "https://accountid_test.apiUrl_test/transaction/create?api_token=token_test",
@@ -1086,7 +1090,7 @@ class CineDigitalServiceBookTicketTest:
             },
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
 
@@ -1151,10 +1155,10 @@ class CineDigitalServiceBookTicketTest:
         assert first_external_booking_info["timestamp"]
 
     @time_machine.travel("2025-09-22T09:23:40.464832", tick=False)
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_show")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_screen")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_pc_voucher_types")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_voucher_payment_type")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_show")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_screen")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_pc_voucher_types")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_voucher_payment_type")
     def test_should_call_connector_with_correct_args_and_return_barcode_when_setamap_is_disabled(
         self,
         mocked_get_voucher_payment_type,
@@ -1165,21 +1169,21 @@ class CineDigitalServiceBookTicketTest:
     ):
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         booking = bookings_factories.BookingFactory(user=beneficiary, quantity=1)
-        mocked_get_voucher_payment_type.return_value = cds_serializers.PaymentTypeCDS(
+        mocked_get_voucher_payment_type.return_value = cine_office_serializers.PaymentTypeCDS(
             id=12, internal_code="VCH", is_active=True
         )
         mocked_get_pc_voucher_types.return_value = [
-            cds_serializers.VoucherTypeCDS(
+            cine_office_serializers.VoucherType(
                 id=3,
                 code="PSCULTURE",
-                tariff=cds_serializers.TariffCDS(id=42, price=5, is_active=True, label="pass Culture"),
+                tariff=cine_office_serializers.Tariff(id=42, price=5, is_active=True, label="pass Culture"),
             )
         ]
 
-        mocked_get_show.return_value = create_show_cds(
+        mocked_get_show.return_value = create_show(
             id_=181, shows_tariff_pos_type_ids=[42], is_disabled_seatmap=True, is_empty_seatmap=True
         )
-        mocked_get_screen.return_value = create_screen_cds()
+        mocked_get_screen.return_value = create_screen()
 
         requests_mock.post(
             "https://accountid_test.apiUrl_test/transaction/create?api_token=token_test",
@@ -1197,7 +1201,7 @@ class CineDigitalServiceBookTicketTest:
             },
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="test_id", account_id="accountid_test", cinema_api_token="token_test"
         )
 
@@ -1236,7 +1240,7 @@ class CineDigitalServiceBookTicketTest:
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceGetMoviesTest:
+class CineOfficeGetMoviesTest:
     def test_should_return_movies_information(self, requests_mock):
         requests_mock.get(
             "https://accountid_test.apiUrl_test/media?api_token=token_test",
@@ -1265,7 +1269,7 @@ class CineDigitalServiceGetMoviesTest:
             ],
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="cinemaid_test",
             account_id="accountid_test",
             cinema_api_token="token_test",
@@ -1276,9 +1280,9 @@ class CineDigitalServiceGetMoviesTest:
 
 
 @pytest.mark.settings(CDS_API_URL="apiUrl_test/")
-class CineDigitalServiceGetHardcodedSeatmapTest:
+class CineOfficeGetHardcodedSeatmapTest:
     def test_should_return_hardcoded_seatmap_when_exists(self, requests_mock):
-        show = create_show_cds(screen_id=30)
+        show = create_show(screen_id=30)
 
         expected_hardcoded_seatmap = [
             ["C_17", "C_15", 0, "C_13", "C_11", "C_9"],
@@ -1303,7 +1307,7 @@ class CineDigitalServiceGetHardcodedSeatmapTest:
             ],
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="cinemaid_test",
             account_id="accountid_test",
             cinema_api_token="token_test",
@@ -1315,14 +1319,14 @@ class CineDigitalServiceGetHardcodedSeatmapTest:
 
     def test_should_return_none_when_hardcoded_seatmap_does_not_exist(self, requests_mock):
         cinema_id = "cinemaid_test"
-        show = create_show_cds(screen_id=30)
+        show = create_show(screen_id=30)
 
         requests_mock.get(
             "https://accountid_test.apiUrl_test/cinemas?api_token=token_test",
             json=[{"internetsalegaugeactive": True, "id": cinema_id, "cinemaParameters": []}],
         )
 
-        cine_digital_service = CineDigitalServiceAPIClient(
+        cine_digital_service = CineOfficeAPIClient(
             cinema_id="cinemaid_test",
             account_id="accountid_test",
             cinema_api_token="token_test",

--- a/api/tests/core/providers/etls/test_cine_office_etl.py
+++ b/api/tests/core/providers/etls/test_cine_office_etl.py
@@ -10,8 +10,8 @@ import pcapi.core.offers.models as offers_models
 import pcapi.core.providers.exceptions as providers_exceptions
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.categories import subcategories
-from pcapi.core.providers.clients import cds_serializers
-from pcapi.core.providers.etls.cds_etl import CDSExtractTransformLoadProcess
+from pcapi.core.providers.clients import cine_office_serializers
+from pcapi.core.providers.etls.cine_office_etl import CineOfficeExtractTransformLoadProcess
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.core.search import models as search_models
 from pcapi.models import db
@@ -27,7 +27,7 @@ FUTURE_DATE_STR = (datetime.date.today() + datetime.timedelta(days=60)).strftime
 
 
 @mock.patch("pcapi.settings.CDS_API_URL", "cds_api.fake/")
-class CDSExtractTransformLoadProcessTest:
+class CineOfficeExtractTransformLoadProcessTest:
     def setup_cinema_objects(self):
         cds_provider = get_provider_by_local_class("CDSStocks")
         venue_provider = providers_factories.VenueProviderFactory(
@@ -72,7 +72,7 @@ class CDSExtractTransformLoadProcessTest:
     def test_execute_should_raise_inactive_provider(self):
         venue_provider = self.setup_cinema_objects()
         venue_provider.provider.isActive = False
-        etl_process = CDSExtractTransformLoadProcess(venue_provider)
+        etl_process = CineOfficeExtractTransformLoadProcess(venue_provider)
 
         with pytest.raises(providers_exceptions.InactiveProvider):
             etl_process.execute()
@@ -80,14 +80,14 @@ class CDSExtractTransformLoadProcessTest:
     def test_execute_should_raise_inactive_venue_provider_provider(self):
         venue_provider = self.setup_cinema_objects()
         venue_provider.isActive = False
-        etl_process = CDSExtractTransformLoadProcess(venue_provider)
+        etl_process = CineOfficeExtractTransformLoadProcess(venue_provider)
 
         with pytest.raises(providers_exceptions.InactiveVenueProvider):
             etl_process.execute()
 
     def test_should_log_and_raise_error_if_extract_fails(self, caplog, requests_mock):
         venue_provider = self.setup_cinema_objects()
-        etl_process = CDSExtractTransformLoadProcess(venue_provider)
+        etl_process = CineOfficeExtractTransformLoadProcess(venue_provider)
         requests_mock.get(
             "https://account_id.cds_api.fake/media?api_token=fake_token",
             exc=requests.exceptions.ConnectTimeout("pas le time"),
@@ -99,7 +99,7 @@ class CDSExtractTransformLoadProcessTest:
 
         assert len(caplog.records) >= 1
         last_record = caplog.records[-1]
-        assert last_record.message == "[CDSExtractTransformLoadProcess] Step 1 - Extract failed"
+        assert last_record.message == "[CineOfficeExtractTransformLoadProcess] Step 1 - Extract failed"
         assert last_record.extra == {
             "venue_id": venue_provider.venueId,
             "provider_id": venue_provider.providerId,
@@ -112,13 +112,13 @@ class CDSExtractTransformLoadProcessTest:
         venue_provider = self.setup_cinema_objects()
         self.setup_requests_mock(requests_mock)
 
-        etl_process = CDSExtractTransformLoadProcess(venue_provider)
+        etl_process = CineOfficeExtractTransformLoadProcess(venue_provider)
 
         extract_result = etl_process._extract()
 
         assert extract_result == {
             "movies": [
-                cds_serializers.MediaCDS(
+                cine_office_serializers.Media(
                     id=1,
                     title="Test movie #1",
                     duration=7200,
@@ -127,7 +127,7 @@ class CDSExtractTransformLoadProcessTest:
                     visanumber="123",
                     allocineid=None,
                 ),
-                cds_serializers.MediaCDS(
+                cine_office_serializers.Media(
                     id=2,
                     title="Test movie #2",
                     duration=5400,
@@ -136,7 +136,7 @@ class CDSExtractTransformLoadProcessTest:
                     visanumber="456",
                     allocineid=None,
                 ),
-                cds_serializers.MediaCDS(
+                cine_office_serializers.Media(
                     id=3,
                     title="Test movie #3",
                     duration=6600,
@@ -152,20 +152,22 @@ class CDSExtractTransformLoadProcessTest:
                 14: "3D",
             },
             "voucher_types": [
-                cds_serializers.VoucherTypeCDS(
+                cine_office_serializers.VoucherType(
                     id=2,
                     code="PSCULTURE",
-                    tariff=cds_serializers.TariffCDS(id=96, price=5, active=True, labeltariff="Tarif pass Culture"),
+                    tariff=cine_office_serializers.Tariff(
+                        id=96, price=5, active=True, labeltariff="Tarif pass Culture"
+                    ),
                 ),
-                cds_serializers.VoucherTypeCDS(
+                cine_office_serializers.VoucherType(
                     id=3,
                     code="PSCULTURE",
-                    tariff=cds_serializers.TariffCDS(id=97, price=6, active=True, labeltariff="Tarif PC"),
+                    tariff=cine_office_serializers.Tariff(id=97, price=6, active=True, labeltariff="Tarif PC"),
                 ),
             ],
             "is_internet_sale_gauge_active": False,
             "shows": [
-                cds_serializers.ShowCDS(
+                cine_office_serializers.Show(
                     id=1,
                     is_cancelled=False,
                     is_deleted=False,
@@ -177,17 +179,19 @@ class CDSExtractTransformLoadProcessTest:
                         2022, 3, 28, 12, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))
                     ),
                     shows_tariff_pos_type_collection=[
-                        cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=96)),
-                        cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=3)),
-                        cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=2)),
+                        cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=96)),
+                        cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=3)),
+                        cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=2)),
                     ],
-                    screen=cds_serializers.IdObjectCDS(id=10),
-                    media=cds_serializers.IdObjectCDS(id=1),
+                    screen=cine_office_serializers.IdObject(id=10),
+                    media=cine_office_serializers.IdObject(id=1),
                     shows_mediaoptions_collection=[
-                        cds_serializers.ShowsMediaoptionsCDS(media_options_id=cds_serializers.IdObjectCDS(id=12))
+                        cine_office_serializers.ShowsMediaOptions(
+                            media_options_id=cine_office_serializers.IdObject(id=12)
+                        )
                     ],
                 ),
-                cds_serializers.ShowCDS(
+                cine_office_serializers.Show(
                     id=2,
                     is_cancelled=False,
                     is_deleted=False,
@@ -199,16 +203,20 @@ class CDSExtractTransformLoadProcessTest:
                         2022, 3, 29, 12, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))
                     ),
                     shows_tariff_pos_type_collection=[
-                        cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=96))
+                        cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=96))
                     ],
-                    screen=cds_serializers.IdObjectCDS(id=10),
-                    media=cds_serializers.IdObjectCDS(id=1),
+                    screen=cine_office_serializers.IdObject(id=10),
+                    media=cine_office_serializers.IdObject(id=1),
                     shows_mediaoptions_collection=[
-                        cds_serializers.ShowsMediaoptionsCDS(media_options_id=cds_serializers.IdObjectCDS(id=12)),
-                        cds_serializers.ShowsMediaoptionsCDS(media_options_id=cds_serializers.IdObjectCDS(id=14)),
+                        cine_office_serializers.ShowsMediaOptions(
+                            media_options_id=cine_office_serializers.IdObject(id=12)
+                        ),
+                        cine_office_serializers.ShowsMediaOptions(
+                            media_options_id=cine_office_serializers.IdObject(id=14)
+                        ),
                     ],
                 ),
-                cds_serializers.ShowCDS(
+                cine_office_serializers.Show(
                     id=3,
                     is_cancelled=False,
                     is_deleted=False,
@@ -220,12 +228,14 @@ class CDSExtractTransformLoadProcessTest:
                         2022, 3, 30, 12, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))
                     ),
                     shows_tariff_pos_type_collection=[
-                        cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=96))
+                        cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=96))
                     ],
-                    screen=cds_serializers.IdObjectCDS(id=20),
-                    media=cds_serializers.IdObjectCDS(id=2),
+                    screen=cine_office_serializers.IdObject(id=20),
+                    media=cine_office_serializers.IdObject(id=2),
                     shows_mediaoptions_collection=[
-                        cds_serializers.ShowsMediaoptionsCDS(media_options_id=cds_serializers.IdObjectCDS(id=13))
+                        cine_office_serializers.ShowsMediaOptions(
+                            media_options_id=cine_office_serializers.IdObject(id=13)
+                        )
                     ],
                 ),
             ],
@@ -236,7 +246,7 @@ class CDSExtractTransformLoadProcessTest:
         venue_id = venue_provider.venueId
         self.setup_requests_mock(requests_mock)
 
-        etl_process = CDSExtractTransformLoadProcess(venue_provider)
+        etl_process = CineOfficeExtractTransformLoadProcess(venue_provider)
 
         extract_result = etl_process._extract()
         transform_result = etl_process._transform(extract_result)
@@ -298,10 +308,10 @@ class CDSExtractTransformLoadProcessTest:
     def test_transform_should_drop_show_without_pc_voucher_type(self, caplog):
         venue_provider = self.setup_cinema_objects()
         venue_id = venue_provider.venueId
-        etl_process = CDSExtractTransformLoadProcess(venue_provider)
+        etl_process = CineOfficeExtractTransformLoadProcess(venue_provider)
         extract_result = {
             "movies": [
-                cds_serializers.MediaCDS(
+                cine_office_serializers.Media(
                     id=1,
                     title="Test movie #1",
                     duration=7200,
@@ -313,15 +323,15 @@ class CDSExtractTransformLoadProcessTest:
             ],
             "media_options": {},
             "voucher_types": [
-                cds_serializers.VoucherTypeCDS(
+                cine_office_serializers.VoucherType(
                     id=2,
                     code="FULL_PRICE",
-                    tariff=cds_serializers.TariffCDS(id=96, price=5, active=True, labeltariff="Plein tarif"),
+                    tariff=cine_office_serializers.Tariff(id=96, price=5, active=True, labeltariff="Plein tarif"),
                 ),
             ],
             "is_internet_sale_gauge_active": False,
             "shows": [
-                cds_serializers.ShowCDS(
+                cine_office_serializers.Show(
                     id=53,
                     is_cancelled=False,
                     is_deleted=False,
@@ -334,12 +344,14 @@ class CDSExtractTransformLoadProcessTest:
                     ),
                     shows_tariff_pos_type_collection=[
                         # only full price tariff
-                        cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=2)),
+                        cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=2)),
                     ],
-                    screen=cds_serializers.IdObjectCDS(id=10),
-                    media=cds_serializers.IdObjectCDS(id=1),
+                    screen=cine_office_serializers.IdObject(id=10),
+                    media=cine_office_serializers.IdObject(id=1),
                     shows_mediaoptions_collection=[
-                        cds_serializers.ShowsMediaoptionsCDS(media_options_id=cds_serializers.IdObjectCDS(id=12))
+                        cine_office_serializers.ShowsMediaOptions(
+                            media_options_id=cine_office_serializers.IdObject(id=12)
+                        )
                     ],
                 ),
             ],
@@ -351,7 +363,10 @@ class CDSExtractTransformLoadProcessTest:
 
         assert len(caplog.records) >= 2
         missing_tariff_record = caplog.records[-2]
-        assert missing_tariff_record.message == "[CDSExtractTransformLoadProcess] Step 2 - Missing pass Culture pricing"
+        assert (
+            missing_tariff_record.message
+            == "[CineOfficeExtractTransformLoadProcess] Step 2 - Missing pass Culture pricing"
+        )
         assert missing_tariff_record.extra == {
             "venue_id": venue_provider.venueId,
             "provider_id": venue_provider.providerId,
@@ -367,7 +382,8 @@ class CDSExtractTransformLoadProcessTest:
 
         movie_without_show_record = caplog.records[-1]
         assert (
-            movie_without_show_record.message == "[CDSExtractTransformLoadProcess] Step 2 - Movie does not have shows"
+            movie_without_show_record.message
+            == "[CineOfficeExtractTransformLoadProcess] Step 2 - Movie does not have shows"
         )
         assert movie_without_show_record.extra == {
             "venue_id": venue_provider.venueId,
@@ -385,10 +401,10 @@ class CDSExtractTransformLoadProcessTest:
     def test_transform_should_drop_show_without_movie(self, caplog):
         venue_provider = self.setup_cinema_objects()
         venue_id = venue_provider.venueId
-        etl_process = CDSExtractTransformLoadProcess(venue_provider)
+        etl_process = CineOfficeExtractTransformLoadProcess(venue_provider)
         extract_result = {
             "movies": [
-                cds_serializers.MediaCDS(
+                cine_office_serializers.Media(
                     id=1,
                     title="Test movie #1",
                     duration=7200,
@@ -400,15 +416,17 @@ class CDSExtractTransformLoadProcessTest:
             ],
             "media_options": {},
             "voucher_types": [
-                cds_serializers.VoucherTypeCDS(
+                cine_office_serializers.VoucherType(
                     id=2,
                     code="PSCULTURE",
-                    tariff=cds_serializers.TariffCDS(id=96, price=5, active=True, labeltariff="Tarif pass Culture"),
+                    tariff=cine_office_serializers.Tariff(
+                        id=96, price=5, active=True, labeltariff="Tarif pass Culture"
+                    ),
                 ),
             ],
             "is_internet_sale_gauge_active": False,
             "shows": [
-                cds_serializers.ShowCDS(
+                cine_office_serializers.Show(
                     id=56,
                     is_cancelled=False,
                     is_deleted=False,
@@ -420,12 +438,14 @@ class CDSExtractTransformLoadProcessTest:
                         2022, 3, 28, 12, 0, tzinfo=datetime.timezone(datetime.timedelta(seconds=7200))
                     ),
                     shows_tariff_pos_type_collection=[
-                        cds_serializers.ShowTariffCDS(tariff=cds_serializers.IdObjectCDS(id=2)),
+                        cine_office_serializers.ShowTariff(tariff=cine_office_serializers.IdObject(id=2)),
                     ],
-                    screen=cds_serializers.IdObjectCDS(id=10),
-                    media=cds_serializers.IdObjectCDS(id=2),  # not present in movie
+                    screen=cine_office_serializers.IdObject(id=10),
+                    media=cine_office_serializers.IdObject(id=2),  # not present in movie
                     shows_mediaoptions_collection=[
-                        cds_serializers.ShowsMediaoptionsCDS(media_options_id=cds_serializers.IdObjectCDS(id=12))
+                        cine_office_serializers.ShowsMediaOptions(
+                            media_options_id=cine_office_serializers.IdObject(id=12)
+                        )
                     ],
                 ),
             ],
@@ -437,7 +457,7 @@ class CDSExtractTransformLoadProcessTest:
 
         assert len(caplog.records) >= 2
         missing_movie_record = caplog.records[-2]
-        assert missing_movie_record.message == "[CDSExtractTransformLoadProcess] Step 2 - Missing movie"
+        assert missing_movie_record.message == "[CineOfficeExtractTransformLoadProcess] Step 2 - Missing movie"
         assert missing_movie_record.extra == {
             "venue_id": venue_provider.venueId,
             "provider_id": venue_provider.providerId,
@@ -453,7 +473,8 @@ class CDSExtractTransformLoadProcessTest:
 
         movie_without_show_record = caplog.records[-1]
         assert (
-            movie_without_show_record.message == "[CDSExtractTransformLoadProcess] Step 2 - Movie does not have shows"
+            movie_without_show_record.message
+            == "[CineOfficeExtractTransformLoadProcess] Step 2 - Movie does not have shows"
         )
         assert movie_without_show_record.extra == {
             "venue_id": venue_provider.venueId,
@@ -475,7 +496,7 @@ class CDSExtractTransformLoadProcessTest:
         venue_id = venue_provider.venueId
         self.setup_requests_mock(requests_mock)
 
-        CDSExtractTransformLoadProcess(venue_provider).execute()
+        CineOfficeExtractTransformLoadProcess(venue_provider).execute()
 
         offer_1 = db.session.query(offers_models.Offer).filter_by(idAtProvider=f"1%{venue_id}%CDS").one_or_none()
         offer_2 = db.session.query(offers_models.Offer).filter_by(idAtProvider=f"2%{venue_id}%CDS").one_or_none()
@@ -567,7 +588,7 @@ class CDSExtractTransformLoadProcessTest:
         venue_provider = self.setup_cinema_objects()
         self.setup_requests_mock(requests_mock)
 
-        CDSExtractTransformLoadProcess(venue_provider).execute()
+        CineOfficeExtractTransformLoadProcess(venue_provider).execute()
         db.session.query(offers_models.PriceCategory).count() == 2
-        CDSExtractTransformLoadProcess(venue_provider).execute()
+        CineOfficeExtractTransformLoadProcess(venue_provider).execute()
         db.session.query(offers_models.PriceCategory).count() == 2

--- a/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
+++ b/api/tests/local_providers/cinema_providers/cds/cds_stocks_test.py
@@ -22,7 +22,7 @@ from pcapi.core.offers.models import PriceCategoryLabel
 from pcapi.core.offers.models import Product
 from pcapi.core.offers.models import ProductMediation
 from pcapi.core.offers.models import Stock
-from pcapi.core.providers.etls.cds_etl import CDSExtractTransformLoadProcess
+from pcapi.core.providers.etls.cine_office_etl import CineOfficeExtractTransformLoadProcess
 from pcapi.local_providers.cinema_providers.cds.cds_stocks import CDSStocks
 from pcapi.models import db
 
@@ -75,9 +75,9 @@ class CDSStocksTest:
 
     def execute_import(
         self,
-        ProcessClass: Type[CDSExtractTransformLoadProcess] | Type[CDSStocks],
+        ProcessClass: Type[CineOfficeExtractTransformLoadProcess] | Type[CDSStocks],
         venue_provider,
-    ) -> CDSExtractTransformLoadProcess | CDSStocks:
+    ) -> CineOfficeExtractTransformLoadProcess | CDSStocks:
         boost_stocks = ProcessClass(venue_provider=venue_provider)
         if isinstance(boost_stocks, CDSStocks):
             boost_stocks.updateObjects()
@@ -87,7 +87,7 @@ class CDSStocksTest:
         return boost_stocks
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_get_venue_movies(self, mock_get_venue_movies, mock_get_shows, requests_mock):
         # Given
         cds_details, venue_provider = setup_cinema()
@@ -108,7 +108,7 @@ class CDSStocksTest:
         assert len(cds_movies) == 2
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_return_providable_info_on_next(self, mock_get_venue_movies, mock_get_shows, requests_mock):
         # Given
         cds_details, venue_provider = setup_cinema()
@@ -142,7 +142,7 @@ class CDSStocksTest:
         assert stock_providable_info.new_id_at_provider == f"123%{venue_provider.venue.id}%CDS#1"
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_not_return_providable_info_on_next_when_no_stocks_for_movies(
         self, mock_get_venue_movies, mock_get_shows, requests_mock
     ):
@@ -169,7 +169,7 @@ class CDSStocksTest:
         assert providable_infos == []
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_create_offers_for_each_movie(self, mock_get_venue_movies, mock_get_shows, requests_mock):
         # Given
         _cds_details, venue_provider = setup_cinema()
@@ -193,8 +193,8 @@ class CDSStocksTest:
         assert db.session.query(Offer).count() == 2
 
     @time_machine.travel(datetime(2022, 3, 19), tick=False)
-    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CDSExtractTransformLoadProcess])
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CineOfficeExtractTransformLoadProcess])
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_fill_offer_and_stock_informations_for_each_movie(
         self, mock_get_venue_movies, ProcessClass, requests_mock
     ):
@@ -291,8 +291,8 @@ class CDSStocksTest:
         assert get_cinemas_adapter.call_count == 1
         assert get_voucher_types_adapter.call_count == 1
 
-    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CDSExtractTransformLoadProcess])
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CineOfficeExtractTransformLoadProcess])
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_fill_offer_and_stock_informations_for_each_movie_based_on_product(
         self, mock_get_venue_movies, ProcessClass, requests_mock
     ):
@@ -379,8 +379,8 @@ class CDSStocksTest:
         assert get_cinemas_adapter.call_count == 1
         assert get_voucher_types_adapter.call_count == 1
 
-    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CDSExtractTransformLoadProcess])
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CineOfficeExtractTransformLoadProcess])
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def test_synchronization_shouldnt_build_idatproviders_using_showtime(
         self, mock_get_venue_movies, ProcessClass, requests_mock
     ):
@@ -426,8 +426,8 @@ class CDSStocksTest:
         assert get_cinemas_adapter.call_count == 1
         assert get_voucher_types_adapter.call_count == 1
 
-    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CDSExtractTransformLoadProcess])
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CineOfficeExtractTransformLoadProcess])
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def test_synchronization_shouldnt_not_fail_if_api_returns_no_show(
         self, mock_get_venue_movies, ProcessClass, requests_mock
     ):
@@ -448,8 +448,8 @@ class CDSStocksTest:
 
         self.execute_import(ProcessClass, venue_provider)
 
-    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CDSExtractTransformLoadProcess])
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @pytest.mark.parametrize("ProcessClass", [CDSStocks, CineOfficeExtractTransformLoadProcess])
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def test_synchronization_do_not_duplicate_stocks_when_beginning_datetime_changed(
         self, mock_get_venue_movies, ProcessClass, requests_mock
     ):
@@ -514,7 +514,7 @@ class CDSStocksTest:
         assert get_voucher_types_adapter.call_count == 1
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_fill_stocks_and_price_categories_for_a_movie(self, mock_get_venue_movies, mock_get_shows, requests_mock):
         # Given
         self._create_products()
@@ -591,7 +591,7 @@ class CDSStocksTest:
     @patch("pcapi.local_providers.movie_festivals.constants.FESTIVAL_NAME", "My awesome festival")
     @patch("pcapi.local_providers.movie_festivals.api.should_apply_movie_festival_rate")
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_update_stock_with_movie_festival_rate(
         self, mock_get_venue_movies, mock_get_shows, should_apply_movie_festival_rate_mock, requests_mock
     ):
@@ -638,7 +638,7 @@ class CDSStocksTest:
         assert created_price_category_label.label == "My awesome festival"
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_reuse_price_category(self, mock_get_venue_movies, mock_get_shows, requests_mock):
         # Given
         _cds_details, venue_provider = setup_cinema()
@@ -666,8 +666,8 @@ class CDSStocksTest:
         assert db.session.query(PriceCategoryLabel).count() == 1
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_movie_poster")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_movie_poster")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def test_should_create_product_mediation(
         self, mock_get_venue_movies, mocked_get_movie_poster, mock_get_shows, requests_mock
     ):
@@ -711,8 +711,8 @@ class CDSStocksTest:
         assert cds_stocks.erroredThumbs == 0
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_movie_poster")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_movie_poster")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def test_should_not_create_product_mediation(
         self, mock_get_venue_movies, mocked_get_movie_poster, mock_get_shows, requests_mock
     ):
@@ -743,8 +743,8 @@ class CDSStocksTest:
         mocked_get_movie_poster.assert_not_called()
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_movie_poster")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_movie_poster")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_create_offer_even_if_incorrect_thumb(
         self, mock_get_venue_movies, mocked_get_movie_poster, mock_get_shows, requests_mock
     ):
@@ -786,7 +786,7 @@ class CDSStocksTest:
         assert cds_stocks.erroredThumbs == 2
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def test_handle_error_on_movie_poster(self, mock_get_venue_movies, mock_get_shows, requests_mock):
         # Given
         _cds_details, venue_provider = setup_cinema()
@@ -818,8 +818,8 @@ class CDSStocksTest:
         assert {offer.thumbUrl for offer in offers} == {None}
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_movie_poster")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_movie_poster")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_not_update_thumbnail_more_then_once_a_day(
         self, mock_get_venue_movies, mocked_get_movie_poster, mock_get_shows, requests_mock
     ):
@@ -873,7 +873,7 @@ class CDSStocksTest:
         assert get_voucher_type_adapter.call_count == 2
 
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_link_offer_with_known_visa_to_product(self, mock_get_venue_movies, mock_get_shows, requests_mock):
         _cds_details, venue_provider = setup_cinema()
         requests_mock.get(
@@ -909,7 +909,7 @@ class CDSStocksTest:
 @pytest.mark.settings(CDS_API_URL="fakeUrl/")
 class CDSStocksQuantityTest:
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     def should_update_cds_stock_with_correct_stock_quantity(self, mock_get_venue_movies, mock_get_shows, requests_mock):
         # Given
         _cds_details, venue_provider = setup_cinema()

--- a/api/tests/local_providers/cinema_providers/cds/fixtures.py
+++ b/api/tests/local_providers/cinema_providers/cds/fixtures.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 
-from pcapi.core.providers.clients.cds_serializers import IdObjectCDS
-from pcapi.core.providers.clients.cds_serializers import MediaCDS
-from pcapi.core.providers.clients.cds_serializers import ShowCDS
-from pcapi.core.providers.clients.cds_serializers import ShowTariffCDS
-from pcapi.core.providers.clients.cds_serializers import ShowsMediaoptionsCDS
+from pcapi.core.providers.clients.cine_office_serializers import IdObject
+from pcapi.core.providers.clients.cine_office_serializers import Media
+from pcapi.core.providers.clients.cine_office_serializers import Show
+from pcapi.core.providers.clients.cine_office_serializers import ShowTariff
+from pcapi.core.providers.clients.cine_office_serializers import ShowsMediaOptions
 
 
-MOVIE_1 = MediaCDS(
+MOVIE_1 = Media(
     id=123,
     title="Coupez !",
     duration=7200,
@@ -17,7 +17,7 @@ MOVIE_1 = MediaCDS(
     allocineid="291483",
 )
 
-MOVIE_2 = MediaCDS(
+MOVIE_2 = Media(
     id=51,
     title="Top Gun",
     duration=9000,
@@ -27,7 +27,7 @@ MOVIE_2 = MediaCDS(
     allocineid="2133",
 )
 
-MOVIE_1_SHOW_1 = ShowCDS(
+MOVIE_1_SHOW_1 = Show(
     id=1,
     is_cancelled=False,
     is_deleted=False,
@@ -36,13 +36,13 @@ MOVIE_1_SHOW_1 = ShowCDS(
     remaining_place=77,
     internet_remaining_place=10,
     showtime=datetime(2022, 6, 20, 11, 00, 00),
-    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-    screen=IdObjectCDS(id=1),
-    media=IdObjectCDS(id=123),
-    showsMediaoptionsCollection=[ShowsMediaoptionsCDS(mediaoptionsid=IdObjectCDS(id=5))],
+    shows_tariff_pos_type_collection=[ShowTariff(tariff=IdObject(id=4))],
+    screen=IdObject(id=1),
+    media=IdObject(id=123),
+    showsMediaoptionsCollection=[ShowsMediaOptions(mediaoptionsid=IdObject(id=5))],
 )
 
-MOVIE_1_SHOW_1_SOLD_OUT = ShowCDS(
+MOVIE_1_SHOW_1_SOLD_OUT = Show(
     id=1,
     is_cancelled=False,
     is_deleted=False,
@@ -51,13 +51,13 @@ MOVIE_1_SHOW_1_SOLD_OUT = ShowCDS(
     remaining_place=77,
     internet_remaining_place=0,
     showtime=datetime(2022, 6, 20, 11, 00, 00),
-    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-    screen=IdObjectCDS(id=1),
-    media=IdObjectCDS(id=123),
-    showsMediaoptionsCollection=[ShowsMediaoptionsCDS(mediaoptionsid=IdObjectCDS(id=5))],
+    shows_tariff_pos_type_collection=[ShowTariff(tariff=IdObject(id=4))],
+    screen=IdObject(id=1),
+    media=IdObject(id=123),
+    showsMediaoptionsCollection=[ShowsMediaOptions(mediaoptionsid=IdObject(id=5))],
 )
 
-MOVIE_2_SHOW_1 = ShowCDS(
+MOVIE_2_SHOW_1 = Show(
     id=2,
     is_cancelled=False,
     is_deleted=False,
@@ -66,13 +66,13 @@ MOVIE_2_SHOW_1 = ShowCDS(
     remaining_place=78,
     internet_remaining_place=10,
     showtime=datetime(2022, 7, 1, 12, 00, 00),
-    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-    screen=IdObjectCDS(id=1),
-    media=IdObjectCDS(id=51),
-    showsMediaoptionsCollection=[ShowsMediaoptionsCDS(mediaoptionsid=IdObjectCDS(id=5))],
+    shows_tariff_pos_type_collection=[ShowTariff(tariff=IdObject(id=4))],
+    screen=IdObject(id=1),
+    media=IdObject(id=51),
+    showsMediaoptionsCollection=[ShowsMediaOptions(mediaoptionsid=IdObject(id=5))],
 )
 
-MOVIE_1_SHOW_2 = ShowCDS(
+MOVIE_1_SHOW_2 = Show(
     id=3,
     is_cancelled=False,
     is_deleted=False,
@@ -81,13 +81,13 @@ MOVIE_1_SHOW_2 = ShowCDS(
     remaining_place=78,
     internet_remaining_place=11,
     showtime=datetime(2022, 7, 1, 12, 00, 00),
-    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-    screen=IdObjectCDS(id=1),
-    media=IdObjectCDS(id=123),
-    showsMediaoptionsCollection=[ShowsMediaoptionsCDS(mediaoptionsid=IdObjectCDS(id=5))],
+    shows_tariff_pos_type_collection=[ShowTariff(tariff=IdObject(id=4))],
+    screen=IdObject(id=1),
+    media=IdObject(id=123),
+    showsMediaoptionsCollection=[ShowsMediaOptions(mediaoptionsid=IdObject(id=5))],
 )
 
-MOVIE_OTHER_SHOW_1 = ShowCDS(
+MOVIE_OTHER_SHOW_1 = Show(
     id=1,
     is_cancelled=False,
     is_deleted=False,
@@ -96,13 +96,13 @@ MOVIE_OTHER_SHOW_1 = ShowCDS(
     remaining_place=77,
     internet_remaining_place=10,
     showtime=datetime(2022, 6, 20, 11, 00, 00),
-    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-    screen=IdObjectCDS(id=1),
-    media=IdObjectCDS(id=88888),
-    showsMediaoptionsCollection=[ShowsMediaoptionsCDS(mediaoptionsid=IdObjectCDS(id=5))],
+    shows_tariff_pos_type_collection=[ShowTariff(tariff=IdObject(id=4))],
+    screen=IdObject(id=1),
+    media=IdObject(id=88888),
+    showsMediaoptionsCollection=[ShowsMediaOptions(mediaoptionsid=IdObject(id=5))],
 )
 
-MOVIE_OTHER_SHOW_2 = ShowCDS(
+MOVIE_OTHER_SHOW_2 = Show(
     id=2,
     is_cancelled=False,
     is_deleted=False,
@@ -111,10 +111,10 @@ MOVIE_OTHER_SHOW_2 = ShowCDS(
     remaining_place=77,
     internet_remaining_place=10,
     showtime=datetime(2022, 7, 1, 12, 00, 00),
-    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-    screen=IdObjectCDS(id=1),
-    media=IdObjectCDS(id=88888),
-    showsMediaoptionsCollection=[ShowsMediaoptionsCDS(mediaoptionsid=IdObjectCDS(id=5))],
+    shows_tariff_pos_type_collection=[ShowTariff(tariff=IdObject(id=4))],
+    screen=IdObject(id=1),
+    media=IdObject(id=88888),
+    showsMediaoptionsCollection=[ShowsMediaOptions(mediaoptionsid=IdObject(id=5))],
 )
 
 CINEMA_WITH_INTERNET_SALE_GAUGE_ACTIVE_TRUE = {

--- a/api/tests/routes/backoffice/pivots_test.py
+++ b/api/tests/routes/backoffice/pivots_test.py
@@ -11,7 +11,7 @@ from pcapi.core.permissions import models as perm_models
 from pcapi.core.providers import factories as providers_factories
 from pcapi.core.providers import models as providers_models
 from pcapi.core.providers import repository as providers_repository
-from pcapi.core.providers.clients import cds_client
+from pcapi.core.providers.clients import cine_office_client
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.utils.crypto import decrypt
@@ -215,8 +215,10 @@ class ListPivotsTest(GetEndpointHelper):
         cineoffice_rows = html_parser.extract_table_rows(response.data)
         assert cineoffice_rows[0]["Id du partenaire culturel"] == str(cineoffice_pivot.cinemaProviderPivot.venue.id)
         assert cineoffice_rows[0]["Partenaire culturel"] == cineoffice_pivot.cinemaProviderPivot.venue.name
-        assert cineoffice_rows[0]["Identifiant cinéma (CDS)"] == cineoffice_pivot.cinemaProviderPivot.idAtProvider
-        assert cineoffice_rows[0]["Nom de l'utilisateur (CDS)"] == cineoffice_pivot.accountId
+        assert (
+            cineoffice_rows[0]["Identifiant cinéma (Ciné Office)"] == cineoffice_pivot.cinemaProviderPivot.idAtProvider
+        )
+        assert cineoffice_rows[0]["Nom de l'utilisateur (Ciné Office)"] == cineoffice_pivot.accountId
 
     @pytest.mark.parametrize(
         "query_string,expected_venues",
@@ -476,7 +478,7 @@ class CreatePivotTest(PostEndpointHelper):
 
     @patch(
         "pcapi.routes.backoffice.pivots.contexts.cineoffice.CineofficeContext.check_if_api_call_is_ok",
-        side_effect=cds_client.CineDigitalServiceAPIException("Test"),
+        side_effect=cine_office_client.CineOfficeAPIException("Test"),
     )
     def test_create_pivot_with_external_booking_exception(self, mock_check_if_api_call_is_ok, authenticated_client):
         venue_id = offerers_factories.VenueFactory().id

--- a/api/tests/routes/pro/venue_providers/post_venue_provider_test.py
+++ b/api/tests/routes/pro/venue_providers/post_venue_provider_test.py
@@ -9,10 +9,10 @@ import pcapi.core.providers.repository as providers_repository
 import pcapi.core.providers.tasks as providers_tasks
 from pcapi.core.history import models as history_models
 from pcapi.core.offers.models import Movie
-from pcapi.core.providers.clients.cds_serializers import IdObjectCDS
-from pcapi.core.providers.clients.cds_serializers import ShowCDS
-from pcapi.core.providers.clients.cds_serializers import ShowTariffCDS
-from pcapi.core.providers.clients.cds_serializers import ShowsMediaoptionsCDS
+from pcapi.core.providers.clients.cine_office_serializers import IdObject
+from pcapi.core.providers.clients.cine_office_serializers import Show
+from pcapi.core.providers.clients.cine_office_serializers import ShowTariff
+from pcapi.core.providers.clients.cine_office_serializers import ShowsMediaOptions
 from pcapi.core.providers.factories import CinemaProviderPivotFactory
 from pcapi.core.providers.models import Provider
 from pcapi.core.providers.models import VenueProvider
@@ -184,7 +184,7 @@ class Returns201Test:
 
     @pytest.mark.usefixtures("db_session")
     @patch("pcapi.local_providers.cinema_providers.cds.cds_stocks.CDSStocks._get_cds_shows")
-    @patch("pcapi.core.providers.clients.cds_client.CineDigitalServiceAPIClient.get_venue_movies")
+    @patch("pcapi.core.providers.clients.cine_office_client.CineOfficeAPIClient.get_venue_movies")
     @patch("pcapi.settings.CDS_API_URL", "fakeUrl/")
     def test_create_venue_provider_for_cds_cinema(self, mock_get_venue_movies, mock_get_shows, requests_mock, client):
         venue = offerers_factories.VenueFactory()
@@ -226,7 +226,7 @@ class Returns201Test:
 
         mocked_shows = [
             {
-                "show_information": ShowCDS(
+                "show_information": Show(
                     id=1,
                     is_cancelled=False,
                     is_deleted=False,
@@ -235,16 +235,16 @@ class Returns201Test:
                     remaining_place=77,
                     internet_remaining_place=10,
                     showtime=datetime(2022, 6, 20, 11, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=123),
-                    shows_mediaoptions_collection=[ShowsMediaoptionsCDS(media_options_id=IdObjectCDS(id=12))],
+                    shows_tariff_pos_type_collection=[ShowTariff(tariff=IdObject(id=4))],
+                    screen=IdObject(id=1),
+                    media=IdObject(id=123),
+                    shows_mediaoptions_collection=[ShowsMediaOptions(media_options_id=IdObject(id=12))],
                 ),
                 "price": 5,
                 "price_label": "pass Culture",
             },
             {
-                "show_information": ShowCDS(
+                "show_information": Show(
                     id=2,
                     is_cancelled=False,
                     is_deleted=False,
@@ -253,10 +253,10 @@ class Returns201Test:
                     remaining_place=78,
                     internet_remaining_place=11,
                     showtime=datetime(2022, 7, 1, 12, 00, 00),
-                    shows_tariff_pos_type_collection=[ShowTariffCDS(tariff=IdObjectCDS(id=4))],
-                    screen=IdObjectCDS(id=1),
-                    media=IdObjectCDS(id=51),
-                    shows_mediaoptions_collection=[ShowsMediaoptionsCDS(media_options_id=IdObjectCDS(id=12))],
+                    shows_tariff_pos_type_collection=[ShowTariff(tariff=IdObject(id=4))],
+                    screen=IdObject(id=1),
+                    media=IdObject(id=51),
+                    shows_mediaoptions_collection=[ShowsMediaOptions(media_options_id=IdObject(id=12))],
                 ),
                 "price": 6,
                 "price_label": "pass Culture",


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41797)

### Classes :
- Rename `CineDigitalServiceAPIClient` to `CineOfficeAPIClient`
- Rename `CDSExtractTranformLoad` to `CineOfficeExtractTransformLoad`
- Rename `CineDigitalServiceAPIException` to `CineOfficeAPIException`
- Rename `CDSBaseModel` to `CineOfficeBaseModel` (and remove `CDS` from serializers names)

### Files :
- Rename `cds_serializers` to `cine_office_serializers`
- Rename `cds_client` to `cine_office_client`
- Rename `cds_etl` to `cine_office_etl`


