### PR TITLE
(PC-42304)[PRO] refactor: split IndividualVenuePage from VenueEdition

### DIFF
--- a/pro/src/app/AppRouter/routes/venuePageRouteSubgroup.tsx
+++ b/pro/src/app/AppRouter/routes/venuePageRouteSubgroup.tsx
@@ -1,0 +1,20 @@
+import { withUserPermissions } from '@/commons/auth/withUserPermissions'
+import { VenuePageLayout } from '@/layouts/VenuePageLayout/VenuePageLayouts'
+
+import type { CustomRouteGroup } from '../types'
+import { mustBeOnboardedWithSelectedPartnerVenue } from '../utils'
+
+export const venuePageRouteSubgroup: CustomRouteGroup = {
+  path: '/partenaire',
+  loader: withUserPermissions(mustBeOnboardedWithSelectedPartnerVenue),
+  Component: VenuePageLayout,
+  children: [
+    {
+      path: 'page-partenaire',
+      lazy: () => import('@/pages/IndividualVenuePage/IndividualVenuePage'),
+      handle: {
+        title: 'Page sur l’application',
+      },
+    },
+  ],
+}

--- a/pro/src/app/AppRouter/routes/venueSettingsRouteSubgroup.tsx
+++ b/pro/src/app/AppRouter/routes/venueSettingsRouteSubgroup.tsx
@@ -6,7 +6,7 @@ import { VenueSettings } from '@/pages/VenueSettings/VenueSettings'
 import type { CustomRouteGroup } from '../types'
 import { mustHaveSelectedPartnerVenue } from '../utils'
 
-export const settingsRouteGroup: CustomRouteGroup = {
+export const venueSettingsRouteSubgroup: CustomRouteGroup = {
   path: '/parametres',
   loader: withUserPermissions(mustHaveSelectedPartnerVenue),
   handle: {

--- a/pro/src/app/AppRouter/routesMap.tsx
+++ b/pro/src/app/AppRouter/routesMap.tsx
@@ -11,7 +11,8 @@ import { parse } from '@/commons/utils/query-string'
 
 import { administrationRouteGroup } from './routes/administrationRouteGroup'
 import { partnerRouteGroup } from './routes/partnerRouteGroup'
-import { settingsRouteGroup } from './routes/settingsRouteGroup'
+import { venuePageRouteSubgroup } from './routes/venuePageRouteSubgroup'
+import { venueSettingsRouteSubgroup } from './routes/venueSettingsRouteSubgroup'
 import { routesEcoDesign } from './subroutesEcoDesignMap'
 import {
   routesIndividualOfferWizard,
@@ -44,7 +45,8 @@ export const routes: CustomRouteTree = [
   },
   administrationRouteGroup,
   partnerRouteGroup,
-  settingsRouteGroup,
+  venuePageRouteSubgroup,
+  venueSettingsRouteSubgroup,
   {
     lazy: () => import('@/pages/Hub/Hub'),
     loader: withUserPermissions(mustBeAuthenticated),
@@ -123,18 +125,10 @@ export const routes: CustomRouteTree = [
   {
     lazy: () => import('@/pages/VenueEdition/VenueEdition'),
     loader: withUserPermissions(mustBeOnboardedWithSelectedPartnerVenue),
-    path: '/partenaire/page-partenaire',
+    path: '/partenaire/page-partenaire/edition',
     handle: {
-      title: 'Page sur l’application',
+      title: 'Gérer ma page sur l’application',
     },
-    children: [
-      {
-        lazy: () => import('@/pages/VenueEdition/VenueEdition'),
-        loader: withUserPermissions(mustBeOnboardedWithSelectedPartnerVenue),
-        path: '*',
-        title: 'Gérer ma page sur l’application',
-      },
-    ],
   },
   {
     lazy: () => import('@/pages/VenueEdition/VenueEdition'),

--- a/pro/src/commons/utils/__specs__/toStringOrNull.spec.ts
+++ b/pro/src/commons/utils/__specs__/toStringOrNull.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { toStringOrNull } from '../toStringOrNull'
+
+describe('toStringOrNull', () => {
+  it("should trim text when it's non-empty", () => {
+    expect(toStringOrNull(' a word ')).toBe('a word')
+  })
+
+  it('should return null when the text is empty', () => {
+    expect(toStringOrNull('')).toBeNull()
+    expect(toStringOrNull(' ')).toBeNull()
+  })
+
+  it('should return null the text is null', () => {
+    expect(toStringOrNull(null)).toBeNull()
+  })
+
+  it('should return null the text is undefined', () => {
+    expect(toStringOrNull(undefined)).toBeNull()
+  })
+})

--- a/pro/src/commons/utils/toStringOrNull.ts
+++ b/pro/src/commons/utils/toStringOrNull.ts
@@ -1,0 +1,11 @@
+export const toStringOrNull = (
+  text: string | null | undefined
+): string | null => {
+  if (!text) {
+    return null
+  }
+
+  const cleanedText = text.trim()
+
+  return cleanedText || null
+}

--- a/pro/src/layouts/VenuePageLayout/VenuePageLayouts.spec.tsx
+++ b/pro/src/layouts/VenuePageLayout/VenuePageLayouts.spec.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react'
+
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { VenuePageLayout } from './VenuePageLayouts'
+
+vi.mock('@/app/App/layouts/BasicLayout/BasicLayout', () => ({
+  BasicLayout: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+vi.mock('./components/Header', () => ({
+  Header: ({ context }: { context: string }) => (
+    <div data-testid="header">{context}</div>
+  ),
+}))
+
+const renderVenuePageLayout = (path: string) =>
+  renderWithProviders(<VenuePageLayout />, { initialRouterEntries: [path] })
+
+describe('VenuePageLayout', () => {
+  it('should render the partner page context by default', () => {
+    renderVenuePageLayout('/partenaire/page-partenaire')
+
+    expect(screen.getByText(/Page sur l/)).toBeInTheDocument()
+    expect(screen.getByTestId('header')).toHaveTextContent('partnerPage')
+  })
+
+  it('should render the collective context on a collective page', () => {
+    renderVenuePageLayout('/partenaire/page-collective')
+
+    expect(screen.getByText('Page dans ADAGE')).toBeInTheDocument()
+    expect(screen.getByTestId('header')).toHaveTextContent('collective')
+  })
+})

--- a/pro/src/layouts/VenuePageLayout/VenuePageLayouts.tsx
+++ b/pro/src/layouts/VenuePageLayout/VenuePageLayouts.tsx
@@ -1,0 +1,27 @@
+import { Outlet, useLocation } from 'react-router'
+
+import { BasicLayout } from '@/app/App/layouts/BasicLayout/BasicLayout'
+import { MainHeading } from '@/app/App/layouts/components/MainHeading/MainHeading'
+
+import { Header } from './components/Header'
+
+export const VenuePageLayout = () => {
+  const location = useLocation()
+
+  const context = location.pathname.includes('page-collective')
+    ? 'collective'
+    : 'partnerPage'
+  const titleText =
+    context === 'collective' ? 'Page dans ADAGE' : 'Page sur l’application'
+
+  return (
+    <BasicLayout>
+      <MainHeading mainHeading={titleText} />
+      <div>
+        <Header context={context} />
+
+        <Outlet />
+      </div>
+    </BasicLayout>
+  )
+}

--- a/pro/src/layouts/VenuePageLayout/components/Header.module.scss
+++ b/pro/src/layouts/VenuePageLayout/components/Header.module.scss
@@ -1,0 +1,57 @@
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_size.scss" as size;
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-spacing-xl);
+  margin-bottom: var(--size-spacing-xxl);
+
+  @media (min-width: size.$tablet) {
+    flex-direction: row;
+  }
+}
+
+.image-uploader {
+  align-self: center;
+  margin-bottom: 0;
+  width: 100%;
+
+  @media (min-width: size.$tablet) {
+    align-self: flex-start;
+    width: rem.torem(345px);
+
+    &-drag-and-drop {
+      height: rem.torem(230px);
+    }
+  }
+}
+
+.venue-details {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: var(--size-spacing-xl);
+
+  &-links,
+  &-main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-spacing-s);
+  }
+
+  @media (min-width: size.$tablet) {
+    height: rem.torem(230px);
+  }
+}
+
+.venue-type {
+  color: var(--color-text-subtle);
+  text-transform: uppercase;
+}
+
+.venue-name {
+  @include fonts.title2;
+}

--- a/pro/src/layouts/VenuePageLayout/components/Header.spec.tsx
+++ b/pro/src/layouts/VenuePageLayout/components/Header.spec.tsx
@@ -1,0 +1,251 @@
+import { screen, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { forwardRef } from 'react'
+
+import { apiNew } from '@/apiClient/api'
+import * as apiHelpers from '@/apiClient/helpers'
+import {
+  DisplayableActivity,
+  type GetVenueResponseModel,
+} from '@/apiClient/v1/new'
+import * as useAnalytics from '@/app/App/analytics/firebase'
+import { Events } from '@/commons/core/FirebaseEvents/constants'
+import * as useSnackBar from '@/commons/hooks/useSnackBar'
+import { getActivityLabel } from '@/commons/mappings/mappings'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
+import { UploaderModeEnum } from '@/commons/utils/imageUploadTypes'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { Header, type HeaderProps } from './Header'
+
+const bannerMeta = {
+  image_credit: null,
+  original_image_url: 'https://www.example.com/image.png',
+  crop_params: {
+    x_crop_percent: 0,
+    y_crop_percent: 0,
+    width_crop_percent: 0,
+    height_crop_percent: 0,
+  },
+}
+
+vi.mock('@/components/ImageDragAndDrop/getImageDimensions', () => ({
+  getImageDimensions: vi.fn((file) =>
+    Promise.resolve({
+      width: (file as any).width || 0,
+      height: (file as any).height || 0,
+    })
+  ),
+}))
+
+vi.mock('react-avatar-editor', () => {
+  const MockAvatarEditor = forwardRef((_props, _ref) => (
+    <div data-testid="mock-avatar-editor" />
+  ))
+  MockAvatarEditor.displayName = 'MockAvatarEditor'
+  return { __esModule: true, default: MockAvatarEditor }
+})
+
+vi.mock('@/apiClient/helpers', () => ({
+  getFileFromURL: vi.fn(),
+}))
+
+const mockMutate = vi.fn()
+vi.mock('swr', async () => ({
+  ...(await vi.importActual('swr')),
+  useSWRConfig: vi.fn(() => ({ mutate: mockMutate })),
+}))
+
+const mockUseOnVenueImageUpload = vi.hoisted(() => vi.fn())
+vi.mock('@/commons/core/Venue/hooks/useOnVenueImageUpload', () => ({
+  useOnVenueImageUpload: mockUseOnVenueImageUpload,
+}))
+
+const snackBarSuccess = vi.fn()
+const snackBarError = vi.fn()
+
+const renderHeader = (
+  context: HeaderProps['context'] = 'partnerPage',
+  venueOverrides: Partial<GetVenueResponseModel> = {}
+) =>
+  renderWithProviders(<Header context={context} />, {
+    storeOverrides: {
+      user: {
+        currentUser: sharedCurrentUserFactory(),
+        selectedPartnerVenue: makeGetVenueResponseModel({
+          id: 1,
+          ...venueOverrides,
+        }),
+      },
+    },
+  })
+
+describe('Header', () => {
+  beforeEach(async () => {
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    mockUseOnVenueImageUpload.mockReturnValue({
+      imageValues: {},
+      setImageValues: vi.fn(),
+      handleOnImageUpload: vi.fn(),
+    })
+    const snackBarsImport = (await vi.importActual(
+      '@/commons/hooks/useSnackBar'
+    )) as ReturnType<typeof useSnackBar.useSnackBar>
+    vi.spyOn(useSnackBar, 'useSnackBar').mockImplementationOnce(() => ({
+      ...snackBarsImport,
+      success: snackBarSuccess,
+      error: snackBarError,
+    }))
+  })
+
+  it('should display the venue public name and activity label', () => {
+    renderHeader('partnerPage', { activity: DisplayableActivity.FESTIVAL })
+
+    expect(screen.getByText('Nom public de la structure 1')).toBeInTheDocument()
+    expect(
+      screen.getByText(getActivityLabel(DisplayableActivity.FESTIVAL))
+    ).toBeInTheDocument()
+  })
+
+  it('should not display any activity label when the venue has no activity', () => {
+    renderHeader('partnerPage', { activity: null })
+
+    expect(
+      screen.queryByText(getActivityLabel(DisplayableActivity.OTHER))
+    ).not.toBeInTheDocument()
+  })
+
+  it('should display the image uploader when there is no image', () => {
+    renderHeader('partnerPage')
+
+    expect(screen.getByLabelText('Importez une image')).toBeInTheDocument()
+  })
+
+  it('should log an event on image upload', async () => {
+    const user = userEvent.setup()
+    const mockLogEvent = vi.fn()
+    vi.spyOn(useAnalytics, 'useAnalytics').mockImplementationOnce(() => ({
+      logEvent: mockLogEvent,
+    }))
+
+    const mockFile = Object.assign(new File(['fake img'], 'fake_img.jpg'), {
+      width: 100,
+      height: 100,
+    })
+
+    renderHeader('partnerPage')
+
+    await user.upload(screen.getByLabelText('Importez une image'), mockFile)
+
+    await waitFor(() => {
+      expect(mockLogEvent).toHaveBeenCalledWith(Events.DRAG_OR_SELECTED_IMAGE, {
+        imageType: UploaderModeEnum.VENUE,
+        isEdition: true,
+        imageCreationStage: 'add image',
+      })
+    })
+  })
+
+  it('should display the preview link for a permanent venue on the partner page', () => {
+    renderHeader('partnerPage', { isPermanent: true })
+
+    expect(screen.getByText('Visualiser votre page')).toBeInTheDocument()
+  })
+
+  it('should not display the preview link for a non-permanent venue', () => {
+    renderHeader('partnerPage', { isPermanent: false })
+
+    expect(screen.queryByText('Visualiser votre page')).not.toBeInTheDocument()
+  })
+
+  it('should not display the preview link in the collective context', () => {
+    renderHeader('collective', { isPermanent: true })
+
+    expect(screen.queryByText('Visualiser votre page')).not.toBeInTheDocument()
+  })
+
+  it('should display the edit image button when an image is present', () => {
+    mockUseOnVenueImageUpload.mockReturnValueOnce({
+      imageValues: {
+        croppedImageUrl: 'https://www.example.com/image.png',
+        credit: '',
+      },
+      setImageValues: vi.fn(),
+      handleOnImageUpload: vi.fn(),
+    })
+
+    renderHeader('partnerPage', {
+      bannerUrl: 'https://www.example.com/image.png',
+      bannerMeta,
+    })
+
+    expect(screen.getByRole('button', { name: /Modifier/ })).toBeInTheDocument()
+  })
+
+  it('should call the delete endpoint and notify success when deleting the image', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(apiNew, 'deleteVenueBanner').mockResolvedValueOnce()
+    vi.mocked(apiHelpers.getFileFromURL).mockResolvedValueOnce(
+      new File([''], 'mocked_file.jpg', { type: 'image/jpeg' })
+    )
+    mockUseOnVenueImageUpload.mockReturnValueOnce({
+      imageValues: {
+        croppedImageUrl: 'https://www.example.com/image.png',
+        credit: '',
+      },
+      setImageValues: vi.fn(),
+      handleOnImageUpload: vi.fn(),
+    })
+
+    renderHeader('partnerPage', {
+      bannerUrl: 'https://www.example.com/image.png',
+      bannerMeta,
+    })
+
+    await user.click(screen.getByRole('button', { name: /Modifier/ }))
+    await user.click(await screen.findByRole('button', { name: /Supprimer/ }))
+
+    expect(apiNew.deleteVenueBanner).toHaveBeenCalledWith({
+      path: { venue_id: 1 },
+    })
+    await waitFor(() => {
+      expect(snackBarSuccess).toHaveBeenCalledWith(
+        'Votre image a bien été supprimée'
+      )
+    })
+  })
+
+  it('should notify an error when image deletion fails', async () => {
+    const user = userEvent.setup()
+    vi.spyOn(apiNew, 'deleteVenueBanner').mockRejectedValueOnce(
+      'Deletion error'
+    )
+    vi.mocked(apiHelpers.getFileFromURL).mockResolvedValueOnce(
+      new File([''], 'mocked_file.jpg', { type: 'image/jpeg' })
+    )
+    mockUseOnVenueImageUpload.mockReturnValueOnce({
+      imageValues: {
+        croppedImageUrl: 'https://www.example.com/image.png',
+        credit: '',
+      },
+      setImageValues: vi.fn(),
+      handleOnImageUpload: vi.fn(),
+    })
+
+    renderHeader('partnerPage', {
+      bannerUrl: 'https://www.example.com/image.png',
+      bannerMeta,
+    })
+
+    await user.click(screen.getByRole('button', { name: /Modifier/ }))
+    await user.click(await screen.findByRole('button', { name: /Supprimer/ }))
+
+    await waitFor(() => {
+      expect(snackBarError).toHaveBeenCalledWith(
+        "Une erreur est survenue lors de la suppression de l'image"
+      )
+    })
+  })
+})

--- a/pro/src/layouts/VenuePageLayout/components/Header.tsx
+++ b/pro/src/layouts/VenuePageLayout/components/Header.tsx
@@ -1,0 +1,118 @@
+import { apiNew } from '@/apiClient/api'
+import { useAnalytics } from '@/app/App/analytics/firebase'
+import { Events } from '@/commons/core/FirebaseEvents/constants'
+import { useOnVenueImageUpload } from '@/commons/core/Venue/hooks/useOnVenueImageUpload'
+import { buildInitialVenueImageValues } from '@/commons/core/Venue/utils/buildInitialVenueImageValues'
+import { useAppSelector } from '@/commons/hooks/useAppSelector'
+import { useSnackBar } from '@/commons/hooks/useSnackBar'
+import { useSyncVenueCache } from '@/commons/hooks/useSyncVenueCache'
+import { getActivityLabel } from '@/commons/mappings/mappings'
+import { ensureSelectedPartnerVenue } from '@/commons/store/user/selectors'
+import { WEBAPP_URL } from '@/commons/utils/config'
+import { UploaderModeEnum } from '@/commons/utils/imageUploadTypes'
+import { noop } from '@/commons/utils/noop'
+import { ImageDragAndDropUploader } from '@/components/ImageDragAndDropUploader/ImageDragAndDropUploader'
+import { ButtonImageEdit } from '@/components/ImageUploader/components/ButtonImageEdit/ButtonImageEdit'
+import { Button } from '@/design-system/Button/Button'
+import {
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '@/design-system/Button/types'
+
+import styles from './Header.module.scss'
+
+export interface HeaderProps {
+  context: 'collective' | 'partnerPage'
+}
+export const Header = ({ context }: Readonly<HeaderProps>) => {
+  const { logEvent } = useAnalytics()
+  const { syncVenue } = useSyncVenueCache()
+  const selectedPartnerVenue = useAppSelector(ensureSelectedPartnerVenue)
+
+  const snackBar = useSnackBar()
+
+  const { imageValues, setImageValues, handleOnImageUpload } =
+    useOnVenueImageUpload(
+      selectedPartnerVenue.id,
+      selectedPartnerVenue.bannerUrl,
+      selectedPartnerVenue.bannerMeta
+    )
+
+  const handleOnImageDelete = async () => {
+    try {
+      await apiNew.deleteVenueBanner({
+        path: { venue_id: selectedPartnerVenue.id },
+      })
+      setImageValues(buildInitialVenueImageValues(null, null))
+      await syncVenue(selectedPartnerVenue.id)
+
+      snackBar.success('Votre image a bien été supprimée')
+    } catch {
+      snackBar.error(
+        "Une erreur est survenue lors de la suppression de l'image"
+      )
+    }
+  }
+
+  const logButtonAddClick = () => {
+    logEvent(Events.DRAG_OR_SELECTED_IMAGE, {
+      imageType: UploaderModeEnum.VENUE,
+      isEdition: true,
+      imageCreationStage: 'add image',
+    })
+  }
+
+  return (
+    <div className={styles['header']}>
+      <ImageDragAndDropUploader
+        className={styles['image-uploader']}
+        // check-unused-css-disable-next-line
+        dragAndDropClassName={styles['image-uploader-drag-and-drop']}
+        onImageUpload={handleOnImageUpload}
+        onImageDelete={noop}
+        initialValues={imageValues}
+        mode={UploaderModeEnum.VENUE}
+        hideActionButtons
+        onImageDropOrSelected={logButtonAddClick}
+      />
+
+      <div className={styles['venue-details']}>
+        <div className={styles['venue-details-main']}>
+          <div className={styles['venue-type']}>
+            {selectedPartnerVenue.activity &&
+              getActivityLabel(selectedPartnerVenue.activity)}
+          </div>
+          <h2 className={styles['venue-name']}>
+            {selectedPartnerVenue.publicName}
+          </h2>
+        </div>
+
+        <div className={styles['venue-details-links']}>
+          {selectedPartnerVenue.isPermanent && context === 'partnerPage' && (
+            <Button
+              as="a"
+              variant={ButtonVariant.SECONDARY}
+              color={ButtonColor.NEUTRAL}
+              size={ButtonSize.SMALL}
+              to={`${WEBAPP_URL}/lieu/${selectedPartnerVenue.id}`}
+              isExternal
+              opensInNewTab
+              label="Visualiser votre page"
+            />
+          )}
+          {imageValues.croppedImageUrl && (
+            <ButtonImageEdit
+              mode={UploaderModeEnum.VENUE}
+              initialValues={imageValues}
+              onImageUpload={handleOnImageUpload}
+              onImageDelete={handleOnImageDelete}
+              onClickButtonImage={logButtonAddClick}
+              label="Modifier l’image"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/pro/src/pages/IndividualVenuePage/IndividualVenuePage.module.scss
+++ b/pro/src/pages/IndividualVenuePage/IndividualVenuePage.module.scss
@@ -1,0 +1,3 @@
+.page-status {
+  margin-bottom: var(--size-spacing-xxl);
+}

--- a/pro/src/pages/IndividualVenuePage/IndividualVenuePage.spec.tsx
+++ b/pro/src/pages/IndividualVenuePage/IndividualVenuePage.spec.tsx
@@ -1,0 +1,55 @@
+import { screen } from '@testing-library/react'
+import type { SWRResponse } from 'swr'
+
+import type { GetVenueResponseModel } from '@/apiClient/v1/new'
+import * as useEducationalDomainsModule from '@/commons/hooks/swr/useEducationalDomains'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { IndividualVenuePage } from './IndividualVenuePage'
+
+const renderIndividualVenuePage = (
+  venueOverrides: Partial<GetVenueResponseModel> = {}
+) =>
+  renderWithProviders(<IndividualVenuePage />, {
+    storeOverrides: {
+      user: {
+        currentUser: sharedCurrentUserFactory(),
+        selectedPartnerVenue: makeGetVenueResponseModel({
+          id: 1,
+          ...venueOverrides,
+        }),
+      },
+    },
+  })
+
+describe('IndividualVenuePage', () => {
+  beforeEach(() => {
+    vi.spyOn(
+      useEducationalDomainsModule,
+      'useEducationalDomains'
+    ).mockReturnValue({ isLoading: false, data: [] } as SWRResponse)
+  })
+
+  it('should warn that the page is invisible when a permanent venue with offers has no active individual offer', () => {
+    renderIndividualVenuePage({
+      isPermanent: true,
+      hasOffers: true,
+      hasActiveIndividualOffer: false,
+    })
+
+    expect(screen.getByText('Page invisible')).toBeVisible()
+    expect(screen.getByText('Vos informations')).toBeVisible()
+  })
+
+  it('should not warn when the venue has an active individual offer', () => {
+    renderIndividualVenuePage({
+      isPermanent: true,
+      hasOffers: true,
+      hasActiveIndividualOffer: true,
+    })
+
+    expect(screen.queryByText('Page invisible')).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/IndividualVenuePage/IndividualVenuePage.tsx
+++ b/pro/src/pages/IndividualVenuePage/IndividualVenuePage.tsx
@@ -1,0 +1,34 @@
+import { useAppSelector } from '@/commons/hooks/useAppSelector'
+import { ensureSelectedPartnerVenue } from '@/commons/store/user/selectors'
+import { Banner, BannerVariants } from '@/design-system/Banner/Banner'
+
+import { IndividualVenuePageScreen } from './components/IndividualVenuePageScreen'
+import styles from './IndividualVenuePage.module.scss'
+
+export const IndividualVenuePage = () => {
+  const selectedPartnerVenue = useAppSelector(ensureSelectedPartnerVenue)
+
+  const shouldDisplayAccessToPageWarning =
+    selectedPartnerVenue.isPermanent &&
+    selectedPartnerVenue.hasOffers &&
+    !selectedPartnerVenue.hasActiveIndividualOffer
+
+  return (
+    <>
+      {shouldDisplayAccessToPageWarning && (
+        <div className={styles['page-status']}>
+          <Banner
+            title="Page invisible"
+            description="Publiez une offre pour rendre votre page accessible aux jeunes dans l'application."
+            variant={BannerVariants.WARNING}
+          />
+        </div>
+      )}
+
+      <IndividualVenuePageScreen />
+    </>
+  )
+}
+
+// Lazy-loaded by react-router
+export const Component = IndividualVenuePage

--- a/pro/src/pages/IndividualVenuePage/components/AccessibilityCallout.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/AccessibilityCallout.tsx
@@ -1,0 +1,44 @@
+import { useAppSelector } from '@/commons/hooks/useAppSelector'
+import { ensureSelectedPartnerVenue } from '@/commons/store/user/selectors'
+import { Banner } from '@/design-system/Banner/Banner'
+import fullLinkIcon from '@/icons/full-link.svg'
+
+export const AccessibilityCallout = () => {
+  const selectedPartnerVenue = useAppSelector(ensureSelectedPartnerVenue)
+
+  const isAccessibilityDefinedViaAccesLibre =
+    !!selectedPartnerVenue.externalAccessibilityId
+
+  const callout = isAccessibilityDefinedViaAccesLibre
+    ? {
+        label: 'Éditer sur acceslibre',
+        href: `https://acceslibre.beta.gouv.fr/contrib/edit-infos/${selectedPartnerVenue.externalAccessibilityId}/`,
+        content:
+          "Ces modalités proviennent d'acceslibre.gouv.fr et peuvent être modifiées directement sur cette plateforme.",
+        title: 'Données Acceslibre',
+      }
+    : {
+        label: 'Aller sur acceslibre.beta.gouv.fr',
+        href: 'https://acceslibre.beta.gouv.fr/',
+        content:
+          "Complétez les modalités d'accessibilité de votre établissement sur acceslibre.beta.gouv.fr, la plateforme collaborative de l'accessibilité.",
+        title: "Renseignez l'accessibilité",
+      }
+
+  return (
+    <Banner
+      title={callout.title}
+      actions={[
+        {
+          href: callout.href,
+          label: callout.label,
+          isExternal: true,
+          icon: fullLinkIcon,
+          iconAlt: 'Nouvelle fenêtre',
+          type: 'link',
+        },
+      ]}
+      description={callout.content}
+    />
+  )
+}

--- a/pro/src/pages/IndividualVenuePage/components/AccessibilitySubSection.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/AccessibilitySubSection.tsx
@@ -1,0 +1,40 @@
+import { useAppSelector } from '@/commons/hooks/useAppSelector'
+import { ensureSelectedPartnerVenue } from '@/commons/store/user/selectors'
+import { AccessibilitySummarySection as InternalAccessibilitySummarySection } from '@/components/AccessibilitySummarySection/AccessibilitySummarySection'
+import { ExternalAccessibility } from '@/components/ExternalAccessibility/ExternalAccessibility'
+import { SummarySubSection } from '@/ui-kit/SummaryLayout/SummarySubSection'
+
+import { AccessibilityCallout } from './AccessibilityCallout'
+
+export const AccessibilitySubSection = () => {
+  const selectedPartnerVenue = useAppSelector(ensureSelectedPartnerVenue)
+
+  // TODO (igabriele, 2025-07-16): Use `getAccessibilityInfoFromVenue()` common util rather than inlining domain rules.
+  if (!selectedPartnerVenue.externalAccessibilityData) {
+    return (
+      <InternalAccessibilitySummarySection
+        callout={
+          selectedPartnerVenue.isPermanent ? <AccessibilityCallout /> : null
+        }
+        accessibleItem={selectedPartnerVenue}
+        accessibleWording="Votre établissement est accessible aux publics en situation de handicap :"
+        shouldShowDivider={false}
+        isSubSubSection
+      />
+    )
+  }
+
+  return (
+    <SummarySubSection
+      title="Modalités d’accessibilité via acceslibre"
+      shouldShowDivider={false}
+    >
+      <ExternalAccessibility
+        externalAccessibilityId={selectedPartnerVenue.externalAccessibilityId}
+        externalAccessibilityData={
+          selectedPartnerVenue.externalAccessibilityData
+        }
+      />
+    </SummarySubSection>
+  )
+}

--- a/pro/src/pages/IndividualVenuePage/components/ActivitySubSection.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/ActivitySubSection.tsx
@@ -1,0 +1,51 @@
+import { useEducationalDomains } from '@/commons/hooks/swr/useEducationalDomains'
+import { useAppSelector } from '@/commons/hooks/useAppSelector'
+import { getActivityLabel } from '@/commons/mappings/mappings'
+import { ensureSelectedPartnerVenue } from '@/commons/store/user/selectors'
+import { pluralizeFr } from '@/commons/utils/pluralize'
+import { toStringOrNull } from '@/commons/utils/toStringOrNull'
+import { SummaryDescriptionList } from '@/ui-kit/SummaryLayout/SummaryDescriptionList'
+import { SummarySubSection } from '@/ui-kit/SummaryLayout/SummarySubSection'
+
+import { mapVenueDomains } from '../utils/mapVenueDomains'
+
+export const ActivitySubSection = () => {
+  const { data: educationalDomains } = useEducationalDomains()
+  const selectedPartnerVenue = useAppSelector(ensureSelectedPartnerVenue)
+
+  const venueDomains = mapVenueDomains(selectedPartnerVenue, educationalDomains)
+
+  return (
+    <SummarySubSection
+      title="À propos de votre activité"
+      shouldShowDivider={false}
+    >
+      <SummaryDescriptionList
+        descriptions={[
+          ...(selectedPartnerVenue.activity
+            ? [
+                {
+                  title: 'Activité',
+                  text: getActivityLabel(selectedPartnerVenue.activity),
+                },
+              ]
+            : []),
+          {
+            title: pluralizeFr(
+              venueDomains.length,
+              'Domaine d’activité',
+              'Domaines d’activité'
+            ),
+            text: venueDomains.join(', '),
+          },
+          {
+            title: 'Description',
+            text:
+              toStringOrNull(selectedPartnerVenue.description) ??
+              'Non renseignée',
+          },
+        ]}
+      />
+    </SummarySubSection>
+  )
+}

--- a/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/AddressAndOpeningHourSubSection.module.scss
+++ b/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/AddressAndOpeningHourSubSection.module.scss
@@ -1,0 +1,4 @@
+.opening-hours-address {
+  display: block;
+  margin-bottom: var(--size-spacing-s);
+}

--- a/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/AddressAndOpeningHourSubSection.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/AddressAndOpeningHourSubSection.tsx
@@ -1,0 +1,26 @@
+import type { LocationResponseModelV2 } from '@/apiClient/v1'
+import type { GetVenueResponseModel } from '@/apiClient/v1/new'
+import { getFormattedAddress } from '@/commons/utils/getFormattedAddress'
+import { SummarySubSection } from '@/ui-kit/SummaryLayout/SummarySubSection'
+
+import styles from './AddressAndOpeningHourSubSection.module.scss'
+import { OpeningHours } from './OpeningHours'
+
+interface OpeningHoursAndAddressSubSectionProps {
+  address: LocationResponseModelV2
+  openingHours: GetVenueResponseModel['openingHours']
+}
+export function AddressAndOpeningHourSubSection({
+  address,
+  openingHours,
+}: Readonly<OpeningHoursAndAddressSubSectionProps>) {
+  return (
+    <SummarySubSection title="Adresse et horaires" shouldShowDivider={false}>
+      <span className={styles['opening-hours-address']}>
+        {`Adresse : ${getFormattedAddress(address)}`}
+      </span>
+
+      <OpeningHours openingHours={openingHours} />
+    </SummarySubSection>
+  )
+}

--- a/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/OpeningHours.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/OpeningHours.tsx
@@ -1,0 +1,47 @@
+import type {
+  GetVenueResponseModel,
+  WeekdayOpeningHoursTimespans,
+} from '@/apiClient/v1/new'
+import { mapDayToFrench, OPENING_HOURS_DAYS } from '@/commons/utils/date'
+import { areOpeningHoursEmpty } from '@/pages/VenueEdition/commons/areOpeningHoursEmpty'
+import { SummaryDescriptionList } from '@/ui-kit/SummaryLayout/SummaryDescriptionList'
+
+import { OpeningHoursRow } from './OpeningHoursRow'
+
+interface OpeningHoursProps {
+  openingHours: GetVenueResponseModel['openingHours']
+}
+export const OpeningHours = ({ openingHours }: Readonly<OpeningHoursProps>) => {
+  const orderedFilledDays = OPENING_HOURS_DAYS.map((d) => ({
+    day: d,
+    openingHours: openingHours?.[d],
+  })) satisfies {
+    day: string
+    openingHours: WeekdayOpeningHoursTimespans['MONDAY']
+  }[]
+
+  if (areOpeningHoursEmpty(openingHours)) {
+    return (
+      <span>
+        Horaires : Vos horaires d’ouverture ne sont pas affichées sur
+        l'application car votre établissement est indiqué comme fermé tous les
+        jours.
+      </span>
+    )
+  }
+
+  return (
+    <SummaryDescriptionList
+      descriptions={orderedFilledDays
+        .filter((d) => Boolean(d.openingHours))
+        .map((dateAndHour) => {
+          return {
+            title: mapDayToFrench(dateAndHour.day),
+            text: (
+              <OpeningHoursRow openingHoursForDay={dateAndHour.openingHours} />
+            ),
+          }
+        })}
+    />
+  )
+}

--- a/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/OpeningHoursRow.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/OpeningHoursRow.tsx
@@ -1,0 +1,22 @@
+interface OpeningHoursRowProps {
+  openingHoursForDay: string[][] | null | undefined
+}
+export const OpeningHoursRow = ({
+  openingHoursForDay,
+}: Readonly<OpeningHoursRowProps>) => {
+  if (!openingHoursForDay || openingHoursForDay.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      {openingHoursForDay[0][0]}-{openingHoursForDay[0][1]}
+      {openingHoursForDay.length > 1 && (
+        <>
+          {' '}
+          et {openingHoursForDay[1][0]}-{openingHoursForDay[1][1]}
+        </>
+      )}
+    </>
+  )
+}

--- a/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/__specs__/AddressAndOpeningHourSubSection.spec.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/__specs__/AddressAndOpeningHourSubSection.spec.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+
+import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
+
+import { AddressAndOpeningHourSubSection } from '../AddressAndOpeningHourSubSection'
+
+const location = makeGetVenueResponseModel({
+  id: 1,
+  location: {
+    ...makeGetVenueResponseModel({ id: 1 }).location,
+    street: '1 rue de Paris',
+    postalCode: '75001',
+    city: 'Paris',
+  },
+}).location
+
+describe('AddressAndOpeningHourSubSection', () => {
+  it('should display the formatted address', () => {
+    render(
+      <AddressAndOpeningHourSubSection address={location} openingHours={null} />
+    )
+
+    expect(
+      screen.getByText('Adresse : 1 rue de Paris, 75001 Paris')
+    ).toBeInTheDocument()
+  })
+
+  it('should render the opening hours', () => {
+    render(
+      <AddressAndOpeningHourSubSection
+        address={location}
+        openingHours={{ MONDAY: [['09:00', '12:00']] }}
+      />
+    )
+
+    expect(screen.getByText(/Lundi/)).toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/__specs__/OpeningHours.spec.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/__specs__/OpeningHours.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+
+import { OpeningHours } from '../OpeningHours'
+
+describe('OpeningHours', () => {
+  it('should display the closed-all-days message when there are no opening hours', () => {
+    render(<OpeningHours openingHours={null} />)
+
+    expect(screen.getByText(/fermé tous les jours/)).toBeInTheDocument()
+  })
+
+  it('should display the closed-all-days message when every day is empty', () => {
+    render(<OpeningHours openingHours={{ MONDAY: [], SUNDAY: null }} />)
+
+    expect(screen.getByText(/fermé tous les jours/)).toBeInTheDocument()
+  })
+
+  it('should only list the days that have opening hours, in order', () => {
+    const { container } = render(
+      <OpeningHours
+        openingHours={{
+          MONDAY: [['09:00', '12:00']],
+          WEDNESDAY: [
+            ['10:00', '13:00'],
+            ['14:00', '19:00'],
+          ],
+          SUNDAY: null,
+        }}
+      />
+    )
+
+    expect(screen.getByText(/Lundi/)).toBeInTheDocument()
+    expect(screen.getByText(/Mercredi/)).toBeInTheDocument()
+    expect(container).toHaveTextContent('09:00-12:00')
+    expect(container).toHaveTextContent('10:00-13:00 et 14:00-19:00')
+
+    expect(screen.queryByText(/Dimanche/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Mardi/)).not.toBeInTheDocument()
+  })
+})

--- a/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/__specs__/OpeningHoursRow.spec.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/AddressAndOpeningHourSubSection/__specs__/OpeningHoursRow.spec.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+
+import { OpeningHoursRow } from '../OpeningHoursRow'
+
+describe('OpeningHoursRow', () => {
+  it('should render nothing when the day is null', () => {
+    const { container } = render(<OpeningHoursRow openingHoursForDay={null} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should render nothing when the day has no timespan', () => {
+    const { container } = render(<OpeningHoursRow openingHoursForDay={[]} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should render a single timespan', () => {
+    const { container } = render(
+      <OpeningHoursRow openingHoursForDay={[['09:00', '12:00']]} />
+    )
+
+    expect(container).toHaveTextContent('09:00-12:00')
+    expect(screen.queryByText(/et/)).not.toBeInTheDocument()
+  })
+
+  it('should render two timespans separated by "et"', () => {
+    const { container } = render(
+      <OpeningHoursRow
+        openingHoursForDay={[
+          ['09:00', '12:00'],
+          ['14:00', '18:00'],
+        ]}
+      />
+    )
+
+    expect(container).toHaveTextContent('09:00-12:00 et 14:00-18:00')
+  })
+})

--- a/pro/src/pages/IndividualVenuePage/components/IndividualVenuePageScreen.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/IndividualVenuePageScreen.tsx
@@ -1,0 +1,92 @@
+import { useAppSelector } from '@/commons/hooks/useAppSelector'
+import { ensureSelectedPartnerVenue } from '@/commons/store/user/selectors'
+import { formatPhoneNumber } from '@/commons/utils/formatPhoneNumber'
+import { toStringOrNull } from '@/commons/utils/toStringOrNull'
+import { SummaryDescriptionList } from '@/ui-kit/SummaryLayout/SummaryDescriptionList'
+import { SummarySection } from '@/ui-kit/SummaryLayout/SummarySection'
+import { SummarySubSection } from '@/ui-kit/SummaryLayout/SummarySubSection'
+
+import { AccessibilitySubSection } from './AccessibilitySubSection'
+import { ActivitySubSection } from './ActivitySubSection'
+import { AddressAndOpeningHourSubSection } from './AddressAndOpeningHourSubSection/AddressAndOpeningHourSubSection'
+
+export const IndividualVenuePageScreen = () => {
+  const selectedPartnerVenue = useAppSelector(ensureSelectedPartnerVenue)
+
+  return (
+    <SummarySection
+      title="Vos informations"
+      editLink="/partenaire/page-partenaire/edition"
+    >
+      <ActivitySubSection />
+
+      {selectedPartnerVenue.isOpenToPublic && (
+        <>
+          <AddressAndOpeningHourSubSection
+            openingHours={selectedPartnerVenue.openingHours}
+            address={selectedPartnerVenue.location}
+          />
+          <AccessibilitySubSection />
+        </>
+      )}
+
+      <SummarySubSection
+        title="Informations de retrait de vos offres"
+        shouldShowDivider={false}
+      >
+        <SummaryDescriptionList
+          descriptions={[
+            {
+              title: 'Informations de retrait',
+              text:
+                toStringOrNull(selectedPartnerVenue.withdrawalDetails) ??
+                'Non renseignée',
+            },
+          ]}
+        />
+      </SummarySubSection>
+
+      <SummarySubSection title="Bénévolat" shouldShowDivider={false}>
+        <SummaryDescriptionList
+          descriptions={[
+            {
+              title: 'Lien vers votre page organisation JeVeuxAider.gouv.fr',
+              text:
+                toStringOrNull(selectedPartnerVenue.volunteeringUrl) ??
+                'Non renseigné',
+            },
+          ]}
+        />
+      </SummarySubSection>
+
+      <SummarySubSection
+        title="Informations de contact"
+        shouldShowDivider={false}
+      >
+        <SummaryDescriptionList
+          descriptions={[
+            {
+              title: 'Téléphone',
+              text:
+                toStringOrNull(
+                  formatPhoneNumber(selectedPartnerVenue.contact?.phoneNumber)
+                ) ?? 'Non renseigné',
+            },
+            {
+              title: 'Adresse e-mail',
+              text:
+                toStringOrNull(selectedPartnerVenue.contact?.email) ??
+                'Non renseignée',
+            },
+            {
+              title: 'URL de votre site web',
+              text:
+                toStringOrNull(selectedPartnerVenue.contact?.website) ??
+                'Non renseignée',
+            },
+          ]}
+        />
+      </SummarySubSection>
+    </SummarySection>
+  )
+}

--- a/pro/src/pages/IndividualVenuePage/components/__specs__/AccessibilityCallout.spec.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/__specs__/AccessibilityCallout.spec.tsx
@@ -1,0 +1,46 @@
+import { screen } from '@testing-library/react'
+
+import type { GetVenueResponseModel } from '@/apiClient/v1/new'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { AccessibilityCallout } from '../AccessibilityCallout'
+
+const renderAccessibilityCallout = (
+  venueOverrides: Partial<GetVenueResponseModel> = {}
+) =>
+  renderWithProviders(<AccessibilityCallout />, {
+    storeOverrides: {
+      user: {
+        currentUser: sharedCurrentUserFactory(),
+        selectedPartnerVenue: makeGetVenueResponseModel({
+          id: 1,
+          ...venueOverrides,
+        }),
+      },
+    },
+  })
+
+describe('AccessibilityCallout', () => {
+  it('should invite to fill in accessibility when none is defined via acceslibre', () => {
+    renderAccessibilityCallout({ externalAccessibilityId: null })
+
+    expect(screen.getByText(/Renseignez/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Aller sur acceslibre\.beta\.gouv\.fr/ })
+    ).toHaveAttribute('href', 'https://acceslibre.beta.gouv.fr/')
+  })
+
+  it('should link to the acceslibre edition page when accessibility is defined via acceslibre', () => {
+    renderAccessibilityCallout({ externalAccessibilityId: 'slug-123' })
+
+    expect(screen.getByText('Données Acceslibre')).toBeInTheDocument()
+    expect(
+      screen.getByRole('link', { name: /Éditer sur acceslibre/ })
+    ).toHaveAttribute(
+      'href',
+      'https://acceslibre.beta.gouv.fr/contrib/edit-infos/slug-123/'
+    )
+  })
+})

--- a/pro/src/pages/IndividualVenuePage/components/__specs__/AccessibilitySubSection.spec.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/__specs__/AccessibilitySubSection.spec.tsx
@@ -1,0 +1,59 @@
+import { screen } from '@testing-library/react'
+
+import type { GetVenueResponseModel } from '@/apiClient/v1/new'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { AccessibilitySubSection } from '../AccessibilitySubSection'
+
+const renderAccessibilitySubSection = (
+  venueOverrides: Partial<GetVenueResponseModel> = {}
+) =>
+  renderWithProviders(<AccessibilitySubSection />, {
+    storeOverrides: {
+      user: {
+        currentUser: sharedCurrentUserFactory(),
+        selectedPartnerVenue: makeGetVenueResponseModel({
+          id: 1,
+          ...venueOverrides,
+        }),
+      },
+    },
+  })
+
+describe('AccessibilitySubSection', () => {
+  it('should display the internal accessibility section when there is no acceslibre data', () => {
+    renderAccessibilitySubSection({ externalAccessibilityData: null })
+
+    expect(screen.getByText('Non accessible')).toBeVisible()
+  })
+
+  it('should display the acceslibre callout for a permanent venue', () => {
+    renderAccessibilitySubSection({
+      externalAccessibilityData: null,
+      isPermanent: true,
+    })
+
+    expect(screen.getByText(/Renseignez/)).toBeVisible()
+  })
+
+  it('should not display the acceslibre callout for a non-permanent venue', () => {
+    renderAccessibilitySubSection({
+      externalAccessibilityData: null,
+      isPermanent: false,
+    })
+
+    expect(screen.queryByText(/Renseignez/)).not.toBeInTheDocument()
+  })
+
+  it('should display the external accessibility section when acceslibre data is present', () => {
+    renderAccessibilitySubSection({
+      externalAccessibilityId: 'slug-123',
+      externalAccessibilityData: { isAccessibleMotorDisability: true },
+    })
+
+    expect(screen.getByText(/Modalités/)).toBeVisible()
+    expect(screen.getByText('Handicap moteur')).toBeVisible()
+  })
+})

--- a/pro/src/pages/IndividualVenuePage/components/__specs__/ActivitySubSection.spec.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/__specs__/ActivitySubSection.spec.tsx
@@ -1,0 +1,69 @@
+import { screen } from '@testing-library/react'
+import type { SWRResponse } from 'swr'
+
+import {
+  DisplayableActivity,
+  type EducationalDomainsResponseModel,
+  type GetVenueResponseModel,
+} from '@/apiClient/v1/new'
+import * as useEducationalDomainsModule from '@/commons/hooks/swr/useEducationalDomains'
+import { getActivityLabel } from '@/commons/mappings/mappings'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { ActivitySubSection } from '../ActivitySubSection'
+
+const mockEducationalDomains = (data: EducationalDomainsResponseModel) => {
+  vi.spyOn(
+    useEducationalDomainsModule,
+    'useEducationalDomains'
+  ).mockReturnValue({ isLoading: false, data } as SWRResponse)
+}
+
+const renderActivitySubSection = (
+  venueOverrides: Partial<GetVenueResponseModel> = {}
+) =>
+  renderWithProviders(<ActivitySubSection />, {
+    storeOverrides: {
+      user: {
+        currentUser: sharedCurrentUserFactory(),
+        selectedPartnerVenue: makeGetVenueResponseModel({
+          id: 1,
+          ...venueOverrides,
+        }),
+      },
+    },
+  })
+
+describe('ActivitySubSection', () => {
+  it('should display the activity, the domains and the description', () => {
+    mockEducationalDomains([{ id: 1, name: 'Danse', nationalPrograms: [] }])
+
+    renderActivitySubSection({
+      activity: DisplayableActivity.CULTURAL_MEDIATION,
+      collectiveDomains: [{ id: 1, name: 'Danse' }],
+      description: 'Ma description',
+    })
+
+    expect(screen.getByText('Médiation culturelle')).toBeVisible()
+    expect(screen.getByText('Danse')).toBeVisible()
+    expect(screen.getByText('Ma description')).toBeVisible()
+  })
+
+  it('should omit the activity and domains rows and fall back to a placeholder description', () => {
+    mockEducationalDomains([])
+
+    renderActivitySubSection({
+      activity: null,
+      collectiveDomains: [],
+      description: null,
+    })
+
+    expect(
+      screen.queryByText(getActivityLabel(DisplayableActivity.OTHER))
+    ).not.toBeInTheDocument()
+    expect(screen.getByText(/Description/)).toBeVisible()
+    expect(screen.getByText('Non renseignée')).toBeVisible()
+  })
+})

--- a/pro/src/pages/IndividualVenuePage/components/__specs__/IndividualVenuePageScreen.spec.tsx
+++ b/pro/src/pages/IndividualVenuePage/components/__specs__/IndividualVenuePageScreen.spec.tsx
@@ -1,0 +1,73 @@
+import { screen } from '@testing-library/react'
+import type { SWRResponse } from 'swr'
+
+import type { GetVenueResponseModel } from '@/apiClient/v1/new'
+import * as useEducationalDomainsModule from '@/commons/hooks/swr/useEducationalDomains'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
+import { formatPhoneNumber } from '@/commons/utils/formatPhoneNumber'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { IndividualVenuePageScreen } from '../IndividualVenuePageScreen'
+
+const renderScreen = (venueOverrides: Partial<GetVenueResponseModel> = {}) =>
+  renderWithProviders(<IndividualVenuePageScreen />, {
+    storeOverrides: {
+      user: {
+        currentUser: sharedCurrentUserFactory(),
+        selectedPartnerVenue: makeGetVenueResponseModel({
+          id: 1,
+          ...venueOverrides,
+        }),
+      },
+    },
+  })
+
+describe('IndividualVenuePageScreen', () => {
+  beforeEach(() => {
+    vi.spyOn(
+      useEducationalDomainsModule,
+      'useEducationalDomains'
+    ).mockReturnValue({ isLoading: false, data: [] } as SWRResponse)
+  })
+
+  it('should display the venue information for an open-to-public venue', () => {
+    renderScreen({
+      isOpenToPublic: true,
+      externalAccessibilityData: null,
+      withdrawalDetails: 'Au comptoir',
+      volunteeringUrl: 'https://benevolat.example.com',
+      openingHours: { MONDAY: [['09:00', '12:00']] },
+      contact: {
+        phoneNumber: '0612345678',
+        email: 'contact@example.com',
+        website: 'https://example.com',
+        socialMedias: null,
+      },
+    })
+
+    expect(screen.getByText('Vos informations')).toBeVisible()
+    expect(screen.getByText(/Adresse :/)).toBeVisible()
+    expect(screen.getByText('Non accessible')).toBeVisible()
+    expect(screen.getByText('Au comptoir')).toBeVisible()
+    expect(screen.getByText('https://benevolat.example.com')).toBeVisible()
+    expect(screen.getByText(formatPhoneNumber('0612345678'))).toBeVisible()
+    expect(screen.getByText('contact@example.com')).toBeVisible()
+    expect(screen.getByText('https://example.com')).toBeVisible()
+  })
+
+  it('should hide the address and accessibility sections and fall back to placeholders when closed to public and without contact', () => {
+    renderScreen({
+      isOpenToPublic: false,
+      withdrawalDetails: null,
+      volunteeringUrl: null,
+      contact: null,
+    })
+
+    expect(screen.queryByText(/Adresse :/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Non accessible')).not.toBeInTheDocument()
+
+    expect(screen.getAllByText('Non renseigné')).toHaveLength(3)
+    expect(screen.getAllByText('Non renseignée')).toHaveLength(3)
+  })
+})

--- a/pro/src/pages/IndividualVenuePage/utils/__specs__/mapVenueDomains.spec.ts
+++ b/pro/src/pages/IndividualVenuePage/utils/__specs__/mapVenueDomains.spec.ts
@@ -1,0 +1,56 @@
+import type { EducationalDomainsResponseModel } from '@/apiClient/v1/new'
+import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
+
+import { mapVenueDomains } from '../mapVenueDomains'
+
+vi.mock('@/commons/errors/handleUnexpectedError', () => ({
+  handleUnexpectedError: vi.fn(),
+}))
+
+const educationalDomains: EducationalDomainsResponseModel = [
+  { id: 1, name: 'Danse', nationalPrograms: [] },
+  { id: 2, name: 'Musique', nationalPrograms: [] },
+]
+
+describe('mapVenueDomains', () => {
+  it('should return null when there is no educational domain at all', () => {
+    const venue = makeGetVenueResponseModel({
+      id: 1,
+      collectiveDomains: [{ id: 1, name: 'Danse' }],
+    })
+
+    expect(mapVenueDomains(venue, [])).toEqual(['Non renseigné'])
+  })
+
+  it('should map venue collective domain ids to their label', () => {
+    const venue = makeGetVenueResponseModel({
+      id: 1,
+      collectiveDomains: [
+        { id: 1, name: 'Danse' },
+        { id: 2, name: 'Musique' },
+      ],
+    })
+
+    expect(mapVenueDomains(venue, educationalDomains)).toEqual([
+      'Danse',
+      'Musique',
+    ])
+  })
+
+  it('should return a placeholder when the venue has no collective domain', () => {
+    const venue = makeGetVenueResponseModel({ id: 1, collectiveDomains: [] })
+
+    expect(mapVenueDomains(venue, educationalDomains)).toEqual([
+      'Non renseigné',
+    ])
+  })
+
+  it('should throw when a venue collective domain is missing from the API list', () => {
+    const venue = makeGetVenueResponseModel({
+      id: 1,
+      collectiveDomains: [{ id: 99, name: 'Inconnu' }],
+    })
+
+    expect(() => mapVenueDomains(venue, educationalDomains)).toThrow()
+  })
+})

--- a/pro/src/pages/IndividualVenuePage/utils/mapVenueDomains.ts
+++ b/pro/src/pages/IndividualVenuePage/utils/mapVenueDomains.ts
@@ -1,0 +1,26 @@
+import type {
+  EducationalDomainsResponseModel,
+  GetVenueResponseModel,
+} from '@/apiClient/v1/new'
+import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
+
+export const mapVenueDomains = (
+  venue: GetVenueResponseModel,
+  educationalDomains: EducationalDomainsResponseModel
+) => {
+  if (educationalDomains.length === 0 || venue.collectiveDomains.length === 0) {
+    return ['Non renseigné']
+  }
+
+  return venue.collectiveDomains.map((domain) => {
+    const apiValue = educationalDomains.find(
+      (educationalDomain) => educationalDomain.id === domain.id
+    )
+    assertOrFrontendError(
+      apiValue,
+      `CulturalDomain with name ${domain.name} not found`
+    )
+
+    return apiValue.name
+  })
+}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42304)

Le plan est de splitter la page `VenueEdition` en 4 pages avec un layout et un groupe commun de routes + aligner les props entre Back et Front pour simplifier la lecture et séparer les concerns :

- [x] `IndividualVenuePage` (cette PR)
- [ ] `CollectiveVenuePage` (future PR)
- [ ] `IndividualVenuePageEdition` (future PR)
- [ ] `CollectiveVenuePageEdition` (future PR)

> [!NOTE]
> Le premier commit est écrit sans les tests pour faciliter la review.
> Le second commit regroupe l'ensemble des tests.

## 🖥️ Preview

https://pc-pro-testing--igabriele-pc-42304-bbspk7w8.web.app/