### PR TITLE
(BSR)[PRO] fix: remove invalid useAnalytics mock causing Vitest teardown failure

### DIFF
--- a/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx
+++ b/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx
@@ -48,7 +48,6 @@ describe('GenericCinemaProviderForm', () => {
     }
 
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
-      ...vi.importActual('@/app/App/analytics/firebase'),
       logEvent: mockLogEvent,
     }))
   })

--- a/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/StocksProviderForm/StocksProviderForm.spec.tsx
+++ b/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/StocksProviderForm/StocksProviderForm.spec.tsx
@@ -29,7 +29,6 @@ describe('StocksProviderForm', () => {
     }
 
     vi.spyOn(useAnalytics, 'useAnalytics').mockImplementation(() => ({
-      ...vi.importActual('@/app/App/analytics/firebase'),
       logEvent: mockLogEvent,
     }))
   })


### PR DESCRIPTION
## 🐛 Issue

Sur un run complet des tests unitaires `pro/`, Vitest remontait 2 `EnvironmentTeardownError` ("Cannot load firebase.ts?_vitest_original after the environment was torn down"). Les tests eux-mêmes passaient, mais le run échouait.

## ℹ️ Cause

Deux specs mockaient `useAnalytics` avec un `...vi.importActual(...)` : un import dynamique async, sans await, ré-exécuté à chaque render. Quand le test finit avant sa résolution, ça déclenche un erreur de teardown. Le spread était de toute façon inutile (`useAnalytics()` ne renvoie que `{ logEvent }`).

## 🔨 Fix

Suppression du spread.

## 📝 Log

```sh
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Errors ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

Vitest caught 2 unhandled errors during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
EnvironmentTeardownError: Cannot load '/src/app/App/analytics/firebase.ts?_vitest_original' imported from /home/ivan/Workspace/pass-culture/pass-culture-main/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx after the environment was torn down. This is not a bug in Vitest. The last recorded callstack:
- /src/app/App/analytics/firebase.ts?_vitest_original
- /home/ivan/Workspace/pass-culture/pass-culture-main/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx
This error originated in "src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
EnvironmentTeardownError: Cannot load '/src/app/App/analytics/firebase.ts?_vitest_original' imported from /home/ivan/Workspace/pass-culture/pass-culture-main/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx after the environment was torn down. This is not a bug in Vitest. The last recorded callstack:
- /src/app/App/analytics/firebase.ts?_vitest_original
- /home/ivan/Workspace/pass-culture/pass-culture-main/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx
This error originated in "src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/GenericCinemaProviderForm/GenericCinemaProviderForm.spec.tsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯


 Test Files  682 passed (682)
      Tests  4326 passed (4326)
     Errors  2 errors
   Start at  14:26:46
   Duration  146.65s (transform 219.99s, setup 416.52s, import 3998.86s, tests 840.96s, environment 1159.67s)
```
