### PR TITLE
(PC-41433)[PRO] feat: migrate IndividualOfferContext to hey-api

### DIFF
--- a/pro/src/commons/context/IndividualOfferContext/IndividualOfferContext.tsx
+++ b/pro/src/commons/context/IndividualOfferContext/IndividualOfferContext.tsx
@@ -3,17 +3,18 @@ import { createContext, useContext, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router'
 import useSWR, { useSWRConfig } from 'swr'
 
-import { api } from '@/apiClient/api'
+import { apiNew } from '@/apiClient/api'
 import type {
   CategoryResponseModel,
   GetIndividualOfferWithAddressResponseModel,
   SubcategoryResponseModel,
-} from '@/apiClient/v1'
+} from '@/apiClient/v1/new'
 import {
   GET_ACTIVE_VENUE_OFFER_BY_EAN_QUERY_KEY,
   GET_CATEGORIES_QUERY_KEY,
   GET_OFFER_QUERY_KEY,
 } from '@/commons/config/swrQueryKeys'
+import type { OfferExtraData } from '@/commons/core/Offers/types'
 import { isOfferProductBased } from '@/commons/core/Offers/utils/typology'
 import { useAppSelector } from '@/commons/hooks/useAppSelector'
 import { ensureSelectedPartnerVenue } from '@/commons/store/user/selectors'
@@ -75,7 +76,7 @@ export const IndividualOfferContextProvider = ({
     offerId && offerIdAsString !== 'creation'
       ? [GET_OFFER_QUERY_KEY, Number(offerId)]
       : null,
-    ([, offerIdParam]) => api.getOffer(offerIdParam),
+    ([, offerIdParam]) => apiNew.getOffer({ path: { offer_id: offerIdParam } }),
     {
       onError: (error, key) => {
         if (error.status === 404) {
@@ -88,7 +89,8 @@ export const IndividualOfferContextProvider = ({
     }
   )
   const offer = offerQuery.data
-  const offerEan = offer?.extraData?.ean
+  const extraData = offer?.extraData as OfferExtraData | undefined
+  const offerEan = extraData?.ean
 
   //  Get the offer on the venue with the same EAN if it exists
   const publishedOfferWithSameEANQuery = useSWR(
@@ -99,7 +101,10 @@ export const IndividualOfferContextProvider = ({
           offerEan,
         ]
       : null,
-    ([, venueId, ean]) => api.getActiveVenueOfferByEan(venueId, ean),
+    ([, venueId, ean]) =>
+      apiNew.getActiveVenueOfferByEan({
+        path: { venue_id: venueId, ean },
+      }),
     {
       onError: (error) => {
         if (error.status === 404) {
@@ -112,7 +117,7 @@ export const IndividualOfferContextProvider = ({
 
   const categoriesQuery = useSWR(
     [GET_CATEGORIES_QUERY_KEY],
-    () => api.getCategories(),
+    () => apiNew.getCategories(),
     { fallbackData: { categories: [], subcategories: [] } }
   )
 

--- a/pro/src/commons/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
+++ b/pro/src/commons/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
@@ -4,16 +4,18 @@ import { Provider } from 'react-redux'
 import { useParams } from 'react-router'
 import { SWRConfig } from 'swr'
 
-import { api } from '@/apiClient/api'
-import { ApiError } from '@/apiClient/v1'
-import type { ApiRequestOptions } from '@/apiClient/v1/core/ApiRequestOptions'
-import type { ApiResult } from '@/apiClient/v1/core/ApiResult'
-import { configureTestStore } from '@/commons/store/testUtils'
-import { getIndividualOfferFactory } from '@/commons/utils/factories/individualApiFactories'
+import { apiNew } from '@/apiClient/api'
 import {
-  makeGetVenueResponseModel,
-  offerVenueFactory,
-} from '@/commons/utils/factories/venueFactories'
+  ApiError,
+  type ApiRequestOptions,
+  type ApiResult,
+} from '@/apiClient/compat'
+import { configureTestStore } from '@/commons/store/testUtils'
+import {
+  getIndividualOfferFactory,
+  getOfferVenueFactory,
+} from '@/commons/utils/factories/individualApiFactories'
+import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
 import {
   MOCKED_CATEGORIES,
   MOCKED_SUBCATEGORIES,
@@ -78,12 +80,12 @@ describe('IndividualOfferContextProvider', () => {
   })
 
   beforeEach(() => {
-    vi.spyOn(api, 'getActiveVenueOfferByEan')
-    vi.spyOn(api, 'getCategories').mockResolvedValue({
+    vi.spyOn(apiNew, 'getActiveVenueOfferByEan')
+    vi.spyOn(apiNew, 'getCategories').mockResolvedValue({
       categories: MOCKED_CATEGORIES,
       subcategories: MOCKED_SUBCATEGORIES,
     })
-    vi.spyOn(api, 'getOffer')
+    vi.spyOn(apiNew, 'getOffer')
   })
 
   describe.each([
@@ -97,9 +99,9 @@ describe('IndividualOfferContextProvider', () => {
     it('should call the expected api endpoints and return the expected context values', async () => {
       const { result } = await renderUseIndividualOfferContext()
 
-      expect(api.getOffer).not.toHaveBeenCalled()
-      expect(api.getCategories).toHaveBeenCalledOnce()
-      expect(api.getActiveVenueOfferByEan).not.toHaveBeenCalled()
+      expect(apiNew.getOffer).not.toHaveBeenCalled()
+      expect(apiNew.getCategories).toHaveBeenCalledOnce()
+      expect(apiNew.getActiveVenueOfferByEan).not.toHaveBeenCalled()
 
       expect(result.current.categories.length).toBeGreaterThan(0)
       expect(result.current.hasPublishedOfferWithSameEan).toBe(false)
@@ -131,15 +133,17 @@ describe('IndividualOfferContextProvider', () => {
       vi.mocked(useParams).mockReturnValue({
         offerId: '1',
       })
-      vi.spyOn(api, 'getOffer').mockResolvedValue(offerBase)
+      vi.spyOn(apiNew, 'getOffer').mockResolvedValue(offerBase)
     })
 
     it('should call the expected api endpoints and return the expected context values', async () => {
       const { result } = await renderUseIndividualOfferContext()
 
-      expect(api.getOffer).toHaveBeenCalledExactlyOnceWith(1)
-      expect(api.getCategories).toHaveBeenCalledOnce()
-      expect(api.getActiveVenueOfferByEan).not.toHaveBeenCalled() // because `offerBase` doesn't meet EAN check criteria
+      expect(apiNew.getOffer).toHaveBeenCalledExactlyOnceWith({
+        path: { offer_id: 1 },
+      })
+      expect(apiNew.getCategories).toHaveBeenCalledOnce()
+      expect(apiNew.getActiveVenueOfferByEan).not.toHaveBeenCalled() // because `offerBase` doesn't meet EAN check criteria
 
       expect(result.current.categories.length).toBeGreaterThan(0)
       expect(result.current.hasPublishedOfferWithSameEan).toBe(false)
@@ -150,7 +154,7 @@ describe('IndividualOfferContextProvider', () => {
     })
 
     it('should redirect to an error page when the offer does not exist', async () => {
-      vi.spyOn(api, 'getOffer').mockRejectedValueOnce({
+      vi.spyOn(apiNew, 'getOffer').mockRejectedValueOnce({
         status: 404,
       })
 
@@ -162,40 +166,48 @@ describe('IndividualOfferContextProvider', () => {
     })
 
     it('should check for EAN duplicate and set hasPublishedOfferWithSameEan to true when there is one', async () => {
-      vi.spyOn(api, 'getOffer').mockResolvedValueOnce({
+      vi.spyOn(apiNew, 'getOffer').mockResolvedValueOnce({
         ...offerBase,
         extraData: { ean: 2 },
         productId: 3,
-        venue: offerVenueFactory({ id: 4 }),
+        venue: getOfferVenueFactory({ id: 4 }),
       })
-      vi.spyOn(api, 'getActiveVenueOfferByEan').mockResolvedValueOnce({
+      vi.spyOn(apiNew, 'getActiveVenueOfferByEan').mockResolvedValueOnce({
         ...offerBase,
         id: 5,
       })
 
       const { result } = await renderUseIndividualOfferContext()
 
-      expect(api.getOffer).toHaveBeenCalledExactlyOnceWith(1)
-      expect(api.getActiveVenueOfferByEan).toHaveBeenCalledExactlyOnceWith(4, 2)
+      expect(apiNew.getOffer).toHaveBeenCalledExactlyOnceWith({
+        path: { offer_id: 1 },
+      })
+      expect(apiNew.getActiveVenueOfferByEan).toHaveBeenCalledExactlyOnceWith({
+        path: { venue_id: 4, ean: 2 },
+      })
 
       expect(result.current.hasPublishedOfferWithSameEan).toBe(true)
     })
 
     it('should check for EAN duplicate and set hasPublishedOfferWithSameEan to false when there is none', async () => {
-      vi.spyOn(api, 'getOffer').mockResolvedValueOnce({
+      vi.spyOn(apiNew, 'getOffer').mockResolvedValueOnce({
         ...offerBase,
         extraData: { ean: 2 },
         productId: 3,
-        venue: offerVenueFactory({ id: 4 }),
+        venue: getOfferVenueFactory({ id: 4 }),
       })
-      vi.spyOn(api, 'getActiveVenueOfferByEan').mockRejectedValueOnce(
+      vi.spyOn(apiNew, 'getActiveVenueOfferByEan').mockRejectedValueOnce(
         new ApiError({} as ApiRequestOptions, { status: 404 } as ApiResult, '')
       )
 
       const { result } = await renderUseIndividualOfferContext()
 
-      expect(api.getOffer).toHaveBeenCalledExactlyOnceWith(1)
-      expect(api.getActiveVenueOfferByEan).toHaveBeenCalledWith(4, 2)
+      expect(apiNew.getOffer).toHaveBeenCalledExactlyOnceWith({
+        path: { offer_id: 1 },
+      })
+      expect(apiNew.getActiveVenueOfferByEan).toHaveBeenCalledWith({
+        path: { venue_id: 4, ean: 2 },
+      })
 
       expect(result.current.hasPublishedOfferWithSameEan).toBe(false)
     })

--- a/pro/src/commons/core/Offers/types.ts
+++ b/pro/src/commons/core/Offers/types.ts
@@ -8,6 +8,22 @@ export type Pagination = {
   page?: number
 }
 
+// TODO (tpommellet) check if it is still necessary once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+/**
+ * Type of an individual offer's `extraData`, which the API exposes as an untyped object.
+ */
+export type OfferExtraData = {
+  author?: string
+  ean?: string
+  gtl_id?: string
+  performer?: string
+  showSubType?: string
+  showType?: string
+  speaker?: string
+  stageDirector?: string
+  visa?: string
+}
+
 export type CollectiveSearchFiltersParams = Pagination & {
   name: string
   // TODO (igabriele, 2025-11-07): Should be a number. "all" is a case that never happens since there is always a `currentOfferer` in the store.

--- a/pro/src/commons/core/Offers/utils/__specs__/getIndividualOfferImage.spec.ts
+++ b/pro/src/commons/core/Offers/utils/__specs__/getIndividualOfferImage.spec.ts
@@ -26,7 +26,7 @@ describe('getIndividualOfferImage', () => {
     {
       activeMediation: {
         thumbUrl: 'https://image.url',
-        credit: undefined,
+        credit: null,
       },
       expectedImage: {
         url: 'https://image.url',
@@ -40,6 +40,8 @@ describe('getIndividualOfferImage', () => {
     expectedImage,
   }) => {
     const offerApi = getIndividualOfferFactory({
+      // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+      // @ts-expect-error
       activeMediation,
     })
 

--- a/pro/src/commons/core/Offers/utils/__specs__/getOfferEnhancementCardsVisibility.spec.ts
+++ b/pro/src/commons/core/Offers/utils/__specs__/getOfferEnhancementCardsVisibility.spec.ts
@@ -58,7 +58,9 @@ describe('getOfferEnhancementCardsVisibility', () => {
     const offer = getIndividualOfferFactory({
       status: OfferStatus.ACTIVE,
       productId: 12,
-      thumbUrl: undefined,
+      // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+      // @ts-expect-error
+      thumbUrl: null,
     })
 
     const result = getOfferEnhancementCardsVisibility(offer)

--- a/pro/src/commons/core/Offers/utils/__specs__/isOfferSynchronized.spec.ts
+++ b/pro/src/commons/core/Offers/utils/__specs__/isOfferSynchronized.spec.ts
@@ -13,7 +13,9 @@ describe('isOfferSynchronized', () => {
 
   it('should return false when lastProvider is null', () => {
     const offer = getIndividualOfferFactory({
-      lastProvider: undefined,
+      // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+      // @ts-expect-error
+      lastProvider: null,
     })
 
     expect(isOfferSynchronized(offer)).toBe(false)

--- a/pro/src/commons/core/Offers/utils/__specs__/isOfferSynchronizedViaAllocine.spec.ts
+++ b/pro/src/commons/core/Offers/utils/__specs__/isOfferSynchronizedViaAllocine.spec.ts
@@ -31,7 +31,9 @@ describe('isOfferSynchronizedViaAllocine', () => {
     expect(
       isOfferSynchronizedViaAllocine(
         getIndividualOfferFactory({
-          lastProvider: undefined,
+          // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+          // @ts-expect-error
+          lastProvider: null,
         })
       )
     ).toBe(false)

--- a/pro/src/commons/utils/factories/individualApiFactories.ts
+++ b/pro/src/commons/utils/factories/individualApiFactories.ts
@@ -106,6 +106,9 @@ export const getIndividualOfferFactory = (
     isDuo: true,
     isNational: true,
     subcategoryId: SubcategoryIdEnum.SEANCE_CINE,
+    // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+    // @ts-expect-error
+    lastProvider: null,
     bookingsCount: 0,
     isNonFreeOffer: true,
     visualDisabilityCompliant: true,

--- a/pro/src/commons/utils/factories/venueFactories.ts
+++ b/pro/src/commons/utils/factories/venueFactories.ts
@@ -1,5 +1,4 @@
 import type {
-  GetOfferVenueResponseModel,
   GetVenueAddressResponseModel,
   GetVenueManagingOffererResponseModel,
   LocationResponseModelV2,
@@ -11,29 +10,6 @@ import {
 } from '@/apiClient/v1/new'
 
 import type { PartialExcept } from '../types'
-
-let VENUE_ID = 0
-
-export const offerVenueFactory = (
-  customOfferVenue: Partial<GetOfferVenueResponseModel> = {}
-): GetOfferVenueResponseModel => {
-  const id = customOfferVenue.id ?? VENUE_ID++
-
-  return {
-    id,
-    audioDisabilityCompliant: true,
-    managingOfferer: {
-      id: 1,
-      name: 'Le nom de l’offreur 1',
-    },
-    mentalDisabilityCompliant: true,
-    motorDisabilityCompliant: true,
-    name: `Nom de la structure ${id}`,
-    publicName: `Nom public de la structure ${id}`,
-    visualDisabilityCompliant: true,
-    ...customOfferVenue,
-  }
-}
 
 export const makeGetVenueManagingOffererResponseModel = <
   T extends PartialExcept<GetVenueManagingOffererResponseModel, 'id'>,

--- a/pro/src/commons/utils/getDepartmentCode.ts
+++ b/pro/src/commons/utils/getDepartmentCode.ts
@@ -1,7 +1,5 @@
-import type {
-  GetIndividualOfferWithAddressResponseModel,
-  ListOffersOfferResponseModel,
-} from '@/apiClient/v1'
+import type { ListOffersOfferResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 
 export const getDepartmentCode = (
   offer:

--- a/pro/src/components/IndividualOfferLayout/IndividualOfferLayout.tsx
+++ b/pro/src/components/IndividualOfferLayout/IndividualOfferLayout.tsx
@@ -5,7 +5,7 @@ import { api } from '@/apiClient/api'
 import {
   type GetIndividualOfferWithAddressResponseModel,
   OfferStatus,
-} from '@/apiClient/v1'
+} from '@/apiClient/v1/new'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import { OFFER_WIZARD_MODE } from '@/commons/core/Offers/constants'
 import { getOfferEnhancementCardsVisibility } from '@/commons/core/Offers/utils/getOfferEnhancementCardsVisibility'

--- a/pro/src/components/IndividualOfferLayout/components/IndividualOfferNavigation/utils/getLastSubmittedStepIndex.ts
+++ b/pro/src/components/IndividualOfferLayout/components/IndividualOfferNavigation/utils/getLastSubmittedStepIndex.ts
@@ -1,7 +1,5 @@
-import type {
-  GetIndividualOfferWithAddressResponseModel,
-  SubcategoryResponseModel,
-} from '@/apiClient/v1'
+import type { SubcategoryResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 
 import type { StepPattern } from './getSteps'
 

--- a/pro/src/components/IndividualOfferLayout/components/IndividualOfferNavigation/utils/getSteps.tsx
+++ b/pro/src/components/IndividualOfferLayout/components/IndividualOfferNavigation/utils/getSteps.tsx
@@ -1,7 +1,5 @@
-import type {
-  GetIndividualOfferWithAddressResponseModel,
-  SubcategoryResponseModel,
-} from '@/apiClient/v1'
+import type { SubcategoryResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
   OFFER_WIZARD_MODE,

--- a/pro/src/components/IndividualOfferLayout/components/OfferPublicationEdition/OfferPublicationEdition.tsx
+++ b/pro/src/components/IndividualOfferLayout/components/OfferPublicationEdition/OfferPublicationEdition.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { mutate } from 'swr'
 
 import { api } from '@/apiClient/api'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { GET_OFFER_QUERY_KEY } from '@/commons/config/swrQueryKeys'
 import { useSnackBar } from '@/commons/hooks/useSnackBar'
 import { getDepartmentCode } from '@/commons/utils/getDepartmentCode'

--- a/pro/src/components/IndividualOfferLayout/components/OfferPublicationEdition/OfferPublicationEditionForm/OfferPublicationEditionForm.tsx
+++ b/pro/src/components/IndividualOfferLayout/components/OfferPublicationEdition/OfferPublicationEditionForm/OfferPublicationEditionForm.tsx
@@ -3,7 +3,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { format, isAfter } from 'date-fns'
 import { FormProvider, useForm } from 'react-hook-form'
 
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import type { SelectOption } from '@/commons/custom_types/form'
 import { FORMAT_HH_mm, formatShortDateForInput } from '@/commons/utils/date'
 import { getLocalDepartementDateTimeFromUtc } from '@/commons/utils/timezone'

--- a/pro/src/components/IndividualOfferLayout/components/OfferPublicationEdition/OfferPublicationEditionForm/__specs__/OfferPublicationEditionForm.spec.tsx
+++ b/pro/src/components/IndividualOfferLayout/components/OfferPublicationEdition/OfferPublicationEditionForm/__specs__/OfferPublicationEditionForm.spec.tsx
@@ -24,8 +24,12 @@ describe('OfferPublicationEditionForm', () => {
   it('should render the form', async () => {
     renderOfferPublicationEditionForm({
       offer: getIndividualOfferFactory({
-        publicationDatetime: undefined,
-        bookingAllowedDatetime: undefined,
+        // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+        // @ts-expect-error
+        publicationDatetime: null,
+        // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+        // @ts-expect-error
+        bookingAllowedDatetime: null,
       }),
       onSubmit: () => {},
     })
@@ -46,10 +50,12 @@ describe('OfferPublicationEditionForm', () => {
   it('should disable the form if the pause toggle is on', async () => {
     renderOfferPublicationEditionForm({
       offer: getIndividualOfferFactory({
-        // TODO (tpommellet): To remove once the OfferPublicationEditionForm has been migrated to the new offer model.
-        // Currently, the component still reads the legacy (`@/apiClient/v1`) offer model and detects a paused offer via `publicationDatetime === null`
-        publicationDatetime: null as unknown as undefined,
-        bookingAllowedDatetime: undefined,
+        // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+        // @ts-expect-error
+        publicationDatetime: null,
+        // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+        // @ts-expect-error
+        bookingAllowedDatetime: null,
       }),
       onSubmit: () => {},
     })
@@ -78,7 +84,9 @@ describe('OfferPublicationEditionForm', () => {
     renderOfferPublicationEditionForm({
       offer: getIndividualOfferFactory({
         publicationDatetime: publicationDateFomatted,
-        bookingAllowedDatetime: undefined,
+        // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+        // @ts-expect-error
+        bookingAllowedDatetime: null,
       }),
       onSubmit: () => {},
     })
@@ -104,7 +112,9 @@ describe('OfferPublicationEditionForm', () => {
     renderOfferPublicationEditionForm({
       offer: getIndividualOfferFactory({
         publicationDatetime: bookingAllowedDateFormatted,
-        bookingAllowedDatetime: undefined,
+        // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+        // @ts-expect-error
+        bookingAllowedDatetime: null,
       }),
       onSubmit: () => {},
     })

--- a/pro/src/components/IndividualOfferLayout/components/OfferPublicationEdition/OfferPublicationEditionTags/OfferPublicationEditionTags.tsx
+++ b/pro/src/components/IndividualOfferLayout/components/OfferPublicationEdition/OfferPublicationEditionTags/OfferPublicationEditionTags.tsx
@@ -1,9 +1,7 @@
 import { isAfter } from 'date-fns'
 
-import {
-  type GetIndividualOfferWithAddressResponseModel,
-  OfferStatus,
-} from '@/apiClient/v1'
+import { OfferStatus } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { FORMAT_DD_MM_YYYY_HH_mm } from '@/commons/utils/date'
 import { getDepartmentCode } from '@/commons/utils/getDepartmentCode'
 import { formatLocalTimeDateString } from '@/commons/utils/timezone'

--- a/pro/src/components/OfferAppPreview/OfferAppPreview.tsx
+++ b/pro/src/components/OfferAppPreview/OfferAppPreview.tsx
@@ -1,4 +1,4 @@
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { getIndividualOfferImage } from '@/commons/core/Offers/utils/getIndividualOfferImage'
 import { truncateAtWord } from '@/commons/utils/string'
 import { Markdown } from '@/components/Markdown/Markdown'

--- a/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/IndividualOfferConfirmation.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/IndividualOfferConfirmation.spec.tsx
@@ -1,11 +1,11 @@
 import { screen, waitFor } from '@testing-library/react'
 import { Route, Routes } from 'react-router'
 
-import { api } from '@/apiClient/api'
+import { apiNew } from '@/apiClient/api'
 import {
   type GetIndividualOfferWithAddressResponseModel,
   OfferStatus,
-} from '@/apiClient/v1'
+} from '@/apiClient/v1/new'
 import {
   IndividualOfferContext,
   type IndividualOfferContextValues,
@@ -102,7 +102,7 @@ describe('IndividualOfferConfirmation', () => {
     contextOverride = {
       offer: offer,
     }
-    vi.spyOn(api, 'getOffer').mockResolvedValue(
+    vi.spyOn(apiNew, 'getOffer').mockResolvedValue(
       {} as GetIndividualOfferWithAddressResponseModel
     )
     vi.mocked(getOfferEnhancementCardsVisibility).mockReturnValue({

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/commons/__specs__/utils.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/commons/__specs__/utils.spec.tsx
@@ -489,7 +489,9 @@ describe('getFormReadOnlyFields', () => {
 describe('getAccessibilityFormValuesFromOffer', () => {
   it('should coerce all flags to false and set none as true when flags are all false, null or undefined', () => {
     const offer = getIndividualOfferFactory({
-      audioDisabilityCompliant: undefined,
+      // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+      // @ts-expect-error
+      audioDisabilityCompliant: null,
       mentalDisabilityCompliant: undefined,
       motorDisabilityCompliant: false,
       visualDisabilityCompliant: false,

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/IndividualOfferDescriptionScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/IndividualOfferDescriptionScreen.tsx
@@ -15,6 +15,7 @@ import {
   INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
   OFFER_WIZARD_MODE,
 } from '@/commons/core/Offers/constants'
+import type { OfferExtraData } from '@/commons/core/Offers/types'
 import { getIndividualOfferImage } from '@/commons/core/Offers/utils/getIndividualOfferImage'
 import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
 import { isOfferDisabled } from '@/commons/core/Offers/utils/isOfferDisabled'
@@ -65,6 +66,7 @@ export const IndividualOfferDescriptionScreen = () => {
     hasPublishedOfferWithSameEan,
   } = useIndividualOfferContext()
   const initialOfferImage = getIndividualOfferImage(initialOffer)
+  const extraData = initialOffer?.extraData as OfferExtraData | undefined
   const { handleEanImage } = useIndividualOfferImageUpload(initialOfferImage)
 
   const isNewOfferDraft = !initialOffer
@@ -264,7 +266,7 @@ export const IndividualOfferDescriptionScreen = () => {
       {isEanSearchInputDisplayed && (
         <DetailsEanSearch
           isDraftOffer={isNewOfferDraft}
-          initialEan={initialOffer?.extraData?.ean}
+          initialEan={extraData?.ean}
           isProductBased={hasSelectedProduct}
           onEanReset={resetFormAndEanImage}
           onEanSearch={updateProduct}

--- a/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/IndividualOfferLocationScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/IndividualOfferLocationScreen.spec.tsx
@@ -347,6 +347,8 @@ describe('<IndividualOfferLocationScreen />', () => {
       it('should render without error even when url is null', async () => {
         const props = { offer: { ...onlineOffer, url: null } }
 
+        // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+        // @ts-expect-error
         renderIndividualOfferLocationScreen({ props })
 
         expect(

--- a/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/IndividualOfferLocationScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferLocation/components/IndividualOfferLocationScreen.tsx
@@ -3,7 +3,7 @@ import { useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useLocation, useNavigate } from 'react-router'
 
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import {
   INDIVIDUAL_OFFER_WIZARD_STEP_IDS,

--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/IndividualOfferMedia.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/IndividualOfferMedia.spec.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 
-import { api } from '@/apiClient/api'
+import { apiNew } from '@/apiClient/api'
 import { IndividualOfferContextProvider } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import { getIndividualOfferFactory } from '@/commons/utils/factories/individualApiFactories'
 import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
@@ -33,11 +33,11 @@ const renderIndividualOfferMedia = () => {
 
 describe('IndividialOfferMedia', () => {
   beforeEach(() => {
-    vi.spyOn(api, 'getCategories').mockResolvedValue({
+    vi.spyOn(apiNew, 'getCategories').mockResolvedValue({
       categories: [],
       subcategories: [],
     })
-    vi.spyOn(api, 'getOffer').mockResolvedValue(offer)
+    vi.spyOn(apiNew, 'getOffer').mockResolvedValue(offer)
   })
 
   it('should render a spinner until offer is fetched', async () => {

--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/IndividualOfferMedia.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/IndividualOfferMedia.tsx
@@ -1,4 +1,3 @@
-import type { VideoData } from '@/apiClient/v1/new'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import { IndividualOfferLayout } from '@/components/IndividualOfferLayout/IndividualOfferLayout'
 import { Spinner } from '@/ui-kit/Spinner/Spinner'
@@ -16,8 +15,7 @@ const IndividualOfferMedia = (): JSX.Element | null => {
   return (
     <IndividualOfferLayout offer={offer}>
       <VideoUploaderContextProvider
-        // TODO (tpommellet): remove once `IndividualOfferContext` has been migrated to the new offer model
-        initialVideoData={offer.videoData as VideoData}
+        initialVideoData={offer.videoData}
         offerId={offer.id}
       >
         <IndividualOfferMediaScreen offer={offer} />

--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/commons/context/VideoUploaderContext/VideoUploaderContext.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/commons/context/VideoUploaderContext/VideoUploaderContext.tsx
@@ -17,12 +17,12 @@ import type {
 import { noop, noopAsync } from '@/commons/utils/noop'
 
 type VideoUploaderContextValues = {
-  setVideoUrl: Dispatch<SetStateAction<string | undefined>>
+  setVideoUrl: Dispatch<SetStateAction<string | null | undefined>>
   videoData?: VideoData
   handleVideoOnSubmit: () => Promise<GetIndividualOfferWithAddressResponseModel>
   onVideoUpload: (p: onVideoUploadProps) => Promise<void>
   onVideoDelete: () => void
-  videoUrl?: string
+  videoUrl?: string | null
   offerId?: number
 }
 
@@ -114,6 +114,8 @@ export function VideoUploaderContextProvider({
   )
 
   return (
+    // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+    // @ts-expect-error
     <VideoUploaderContext.Provider value={contextValue}>
       {children}
     </VideoUploaderContext.Provider>

--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/IndividualOfferMediaScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/IndividualOfferMediaScreen.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router'
 import { useSWRConfig } from 'swr'
 
 import { getHumanReadableApiError } from '@/apiClient/helpers'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { useAnalytics } from '@/app/App/analytics/firebase'
 import { GET_OFFER_QUERY_KEY } from '@/commons/config/swrQueryKeys'
 import { Events } from '@/commons/core/FirebaseEvents/constants'

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/IndividualOfferPracticalInfos.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/IndividualOfferPracticalInfos.spec.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 
-import { api } from '@/apiClient/api'
+import { api, apiNew } from '@/apiClient/api'
 import { IndividualOfferContextProvider } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import {
   getIndividualOfferFactory,
@@ -39,11 +39,11 @@ const renderIndividualOfferMedia = () => {
 
 describe('IndividialOfferPracticalInfos', () => {
   it('should render a spinner until offer is fetched', async () => {
-    vi.spyOn(api, 'getCategories').mockResolvedValue({
+    vi.spyOn(apiNew, 'getCategories').mockResolvedValue({
       categories: [],
       subcategories: [],
     })
-    vi.spyOn(api, 'getOffer').mockResolvedValue(offer)
+    vi.spyOn(apiNew, 'getOffer').mockResolvedValue(offer)
     vi.spyOn(api, 'getStocks').mockResolvedValue(getStocksResponseFactory({}))
     renderIndividualOfferMedia()
 
@@ -53,8 +53,8 @@ describe('IndividialOfferPracticalInfos', () => {
   })
 
   it('should display the page once the offer is fetched', async () => {
-    vi.spyOn(api, 'getOffer').mockResolvedValue(offer)
-    vi.spyOn(api, 'getCategories').mockResolvedValue({
+    vi.spyOn(apiNew, 'getOffer').mockResolvedValue(offer)
+    vi.spyOn(apiNew, 'getCategories').mockResolvedValue({
       categories: [],
       subcategories: [],
     })

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/getInitialValuesFromOffer.spec.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/__specs__/getInitialValuesFromOffer.spec.ts
@@ -45,6 +45,8 @@ describe('getInitialValuesFromOffer', () => {
           ...offer,
           bookingEmail: undefined,
           bookingAllowedDatetime: undefined,
+          // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+          // @ts-expect-error
           withdrawalType: null,
         },
         nonWithdrawableSubCategory

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/getInitialValuesFromOffer.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/commons/getInitialValuesFromOffer.ts
@@ -1,8 +1,8 @@
 import {
-  type GetIndividualOfferWithAddressResponseModel,
   type SubcategoryResponseModel,
   WithdrawalTypeEnum,
 } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 
 import type { IndividualOfferPracticalInfosFormValues } from './types'
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.tsx
@@ -1,11 +1,11 @@
 import { useFormContext } from 'react-hook-form'
 
 import {
-  type GetIndividualOfferWithAddressResponseModel,
   type GetOfferStockResponseModel,
   SubcategoryIdEnum,
   type SubcategoryResponseModel,
 } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { REIMBURSEMENT_RULES } from '@/commons/core/Finances/constants'
 import { CATEGORY_STATUS } from '@/commons/core/Offers/constants'
 import { isOfferDisabled } from '@/commons/core/Offers/utils/isOfferDisabled'

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosScreen.tsx
@@ -5,10 +5,8 @@ import { useLocation, useNavigate } from 'react-router'
 import { mutate } from 'swr'
 
 import { api } from '@/apiClient/api'
-import type {
-  GetIndividualOfferWithAddressResponseModel,
-  GetOfferStockResponseModel,
-} from '@/apiClient/v1'
+import type { GetOfferStockResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { GET_OFFER_QUERY_KEY } from '@/commons/config/swrQueryKeys'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import {

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/IndividualOfferPriceTable.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/IndividualOfferPriceTable.spec.tsx
@@ -21,7 +21,7 @@ vi.mock('@/apiClient/api', () => ({
 }))
 
 import { api } from '@/apiClient/api'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
 import {
   MOCKED_CATEGORIES,

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/hooks/useSaveOfferPriceTable.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/hooks/useSaveOfferPriceTable.ts
@@ -2,7 +2,7 @@ import type { UseFormReturn } from 'react-hook-form'
 import { useLocation, useNavigate } from 'react-router'
 
 import { isErrorAPIError, serializeApiErrors } from '@/apiClient/helpers'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
   OFFER_WIZARD_MODE,

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/types.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/types.ts
@@ -1,9 +1,9 @@
 import type {
   CreatePriceCategoryModel,
   EditPriceCategoryModel,
-  GetIndividualOfferWithAddressResponseModel,
   GetOfferStockResponseModel,
 } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import type { OFFER_WIZARD_MODE } from '@/commons/core/Offers/constants'
 
 export type PriceTableEntryModel = Partial<

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/utils/makeFieldConstraints.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/utils/makeFieldConstraints.ts
@@ -1,4 +1,4 @@
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { OFFER_WIZARD_MODE } from '@/commons/core/Offers/constants'
 import { getToday, getYearMonthDay, isDateValid } from '@/commons/utils/date'
 import { getDepartmentCode } from '@/commons/utils/getDepartmentCode'

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/utils/saveEventOfferPriceTable.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/utils/saveEventOfferPriceTable.ts
@@ -2,7 +2,7 @@ import type { UseFormReturn } from 'react-hook-form'
 import { mutate } from 'swr'
 
 import { api } from '@/apiClient/api'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   GET_OFFER_QUERY_KEY,
   GET_STOCKS_QUERY_KEY,

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/utils/saveNonEventOfferPriceTable.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/utils/saveNonEventOfferPriceTable.ts
@@ -2,7 +2,7 @@ import type { UseFormReturn } from 'react-hook-form'
 import { mutate } from 'swr'
 
 import { api } from '@/apiClient/api'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   GET_OFFER_QUERY_KEY,
   GET_STOCKS_QUERY_KEY,

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/utils/toFormValues.ts
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/commons/utils/toFormValues.ts
@@ -2,10 +2,10 @@ import { format } from 'date-fns'
 import type { CastOptions } from 'yup'
 
 import type {
-  GetIndividualOfferWithAddressResponseModel,
   GetOfferStockResponseModel,
   PriceCategoryResponseModel,
 } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { FORMAT_ISO_DATE_ONLY, isDateValid } from '@/commons/utils/date'
 import { getDepartmentCode } from '@/commons/utils/getDepartmentCode'
 import { getLocalDepartementDateTimeFromUtc } from '@/commons/utils/timezone'

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/IndividualOfferPriceTableScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/IndividualOfferPriceTableScreen.spec.tsx
@@ -1,10 +1,8 @@
 import { screen } from '@testing-library/react'
 import { axe } from 'vitest-axe'
 
-import type {
-  GetIndividualOfferWithAddressResponseModel,
-  GetOfferStockResponseModel,
-} from '@/apiClient/v1'
+import type { GetOfferStockResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   IndividualOfferContext,
   type IndividualOfferContextValues,

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/IndividualOfferPriceTableScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/IndividualOfferPriceTableScreen.spec.tsx
@@ -205,7 +205,9 @@ describe('<IndividualOfferPriceTableScreen />', () => {
       props: {
         offer: getIndividualOfferFactory({
           subcategoryId: MOCKED_SUBCATEGORY.CAN_BE_DUO.id,
-          lastProvider: undefined,
+          // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+          // @ts-expect-error
+          lastProvider: null,
         }),
       },
     })

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/IndividualOfferPriceTableScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/IndividualOfferPriceTableScreen.tsx
@@ -2,10 +2,8 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useLocation, useNavigate } from 'react-router'
 
-import type {
-  GetIndividualOfferWithAddressResponseModel,
-  GetOfferStockResponseModel,
-} from '@/apiClient/v1'
+import type { GetOfferStockResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import { REIMBURSEMENT_RULES } from '@/commons/core/Finances/constants'
 import {

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/PriceTableForm/PriceTableForm.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/PriceTableForm/PriceTableForm.spec.tsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event'
 import { FormProvider, useForm } from 'react-hook-form'
 import { vi } from 'vitest'
 
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
 import { OfferStatus } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import * as useAnalytics from '@/app/App/analytics/firebase'
 import {
   IndividualOfferContext,

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/PriceTableForm/PriceTableForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/PriceTableForm/PriceTableForm.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { useAnalytics } from '@/app/App/analytics/firebase'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import { Events } from '@/commons/core/FirebaseEvents/constants'

--- a/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
@@ -29,7 +29,7 @@ import {
 import { getIndividualOfferPath } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
 import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { FORMAT_ISO_DATE_ONLY } from '@/commons/utils/date'
-import { getLocationResponseModelV2 } from '@/commons/utils/factories/commonOffersApiFactories'
+import { getLocationResponseModel } from '@/commons/utils/factories/commonOffersApiFactories'
 import {
   getIndividualOfferFactory,
   getOfferManagingOffererFactory,
@@ -674,7 +674,7 @@ describe('IndividualOfferSummaryScreen', () => {
         offer: {
           ...offerBase,
           location: {
-            ...getLocationResponseModelV2({
+            ...getLocationResponseModel({
               label: 'mon adresse',
               city: 'ma ville',
               street: 'ma street',
@@ -687,6 +687,8 @@ describe('IndividualOfferSummaryScreen', () => {
         },
       }
 
+      // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+      // @ts-expect-error
       renderIndividualOfferSummaryScreen({ contextValues, path })
 
       expect(await screen.findByText(/Structure/)).toBeInTheDocument()

--- a/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
@@ -711,7 +711,9 @@ describe('IndividualOfferSummaryScreen', () => {
     it('should render component with new sections and empty address data', async () => {
       contextValuesWithDraftOffer.offer = getIndividualOfferFactory({
         isEvent: true,
-        location: undefined,
+        // TODO (tpommellet) to remove once GetIndividualOfferWithAddressResponseModel is migrated to Pydantic V2
+        // @ts-expect-error
+        location: null,
       })
       const contextValues = {
         offer: {

--- a/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/IndividualOfferSummaryScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/IndividualOfferSummaryScreen.tsx
@@ -6,7 +6,7 @@ import { useSWRConfig } from 'swr'
 
 import { api } from '@/apiClient/api'
 import { getHumanReadableApiError } from '@/apiClient/helpers'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { GET_OFFER_QUERY_KEY } from '@/commons/config/swrQueryKeys'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import {

--- a/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/OfferSection/OfferSection.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/OfferSection/OfferSection.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router'
 
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import {
   CULTURAL_OUTREACH_ALLOWED_ACTIVITIES,

--- a/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/StockSection/StockSection.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/StockSection/StockSection.tsx
@@ -2,7 +2,7 @@ import { useLocation } from 'react-router'
 import useSWR from 'swr'
 
 import { api } from '@/apiClient/api'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   GET_STOCKS_EVENT_STATS_QUERY_KEY,
   GET_STOCKS_QUERY_KEY,

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/IndividualOfferTimetable.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/IndividualOfferTimetable.spec.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from '@testing-library/react'
 
 import { api } from '@/apiClient/api'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   IndividualOfferContext,
   type IndividualOfferContextValues,

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.tsx
@@ -2,11 +2,8 @@ import { type Dispatch, type SetStateAction, useState } from 'react'
 import useSWR, { mutate } from 'swr'
 
 import { api } from '@/apiClient/api'
-import {
-  type EventStockUpdateBodyModel,
-  type GetIndividualOfferWithAddressResponseModel,
-  StocksOrderedBy,
-} from '@/apiClient/v1'
+import { type EventStockUpdateBodyModel, StocksOrderedBy } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { useAnalytics } from '@/app/App/analytics/firebase'
 import {
   GET_OFFER_QUERY_KEY,

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryBookings/components/IndividualOfferSummaryBookingsScreen.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryBookings/components/IndividualOfferSummaryBookingsScreen.spec.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 
 import { api } from '@/apiClient/api'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { IndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import { DEFAULT_PRE_FILTERS } from '@/commons/core/Bookings/constants'
 import {

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryBookings/components/IndividualOfferSummaryBookingsScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryBookings/components/IndividualOfferSummaryBookingsScreen.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import useSWR from 'swr'
 
 import { api } from '@/apiClient/api'
-import type { GetIndividualOfferResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   GET_BOOKINGS_QUERY_KEY,
   GET_EVENT_PRICE_CATEGORIES_AND_SCHEDULES_BY_DATE_QUERY_KEY,
@@ -24,7 +24,7 @@ import { DownloadBookingsModal } from './DownloadBookingsModal/DownloadBookingsM
 import styles from './IndividualOfferSummaryBookingsScreen.module.scss'
 
 interface IndividualOfferSummaryBookingsScreenProps {
-  offer: GetIndividualOfferResponseModel
+  offer: GetIndividualOfferWithAddressResponseModel
 }
 
 export const IndividualOfferSummaryBookingsScreen = ({

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryDetails/components/IndividualOfferSummaryDetailsScreen.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryDetails/components/IndividualOfferSummaryDetailsScreen.spec.tsx
@@ -4,7 +4,7 @@ import { expect } from 'vitest'
 import { DisplayableActivity } from '@/apiClient/v1/new'
 import type { IndividualOfferContextValues } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import { IndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
-import { getLocationResponseModelV2 } from '@/commons/utils/factories/commonOffersApiFactories'
+import { getLocationResponseModel } from '@/commons/utils/factories/commonOffersApiFactories'
 import {
   getIndividualOfferFactory,
   getOfferVenueFactory,
@@ -136,7 +136,7 @@ describe('<IndividualOfferSummaryDetailsScreen />', () => {
       ...offerBase,
       subcategoryId: MOCKED_SUBCATEGORY.NON_EVENT_OFFLINE.id,
       location: {
-        ...getLocationResponseModelV2({
+        ...getLocationResponseModel({
           label: 'mon adresse',
           city: 'ma ville',
           street: 'ma street',
@@ -159,7 +159,7 @@ describe('<IndividualOfferSummaryDetailsScreen />', () => {
       ...offerBase,
       subcategoryId: MOCKED_SUBCATEGORY.NON_EVENT_OFFLINE.id,
       location: {
-        ...getLocationResponseModelV2({
+        ...getLocationResponseModel({
           label: 'mon adresse',
           city: 'ma ville',
           street: 'ma street',

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryDetails/components/IndividualOfferSummaryDetailsScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryDetails/components/IndividualOfferSummaryDetailsScreen.tsx
@@ -1,4 +1,4 @@
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import {
   CULTURAL_OUTREACH_ALLOWED_ACTIVITIES,

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryLocation/components/IndividualOfferSummaryLocationScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryLocation/components/IndividualOfferSummaryLocationScreen.tsx
@@ -1,4 +1,4 @@
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
   OFFER_WIZARD_MODE,

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/components/IndividualOfferSummaryPracticalInfosScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPracticalInfos/components/IndividualOfferSummaryPracticalInfosScreen.tsx
@@ -1,4 +1,4 @@
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
   OFFER_WITHDRAWAL_TYPE_LABELS,

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/IndividualOfferSummaryPriceTable.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/IndividualOfferSummaryPriceTable.spec.tsx
@@ -24,7 +24,7 @@ vi.mock('@/apiClient/api', () => ({
 }))
 
 import { api } from '@/apiClient/api'
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   MOCKED_CATEGORIES,
   MOCKED_SUBCATEGORIES,

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/components/IndividualOfferSummaryPriceTableScreen.spec.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/components/IndividualOfferSummaryPriceTableScreen.spec.tsx
@@ -1,11 +1,8 @@
 import { screen } from '@testing-library/react'
 import { vi } from 'vitest'
 
-import {
-  type GetIndividualOfferWithAddressResponseModel,
-  type GetOfferStockResponseModel,
-  OfferStatus,
-} from '@/apiClient/v1'
+import { type GetOfferStockResponseModel, OfferStatus } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   IndividualOfferContext,
   type IndividualOfferContextValues,

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/components/IndividualOfferSummaryPriceTableScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryPriceTable/components/IndividualOfferSummaryPriceTableScreen.tsx
@@ -1,7 +1,5 @@
-import type {
-  GetIndividualOfferWithAddressResponseModel,
-  GetOfferStockResponseModel,
-} from '@/apiClient/v1'
+import type { GetOfferStockResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { useIndividualOfferContext } from '@/commons/context/IndividualOfferContext/IndividualOfferContext'
 import {
   INDIVIDUAL_OFFER_WIZARD_STEP_IDS,

--- a/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryStocks/components/IndividualOfferSummaryStocksCalendarScreen/IndividualOfferSummaryStocksCalendarScreen.tsx
+++ b/pro/src/pages/IndividualOfferSummary/IndividualOfferSummaryStocks/components/IndividualOfferSummaryStocksCalendarScreen/IndividualOfferSummaryStocksCalendarScreen.tsx
@@ -1,4 +1,4 @@
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import {
   INDIVIDUAL_OFFER_WIZARD_STEP_IDS,
   OFFER_WIZARD_MODE,

--- a/pro/src/pages/IndividualOfferSummary/commons/__specs__/serializer.spec.ts
+++ b/pro/src/pages/IndividualOfferSummary/commons/__specs__/serializer.spec.ts
@@ -1,12 +1,12 @@
 import {
   ArtistType,
   type CategoryResponseModel,
-  type GetIndividualOfferWithAddressResponseModel,
   OfferStatus,
   SubcategoryIdEnum,
   type SubcategoryResponseModel,
   WithdrawalTypeEnum,
 } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { CATEGORY_STATUS } from '@/commons/core/Offers/constants'
 import {
   getIndividualOfferFactory,
@@ -20,19 +20,21 @@ describe('IndividualOfferSummary:serializer', () => {
   let categories: CategoryResponseModel[]
   let subCategoryList: SubcategoryResponseModel[]
 
+  const extraData = {
+    author: 'Offer author',
+    performer: 'Offer performer',
+    ean: '',
+    showSubType: '',
+    showType: '',
+    stageDirector: 'Offer stageDirector',
+    speaker: 'Offer speaker',
+    visa: '',
+  }
+
   beforeEach(() => {
     offer = getIndividualOfferFactory({
       id: 12,
-      extraData: {
-        author: 'Offer author',
-        performer: 'Offer performer',
-        ean: '',
-        showSubType: '',
-        showType: '',
-        stageDirector: 'Offer stageDirector',
-        speaker: 'Offer speaker',
-        visa: '',
-      },
+      extraData,
       bookingEmail: 'booking@email.com',
       bookingContact: 'alfonsoLeBg@exampple.com',
       description: 'Offer description',
@@ -114,7 +116,7 @@ describe('IndividualOfferSummary:serializer', () => {
     offer = {
       ...offer,
       extraData: {
-        ...offer.extraData,
+        ...extraData,
         showType: '400',
         showSubType: '401',
       },

--- a/pro/src/pages/IndividualOfferSummary/commons/serializer.ts
+++ b/pro/src/pages/IndividualOfferSummary/commons/serializer.ts
@@ -1,12 +1,12 @@
 import {
   ArtistType,
   type CategoryResponseModel,
-  type GetIndividualOfferResponseModel,
-  type GetIndividualOfferWithAddressResponseModel,
   type GetMusicTypesResponse,
   type SubcategoryResponseModel,
 } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { showOptionsTree } from '@/commons/core/Offers/categoriesSubTypes'
+import type { OfferExtraData } from '@/commons/core/Offers/types'
 import { isOfferProductBased } from '@/commons/core/Offers/utils/typology'
 
 function stringifyArtist(
@@ -24,8 +24,8 @@ function stringifyArtist(
 }
 
 export function serializeArtist(
-  offer: GetIndividualOfferResponseModel,
-  artistExtraData: string,
+  offer: GetIndividualOfferWithAddressResponseModel,
+  artistExtraData: string | undefined,
   defaultValue: string,
   artistType: ArtistType
 ) {
@@ -39,7 +39,7 @@ export function serializeArtist(
 }
 
 const getMusicData = (
-  offer: GetIndividualOfferResponseModel,
+  offer: GetIndividualOfferWithAddressResponseModel,
   musicTypes?: GetMusicTypesResponse,
   gtl_id?: string
 ): {
@@ -47,6 +47,8 @@ const getMusicData = (
   musicSubTypeName?: string
   gtl_id?: string
 } => {
+  const extraData = offer.extraData as OfferExtraData | undefined
+
   return {
     musicTypeName:
       (musicTypes ?? []).length === 0
@@ -54,12 +56,12 @@ const getMusicData = (
         : musicTypes?.find(
             (item) => item.gtl_id.substring(0, 2) === gtl_id?.substring(0, 2) // Gtl_id is a string of 8 characters, only first 2 are relevant to music genre
           )?.label,
-    gtl_id: offer.extraData?.gtl_id,
+    gtl_id: extraData?.gtl_id,
   }
 }
 
 const serializerOfferSubCategoryFields = (
-  offer: GetIndividualOfferResponseModel,
+  offer: GetIndividualOfferWithAddressResponseModel,
   subCategory?: SubcategoryResponseModel,
   musicTypes?: GetMusicTypesResponse
 ): {
@@ -92,17 +94,19 @@ const serializerOfferSubCategoryFields = (
       durationMinutes: '',
     }
   }
+  const extraData = offer.extraData as OfferExtraData | undefined
+
   const showType = showOptionsTree.find(
-    (item) => item.code === Number.parseInt(offer.extraData?.showType, 10)
+    (item) => item.code === Number.parseInt(extraData?.showType ?? '', 10)
   )
   const showSubType = showType?.children.find(
-    (item) => item.code === Number.parseInt(offer.extraData?.showSubType, 10)
+    (item) => item.code === Number.parseInt(extraData?.showSubType ?? '', 10)
   )
 
   const { musicTypeName, musicSubTypeName, gtl_id } = getMusicData(
     offer,
     musicTypes,
-    offer.extraData?.gtl_id
+    extraData?.gtl_id
   )
 
   const defaultValue = (fieldName: string) =>
@@ -110,13 +114,13 @@ const serializerOfferSubCategoryFields = (
   return {
     author: serializeArtist(
       offer,
-      offer.extraData?.author,
+      extraData?.author,
       defaultValue('author'),
       ArtistType.AUTHOR
     ),
     stageDirector: serializeArtist(
       offer,
-      offer.extraData?.stageDirector,
+      extraData?.stageDirector,
       defaultValue('stageDirector'),
       ArtistType.STAGE_DIRECTOR
     ),
@@ -125,15 +129,15 @@ const serializerOfferSubCategoryFields = (
     gtl_id: gtl_id,
     showTypeName: showType?.label || defaultValue('showType'),
     showSubTypeName: showSubType?.label || defaultValue('showSubType'),
-    speaker: offer.extraData?.speaker || defaultValue('speaker'),
-    visa: offer.extraData?.visa || defaultValue('visa'),
+    speaker: extraData?.speaker || defaultValue('speaker'),
+    visa: extraData?.visa || defaultValue('visa'),
     performer: serializeArtist(
       offer,
-      offer.extraData?.performer,
+      extraData?.performer,
       defaultValue('performer'),
       ArtistType.PERFORMER
     ),
-    ean: offer.extraData?.ean || defaultValue('ean'),
+    ean: extraData?.ean || defaultValue('ean'),
     durationMinutes:
       offer.durationMinutes?.toString() || defaultValue('durationMinutes'),
   }

--- a/pro/src/pages/IndividualOfferWizard/IndividualOfferTitle/IndividualOfferTitle.tsx
+++ b/pro/src/pages/IndividualOfferWizard/IndividualOfferTitle/IndividualOfferTitle.tsx
@@ -1,4 +1,4 @@
-import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1'
+import type { GetIndividualOfferWithAddressResponseModel } from '@/apiClient/v1/new'
 import { OFFER_WIZARD_MODE } from '@/commons/core/Offers/constants'
 
 import styles from './IndividualOfferTitle.module.scss'


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41433)

### premier commit : revert d'une partie de [cette PR](https://github.com/pass-culture/pass-culture-main/pull/23016) : 
j'avais en effet passé certains types de `null` à `undefined` pour éviter des erreurs ts, mais en fait les types sont valides. Les erreurs disparaîtront lorsque les modèles backend seront migrés vers pydantic v2

### deuxième commit : migration de `IndividualOfferContext`
**la migration modifie le modèle `GetIndividualOfferWithAddressResponseModel` passée** à TOUS les composants du parcours `IndividualOffers`, d'où les nombreux changements. Ça se passe plutôt bien à part : 
- pour les `extradata` qui sont **typées** `unknown` dans le nouveau modèle => j'ai créé un typage spécifique dans le front pour accéder aux différentes propriétés sans erreur **TypeScript**.
- pour la disparition du type `null` sur les paramètres optionnels du modèle : j'ai commenté les erreurs typescripts associées, elles disparaîtront lorsque le modèle backend aura été migré vers pydantic V2.


