### PR TITLE
(PC-42398)[API] feat: move jwt utils from core.users.utils to utils.jwt

### DIFF
--- a/api/src/pcapi/connectors/discord.py
+++ b/api/src/pcapi/connectors/discord.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
 
 from pcapi import settings
-from pcapi.core.users import utils as users_utils
 from pcapi.utils import date as date_utils
+from pcapi.utils import jwt as jwt_utils
 from pcapi.utils import requests
 
 
@@ -32,7 +32,7 @@ def build_discord_redirection_uri(user_id: int) -> str:
 def _sign_state(user_id: int) -> str:
     payload = {"user_id": user_id}
     expiration = date_utils.get_naive_utc_now() + DISCORD_STATE_TTL
-    return users_utils.encode_jwt_payload_rs256(
+    return jwt_utils.encode_jwt_payload_rs256(
         payload, private_key=settings.DISCORD_JWT_PRIVATE_KEY, expiration_date=expiration
     )
 
@@ -42,7 +42,7 @@ def verify_state(state: str) -> int:
 
     Raises jwt.PyJWTError on invalid or expired state.
     """
-    payload = users_utils.decode_jwt_token_rs256(state, public_key=settings.DISCORD_JWT_PUBLIC_KEY)
+    payload = jwt_utils.decode_jwt_token_rs256(state, public_key=settings.DISCORD_JWT_PUBLIC_KEY)
     return payload["user_id"]
 
 

--- a/api/src/pcapi/core/educational/utils.py
+++ b/api/src/pcapi/core/educational/utils.py
@@ -11,11 +11,11 @@ from psycopg2.extras import DateTimeRange
 from pcapi.core.educational import exceptions
 from pcapi.core.educational import models
 from pcapi.core.offerers.utils import is_venue_address
-from pcapi.core.users.utils import ALGORITHM_RS_256
 from pcapi.models import db
 from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 from pcapi.utils import requests
+from pcapi.utils.jwt import ALGORITHM_RS_256
 
 
 logger = logging.getLogger(__name__)

--- a/api/src/pcapi/core/token/__init__.py
+++ b/api/src/pcapi/core/token/__init__.py
@@ -17,8 +17,8 @@ from flask import current_app
 
 from pcapi import settings
 from pcapi.core.users import exceptions as users_exceptions
-from pcapi.core.users import utils
 from pcapi.utils import date as date_utils
+from pcapi.utils import jwt as jwt_utils
 
 
 logger = logging.getLogger(__name__)
@@ -141,7 +141,7 @@ class Token(AbstractToken):
     @classmethod
     def load_without_checking(cls, encoded_token: str, *args: typing.Any, **kwargs: typing.Any) -> "Token":
         try:
-            payload = utils.decode_jwt_token(encoded_token)
+            payload = jwt_utils.decode_jwt_token(encoded_token)
             type_ = TokenType(payload["token_type"])
             user_id = payload["user_id"]
         except jwt.exceptions.ExpiredSignatureError as e:
@@ -168,7 +168,7 @@ class Token(AbstractToken):
         if ttl:
             payload["exp"] = (date_utils.get_naive_utc_now() + ttl).timestamp()
 
-        encoded_token = utils.encode_jwt_payload(payload)
+        encoded_token = jwt_utils.encode_jwt_payload(payload)
         if ttl is None or ttl > timedelta(0):
             current_app.redis_client.set(cls.get_redis_key(type_, user_id), encoded_token, ex=ttl)
         token = Token.load_without_checking(encoded_token)
@@ -196,7 +196,7 @@ class UUIDToken(AbstractToken):
         **kwargs: typing.Any,
     ) -> "UUIDToken":
         try:
-            payload = utils.decode_jwt_token(encoded_token)
+            payload = jwt_utils.decode_jwt_token(encoded_token)
         except jwt.exceptions.ExpiredSignatureError as e:
             raise users_exceptions.ExpiredToken() from e
         except (KeyError, ValueError, jwt.PyJWTError) as e:
@@ -217,7 +217,7 @@ class UUIDToken(AbstractToken):
         }
         if ttl:
             payload["exp"] = (date_utils.get_naive_utc_now() + ttl).timestamp()
-        encoded_token = utils.encode_jwt_payload(payload)
+        encoded_token = jwt_utils.encode_jwt_payload(payload)
 
         if ttl is None or ttl > timedelta(0):
             redis_key = cls.get_redis_key(type_, random_uuid)
@@ -275,7 +275,7 @@ class AsymetricToken(AbstractToken):
         cls, encoded_token: str, public_key: bytes, *args: typing.Any, **kwargs: typing.Any
     ) -> "AsymetricToken":
         try:
-            payload = utils.decode_jwt_token_rs256(
+            payload = jwt_utils.decode_jwt_token_rs256(
                 encoded_token, public_key=public_key
             )  # do we want to use the same key to all our tokens?
             type_ = TokenType(payload["token_type"])
@@ -293,7 +293,7 @@ class AsymetricToken(AbstractToken):
         """Decode the JWT token without verifying signature. If you want to be able to trust
         the data within the payload, you must use `load_and_check`
         """
-        payload = utils.decode_jwt_token_rs256(encoded_token, verify_signature=False)
+        payload = jwt_utils.decode_jwt_token_rs256(encoded_token, verify_signature=False)
         type_ = TokenType(payload["token_type"])
         uuid4 = payload["uuid"]
 
@@ -318,7 +318,7 @@ class AsymetricToken(AbstractToken):
         if ttl:
             payload["exp"] = (date_utils.get_naive_utc_now() + ttl).timestamp()
 
-        encoded_token = utils.encode_jwt_payload_rs256(payload, private_key=private_key)
+        encoded_token = jwt_utils.encode_jwt_payload_rs256(payload, private_key=private_key)
         if ttl is None or ttl > timedelta(0):
             current_app.redis_client.set(cls.get_redis_key(type_, random_uuid), encoded_token, ex=ttl)
         token = cls(type_, random_uuid, encoded_token, payload["data"])
@@ -366,7 +366,7 @@ def create_passwordless_login_token(user_id: int, ttl: timedelta) -> str:
     }
     current_app.redis_client.set(redis_key, value, ex=ttl)
 
-    token = utils.encode_jwt_payload_rs256(
+    token = jwt_utils.encode_jwt_payload_rs256(
         {"sub": sub, "iat": iat, "exp": exp, "jti": jti},
         private_key=settings.PASSWORDLESS_LOGIN_PRIVATE_KEY,
         expiration_date=expiration_date,
@@ -385,7 +385,7 @@ def validate_passwordless_token(token: str) -> dict:
         InvalidToken (exception): If anything goes wrong while decoding or validating the token, we don’t want to give any additional hints, we raise `InvalidToken` in any cases.
     """
     try:
-        payload = utils.decode_jwt_token_rs256(
+        payload = jwt_utils.decode_jwt_token_rs256(
             token, public_key=settings.PASSWORDLESS_LOGIN_PUBLIC_KEY, require=["exp", "iat", "sub", "jti"]
         )
     except jwt.ExpiredSignatureError as exc:

--- a/api/src/pcapi/core/users/utils.py
+++ b/api/src/pcapi/core/users/utils.py
@@ -2,60 +2,13 @@ import logging
 from datetime import date
 from datetime import datetime
 
-import jwt
 from dateutil.relativedelta import relativedelta
 
-from pcapi import settings
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import utc_datetime_to_department_timezone
 
 
 logger = logging.getLogger(__name__)
-JWT_ADAGE_PUBLIC_KEY_PATH = f"src/pcapi/routes/adage_iframe/public_key/{settings.JWT_ADAGE_PUBLIC_KEY_FILENAME}"
-
-
-ALGORITHM_HS_256 = "HS256"
-ALGORITHM_RS_256 = "RS256"
-
-
-def encode_jwt_payload(token_payload: dict, expiration_date: datetime | None = None) -> str:
-    if expiration_date:
-        # do not fill exp key if expiration_date is None or jwt.decode would fail
-        token_payload["exp"] = int(expiration_date.timestamp())
-
-    return jwt.encode(
-        token_payload,
-        settings.JWT_SECRET_KEY,
-        algorithm=ALGORITHM_HS_256,
-    )
-
-
-def decode_jwt_token(jwt_token: str) -> dict:
-    return jwt.decode(jwt_token, settings.JWT_SECRET_KEY, algorithms=[ALGORITHM_HS_256])
-
-
-def encode_jwt_payload_rs256(
-    token_payload: dict,
-    private_key: str | bytes,
-    expiration_date: datetime | None = None,
-) -> str:
-    if expiration_date:
-        # do not fill exp key if expiration_date is None or jwt.decode would fail
-        token_payload["exp"] = int(expiration_date.timestamp())
-    return jwt.encode(token_payload, key=private_key, algorithm=ALGORITHM_RS_256)
-
-
-def decode_jwt_token_rs256(
-    jwt_token: str, public_key: str | bytes | None = None, verify_signature: bool = True, require: list | None = None
-) -> dict:
-    if (not public_key and verify_signature) or (public_key and not verify_signature):
-        raise RuntimeError(
-            "You have to either provide the public_key to verify the signature or the use the `verify_signature` options set to False"
-        )
-    options = jwt.types.Options({"verify_signature": verify_signature, "require": require or []})
-    if public_key:
-        return jwt.decode(jwt_token, key=public_key, algorithms=[ALGORITHM_RS_256], options=options)
-    return jwt.decode(jwt_token, algorithms=[ALGORITHM_RS_256], options=options)
 
 
 def get_age_at_date(birth_date: date, specified_datetime: datetime, department_code: str | None = None) -> int:

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -32,6 +32,7 @@ from pcapi.core.logging import install_logging
 from pcapi.models import db
 from pcapi.models import install_models
 from pcapi.scripts.install import install_commands
+from pcapi.utils import jwt
 from pcapi.utils import transaction_manager
 from pcapi.utils.json_encoder import EnumJSONEncoder
 from pcapi.utils.sentry import init_sentry_sdk
@@ -208,9 +209,6 @@ if settings.PROFILE_REQUESTS:
 # header: the client IP and the Google Front End IP. Hence `x_for=2`.
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=2)
 
-if not settings.JWT_SECRET_KEY:
-    raise ValueError("JWT_SECRET_KEY not found in env")
-
 app.secret_key = settings.FLASK_SECRET
 app.json_provider_class = EnumJSONEncoder
 app.json = EnumJSONEncoder(app)
@@ -265,6 +263,7 @@ def generate_error_response(errors: dict, backoffice_template_name: str = "not u
 with app.app_context():
     app.redis_client = redis.from_url(url=settings.REDIS_URL, decode_responses=True)
     app.generate_error_response = generate_error_response
+    jwt.setup_backend(app)
 
 
 @app.shell_context_processor

--- a/api/src/pcapi/routes/adage_iframe/security.py
+++ b/api/src/pcapi/routes/adage_iframe/security.py
@@ -6,11 +6,11 @@ import flask
 from jwt import ExpiredSignatureError
 from jwt import InvalidSignatureError
 
-from pcapi.core.users import utils as user_utils
 from pcapi.models.api_errors import UnauthorizedError
 from pcapi.routes.adage_iframe.blueprint import JWT_AUTH
 from pcapi.routes.adage_iframe.serialization.adage_authentication import AuthenticatedInformation
 from pcapi.serialization.spec_tree import add_security_scheme
+from pcapi.utils import jwt as jwt_utils
 
 
 logger = logging.getLogger(__name__)
@@ -27,9 +27,9 @@ def adage_jwt_required(route_function: typing.Callable) -> typing.Callable:
         if authorization_header and mandatory_authorization_type in authorization_header:
             adage_jwt = authorization_header.replace(mandatory_authorization_type, "")
             try:
-                with open(user_utils.JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
+                with open(jwt_utils.JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
                     public_key = reader.read()
-                    adage_jwt_decoded = user_utils.decode_jwt_token_rs256(adage_jwt, public_key)
+                    adage_jwt_decoded = jwt_utils.decode_jwt_token_rs256(adage_jwt, public_key)
             except InvalidSignatureError as invalid_signature_error:
                 logger.error("Signature of adage jwt cannot be verified", extra={"error": invalid_signature_error})
                 raise UnauthorizedError(errors={"msg": "Unrecognized token"})

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -236,6 +236,7 @@ NATIVE_RECAPTCHA_SECRET = secrets_utils.get("NATIVE_RECAPTCHA_SECRET")
 RECAPTCHA_IGNORE_VALIDATION = bool(int(os.environ.get("RECAPTCHA_IGNORE_VALIDATION", 0)))
 
 # JWT
+JWT_BACKEND = os.environ.get("JWT_BACKEND", "pcapi.utils.jwt.JwtSimpleBackend")
 JWT_SECRET_KEY = secrets_utils.get("JWT_SECRET_KEY")
 DISCORD_JWT_PRIVATE_KEY = secrets_utils.get("DISCORD_JWT_PRIVATE_KEY").encode("ascii")
 DISCORD_JWT_PUBLIC_KEY = secrets_utils.get("DISCORD_JWT_PUBLIC_KEY").encode("ascii")

--- a/api/src/pcapi/utils/jwt.py
+++ b/api/src/pcapi/utils/jwt.py
@@ -1,0 +1,53 @@
+import logging
+from datetime import datetime
+
+import jwt
+
+from pcapi import settings
+
+
+JWT_ADAGE_PUBLIC_KEY_PATH = f"src/pcapi/routes/adage_iframe/public_key/{settings.JWT_ADAGE_PUBLIC_KEY_FILENAME}"
+
+
+ALGORITHM_HS_256 = "HS256"
+ALGORITHM_RS_256 = "RS256"
+
+
+def encode_jwt_payload(token_payload: dict, expiration_date: datetime | None = None) -> str:
+    if expiration_date:
+        # do not fill exp key if expiration_date is None or jwt.decode would fail
+        token_payload["exp"] = int(expiration_date.timestamp())
+
+    return jwt.encode(
+        token_payload,
+        settings.JWT_SECRET_KEY,
+        algorithm=ALGORITHM_HS_256,
+    )
+
+
+def decode_jwt_token(jwt_token: str) -> dict:
+    return jwt.decode(jwt_token, settings.JWT_SECRET_KEY, algorithms=[ALGORITHM_HS_256])
+
+
+def encode_jwt_payload_rs256(
+    token_payload: dict,
+    private_key: str | bytes,
+    expiration_date: datetime | None = None,
+) -> str:
+    if expiration_date:
+        # do not fill exp key if expiration_date is None or jwt.decode would fail
+        token_payload["exp"] = int(expiration_date.timestamp())
+    return jwt.encode(token_payload, key=private_key, algorithm=ALGORITHM_RS_256)
+
+
+def decode_jwt_token_rs256(
+    jwt_token: str, public_key: str | bytes | None = None, verify_signature: bool = True, require: list | None = None
+) -> dict:
+    if (not public_key and verify_signature) or (public_key and not verify_signature):
+        raise RuntimeError(
+            "You have to either provide the public_key to verify the signature or the use the `verify_signature` options set to False"
+        )
+    options = jwt.types.Options({"verify_signature": verify_signature, "require": require or []})
+    if public_key:
+        return jwt.decode(jwt_token, key=public_key, algorithms=[ALGORITHM_RS_256], options=options)
+    return jwt.decode(jwt_token, algorithms=[ALGORITHM_RS_256], options=options)

--- a/api/src/pcapi/utils/jwt.py
+++ b/api/src/pcapi/utils/jwt.py
@@ -1,32 +1,42 @@
-import logging
+import time
 from datetime import datetime
 
 import jwt
+from flask import Flask
+from flask import current_app
 
 from pcapi import settings
+from pcapi.utils.module_loading import import_string
 
 
 JWT_ADAGE_PUBLIC_KEY_PATH = f"src/pcapi/routes/adage_iframe/public_key/{settings.JWT_ADAGE_PUBLIC_KEY_FILENAME}"
-
-
 ALGORITHM_HS_256 = "HS256"
 ALGORITHM_RS_256 = "RS256"
+_JWT_BACKEND_ATTR = "pc_jwt_backend"
+
+
+def setup_backend(app: Flask) -> None:
+    if not hasattr(app, _JWT_BACKEND_ATTR):
+        backend_class = import_string(settings.JWT_BACKEND)
+        setattr(app, _JWT_BACKEND_ATTR, backend_class())
+
+
+def get_backend() -> "JwtSimpleBackend":
+    jwt_backend = getattr(current_app, _JWT_BACKEND_ATTR, None)
+    if jwt_backend is None:
+        raise RuntimeError("get_backend should not be called before setup_backend.")
+    return jwt_backend
 
 
 def encode_jwt_payload(token_payload: dict, expiration_date: datetime | None = None) -> str:
     if expiration_date:
         # do not fill exp key if expiration_date is None or jwt.decode would fail
         token_payload["exp"] = int(expiration_date.timestamp())
-
-    return jwt.encode(
-        token_payload,
-        settings.JWT_SECRET_KEY,
-        algorithm=ALGORITHM_HS_256,
-    )
+    return get_backend().encode(payload=token_payload)
 
 
 def decode_jwt_token(jwt_token: str) -> dict:
-    return jwt.decode(jwt_token, settings.JWT_SECRET_KEY, algorithms=[ALGORITHM_HS_256])
+    return get_backend().decode(jwt_token=jwt_token)
 
 
 def encode_jwt_payload_rs256(
@@ -51,3 +61,29 @@ def decode_jwt_token_rs256(
     if public_key:
         return jwt.decode(jwt_token, key=public_key, algorithms=[ALGORITHM_RS_256], options=options)
     return jwt.decode(jwt_token, algorithms=[ALGORITHM_RS_256], options=options)
+
+
+class JwtSimpleBackend:
+    def __init__(self) -> None:
+        if not settings.JWT_SECRET_KEY:
+            raise ValueError("JWT_SECRET_KEY not found in env")
+
+    def encode(self, payload: dict, key: str | None = None) -> str:
+        key = key if key is not None else settings.JWT_SECRET_KEY
+        # ensure minimum required fields
+        if "nbf" not in payload:
+            payload["nbf"] = int(time.time())
+        if "iat" not in payload:
+            payload["iat"] = payload["nbf"]
+        if "exp" not in payload:
+            payload["exp"] = payload["nbf"] + 20 * 60  # default 20 minutes validity
+        return jwt.encode(
+            payload,
+            key,
+            algorithm=ALGORITHM_HS_256,
+        )
+
+    def decode(self, jwt_token: str, key: str | None = None) -> dict:
+        key = key if key is not None else settings.JWT_SECRET_KEY
+
+        return jwt.decode(jwt_token, key, algorithms=[ALGORITHM_HS_256])

--- a/api/tests/core/token/test_token.py
+++ b/api/tests/core/token/test_token.py
@@ -15,8 +15,8 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from pcapi import settings
 from pcapi.core import token as token_tools
 from pcapi.core.users.exceptions import InvalidToken
-from pcapi.core.users.utils import encode_jwt_payload
 from pcapi.utils import date as date_utils
+from pcapi.utils.jwt import encode_jwt_payload
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -346,7 +346,7 @@ class PasswordLessLoginTokenTest:
         PASSWORDLESS_LOGIN_PRIVATE_KEY=private_pem_file, PASSWORDLESS_LOGIN_PUBLIC_KEY=public_pem_file
     )
     @pytest.mark.parametrize("missing_claim", ["exp", "iat", "sub", "jti"])
-    @mock.patch("pcapi.core.users.utils.encode_jwt_payload_rs256")
+    @mock.patch("pcapi.utils.jwt.encode_jwt_payload_rs256")
     @mock.patch("flask.current_app.redis_client.set")
     @mock.patch("uuid.uuid4", return_value=uuid.uuid4())
     def test_token_with_missing_mandatory_claim_raise_decode_error_accordingly(

--- a/api/tests/core/users/email/test_update.py
+++ b/api/tests/core/users/email/test_update.py
@@ -13,8 +13,8 @@ from pcapi.core.mails.transactional.brevo_template_ids import TransactionalEmail
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users.models import EmailHistoryEventTypeEnum
 from pcapi.core.users.models import User
-from pcapi.core.users.utils import encode_jwt_payload
 from pcapi.models import db
+from pcapi.utils.jwt import encode_jwt_payload
 
 
 pytestmark = pytest.mark.usefixtures("db_session")

--- a/api/tests/core/users/test_utils.py
+++ b/api/tests/core/users/test_utils.py
@@ -4,13 +4,13 @@ import jwt
 import pytest
 
 from pcapi import settings
-from pcapi.core.users import utils as user_utils
-from pcapi.core.users.utils import ALGORITHM_HS_256
-from pcapi.core.users.utils import ALGORITHM_RS_256
-from pcapi.core.users.utils import decode_jwt_token_rs256
-from pcapi.core.users.utils import encode_jwt_payload
 from pcapi.core.users.utils import format_login_location
 from pcapi.utils import date as date_utils
+from pcapi.utils.jwt import ALGORITHM_HS_256
+from pcapi.utils.jwt import ALGORITHM_RS_256
+from pcapi.utils.jwt import JWT_ADAGE_PUBLIC_KEY_PATH
+from pcapi.utils.jwt import decode_jwt_token_rs256
+from pcapi.utils.jwt import encode_jwt_payload
 
 from tests.routes.adage_iframe import INVALID_RSA_PRIVATE_KEY_PATH
 from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH
@@ -43,7 +43,7 @@ class DecodeJWTPayloadRS256Test:
         payload = dict(data="value")
         with open(VALID_RSA_PRIVATE_KEY_PATH, "rb") as reader:
             valid_encoded_token = jwt.encode(payload, key=reader.read(), algorithm=ALGORITHM_RS_256)
-        with open(user_utils.JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
+        with open(JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
             public_key = reader.read()
             decoded = decode_jwt_token_rs256(valid_encoded_token, public_key)
 
@@ -55,7 +55,7 @@ class DecodeJWTPayloadRS256Test:
             corrupted_token = jwt.encode(payload, key=reader.read(), algorithm=ALGORITHM_RS_256)
 
         with pytest.raises(jwt.InvalidSignatureError) as error:
-            with open(user_utils.JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
+            with open(JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
                 public_key = reader.read()
                 decode_jwt_token_rs256(corrupted_token, public_key=public_key)
 

--- a/api/tests/core/users/test_utils.py
+++ b/api/tests/core/users/test_utils.py
@@ -1,65 +1,6 @@
-import datetime
-
-import jwt
 import pytest
 
-from pcapi import settings
 from pcapi.core.users.utils import format_login_location
-from pcapi.utils import date as date_utils
-from pcapi.utils.jwt import ALGORITHM_HS_256
-from pcapi.utils.jwt import ALGORITHM_RS_256
-from pcapi.utils.jwt import JWT_ADAGE_PUBLIC_KEY_PATH
-from pcapi.utils.jwt import decode_jwt_token_rs256
-from pcapi.utils.jwt import encode_jwt_payload
-
-from tests.routes.adage_iframe import INVALID_RSA_PRIVATE_KEY_PATH
-from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH
-
-
-class EncodeJWTPayloadTest:
-    def test_encode_jwt_payload(self):
-        payload = dict(data="value")
-        expiration_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
-
-        jwt_token = encode_jwt_payload(payload, expiration_date)
-
-        decoded = jwt.decode(jwt_token, settings.JWT_SECRET_KEY, algorithms=ALGORITHM_HS_256)
-
-        assert decoded == {"data": "value", "exp": int(expiration_date.timestamp())}
-
-    def test_encode_jwt_payload_without_expiration_date(self):
-        payload = dict(data="value")
-
-        jwt_token = encode_jwt_payload(payload)
-
-        decoded = jwt.decode(jwt_token, settings.JWT_SECRET_KEY, algorithms=ALGORITHM_HS_256)
-
-        assert decoded["data"] == "value"
-        assert "exp" not in decoded
-
-
-class DecodeJWTPayloadRS256Test:
-    def test_decode_jwt_payload_rs256_algorithm(self):
-        payload = dict(data="value")
-        with open(VALID_RSA_PRIVATE_KEY_PATH, "rb") as reader:
-            valid_encoded_token = jwt.encode(payload, key=reader.read(), algorithm=ALGORITHM_RS_256)
-        with open(JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
-            public_key = reader.read()
-            decoded = decode_jwt_token_rs256(valid_encoded_token, public_key)
-
-        assert decoded["data"] == "value"
-
-    def test_decode_jwt_payload_rs256_algorithm_corrupted(self):
-        payload = dict(data="value")
-        with open(INVALID_RSA_PRIVATE_KEY_PATH, "rb") as reader:
-            corrupted_token = jwt.encode(payload, key=reader.read(), algorithm=ALGORITHM_RS_256)
-
-        with pytest.raises(jwt.InvalidSignatureError) as error:
-            with open(JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
-                public_key = reader.read()
-                decode_jwt_token_rs256(corrupted_token, public_key=public_key)
-
-        assert "Signature verification failed" in str(error.value)
 
 
 class FormatLoginLocationTest:

--- a/api/tests/routes/adage_iframe/utils_create_test_token.py
+++ b/api/tests/routes/adage_iframe/utils_create_test_token.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 
 import jwt
 
-from pcapi.core.users.utils import ALGORITHM_RS_256
 from pcapi.utils import date as date_utils
+from pcapi.utils.jwt import ALGORITHM_RS_256
 
 from tests.routes.adage_iframe import INVALID_RSA_PRIVATE_KEY_PATH
 from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH

--- a/api/tests/routes/auth/discord_test.py
+++ b/api/tests/routes/auth/discord_test.py
@@ -15,9 +15,9 @@ from pcapi.core.history import factories as history_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import factories as users_factories
-from pcapi.core.users import utils as users_utils
 from pcapi.core.users.models import DiscordUser
 from pcapi.models import db
+from pcapi.utils import jwt as jwt_utils
 from pcapi.utils import requests
 
 
@@ -94,7 +94,7 @@ class DiscordSigninTest:
         assert "&state=" in uri
         # Verify the state is a signed RS256 JWT containing the user_id
         state = uri.split("&state=")[1]
-        payload = users_utils.decode_jwt_token_rs256(state, public_key=settings.DISCORD_JWT_PUBLIC_KEY)
+        payload = jwt_utils.decode_jwt_token_rs256(state, public_key=settings.DISCORD_JWT_PUBLIC_KEY)
         assert payload["user_id"] == 1
         assert "exp" in payload
 

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -43,11 +43,11 @@ from pcapi.core.users import schemas as users_schemas
 from pcapi.core.users import testing as users_testing
 from pcapi.core.users import young_status
 from pcapi.core.users.email.repository import get_email_update_latest_event
-from pcapi.core.users.utils import ALGORITHM_HS_256
 from pcapi.models import db
 from pcapi.routes.native.v1.serialization import account as account_serializers
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
+from pcapi.utils.jwt import ALGORITHM_HS_256
 from pcapi.utils.postal_code import INELIGIBLE_POSTAL_CODES
 
 

--- a/api/tests/utils/jwt_test.py
+++ b/api/tests/utils/jwt_test.py
@@ -1,0 +1,99 @@
+import datetime
+import time
+
+import jwt
+import pytest
+
+from pcapi import settings
+from pcapi.utils import date as date_utils
+from pcapi.utils.jwt import ALGORITHM_HS_256
+from pcapi.utils.jwt import ALGORITHM_RS_256
+from pcapi.utils.jwt import JWT_ADAGE_PUBLIC_KEY_PATH
+from pcapi.utils.jwt import decode_jwt_token
+from pcapi.utils.jwt import decode_jwt_token_rs256
+from pcapi.utils.jwt import encode_jwt_payload
+
+from tests.routes.adage_iframe import INVALID_RSA_PRIVATE_KEY_PATH
+from tests.routes.adage_iframe import VALID_RSA_PRIVATE_KEY_PATH
+
+
+class EncodeJWTPayloadTest:
+    def test_encode_jwt_payload(self):
+        payload = dict(data="value")
+        expiration_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=1)
+        start = int(time.time())
+        jwt_token = encode_jwt_payload(payload, expiration_date)
+
+        decoded = jwt.decode(jwt_token, settings.JWT_SECRET_KEY, algorithms=ALGORITHM_HS_256)
+
+        assert decoded["data"] == "value"
+        assert decoded["exp"] == int(expiration_date.timestamp())
+        assert decoded["nbf"] <= start + 1
+        assert decoded["nbf"] >= start
+        assert decoded["iat"] == decoded["nbf"]
+        assert len(decoded) == 4
+
+    def test_force_expiration(self):
+        jwt_token = encode_jwt_payload({})
+
+        decoded = jwt.decode(jwt_token, settings.JWT_SECRET_KEY, algorithms=ALGORITHM_HS_256)
+
+        assert "exp" in decoded
+        assert decoded["exp"] == decoded["nbf"] + 20 * 60
+
+
+class DecodeJWTTokenTest:
+    def test_decode_jwt_token(self):
+        token = jwt.encode({"data": "value"}, key=settings.JWT_SECRET_KEY, algorithm=ALGORITHM_HS_256)
+
+        decoded = decode_jwt_token(token)
+
+        assert decoded["data"] == "value"
+
+    def test_decode_jwt_token_invalid_key(self):
+        token = jwt.encode({"data": "value"}, key="secret jwt key", algorithm=ALGORITHM_HS_256)
+
+        with pytest.raises(jwt.exceptions.InvalidSignatureError):
+            decode_jwt_token(token)
+
+    def test_decode_jwt_token_before_nbf(self):
+        token = jwt.encode({"nbf": int(time.time()) + 60}, key=settings.JWT_SECRET_KEY, algorithm=ALGORITHM_HS_256)
+
+        with pytest.raises(jwt.exceptions.ImmatureSignatureError):
+            decode_jwt_token(token)
+
+    def test_decode_jwt_token_before_iat(self):
+        token = jwt.encode({"iat": int(time.time()) + 60}, key=settings.JWT_SECRET_KEY, algorithm=ALGORITHM_HS_256)
+
+        with pytest.raises(jwt.exceptions.ImmatureSignatureError):
+            decode_jwt_token(token)
+
+    def test_decode_jwt_token_after_exp(self):
+        token = jwt.encode({"exp": int(time.time()) - 60}, key=settings.JWT_SECRET_KEY, algorithm=ALGORITHM_HS_256)
+
+        with pytest.raises(jwt.exceptions.ExpiredSignatureError):
+            decode_jwt_token(token)
+
+
+class DecodeJWTPayloadRS256Test:
+    def test_decode_jwt_payload_rs256_algorithm(self):
+        payload = dict(data="value")
+        with open(VALID_RSA_PRIVATE_KEY_PATH, "rb") as reader:
+            valid_encoded_token = jwt.encode(payload, key=reader.read(), algorithm=ALGORITHM_RS_256)
+        with open(JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
+            public_key = reader.read()
+            decoded = decode_jwt_token_rs256(valid_encoded_token, public_key)
+
+        assert decoded["data"] == "value"
+
+    def test_decode_jwt_payload_rs256_algorithm_corrupted(self):
+        payload = dict(data="value")
+        with open(INVALID_RSA_PRIVATE_KEY_PATH, "rb") as reader:
+            corrupted_token = jwt.encode(payload, key=reader.read(), algorithm=ALGORITHM_RS_256)
+
+        with pytest.raises(jwt.InvalidSignatureError) as error:
+            with open(JWT_ADAGE_PUBLIC_KEY_PATH, "rb") as reader:
+                public_key = reader.read()
+                decode_jwt_token_rs256(corrupted_token, public_key=public_key)
+
+        assert "Signature verification failed" in str(error.value)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42398)

Le premier commit n'est qu'un déplacement du code pour rendre le second plus lisible.
Le second commit met en place une infrastructure pour permetre de facilement implémenter la rotation de clefs jwt (qui arrivera plus tard). Pour l'instant cette PR est neutre au niveau fonctionnel