### PR TITLE
(BSR)[API] fix: user deletion when creating account from mobile

### DIFF
--- a/api/src/pcapi/routes/backoffice/dev/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/dev/blueprint.py
@@ -290,6 +290,9 @@ def delete_user() -> response_utils.BackofficeResponse:
         return render_template("dev/users_deletion.html", form=form), 400
 
     try:
+        db.session.query(users_models.TrustedDevice).filter_by(userId=user.id).delete()
+        db.session.query(users_models.LoginDeviceHistory).filter_by(userId=user.id).delete()
+        db.session.query(users_models.GdprUserAnonymization).filter_by(userId=user.id).delete()
         db.session.query(users_models.User).filter_by(id=user.id).delete()
         db.session.flush()
     except IntegrityError as e:

--- a/api/tests/routes/backoffice/dev_test.py
+++ b/api/tests/routes/backoffice/dev_test.py
@@ -252,10 +252,12 @@ class UserDeletionPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermissi
     endpoint = "backoffice_web.dev.delete_user"
     needed_permission = None
 
-    def test_sso_user_deletion(self, authenticated_client):
+    def test_user_deletion(self, authenticated_client):
         user = users_factories.UserFactory()
         users_factories.SingleSignOnFactory(user=user)
         users_factories.TrustedDeviceFactory(user=user)
+        users_factories.LoginDeviceHistoryFactory(user=user)
+        users_factories.GdprUserAnonymizationFactory(user=user)
 
         response = self.post_to_endpoint(authenticated_client, form={"email": user.email})
 


### PR DESCRIPTION
When testing SSO user creation through mobile app, some relationships are created that prevent the deletion of the account.

Since we have limited SSO accounts in the dev team, we must be able to delete those account to recreate a new user with the same SSO account.

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-XXXXX)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
