### PR TITLE
(IC-1378) ci(workflow) fix: linter on source branch name

### DIFF
--- a/.github/workflows/ci_deploy_pr_preview_v2.yml
+++ b/.github/workflows/ci_deploy_pr_preview_v2.yml
@@ -52,7 +52,7 @@ jobs:
         id: compute-labels
         env:
           FRONT_ONLY: ${{ inputs.front-only }}
-          SOURCE_BRANCH: ${{ github.source_branch }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
         run: |
           # TODO: use PR number instead of branch SHA1 — more readable, no collision risk.
           # Requires changing trigger to pull_request.


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

- [Front](?expand=1&template=template_front.md)
- [Back](?expand=1&template=template_back.md)
- [Script](?expand=1&template=template_script.md)
- [DS](?expand=1&template=template_DS.md)
