### PR TITLE
(PC-41893)[API] fix: use bannerUrl instead of thumbUrl for venue pro …

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -756,11 +756,14 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
         return sum(result for (result,) in results)
 
     @property
-    def thumbUrl(self) -> str:
+    def thumbUrl(self) -> str | None:
         """
-        Override to discard the thumbCount column: not used by Venues
-        which have at most one banner (thumb).
+        Override because venues have at most one banner (thumb), so the
+        suffix logic from HasThumbMixin is unnecessary. Returns None when
+        no thumbnail has been uploaded (thumbCount == 0).
         """
+        if self.thumbCount == 0:
+            return None
         return "{}/{}/{}".format(self.thumb_base_url, self.thumb_path_component, humanize(self.id))
 
     @property

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -628,11 +628,17 @@ def get_pro_advices(
         .join(models.ProAdvice.venue)
         .join(offerers_models.Venue.managingOfferer)
         .options(
-            sa_orm.contains_eager(models.ProAdvice.venue).load_only(
-                offerers_models.Venue.id,
-                offerers_models.Venue.isOpenToPublic,
-                offerers_models.Venue.publicName,
-                offerers_models.Venue.thumbCount,
+            sa_orm.contains_eager(models.ProAdvice.venue).options(
+                sa_orm.load_only(
+                    offerers_models.Venue.id,
+                    offerers_models.Venue.isOpenToPublic,
+                    offerers_models.Venue.publicName,
+                    offerers_models.Venue._bannerUrl,
+                    offerers_models.Venue.venueTypeCode,
+                ),
+                sa_orm.joinedload(offerers_models.Venue.googlePlacesInfo).load_only(
+                    offerers_models.GooglePlacesInfo.bannerUrl,
+                ),
             )
         )
         .where(offerers_models.Offerer.isActive, offerers_models.Offerer.isValidated)

--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -782,7 +782,7 @@ class OfferProAdvice(HttpBodyModel):
             distance=distance if pro_advice.venue.isOpenToPublic else None,
             venue_id=pro_advice.venue.id,
             venue_name=pro_advice.venue.publicName,
-            venue_thumb_url=pro_advice.venue.thumbUrl,
+            venue_thumb_url=pro_advice.venue.bannerUrl,
             publication_datetime=pro_advice.updatedAt,
         )
 

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -2421,7 +2421,7 @@ class GetProAdvicesTest:
                     "distance": None,
                     "venueId": offer.venue.id,
                     "venueName": offer.venue.name,
-                    "venueThumbUrl": offer.venue.thumbUrl,
+                    "venueThumbUrl": offer.venue.bannerUrl,
                     "publicationDatetime": date_utils.format_into_utc_date(pro_advice.updatedAt),
                 }
             ],
@@ -2445,7 +2445,7 @@ class GetProAdvicesTest:
                     "distance": None,
                     "venueId": offer.venue.id,
                     "venueName": offer.venue.publicName,
-                    "venueThumbUrl": offer.venue.thumbUrl,
+                    "venueThumbUrl": offer.venue.bannerUrl,
                     "publicationDatetime": date_utils.format_into_utc_date(pro_advice.updatedAt),
                 }
             ],
@@ -2495,7 +2495,7 @@ class GetProAdvicesTest:
                     "distance": 1000,
                     "venueId": offer.venue.id,
                     "venueName": offer.venue.publicName,
-                    "venueThumbUrl": offer.venue.thumbUrl,
+                    "venueThumbUrl": offer.venue.bannerUrl,
                     "publicationDatetime": date_utils.format_into_utc_date(pro_advice.updatedAt),
                 }
             ],
@@ -2515,6 +2515,27 @@ class GetProAdvicesTest:
 
         assert response.status_code == 200
         assert response.json["proAdvices"][0]["distance"] == 1000
+
+    def test_venue_thumb_url_uses_pro_uploaded_banner(self, client):
+        venue = offerers_factories.VenueFactory(_bannerUrl="https://example.com/my-banner.jpg")
+        offer = offers_factories.OfferFactory(venue=venue)
+        offers_factories.ProAdviceFactory(offer=offer)
+
+        response = client.get(f"/native/v1/offer/{offer.id}/advices")
+
+        assert response.status_code == 200
+        assert response.json["proAdvices"][0]["venueThumbUrl"] == "https://example.com/my-banner.jpg"
+
+    def test_venue_thumb_url_falls_back_to_google_places(self, client):
+        venue = offerers_factories.VenueFactory(_bannerUrl=None)
+        offerers_factories.GooglePlacesInfoFactory(venue=venue, bannerUrl="https://maps.google.com/photo.jpg")
+        offer = offers_factories.OfferFactory(venue=venue)
+        offers_factories.ProAdviceFactory(offer=offer)
+
+        response = client.get(f"/native/v1/offer/{offer.id}/advices")
+
+        assert response.status_code == 200
+        assert response.json["proAdvices"][0]["venueThumbUrl"] == "https://maps.google.com/photo.jpg"
 
     def test_does_not_return_advices_from_not_validated_offerer(self, client):
         venue = offerers_factories.VenueFactory(


### PR DESCRIPTION
[Ticket Jira](https://passculture.atlassian.net/browse/PC-41893)

L'endpoint /native/v1/offer/{id}/advices renvoyait venueThumbUrl en utilisant Venue.thumbUrl, une propriété qui ne couvrait que les images uploadées directement par le pro. Pour les lieux sans upload, elle générait quand même une URL pointant vers un fichier inexistant dans GCS (NoSuchKey), d'où l'image blanche côté app.

On est passé sur Venue.bannerUrl, la propriété utilisée partout ailleurs dans le code pour représenter l'image d'un lieu (fallback : image pro → Google Places → image générique par type de lieu).

Mise à jour du load_only dans get_pro_advices pour charger les colonnes nécessaires à bannerUrl sans requête supplémentaire.