### PR TITLE
(BSR) ci: replace pnpm version with jq in pre-release workflow

### DIFF
--- a/.github/workflows/cd_sub_create_pre_release_on_github.yml
+++ b/.github/workflows/cd_sub_create_pre_release_on_github.yml
@@ -61,7 +61,7 @@ jobs:
           TAG_NUMBER: ${{ inputs.tag_number }}
         working-directory: pro
         run: |
-          pnpm version --no-commit-hooks --no-git-tag-version "$TAG_NUMBER"
+          contents="$(jq --arg v "$TAG_NUMBER" '.version = $v' package.json)" && echo "$contents" > package.json
           git add package.json
 
       - name: Add version to image-resizing


### PR DESCRIPTION
## 🔧 Changes Made

Fix CI : commande pnpm introuvable lors de la création de pre-release

Depuis la migration `yarn` vers `pnpm`, le step "Add version to pro" du workflow cd_sub_create_pre_release_on_github échoue car pnpm n'est pas installé sur le runner.

Contrairement à yarn v1 qui était pré-installé sur les runners GitHub Actions, `pnpm` nécessite un setup explicite (`pnpm/action-setup`).

Plutôt que d'ajouter cette dépendance, la commande `pnpm version` est remplacée par `jq` (déjà disponible sur le runner) puisque le step ne fait que mettre à jour le champ version dans `package.json`