### PR TITLE
(BSR) ci: edit step name in PR Deploy workflow

### DIFF
--- a/.github/workflows/ci_deploy_pr_preview.yml
+++ b/.github/workflows/ci_deploy_pr_preview.yml
@@ -73,7 +73,7 @@ jobs:
           echo "API_TAG=$API_TAG"
           echo "$PUSH_TAGS" >> "$GITHUB_OUTPUT"
           echo "$API_TAG" >> "$GITHUB_OUTPUT"
-      - name: "Authentification to Google"
+      - name: "Authentification to Google (branch name length must be <= 77 chars — it might change)"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}


### PR DESCRIPTION
Fournit un indice si le step rencontre l'erreur "The size of mapped attribute google.subject exceeds the 127 bytes limit"
