### PR TITLE
(PC-41769)[PRO] feat: admin account distance adage

### DIFF
--- a/pro/src/commons/utils/getDistance.ts
+++ b/pro/src/commons/utils/getDistance.ts
@@ -13,7 +13,7 @@ export const getHumanizeRelativeDistance = (
   return humanizeDistance(distanceInMeters).replace('.', ',')
 }
 
-const computeDistanceInMeters = (from: Coordinates, to: Coordinates) => {
+export const computeDistanceInMeters = (from: Coordinates, to: Coordinates) => {
   const newLat = (to.latitude * Math.PI) / 180 - (from.latitude * Math.PI) / 180
   const newLng =
     (to.longitude * Math.PI) / 180 - (from.longitude * Math.PI) / 180
@@ -28,7 +28,7 @@ const computeDistanceInMeters = (from: Coordinates, to: Coordinates) => {
   return EARTH_RADIUS_KM * c * 1000
 }
 
-const humanizeDistance = (distance: number) => {
+export const humanizeDistance = (distance: number) => {
   if (distance < 30) {
     return `${Math.round(distance)} m`
   }

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
@@ -2,7 +2,10 @@ import type {
   AuthenticatedResponse,
   CollectiveOfferTemplateResponseModel,
 } from '@/apiClient/adage'
-import { getHumanizeRelativeDistance } from '@/commons/utils/getDistance'
+import {
+  computeDistanceInMeters,
+  humanizeDistance,
+} from '@/commons/utils/getDistance'
 import { Banner } from '@/design-system/Banner/Banner'
 import { Button } from '@/design-system/Button/Button'
 import { ButtonColor, ButtonVariant } from '@/design-system/Button/types'
@@ -27,26 +30,27 @@ export function AdageOfferPartnerPanel({
 }: AdageOfferPartnerPanelProps) {
   const venue = offer.venue
 
-  const distanceToSchool =
-    venue.coordinates.latitude !== null &&
-    venue.coordinates.latitude !== undefined &&
-    venue.coordinates.longitude !== null &&
-    venue.coordinates.longitude !== undefined &&
-    adageUser &&
-    adageUser.lat !== null &&
-    adageUser.lat !== undefined &&
-    adageUser.lon !== null &&
-    adageUser.lon !== undefined &&
-    getHumanizeRelativeDistance(
-      {
-        latitude: venue.coordinates.latitude,
-        longitude: venue.coordinates.longitude,
-      },
-      {
-        latitude: adageUser.lat,
-        longitude: adageUser.lon,
-      }
-    )
+  const venueCoords =
+    venue.coordinates.latitude != null && venue.coordinates.longitude != null
+      ? {
+          latitude: venue.coordinates.latitude,
+          longitude: venue.coordinates.longitude,
+        }
+      : null
+
+  const userCoords =
+    adageUser?.lat != null && adageUser?.lon != null
+      ? { latitude: adageUser.lat, longitude: adageUser.lon }
+      : null
+
+  let isFarFromSchool = false
+  let distanceText = ''
+
+  if (venueCoords && userCoords) {
+    const meters = computeDistanceInMeters(venueCoords, userCoords)
+    isFarFromSchool = meters >= 10_000
+    distanceText = humanizeDistance(meters)
+  }
 
   return (
     <div className={styles['partner-panel']}>
@@ -86,16 +90,15 @@ export function AdageOfferPartnerPanel({
       </div>
 
       <div className={styles['partner-panel-location']}>
-        {(venue.city || venue.postalCode || distanceToSchool || isPreview) && (
+        {(isPreview || isFarFromSchool) && (
           <Banner
             title="Distance importante"
             description={
               <>
                 Ce partenaire est situé{' '}
                 {(venue.city || venue.postalCode) &&
-                  `à ${venue.city ?? ''} ${venue.postalCode ?? ''}, `}
-                {(isPreview || distanceToSchool) &&
-                  `à ${isPreview ? 'X km' : distanceToSchool} de votre établissement scolaire`}
+                  `à ${venue.city ?? ''} ${venue.postalCode ?? ''},`}
+                {`à ${isPreview ? 'X km' : distanceText} de votre établissement scolaire`}
                 .
               </>
             }

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/utils/__specs__/getOfferTags.spec.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/utils/__specs__/getOfferTags.spec.ts
@@ -127,6 +127,60 @@ describe('getOfferTags', () => {
     expect(tagsReduced).toEqual(['Lieu à déterminer'])
   })
 
+  it('should return "Sortie" without distance when adage user has no coordinates', () => {
+    const offer: CollectiveOfferTemplateResponseModel = {
+      ...templateOffer,
+      location: {
+        locationType: CollectiveLocationType.ADDRESS,
+        location: {
+          isManualEdition: false,
+          isVenueLocation: false,
+          id: 1,
+          label: 'Le nom du lieu 1',
+          city: 'Paris',
+          postalCode: '75001',
+          latitude: 1,
+          longitude: 1,
+        },
+      },
+      dates: undefined,
+    }
+    const tags = getOfferTags(
+      offer,
+      { ...adageUser, lat: null, lon: null },
+      false
+    ).map((tag) => tag.text)
+
+    expect(tags).toEqual(['Sortie'])
+  })
+
+  it('should return "Sortie" without distance when offer location has no coordinates', () => {
+    const offer: CollectiveOfferTemplateResponseModel = {
+      ...templateOffer,
+      location: {
+        locationType: CollectiveLocationType.ADDRESS,
+        location: {
+          isManualEdition: false,
+          isVenueLocation: false,
+          id: 1,
+          label: 'Le nom du lieu 1',
+          city: 'Paris',
+          postalCode: '75001',
+          latitude: 0,
+          longitude: 0,
+        },
+      },
+      dates: undefined,
+    }
+    const tags = getOfferTags(
+      offer,
+      { ...adageUser, lat: 0, lon: 0 },
+      false
+    ).map((tag) => tag.text)
+
+    expect(tags).toEqual(['Sortie'])
+  })
+
   it('should return a multi level tag if there are multiple student levels', () => {
     const offer: CollectiveOfferTemplateResponseModel = {
       ...templateOffer,

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/utils/getOfferTags.ts
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/utils/getOfferTags.ts
@@ -78,7 +78,7 @@ export function getOfferTags(
       },
       [CollectiveLocationType.ADDRESS]: {
         icon: fullLocationIcon,
-        text: `Sortie à ${distanceFromOffer}`,
+        text: distanceFromOffer ? `Sortie à ${distanceFromOffer}` : 'Sortie',
       },
       [CollectiveLocationType.TO_BE_DEFINED]: {
         icon: fullLocationIcon,


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41769)

Page offre : Si le compte n'a pas de latitude et longitude ou si la distance est < à 10km on n'affiche plus la bannière "Distance importante" 
Page recherche/découverte : Si le compte n'a pas de latitude et longitude, au lieu du tag Sortie à false, on affiche seulement Sortie

Avant : 
<img width="493" height="358" alt="Capture d’écran 2026-06-01 à 16 46 45" src="https://github.com/user-attachments/assets/d9d92c91-ce18-41e6-b8cb-92f1436167cf" />

<img width="240" height="82" alt="image" src="https://github.com/user-attachments/assets/3095a2a9-39b4-46af-85b1-6696f207f197" />
