### PR TITLE
(PC-41945)[API] test: add sandbox data for artist page QA edge cases

### DIFF
--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -473,6 +473,8 @@ def create_artists() -> None:
 
     _create_multi_artists_offer(venue)
     _create_library_with_writers()
+    _create_multi_category_artist(venue)
+    _create_artist_without_offers()
 
 
 def _create_offers_for_artist(
@@ -564,6 +566,48 @@ def _create_library_with_writers() -> None:
             )
 
             offers_factories.StockFactory.create(offer=offer)
+
+
+def _create_multi_category_artist(venue: offerers_models.Venue) -> None:
+    """QA edge case: artist with offers in several categories.
+
+    The artist page should display one playlist per category, in the expected order.
+    """
+    artist = artist_factories.ArtistFactory.create(
+        name="Charles Aznavour",
+        description="auteur-compositeur-interprète et acteur franco-arménien",
+        biography=(
+            "Charles Aznavour, né le 22 mai 1924 à Paris et mort le 1er octobre 2018, est un"
+            " auteur-compositeur-interprète et acteur franco-arménien. Auteur de plus de mille"
+            " chansons en plusieurs langues et présent dans plus de soixante films, il est l'une"
+            " des figures les plus emblématiques de la chanson française du XXe siècle."
+        ),
+        wikidata_id="Q170348",
+        wikipedia_url="https://fr.wikipedia.org/wiki/Charles_Aznavour",
+    )
+    _create_offers_for_artist(
+        venue, artist, subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id, ArtistType.PERFORMER, count=3
+    )
+    _create_offers_for_artist(
+        venue, artist, subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id, ArtistType.PERFORMER, count=2
+    )
+    _create_offers_for_artist(venue, artist, subcategories.SEANCE_CINE.id, ArtistType.FILM_ACTOR, count=2)
+    _create_offers_for_artist(venue, artist, subcategories.LIVRE_PAPIER.id, ArtistType.AUTHOR, count=2)
+
+
+def _create_artist_without_offers() -> None:
+    """QA edge case: artist exists but has no offer.
+
+    The artist page should show the bio but display no category playlist.
+    """
+    artist_factories.ArtistFactory.create(
+        name="Artiste sans offre",
+        description="cas limite QA — artiste sans aucune offre liée",
+        biography=(
+            "Cet artiste est volontairement dépourvu d'offres afin de valider que la page artiste"
+            " n'affiche aucune playlist de catégorie lorsque aucune œuvre n'est rattachée."
+        ),
+    )
 
 
 @log_func_duration

--- a/api/tests/sandboxes/scripts/test_create_artists.py
+++ b/api/tests/sandboxes/scripts/test_create_artists.py
@@ -1,0 +1,64 @@
+import pytest
+
+from pcapi.core.artist.models import Artist
+from pcapi.core.artist.models import ArtistOfferLink
+from pcapi.core.artist.models import ArtistProductLink
+from pcapi.core.artist.models import ArtistType
+from pcapi.core.categories import subcategories
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.models import db
+from pcapi.sandboxes.scripts.creators.test_cases import _create_artist_without_offers
+from pcapi.sandboxes.scripts.creators.test_cases import _create_multi_category_artist
+
+
+@pytest.mark.usefixtures("db_session")
+class CreateMultiCategoryArtistTest:
+    def test_creates_one_artist_with_offers_in_several_subcategories(self):
+        venue = offerers_factories.VenueFactory.create(name="QA — multi catégories")
+
+        _create_multi_category_artist(venue)
+
+        artist = db.session.query(Artist).filter_by(name="Charles Aznavour").one()
+        assert artist.wikidata_id == "Q170348"
+        assert artist.biography is not None
+        assert artist.wikipedia_url == "https://fr.wikipedia.org/wiki/Charles_Aznavour"
+
+        product_subcategories = {
+            link.product.subcategoryId
+            for link in db.session.query(ArtistProductLink).filter_by(artist_id=artist.id).all()
+        }
+        assert product_subcategories == {
+            subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
+            subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id,
+            subcategories.SEANCE_CINE.id,
+            subcategories.LIVRE_PAPIER.id,
+        }
+
+    def test_links_use_expected_artist_types_per_category(self):
+        venue = offerers_factories.VenueFactory.create(name="QA — multi catégories types")
+
+        _create_multi_category_artist(venue)
+
+        artist = db.session.query(Artist).filter_by(name="Charles Aznavour").one()
+        links_by_subcategory: dict[str, set[ArtistType]] = {}
+        for link in db.session.query(ArtistProductLink).filter_by(artist_id=artist.id).all():
+            links_by_subcategory.setdefault(link.product.subcategoryId, set()).add(link.artist_type)
+
+        assert links_by_subcategory[subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id] == {ArtistType.PERFORMER}
+        assert links_by_subcategory[subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id] == {ArtistType.PERFORMER}
+        assert links_by_subcategory[subcategories.SEANCE_CINE.id] == {ArtistType.FILM_ACTOR}
+        assert links_by_subcategory[subcategories.LIVRE_PAPIER.id] == {ArtistType.AUTHOR}
+
+
+@pytest.mark.usefixtures("db_session")
+class CreateArtistWithoutOffersTest:
+    def test_creates_artist_without_any_offer_link(self):
+        _create_artist_without_offers()
+
+        artist = db.session.query(Artist).filter_by(name="Artiste sans offre").one()
+        assert artist.biography is not None
+
+        product_links = db.session.query(ArtistProductLink).filter_by(artist_id=artist.id).count()
+        offer_links = db.session.query(ArtistOfferLink).filter_by(artist_id=artist.id).count()
+        assert product_links == 0
+        assert offer_links == 0


### PR DESCRIPTION
[ticket associé](https://passculture.atlassian.net/browse/PC-41945)

Ajout de deux nouvelles fonctions de peuplement sandbox pour couvrir les cas edge de la page artiste :

- La fonction _create_multi_category_artist : crée Charles Aznavour avec des offres dans 4 sous-catégories (CD, Vinyle, Cinéma, Livre)
- La fonciton_create_artist_without_offers : crée un artiste sans aucune offre liée

Les deux fonctions sont couvertes par des tests unitaires (test_create_artists.py).