### PR TITLE
(BSR) ci: edit workflow schedules with timezone

### DIFF
--- a/.github/workflows/cd_deploy_testing.yml
+++ b/.github/workflows/cd_deploy_testing.yml
@@ -3,14 +3,8 @@ name: 1 [CD] Deploy testing
 on:
   workflow_dispatch:
   schedule:
-    # This cron is defined in UTC timezone. It means that it will run:
-    # - during summer hours between 8:28am - 7:28pm
-    # - during winter hours between 7:28am - 6:28pm
-    # we cannot yet specify timezone :
-    # https://github.com/orgs/community/discussions/13454
-    # Why 27? Choosing an exact hour or half-hour is discouraged by GitHub due to high load.
-    # Cron jobs might be delayed or even completely skipped.
-    - cron: "27 6-17 * * 1-5"
+    - cron: "27 5-17 * * 1-5"
+      timezone: "Europe/Paris"
 
 permissions: write-all
 

--- a/.github/workflows/ci_clean_delete_pr_deployments.yml
+++ b/.github/workflows/ci_clean_delete_pr_deployments.yml
@@ -3,14 +3,8 @@ name: 2 [CI] Delete PR deployments
 on:
   workflow_dispatch:
   schedule:
-    # This cron is defined in UTC timezone. It means that it will run :
-    # - during summer hours between 7:26am - 7:26pm
-    # - during winter hours between 6:26am - 6:26pm
-    # we cannot yet specify timezone :
-    # https://github.com/orgs/community/discussions/13454
-    # Why 26? Choosing an exact hour or half-hour is discouraged by GitHub due to high load.
-    # Cron jobs might be delayed or even completely skipped.
     - cron: "26 5-17 * * *"
+      timezone: "Europe/Paris"
 
 permissions: write-all
 


### PR DESCRIPTION
Also: start earlier because GHA is running very late
