### PR TITLE
(BSR)[PRO] chore: bump check-unused-css and clean up tsconfig workaround

### DIFF
--- a/pro/package.json
+++ b/pro/package.json
@@ -103,7 +103,7 @@
     "allure-js-commons": "3.9.0",
     "allure-vitest": "3.9.0",
     "axe-core": "4.11.4",
-    "check-unused-css": "^0.4.0",
+    "check-unused-css": "^0.4.1",
     "jsdom": "29.1.1",
     "mustache": "4.2.0",
     "node-fetch": "3.3.2",

--- a/pro/package.json
+++ b/pro/package.json
@@ -103,7 +103,7 @@
     "allure-js-commons": "3.9.0",
     "allure-vitest": "3.9.0",
     "axe-core": "4.11.4",
-    "check-unused-css": "^0.4.1",
+    "check-unused-css": "0.4.1",
     "jsdom": "29.1.1",
     "mustache": "4.2.0",
     "node-fetch": "3.3.2",

--- a/pro/package.json
+++ b/pro/package.json
@@ -21,7 +21,7 @@
     "lint:scss:fix": "yarn lint:scss --fix",
     "lint:scss:hook": "stylelint",
     "lint:scss:hook:fix": "yarn lint:scss:hook --fix",
-    "lint:scss:checkunused": "check-unused-css --exclude \"scr/apiClient/**\"",
+    "lint:scss:checkunused": "check-unused-css --exclude \"src/apiClient/**\"",
     "lint:dead-code": "ts-unused-exports tsconfig.json --excludePathsFromReport='stories;apiClient;vite.config.ts'",
     "prettier:js:changed:fix": "./scripts/lint_diff.sh",
     "serve": "vite preview",

--- a/pro/tsconfig.json
+++ b/pro/tsconfig.json
@@ -23,10 +23,6 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "outDir": "./built",
-    // TODO (mdesquilbet - 17/05/2026): remove `baseUrl` and `ignoreDeprecations` when `check-unused-css`
-    // has fix this issue : https://github.com/malinindev/check-unused-css/issues/73
-    "ignoreDeprecations": "6.0",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "*": ["./src/*"]

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -2554,10 +2554,10 @@ check-error@^2.1.1:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
   integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
-check-unused-css@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/check-unused-css/-/check-unused-css-0.4.0.tgz#a7c1101feb53ef026a6d2e1060887009fe47042a"
-  integrity sha512-WrxDEbuGcJTPFNGXLxwzYJl3GSnnztIOesYZSOr07mpoow+H+LEq8amiPXZuGqrlcOjceX2GKlgB8Lt5P4GvOA==
+check-unused-css@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/check-unused-css/-/check-unused-css-0.4.1.tgz#5a4b3d99b2839b89b3aac951ea9254dea7f2ffe7"
+  integrity sha512-DqmdpruM86Ey2Bha942URGEtwgcLF/syATk1abKZaMn5ymEOJCyQUsABQdsqCwICIjYGipA1onpCl1veWR6tOw==
   dependencies:
     "@typescript-eslint/typescript-estree" "^8.58.2"
     css-selector-parser "^3.3.0"

--- a/pro/yarn.lock
+++ b/pro/yarn.lock
@@ -2554,7 +2554,7 @@ check-error@^2.1.1:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
   integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
-check-unused-css@^0.4.1:
+check-unused-css@0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/check-unused-css/-/check-unused-css-0.4.1.tgz#5a4b3d99b2839b89b3aac951ea9254dea7f2ffe7"
   integrity sha512-DqmdpruM86Ey2Bha942URGEtwgcLF/syATk1abKZaMn5ymEOJCyQUsABQdsqCwICIjYGipA1onpCl1veWR6tOw==


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

- Bump `check-unused-css` to 0.4.1 and remove the `baseUrl` / `ignoreDeprecations` tsconfig workaround (fixed upstream in malinindev/check-unused-css#74)
- Fix typo `scr` → `src` in the `lint:scss:checkunused` exclude path