### PR TITLE
(PC-42110)[BO] perf: avoid timeout in _get_editable_stock when offer has thousands of stocks

### DIFF
--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -1786,30 +1786,31 @@ def get_offer_details(offer_id: int) -> response_utils.BackofficeResponse:
 def _get_editable_stock(offer_id: int) -> set[int]:
     raw_stock_ids = (
         db.session.query(offers_models.Stock.id)
-        .join(bookings_models.Booking, offers_models.Stock.bookings)
         .join(offers_models.Offer, offers_models.Stock.offer)
         .filter(
             offers_models.Offer.isEvent,
             offers_models.Stock.offerId == offer_id,
-            bookings_models.Booking.status.in_(
-                (
-                    bookings_models.BookingStatus.CONFIRMED,
-                    bookings_models.BookingStatus.USED,
+            # Fast parrallel subqueries with EXISTS are faster than a single flat query which iterates on bookings
+            sa.select(1)
+            .select_from(bookings_models.Booking)
+            .where(
+                bookings_models.Booking.stockId == offers_models.Stock.id,
+                bookings_models.Booking.status.in_(
+                    (bookings_models.BookingStatus.CONFIRMED, bookings_models.BookingStatus.USED)
                 ),
-            ),
-            offers_models.Stock.id.not_in(
-                db.session.query(offers_models.Stock.offerId)
-                .join(bookings_models.Booking, offers_models.Stock.bookings)
-                .join(finance_models.Pricing, bookings_models.Booking.pricings)
-                .filter(
+            )
+            .exists(),
+            sa.not_(
+                sa.select(1)
+                .select_from(bookings_models.Booking)
+                .join(bookings_models.Booking.pricings)
+                .where(
+                    bookings_models.Booking.stockId == offers_models.Stock.id,
                     finance_models.Pricing.status.in_(
-                        (
-                            finance_models.PricingStatus.PROCESSED,
-                            finance_models.PricingStatus.INVOICED,
-                        )
+                        (finance_models.PricingStatus.PROCESSED, finance_models.PricingStatus.INVOICED)
                     ),
-                    offers_models.Stock.offerId == offer_id,
-                ),
+                )
+                .exists()
             ),
         )
     )


### PR DESCRIPTION
Ticket Jira : https://passculture.atlassian.net/browse/PC-42110
Sentry : https://pass-culture.sentry.io/issues/122518544/

Test sur staging avec une offre reliée à 7970 stocks et 4 réservations.

Avant :

```
pcapi-staging> EXPLAIN ANALYZE SELECT stock.id AS stock_id
FROM stock
JOIN booking ON stock.id = booking."stockId"
JOIN offer ON offer.id = stock."offerId"
WHERE offer."subcategoryId" IN ('ACTIVATION_EVENT', 'ATELIER_PRATIQUE_ART', 'CINE_PLEIN_AIR', 'CONCERT', 'CONCOURS', 'CONFERENCE', 'DECOUVERTE_METIERS', 'EVENEMENT_CINE', 'EVENEMENT_JEU', 'EVENEMENT_MUSIQUE', 'EVENEMENT_PATRIMOINE', 'FESTIVAL_ART_VISUEL', 'FESTIVAL_CINE', 'FESTIVAL_LIVRE', 'FESTIVAL_MUSIQUE', 'FESTIVAL_SPECTACLE', 'LIVESTREAM_EVENEMENT', 'LIVESTREAM_MUSIQUE', 'LIVESTREAM_PRATIQUE_ARTISTIQUE', 'RENCONTRE_EN_LIGNE', 'RENCONTRE_JEU', 'RENCONTRE', 'SALON', 'SEANCE_CINE', 'SEANCE_ESSAI_PRATIQUE_ART', 'SPECTACLE_REPRESENTATION', 'VISITE_GUIDEE', 'VISITE')
AND stock."offerId" = 95535937
AND booking.status IN ('CONFIRMED', 'USED')
AND (
    stock.id NOT IN (
        SELECT stock.id
        FROM stock
        JOIN booking ON stock.id = booking."stockId"
        JOIN pricing ON booking.id = pricing."bookingId"
        WHERE pricing.status IN ('processed', 'invoiced')
        AND stock."offerId" = 95535937
    )
);
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| QUERY PLAN                                                                                                                                                                                                                                                                                                                                                            >
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| Nested Loop  (cost=2866441.74..4410951.69 rows=239 width=8) (actual time=252145.274..252145.717 rows=0 loops=1)                                                                                                                                                                                                                                                       >
|   ->  Index Scan using offer_pkey on offer  (cost=0.64..2.66 rows=1 width=8) (actual time=0.110..0.143 rows=1 loops=1)                                                                                                                                                                                                                                                >
|         Index Cond: (id = 95535937)                                                                                                                                                                                                                                                                                                                                   >
|         Filter: ("subcategoryId" = ANY ('{ACTIVATION_EVENT,ATELIER_PRATIQUE_ART,CINE_PLEIN_AIR,CONCERT,CONCOURS,CONFERENCE,DECOUVERTE_METIERS,EVENEMENT_CINE,EVENEMENT_JEU,EVENEMENT_MUSIQUE,EVENEMENT_PATRIMOINE,FESTIVAL_ART_VISUEL,FESTIVAL_CINE,FESTIVAL_LIVRE,FESTIVAL_MUSIQUE,FESTIVAL_SPECTACLE,LIVESTREAM_EVENEMENT,LIVESTREAM_MUSIQUE,LIVESTREAM_PRATIQUE_ART>
|   ->  Hash Join  (cost=2866441.10..4410946.63 rows=239 width=16) (actual time=252145.126..252145.567 rows=0 loops=1)                                                                                                                                                                                                                                                  >
|         Hash Cond: (booking."stockId" = stock.id)                                                                                                                                                                                                                                                                                                                     >
|         ->  Index Scan using ix_booking_status on booking  (cost=0.57..1538222.63 rows=2393704 width=8) (actual time=2.043..173022.851 rows=2354263 loops=1)                                                                                                                                                                                                          >
|               Index Cond: (status = ANY ('{CONFIRMED,USED}'::booking_status[]))                                                                                                                                                                                                                                                                                       >
|         ->  Hash  (cost=2866154.95..2866154.95 rows=22847 width=16) (actual time=78323.634..78324.074 rows=7967 loops=1)                                                                                                                                                                                                                                              >
|               Buckets: 32768  Batches: 1  Memory Usage: 630kB                                                                                                                                                                                                                                                                                                         >
|               ->  Index Scan using "ix_stock_offerId" on stock  (cost=2820027.34..2866154.95 rows=22847 width=16) (actual time=78313.154..78321.365 rows=7967 loops=1)                                                                                                                                                                                                >
|                     Index Cond: ("offerId" = 95535937)                                                                                                                                                                                                                                                                                                                >
|                     Filter: (NOT (hashed SubPlan 1))                                                                                                                                                                                                                                                                                                                  >
|                     Rows Removed by Filter: 3                                                                                                                                                                                                                                                                                                                         >
|                     SubPlan 1                                                                                                                                                                                                                                                                                                                                         >
|                       ->  Gather  (cost=46985.96..2820002.30 rows=9785 width=8) (actual time=21280.286..78306.218 rows=3 loops=1)                                                                                                                                                                                                                                     >
|                             Workers Planned: 2                                                                                                                                                                                                                                                                                                                        >
|                             Workers Launched: 2                                                                                                                                                                                                                                                                                                                       >
|                             ->  Nested Loop  (cost=45985.96..2818023.80 rows=4077 width=8) (actual time=35546.195..78299.182 rows=1 loops=3)                                                                                                                                                                                                                          >
|                                   ->  Parallel Hash Join  (cost=45985.39..2804225.20 rows=5635 width=16) (actual time=31308.828..78289.954 rows=1 loops=3)                                                                                                                                                                                                            >
|                                         Hash Cond: (booking_1."stockId" = stock_1.id)                                                                                                                                                                                                                                                                                 >
|                                         ->  Parallel Seq Scan on booking booking_1  (cost=0.00..2684281.80 rows=28174480 width=16) (actual time=2.420..73695.067 rows=22538632 loops=3)                                                                                                                                                                               >
|                                         ->  Parallel Hash  (cost=45747.41..45747.41 rows=19039 width=8) (actual time=121.501..121.503 rows=2657 loops=3)                                                                                                                                                                                                              >
|                                               Buckets: 65536  Batches: 1  Memory Usage: 864kB                                                                                                                                                                                                                                                                         >
|                                               ->  Parallel Index Scan using "ix_stock_offerId" on stock stock_1  (cost=0.57..45747.41 rows=19039 width=8) (actual time=1.182..102.901 rows=2657 loops=3)                                                                                                                                                              >
|                                                     Index Cond: ("offerId" = 95535937)                                                                                                                                                                                                                                                                                >
|                                   ->  Index Scan using idx_uniq_booking_id on pricing  (cost=0.56..2.44 rows=1 width=8) (actual time=6.902..6.906 rows=1 loops=4)                                                                                                                                                                                                     >
|                                         Index Cond: ("bookingId" = booking_1.id)                                                                                                                                                                                                                                                                                      >
|                                         Filter: (status = ANY ('{processed,invoiced}'::text[]))                                                                                                                                                                                                                                                                       >
| Planning Time: 1.200 ms                                                                                                                                                                                                                                                                                                                                               >
| Execution Time: 252146.133 ms                                                                                                                                                                                                                                                                                                                                         >
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
EXPLAIN 31
Time: 252.326s (4 minutes 12 seconds), executed in: 252.318s (4 minutes 12 seconds)
```

Après :
```
pcapi-staging> EXPLAIN ANALYZE SELECT stock.id AS stock_id
FROM stock
JOIN offer ON offer.id = stock."offerId"
WHERE offer."subcategoryId" IN ('ACTIVATION_EVENT', 'ATELIER_PRATIQUE_ART', 'CINE_PLEIN_AIR', 'CONCERT', 'CONCOURS', 'CONFERENCE', 'DECOUVERTE_METIERS', 'EVENEMENT_CINE', 'EVENEMENT_JEU', 'EVENEMENT_MUSIQUE', 'EVENEMENT_PATRIMOINE', 'FESTIVAL_ART_VISUEL', 'FESTIVAL_CINE', 'FESTIVAL_LIVRE', 'FESTIVAL_MUSIQUE', 'FESTIVAL_SPECTACLE', 'LIVESTREAM_EVENEMENT', 'LIVESTREAM_MUSIQUE', 'LIVESTREAM_PRATIQUE_ARTISTIQUE', 'RENCONTRE_EN_LIGNE', 'RENCONTRE_JEU', 'RENCONTRE', 'SALON', 'SEANCE_CINE', 'SEANCE_ESSAI_PRATIQUE_ART', 'SPECTACLE_REPRESENTATION', 'VISITE_GUIDEE', 'VISITE')
AND stock."offerId" = 95535937
AND (
    EXISTS (
        SELECT 1
        FROM booking
        WHERE booking."stockId" = stock.id
        AND booking.status IN ('CONFIRMED', 'USED')
    )
)
AND NOT (
    EXISTS (
        SELECT 1
        FROM booking
        JOIN pricing ON booking.id = pricing."bookingId"
        WHERE booking."stockId" = stock.id
        AND pricing.status IN ('processed', 'invoiced')
    )
);
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| QUERY PLAN                                                                                                                                                                                                                                                                                                                                                            >
|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| Nested Loop  (cost=1002.91..579278.27 rows=30 width=8) (actual time=158.488..161.676 rows=0 loops=1)                                                                                                                                                                                                                                                                  >
|   ->  Index Scan using offer_pkey on offer  (cost=0.64..2.66 rows=1 width=8) (actual time=1.388..1.394 rows=1 loops=1)                                                                                                                                                                                                                                                >
|         Index Cond: (id = 95535937)                                                                                                                                                                                                                                                                                                                                   >
|         Filter: ("subcategoryId" = ANY ('{ACTIVATION_EVENT,ATELIER_PRATIQUE_ART,CINE_PLEIN_AIR,CONCERT,CONCOURS,CONFERENCE,DECOUVERTE_METIERS,EVENEMENT_CINE,EVENEMENT_JEU,EVENEMENT_MUSIQUE,EVENEMENT_PATRIMOINE,FESTIVAL_ART_VISUEL,FESTIVAL_CINE,FESTIVAL_LIVRE,FESTIVAL_MUSIQUE,FESTIVAL_SPECTACLE,LIVESTREAM_EVENEMENT,LIVESTREAM_MUSIQUE,LIVESTREAM_PRATIQUE_ART>
|   ->  Gather  (cost=1002.27..579275.31 rows=30 width=16) (actual time=157.086..160.272 rows=0 loops=1)                                                                                                                                                                                                                                                                >
|         Workers Planned: 2                                                                                                                                                                                                                                                                                                                                            >
|         Workers Launched: 2                                                                                                                                                                                                                                                                                                                                           >
|         ->  Nested Loop Anti Join  (cost=2.27..578272.31 rows=12 width=16) (actual time=133.227..133.230 rows=0 loops=3)                                                                                                                                                                                                                                              >
|               ->  Nested Loop Semi Join  (cost=1.14..559331.79 rows=12 width=16) (actual time=133.226..133.228 rows=0 loops=3)                                                                                                                                                                                                                                        >
|                     ->  Parallel Index Scan using "ix_stock_offerId" on stock  (cost=0.57..45747.41 rows=19039 width=16) (actual time=18.870..125.804 rows=2657 loops=3)                                                                                                                                                                                              >
|                           Index Cond: ("offerId" = 95535937)                                                                                                                                                                                                                                                                                                          >
|                     ->  Index Scan using "ix_booking_stockId" on booking  (cost=0.57..422.84 rows=16 width=8) (actual time=0.002..0.002 rows=0 loops=7970)                                                                                                                                                                                                            >
|                           Index Cond: ("stockId" = stock.id)                                                                                                                                                                                                                                                                                                          >
|                           Filter: (status = ANY ('{CONFIRMED,USED}'::booking_status[]))                                                                                                                                                                                                                                                                               >
|                           Rows Removed by Filter: 0                                                                                                                                                                                                                                                                                                                   >
|               ->  Nested Loop  (cost=1.13..1575.13 rows=325 width=8) (never executed)                                                                                                                                                                                                                                                                                 >
|                     ->  Index Scan using "ix_booking_stockId" on booking booking_1  (cost=0.57..421.71 rows=449 width=16) (never executed)                                                                                                                                                                                                                            >
|                           Index Cond: ("stockId" = stock.id)                                                                                                                                                                                                                                                                                                          >
|                     ->  Index Scan using idx_uniq_booking_id on pricing  (cost=0.56..2.56 rows=1 width=8) (never executed)                                                                                                                                                                                                                                            >
|                           Index Cond: ("bookingId" = booking_1.id)                                                                                                                                                                                                                                                                                                    >
|                           Filter: (status = ANY ('{processed,invoiced}'::text[]))                                                                                                                                                                                                                                                                                     >
| Planning Time: 10.771 ms                                                                                                                                                                                                                                                                                                                                              >
| Execution Time: 161.952 ms                                                                                                                                                                                                                                                                                                                                            >
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
EXPLAIN 23
Time: 1.226s (1 second), executed in: 1.218s (1 second)
```