### PR TITLE
(PC-41346)[PRO] refactor: make Backend the direct SSOT for venue association

### DIFF
--- a/pro/src/app/AppRouter/__specs__/utils.spec.ts
+++ b/pro/src/app/AppRouter/__specs__/utils.spec.ts
@@ -21,9 +21,9 @@ const makeUserPermissions = (
   hasSelectedPartnerVenue: false,
   hasVenues: false,
   isAuthenticated: false,
-  isOnboarded: false,
   isSelectedAdminOffererAssociated: false,
   isSelectedPartnerVenueAssociated: false,
+  isSelectedPartnerVenueOnboarded: false,
   ...overrides,
 })
 
@@ -63,7 +63,7 @@ describe('utils', () => {
     it('should return true when user is onboarded whatever the sessions storage value is', () => {
       mockCookie('')
       const permissions = makeUserPermissions({
-        isOnboarded: true,
+        isSelectedPartnerVenueOnboarded: true,
       })
       expect(mustBeOnboardedOrSkipped(permissions)).toBe(true)
 
@@ -74,7 +74,7 @@ describe('utils', () => {
     it('should return false when user is not onboarded with no cookie', () => {
       mockCookie('')
       const permissions = makeUserPermissions({
-        isOnboarded: false,
+        isSelectedPartnerVenueOnboarded: false,
       })
 
       expect(mustBeOnboardedOrSkipped(permissions)).toBe(false)
@@ -83,7 +83,7 @@ describe('utils', () => {
     it('should return true when user is not onboarded with the cookie set', () => {
       mockCookie(`${COOKIES.DID_SKIP_ONBOARDING}=true`)
       const permissions = makeUserPermissions({
-        isOnboarded: false,
+        isSelectedPartnerVenueOnboarded: false,
       })
 
       expect(mustBeOnboardedOrSkipped(permissions)).toBe(true)
@@ -94,7 +94,7 @@ describe('utils', () => {
     it('should return true when user is authenticated, onboarded, and has associated venue', () => {
       const permissions = makeUserPermissions({
         isAuthenticated: true,
-        isOnboarded: true,
+        isSelectedPartnerVenueOnboarded: true,
         isSelectedPartnerVenueAssociated: true,
       })
 
@@ -104,7 +104,7 @@ describe('utils', () => {
     it('should return false when user is not authenticated', () => {
       const permissions = makeUserPermissions({
         isAuthenticated: false,
-        isOnboarded: true,
+        isSelectedPartnerVenueOnboarded: true,
         isSelectedPartnerVenueAssociated: true,
       })
 
@@ -115,7 +115,7 @@ describe('utils', () => {
       mockCookie('')
       const permissions = makeUserPermissions({
         isAuthenticated: true,
-        isOnboarded: false,
+        isSelectedPartnerVenueOnboarded: false,
         isSelectedPartnerVenueAssociated: true,
       })
 
@@ -125,7 +125,7 @@ describe('utils', () => {
     it('should return false when venue is not associated', () => {
       const permissions = makeUserPermissions({
         isAuthenticated: true,
-        isOnboarded: true,
+        isSelectedPartnerVenueOnboarded: true,
         isSelectedPartnerVenueAssociated: false,
       })
 
@@ -137,7 +137,7 @@ describe('utils', () => {
     it('should return true when user is authenticated but not onboarded', () => {
       const permissions = makeUserPermissions({
         isAuthenticated: true,
-        isOnboarded: false,
+        isSelectedPartnerVenueOnboarded: false,
       })
 
       expect(mustNotBeOnboardedWithSelectedPartnerVenue(permissions)).toBe(true)
@@ -146,7 +146,7 @@ describe('utils', () => {
     it('should return false when user is not authenticated', () => {
       const permissions = makeUserPermissions({
         isAuthenticated: false,
-        isOnboarded: false,
+        isSelectedPartnerVenueOnboarded: false,
       })
 
       expect(mustNotBeOnboardedWithSelectedPartnerVenue(permissions)).toBe(
@@ -157,7 +157,7 @@ describe('utils', () => {
     it('should return false when user is onboarded', () => {
       const permissions = makeUserPermissions({
         isAuthenticated: true,
-        isOnboarded: true,
+        isSelectedPartnerVenueOnboarded: true,
       })
 
       expect(mustNotBeOnboardedWithSelectedPartnerVenue(permissions)).toBe(

--- a/pro/src/app/AppRouter/__specs__/utils.spec.ts
+++ b/pro/src/app/AppRouter/__specs__/utils.spec.ts
@@ -19,6 +19,7 @@ const makeUserPermissions = (
 ): UserPermissions => ({
   isAuthenticated: false,
   hasSelectedPartnerVenue: false,
+  hasVenues: false,
   isOnboarded: false,
   isSelectedPartnerVenueAssociated: false,
   hasSelectedAdminOfferer: false,

--- a/pro/src/app/AppRouter/__specs__/utils.spec.ts
+++ b/pro/src/app/AppRouter/__specs__/utils.spec.ts
@@ -17,12 +17,13 @@ import {
 const makeUserPermissions = (
   overrides: Partial<UserPermissions> = {}
 ): UserPermissions => ({
-  isAuthenticated: false,
+  hasSelectedAdminOfferer: false,
   hasSelectedPartnerVenue: false,
   hasVenues: false,
+  isAuthenticated: false,
   isOnboarded: false,
+  isSelectedAdminOffererAssociated: false,
   isSelectedPartnerVenueAssociated: false,
-  hasSelectedAdminOfferer: false,
   ...overrides,
 })
 

--- a/pro/src/app/AppRouter/routesMap.tsx
+++ b/pro/src/app/AppRouter/routesMap.tsx
@@ -520,7 +520,8 @@ export const routes: CustomRouteTree = [
       ),
     loader: withUserPermissions(
       (userPermissions) =>
-        userPermissions.isAuthenticated && !userPermissions.isOnboarded
+        userPermissions.isAuthenticated &&
+        !userPermissions.isSelectedPartnerVenueOnboarded
     ),
     path: '/onboarding/individuel',
     handle: {

--- a/pro/src/app/AppRouter/utils.ts
+++ b/pro/src/app/AppRouter/utils.ts
@@ -10,7 +10,7 @@ export const mustBeUnauthenticated = (userPermissions: UserPermissions) =>
   !userPermissions.isAuthenticated
 
 export const mustBeOnboardedOrSkipped = (userPermissions: UserPermissions) =>
-  userPermissions.isOnboarded ||
+  userPermissions.isSelectedPartnerVenueOnboarded ||
   document.cookie.includes(COOKIES.DID_SKIP_ONBOARDING)
 
 export const mustBeOnboardedWithSelectedPartnerVenue = (
@@ -31,7 +31,9 @@ export const mustHaveSelectedAdminOfferer = (
 
 export const mustNotBeOnboardedWithSelectedPartnerVenue = (
   userPermissions: UserPermissions
-) => userPermissions.isAuthenticated && !userPermissions.isOnboarded
+) =>
+  userPermissions.isAuthenticated &&
+  !userPermissions.isSelectedPartnerVenueOnboarded
 
 export const isNewHomepageEnabled = () => {
   const state = rootStore.getState()

--- a/pro/src/app/AppRouter/utils/__specs__/getUserDefaultPath.spec.ts
+++ b/pro/src/app/AppRouter/utils/__specs__/getUserDefaultPath.spec.ts
@@ -67,7 +67,7 @@ describe('getUserDefaultPath', () => {
     expect(getUserDefaultPath()).toBe('/hub')
   })
 
-  it('should return /rattachement-en-cours when user has selected + non-associated venue', () => {
+  it('should return /rattachement-en-cours when user has selected + no venue associated', () => {
     setupStore({
       hasUser: true,
       hasVenue: true,

--- a/pro/src/app/AppRouter/utils/__specs__/getUserDefaultPath.spec.ts
+++ b/pro/src/app/AppRouter/utils/__specs__/getUserDefaultPath.spec.ts
@@ -1,6 +1,5 @@
 import * as storeModule from '@/commons/store/store'
 import { configureTestStore } from '@/commons/store/testUtils'
-import type { UserAccess } from '@/commons/store/user/reducer'
 import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
 import {
   makeGetVenueResponseModel,
@@ -9,34 +8,37 @@ import {
 
 import { getUserDefaultPath } from '../getUserDefaultPath'
 
-const setupStore = (options: {
-  access?: UserAccess | null
+const setupStore = ({
+  hasUser = false,
+  hasVenueAssiociated = false,
+  hasVenueOnboarded = false,
+  hasVenueSelected = false,
+  hasVenue = false,
+}: {
   hasUser?: boolean
+  hasVenueAssiociated?: boolean
   hasVenueOnboarded?: boolean
   hasVenueSelected?: boolean
   hasVenue?: boolean
 }) => {
+  const fakeVenue = makeVenueListItemLiteResponseModel({
+    id: 101,
+    managingOffererId: 100,
+    name: 'Digital Venue A1',
+  })
   const store = configureTestStore({
     user: {
-      access: options.access ?? null,
-      currentUser: options.hasUser ? sharedCurrentUserFactory() : null,
+      currentUser: hasUser ? sharedCurrentUserFactory() : null,
       selectedAdminOfferer: null,
-      selectedPartnerVenue: options.hasVenueSelected
+      selectedPartnerVenue: hasVenueSelected
         ? makeGetVenueResponseModel({
-            id: 1,
-            isOnboarded: !!options.hasVenueOnboarded,
+            id: fakeVenue.id,
+            isOnboarded: hasVenueOnboarded,
           })
         : null,
-      venues: options.hasVenue
-        ? [
-            makeVenueListItemLiteResponseModel({
-              id: 3,
-              managingOffererId: 1,
-              name: 'Digital Venue A1',
-            }),
-          ]
-        : null,
-      venuesWithPendingValidation: null,
+      venues: hasVenue ? [fakeVenue] : null,
+      venuesWithPendingValidation:
+        hasVenue && !hasVenueAssiociated ? [fakeVenue] : null,
     },
   })
   vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
@@ -56,17 +58,21 @@ describe('getUserDefaultPath', () => {
   })
 
   it('should return /hub when user has venues but no venue selected', () => {
-    setupStore({ hasUser: true, hasVenue: true, hasVenueSelected: false })
+    setupStore({
+      hasUser: true,
+      hasVenue: true,
+      hasVenueSelected: false,
+    })
 
     expect(getUserDefaultPath()).toBe('/hub')
   })
 
-  it('should return /rattachement-en-cours when user has selected venue and "unattached" access', () => {
+  it('should return /rattachement-en-cours when user has selected + non-associated venue', () => {
     setupStore({
       hasUser: true,
       hasVenue: true,
+      hasVenueAssiociated: false,
       hasVenueSelected: true,
-      access: 'unattached',
     })
 
     expect(getUserDefaultPath()).toBe('/rattachement-en-cours')
@@ -76,6 +82,7 @@ describe('getUserDefaultPath', () => {
     setupStore({
       hasUser: true,
       hasVenue: true,
+      hasVenueAssiociated: true,
       hasVenueOnboarded: false,
       hasVenueSelected: true,
     })
@@ -83,10 +90,11 @@ describe('getUserDefaultPath', () => {
     expect(getUserDefaultPath()).toBe('/onboarding')
   })
 
-  it('should return /accueil when user has selected + onboarded venue and non-"unattached" access', () => {
+  it('should return /accueil when user has selected + onboarded + associated venue', () => {
     setupStore({
       hasUser: true,
       hasVenue: true,
+      hasVenueAssiociated: true,
       hasVenueOnboarded: true,
       hasVenueSelected: true,
     })

--- a/pro/src/app/AppRouter/utils/getUserDefaultPath.ts
+++ b/pro/src/app/AppRouter/utils/getUserDefaultPath.ts
@@ -17,7 +17,7 @@ export const getUserDefaultPath = () => {
     case !userPermissions.isSelectedPartnerVenueAssociated:
       return '/rattachement-en-cours'
 
-    case !userPermissions.isOnboarded:
+    case !userPermissions.isSelectedPartnerVenueOnboarded:
       return '/onboarding'
 
     default:

--- a/pro/src/app/AppRouter/utils/getUserDefaultPath.ts
+++ b/pro/src/app/AppRouter/utils/getUserDefaultPath.ts
@@ -1,17 +1,13 @@
 import { getCurrentUserPermissions } from '@/commons/auth/getCurrentUserPermissions'
-import { rootStore } from '@/commons/store/store'
 
 export const getUserDefaultPath = () => {
-  const state = rootStore.getState()
-
   const userPermissions = getCurrentUserPermissions()
-  const hasVenues = state.user.venues && state.user.venues.length > 0
 
   switch (true) {
     case !userPermissions.isAuthenticated:
       return '/connexion'
 
-    case !hasVenues:
+    case !userPermissions.hasVenues:
       return '/inscription/structure/recherche'
 
     case !userPermissions.hasSelectedPartnerVenue:

--- a/pro/src/app/AppRouter/utils/getUserDefaultPath.ts
+++ b/pro/src/app/AppRouter/utils/getUserDefaultPath.ts
@@ -1,7 +1,8 @@
 import { getCurrentUserPermissions } from '@/commons/auth/getCurrentUserPermissions'
+import { rootStore } from '@/commons/store/store'
 
 export const getUserDefaultPath = () => {
-  const userPermissions = getCurrentUserPermissions()
+  const userPermissions = getCurrentUserPermissions(rootStore.getState().user)
 
   switch (true) {
     case !userPermissions.isAuthenticated:

--- a/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
+++ b/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
@@ -1,7 +1,8 @@
-import * as storeModule from '@/commons/store/store'
-import { configureTestStore } from '@/commons/store/testUtils'
 import { defaultGetOffererResponseModel } from '@/commons/utils/factories/individualApiFactories'
-import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import {
+  makeUserSliceState,
+  sharedCurrentUserFactory,
+} from '@/commons/utils/factories/storeFactories'
 import {
   makeGetVenueResponseModel,
   makeVenueListItemLiteResponseModel,
@@ -12,21 +13,16 @@ import { getCurrentUserPermissions } from '../getCurrentUserPermissions'
 describe('getCurrentUserPermissions', () => {
   describe('when user is not authenticated', () => {
     it('should return all permissions as false', () => {
-      const store = configureTestStore({
-        user: {
-          currentUser: null,
-          selectedAdminOfferer: null,
-          selectedPartnerVenue: null,
-          venues: null,
-          venuesWithPendingValidation: null,
-        },
+      const userSliceState = makeUserSliceState({
+        currentUser: null,
+        selectedPartnerVenue: null,
+        venues: null,
+        venuesWithPendingValidation: null,
       })
-      vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-      const result = getCurrentUserPermissions()
+      const result = getCurrentUserPermissions(userSliceState)
 
-      expect(result).toEqual({
-        hasSelectedAdminOfferer: false,
+      expect(result).toMatchObject({
         hasSelectedPartnerVenue: false,
         hasVenues: false,
         isAuthenticated: false,
@@ -40,21 +36,16 @@ describe('getCurrentUserPermissions', () => {
     const fakeCurrentUser = sharedCurrentUserFactory()
 
     it('should return isAuthenticated as true', () => {
-      const store = configureTestStore({
-        user: {
-          currentUser: fakeCurrentUser,
-          selectedAdminOfferer: null,
-          selectedPartnerVenue: null,
-          venues: null,
-          venuesWithPendingValidation: null,
-        },
+      const userSliceState = makeUserSliceState({
+        currentUser: fakeCurrentUser,
+        selectedPartnerVenue: null,
+        venues: null,
+        venuesWithPendingValidation: null,
       })
-      vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-      const result = getCurrentUserPermissions()
+      const result = getCurrentUserPermissions(userSliceState)
 
-      expect(result).toEqual({
-        hasSelectedAdminOfferer: false,
+      expect(result).toMatchObject({
         hasSelectedPartnerVenue: false,
         hasVenues: false,
         isAuthenticated: true,
@@ -65,21 +56,16 @@ describe('getCurrentUserPermissions', () => {
 
     describe('without venues', () => {
       it('should return hasVenues as false', () => {
-        const store = configureTestStore({
-          user: {
-            currentUser: fakeCurrentUser,
-            selectedAdminOfferer: null,
-            selectedPartnerVenue: null,
-            venues: null,
-            venuesWithPendingValidation: null,
-          },
+        const userSliceState = makeUserSliceState({
+          currentUser: fakeCurrentUser,
+          selectedPartnerVenue: null,
+          venues: null,
+          venuesWithPendingValidation: null,
         })
-        vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-        const result = getCurrentUserPermissions()
+        const result = getCurrentUserPermissions(userSliceState)
 
-        expect(result).toEqual({
-          hasSelectedAdminOfferer: false,
+        expect(result).toMatchObject({
           hasSelectedPartnerVenue: false,
           hasVenues: false,
           isAuthenticated: true,
@@ -94,21 +80,16 @@ describe('getCurrentUserPermissions', () => {
       const fakeVenues = [fakeVenue]
 
       it('should return hasVenues as true', () => {
-        const store = configureTestStore({
-          user: {
-            currentUser: fakeCurrentUser,
-            selectedAdminOfferer: null,
-            selectedPartnerVenue: null,
-            venues: fakeVenues,
-            venuesWithPendingValidation: null,
-          },
+        const userSliceState = makeUserSliceState({
+          currentUser: fakeCurrentUser,
+          selectedPartnerVenue: null,
+          venues: fakeVenues,
+          venuesWithPendingValidation: null,
         })
-        vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-        const result = getCurrentUserPermissions()
+        const result = getCurrentUserPermissions(userSliceState)
 
-        expect(result).toEqual({
-          hasSelectedAdminOfferer: false,
+        expect(result).toMatchObject({
           hasSelectedPartnerVenue: false,
           hasVenues: true,
           isAuthenticated: true,
@@ -117,23 +98,21 @@ describe('getCurrentUserPermissions', () => {
         })
       })
 
+      // =======================================================================
+      // Partner Space Permissions
+
       describe('without selected partner venue', () => {
         it('should return hasSelectedPartnerVenue as false', () => {
-          const store = configureTestStore({
-            user: {
-              currentUser: fakeCurrentUser,
-              selectedAdminOfferer: null,
-              selectedPartnerVenue: null,
-              venues: fakeVenues,
-              venuesWithPendingValidation: null,
-            },
+          const userSliceState = makeUserSliceState({
+            currentUser: fakeCurrentUser,
+            selectedPartnerVenue: null,
+            venues: fakeVenues,
+            venuesWithPendingValidation: null,
           })
-          vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-          const result = getCurrentUserPermissions()
+          const result = getCurrentUserPermissions(userSliceState)
 
-          expect(result).toEqual({
-            hasSelectedAdminOfferer: false,
+          expect(result).toMatchObject({
             hasSelectedPartnerVenue: false,
             hasVenues: true,
             isAuthenticated: true,
@@ -143,26 +122,21 @@ describe('getCurrentUserPermissions', () => {
         })
       })
 
-      describe('with selected venue', () => {
+      describe('with selected partner venue', () => {
         it('should return hasSelectedPartnerVenue as true', () => {
-          const store = configureTestStore({
-            user: {
-              currentUser: fakeCurrentUser,
-              selectedAdminOfferer: null,
-              selectedPartnerVenue: makeGetVenueResponseModel({
-                id: fakeVenue.id,
-                isOnboarded: false,
-              }),
-              venues: fakeVenues,
-              venuesWithPendingValidation: null,
-            },
+          const userSliceState = makeUserSliceState({
+            currentUser: fakeCurrentUser,
+            selectedPartnerVenue: makeGetVenueResponseModel({
+              id: fakeVenue.id,
+              isOnboarded: false,
+            }),
+            venues: fakeVenues,
+            venuesWithPendingValidation: null,
           })
-          vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-          const result = getCurrentUserPermissions()
+          const result = getCurrentUserPermissions(userSliceState)
 
-          expect(result).toEqual({
-            hasSelectedAdminOfferer: false,
+          expect(result).toMatchObject({
             hasSelectedPartnerVenue: true,
             hasVenues: true,
             isAuthenticated: true,
@@ -173,24 +147,19 @@ describe('getCurrentUserPermissions', () => {
 
         describe('when venue is not onboarded', () => {
           it('should return isOnboarded as false', () => {
-            const store = configureTestStore({
-              user: {
-                currentUser: fakeCurrentUser,
-                selectedAdminOfferer: null,
-                selectedPartnerVenue: makeGetVenueResponseModel({
-                  id: fakeVenue.id,
-                  isOnboarded: false,
-                }),
-                venues: fakeVenues,
-                venuesWithPendingValidation: null,
-              },
+            const userSliceState = makeUserSliceState({
+              currentUser: fakeCurrentUser,
+              selectedPartnerVenue: makeGetVenueResponseModel({
+                id: fakeVenue.id,
+                isOnboarded: false,
+              }),
+              venues: fakeVenues,
+              venuesWithPendingValidation: null,
             })
-            vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-            const result = getCurrentUserPermissions()
+            const result = getCurrentUserPermissions(userSliceState)
 
-            expect(result).toEqual({
-              hasSelectedAdminOfferer: false,
+            expect(result).toMatchObject({
               hasSelectedPartnerVenue: true,
               hasVenues: true,
               isAuthenticated: true,
@@ -200,26 +169,21 @@ describe('getCurrentUserPermissions', () => {
           })
         })
 
-        describe('when selected venue is part of venues with pending validation', () => {
+        describe('when selected partner venue is part of venues with pending validation', () => {
           it('should return isSelectedPartnerVenueAssociated as false', () => {
-            const store = configureTestStore({
-              user: {
-                currentUser: fakeCurrentUser,
-                selectedAdminOfferer: null,
-                selectedPartnerVenue: makeGetVenueResponseModel({
-                  id: fakeVenue.id,
-                  isOnboarded: false,
-                }),
-                venues: fakeVenues,
-                venuesWithPendingValidation: fakeVenues,
-              },
+            const userSliceState = makeUserSliceState({
+              currentUser: fakeCurrentUser,
+              selectedPartnerVenue: makeGetVenueResponseModel({
+                id: fakeVenue.id,
+                isOnboarded: false,
+              }),
+              venues: fakeVenues,
+              venuesWithPendingValidation: fakeVenues,
             })
-            vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-            const result = getCurrentUserPermissions()
+            const result = getCurrentUserPermissions(userSliceState)
 
-            expect(result).toEqual({
-              hasSelectedAdminOfferer: false,
+            expect(result).toMatchObject({
               hasSelectedPartnerVenue: true,
               hasVenues: true,
               isAuthenticated: true,
@@ -229,26 +193,21 @@ describe('getCurrentUserPermissions', () => {
           })
         })
 
-        describe('when selected venue is both onboarded and not part of venues with pending validation', () => {
+        describe('when selected partner venue is both onboarded and not part of venues with pending validation', () => {
           it('should return all venue-related permissions as true', () => {
-            const store = configureTestStore({
-              user: {
-                currentUser: fakeCurrentUser,
-                selectedAdminOfferer: null,
-                selectedPartnerVenue: makeGetVenueResponseModel({
-                  id: fakeVenue.id,
-                  isOnboarded: true,
-                }),
-                venues: fakeVenues,
-                venuesWithPendingValidation: null,
-              },
+            const userSliceState = makeUserSliceState({
+              currentUser: fakeCurrentUser,
+              selectedPartnerVenue: makeGetVenueResponseModel({
+                id: fakeVenue.id,
+                isOnboarded: true,
+              }),
+              venues: fakeVenues,
+              venuesWithPendingValidation: null,
             })
-            vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-            const result = getCurrentUserPermissions()
+            const result = getCurrentUserPermissions(userSliceState)
 
-            expect(result).toEqual({
-              hasSelectedAdminOfferer: false,
+            expect(result).toMatchObject({
               hasSelectedPartnerVenue: true,
               hasVenues: true,
               isAuthenticated: true,
@@ -259,30 +218,91 @@ describe('getCurrentUserPermissions', () => {
         })
       })
 
+      // =======================================================================
+      // Administration Space Permissions
+
+      describe('without selected admin offerer', () => {
+        it('should return hasSelectedAdminOfferer as false', () => {
+          const userSliceState = makeUserSliceState({
+            currentUser: fakeCurrentUser,
+            offerersNamesWithPendingValidation: null,
+            selectedAdminOfferer: null,
+            venues: fakeVenues,
+          })
+
+          const result = getCurrentUserPermissions(userSliceState)
+
+          expect(result).toMatchObject({
+            hasSelectedAdminOfferer: false,
+            hasVenues: true,
+            isAuthenticated: true,
+            isOnboarded: false,
+            isSelectedAdminOffererAssociated: false,
+          })
+        })
+      })
+
       describe('with selected admin offerer', () => {
         const fakeAdminOfferer = defaultGetOffererResponseModel
 
         it('should return hasSelectedAdminOfferer as true', () => {
-          const store = configureTestStore({
-            user: {
-              currentUser: fakeCurrentUser,
-              selectedAdminOfferer: fakeAdminOfferer,
-              selectedPartnerVenue: null,
-              venues: fakeVenues,
-              venuesWithPendingValidation: null,
-            },
+          const userSliceState = makeUserSliceState({
+            currentUser: fakeCurrentUser,
+            offerersNamesWithPendingValidation: null,
+            selectedAdminOfferer: fakeAdminOfferer,
+            venues: fakeVenues,
           })
-          vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
 
-          const result = getCurrentUserPermissions()
+          const result = getCurrentUserPermissions(userSliceState)
 
-          expect(result).toEqual({
+          expect(result).toMatchObject({
             hasSelectedAdminOfferer: true,
-            hasSelectedPartnerVenue: false,
             hasVenues: true,
             isAuthenticated: true,
             isOnboarded: false,
-            isSelectedPartnerVenueAssociated: false,
+            isSelectedAdminOffererAssociated: true,
+          })
+        })
+
+        describe('when selected admin offerer is part of offerer names with pending validation', () => {
+          it('should return isSelectedAdminOffererAssociated as false', () => {
+            const userSliceState = makeUserSliceState({
+              currentUser: fakeCurrentUser,
+              offerersNamesWithPendingValidation: [fakeAdminOfferer],
+              selectedAdminOfferer: fakeAdminOfferer,
+              venues: fakeVenues,
+            })
+
+            const result = getCurrentUserPermissions(userSliceState)
+
+            expect(result).toMatchObject({
+              hasSelectedAdminOfferer: true,
+              hasVenues: true,
+              isAuthenticated: true,
+              isOnboarded: false,
+              isSelectedAdminOffererAssociated: false,
+            })
+          })
+        })
+
+        describe('when selected admin offerer is not part of offerer names with pending validation', () => {
+          it('should return isSelectedAdminOffererAssociated as true', () => {
+            const userSliceState = makeUserSliceState({
+              currentUser: fakeCurrentUser,
+              offerersNamesWithPendingValidation: null,
+              selectedAdminOfferer: fakeAdminOfferer,
+              venues: fakeVenues,
+            })
+
+            const result = getCurrentUserPermissions(userSliceState)
+
+            expect(result).toMatchObject({
+              hasSelectedAdminOfferer: true,
+              hasVenues: true,
+              isAuthenticated: true,
+              isOnboarded: false,
+              isSelectedAdminOffererAssociated: true,
+            })
           })
         })
       })

--- a/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
+++ b/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
@@ -26,8 +26,8 @@ describe('getCurrentUserPermissions', () => {
         hasSelectedPartnerVenue: false,
         hasVenues: false,
         isAuthenticated: false,
-        isOnboarded: false,
         isSelectedPartnerVenueAssociated: false,
+        isSelectedPartnerVenueOnboarded: false,
       })
     })
   })
@@ -49,8 +49,8 @@ describe('getCurrentUserPermissions', () => {
         hasSelectedPartnerVenue: false,
         hasVenues: false,
         isAuthenticated: true,
-        isOnboarded: false,
         isSelectedPartnerVenueAssociated: false,
+        isSelectedPartnerVenueOnboarded: false,
       })
     })
 
@@ -69,8 +69,8 @@ describe('getCurrentUserPermissions', () => {
           hasSelectedPartnerVenue: false,
           hasVenues: false,
           isAuthenticated: true,
-          isOnboarded: false,
           isSelectedPartnerVenueAssociated: false,
+          isSelectedPartnerVenueOnboarded: false,
         })
       })
     })
@@ -93,8 +93,8 @@ describe('getCurrentUserPermissions', () => {
           hasSelectedPartnerVenue: false,
           hasVenues: true,
           isAuthenticated: true,
-          isOnboarded: false,
           isSelectedPartnerVenueAssociated: false,
+          isSelectedPartnerVenueOnboarded: false,
         })
       })
 
@@ -116,8 +116,8 @@ describe('getCurrentUserPermissions', () => {
             hasSelectedPartnerVenue: false,
             hasVenues: true,
             isAuthenticated: true,
-            isOnboarded: false,
             isSelectedPartnerVenueAssociated: false,
+            isSelectedPartnerVenueOnboarded: false,
           })
         })
       })
@@ -140,13 +140,13 @@ describe('getCurrentUserPermissions', () => {
             hasSelectedPartnerVenue: true,
             hasVenues: true,
             isAuthenticated: true,
-            isOnboarded: false,
             isSelectedPartnerVenueAssociated: true,
+            isSelectedPartnerVenueOnboarded: false,
           })
         })
 
         describe('when venue is not onboarded', () => {
-          it('should return isOnboarded as false', () => {
+          it('should return isSelectedPartnerVenueOnboarded as false', () => {
             const userSliceState = makeUserSliceState({
               currentUser: fakeCurrentUser,
               selectedPartnerVenue: makeGetVenueResponseModel({
@@ -163,8 +163,8 @@ describe('getCurrentUserPermissions', () => {
               hasSelectedPartnerVenue: true,
               hasVenues: true,
               isAuthenticated: true,
-              isOnboarded: false,
               isSelectedPartnerVenueAssociated: true,
+              isSelectedPartnerVenueOnboarded: false,
             })
           })
         })
@@ -187,8 +187,8 @@ describe('getCurrentUserPermissions', () => {
               hasSelectedPartnerVenue: true,
               hasVenues: true,
               isAuthenticated: true,
-              isOnboarded: false,
               isSelectedPartnerVenueAssociated: false,
+              isSelectedPartnerVenueOnboarded: false,
             })
           })
         })
@@ -211,8 +211,8 @@ describe('getCurrentUserPermissions', () => {
               hasSelectedPartnerVenue: true,
               hasVenues: true,
               isAuthenticated: true,
-              isOnboarded: true,
               isSelectedPartnerVenueAssociated: true,
+              isSelectedPartnerVenueOnboarded: true,
             })
           })
         })
@@ -236,8 +236,8 @@ describe('getCurrentUserPermissions', () => {
             hasSelectedAdminOfferer: false,
             hasVenues: true,
             isAuthenticated: true,
-            isOnboarded: false,
             isSelectedAdminOffererAssociated: false,
+            isSelectedPartnerVenueOnboarded: false,
           })
         })
       })
@@ -259,8 +259,8 @@ describe('getCurrentUserPermissions', () => {
             hasSelectedAdminOfferer: true,
             hasVenues: true,
             isAuthenticated: true,
-            isOnboarded: false,
             isSelectedAdminOffererAssociated: true,
+            isSelectedPartnerVenueOnboarded: false,
           })
         })
 
@@ -279,8 +279,8 @@ describe('getCurrentUserPermissions', () => {
               hasSelectedAdminOfferer: true,
               hasVenues: true,
               isAuthenticated: true,
-              isOnboarded: false,
               isSelectedAdminOffererAssociated: false,
+              isSelectedPartnerVenueOnboarded: false,
             })
           })
         })
@@ -300,8 +300,8 @@ describe('getCurrentUserPermissions', () => {
               hasSelectedAdminOfferer: true,
               hasVenues: true,
               isAuthenticated: true,
-              isOnboarded: false,
               isSelectedAdminOffererAssociated: true,
+              isSelectedPartnerVenueOnboarded: false,
             })
           })
         })

--- a/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
+++ b/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
@@ -2,7 +2,10 @@ import * as storeModule from '@/commons/store/store'
 import { configureTestStore } from '@/commons/store/testUtils'
 import { defaultGetOffererResponseModel } from '@/commons/utils/factories/individualApiFactories'
 import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
-import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
+import {
+  makeGetVenueResponseModel,
+  makeVenueListItemLiteResponseModel,
+} from '@/commons/utils/factories/venueFactories'
 
 import { getCurrentUserPermissions } from '../getCurrentUserPermissions'
 
@@ -25,6 +28,7 @@ describe('getCurrentUserPermissions', () => {
       expect(result).toEqual({
         hasSelectedAdminOfferer: false,
         hasSelectedPartnerVenue: false,
+        hasVenues: false,
         isAuthenticated: false,
         isOnboarded: false,
         isSelectedPartnerVenueAssociated: false,
@@ -33,10 +37,12 @@ describe('getCurrentUserPermissions', () => {
   })
 
   describe('when user is authenticated', () => {
+    const fakeCurrentUser = sharedCurrentUserFactory()
+
     it('should return isAuthenticated as true', () => {
       const store = configureTestStore({
         user: {
-          currentUser: sharedCurrentUserFactory(),
+          currentUser: fakeCurrentUser,
           selectedAdminOfferer: null,
           selectedPartnerVenue: null,
           venues: null,
@@ -50,17 +56,18 @@ describe('getCurrentUserPermissions', () => {
       expect(result).toEqual({
         hasSelectedAdminOfferer: false,
         hasSelectedPartnerVenue: false,
+        hasVenues: false,
         isAuthenticated: true,
         isOnboarded: false,
         isSelectedPartnerVenueAssociated: false,
       })
     })
 
-    describe('without selected venue', () => {
-      it('should return hasSelectedPartnerVenue as false', () => {
+    describe('without venues', () => {
+      it('should return hasVenues as false', () => {
         const store = configureTestStore({
           user: {
-            currentUser: sharedCurrentUserFactory(),
+            currentUser: fakeCurrentUser,
             selectedAdminOfferer: null,
             selectedPartnerVenue: null,
             venues: null,
@@ -74,6 +81,7 @@ describe('getCurrentUserPermissions', () => {
         expect(result).toEqual({
           hasSelectedAdminOfferer: false,
           hasSelectedPartnerVenue: false,
+          hasVenues: false,
           isAuthenticated: true,
           isOnboarded: false,
           isSelectedPartnerVenueAssociated: false,
@@ -81,45 +89,17 @@ describe('getCurrentUserPermissions', () => {
       })
     })
 
-    describe('with selected admin offerer', () => {
-      it('should return hasSelectedAdminOfferer as true', () => {
+    describe('with venues', () => {
+      const fakeVenue = makeVenueListItemLiteResponseModel({ id: 1 })
+      const fakeVenues = [fakeVenue]
+
+      it('should return hasVenues as true', () => {
         const store = configureTestStore({
           user: {
-            currentUser: sharedCurrentUserFactory(),
-            selectedAdminOfferer: {
-              ...defaultGetOffererResponseModel,
-              id: 100,
-            },
-            selectedPartnerVenue: null,
-            venues: null,
-            venuesWithPendingValidation: null,
-          },
-        })
-        vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
-
-        const result = getCurrentUserPermissions()
-
-        expect(result).toEqual({
-          hasSelectedAdminOfferer: true,
-          hasSelectedPartnerVenue: false,
-          isAuthenticated: true,
-          isOnboarded: false,
-          isSelectedPartnerVenueAssociated: false,
-        })
-      })
-    })
-
-    describe('with selected venue', () => {
-      it('should return hasSelectedPartnerVenue as true', () => {
-        const store = configureTestStore({
-          user: {
-            currentUser: sharedCurrentUserFactory(),
+            currentUser: fakeCurrentUser,
             selectedAdminOfferer: null,
-            selectedPartnerVenue: makeGetVenueResponseModel({
-              id: 1,
-              isOnboarded: false,
-            }),
-            venues: null,
+            selectedPartnerVenue: null,
+            venues: fakeVenues,
             venuesWithPendingValidation: null,
           },
         })
@@ -129,24 +109,22 @@ describe('getCurrentUserPermissions', () => {
 
         expect(result).toEqual({
           hasSelectedAdminOfferer: false,
-          hasSelectedPartnerVenue: true,
+          hasSelectedPartnerVenue: false,
+          hasVenues: true,
           isAuthenticated: true,
           isOnboarded: false,
-          isSelectedPartnerVenueAssociated: true,
+          isSelectedPartnerVenueAssociated: false,
         })
       })
 
-      describe('when venue is not onboarded', () => {
-        it('should return isOnboarded as false', () => {
+      describe('without selected partner venue', () => {
+        it('should return hasSelectedPartnerVenue as false', () => {
           const store = configureTestStore({
             user: {
-              currentUser: sharedCurrentUserFactory(),
+              currentUser: fakeCurrentUser,
               selectedAdminOfferer: null,
-              selectedPartnerVenue: makeGetVenueResponseModel({
-                id: 1,
-                isOnboarded: false,
-              }),
-              venues: null,
+              selectedPartnerVenue: null,
+              venues: fakeVenues,
               venuesWithPendingValidation: null,
             },
           })
@@ -156,37 +134,8 @@ describe('getCurrentUserPermissions', () => {
 
           expect(result).toEqual({
             hasSelectedAdminOfferer: false,
-            hasSelectedPartnerVenue: true,
-            isAuthenticated: true,
-            isOnboarded: false,
-            isSelectedPartnerVenueAssociated: true,
-          })
-        })
-      })
-
-      describe('when selected venue is part of venues with pending validation', () => {
-        it('should return isSelectedPartnerVenueAssociated as false', () => {
-          const selectedPartnerVenueId = 1
-
-          const store = configureTestStore({
-            user: {
-              currentUser: sharedCurrentUserFactory(),
-              selectedAdminOfferer: null,
-              selectedPartnerVenue: makeGetVenueResponseModel({
-                id: selectedPartnerVenueId,
-                isOnboarded: false,
-              }),
-              venues: null,
-              venuesWithPendingValidation: [{ id: selectedPartnerVenueId }],
-            },
-          })
-          vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
-
-          const result = getCurrentUserPermissions()
-
-          expect(result).toEqual({
-            hasSelectedAdminOfferer: false,
-            hasSelectedPartnerVenue: true,
+            hasSelectedPartnerVenue: false,
+            hasVenues: true,
             isAuthenticated: true,
             isOnboarded: false,
             isSelectedPartnerVenueAssociated: false,
@@ -194,17 +143,17 @@ describe('getCurrentUserPermissions', () => {
         })
       })
 
-      describe('when access is full', () => {
-        it('should return all permissions as true', () => {
+      describe('with selected venue', () => {
+        it('should return hasSelectedPartnerVenue as true', () => {
           const store = configureTestStore({
             user: {
-              currentUser: sharedCurrentUserFactory(),
+              currentUser: fakeCurrentUser,
               selectedAdminOfferer: null,
               selectedPartnerVenue: makeGetVenueResponseModel({
-                id: 1,
-                isOnboarded: true,
+                id: fakeVenue.id,
+                isOnboarded: false,
               }),
-              venues: null,
+              venues: fakeVenues,
               venuesWithPendingValidation: null,
             },
           })
@@ -215,9 +164,125 @@ describe('getCurrentUserPermissions', () => {
           expect(result).toEqual({
             hasSelectedAdminOfferer: false,
             hasSelectedPartnerVenue: true,
+            hasVenues: true,
             isAuthenticated: true,
-            isOnboarded: true,
+            isOnboarded: false,
             isSelectedPartnerVenueAssociated: true,
+          })
+        })
+
+        describe('when venue is not onboarded', () => {
+          it('should return isOnboarded as false', () => {
+            const store = configureTestStore({
+              user: {
+                currentUser: fakeCurrentUser,
+                selectedAdminOfferer: null,
+                selectedPartnerVenue: makeGetVenueResponseModel({
+                  id: fakeVenue.id,
+                  isOnboarded: false,
+                }),
+                venues: fakeVenues,
+                venuesWithPendingValidation: null,
+              },
+            })
+            vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
+
+            const result = getCurrentUserPermissions()
+
+            expect(result).toEqual({
+              hasSelectedAdminOfferer: false,
+              hasSelectedPartnerVenue: true,
+              hasVenues: true,
+              isAuthenticated: true,
+              isOnboarded: false,
+              isSelectedPartnerVenueAssociated: true,
+            })
+          })
+        })
+
+        describe('when selected venue is part of venues with pending validation', () => {
+          it('should return isSelectedPartnerVenueAssociated as false', () => {
+            const store = configureTestStore({
+              user: {
+                currentUser: fakeCurrentUser,
+                selectedAdminOfferer: null,
+                selectedPartnerVenue: makeGetVenueResponseModel({
+                  id: fakeVenue.id,
+                  isOnboarded: false,
+                }),
+                venues: fakeVenues,
+                venuesWithPendingValidation: fakeVenues,
+              },
+            })
+            vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
+
+            const result = getCurrentUserPermissions()
+
+            expect(result).toEqual({
+              hasSelectedAdminOfferer: false,
+              hasSelectedPartnerVenue: true,
+              hasVenues: true,
+              isAuthenticated: true,
+              isOnboarded: false,
+              isSelectedPartnerVenueAssociated: false,
+            })
+          })
+        })
+
+        describe('when selected venue is both onboarded and not part of venues with pending validation', () => {
+          it('should return all venue-related permissions as true', () => {
+            const store = configureTestStore({
+              user: {
+                currentUser: fakeCurrentUser,
+                selectedAdminOfferer: null,
+                selectedPartnerVenue: makeGetVenueResponseModel({
+                  id: fakeVenue.id,
+                  isOnboarded: true,
+                }),
+                venues: fakeVenues,
+                venuesWithPendingValidation: null,
+              },
+            })
+            vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
+
+            const result = getCurrentUserPermissions()
+
+            expect(result).toEqual({
+              hasSelectedAdminOfferer: false,
+              hasSelectedPartnerVenue: true,
+              hasVenues: true,
+              isAuthenticated: true,
+              isOnboarded: true,
+              isSelectedPartnerVenueAssociated: true,
+            })
+          })
+        })
+      })
+
+      describe('with selected admin offerer', () => {
+        const fakeAdminOfferer = defaultGetOffererResponseModel
+
+        it('should return hasSelectedAdminOfferer as true', () => {
+          const store = configureTestStore({
+            user: {
+              currentUser: fakeCurrentUser,
+              selectedAdminOfferer: fakeAdminOfferer,
+              selectedPartnerVenue: null,
+              venues: fakeVenues,
+              venuesWithPendingValidation: null,
+            },
+          })
+          vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
+
+          const result = getCurrentUserPermissions()
+
+          expect(result).toEqual({
+            hasSelectedAdminOfferer: true,
+            hasSelectedPartnerVenue: false,
+            hasVenues: true,
+            isAuthenticated: true,
+            isOnboarded: false,
+            isSelectedPartnerVenueAssociated: false,
           })
         })
       })

--- a/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
+++ b/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
@@ -11,7 +11,6 @@ describe('getCurrentUserPermissions', () => {
     it('should return all permissions as false', () => {
       const store = configureTestStore({
         user: {
-          access: null,
           currentUser: null,
           selectedAdminOfferer: null,
           selectedPartnerVenue: null,
@@ -37,7 +36,6 @@ describe('getCurrentUserPermissions', () => {
     it('should return isAuthenticated as true', () => {
       const store = configureTestStore({
         user: {
-          access: null,
           currentUser: sharedCurrentUserFactory(),
           selectedAdminOfferer: null,
           selectedPartnerVenue: null,
@@ -62,7 +60,6 @@ describe('getCurrentUserPermissions', () => {
       it('should return hasSelectedPartnerVenue as false', () => {
         const store = configureTestStore({
           user: {
-            access: null,
             currentUser: sharedCurrentUserFactory(),
             selectedAdminOfferer: null,
             selectedPartnerVenue: null,
@@ -88,7 +85,6 @@ describe('getCurrentUserPermissions', () => {
       it('should return hasSelectedAdminOfferer as true', () => {
         const store = configureTestStore({
           user: {
-            access: null,
             currentUser: sharedCurrentUserFactory(),
             selectedAdminOfferer: {
               ...defaultGetOffererResponseModel,
@@ -117,10 +113,12 @@ describe('getCurrentUserPermissions', () => {
       it('should return hasSelectedPartnerVenue as true', () => {
         const store = configureTestStore({
           user: {
-            access: null,
             currentUser: sharedCurrentUserFactory(),
             selectedAdminOfferer: null,
-            selectedPartnerVenue: makeGetVenueResponseModel({ id: 1 }),
+            selectedPartnerVenue: makeGetVenueResponseModel({
+              id: 1,
+              isOnboarded: false,
+            }),
             venues: null,
             venuesWithPendingValidation: null,
           },
@@ -142,7 +140,6 @@ describe('getCurrentUserPermissions', () => {
         it('should return isOnboarded as false', () => {
           const store = configureTestStore({
             user: {
-              access: null,
               currentUser: sharedCurrentUserFactory(),
               selectedAdminOfferer: null,
               selectedPartnerVenue: makeGetVenueResponseModel({
@@ -167,16 +164,20 @@ describe('getCurrentUserPermissions', () => {
         })
       })
 
-      describe('when access is unattached', () => {
+      describe('when selected venue is part of venues with pending validation', () => {
         it('should return isSelectedPartnerVenueAssociated as false', () => {
+          const selectedPartnerVenueId = 1
+
           const store = configureTestStore({
             user: {
-              access: 'unattached',
               currentUser: sharedCurrentUserFactory(),
               selectedAdminOfferer: null,
-              selectedPartnerVenue: makeGetVenueResponseModel({ id: 1 }),
+              selectedPartnerVenue: makeGetVenueResponseModel({
+                id: selectedPartnerVenueId,
+                isOnboarded: false,
+              }),
               venues: null,
-              venuesWithPendingValidation: null,
+              venuesWithPendingValidation: [{ id: selectedPartnerVenueId }],
             },
           })
           vi.spyOn(storeModule, 'rootStore', 'get').mockReturnValue(store)
@@ -197,7 +198,6 @@ describe('getCurrentUserPermissions', () => {
         it('should return all permissions as true', () => {
           const store = configureTestStore({
             user: {
-              access: 'full',
               currentUser: sharedCurrentUserFactory(),
               selectedAdminOfferer: null,
               selectedPartnerVenue: makeGetVenueResponseModel({

--- a/pro/src/commons/auth/__specs__/useCurrentUserPermissions.spec.tsx
+++ b/pro/src/commons/auth/__specs__/useCurrentUserPermissions.spec.tsx
@@ -52,7 +52,7 @@ describe('useCurrentUserPermissions', () => {
     )
 
     expect(result.current.hasSelectedPartnerVenue).toBe(true)
-    expect(result.current.isOnboarded).toBe(false)
+    expect(result.current.isSelectedPartnerVenueOnboarded).toBe(false)
 
     act(() => {
       store.dispatch(
@@ -61,7 +61,7 @@ describe('useCurrentUserPermissions', () => {
     })
 
     expect(result.current.hasSelectedPartnerVenue).toBe(true)
-    expect(result.current.isOnboarded).toBe(true)
+    expect(result.current.isSelectedPartnerVenueOnboarded).toBe(true)
   })
 
   it('should return a stable reference between renders when the user slice state is unchanged', () => {

--- a/pro/src/commons/auth/__specs__/useCurrentUserPermissions.spec.tsx
+++ b/pro/src/commons/auth/__specs__/useCurrentUserPermissions.spec.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { Provider } from 'react-redux'
+
+import { configureTestStore } from '@/commons/store/testUtils'
+import {
+  setSelectedPartnerVenue,
+  type UserSliceState,
+} from '@/commons/store/user/reducer'
+import {
+  makeUserSliceState,
+  sharedCurrentUserFactory,
+} from '@/commons/utils/factories/storeFactories'
+import {
+  makeGetVenueResponseModel,
+  makeVenueListItemLiteResponseModel,
+} from '@/commons/utils/factories/venueFactories'
+
+import { useCurrentUserPermissions } from '../useCurrentUserPermissions'
+
+const renderUseCurrentUserPermissions = (
+  initialUserSliceState: UserSliceState
+) => {
+  const store = configureTestStore({ user: initialUserSliceState })
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  )
+
+  return {
+    ...renderHook(() => useCurrentUserPermissions(), { wrapper }),
+    store,
+  }
+}
+
+describe('useCurrentUserPermissions', () => {
+  const fakeVenueId = 1
+  const fakeVenue = makeGetVenueResponseModel({
+    id: fakeVenueId,
+    isOnboarded: false,
+  })
+  const fakeVenueLite = makeVenueListItemLiteResponseModel({ id: fakeVenueId })
+
+  it('should refresh permissions when the user slice state changes changes', () => {
+    const initialUserSliceState = makeUserSliceState({
+      currentUser: sharedCurrentUserFactory(),
+      selectedPartnerVenue: fakeVenue,
+      venues: [fakeVenueLite],
+    })
+
+    const { result, store } = renderUseCurrentUserPermissions(
+      initialUserSliceState
+    )
+
+    expect(result.current.hasSelectedPartnerVenue).toBe(true)
+    expect(result.current.isOnboarded).toBe(false)
+
+    act(() => {
+      store.dispatch(
+        setSelectedPartnerVenue({ ...fakeVenue, isOnboarded: true })
+      )
+    })
+
+    expect(result.current.hasSelectedPartnerVenue).toBe(true)
+    expect(result.current.isOnboarded).toBe(true)
+  })
+
+  it('should return a stable reference between renders when the user slice state is unchanged', () => {
+    const initialUserSliceState = makeUserSliceState({
+      currentUser: sharedCurrentUserFactory(),
+      selectedPartnerVenue: fakeVenue,
+      venues: [fakeVenueLite],
+    })
+
+    const { result, rerender } = renderUseCurrentUserPermissions(
+      initialUserSliceState
+    )
+
+    const firstResult = result.current
+    rerender()
+
+    expect(result.current).toBe(firstResult)
+  })
+})

--- a/pro/src/commons/auth/__specs__/withUserPermissions.spec.ts
+++ b/pro/src/commons/auth/__specs__/withUserPermissions.spec.ts
@@ -31,7 +31,6 @@ const setupStore = (options: {
 }) => {
   const store = configureTestStore({
     user: {
-      access: null,
       currentUser: options.hasUser ? sharedCurrentUserFactory() : null,
       selectedAdminOfferer: null,
       selectedPartnerVenue: options.hasVenueSelected

--- a/pro/src/commons/auth/getCurrentUserPermissions.ts
+++ b/pro/src/commons/auth/getCurrentUserPermissions.ts
@@ -1,15 +1,22 @@
-import { rootStore } from '@/commons/store/store'
-
+import type { UserSliceState } from '../store/user/reducer'
 import type { UserPermissions } from './types'
 
-export const getCurrentUserPermissions = (): UserPermissions => {
+/**
+ * /!\ If you need to get the current user permissions within React lifecyle (components),
+ * DO NOT use this function directly. Use the `useCurrentUserPermissions` hook instead
+ * to ensure the permissions are refreshed on every user state update.
+ */
+export const getCurrentUserPermissions = (
+  userSliceState: UserSliceState
+): UserPermissions => {
   const {
     currentUser,
+    offerersNamesWithPendingValidation,
     selectedAdminOfferer,
     selectedPartnerVenue,
     venues,
     venuesWithPendingValidation,
-  } = rootStore.getState().user
+  } = userSliceState
 
   if (!currentUser) {
     return {
@@ -17,6 +24,7 @@ export const getCurrentUserPermissions = (): UserPermissions => {
       hasVenues: false,
       isAuthenticated: false,
       isOnboarded: false,
+      isSelectedAdminOffererAssociated: false,
       isSelectedPartnerVenueAssociated: false,
       hasSelectedAdminOfferer: false,
     }
@@ -24,6 +32,11 @@ export const getCurrentUserPermissions = (): UserPermissions => {
 
   const hasSelectedAdminOfferer = !!selectedAdminOfferer
   const hasSelectedPartnerVenue = !!selectedPartnerVenue
+  const isSelectedAdminOffererAssociated =
+    hasSelectedAdminOfferer &&
+    !offerersNamesWithPendingValidation?.some(
+      (offerer) => offerer.id === selectedAdminOfferer.id
+    )
   const isSelectedPartnerVenueAssociated =
     hasSelectedPartnerVenue &&
     !venuesWithPendingValidation?.some(
@@ -36,6 +49,7 @@ export const getCurrentUserPermissions = (): UserPermissions => {
     hasVenues: !!venues?.length,
     isAuthenticated: true,
     isOnboarded: !!selectedPartnerVenue?.isOnboarded,
+    isSelectedAdminOffererAssociated,
     isSelectedPartnerVenueAssociated,
   }
 }

--- a/pro/src/commons/auth/getCurrentUserPermissions.ts
+++ b/pro/src/commons/auth/getCurrentUserPermissions.ts
@@ -21,12 +21,12 @@ export const getCurrentUserPermissions = (
   if (!currentUser) {
     return {
       hasSelectedPartnerVenue: false,
+      hasSelectedAdminOfferer: false,
       hasVenues: false,
       isAuthenticated: false,
-      isOnboarded: false,
       isSelectedAdminOffererAssociated: false,
       isSelectedPartnerVenueAssociated: false,
-      hasSelectedAdminOfferer: false,
+      isSelectedPartnerVenueOnboarded: false,
     }
   }
 
@@ -48,8 +48,8 @@ export const getCurrentUserPermissions = (
     hasSelectedPartnerVenue,
     hasVenues: !!venues?.length,
     isAuthenticated: true,
-    isOnboarded: !!selectedPartnerVenue?.isOnboarded,
     isSelectedAdminOffererAssociated,
     isSelectedPartnerVenueAssociated,
+    isSelectedPartnerVenueOnboarded: !!selectedPartnerVenue?.isOnboarded,
   }
 }

--- a/pro/src/commons/auth/getCurrentUserPermissions.ts
+++ b/pro/src/commons/auth/getCurrentUserPermissions.ts
@@ -7,12 +7,14 @@ export const getCurrentUserPermissions = (): UserPermissions => {
     currentUser,
     selectedAdminOfferer,
     selectedPartnerVenue,
+    venues,
     venuesWithPendingValidation,
   } = rootStore.getState().user
 
   if (!currentUser) {
     return {
       hasSelectedPartnerVenue: false,
+      hasVenues: false,
       isAuthenticated: false,
       isOnboarded: false,
       isSelectedPartnerVenueAssociated: false,
@@ -29,10 +31,11 @@ export const getCurrentUserPermissions = (): UserPermissions => {
     )
 
   return {
-    hasSelectedPartnerVenue: hasSelectedPartnerVenue,
+    hasSelectedAdminOfferer,
+    hasSelectedPartnerVenue,
+    hasVenues: !!venues?.length,
     isAuthenticated: true,
     isOnboarded: !!selectedPartnerVenue?.isOnboarded,
     isSelectedPartnerVenueAssociated,
-    hasSelectedAdminOfferer,
   }
 }

--- a/pro/src/commons/auth/getCurrentUserPermissions.ts
+++ b/pro/src/commons/auth/getCurrentUserPermissions.ts
@@ -3,8 +3,12 @@ import { rootStore } from '@/commons/store/store'
 import type { UserPermissions } from './types'
 
 export const getCurrentUserPermissions = (): UserPermissions => {
-  const { access, currentUser, selectedAdminOfferer, selectedPartnerVenue } =
-    rootStore.getState().user
+  const {
+    currentUser,
+    selectedAdminOfferer,
+    selectedPartnerVenue,
+    venuesWithPendingValidation,
+  } = rootStore.getState().user
 
   if (!currentUser) {
     return {
@@ -18,9 +22,11 @@ export const getCurrentUserPermissions = (): UserPermissions => {
 
   const hasSelectedAdminOfferer = !!selectedAdminOfferer
   const hasSelectedPartnerVenue = !!selectedPartnerVenue
-  // TODO (igabriele, 2026-02-04): Replace `access !== 'unattached'` with `selectedPartnerVenue.isAssociated` as soon as the prop is available (WIP_SWITCH_VENUE FF).
   const isSelectedPartnerVenueAssociated =
-    hasSelectedPartnerVenue && access !== 'unattached'
+    hasSelectedPartnerVenue &&
+    !venuesWithPendingValidation?.some(
+      (venue) => venue.id === selectedPartnerVenue.id
+    )
 
   return {
     hasSelectedPartnerVenue: hasSelectedPartnerVenue,

--- a/pro/src/commons/auth/types.ts
+++ b/pro/src/commons/auth/types.ts
@@ -3,7 +3,7 @@ export interface UserPermissions {
   hasSelectedPartnerVenue: boolean
   hasVenues: boolean
   isAuthenticated: boolean
-  isOnboarded: boolean
   isSelectedAdminOffererAssociated: boolean
   isSelectedPartnerVenueAssociated: boolean
+  isSelectedPartnerVenueOnboarded: boolean
 }

--- a/pro/src/commons/auth/types.ts
+++ b/pro/src/commons/auth/types.ts
@@ -1,6 +1,7 @@
 export interface UserPermissions {
   hasSelectedAdminOfferer: boolean
   hasSelectedPartnerVenue: boolean
+  hasVenues: boolean
   isAuthenticated: boolean
   isOnboarded: boolean
   isSelectedPartnerVenueAssociated: boolean

--- a/pro/src/commons/auth/types.ts
+++ b/pro/src/commons/auth/types.ts
@@ -4,5 +4,6 @@ export interface UserPermissions {
   hasVenues: boolean
   isAuthenticated: boolean
   isOnboarded: boolean
+  isSelectedAdminOffererAssociated: boolean
   isSelectedPartnerVenueAssociated: boolean
 }

--- a/pro/src/commons/auth/useCurrentUserPermissions.ts
+++ b/pro/src/commons/auth/useCurrentUserPermissions.ts
@@ -1,0 +1,11 @@
+import { useMemo } from 'react'
+
+import { useAppSelector } from '../hooks/useAppSelector'
+import { getCurrentUserPermissions } from './getCurrentUserPermissions'
+import type { UserPermissions } from './types'
+
+export const useCurrentUserPermissions = (): UserPermissions => {
+  const user = useAppSelector((state) => state.user)
+
+  return useMemo(() => getCurrentUserPermissions(user), [user])
+}

--- a/pro/src/commons/auth/withUserPermissions.ts
+++ b/pro/src/commons/auth/withUserPermissions.ts
@@ -1,6 +1,7 @@
 import { type LoaderFunctionArgs, redirect } from 'react-router'
 
 import { getUserDefaultPath } from '../../app/AppRouter/utils/getUserDefaultPath'
+import { rootStore } from '../store/store'
 import { getCurrentUserPermissions } from './getCurrentUserPermissions'
 import type { UserPermissions } from './types'
 
@@ -9,7 +10,7 @@ export const withUserPermissions = (
   loader?: (args: LoaderFunctionArgs) => unknown
 ) => {
   return (args: LoaderFunctionArgs) => {
-    const userPermissions = getCurrentUserPermissions()
+    const userPermissions = getCurrentUserPermissions(rootStore.getState().user)
     if (!requireUserPermissions(userPermissions)) {
       throw redirect(getUserDefaultPath())
     }

--- a/pro/src/commons/store/user/dispatchers/__specs__/initializeUser.spec.ts
+++ b/pro/src/commons/store/user/dispatchers/__specs__/initializeUser.spec.ts
@@ -77,7 +77,6 @@ describe('initializeUser', () => {
     await store.dispatch(initializeUser({ user })).unwrap()
 
     const state = store.getState()
-    expect(state.user.access).toBe('full')
     expect(state.user.selectedPartnerVenue?.id).toBe(101)
     expect(state.user.selectedAdminOfferer?.id).toBe(100)
 
@@ -119,7 +118,6 @@ describe('initializeUser', () => {
     await store.dispatch(initializeUser({ user })).unwrap()
 
     const state = store.getState()
-    expect(state.user.access).toBe('full')
     expect(state.user.selectedPartnerVenue?.id).toBe(101)
   })
 
@@ -156,7 +154,6 @@ describe('initializeUser', () => {
     expect(apiGetVenueSpy).not.toHaveBeenCalled()
 
     const state = store.getState()
-    expect(state.user.access).toBeNull()
     expect(state.user.selectedPartnerVenue).toBeNull()
   })
 
@@ -182,9 +179,6 @@ describe('initializeUser', () => {
     await store.dispatch(initializeUser({ user })).unwrap()
 
     expect(apiGetVenueSpy).not.toHaveBeenCalled()
-
-    const state = store.getState()
-    expect(state.user.access).toBeNull()
   })
 
   it('should return early without selection when no offerers and no venues', async () => {
@@ -209,7 +203,6 @@ describe('initializeUser', () => {
     expect(apiGetVenueSpy).not.toHaveBeenCalled()
 
     const state = store.getState()
-    expect(state.user.access).toBeNull()
     expect(state.user.selectedAdminOfferer).toBeNull()
     expect(
       localStorage.getItem(LOCAL_STORAGE_KEY.SELECTED_ADMIN_OFFERER_ID)
@@ -351,7 +344,6 @@ describe('initializeUser', () => {
     await store.dispatch(initializeUser({ user })).unwrap()
 
     const state = store.getState()
-    expect(state.user.access).toBeNull()
     expect(state.user.selectedPartnerVenue).toBeNull()
   })
 
@@ -394,7 +386,6 @@ describe('initializeUser', () => {
     await store.dispatch(initializeUser({ user })).unwrap()
 
     const state = store.getState()
-    expect(state.user.access).toBe('full')
     expect(state.user.selectedPartnerVenue?.id).toBe(201)
   })
 
@@ -502,7 +493,6 @@ describe('error handling', () => {
     expect(logoutSpy).toHaveBeenCalledTimes(1)
 
     const state = store.getState()
-    expect(state.user.access).toBeNull()
     expect(state.user.currentUser).toBeNull()
     expect(state.user.selectedAdminOfferer).toBeNull()
     expect(state.user.offererNamesValidated).toBeNull()

--- a/pro/src/commons/store/user/dispatchers/__specs__/setSelectedPartnerVenueById.spec.ts
+++ b/pro/src/commons/store/user/dispatchers/__specs__/setSelectedPartnerVenueById.spec.ts
@@ -34,7 +34,6 @@ vi.mock('@/commons/errors/handleError', () => ({
 describe('setSelectedPartnerVenueById', () => {
   const storeDataBase: Partial<RootState> = {
     user: {
-      access: null,
       currentUser: null,
       selectedAdminOfferer: null,
       selectedPartnerVenue: makeGetVenueResponseModel({
@@ -105,7 +104,7 @@ describe('setSelectedPartnerVenueById', () => {
     )
   })
 
-  it('should compute nextSelectedPartnerVenue, fetch its offerer, update user access and persist it', async () => {
+  it('should compute nextSelectedPartnerVenue, fetch its offerer, and persist it', async () => {
     vi.spyOn(api, 'getVenue').mockResolvedValue(
       makeGetVenueResponseModel({ id: 101, managingOffererId: 100 })
     )
@@ -130,7 +129,6 @@ describe('setSelectedPartnerVenueById', () => {
     expect(api.getOfferer).toHaveBeenCalledTimes(1)
 
     const state = store.getState()
-    expect(state.user.access).toBe('full')
     expect(state.user.selectedPartnerVenue?.id).toBe(101)
 
     expect(localStorage.getItem(LOCAL_STORAGE_KEY.SELECTED_VENUE_ID)).toBe(
@@ -138,40 +136,7 @@ describe('setSelectedPartnerVenueById', () => {
     )
   })
 
-  it('should set access to no-onboarding when offerer is not onboarded', async () => {
-    vi.spyOn(api, 'getVenue').mockResolvedValue(
-      makeGetVenueResponseModel({ id: 101, managingOffererId: 100 })
-    )
-    vi.spyOn(api, 'getOfferer').mockResolvedValue({
-      ...defaultGetOffererResponseModel,
-      id: 100,
-      isOnboarded: false,
-    })
-
-    const store = configureTestStore(storeDataBase)
-
-    await store
-      .dispatch(
-        setSelectedPartnerVenueById({
-          nextSelectedPartnerVenueId: 101,
-          shouldAlignSelectedAdminOfferer: false,
-        })
-      )
-      .unwrap()
-
-    expect(api.getVenue).toHaveBeenCalledTimes(1)
-    expect(api.getOfferer).toHaveBeenCalledTimes(1)
-
-    const state = store.getState()
-    expect(state.user.access).toBe('no-onboarding')
-    expect(state.user.selectedPartnerVenue?.id).toBe(101)
-
-    expect(localStorage.getItem(LOCAL_STORAGE_KEY.SELECTED_VENUE_ID)).toBe(
-      '101'
-    )
-  })
-
-  it('should not call getVenue, getOfferer, and set access to unattached when offerer is not attached', async () => {
+  it('should not call getVenue and getOfferer when offerer is not attached', async () => {
     const store = configureTestStore(storeDataBase)
 
     await store
@@ -187,7 +152,6 @@ describe('setSelectedPartnerVenueById', () => {
     expect(api.getOfferer).toHaveBeenCalledTimes(0)
 
     const state = store.getState()
-    expect(state.user.access).toBe('unattached')
     expect(state.user.selectedPartnerVenue?.id).toBe(301)
     expect(state.user.selectedPartnerVenue?.managingOfferer?.id).toBe(300)
 
@@ -246,7 +210,6 @@ describe('setSelectedPartnerVenueById', () => {
 
     const store = configureTestStore({
       user: {
-        access: null,
         currentUser: null,
         selectedAdminOfferer: null,
         selectedPartnerVenue: makeGetVenueResponseModel({
@@ -437,7 +400,6 @@ describe('setSelectedPartnerVenueById', () => {
       expect(api.getOfferer).toHaveBeenCalledExactlyOnceWith(200)
 
       const state = store.getState()
-      expect(state.user.access).toBe('full')
       expect(state.user.selectedPartnerVenue?.id).toBe(201)
       expect(state.user.selectedPartnerVenue?.isOnboarded).toBe(true)
     })

--- a/pro/src/commons/store/user/dispatchers/setSelectedPartnerVenueById.ts
+++ b/pro/src/commons/store/user/dispatchers/setSelectedPartnerVenueById.ts
@@ -13,18 +13,16 @@ import {
 } from '@/commons/utils/localStorageManager'
 
 import type { AppThunkApiConfig } from '../../store'
-import {
-  setSelectedPartnerVenue,
-  type UserAccess,
-  updateUserAccess,
-} from '../reducer'
+import { setSelectedPartnerVenue } from '../reducer'
 import { logout } from './logout'
 import { setSelectedAdminOffererById } from './setSelectedAdminOffererById'
 
+type SetSelectedPartnerVenueByIdReturn = {
+  selectedPartnerVenue: GetVenueResponseModel
+}
+
 export const setSelectedPartnerVenueById = createAsyncThunk<
-  {
-    selectedPartnerVenue: GetVenueResponseModel
-  },
+  SetSelectedPartnerVenueByIdReturn,
   {
     nextSelectedPartnerVenueId: number
     // We want to keep that prop mandatory to make related UX rules explicit
@@ -41,7 +39,7 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
       shouldRefresh,
     },
     { dispatch, getState }
-  ) => {
+  ): Promise<SetSelectedPartnerVenueByIdReturn> => {
     try {
       const state = getState()
 
@@ -54,7 +52,6 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
       ) {
         return {
           selectedPartnerVenue: previousSelectedPartnerVenue,
-          newUserAccess: state.user.access,
         }
       }
 
@@ -62,7 +59,6 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
         state.user.venuesWithPendingValidation?.map((v) => v.id)
       let nextSelectedPartnerVenue: GetVenueResponseModel
       let nextSelectedOfferer: GetOffererResponseModel | undefined
-      let nextUserAccess: UserAccess
       if (
         venuesWithPendingValidationIds?.length &&
         venuesWithPendingValidationIds.includes(nextSelectedPartnerVenueId)
@@ -77,10 +73,6 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
         nextSelectedOfferer = {
           id: venue?.managingOffererId,
         } as GetOffererResponseModel
-
-        // TODO (igabriele, 2026-02-04): Delete those 2 statements once `WIP_SWITCH_VENUE` FF is enabled and removed.
-        nextUserAccess = 'unattached'
-        dispatch(updateUserAccess(nextUserAccess))
       } else {
         nextSelectedPartnerVenue = await api.getVenue(
           nextSelectedPartnerVenueId
@@ -88,12 +80,6 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
         nextSelectedOfferer = await api.getOfferer(
           nextSelectedPartnerVenue.managingOfferer.id
         )
-
-        // TODO (igabriele, 2026-02-04): Delete those 2 statements once `WIP_SWITCH_VENUE` FF is enabled and removed.
-        nextUserAccess = nextSelectedOfferer.isOnboarded
-          ? 'full'
-          : 'no-onboarding'
-        dispatch(updateUserAccess(nextUserAccess))
       }
 
       if (
@@ -125,7 +111,6 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
       dispatch(setSelectedPartnerVenue(nextSelectedPartnerVenue))
       return {
         selectedPartnerVenue: nextSelectedPartnerVenue,
-        newUserAccess: nextUserAccess,
       }
     } catch (err) {
       handleError(

--- a/pro/src/commons/store/user/reducer.ts
+++ b/pro/src/commons/store/user/reducer.ts
@@ -8,12 +8,8 @@ import type {
   VenueListItemLiteResponseModel,
 } from '@/apiClient/v1/new'
 
-export type UserAccess = 'no-offerer' | 'no-onboarding' | 'unattached' | 'full'
-
 type UserState = {
   currentUser: null | SharedCurrentUserResponseModel
-  // TODO (igabriele, 2025-02-04): Delete this prop once `WIP_SWITCH_VENUE` FF is enabled and removed.
-  access: null | UserAccess
   selectedAdminOfferer: GetOffererResponseModel | null
   selectedPartnerVenue: GetVenueResponseModel | null
   venues: VenueListItemLiteResponseModel[] | null
@@ -26,7 +22,6 @@ type UserState = {
 
 const initialState: UserState = {
   currentUser: null,
-  access: null,
   selectedAdminOfferer: null,
   selectedPartnerVenue: null,
   venues: null,
@@ -55,10 +50,6 @@ const userSlice = createSlice({
       action: PayloadAction<SharedCurrentUserResponseModel | null>
     ) => {
       state.currentUser = action.payload
-    },
-
-    updateUserAccess: (state, action: PayloadAction<null | UserAccess>) => {
-      state.access = action.payload
     },
 
     setSelectedAdminOfferer(
@@ -103,7 +94,6 @@ export const userReducer = userSlice.reducer
 
 export const {
   updateUser,
-  updateUserAccess,
   setSelectedAdminOfferer,
   setSelectedPartnerVenue,
   setVenues,

--- a/pro/src/commons/store/user/reducer.ts
+++ b/pro/src/commons/store/user/reducer.ts
@@ -8,8 +8,8 @@ import type {
   VenueListItemLiteResponseModel,
 } from '@/apiClient/v1/new'
 
-type UserState = {
-  currentUser: null | SharedCurrentUserResponseModel
+export interface UserSliceState {
+  currentUser: SharedCurrentUserResponseModel | null
   selectedAdminOfferer: GetOffererResponseModel | null
   selectedPartnerVenue: GetVenueResponseModel | null
   venues: VenueListItemLiteResponseModel[] | null
@@ -20,7 +20,7 @@ type UserState = {
   offerersNamesWithPendingValidation: GetOffererNameResponseModel[] | null
 }
 
-const initialState: UserState = {
+const initialState: UserSliceState = {
   currentUser: null,
   selectedAdminOfferer: null,
   selectedPartnerVenue: null,
@@ -53,20 +53,23 @@ const userSlice = createSlice({
     },
 
     setSelectedAdminOfferer(
-      state: UserState,
+      state: UserSliceState,
       action: PayloadAction<GetOffererResponseModel | null>
     ) {
       state.selectedAdminOfferer = action.payload
     },
 
     setSelectedPartnerVenue(
-      state: UserState,
+      state: UserSliceState,
       action: PayloadAction<GetVenueResponseModel | null>
     ) {
       state.selectedPartnerVenue = action.payload
     },
 
-    setVenues(state: UserState, action: PayloadAction<UpdateVenuesPayload>) {
+    setVenues(
+      state: UserSliceState,
+      action: PayloadAction<UpdateVenuesPayload>
+    ) {
       state.venues =
         action.payload.venues?.concat(
           action.payload.venuesWithPendingValidation ?? []
@@ -76,7 +79,7 @@ const userSlice = createSlice({
     },
 
     updateOffererNames: (
-      state: UserState,
+      state: UserSliceState,
       action: PayloadAction<UpdateOffererNamesPayload>
     ) => {
       state.offererNames =

--- a/pro/src/commons/utils/factories/authFactories.ts
+++ b/pro/src/commons/utils/factories/authFactories.ts
@@ -1,0 +1,14 @@
+import type { UserPermissions } from '@/commons/auth/types'
+
+export const makeUserPermissions = (
+  overrides: Partial<UserPermissions>
+): UserPermissions => ({
+  hasSelectedAdminOfferer: false,
+  hasSelectedPartnerVenue: false,
+  hasVenues: false,
+  isAuthenticated: false,
+  isOnboarded: false,
+  isSelectedAdminOffererAssociated: false,
+  isSelectedPartnerVenueAssociated: false,
+  ...overrides,
+})

--- a/pro/src/commons/utils/factories/authFactories.ts
+++ b/pro/src/commons/utils/factories/authFactories.ts
@@ -7,8 +7,8 @@ export const makeUserPermissions = (
   hasSelectedPartnerVenue: false,
   hasVenues: false,
   isAuthenticated: false,
-  isOnboarded: false,
   isSelectedAdminOffererAssociated: false,
   isSelectedPartnerVenueAssociated: false,
+  isSelectedPartnerVenueOnboarded: false,
   ...overrides,
 })

--- a/pro/src/commons/utils/factories/storeFactories.ts
+++ b/pro/src/commons/utils/factories/storeFactories.ts
@@ -1,5 +1,21 @@
 import type { SharedCurrentUserResponseModel } from '@/apiClient/v1'
 
+import type { UserSliceState } from '../../store/user/reducer'
+
+export const makeUserSliceState = (
+  overrides: Partial<UserSliceState> = {}
+): UserSliceState => ({
+  currentUser: null,
+  offererNames: null,
+  offererNamesValidated: null,
+  offerersNamesWithPendingValidation: null,
+  selectedAdminOfferer: null,
+  selectedPartnerVenue: null,
+  venues: null,
+  venuesWithPendingValidation: null,
+  ...overrides,
+})
+
 export const sharedCurrentUserFactory = (
   customSharedCurrentUser: Partial<SharedCurrentUserResponseModel> = {}
 ): SharedCurrentUserResponseModel => ({

--- a/pro/src/components/OnboardingOffersChoice/components/OnboardingCollectiveModal/OnboardingCollectiveModal.spec.tsx
+++ b/pro/src/components/OnboardingOffersChoice/components/OnboardingCollectiveModal/OnboardingCollectiveModal.spec.tsx
@@ -45,7 +45,6 @@ const renderOnboardingCollectiveModal = (
   return renderWithProviders(<OnboardingCollectiveModal />, {
     storeOverrides: {
       user: {
-        access: null,
         currentUser: sharedCurrentUserFactory(),
         offererNames: [getOffererNameFactory({ id: SELECTED_OFFERER_ID })],
         offererNamesValidated: [

--- a/pro/src/components/RedirectToBankAccountDialog/RedirectToBankAccountDialog.spec.tsx
+++ b/pro/src/components/RedirectToBankAccountDialog/RedirectToBankAccountDialog.spec.tsx
@@ -50,7 +50,6 @@ const renderDialog = (
   return renderWithProviders(<RedirectToBankAccountDialog {...props} />, {
     storeOverrides: {
       user: {
-        access: null,
         currentUser: sharedCurrentUserFactory(),
         offererNames: [
           getOffererNameFactory({

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.spec.tsx
@@ -574,13 +574,7 @@ describe('ValidationScreen', () => {
       })
 
       it('should navigate to user default path after creation', async () => {
-        renderValidationScreen(contextValue, {
-          storeOverrides: {
-            user: {
-              access: 'full',
-            },
-          },
-        })
+        renderValidationScreen(contextValue)
         await userEvent.click(screen.getByText('Valider et créer ma structure'))
         await waitFor(() => {
           expect(initializeUserMock).toHaveBeenCalled()

--- a/pro/src/layouts/AdministrationLayout/AdministrationLayout.spec.tsx
+++ b/pro/src/layouts/AdministrationLayout/AdministrationLayout.spec.tsx
@@ -1,118 +1,82 @@
 import { screen } from '@testing-library/react'
-import type { RouteObject } from 'react-router'
 
-import { api } from '@/apiClient/api'
+import * as useCurrentUserPermissionsModule from '@/commons/auth/useCurrentUserPermissions'
+import { makeUserPermissions } from '@/commons/utils/factories/authFactories'
 import { defaultGetOffererResponseModel } from '@/commons/utils/factories/individualApiFactories'
-import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
-import {
-  type RenderWithProvidersOptions,
-  renderWithProviders,
-} from '@/commons/utils/renderWithProviders'
+import { makeUserSliceState } from '@/commons/utils/factories/storeFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
 
 import { AdministrationLayout } from './AdministrationLayout'
 
-vi.mock('@/commons/hooks/swr/useOffererNamesQuery', () => ({
-  useOffererNamesQuery: () => ({ isLoading: false }),
-}))
-
-const user = sharedCurrentUserFactory()
-
-const buildRoutes = (): RouteObject[] => [
-  {
-    path: '/administration',
-    Component: AdministrationLayout,
-    children: [
-      {
-        path: 'donnees-activite/individuel',
-        element: <div data-testid="outlet-content">Page content</div>,
-      },
-    ],
-  },
-]
-
-const offererNamesValidated = [
-  {
+const renderAdministrationLayout = (offererCount = 1) => {
+  const offererNames = Array.from({ length: offererCount }, (_, i) => ({
     ...defaultGetOffererResponseModel,
-    id: 1,
-    name: `Offerer 1`,
-  },
-]
-
-const renderAdministrationLayout = (
-  offererCount = 1,
-  options?: RenderWithProvidersOptions
-) => {
-  const offererNamesValidated = Array.from(
-    { length: offererCount },
-    (_, i) => ({
-      ...defaultGetOffererResponseModel,
-      id: i + 1,
-      name: `Offerer ${i + 1}`,
-    })
-  )
+    id: i + 1,
+    name: `Offerer ${i + 1}`,
+  }))
 
   renderWithProviders(null, {
-    routes: buildRoutes(),
-    initialRouterEntries: ['/administration/donnees-activite/individuel'],
-    user,
-    storeOverrides: {
-      user: {
-        currentUser: user,
-        selectedAdminOfferer: offererNamesValidated[0],
-        offererNamesValidated,
-        offererNames: offererNamesValidated,
+    routes: [
+      {
+        path: '/administration',
+        Component: AdministrationLayout,
+        children: [
+          {
+            path: 'donnees-activite/individuel',
+            element: <div data-testid="outlet-content">Page content</div>,
+          },
+        ],
       },
+    ],
+    initialRouterEntries: ['/administration/donnees-activite/individuel'],
+    storeOverrides: {
+      user: makeUserSliceState({ offererNames }),
     },
-    ...options,
   })
 }
 
 describe('AdministrationLayout', () => {
-  it('should render the outlet content', () => {
-    renderAdministrationLayout()
-
-    expect(screen.getByTestId('outlet-content')).toBeInTheDocument()
-  })
-
   it('should not display offerer select when there is only one offerer', () => {
+    vi.spyOn(
+      useCurrentUserPermissionsModule,
+      'useCurrentUserPermissions'
+    ).mockReturnValue(
+      makeUserPermissions({ isSelectedAdminOffererAssociated: true })
+    )
+
     renderAdministrationLayout(1)
 
-    expect(screen.queryByLabelText('Entité juridique')).not.toBeInTheDocument()
+    expect(screen.getByTestId('outlet-content')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('combobox', { name: 'Entité juridique' })
+    ).not.toBeInTheDocument()
   })
 
   it('should display offerer select when there are multiple offerers', () => {
+    vi.spyOn(
+      useCurrentUserPermissionsModule,
+      'useCurrentUserPermissions'
+    ).mockReturnValue(
+      makeUserPermissions({ isSelectedAdminOffererAssociated: true })
+    )
+
     renderAdministrationLayout(2)
 
-    expect(screen.getByLabelText('Entité juridique')).toBeInTheDocument()
-  })
-  it('should render non attached banner if offerer is not attached', () => {
-    renderAdministrationLayout(2, {
-      storeOverrides: {
-        user: {
-          offererNamesValidated: [],
-          offererNames: offererNamesValidated,
-          selectedAdminOfferer: offererNamesValidated[0],
-        },
-      },
-    })
-
+    expect(screen.getByTestId('outlet-content')).toBeInTheDocument()
     expect(
-      screen.getByText(
-        'Votre rattachement est en cours de traitement par les équipes du pass Culture'
-      )
+      screen.getByRole('combobox', { name: 'Entité juridique' })
     ).toBeInTheDocument()
   })
-  it('should not render outlet content on getOffererNames error', () => {
-    vi.spyOn(api, 'listOfferersNames').mockRejectedValue({})
-    renderAdministrationLayout(2, {
-      storeOverrides: {
-        user: {
-          offererNamesValidated: [],
-          offererNames: [],
-          selectedAdminOfferer: offererNamesValidated[0],
-        },
-      },
-    })
+
+  it('should render non attached banner if selected admin offerer is not associated', () => {
+    vi.spyOn(
+      useCurrentUserPermissionsModule,
+      'useCurrentUserPermissions'
+    ).mockReturnValue(
+      makeUserPermissions({ isSelectedAdminOffererAssociated: false })
+    )
+
+    renderAdministrationLayout(1)
 
     expect(
       screen.getByText(

--- a/pro/src/layouts/AdministrationLayout/AdministrationLayout.tsx
+++ b/pro/src/layouts/AdministrationLayout/AdministrationLayout.tsx
@@ -2,39 +2,25 @@ import { Outlet } from 'react-router'
 
 import { BasicLayout } from '@/app/App/layouts/BasicLayout/BasicLayout'
 import { MainHeading } from '@/app/App/layouts/components/MainHeading/MainHeading'
-import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
+import { useCurrentUserPermissions } from '@/commons/auth/useCurrentUserPermissions'
 import { useAppSelector } from '@/commons/hooks/useAppSelector'
 import { useCurrentRoute } from '@/commons/hooks/useCurrentRoute'
-import {
-  ensureOffererNames,
-  ensureOffererNamesValidated,
-  ensureSelectedAdminOfferer,
-} from '@/commons/store/user/selectors'
+import { ensureOffererNames } from '@/commons/store/user/selectors'
 import { NonAttachedBanner } from '@/components/NonAttachedBanner/NonAttachedBanner'
 import { OffererSelect } from '@/components/OffererSelect/OffererSelect'
 
 export const AdministrationLayout = () => {
   const offererNames = useAppSelector(ensureOffererNames)
   const currentRoute = useCurrentRoute()
+  const userPermissions = useCurrentUserPermissions()
+
   const title = currentRoute.handle?.title
-  const selectedAdminOfferer = useAppSelector(ensureSelectedAdminOfferer)
-
-  assertOrFrontendError(
-    selectedAdminOfferer,
-    '`selectedAdminOfferer` is undefined'
-  )
-
-  const offererId = selectedAdminOfferer?.id
-  const offererNamesValidated = useAppSelector(ensureOffererNamesValidated)
-  const isSelectedOffererValidated = offererNamesValidated.some(
-    (offerer) => offerer.id === offererId
-  )
 
   return (
     <BasicLayout isAdminArea>
       <MainHeading mainHeading={title} />
       {offererNames.length > 1 && <OffererSelect />}
-      {isSelectedOffererValidated ? (
+      {userPermissions.isSelectedAdminOffererAssociated ? (
         <Outlet />
       ) : (
         <NonAttachedBanner></NonAttachedBanner>

--- a/pro/src/pages/Hub/Hub.spec.tsx
+++ b/pro/src/pages/Hub/Hub.spec.tsx
@@ -36,7 +36,6 @@ const renderHub: RenderComponentFunction<
   return renderWithProviders(<Hub />, {
     storeOverrides: {
       user: {
-        access: 'full',
         currentUser: sharedCurrentUserFactory(),
         selectedPartnerVenue: null,
         venues,


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41346)

Rebasé sur la PR https://github.com/pass-culture/pass-culture-main/pull/22663 pour l'instant.

1. Supprime complètement la prop `user.access` du store Redux.
2. Ajoute `UserPermissions.hasVenues`.
3. Ajoute `UserPermissions.isSelectedAdminOffererAssociated`.
4. Renomme `UserPermissions.isOnboarded` -> `UserPermissions.isSelectedPartnerVenueOnboarded`.

Cette PR finit donc de centraliser toutes les permissions possibles dans `UserPermission` :

```ts
export interface UserPermissions {
  hasSelectedAdminOfferer: boolean
  hasSelectedPartnerVenue: boolean
  hasVenues: boolean
  isAuthenticated: boolean
  isSelectedAdminOffererAssociated: boolean
  isSelectedPartnerVenueAssociated: boolean
  isSelectedPartnerVenueOnboarded: boolean
}
```

> [!NOTE]
> Une dernière permission qu'on pourra passer dans cette objet à l'occasion est `isAllowedOnAdage`, ce qui (si associé proprement au routing) permettrait de garantir le fait qu'il soit **toujours** `true` sur les pages EAC. @anoukhello

## 🖥️ Preview

https://pc-pro-testing--662d290-ykhwy4zj.web.app/

---

- [x] Travail pair testé en environnement de preview
