### PR TITLE
(BSR)[PRO] test: load E2E_API_KEY from .env.local.secret for Playwright

### DIFF
--- a/pro/.gitignore
+++ b/pro/.gitignore
@@ -22,6 +22,7 @@ target.zip
 # misc
 .DS_Store
 .env.local
+.env.local.secret
 .env.development.local
 .env.staging.local
 .env.integration.local

--- a/pro/config/playwright.config.ts
+++ b/pro/config/playwright.config.ts
@@ -1,4 +1,14 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig, devices } from '@playwright/test'
+import dotenv from 'dotenv'
+
+dotenv.config({
+  path: resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../.env.local.secret'
+  ),
+})
 
 const BASE_URL = process.env.BASE_URL ?? 'http://localhost:3001'
 

--- a/pro/e2e/README.md
+++ b/pro/e2e/README.md
@@ -5,6 +5,15 @@
 Les tests E2E sont lancés sur l'app react en local (sur votre machine, et la CI). Il faut donc lancer l'app pro.
 Il faudra aussi lancer pcapi, et vérifier qu'il n'y ait pas d'erreurs lors de l'execution des tests.
 
+### Clé d'API E2E (`E2E_API_KEY`)
+
+Les routes internes de seeding de l'API (`/sandboxes/...`, `/e2e/...`, `/testing/...`) sont protégées par un header `x-api-key`. Les tests Playwright envoient ce header en lisant `process.env.E2E_API_KEY`.
+
+Il faut donc définir la **même valeur** des deux côtés, dans deux fichiers `.env.local.secret` (tous deux sont gitignorés) :
+
+- `api/.env.local.secret` : `E2E_API_KEY="dummysecret"`
+- `pro/.env.local.secret` : `E2E_API_KEY="dummysecret"`
+
 NB: Les tests e2e écrasent et recréent les données dans postgres. Pour éviter d'utiliser votre postrge de développement, vous pouvez ajouter la variable d'environnement `IS_E2E_TESTS=1` dans l'api.
 Par exemple, si vous lancez l'api dans docker, vous pouvez ajouter dans le `docker-compose-backend.yml` :
 

--- a/pro/e2e/helpers/sandbox.ts
+++ b/pro/e2e/helpers/sandbox.ts
@@ -9,6 +9,12 @@ export async function sandboxCall<T = unknown>(
   method: 'GET' | 'POST',
   url: string
 ): Promise<T> {
+  if (!process.env.E2E_API_KEY) {
+    throw new Error(
+      'E2E_API_KEY is not set. Please add it to env vars or to your `.env.local.secret` file.'
+    )
+  }
+
   const response = await request.fetch(url, {
     method,
     timeout: SANDBOX_TIMEOUT,

--- a/pro/package.json
+++ b/pro/package.json
@@ -103,6 +103,7 @@
     "@vitest/coverage-istanbul": "4.1.7",
     "axe-core": "4.11.4",
     "check-unused-css": "0.5.0",
+    "dotenv": "16.6.1",
     "jsdom": "29.1.1",
     "knip": "6.15.0",
     "node-fetch": "3.3.2",

--- a/pro/pnpm-lock.yaml
+++ b/pro/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       check-unused-css:
         specifier: 0.5.0
         version: 0.5.0(typescript@6.0.3)
+      dotenv:
+        specifier: 16.6.1
+        version: 16.6.1
       jsdom:
         specifier: 29.1.1
         version: 29.1.1


### PR DESCRIPTION
Normalise le principe d'utiliser un `.env.local.secret` pour clarifier/expliciter l'onboarding E2E et s'aligner avec la même convention que le Backend.