### PR TITLE
(PC-42468)[API] feat: add isDuo field to test offers generator form

### DIFF
--- a/api/src/pcapi/core/offers/generator.py
+++ b/api/src/pcapi/core/offers/generator.py
@@ -35,7 +35,9 @@ def _create_offerer() -> offerers_models.Offerer:
     return offerer
 
 
-def _create_cinema_offer(venue: offerers_models.Venue, offer_name: str, price: decimal.Decimal) -> offers_models.Offer:
+def _create_cinema_offer(
+    venue: offerers_models.Venue, offer_name: str, price: decimal.Decimal, is_duo: bool
+) -> offers_models.Offer:
     fake = faker.Faker(["fr-FR"])
     offer_description = fake.paragraph(nb_sentences=30)
     product = offers_factories.ProductFactory.create(
@@ -46,6 +48,7 @@ def _create_cinema_offer(venue: offerers_models.Venue, offer_name: str, price: d
     )
     db.session.add(product)
     offer = offers_factories.OfferFactory.build(
+        isDuo=is_duo,
         name=offer_name,
         description=offer_description,
         venue=venue,
@@ -159,14 +162,16 @@ def _create_venue(offerer: offerers_models.Offerer, activity: offerers_models.Ac
     return venue
 
 
-def create_offer(offer_name: str, price: decimal.Decimal, subcategory_id: str) -> offers_models.Offer | None:
+def create_offer(
+    offer_name: str, price: decimal.Decimal, subcategory_id: str, is_duo: bool
+) -> offers_models.Offer | None:
     # For the moment this function can only generate offers having SEANCE_CINE subcategory
     offerer = _create_offerer()
     offer = None
     venue = None
     if subcategory_id == subcategories.SEANCE_CINE.id:
         venue = _create_venue(offerer, offerers_models.Activity.CINEMA)
-        offer = _create_cinema_offer(venue, offer_name, price)
+        offer = _create_cinema_offer(venue, offer_name, price, is_duo)
 
     if offer is not None and venue is not None:
         search.async_index_venue_ids([venue.id], search_models.IndexationReason.VENUE_CREATION)

--- a/api/src/pcapi/routes/backoffice/dev/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/dev/blueprint.py
@@ -567,6 +567,7 @@ def generate_offer() -> response_utils.BackofficeResponse:
         offer_name=form.name.data,
         price=form.price.data,
         subcategory_id=form.subcategory_id.data,
+        is_duo=form.is_duo.data,
     )
 
     flash("Offre créée avec succès", "success")

--- a/api/src/pcapi/routes/backoffice/dev/forms.py
+++ b/api/src/pcapi/routes/backoffice/dev/forms.py
@@ -231,3 +231,4 @@ class OfferGeneratorForm(utils.PCForm):
         choices=[(subcategories.SEANCE_CINE.id, subcategories.SEANCE_CINE.app_label)],
         default=subcategories.SEANCE_CINE.id,
     )
+    is_duo = fields.PCSwitchBooleanField("Offre Duo", default=False)

--- a/api/src/pcapi/routes/backoffice/templates/dev/offers_generator.html
+++ b/api/src/pcapi/routes/backoffice/templates/dev/offers_generator.html
@@ -55,6 +55,10 @@
                   {{ offer.status | format_offer_status }}
                 </p>
                 <p class="mb-1">
+                  <span class="fw-bold">Offre Duo</span>
+                  {{ offer.isDuo | format_bool_badge }}
+                </p>
+                <p class="mb-1">
                   <span class="fw-bold">Description</span>
                   {{ offer.description }}
                 </p>

--- a/api/src/pcapi/routes/internal/e2e_offer.py
+++ b/api/src/pcapi/routes/internal/e2e_offer.py
@@ -21,6 +21,7 @@ def generate_offer() -> tuple[dict, int]:
         offer_name=form.name.data,
         price=form.price.data,
         subcategory_id=form.subcategory_id.data,
+        is_duo=form.is_duo.data,
     )
 
     if offer is None:
@@ -31,6 +32,7 @@ def generate_offer() -> tuple[dict, int]:
         "name": offer.name,
         "subcategoryId": offer.subcategoryId,
         "venueId": offer.venueId,
+        "isDuo": offer.isDuo,
     }, 200
 
 

--- a/api/tests/routes/backoffice/dev_test.py
+++ b/api/tests/routes/backoffice/dev_test.py
@@ -311,6 +311,16 @@ class OfferGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermi
         assert offer.publicationDatetime is not None
         assert offer.name == "Test Offer"
 
+    @pytest.mark.settings(ENABLE_TEST_OFFER_GENERATION=True)
+    @pytest.mark.parametrize("is_duo", [True, False])
+    def test_offer_creation_duo(self, authenticated_client, is_duo):
+        form = {"name": "Test Offer", "price": 13.4, "subcategory_id": "SEANCE_CINE", "is_duo": is_duo}
+        response = self.post_to_endpoint(authenticated_client, form=form, follow_redirects=True)
+        assert response.status_code == 200
+        offer_id = response.request.path.rsplit("/")[-1]
+        offer = db.session.query(offers_models.Offer).get(offer_id)
+        assert offer.isDuo == is_duo
+
 
 class OfferGenerationGetRouteTest(GetEndpointWithoutPermissionHelper):
     endpoint = "backoffice_web.dev.get_generated_offer"

--- a/api/tests/routes/internal/offer_test.py
+++ b/api/tests/routes/internal/offer_test.py
@@ -35,6 +35,21 @@ class E2EOfferTest:
         assert response.json["subcategoryId"] == "SEANCE_CINE"
         assert response.json["venueId"] == offer.venueId
 
+    @pytest.mark.parametrize("is_duo", [True, False])
+    def test_create_offer_duo(self, auth_client, is_duo):
+        response = auth_client.post(
+            "/e2e/offer", {"name": "Test Offer", "subcategory_id": "SEANCE_CINE", "price": 8.2, "is_duo": is_duo}
+        )
+        assert response.status_code == 200
+
+        offers = db.session.query(offers_models.Offer).all()
+
+        assert len(offers) == 1
+        offer = offers[0]
+        assert offer.isDuo == is_duo
+
+        assert response.json["isDuo"] == is_duo
+
     def test_create_offer_missing_subcategory(self, auth_client):
         response = auth_client.post("/e2e/offer", {"name": "Test Offer", "price": 8.2})
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42468)

Add `is_duo` field to `/e2e/offers` endpoint and Offers generator BO page

- [ ] Travail pair testé en environnement de preview
