### PR TITLE
(PC-41712)[API] chore: explain how the csrf check is activated for a single api endpoint

### DIFF
--- a/api/src/pcapi/app.py
+++ b/api/src/pcapi/app.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 from flask_jwt_extended import JWTManager
-from flask_wtf.csrf import CSRFProtect
 
 from pcapi import settings
 from pcapi.core.users.sessions import install_routed_login
 from pcapi.flask_app import app
+from pcapi.flask_app import csrf
 from pcapi.flask_app import setup_metrics
 
 
@@ -15,15 +15,16 @@ app.config["REMEMBER_COOKIE_HTTPONLY"] = True
 app.config["REMEMBER_COOKIE_SECURE"] = settings.SESSION_COOKIE_SECURE
 app.config["REMEMBER_COOKIE_DURATION"] = 90 * 24 * 3600
 app.config["PERMANENT_SESSION_LIFETIME"] = 90 * 24 * 3600
-app.config["FLASK_ADMIN_SWATCH"] = "flatly"
-app.config["FLASK_ADMIN_FLUID_LAYOUT"] = True
 app.config["JWT_SECRET_KEY"] = settings.JWT_SECRET_KEY
 app.config["JWT_ACCESS_TOKEN_EXPIRES"] = settings.JWT_ACCESS_TOKEN_EXPIRES
+# CSRF is disabled by default because it's used nowhere in the API except for the discord signin page.
+# The SigninForm in charge of gathering the username/password has the csrf protection explicitly activated
+# cf. pcapi.routes.auth.forms.forms.SigninForm used by this endpoint : `/auth/discord/signin`
 app.config["WTF_CSRF_ENABLED"] = False
 app.config["USE_GLOBAL_ATOMIC"] = False
 
 jwt = JWTManager(app)
-csrf = CSRFProtect()
+# The csrf is configured here to be able to perform the check in discord's signin form, the single form where it's needed
 csrf.init_app(app)
 
 with app.app_context():

--- a/api/src/pcapi/backoffice_app.py
+++ b/api/src/pcapi/backoffice_app.py
@@ -7,11 +7,11 @@ from flask import make_response
 from flask import render_template
 from flask import request
 from flask_wtf.csrf import CSRFError
-from flask_wtf.csrf import CSRFProtect
 
 from pcapi import settings
 from pcapi.core.users.sessions import install_backoffice_login
 from pcapi.flask_app import app
+from pcapi.flask_app import csrf
 from pcapi.flask_app import setup_metrics
 from pcapi.routes.backoffice.utils import static as static_utils
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
@@ -28,7 +28,6 @@ app.config["REMEMBER_COOKIE_NAME"] = "bo_remember_me"
 app.config["PERMANENT_SESSION_LIFETIME"] = 120 * 60
 app.config["USE_GLOBAL_ATOMIC"] = True
 
-csrf = CSRFProtect()
 csrf.init_app(app)
 
 

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -18,6 +18,7 @@ from flask import jsonify
 from flask import request
 from flask.logging import default_handler
 from flask_login import current_user
+from flask_wtf.csrf import CSRFProtect
 from sqlalchemy.event import listens_for
 from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -63,6 +64,8 @@ init_sentry_sdk()
 
 
 app = Flask(__name__, static_url_path="/static")
+
+csrf = CSRFProtect()
 
 
 def setup_metrics(app_: Flask) -> None:

--- a/api/src/pcapi/routes/auth/discord.py
+++ b/api/src/pcapi/routes/auth/discord.py
@@ -6,7 +6,6 @@ import jwt
 from flask import redirect
 from flask import render_template
 from flask import request
-from flask_wtf.csrf import CSRFProtect
 from werkzeug.wrappers.response import Response
 
 from pcapi import settings
@@ -25,7 +24,6 @@ from pcapi.utils.transaction_manager import atomic
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
 
 from . import blueprint
-from . import utils
 
 
 logger = logging.getLogger(__name__)
@@ -158,11 +156,9 @@ def discord_signin_post() -> Response | str:
     if not FeatureToggle.DISCORD_ENABLE_NEW_ACCESS.is_active():
         return render_template("discord_signin_disabled.html")
 
-    csrf = CSRFProtect()
-    csrf.protect()
     form = SigninForm()
     if not form.validate():
-        form.error_message = utils.build_form_error_msg(form)
+        form.error_message = "La tentative de connexion a échoué, réessayer."
         return render_template("discord_signin.html", form=form)
 
     email = form.email.data

--- a/api/src/pcapi/routes/auth/forms/forms.py
+++ b/api/src/pcapi/routes/auth/forms/forms.py
@@ -7,3 +7,6 @@ class SigninForm(PCForm):
     password = fields.PCPasswordField("Mot de passe")
     recaptcha_token = fields.PCLongHiddenField("Recaptcha Token")
     error_message: str = ""
+
+    class Meta:
+        csrf = True

--- a/api/src/pcapi/routes/auth/utils.py
+++ b/api/src/pcapi/routes/auth/utils.py
@@ -2,7 +2,6 @@ import random
 import typing
 
 from flask_wtf import FlaskForm
-from markupsafe import Markup
 
 from pcapi import settings
 from pcapi.utils import email as email_utils
@@ -25,23 +24,3 @@ def random_hash() -> str:
 
 def get_setting(setting_name: str) -> typing.Any:
     return getattr(settings, setting_name)
-
-
-def build_form_error_msg(form: FlaskForm) -> str:
-    error_msg = Markup("Les données envoyées comportent des erreurs.")
-    for field in form:
-        if field.errors:
-            field_errors = []
-            for error in field.errors:
-                # form field errors are a dict, where keys are the failing field's name, and
-                # the value is a list of all error messages
-                if isinstance(error, dict):
-                    field_errors += [
-                        ", ".join(error_text for error_text in field_error_list) for field_error_list in error.values()
-                    ]
-                else:
-                    field_errors.append(error)
-            error_msg += Markup(" {label} : {errors} ;").format(
-                label=field.label.text, errors=", ".join(error for error in field_errors)
-            )
-    return error_msg

--- a/api/tests/routes/auth/discord_test.py
+++ b/api/tests/routes/auth/discord_test.py
@@ -72,6 +72,20 @@ class DiscordSigninTest:
         return discord_connector._sign_state(user_id)
 
     @pytest.mark.settings(DISCORD_JWT_PUBLIC_KEY=public_key_pem, DISCORD_JWT_PRIVATE_KEY=private_key_pem)
+    def test_csrf_check(self, client):
+        form_data = {
+            "email": "user@test.com",
+            "password": settings.TEST_DEFAULT_PASSWORD,
+            "recaptcha_token": "recaptcha_token",
+        }
+        users_factories.BeneficiaryFactory(email=form_data["email"], password=form_data["password"], isActive=True)
+
+        response = client.post(url_for(self.endpoint), form=form_data)
+
+        assert response.status_code == 200
+        assert "La tentative de connexion a échoué, réessayer." in response.data.decode("utf-8")
+
+    @pytest.mark.settings(DISCORD_JWT_PUBLIC_KEY=public_key_pem, DISCORD_JWT_PRIVATE_KEY=private_key_pem)
     def test_build_discord_redirection_uri(self):
         uri = discord_connector.build_discord_redirection_uri(1)
         assert uri.startswith(
@@ -299,7 +313,7 @@ class DiscordSigninTest:
         assert response.status_code == 200
 
         response_data = response.data.decode("utf-8")
-        assert "Mot de passe : Information obligatoire" in response_data
+        assert "La tentative de connexion a échoué, réessayer." in response_data
 
     @unittest.mock.patch(
         "pcapi.routes.auth.discord.discord_connector.retrieve_access_token", return_value="access_token"

--- a/api/tests/test_flask_app.py
+++ b/api/tests/test_flask_app.py
@@ -44,6 +44,7 @@ KNOWN_PUBLIC_ENDPOINTS = [
     "adage_iframe.create_adage_jwt_fake_token",  # → response.status_code = 200
     "auth.discord_call_back",  # → response.status_code = 303
     "auth.discord_signin",  # → response.status_code = 200
+    "auth.discord_signin_post",  # → response.status_code = 200
     "auth.discord_success",  # → response.status_code = 303
     "native.native_v1.email_validation_remaining_resends",  # → response.status_code = 200
     "native.native_v1.empty_email_validation_remaining_resends",  # → response.status_code = 200


### PR DESCRIPTION
Ticket jira : https://passculture.atlassian.net/browse/PC-41712

 - Disable csrf protection by default for API endpoints by setting `WTF_CSRF_ENABLED` to `False`
 - Init `csrf` to have it configured in the concerned endpoints
 - Endpoints with forms needing csrf protection have to activate it in the `Meta` class of the form: 
```python
 class MyForm(FlaskForm):
     …
     class Meta(FlaskForm.Meta):
          csrf = True
```
 - Currently the csrf protection is required by a single endpoint: `/auth/discord/signin` 