### PR TITLE
(BSR)[PRO] chore: bump react-avatar-editor

### DIFF
--- a/pro/e2e/createIndividualOffer.e2e.ts
+++ b/pro/e2e/createIndividualOffer.e2e.ts
@@ -41,11 +41,11 @@ async function handleImageUpload(
   await expect(page.getByTestId('image-preview')).toBeVisible()
   await expect(page.getByTestId('image-preview')).toHaveJSProperty(
     'naturalWidth',
-    470
+    471
   )
   await expect(page.getByTestId('image-preview')).toHaveJSProperty(
     'naturalHeight',
-    705
+    706
   )
 
   await checkAccessibility()

--- a/pro/package.json
+++ b/pro/package.json
@@ -64,7 +64,7 @@
     "lodash.invert": "4.3.0",
     "qrcode.react": "4.2.0",
     "react": "19.2.6",
-    "react-avatar-editor": "14.0.0",
+    "react-avatar-editor": "15.1.0",
     "react-chartjs-2": "5.3.1",
     "react-dom": "19.2.6",
     "react-dropzone": "15.0.0",

--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import cn from 'classnames'
 import { useEffect, useRef, useState } from 'react'
-import type AvatarEditor from 'react-avatar-editor'
+import type { AvatarEditorRef } from 'react-avatar-editor'
 
 type CroppedRect = { x: number; y: number; width: number; height: number }
 
@@ -99,7 +99,7 @@ export const ModalImageUpsertOrEdit = ({
       ? coordonateToPosition(initalYCropPercent, initalHeightCropPercent)
       : defaultPositions.y
 
-  const editorRef = useRef<AvatarEditor>(null)
+  const editorRef = useRef<AvatarEditorRef>(null)
   const snackBar = useSnackBar()
   const [isLoadingImage, setIsLoadingImage] = useState(
     !!previouslyUploadedImageUrl

--- a/pro/src/components/ModalImageUpsertOrEdit/components/ImageEditor/ImageEditor.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/components/ImageEditor/ImageEditor.tsx
@@ -1,5 +1,8 @@
 import { forwardRef, useCallback, useEffect, useId, useState } from 'react'
-import AvatarEditor, { type Position } from 'react-avatar-editor'
+import AvatarEditor, {
+  type AvatarEditorRef,
+  type Position,
+} from 'react-avatar-editor'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { Slider } from '@/ui-kit/form/Slider/Slider'
@@ -43,7 +46,7 @@ interface ImageEditorProps extends ImageEditorConfig {
   onImageError?: () => void
 }
 
-export const ImageEditor = forwardRef<AvatarEditor, ImageEditorProps>(
+export const ImageEditor = forwardRef<AvatarEditorRef, ImageEditorProps>(
   (
     {
       image,
@@ -139,7 +142,14 @@ export const ImageEditor = forwardRef<AvatarEditor, ImageEditorProps>(
     }
 
     return (
-      <div className={style['image-editor']}>
+      <div
+        className={style['image-editor']}
+        ref={(el) =>
+          el
+            ?.querySelector('canvas')
+            ?.setAttribute('aria-label', "Editeur d'image")
+        }
+      >
         <AvatarEditor
           color={[0, 0, 0, 0.2]}
           crossOrigin="anonymous"
@@ -163,7 +173,6 @@ export const ImageEditor = forwardRef<AvatarEditor, ImageEditorProps>(
               responsiveCropBorderHeight,
             ] as unknown as number
           }
-          aria-label="Editeur d'image"
         />
         <label className={style['image-editor-label']} htmlFor="scale">
           Zoom

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -4263,10 +4263,10 @@ rc9@^3.0.1:
     defu "^6.1.6"
     destr "^2.0.5"
 
-react-avatar-editor@14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/react-avatar-editor/-/react-avatar-editor-14.0.0.tgz#d5b3ca075c332632875dcce2c6d83769ad646172"
-  integrity sha512-NaQM3oo4u0a1/Njjutc2FjwKX35vQV+t6S8hovsbAlMpBN1ntIwP/g+Yr9eDIIfaNtRXL0AqboTnPmRxhD/i8A==
+react-avatar-editor@15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/react-avatar-editor/-/react-avatar-editor-15.1.0.tgz#f7d00cf6983b07cd9cd7c874e0ec5558e7cfbfba"
+  integrity sha512-Zto7u9l6Wd5LPPtjeFJ+7uwoT4bs01OSgkN2kxD18lWl8IiZ0GY3nWCbKPx4qIU7Au1vENsMJm19rfVWHHayaQ==
 
 react-chartjs-2@5.3.1:
   version "5.3.1"


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

### Breaking Changes
https://github.com/mosch/react-avatar-editor/compare/v14.0.0...v15.1.0

- **Removed `...rest` prop forwarding** — unknown props are no longer spread onto the `<canvas>` element. If you relied on passing custom HTML attributes (e.g. `id`, `className`, `data-*`) directly to the canvas, this will no longer work.

On utilisait un aria-label, mais on ne peut plus le faire avec la nouvelle version