### PR TITLE
(BSR)[API] fix: prevent docker compose sync loop on test changes

### DIFF
--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -44,10 +44,13 @@ services:
         - action: sync
           path: ./api
           target: /usr/src/app
-          # Exclude the project virtual environment — it could be for a
-          # different platform in the container
           ignore:
+            # Exclude the project virtual environment — it could be for a
+            # different platform in the container
             - .venv/
+            # Exclude mounted volumes
+            - tests/
+            - documentation/static/openapi.json
         - action: rebuild
           path: ./api/uv.lock
     env_file:
@@ -81,10 +84,12 @@ services:
         - action: sync
           path: ./api
           target: /usr/src/app
-          # Exclude the project virtual environment — it could be for a
-          # different platform in the container
           ignore:
+            # Exclude the project virtual environment — it could be for a
+            # different platform in the container
             - .venv/
+            # Exclude mounted volumes
+            - tests/
         - action: rebuild
           path: ./api/uv.lock
     env_file:


### PR DESCRIPTION
Having the same targets both mounted onto and synced to the Docker container causes a sync loop.

The new file system target is synced to the container, which then applies the change to our file system through the mount, trigger another sync to the container, and so on.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-XXXXX)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
