### PR TITLE
(PC-41555)[PRO] fix: remove maxCharactersCount which broke qr-code scan on Desk

### DIFF
--- a/pro/e2e/desk.e2e.ts
+++ b/pro/e2e/desk.e2e.ts
@@ -46,6 +46,16 @@ test.describe('Desk (Guichet)', () => {
     expect(a11yResults.violations).toHaveLength(0)
   })
 
+  test('should extract token from QR code scan with prefix', async ({
+    authenticatedPage: page,
+    deskData,
+  }) => {
+    const tokenInput = page.getByLabel('Contremarque')
+    await tokenInput.fill(`PASSCULTURE:v3,TOKEN:${deskData.tokenUsed}`)
+
+    await expect(tokenInput).toHaveValue(deskData.tokenUsed)
+  })
+
   test('should decline a non-valid countermark', async ({
     authenticatedPage: page,
   }) => {

--- a/pro/src/pages/Desk/Desk.spec.tsx
+++ b/pro/src/pages/Desk/Desk.spec.tsx
@@ -54,7 +54,7 @@ describe('Desk', () => {
       expect(input).toHaveValue('ZERRZ')
     })
 
-    it('updates character counter', async () => {
+    it('extracts token from QR code content with prefix', async () => {
       vi.spyOn(apiNew, 'getBookingByToken').mockResolvedValue(
         defaultGetBookingResponse
       )
@@ -62,12 +62,13 @@ describe('Desk', () => {
       const user = userEvent.setup()
       renderDesk()
 
-      expect(screen.getByText('0/6')).toBeInTheDocument()
-
       const input = screen.getByRole('textbox', { name: 'Contremarque' })
-      await user.type(input, 'AA')
+      await user.type(input, 'PASSCULTURE:v3,TOKEN:AAAAAA')
 
-      expect(screen.getByText('2/6')).toBeInTheDocument()
+      expect(input).toHaveValue('AAAAAA')
+      expect(apiNew.getBookingByToken).toHaveBeenCalledWith({
+        path: { token: 'AAAAAA' },
+      })
     })
 
     it('calls API and displays booking details when token valid', async () => {

--- a/pro/src/pages/Desk/Desk.tsx
+++ b/pro/src/pages/Desk/Desk.tsx
@@ -157,7 +157,6 @@ export const Desk = (): JSX.Element => {
                 autoComplete="off"
                 required
                 requiredIndicator="explicit"
-                maxCharactersCount={6}
                 error={errors?.token?.message}
               />
 


### PR DESCRIPTION
## 🎯 Related Ticket

[PC-41555](https://passculture.atlassian.net/browse/PC-41555)

### Problème

Sur la page Guichet, le contenu envoyé par le scanner est de la forme `PASSCULTURE:AADNEV`. Or, le composant `TextInput` avait `maxCharactersCount={6}`, ce qui applique `maxLength={6}` sur l'élément HTML `<input>`. Le navigateur tronquait alors le contenu scanné à 6 caractères (`PASSCU`) **avant** que le handler `onChange` ne soit appelé. La logique de découpage sur `:` dans `handleOnChangeToken` ne voyait jamais le séparateur, et le champ affichait `PASSCU` au lieu de la contremarque réelle.

### Correction

- **`Desk.tsx`** : suppression de `maxCharactersCount={6}` sur le `TextInput` pour que le contenu complet du QR code atteigne le handler `onChange`, qui extrait correctement le token après le séparateur `:`.

[PC-41555]: https://passculture.atlassian.net/browse/PC-41555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ