### PR TITLE
(PC-42105)[API] feat: use celery task rate limit for `external_api_booking_notification_task`

### DIFF
--- a/api/src/pcapi/celery_tasks/tasks.py
+++ b/api/src/pcapi/celery_tasks/tasks.py
@@ -12,7 +12,7 @@ import pcapi.celery_tasks.metrics as metrics
 from pcapi import settings
 from pcapi.utils import requests
 from pcapi.utils.rate_limit import RateLimitedError
-from pcapi.utils.rate_limit import rate_limit
+from pcapi.utils.rate_limit import rate_limit as custom_rate_limit
 
 
 # These values will prevent retrying tasks too far in the future as this can have negative effects
@@ -37,6 +37,7 @@ def celery_async_task(
     max_retries: int = settings.CELERY_TASK_MAX_RETRIES,
     time_window_size: int = 60,
     max_per_time_window: int | None = None,
+    rate_limit: int | str | None = None,
 ) -> typing.Callable:
     """
     celery_async_task decorator is used to defer the function execution to a Celery worker.
@@ -58,6 +59,9 @@ def celery_async_task(
     if time_window_size > MAX_TIME_WINDOW_SIZE:
         raise ValueError("task rate limit time_window_size above maximum")
 
+    if max_per_time_window and rate_limit:
+        raise ValueError("You cannot set both `max_per_time_window` and `rate_limit`")
+
     def decorator(f: typing.Callable) -> typing.Callable:
         @shared_task(
             bind=True,
@@ -66,6 +70,7 @@ def celery_async_task(
             retry_backoff=retry_backoff,
             retry_backoff_max=retry_backoff_max,
             max_retries=max_retries,
+            rate_limit=rate_limit,
         )
         @wraps(f)
         def task(self: Task, payload: dict) -> None:
@@ -84,7 +89,7 @@ def celery_async_task(
                     parsed_payload = json.loads(parsed_payload.model_dump_json())
                     parsed_payload = model.model_validate(parsed_payload)
                 if max_per_time_window:
-                    with rate_limit(f"celery:bucket:{name}", time_window_size, max_per_time_window):
+                    with custom_rate_limit(f"celery:bucket:{name}", time_window_size, max_per_time_window):
                         f(parsed_payload)
                 else:
                     f(parsed_payload)

--- a/api/src/pcapi/core/external_bookings/api.py
+++ b/api/src/pcapi/core/external_bookings/api.py
@@ -374,7 +374,14 @@ def send_booking_notification_to_external_service(
             notificationUrl=notification_url,
             signature=signature,
         )
-        on_commit(functools.partial(providers_tasks.external_api_booking_notification_task.delay, payload.model_dump()))
+
+        if FeatureToggle.WIP_USE_BUILT_IN_CELERY_RATE_LIMIT.is_active():
+            celery_task = providers_tasks.external_api_booking_notification_task_with_built_in_rate_limit
+        else:
+            celery_task = providers_tasks.external_api_booking_notification_task
+
+        on_commit(functools.partial(celery_task.delay, payload.model_dump()))
+
     except Exception as err:
         logger.exception(
             "Error: %s. Could not send external booking notification for: booking: %s, action %s",

--- a/api/src/pcapi/core/providers/tasks.py
+++ b/api/src/pcapi/core/providers/tasks.py
@@ -74,3 +74,27 @@ def external_api_booking_notification_task(payload: ExternalApiBookingNotificati
             exception,
             extra={"stock_id": payload.data.stock_id, "booking_creation_date": payload.data.booking_creation_date},
         )
+
+
+@celery_async_task(
+    name="tasks.providers.default.external_api_booking_notification",
+    model=ExternalApiBookingNotificationTaskPayload,
+    rate_limit="200/m",
+)
+def external_api_booking_notification_task_with_built_in_rate_limit(
+    payload: ExternalApiBookingNotificationTaskPayload,
+) -> None:
+    try:
+        response = requests.post(
+            payload.notificationUrl,
+            json=payload.data.model_dump_json(),
+            hmac=payload.signature,
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exception:
+        logger.warning(
+            "Failed to call provider notification url: %s",
+            exception,
+            extra={"stock_id": payload.data.stock_id, "booking_creation_date": payload.data.booking_creation_date},
+        )

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -136,8 +136,9 @@ class FeatureToggle(enum.Enum):
     WIP_ASYNCHRONOUS_CELERY_BATCH = (
         "Activer le backend de tâches asynchrones Celery pour la synchro et les notifs Batch"
     )
-    WIP_ASYNCHRONOUS_CELERY_EXTERNAL_BOOKING = (
-        "Activer le backend de tâches asynchrones Celery pour l'envoi de notification aux providers"
+
+    WIP_USE_BUILT_IN_CELERY_RATE_LIMIT = (
+        "Activer le rate limit propre à Celery pour l'envoi de notification aux providers"
     )
     WIP_ENABLE_CRON_FOR_PRO_ATTRIBUTES_UPDATES = "Active l'utilisation du cron pour les màj des attributs pro"
     WIP_ENABLE_FINANCE_SETTLEMENTS = "Active le workflow finance des règlements"
@@ -214,7 +215,6 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.VENUE_REGULARIZATION,
     FeatureToggle.WIP_ASYNCHRONOUS_CELERY_CHECK_OFFERERS,
     FeatureToggle.WIP_ASYNCHRONOUS_CELERY_BATCH,
-    FeatureToggle.WIP_ASYNCHRONOUS_CELERY_EXTERNAL_BOOKING,
     FeatureToggle.WIP_ENABLE_CRON_FOR_PRO_ATTRIBUTES_UPDATES,
     FeatureToggle.WIP_ENABLE_CULTURAL_OUTREACH,
     FeatureToggle.WIP_ENABLE_FINANCE_SETTLEMENTS,


### PR DESCRIPTION
Remove `external_api_booking_notification_task` cloud task

[Ticket Jira](https://passculture.atlassian.net/browse/PC-XXXXX)

## TL;DR

- Suppression de la cloud task `external_api_booking_notification_task` et du FF lié 
- Ajout du FF `WIP_USE_BUILT_IN_CELERY_RATE_LIMIT` pour pouvoir facilement changer entre le rate limit Celery et le rate limit custom sur la tâche celery `external_api_booking_notification_task` 
- le dernier commit est un commit de test et sera supprimé avant le merge

## Contexte

### **Le problème actuel**

Nous avons mis en place un ratelimit custom sur les tâches celery car le `ratelimit` interne à Celery ne marche que si les tâches sont consommées que par une seul `worker` (le ratelimit est un ratelimit par worker - [cf doc](https://docs.celeryq.dev/en/stable/userguide/tasks.html#Task.rate_limit)).

Notre algo maiseon est simple : pour une `timewindow` donnée compte le nombre de tâches qui peuvent être lancées et une fois que la limite a été dépassée, reporte les tâches `n * timewindows.` Comme Celery n'est pas fait pour schedule des tâches longtemps dans l'avenir, le report d'une tâche est limité à maximum 20 minutes. 

=> **Cela a la conséquence suivante :** si trop de tâches sont empilées en même temps dans la file, elles se retrouvent reportées 3 fois à 20 minutes avant d'échouer car nous avons limité le nombre de retry à 3 au niveau de Celery. Cela crée beaucoup d’erreurs de type `RateLimitedError` ([logs sentry](https://pass-culture.sentry.io/issues/78548096/?environment=production)).

### **La non pertinence du choix initial**

La raison qui avait fait opter pour un _ratelimit custom_, à savoir que le _ratelimit_ est par _worker_ et donc que la tâche ne peut être distribuée entre plusieurs _workers_ ne nous semble par pertinent : 

- aucune de nos tâches n’est actuellement distribuée entre plusieurs workers
- une tâche ratelimitée a par essence vocation à être dépilée “lentement”, donc elle n’a pas de raison d’être dépilée par plusieurs workers à la fois.

## But du ticket

Le but du ticket est d’utiliser le ratelimit interne à Celery plutôt que notre ratelimit custom sur la tâche `external_api_booking_notification_task`, afin de voir si celui-ci gère mieux les burst de tâches.

## Tester les deux types de rate limit

```bash 
pc python
```
Puis dans le shell python :
```python
for i in range(0, 100):
     fake_task.task_with_celery_rate_limit.delay({"count": i})  # toutes les tâches vont être éxecutées

for i in range(0, 100):
     fake_task.task_with_custom_rate_limit.delay({"count": i})  # des tâches vont échouées en `RateLimitedError` (le MAX_RETRY_DURATION a été diminué à 10s pour le test, et montrer le problème que pose notre rate limit actuel)
```
