### PR TITLE
(PC-41746)[API] feat: add 'retrieval_model' query param

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/recommendation.py
+++ b/api/src/pcapi/routes/native/v1/serialization/recommendation.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field
 from pydantic import field_validator
 
@@ -10,6 +12,7 @@ class SimilarOffersRequestQuery(HttpBodyModel):
     categories: list[str] | None = None
     subcategories: list[str] | None = None
     search_group_names: list[str] | None = None
+    retrieval_model: Literal["coreservation", "graph"] = "coreservation"
 
     @field_validator("categories", "subcategories", "search_group_names", mode="before")
     def validate_categories(cls, v: list[str] | str | None) -> list[str] | None:

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -7424,6 +7424,15 @@
                         "default": null,
                         "title": "Longitude"
                     },
+                    "retrievalModel": {
+                        "default": "coreservation",
+                        "enum": [
+                            "coreservation",
+                            "graph"
+                        ],
+                        "title": "Retrievalmodel",
+                        "type": "string"
+                    },
                     "searchGroupNames": {
                         "anyOf": [
                             {
@@ -11802,6 +11811,21 @@
                             ],
                             "default": null,
                             "title": "Searchgroupnames"
+                        }
+                    },
+                    {
+                        "description": "",
+                        "in": "query",
+                        "name": "retrievalModel",
+                        "required": false,
+                        "schema": {
+                            "default": "coreservation",
+                            "enum": [
+                                "coreservation",
+                                "graph"
+                            ],
+                            "title": "Retrievalmodel",
+                            "type": "string"
                         }
                     }
                 ],

--- a/api/tests/routes/native/v1/recommendation_test.py
+++ b/api/tests/routes/native/v1/recommendation_test.py
@@ -59,6 +59,47 @@ class SimilarOffersTest:
             assert response.status_code == 200
         query = dict(urllib.parse.parse_qsl(mocked.last_request.query))
         assert query["longitude"] == "12.23"
+        assert query["retrieval_model"] == "coreservation"
+
+    def test_coreservation_explicit_matches_default(self, client):
+        default_response = client.get("/native/v1/recommendation/similar_offers/2")
+        explicit_response = client.get(
+            "/native/v1/recommendation/similar_offers/2",
+            params={"retrievalModel": "coreservation"},
+        )
+
+        assert default_response.status_code == 200
+        assert explicit_response.status_code == 200
+        assert explicit_response.json["results"] == default_response.json["results"]
+
+    @pytest.mark.settings(
+        RECOMMENDATION_BACKEND="pcapi.connectors.recommendation.HttpBackend",
+        RECOMMENDATION_API_URL="https://example.com/recommendation/",
+    )
+    def test_retrieval_model_defaults_to_coreservation(self, requests_mock, client):
+        mocked = requests_mock.get("https://example.com/recommendation/similar_offers/2")
+
+        with testing.assert_num_queries(0):
+            response = client.get("/native/v1/recommendation/similar_offers/2")
+            assert response.status_code == 200
+        query = dict(urllib.parse.parse_qsl(mocked.last_request.query))
+        assert query["retrieval_model"] == "coreservation"
+
+    @pytest.mark.settings(
+        RECOMMENDATION_BACKEND="pcapi.connectors.recommendation.HttpBackend",
+        RECOMMENDATION_API_URL="https://example.com/recommendation/",
+    )
+    def test_retrieval_model_graph_is_forwarded(self, requests_mock, client):
+        mocked = requests_mock.get("https://example.com/recommendation/similar_offers/2")
+
+        with testing.assert_num_queries(0):
+            response = client.get(
+                "/native/v1/recommendation/similar_offers/2",
+                params={"retrievalModel": "graph"},
+            )
+            assert response.status_code == 200
+        query = dict(urllib.parse.parse_qsl(mocked.last_request.query))
+        assert query["retrieval_model"] == "graph"
 
     @pytest.mark.settings(
         RECOMMENDATION_BACKEND="pcapi.connectors.recommendation.HttpBackend",
@@ -73,7 +114,11 @@ class SimilarOffersTest:
             assert response.status_code == 200
         query = urllib.parse.parse_qsl(mocked.last_request.query)
 
-        assert query == [("categories", "TEST_CATEGORY"), ("categories", "TEST_CATEGORY2")]
+        assert query == [
+            ("categories", "TEST_CATEGORY"),
+            ("categories", "TEST_CATEGORY2"),
+            ("retrieval_model", "coreservation"),
+        ]
 
     @pytest.mark.settings(
         RECOMMENDATION_BACKEND="pcapi.connectors.recommendation.HttpBackend",


### PR DESCRIPTION
[Ticket Jira](https://passculture.atlassian.net/browse/PC-41746)

## Résumé des changements

- Ajout du paramètre de requête retrievalModel sur GET /native/v1/recommendation/similar_offers/{offer_id} (coreservation | graph), avec coreservation par défaut (même comportement qu’aujourd’hui si le paramètre est absent ou explicite).
- Transmission du paramètre vers l’API de recommandation en query (retrieval_model en snake_case).
- Mise à jour des tests
- Mise à jour du fichier native_openapi.json

## Tests lancés pour vérifier le comportement (en local)

- pytest tests/routes/native/v1/recommendation_test.py
- pytest tests/routes/native/openapi_test.py
- pytest tests/test_flask_app.py