### PR TITLE
(PC-41294)[API] fix: correctly handle race condition when creating a favorite

### DIFF
--- a/api/src/pcapi/db_utils.py
+++ b/api/src/pcapi/db_utils.py
@@ -181,6 +181,7 @@ tables_to_clean: list[type[Model]] = [
     users_models.UserAccountUpdateRequest,
     users_models.User,
     users_models.UserSession,
+    users_models.NativeUserSession,
     geography_models.IrisFrance,
     providers_models.Provider,
     offerers_models.VenueLabel,

--- a/api/src/pcapi/routes/native/v1/favorites.py
+++ b/api/src/pcapi/routes/native/v1/favorites.py
@@ -1,6 +1,7 @@
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 from flask_login import current_user
+from sqlalchemy.dialects.postgresql import insert
 
 from pcapi import settings
 from pcapi.core.external.attributes.api import update_external_user
@@ -163,15 +164,28 @@ def create_favorite(body: serializers.FavoriteRequest) -> serializers.FavoriteRe
     if not (offer.venue.managingOfferer.isActive and offer.venue.managingOfferer.isValidated):
         raise ResourceNotFoundError()
 
-    favorite = db.session.query(Favorite).filter_by(offerId=body.offer_id, userId=current_user.id).one_or_none()
-    if not favorite:
-        favorite = Favorite(offer=offer, user=current_user)
-        db.session.add(favorite)
-        db.session.flush()
+    stmt: sa.sql.dml.ReturningInsert = (
+        insert(Favorite)
+        .values({"offerId": body.offer_id, "userId": current_user.id})
+        .on_conflict_do_update(
+            index_elements=[Favorite.offerId, Favorite.userId],
+            set_={"offerId": body.offer_id},
+        )
+        .returning(
+            Favorite.id,
+            # xmax is a "system" column that returns the transaction id that modified the row.
+            # In case of insertion, no row has been modified → xmax = 0
+            sa.literal_column("xmax = 0").label("is_inserted"),
+        )
+    )
+    favorite_ids = db.session.execute(stmt).all()
+    favorite_id, inserted = favorite_ids[0]
+
+    if inserted:
         update_external_user(current_user)
         track_offer_added_to_favorites_event(current_user.id, offer)
 
-    favorite_data = get_favorites_for(current_user, favorite.id)[0]
+    favorite_data = get_favorites_for(current_user, favorite_id)[0]
     return serializers.FavoriteResponse(
         id=favorite_data.favorite.id, offer=serializers.FavoriteOfferResponse.build(favorite_data)
     )

--- a/api/tests/routes/native/v1/favorites_test.py
+++ b/api/tests/routes/native/v1/favorites_test.py
@@ -1,9 +1,13 @@
+import concurrent.futures
+import time
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from decimal import Decimal
+from unittest import mock
 
 import pytest
+import sqlalchemy as sa
 
 import pcapi.core.offerers.factories as offerers_factories
 from pcapi.core.bookings import factories as bookings_factories
@@ -18,6 +22,7 @@ from pcapi.core.users import testing as users_testing
 from pcapi.core.users.models import Favorite
 from pcapi.models import db
 from pcapi.models.validation_status_mixin import ValidationStatus
+from pcapi.routes.native.v1.favorites import get_favorites_for
 from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 
@@ -505,6 +510,54 @@ class CreateFavoriteTest:
         # Then
         assert response.status_code == status_code
         assert db.session.query(Favorite).count() == count
+
+    @pytest.mark.usefixtures("clean_database")
+    def test_create_favorite_concurrently(self, client, app, settings):
+        user = users_factories.BeneficiaryGrant18Factory()
+        offer = offers_factories.ThingOfferFactory()
+        offer_id = offer.id
+        client_with_user = client.with_token(user)
+
+        def add_to_favorite(position):
+            def slow_get_favorites(*args, **kwargs):
+                time.sleep(position % 2)
+                # return the mocked function's return value
+                return mock.DEFAULT
+
+            with (
+                mock.patch("pcapi.routes.native.v1.favorites.update_external_user") as update_external_user_mock,
+                mock.patch(
+                    "pcapi.routes.native.v1.favorites.track_offer_added_to_favorites_event",
+                ) as track_offer_added_to_favorites_event_mock,
+                mock.patch(
+                    "pcapi.routes.native.v1.favorites.get_favorites_for", wraps=get_favorites_for
+                ) as get_favorites_for_mock,
+            ):
+                # Use the app context in the new thread
+                app.app_context().push()
+                # Simulate a slow db transaction so we can get the race condition
+                get_favorites_for_mock.side_effect = slow_get_favorites
+                # Allow lock_timeout to be sure that the db transaction is waiting while another transaction is inserting the same row
+                db.session.execute(sa.text("SET LOCAL lock_timeout='3s'"))
+                try:
+                    response = client_with_user.post(FAVORITES_URL, json={"offerId": offer_id})
+                finally:
+                    db.session.execute(sa.text(f"SET LOCAL lock_timeout='{settings.DATABASE_LOCK_TIMEOUT}'"))
+            return (
+                response.status_code,
+                update_external_user_mock.call_count,
+                track_offer_added_to_favorites_event_mock.call_count,
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+            futures = []
+            for i in range(3):
+                futures.append(executor.submit(add_to_favorite, i))
+            results = [future.result() for future in futures]
+
+        # all returned status codes should be == 200. update_external_user and track_offer_added_to_favorites_event should be called once
+        assert set(results) == {(200, 1, 1), (200, 0, 0)}
+        assert db.session.query(Favorite).filter(Favorite.offerId == offer_id, Favorite.userId == user.id).count() == 1
 
 
 class DeleteTest:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41294)

Old behavior:
 - The user adds an offer to his favorites through the front (native or web, it doesn't matter)
 - The endpoint `/native/v1/me/favorites` is called:
   1. Some checks are done on the offer/user
   2. We try to retrieve the favorite for the concerned offer/user from the db
   3. If it's already there, nothing is done
   4. Otherwise a new `Favorite` is inserted in the db with a unicity constraint on `(offerId, userId)` columns
 - The main issue here is that the endpoint is often called multiple times successively. This leads to an integrity error when trying to insert the same row in the `Favorite` table when the following scenario happens:
   1. A First call to the endpoint operates checks on offer → tries to fetch existing `Favorite` → finds nothing and start inserting it in the db 
   2. A Second call to the endpoint happening some microseconds later start the same process except that the first call finished inserting the row right after retrieval of the second call → this leads to attempting to insert the exact same row in the db and breaks the constraint's rule 💥

New behavior:
 - Replace the retrieval + insertion operations with a single `upsert` operation and let the db handle the concurrency issue by skipping the insertion in case of already existing `Favorite` row with the same `(offerId, userId)`