### PR TITLE
(PC-41877)[PRO] fix: remove toSorted usage that is not supported by old browsers

### DIFF
--- a/pro/src/pages/Homepage/components/StatisticsDashboard/components/CumulatedViews.tsx
+++ b/pro/src/pages/Homepage/components/StatisticsDashboard/components/CumulatedViews.tsx
@@ -48,7 +48,7 @@ export const CumulatedViews = ({
   totalViewsLast30Days,
   showTitle = true,
 }: CumulatedViewsProps) => {
-  const sortedDailyViews = dailyViews.toSorted(
+  const sortedDailyViews = [...dailyViews].sort(
     (a, b) => new Date(a.day).getTime() - new Date(b.day).getTime()
   )
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41877)

[Sentry error](https://pass-culture.sentry.io/issues/116630880/?project=4508818035638352)

`toSorted()` is an ES2023 method that isn't available in older browsers

