### PR TITLE
(BSR)[API] fix: script template imports

### DIFF
--- a/api/bin/generate_script_file.py
+++ b/api/bin/generate_script_file.py
@@ -53,7 +53,6 @@ PYTHON_TEMPLATE = """\
 import argparse
 import logging
 
-from pcapi.app import app
 from pcapi.models import db
 
 
@@ -64,6 +63,8 @@ def main() -> None:
     pass
 
 if __name__ == "__main__":
+    from pcapi.app import app
+
     app.app_context().push()
 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Move the Flask app in order to delay the blueprint creation. Otherwise, the blueprint creation is frozen and sentry / celery task will crash the pytest collection step because adding routes to a "frozen" blueprint raises an error, prevents test collection - even if they are not run -, fails the CI and make the world a worst place.