### PR TITLE
(PC-42374) ci: Create a GH deployment when useful

### DIFF
--- a/.github/workflows/cd_deploy_production.yml
+++ b/.github/workflows/cd_deploy_production.yml
@@ -34,7 +34,9 @@ jobs:
     needs: check-ref-is-a-version-tag
     runs-on: ubuntu-22.04
     # `deploy` is an artificial environment with protection rules, which allows a single required review instead of many
-    environment: "deploy"
+    environment:
+      name: "deploy"
+      deployment: false
     outputs:
       APP_VERSION: ${{ steps.app-version.outputs.APP_VERSION }}
     steps:

--- a/.github/workflows/cd_sub_deploy_api_doc.yml
+++ b/.github/workflows/cd_sub_deploy_api_doc.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     environment:
       name: api-doc-${{ inputs.environment }}
-      deployment: true
+      deployment: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/cd_sub_deploy_app.yml
+++ b/.github/workflows/cd_sub_deploy_app.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-22.04
     environment:
       name: pcapi-${{ inputs.environment_short_name }}
-      deployment: true
+      deployment: false
     permissions:
       id-token: write
       contents: read
@@ -183,7 +183,9 @@ jobs:
       - deploy-pro-on-firebase-testing
       - deploy-pro-on-firebase
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }} # GitHub will create a deployment for this environment
+    environment:
+      name: ${{ inputs.environment }}
+      deployment: true # Github creates a deployment for this environment only if all deploys succeed (pcapi, pro, doc)
     if: always()
     env:
       ENV: ${{ inputs.environment }}

--- a/.github/workflows/cd_sub_deploy_front_pro.yml
+++ b/.github/workflows/cd_sub_deploy_front_pro.yml
@@ -44,7 +44,9 @@ defaults:
 
 jobs:
   deploy_on_firebase:
-    environment: pro-${{ inputs.ENV }}
+    environment:
+      name: pro-${{ inputs.ENV }}
+      deployment: false
     runs-on: ubuntu-22.04
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     outputs:

--- a/.github/workflows/cd_sub_deploy_maintenance_site.yml
+++ b/.github/workflows/cd_sub_deploy_maintenance_site.yml
@@ -7,7 +7,9 @@ jobs:
   deploy:
     name: "Deploy maintenance site to bucket"
     runs-on: ubuntu-22.04
-    environment: site-maintenance-ci-prd
+    environment:
+      name: site-maintenance-ci-prd
+      deployment: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci_deploy_pr_preview.yml
+++ b/.github/workflows/ci_deploy_pr_preview.yml
@@ -146,7 +146,9 @@ jobs:
       - push-pcapi
       - deploy-pro-on-firebase-preview-env
     if: always() && !failure() && !cancelled() && inputs.front-only == false
-    environment: pullrequest
+    environment:
+      name: pullrequest
+      deployment: true
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/dev_on_workflow_configure_live_channel_pro_generic.yml
+++ b/.github/workflows/dev_on_workflow_configure_live_channel_pro_generic.yml
@@ -31,6 +31,9 @@ jobs:
       id-token: write
     runs-on: ubuntu-22.04
     continue-on-error: ${{ inputs.continue_on_error }}
+    environment:
+      name: pro-${{ inputs.ENV }}
+      deployment: false
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/dev_on_workflow_deploy_app_engine_image_resizing.yml
+++ b/.github/workflows/dev_on_workflow_deploy_app_engine_image_resizing.yml
@@ -56,7 +56,9 @@ jobs:
     name: "Deploy image resizing"
     needs: check-image-resizing-folder-changes
     if: ${{ needs.check-image-resizing-folder-changes.outputs.folder_changed == 'true' }}
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
+      deployment: false
     runs-on: ubuntu-22.04
     steps:
       - name: "Checkout actual repository"


### PR DESCRIPTION
[Ticket JIRA](https://passculture.atlassian.net/browse/PC-42374)

[Using environments without deployments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments)

On ne conserve que les deployments créés en fin de workflow ainsi que ceux des envs de preview
