### PR TITLE
(PC-41631)[API] feat: can ask QF if emancipated

### DIFF
--- a/api/src/pcapi/core/subscription/bonus/api.py
+++ b/api/src/pcapi/core/subscription/bonus/api.py
@@ -109,7 +109,7 @@ def _get_user_quotient_familial_response(
     MONTHS_IN_A_YEAR = 12
     api_particulier_cutoff_date = datetime.date.today() - relativedelta(years=2)
     cutoff_month = api_particulier_cutoff_date.replace(month=1, day=1)
-    all_quotient_familial_responses = []
+    all_quotient_familial_responses: list[api_particulier.QuotientFamilialResponse] = []
     for month_offset in range(MONTHS_IN_A_YEAR):
         at_date = seventeenth_birthday + relativedelta(months=month_offset)
         if at_date < cutoff_month:
@@ -123,7 +123,9 @@ def _get_user_quotient_familial_response(
         all_quotient_familial_responses.append(quotient_familial_at_date)
 
     quotients_familial_with_user = [
-        qf for qf in all_quotient_familial_responses if _is_user_part_of_tax_household(user, qf.data.enfants)
+        qf
+        for qf in all_quotient_familial_responses
+        if _is_user_part_of_tax_household(user, qf.data.enfants, qf.data.allocataires)
     ]
     if quotients_familial_with_user:
         relevant_qf_responses = quotients_familial_with_user
@@ -137,17 +139,16 @@ def _get_user_quotient_familial_response(
 
 
 def _is_user_part_of_tax_household(
-    user: users_models.User, tax_household_children: list[api_particulier.QuotientFamilialPerson]
+    user: users_models.User,
+    tax_household_children: list[api_particulier.QuotientFamilialPerson],
+    tax_householders: list[api_particulier.QuotientFamilialPerson],
 ) -> bool:
     for child in tax_household_children:
-        has_first_name_match = _does_names_match(user.firstName, child.prenoms)
-        has_last_name_match = _does_names_match(user.lastName, child.nom_naissance) or _does_names_match(
-            user.lastName, child.nom_usage
-        )
-        has_birth_day_match = user.validatedBirthDate == child.date_naissance
-        has_gender_match = user.gender == child.sexe
+        if _does_user_match_person(user, child):
+            return True
 
-        if has_first_name_match and has_last_name_match and has_birth_day_match and has_gender_match:
+    for householder in tax_householders:
+        if _does_user_match_person(user, householder):
             return True
 
     return False
@@ -159,10 +160,21 @@ def _does_names_match(name_1: str | None, name_2: str | None) -> bool:
     return clean_accents(name_1).upper() in clean_accents(name_2).upper()
 
 
+def _does_user_match_person(user: users_models.User, person: api_particulier.QuotientFamilialPerson) -> bool:
+    has_first_name_match = _does_names_match(user.firstName, person.prenoms)
+    has_last_name_match = _does_names_match(user.lastName, person.nom_naissance) or _does_names_match(
+        user.lastName, person.nom_usage
+    )
+    has_birth_day_match = user.validatedBirthDate == person.date_naissance
+    has_gender_match = user.gender == person.sexe
+
+    return has_first_name_match and has_last_name_match and has_birth_day_match and has_gender_match
+
+
 def _get_credit_bonus_status(
     user: users_models.User, quotient_familial_data: api_particulier.QuotientFamilialData
 ) -> tuple[subscription_models.FraudCheckStatus, list[subscription_models.FraudReasonCode]]:
-    if not _is_user_part_of_tax_household(user, quotient_familial_data.enfants):
+    if not _is_user_part_of_tax_household(user, quotient_familial_data.enfants, quotient_familial_data.allocataires):
         return subscription_models.FraudCheckStatus.KO, [subscription_models.FraudReasonCode.NOT_IN_TAX_HOUSEHOLD]
 
     if quotient_familial_data.quotient_familial.valeur > bonus_constants.QUOTIENT_FAMILIAL_THRESHOLD:
@@ -200,8 +212,20 @@ def _update_bonus_fraud_check_content(
         )
         fraud_check.resultContent["quotient_familial"].update(**quotient_familial_content.model_dump())
 
+        tax_householders = [
+            bonus_schemas.QuotientFamilialPerson(
+                last_name=householder.nom_naissance,
+                common_name=householder.nom_usage,
+                first_names=householder.prenoms.split(" ") if householder.prenoms else [],
+                birth_date=householder.date_naissance,
+                gender=householder.sexe,
+            )
+            for householder in quotient_familial_data.allocataires
+        ]
+        fraud_check.resultContent["householders"] = [householder.model_dump() for householder in tax_householders]
+
         tax_household_children = [
-            bonus_schemas.QuotientFamilialChild(
+            bonus_schemas.QuotientFamilialPerson(
                 last_name=child.nom_naissance,
                 common_name=child.nom_usage,
                 first_names=child.prenoms.split(" ") if child.prenoms else [],

--- a/api/src/pcapi/core/subscription/bonus/schemas.py
+++ b/api/src/pcapi/core/subscription/bonus/schemas.py
@@ -25,7 +25,7 @@ class Person(BaseModelV2):
     birth_city_cog_code: CogCode | None = None
 
 
-class QuotientFamilialChild(BaseModelV2):
+class QuotientFamilialPerson(BaseModelV2):
     last_name: str | None = None
     common_name: str | None = None
     first_names: list[str]
@@ -45,7 +45,8 @@ class QuotientFamilialContent(BaseModelV2):
 class QuotientFamilialBonusCreditContent(BaseModelV2):
     custodian: Person
     quotient_familial: QuotientFamilialContent | None = None
-    children: list[QuotientFamilialChild] | None = None
+    householders: list[QuotientFamilialPerson] | None = None
+    children: list[QuotientFamilialPerson] | None = None
     http_status_code: int | None = None
     error_code: str | None = None
 

--- a/api/src/pcapi/core/subscription/bonus/staging_api.py
+++ b/api/src/pcapi/core/subscription/bonus/staging_api.py
@@ -111,7 +111,7 @@ def _build_api_quotient_familial_response(
     )
 
 
-def _build_api_enfants_response(child: bonus_schemas.QuotientFamilialChild) -> api_particulier.QuotientFamilialPerson:
+def _build_api_enfants_response(child: bonus_schemas.QuotientFamilialPerson) -> api_particulier.QuotientFamilialPerson:
     return api_particulier.QuotientFamilialPerson(
         nom_naissance=child.last_name,
         nom_usage=child.common_name,

--- a/api/src/pcapi/routes/backoffice/dev/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/dev/blueprint.py
@@ -86,7 +86,7 @@ def create_qf_fraud_check(user: users_models.User, form: forms.QuotientFamilialC
                 value=form.quotient_familial_value.data
             ),
             children=[
-                bonus_schemas.QuotientFamilialChild(
+                bonus_schemas.QuotientFamilialPerson(
                     last_name=form.last_name.data,
                     common_name=form.common_name.data,
                     first_names=[first_name.strip() for first_name in form.first_names.data.split(",")],

--- a/api/tests/connectors/api_particulier_test.py
+++ b/api/tests/connectors/api_particulier_test.py
@@ -26,7 +26,7 @@ class QuotientFamilialTest:
             common_name=None,
             first_names=["aleixs", "gréôme", "jean-philippe"],
             birth_date=date(1982, 12, 27),
-            gender=users_models.GenderEnum.F,
+            gender=users_models.GenderEnum.M,
             birth_country_cog_code=countries_utils.FRANCE_INSEE_CODE,
             birth_city_cog_code="08480",
         )
@@ -45,7 +45,7 @@ class QuotientFamilialTest:
             "anneeDateNaissance": ["1982"],
             "moisDateNaissance": ["12"],
             "jourDateNaissance": ["27"],
-            "sexeEtatCivil": ["F"],
+            "sexeEtatCivil": ["M"],
             "codeCogInseePaysNaissance": [countries_utils.FRANCE_INSEE_CODE],
             "codeCogInseeCommuneNaissance": ["08480"],
             "annee": ["2023"],
@@ -59,7 +59,7 @@ class QuotientFamilialTest:
                         nom_naissance="LEFEBVRE",
                         prenoms="ALEXIS GÉRÔME JEAN-PHILIPPE",
                         date_naissance=date(1982, 12, 27),
-                        sexe=users_models.GenderEnum.F,
+                        sexe=users_models.GenderEnum.M,
                     )
                 ],
                 enfants=[
@@ -101,7 +101,7 @@ class QuotientFamilialTest:
             common_name=None,
             first_names=["aleixs", "gréôme", "jean-philippe"],
             birth_date=date(1982, 12, 27),
-            gender=users_models.GenderEnum.F,
+            gender=users_models.GenderEnum.M,
             birth_country_cog_code="99243",
             birth_city_cog_code="ignor",
         )
@@ -120,7 +120,7 @@ class QuotientFamilialTest:
             "anneeDateNaissance": ["1982"],
             "moisDateNaissance": ["12"],
             "jourDateNaissance": ["27"],
-            "sexeEtatCivil": ["F"],
+            "sexeEtatCivil": ["M"],
             "codeCogInseePaysNaissance": ["99243"],
             "annee": ["2023"],
             "mois": ["6"],
@@ -194,7 +194,7 @@ class DisabledAdultAllowanceTest:
             common_name=None,
             first_names=["aleixs", "gréôme", "jean-philippe"],
             birth_date=date(1982, 12, 27),
-            gender=users_models.GenderEnum.F,
+            gender=users_models.GenderEnum.M,
             birth_country_cog_code="99243",
             birth_city_cog_code="ignor",
         )
@@ -210,7 +210,7 @@ class DisabledAdultAllowanceTest:
             "anneeDateNaissance": ["1982"],
             "moisDateNaissance": ["12"],
             "jourDateNaissance": ["27"],
-            "sexeEtatCivil": ["F"],
+            "sexeEtatCivil": ["M"],
             "codeCogInseePaysNaissance": ["99243"],
         }
         assert "codeCogInseeCommuneNaissance" not in post_request.qs.keys()
@@ -283,7 +283,7 @@ class DisabledChildEducationAllowanceTest:
             common_name=None,
             first_names=["aleixs", "gréôme", "jean-philippe"],
             birth_date=date(1982, 12, 27),
-            gender=users_models.GenderEnum.F,
+            gender=users_models.GenderEnum.M,
             birth_country_cog_code="99243",
             birth_city_cog_code="ignor",
         )
@@ -299,7 +299,7 @@ class DisabledChildEducationAllowanceTest:
             "anneeDateNaissance": ["1982"],
             "moisDateNaissance": ["12"],
             "jourDateNaissance": ["27"],
-            "sexeEtatCivil": ["F"],
+            "sexeEtatCivil": ["M"],
             "codeCogInseePaysNaissance": ["99243"],
         }
         assert "codeCogInseeCommuneNaissance" not in post_request.qs.keys()

--- a/api/tests/core/subscription/bonus/bonus_fixtures.py
+++ b/api/tests/core/subscription/bonus/bonus_fixtures.py
@@ -13,7 +13,7 @@ QUOTIENT_FAMILIAL_FIXTURE = {
                 "nom_usage": None,
                 "prenoms": "ALEXIS GÉRÔME JEAN-PHILIPPE",
                 "date_naissance": "1982-12-27",
-                "sexe": "F",
+                "sexe": "M",
             }
         ],
         "enfants": [

--- a/api/tests/core/subscription/bonus/test_bonus_api.py
+++ b/api/tests/core/subscription/bonus/test_bonus_api.py
@@ -44,7 +44,7 @@ class QuotientFamilialApplicationTest:
                     "last_name": "LEFEBVRE",
                     "first_names": ["ALEIXS", "GRÉÔME", "JEAN-PHILIPPE"],
                     "birth_date": datetime.date(1982, 12, 27),
-                    "gender": users_models.GenderEnum.F.value,
+                    "gender": users_models.GenderEnum.M.value,
                     "birth_country_cog_code": "99243",
                     "birth_city_cog_code": "08480",
                 },
@@ -58,13 +58,14 @@ class QuotientFamilialApplicationTest:
             bonus_api.apply_for_quotient_familial_bonus(bonus_fraud_check)
 
         assert bonus_fraud_check.status == subscription_models.FraudCheckStatus.OK
+        householder_data = with_18_child_quotient_familial["data"]["allocataires"][0]
         assert bonus_fraud_check.source_data() == bonus_schemas.QuotientFamilialBonusCreditContent(
             custodian=bonus_schemas.Person(
                 last_name="LEFEBVRE",
                 common_name=None,
                 first_names=["ALEIXS", "GRÉÔME", "JEAN-PHILIPPE"],
                 birth_date=datetime.date(1982, 12, 27),
-                gender=users_models.GenderEnum.F,
+                gender=users_models.GenderEnum.M,
                 birth_country_cog_code="99243",
                 birth_city_cog_code="08480",
             ),
@@ -76,15 +77,108 @@ class QuotientFamilialApplicationTest:
                 computation_year=2024,
                 computation_month=12,
             ),
-            children=[
-                bonus_schemas.QuotientFamilialChild(
-                    last_name="LEFEBVRE",
+            householders=[
+                bonus_schemas.QuotientFamilialPerson(
+                    last_name=householder_data["nom_naissance"],
                     common_name=None,
-                    first_names=["LEO"],
-                    birth_date=eighteen_years_ago.isoformat(),
+                    first_names=householder_data["prenoms"].split(),
+                    birth_date=householder_data["date_naissance"],
                     gender=users_models.GenderEnum.M,
                 )
             ],
+            children=[
+                bonus_schemas.QuotientFamilialPerson(
+                    last_name="LEFEBVRE",
+                    common_name=None,
+                    first_names=["LEO"],
+                    birth_date=eighteen_years_ago,
+                    gender=users_models.GenderEnum.M,
+                )
+            ],
+            http_status_code=200,
+        )
+        assert finance_models.RecreditType.BONUS_CREDIT in [
+            recredit.recreditType for recredit in user.deposit.recredits
+        ]
+        # Ensure that a Batch notification is triggered
+        assert push_testing.requests == [
+            {
+                "can_be_asynchronously_retried": True,
+                "user_id": user.id,
+                "event_name": batch_models.BatchEvent.HAS_RECEIVED_BONUS.value,
+                "event_payload": {"has_received_bonus": True},
+            }
+        ]
+        update_external_user_mock.assert_called_once_with(user)
+
+        assert len(mails_testing.outbox) == 1
+        out_mail = mails_testing.outbox[0]
+        assert out_mail["template"] == TransactionalEmail.BONUS_GRANTED.value.__dict__
+
+    @patch("pcapi.core.external.attributes.api.update_external_user")
+    def test_apply_for_quotient_familial_bonus_as_householder(self, update_external_user_mock):
+        eighteen_years_ago = datetime.date.today() - relativedelta(years=18)
+        without_child_quotient_familial = copy.deepcopy(bonus_fixtures.QUOTIENT_FAMILIAL_FIXTURE)
+        without_child_quotient_familial["data"]["enfants"] = []
+        without_child_quotient_familial["data"]["allocataires"][0]["date_naissance"] = eighteen_years_ago.isoformat()
+        householder_data = without_child_quotient_familial["data"]["allocataires"][0]
+        last_name = householder_data["nom_naissance"]
+        first_names = householder_data["prenoms"]
+        birth_date = datetime.date.fromisoformat(householder_data["date_naissance"])
+        user = users_factories.BeneficiaryFactory(
+            lastName=last_name, firstName=first_names, validatedBirthDate=birth_date
+        )
+        bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory.create(
+            user=user,
+            type=subscription_models.FraudCheckType.QF_BONUS_CREDIT,
+            status=subscription_models.FraudCheckStatus.STARTED,
+            resultContent={
+                "custodian": {
+                    "last_name": householder_data["nom_naissance"],
+                    "first_names": householder_data["prenoms"].split(),
+                    "birth_date": householder_data["date_naissance"],
+                    "gender": users_models.GenderEnum.M.value,
+                    "birth_country_cog_code": "99243",
+                    "birth_city_cog_code": "08480",
+                },
+                "quotient_familial": None,
+            },
+        )
+
+        with requests_mock.Mocker() as mock:
+            mock.get(api_particulier.QUOTIENT_FAMILIAL_ENDPOINT, json=without_child_quotient_familial)
+
+            bonus_api.apply_for_quotient_familial_bonus(bonus_fraud_check)
+
+        assert bonus_fraud_check.status == subscription_models.FraudCheckStatus.OK
+        assert bonus_fraud_check.source_data() == bonus_schemas.QuotientFamilialBonusCreditContent(
+            custodian=bonus_schemas.Person(
+                last_name=householder_data["nom_naissance"],
+                common_name=None,
+                first_names=householder_data["prenoms"].split(),
+                birth_date=householder_data["date_naissance"],
+                gender=users_models.GenderEnum.M,
+                birth_country_cog_code="99243",
+                birth_city_cog_code="08480",
+            ),
+            quotient_familial=bonus_schemas.QuotientFamilialContent(
+                provider="CNAF",
+                value=bonus_constants.QUOTIENT_FAMILIAL_THRESHOLD,
+                year=2023,
+                month=6,
+                computation_year=2024,
+                computation_month=12,
+            ),
+            householders=[
+                bonus_schemas.QuotientFamilialPerson(
+                    last_name=householder_data["nom_naissance"],
+                    common_name=None,
+                    first_names=householder_data["prenoms"].split(),
+                    birth_date=eighteen_years_ago,
+                    gender=users_models.GenderEnum.M,
+                )
+            ],
+            children=[],
             http_status_code=200,
         )
         assert finance_models.RecreditType.BONUS_CREDIT in [

--- a/api/tests/core/subscription/bonus/test_bonus_staging_api.py
+++ b/api/tests/core/subscription/bonus/test_bonus_staging_api.py
@@ -27,7 +27,7 @@ class StagingQuotientFamilialTest:
                     provider="CNAF", value=123, year=2023, month=6, computation_year=2024, computation_month=12
                 ),
                 children=[
-                    bonus_schemas.QuotientFamilialChild(
+                    bonus_schemas.QuotientFamilialPerson(
                         last_name=user.lastName,
                         common_name=None,
                         first_names=[user.firstName],
@@ -67,7 +67,7 @@ class StagingQuotientFamilialTest:
                     provider="CNAF", value=999_999_999, year=2023, month=6, computation_year=2024, computation_month=12
                 ),
                 children=[
-                    bonus_schemas.QuotientFamilialChild(
+                    bonus_schemas.QuotientFamilialPerson(
                         last_name=user.lastName,
                         common_name=None,
                         first_names=[user.firstName],


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41631)

Pour qu'un utilisateur émancipé puisse faire une demande de QF avec ses propres informations d'identité en entrée au lieu de celle de son parent
