### PR TITLE
Pc 41901 rpa disconnect native user on suspend

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -397,6 +397,7 @@ def suspend_account(
         )
 
         sessions.disconnect_user_session(user_id=user.id)
+        sessions.disconnect_native_user_sessions(user_id=user.id)
 
         if user.backoffice_profile:
             user.backoffice_profile.roles = []

--- a/api/src/pcapi/core/users/sessions/__init__.py
+++ b/api/src/pcapi/core/users/sessions/__init__.py
@@ -9,6 +9,7 @@ from ._common import disconnect_user_session
 from ._native import JwtType
 from ._native import create_user_jwt_tokens
 from ._native import delete_expired_jwt
+from ._native import disconnect_native_user_sessions
 from ._native import load_jwt
 from ._native import refresh_user_jwt_tokens
 from ._router import install_login as install_routed_login
@@ -24,4 +25,5 @@ __all__ = [
     "delete_expired_jwt",
     "delete_expired_sessions",
     "disconnect_user_session",
+    "disconnect_native_user_sessions",
 ]

--- a/api/src/pcapi/core/users/sessions/_native.py
+++ b/api/src/pcapi/core/users/sessions/_native.py
@@ -214,3 +214,11 @@ def delete_expired_jwt() -> None:
     db.session.query(users_models.NativeUserSession).filter(
         users_models.NativeUserSession.expirationDatetime < date_utils.get_naive_utc_now()
     ).delete(synchronize_session=False)
+
+
+def disconnect_native_user_sessions(user_id: int) -> int:
+    return (
+        db.session.query(users_models.NativeUserSession)
+        .filter(users_models.NativeUserSession.userId == user_id)
+        .delete(synchronize_session=False)
+    )

--- a/api/src/pcapi/core/users/sessions/_native.py
+++ b/api/src/pcapi/core/users/sessions/_native.py
@@ -63,7 +63,15 @@ class SessionManager(_common.AbstractSessionManager):
 
     @staticmethod
     def discard_session(app: flask.ctx.AppContext | None = None, user: users_models.User | None = None) -> None:
-        return None
+        db.session.query(users_models.NativeUserSession).filter(
+            users_models.NativeUserSession.accessToken == flask.g.jwt.data.jti,
+        ).delete(synchronize_session=False)
+        flask.session.clear()
+
+        if is_managed_transaction():
+            db.session.flush()
+        else:
+            db.session.commit()
 
     @staticmethod
     def request_loader(request: flask.Request) -> users_models.User | None:
@@ -205,10 +213,4 @@ def _register_tokens(access_token: str, refresh_token: str, device_id: str) -> N
 def delete_expired_jwt() -> None:
     db.session.query(users_models.NativeUserSession).filter(
         users_models.NativeUserSession.expirationDatetime < date_utils.get_naive_utc_now()
-    ).delete(synchronize_session=False)
-
-
-def delete_jwt() -> None:
-    db.session.query(users_models.NativeUserSession).filter(
-        users_models.NativeUserSession.accessToken == flask.g.jwt.data.jti,
     ).delete(synchronize_session=False)

--- a/api/src/pcapi/routes/native/v1/authentication.py
+++ b/api/src/pcapi/routes/native/v1/authentication.py
@@ -2,6 +2,7 @@ import logging
 
 from flask import request
 from flask_login import current_user
+from flask_login import logout_user
 from sqlalchemy import exc as sa_exc
 
 import pcapi.core.token as token_utils
@@ -19,7 +20,6 @@ from pcapi.core.users.password_utils import check_password_strength
 from pcapi.core.users.repository import find_user_by_email
 from pcapi.core.users.sessions import create_user_jwt_tokens
 from pcapi.core.users.sessions import refresh_user_jwt_tokens
-from pcapi.core.users.sessions._native import delete_jwt
 from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.models.api_errors import ApiErrors
@@ -94,7 +94,7 @@ def signin(body: authentication.SigninRequest) -> authentication.SigninResponse:
     api=blueprint.api,
 )
 def signout() -> None:
-    delete_jwt()
+    logout_user()
 
 
 @blueprint.native_route("/refresh_access_token", methods=["POST"])

--- a/api/tests/core/users/sessions/test_native.py
+++ b/api/tests/core/users/sessions/test_native.py
@@ -12,6 +12,7 @@ from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.core.users.sessions import _native
 from pcapi.core.users.sessions import create_user_jwt_tokens
+from pcapi.core.users.sessions import disconnect_native_user_sessions
 from pcapi.core.users.sessions import refresh_user_jwt_tokens
 from pcapi.models import db
 from pcapi.routes.native.v1.serialization import common_models
@@ -214,3 +215,32 @@ class DeleteJwtTest:
 
         assert db.session.query(users_models.NativeUserSession).count() == 1
         assert db.session.query(users_models.NativeUserSession.id).scalar() == user_2_session.id
+
+
+class DisconnectNativeUserSessionsTest:
+    def test_disconnect_all_for_user(self):
+        user = users_factories.BaseUserFactory()
+        users_factories.NativeUserSessionFactory(user=user)
+        users_factories.NativeUserSessionFactory(user=user)
+        dummy_user = users_factories.BaseUserFactory()
+        users_factories.NativeUserSessionFactory(user=dummy_user)
+        users_factories.NativeUserSessionFactory(user=dummy_user)
+
+        disconnect_native_user_sessions(user_id=user.id)
+
+        assert (
+            db.session.query(users_models.NativeUserSession)
+            .filter(users_models.NativeUserSession.userId == user.id)
+            .count()
+            == 0
+        )
+        assert db.session.query(users_models.NativeUserSession).count() == 2
+
+    def test_user_does_not_exists(self):
+        dummy_user = users_factories.BaseUserFactory()
+        users_factories.NativeUserSessionFactory(user=dummy_user)
+        users_factories.NativeUserSessionFactory(user=dummy_user)
+
+        disconnect_native_user_sessions(user_id=0)
+
+        assert db.session.query(users_models.NativeUserSession).count() == 2

--- a/api/tests/core/users/sessions/test_native.py
+++ b/api/tests/core/users/sessions/test_native.py
@@ -210,7 +210,7 @@ class DeleteJwtTest:
 
         assert db.session.query(users_models.NativeUserSession).count() == 2
 
-        _native.delete_jwt()
+        _native.SessionManager.discard_session()
 
         assert db.session.query(users_models.NativeUserSession).count() == 1
         assert db.session.query(users_models.NativeUserSession.id).scalar() == user_2_session.id

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -214,6 +214,7 @@ class SuspendAccountTest:
 
     def test_suspend_beneficiary(self):
         user = users_factories.BeneficiaryGrant18Factory()
+        users_factories.NativeUserSessionFactory(user=user)
         cancellable_booking = bookings_factories.BookingFactory(user=user)
         yesterday = date_utils.get_naive_utc_now() - datetime.timedelta(days=1)
         confirmed_booking = bookings_factories.BookingFactory(
@@ -237,6 +238,7 @@ class SuspendAccountTest:
         assert cancellable_booking.status is BookingStatus.CANCELLED
         assert confirmed_booking.status is BookingStatus.CONFIRMED
         assert used_booking.status is BookingStatus.USED
+        assert db.session.query(users_models.NativeUserSession).count() == 0
 
         history = db.session.query(history_models.ActionHistory).filter_by(userId=user.id).all()
         assert len(history) == 1


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41901)

utilise la refonte des JWT pour déconnecter un utilisateur natif quand il est suspendu (quel que soit l'origine de la suspenstion)