### PR TITLE
(PC-41807)[API] feat: close venue entrypoint (api not route)

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -3471,3 +3471,11 @@ def get_user_pending_and_validated_offerers(
     validated = query.filter(offerers_models.UserOfferer.isValidated).all()
 
     return PendingAndValidatedOfferers(validated=validated, pending=pending)
+
+
+def close_venue(venue: models.Venue) -> None:
+    if venue.is_closed:
+        return
+
+    venue.state = models.VenueState.CLOSED
+    db.session.flush()

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -957,6 +957,10 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
             .exists()
         ).scalar()
 
+    @property
+    def is_closed(self) -> bool:
+        return self.state == VenueState.CLOSED
+
 
 class GooglePlacesInfo(PcObject, Model):
     __tablename__ = "google_places_info"

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -51,6 +51,7 @@ from pcapi.routes.serialization import offerers_serialize
 from pcapi.routes.serialization import venue_serialize
 from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
+from pcapi.utils.transaction_manager import atomic
 
 import tests
 from tests.test_utils import gen_offerer_tags
@@ -4035,3 +4036,23 @@ class GetUserPendingAndValidatedOffererTest:
 
         res = offerers_api.get_user_pending_and_validated_offerers(user)
         assert res == offerers_api.PendingAndValidatedOfferers(pending=[pending_offerer], validated=[validated_offerer])
+
+
+class CloseVenueTest:
+    def test_open_venue_becomes_closed(self):
+        venue = offerers_factories.VenueFactory(state=None)
+
+        with atomic():
+            offerers_api.close_venue(venue)
+
+        db.session.refresh(venue)
+        assert venue.state == offerers_models.VenueState.CLOSED
+
+    def test_closed_venue_stays_closed(self):
+        venue = offerers_factories.VenueFactory(state=offerers_models.VenueState.CLOSED)
+
+        with atomic():
+            offerers_api.close_venue(venue)
+
+        db.session.refresh(venue)
+        assert venue.state == offerers_models.VenueState.CLOSED


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41807)

Ajout d'une fonction, presque vide, qui servira de point d'entrée à la fermeture d'un lieu. Elle sera enrichie avec les tickets suivants qui implémenteront chacun un aspect de cette fermeture (désactivation des emails et des offres, désindexation, etc.).

Pour l'instant elle se contente de passer l'état du lieu à `CLOSED`.