### PR TITLE
(BSR)[PRO] build: restrict modern ES2022+ APIs in TypeScript

### DIFF
--- a/pro/tsconfig.json
+++ b/pro/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "es2021"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,


### PR DESCRIPTION
## 🔧 Changes Made

Passer `lib` vers `es2021` permet d'indiquer à TypeScript de limiter la syntaxe des APIs modernes comme `Array.prototype.toSorted` …

Il s'agit d'une simple erreur TS pour éviter d'introduire par erreur des méthodes encore trop récentes pour les vieux navigateurs de certains AC.

<img width="467" height="148" alt="image" src="https://github.com/user-attachments/assets/bec2f6be-73dd-4bae-a11f-ba6e3d1d5faa" />
