### PR TITLE
(PC-41810)[PRO] feat: do not send same requests twice in a row

### DIFF
--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/OffersSearch.tsx
@@ -143,19 +143,28 @@ export const OffersSearch = ({
     })
   }
 
+  const lastLoggedFiltersRef = useRef<string | null>(null)
+
   const logFiltersOnSearch = useCallback(
     async (nbHits: number, queryId?: string) => {
       /* istanbul ignore next: TO FIX the current structure make it hard to test, we probably should not mock Offers in OfferSearch tests */
       if (form.formState.submitCount > 0 || adageQueryFromSelector !== null) {
+        const filterValues = serializeFiltersForData(
+          form.watch(),
+          adageQueryFromSelector,
+          domainsOptions
+        )
+        const serializedFilters = JSON.stringify(filterValues)
+        if (serializedFilters === lastLoggedFiltersRef.current) {
+          return
+        }
+        lastLoggedFiltersRef.current = serializedFilters
+
         await logTrackingFilter({
           iframeFrom: location.pathname,
           resultNumber: nbHits,
           queryId: queryId ?? null,
-          filterValues: serializeFiltersForData(
-            form.watch(),
-            adageQueryFromSelector,
-            domainsOptions
-          ),
+          filterValues,
         })
       }
     },


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41810)

Il y avait beaucoup d'appels à la route https://backend.passculture.pro/adage-iframe/logs/tracking-filter
Il y a des IP qui dépassent les 1000 requêtes par minute

On a déjà un code côté back qui permet de limité ça :
<img width="502" height="166" alt="Capture d’écran 2026-05-20 à 14 49 05" src="https://github.com/user-attachments/assets/147312a3-4dbf-4e2b-8ef2-7c8d6884bb5e" />

Côté front on ne renvoie pas la requête si c'est la même que l'ancienne
