### PR TITLE
(PC-41899)[API] feat: update logic and add log for tickets cancellation on provider side

### DIFF
--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -672,7 +672,34 @@ def _execute_cancel_booking(
                     provider = booking.stock.offer.lastProvider
                     assert provider  # to make mypy happy
                     barcodes = [external_booking.barcode for external_booking in booking.externalBookings]
-                    external_bookings_api.cancel_tickets(barcodes, provider=provider, stock=stock)
+                    try:
+                        external_bookings_api.cancel_tickets(barcodes, provider=provider, stock=stock)
+                        logger.info(
+                            "Tickets successfully cancelled on provider side",
+                            extra={
+                                "user_id": booking.userId,
+                                "booking_id": booking.id,
+                                "offer_id": booking.stock.offerId,
+                                "provider_id": provider.id,
+                                "venue_id": booking.stock.offer.venueId,
+                            },
+                            technical_message_id="providers.external.cancellation",
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Unable to cancel tickets on provider side",
+                            extra={
+                                "user_id": booking.userId,
+                                "booking_id": booking.id,
+                                "offer_id": booking.stock.offerId,
+                                "provider_id": provider.id,
+                                "venue_id": booking.stock.offer.venueId,
+                                "exception_class": exc.__class__.__name__,
+                                "exception_message": str(exc),
+                            },
+                            technical_message_id="providers.external.cancellation",
+                        )
+                        raise
             except (
                 exceptions.BookingIsAlreadyUsed,
                 exceptions.BookingIsAlreadyCancelled,

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -669,7 +669,10 @@ def _execute_cancel_booking(
                         booking=booking,
                     )
                 if not one_side_cancellation and booking.isExternal:
-                    _cancel_external_booking(booking, stock)
+                    provider = booking.stock.offer.lastProvider
+                    assert provider  # to make mypy happy
+                    barcodes = [external_booking.barcode for external_booking in booking.externalBookings]
+                    external_bookings_api.cancel_tickets(barcodes, provider=provider, stock=stock)
             except (
                 exceptions.BookingIsAlreadyUsed,
                 exceptions.BookingIsAlreadyCancelled,
@@ -721,23 +724,6 @@ def _execute_cancel_booking(
                     )
                 raise
     return True
-
-
-def _cancel_external_booking(booking: models.Booking, stock: offers_models.Stock) -> None:
-    offer = stock.offer
-    barcodes = [external_booking.barcode for external_booking in booking.externalBookings]
-
-    # Cinema ticket
-    if offer.isFromCinemaProvider:
-        return external_bookings_api.cancel_booking(stock.offer.venueId, barcodes)
-
-    # Event with ticketing service ticket
-    assert offer.lastProvider  # to make mypy happy
-    venue_provider = providers_repository.get_venue_provider_by_venue_and_provider_ids(
-        offer.venueId, offer.lastProvider.id
-    )
-
-    return external_bookings_api.cancel_event_ticket(offer.lastProvider, stock, barcodes, True, venue_provider)
 
 
 def _cancel_bookings_from_stock(

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -1452,7 +1452,7 @@ def cancel_unstored_external_bookings() -> None:
                 external_bookings_api.cancel_event_ticket(provider, stock, [barcode], False, venue_provider)
             else:
                 venue_id = int(external_booking_info["venue_id"])
-                external_bookings_api.cancel_booking(venue_id, [barcode])
+                external_bookings_api.cancel_cinema_ticket(venue_id, [barcode])
 
 
 def cancel_ems_external_bookings() -> None:

--- a/api/src/pcapi/core/bookings/api.py
+++ b/api/src/pcapi/core/bookings/api.py
@@ -727,16 +727,17 @@ def _cancel_external_booking(booking: models.Booking, stock: offers_models.Stock
     offer = stock.offer
     barcodes = [external_booking.barcode for external_booking in booking.externalBookings]
 
-    # FIXME: `offer.lastProvider.hasTicketingService` is legacy to support old public API
-    if offer.lastProvider and (
-        offer.isEventLinkedToTicketingService or offer.lastProvider.hasTicketingService
-    ):  # Linked to ticketing service
-        venue_provider = providers_repository.get_venue_provider_by_venue_and_provider_ids(
-            offer.venueId, offer.lastProvider.id
-        )
-        external_bookings_api.cancel_event_ticket(offer.lastProvider, stock, barcodes, True, venue_provider)
-    else:  # cinema provider
-        external_bookings_api.cancel_booking(stock.offer.venueId, barcodes)
+    # Cinema ticket
+    if offer.isFromCinemaProvider:
+        return external_bookings_api.cancel_booking(stock.offer.venueId, barcodes)
+
+    # Event with ticketing service ticket
+    assert offer.lastProvider  # to make mypy happy
+    venue_provider = providers_repository.get_venue_provider_by_venue_and_provider_ids(
+        offer.venueId, offer.lastProvider.id
+    )
+
+    return external_bookings_api.cancel_event_ticket(offer.lastProvider, stock, barcodes, True, venue_provider)
 
 
 def _cancel_bookings_from_stock(

--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -48,6 +48,23 @@ EXTERNAL_BOOKINGS_FF = (
 EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS = settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS
 
 
+def cancel_tickets(barcodes: list[str], *, provider: providers_models.Provider, stock: offers_models.Stock) -> None:
+    # Cinema ticket
+    if provider.isCinemaProvider:
+        return cancel_booking(stock.offer.venueId, barcodes)
+
+    # Event with ticketing service ticket
+    venue_provider = providers_repository.get_venue_provider_by_venue_and_provider_ids(stock.offer.venueId, provider.id)
+
+    return cancel_event_ticket(
+        provider,
+        stock,
+        barcodes,
+        is_booking_saved=True,
+        venue_provider=venue_provider,
+    )
+
+
 def cancel_booking(venue_id: int, barcodes: list[str]) -> None:
     client = _instantiate_cinema_api_client(venue_id)
     client.cancel_booking(barcodes)

--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -51,7 +51,7 @@ EXTERNAL_BOOKINGS_TIMEOUT_IN_SECONDS = settings.EXTERNAL_BOOKINGS_TIMEOUT_IN_SEC
 def cancel_tickets(barcodes: list[str], *, provider: providers_models.Provider, stock: offers_models.Stock) -> None:
     # Cinema ticket
     if provider.isCinemaProvider:
-        return cancel_booking(stock.offer.venueId, barcodes)
+        return cancel_cinema_ticket(stock.offer.venueId, barcodes)
 
     # Event with ticketing service ticket
     venue_provider = providers_repository.get_venue_provider_by_venue_and_provider_ids(stock.offer.venueId, provider.id)
@@ -65,7 +65,7 @@ def cancel_tickets(barcodes: list[str], *, provider: providers_models.Provider, 
     )
 
 
-def cancel_booking(venue_id: int, barcodes: list[str]) -> None:
+def cancel_cinema_ticket(venue_id: int, barcodes: list[str]) -> None:
     client = _instantiate_cinema_api_client(venue_id)
     client.cancel_booking(barcodes)
 

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1438,12 +1438,12 @@ class CancelByBeneficiaryTest:
         assert booking.cancellationReason == BookingCancellationReasons.BENEFICIARY
         assert booking.stock.remainingQuantity == "unlimited"
 
-    @patch("pcapi.core.bookings.api.external_bookings_api.cancel_booking")
+    @patch("pcapi.core.bookings.api.external_bookings_api.cancel_cinema_ticket")
     @pytest.mark.features(ENABLE_CDS_IMPLEMENTATION=True)
-    def test_cds_cancel_external_booking(self, mocked_cancel_booking):
+    def test_cds_cancel_external_booking(self, mocked_cancel_cinema_ticket):
         cds_provider = get_provider_by_local_class("CDSStocks")
         venue_provider = providers_factories.VenueProviderFactory(provider=cds_provider)
-        mocked_cancel_booking.return_value = None
+        mocked_cancel_cinema_ticket.return_value = None
 
         # Given
         beneficiary = users_factories.BeneficiaryGrant18Factory()
@@ -1458,7 +1458,7 @@ class CancelByBeneficiaryTest:
         ExternalBookingFactory(booking=booking)
         api._cancel_booking(booking, BookingCancellationReasons.BENEFICIARY)
 
-        mocked_cancel_booking.assert_called()
+        mocked_cancel_cinema_ticket.assert_called()
 
     @pytest.mark.features(ENABLE_EMS_INTEGRATION=True)
     def test_ems_cancel_external_booking(self, requests_mock):
@@ -2447,9 +2447,9 @@ class PopBarcodesFromQueueAndCancelWastedExternalBookingTest:
 
         assert app.redis_client.llen("api:external_bookings:barcodes") == 1
 
-    @patch("pcapi.core.bookings.api.external_bookings_api.cancel_booking")
+    @patch("pcapi.core.bookings.api.external_bookings_api.cancel_cinema_ticket")
     def test_should_pop_and_cancel_only_external_booking_reached_minimum_age(
-        self, mocked_cancel_external_booking, app, requests_mock
+        self, mocked_cancel_cinema_ticket, app, requests_mock
     ):
         now = date_utils.get_naive_utc_now()
         provider = providers_factories.ProviderFactory(
@@ -2512,7 +2512,7 @@ class PopBarcodesFromQueueAndCancelWastedExternalBookingTest:
 
         cancel_unstored_external_bookings()
 
-        mocked_cancel_external_booking.assert_called_once_with(14, ["CCC-123456789"])
+        mocked_cancel_cinema_ticket.assert_called_once_with(14, ["CCC-123456789"])
 
         assert app.redis_client.llen("api:external_bookings:barcodes") == 2
         assert stock.quantity == 26

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1447,7 +1447,10 @@ class CancelByBeneficiaryTest:
         # Given
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         offer_solo = offers_factories.EventOfferFactory(
-            name="Séance ciné solo", subcategoryId=subcategories.SEANCE_CINE.id, venue=venue_provider.venue
+            name="Séance ciné solo",
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            venue=venue_provider.venue,
+            lastProvider=cds_provider,
         )
         stock_solo = offers_factories.EventStockFactory(offer=offer_solo, idAtProviders="1111")
         booking = bookings_factories.BookingFactory(stock=stock_solo, user=beneficiary)
@@ -1461,12 +1464,12 @@ class CancelByBeneficiaryTest:
         beneficiary = users_factories.BeneficiaryGrant18Factory()
         ems_provider = get_provider_by_local_class("EMSStocks")
         venue_provider = providers_factories.VenueProviderFactory(provider=ems_provider)
-        cinema_provider_pivot = providers_factories.CinemaProviderPivotFactory(venue=venue_provider.venue)
+        providers_factories.CinemaProviderPivotFactory(venue=venue_provider.venue)
         offer = offers_factories.EventOfferFactory(
             name="Film",
             venue=venue_provider.venue,
             subcategoryId=subcategories.SEANCE_CINE.id,
-            lastProviderId=cinema_provider_pivot.provider.id,
+            lastProvider=ems_provider,
         )
         stock = offers_factories.EventStockFactory(offer=offer, idAtProviders="1111%2222%EMS#3333")
         booking = bookings_factories.BookingFactory(stock=stock, user=beneficiary)

--- a/api/tests/core/bookings/test_api.py
+++ b/api/tests/core/bookings/test_api.py
@@ -1135,16 +1135,17 @@ class BookOfferTest:
 
 @pytest.mark.usefixtures("db_session")
 class CancelByBeneficiaryTest:
-    @patch("pcapi.core.bookings.api._cancel_external_booking")
-    def test_cancel_booking(self, mocked_cancel_external_booking):
-        stock = offers_factories.StockFactory(offer__bookingEmail="offerer@example.com")
+    @patch("pcapi.core.external_bookings.api.cancel_tickets")
+    def test_cancel_booking(self, mocked_cancel_tickets):
+        provider = providers_factories.PublicApiProviderFactory()
+        stock = offers_factories.StockFactory(offer__bookingEmail="offerer@example.com", offer__lastProvider=provider)
         booking = bookings_factories.BookingFactory.create_batch(20, stock=stock)[0]
-        bookings_factories.ExternalBookingFactory(booking=booking)
+        bookings_factories.ExternalBookingFactory(booking=booking, barcode="HELLO!")
         user = booking.user
         with assert_no_duplicated_queries():
             api.cancel_booking_by_beneficiary(user, booking)
 
-        mocked_cancel_external_booking.assert_called_once_with(booking, stock)
+        mocked_cancel_tickets.assert_called_once_with(["HELLO!"], provider=provider, stock=stock)
         # cancellation can trigger more than one request to Batch
         assert len(push_testing.requests) >= 1
 

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -1521,8 +1521,8 @@ class CancelBookingTest:
         assert response.status_code == 204
         assert len(mails_testing.outbox) == 0
 
-    @patch("pcapi.core.bookings.api._cancel_external_booking")
-    def test_unexpected_offer_provider(self, mocked_cancel_external_booking, client):
+    @patch("pcapi.core.external_bookings.api.cancel_tickets")
+    def test_unexpected_offer_provider(self, mocked_cancel_tickets, client):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
         cds_provider = providers_api.get_provider_by_local_class("CDSStocks")
         venue_provider = providers_factories.VenueProviderFactory(provider=cds_provider)
@@ -1540,7 +1540,7 @@ class CancelBookingTest:
         stock = offers_factories.EventStockFactory(offer=offer, idAtProviders="1111%4444#111/datetime")
         booking = booking_factories.BookingFactory(user=user, stock=stock)
         booking_factories.ExternalBookingFactory(booking=booking)
-        mocked_cancel_external_booking.side_effect = UnexpectedCinemaProvider("Unknown Provider: Toto")
+        mocked_cancel_tickets.side_effect = UnexpectedCinemaProvider("Unknown Provider: Toto")
 
         client = client.with_token(user)
         response = client.post(f"/native/v1/bookings/{booking.id}/cancel")
@@ -1548,8 +1548,8 @@ class CancelBookingTest:
         assert response.status_code == 400
         assert response.json["external_booking"] == "L'annulation de réservation a échoué."
 
-    @patch("pcapi.core.bookings.api._cancel_external_booking")
-    def test_inactive_provider(self, mocked_cancel_external_booking, client):
+    @patch("pcapi.core.external_bookings.api.cancel_tickets")
+    def test_inactive_provider(self, mocked_cancel_tickets, client):
         user = users_factories.BeneficiaryGrant18Factory(email=self.identifier)
         cds_provider = providers_api.get_provider_by_local_class("CDSStocks")
         venue_provider = providers_factories.VenueProviderFactory(provider=cds_provider)
@@ -1568,7 +1568,7 @@ class CancelBookingTest:
         booking = booking_factories.BookingFactory(user=user, stock=stock)
         booking_factories.ExternalBookingFactory(booking=booking)
 
-        mocked_cancel_external_booking.side_effect = InactiveProvider(
+        mocked_cancel_tickets.side_effect = InactiveProvider(
             f"No active cinema venue provider found for venue #{venue_provider.venue.id}"
         )
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41899)

[La petite PR côte mock pour permettre les tests en local avec notre proxy préféré](https://github.com/pass-culture/mock-api-billeterie/pull/73)

### Fait dans ce ticket

- Déplacement, refacto et renommage de la fonction `bookings.api._cancel_external_booking` : renommée en `cancel_tickets` dans le module `external_bookings.api`
- Ajout de logs de succès ou d'echec dans la méthode `_execute_cancel_booking` quand la méthode `cancel_tickets` est appelée
- Renommage de `external_bookings.api.cancel_booking` en `external_bookings.api.cancel_cinema_ticket`

### Tests manuels 

- [x] Annulation d'une réservation cinéma (CGR, EMS, Ciné Office ou Boost)
- [x] Annulation d'une réservation d'un billet billetterie -> succès
<img width="732" height="75" alt="image" src="https://github.com/user-attachments/assets/a69f9cf3-14ac-4c9a-8abc-83ba45a472e4" />

- [x] Annulation d'une réservation d'un billet billetterie -> echec
<img width="1348" height="136" alt="image" src="https://github.com/user-attachments/assets/c91ed27c-34cd-4c7c-9f6e-ec2dd9d2e323" />

