### PR TITLE
(BSR) chore: css variables autocomplete from DS tokens

### DIFF
--- a/pro/.vscode/extensions.json
+++ b/pro/.vscode/extensions.json
@@ -4,6 +4,6 @@
     "vitest.explorer",
     "stylelint.vscode-stylelint",
     "biomejs.biome",
-    "phoenisx.cssvar"
+    "vunguyentuan.vscode-css-variables"
   ]
 }

--- a/pro/.vscode/settings.json
+++ b/pro/.vscode/settings.json
@@ -23,5 +23,10 @@
   },
   "[typescriptreact]": {
     "editor.defaultFormatter": "biomejs.biome"
-  }
+  },
+  "cssVariables.lookupFiles": [
+    "./node_modules/@pass-culture/design-system/lib/pro/light.css",
+    "**/*.css",
+    "**/*.scss"
+  ]
 }


### PR DESCRIPTION
## 🔧 Changes Made

Amélioration de l'expérience développeur en remplaçant l'extension VS Code `phoenisx.cssvar` par `vunguyentuan.vscode-css-variables`, mieux maintenue et plus complète.

- Remplacement de l'extension `phoenisx.cssvar` par `vunguyentuan.vscode-css-variables` dans `.vscode/extensions.json`
- Ajout de la config `cssVariables.lookupFiles` dans `.vscode/settings.json` pour indexer :
  - Les tokens du Design System (`@pass-culture/design-system/lib/pro/light.css`)
  - Tous les fichiers `.css` et `.scss` locaux du projet

## Test plan

- [ ] Installer l'extension recommandée `vunguyentuan.vscode-css-variables` (VS Code proposera l'install via `.vscode/extensions.json`)
- [ ] Ouvrir un fichier `.scss` et taper `var(--` → vérifier que les tokens du DS apparaissent en autocomplétion
- [ ] Vérifier que les variables CSS définies localement dans le projet sont aussi proposées

<img width="570" height="276" alt="image" src="https://github.com/user-attachments/assets/9d09697c-c1bc-43a4-ab7b-0af3536780d9" />