### PR TITLE
(PC-41904)[PRO] fix: phone number correction

### DIFF
--- a/pro/src/commons/utils/stripPhoneSeparators.ts
+++ b/pro/src/commons/utils/stripPhoneSeparators.ts
@@ -1,0 +1,14 @@
+/**
+ * Removes spaces, dots, and hyphens from the given phone number string.
+ *
+ * @param value - The phone number string to clean.
+ * @returns The phone number string without spaces, dots or hyphens.
+ *
+ * @example
+ * stripPhoneSeparators('06 12 34 56 78') // '612345678'
+ * stripPhoneSeparators('06-12-34-56-78') // '612345678'
+ * stripPhoneSeparators('06.12.34.56.78') // '612345678'
+ * stripPhoneSeparators('6 12 34 56 78') // '612345678'
+ */
+export const stripPhoneSeparators = (value: string | null | undefined) =>
+  value?.replaceAll(/(\s|\.|-)/g, '') ?? ''

--- a/pro/src/commons/utils/yup/phoneNumberSchema.ts
+++ b/pro/src/commons/utils/yup/phoneNumberSchema.ts
@@ -8,6 +8,7 @@ import {
   type PlusString,
 } from '@/commons/core/Phone/constants'
 import { isCountryCodeHandledByPassCulture } from '@/commons/core/Phone/utils/isCountryCodeHandledByPassCulture'
+import { stripPhoneSeparators } from '@/commons/utils/stripPhoneSeparators'
 
 const validateAndParseFrenchPhoneNumber = (
   phoneNumber: string
@@ -47,36 +48,26 @@ const validateAndParseFrenchPhoneNumber = (
  * phoneNumberSchema().required('Phone is required') // required phone number
  */
 export const phoneNumberSchema = () => {
-  return (
-    yup
-      .string()
-      // Transform values that contains ONLY the countryCode to an empty string ("+33" -> "")
-      // because the <PhoneNumberInput> component will always give a value with at least the countryCode,
-      // even when the text field is empty
-      .transform(
-        (value: string | null | undefined) =>
-          isCountryCodeHandledByPassCulture(value as PlusString)
-            ? ''
-            : value?.replaceAll(/(\s|\.|-)/g, '') // Normalize without spaces, caret or dots
-      )
-      .test('isPhoneValid', function isPhoneValidWithErrorMessage(this: yup.TestContext, value:
-        | string
-        | null
-        | undefined): boolean {
-        if (!value) {
-          return true
-        }
-        try {
-          validateAndParseFrenchPhoneNumber(value)
-          return true
-        } catch (error) {
-          throw this.createError({
-            message:
-              error instanceof Error
-                ? error.message
-                : 'Veuillez renseigner un numéro de téléphone valide',
-          })
-        }
-      })
-  )
+  return yup
+    .string()
+    .transform(stripPhoneSeparators)
+    .test('isPhoneValid', function isPhoneValidWithErrorMessage(this: yup.TestContext, value:
+      | string
+      | null
+      | undefined): boolean {
+      if (!value) {
+        return true
+      }
+      try {
+        validateAndParseFrenchPhoneNumber(value)
+        return true
+      } catch (error) {
+        throw this.createError({
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Veuillez renseigner un numéro de téléphone valide',
+        })
+      }
+    })
 }

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.tsx
@@ -15,6 +15,7 @@ import {
   PHONE_EXAMPLE_MAP,
 } from '@/commons/core/Phone/constants'
 import { isCountryCodeHandledByPassCulture } from '@/commons/core/Phone/utils/isCountryCodeHandledByPassCulture'
+import { stripPhoneSeparators } from '@/commons/utils/stripPhoneSeparators'
 import { FieldFooter } from '@/design-system/common/FieldFooter/FieldFooter'
 import type { RequiredIndicator } from '@/design-system/common/types'
 
@@ -112,6 +113,10 @@ export const PhoneNumberInput = forwardRef<
     }, [value, setCountryCodeAndPhoneNumberFrom])
 
     // When <CountryCodeSelect> changes, combine countryCode and phoneNumber and notify the change up
+    // Combine countryCode and phoneNumber, emitting empty string when phoneNumber is empty
+    const getCombinedValue = (code: string, number: string) =>
+      number ? code + stripPhoneSeparators(number) : ''
+
     const handleCountryCodeChange = (
       e: React.ChangeEvent<HTMLSelectElement>
     ) => {
@@ -121,7 +126,11 @@ export const PhoneNumberInput = forwardRef<
         // fire an event object based on the original event, but with the combined value
         onChange({
           ...e,
-          target: { ...e.target, value: newCountryCode + phoneNumber, name },
+          target: {
+            ...e.target,
+            value: getCombinedValue(newCountryCode, phoneNumber),
+            name,
+          },
         })
       }
     }
@@ -134,7 +143,11 @@ export const PhoneNumberInput = forwardRef<
         // fire an event object based on the original event, but with the combined value
         onChange({
           ...e,
-          target: { ...e.target, value: countryCode + newPhoneNumber, name },
+          target: {
+            ...e.target,
+            value: getCombinedValue(countryCode, newPhoneNumber),
+            name,
+          },
         })
       }
     }
@@ -147,7 +160,11 @@ export const PhoneNumberInput = forwardRef<
         // fire an event object based on the original event, but with the combined value
         onBlur({
           ...e,
-          target: { ...e.target, value: countryCode + phoneNumber, name },
+          target: {
+            ...e.target,
+            value: getCombinedValue(countryCode, phoneNumber),
+            name,
+          },
         })
       }
     }
@@ -158,8 +175,12 @@ export const PhoneNumberInput = forwardRef<
       const element = document.createElement('input')
 
       Object.defineProperty(element, 'value', {
-        get: () => countryCode + phoneNumber,
+        get: () => getCombinedValue(countryCode, phoneNumber),
         set: (newValue) => {
+          if (!newValue) {
+            return
+          }
+
           setCountryCodeAndPhoneNumberFrom(newValue)
         },
       })


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket ](https://passculture.atlassian.net/browse/PC-41904)

Lors du patch d'une offre réservable, le champ `contactPhone` était envoyé avec la valeur `+33` même quand le téléphone n'était pas renseigné.
