### PR TITLE
(PC-41695)[API] feat: link cinema endpoint to cinema task

### DIFF
--- a/api/documentation/src/pages/change-logs.md
+++ b/api/documentation/src/pages/change-logs.md
@@ -14,6 +14,7 @@ You will have two dates at your disposal :
   :::
 
 ## June 2026
+- A new endpoint has been added to synchronize cinema sessions: [**Batch Update Cinema Sessions**](/rest-api#tag/Event-Offers/operation/PutBatchUpdateCinemaSessions)
 - The `additionalDetails`, `price`, `servicePrice`, `additionalFees` and `numberOfTeachers` fields have been added to the [**Get Collective Offer endpoint**](/rest-api#tag/Collective-Offers/operation/GetCollectiveOfferPublic).
 - The `totalPrice` and `educationalPriceDetail` fields are now deprecated in the collective endpoints.
   - Please use the `price` field instead of `totalPrice`.

--- a/api/documentation/static/openapi.json
+++ b/api/documentation/static/openapi.json
@@ -1670,7 +1670,6 @@
                             "$ref": "#/components/schemas/CinemaStock"
                         },
                         "maxItems": 850,
-                        "minItems": 1,
                         "title": "Stocks",
                         "type": "array"
                     }
@@ -10931,7 +10930,7 @@
         },
         "/public/offers/v1/events/cinema_sessions": {
             "put": {
-                "description": "**\u26a0\ufe0f WARNING: This endpoint is not yet functional (offers & stocks will not be created), this is an endpoint preview to test its interface.**\n\nThis endpoint allows for the batch update (update/insert/delete) of cinema sessions for a venue.\n\n**\u2139\ufe0fImportant information:**\n\n- On pass Culture side, a film corresponds to an offer and a session/show corresponds to a stock. Therefore, **for a given `\"filmId\"`, there can be only one offer in each location** (a location being the venue address or an address specified in the `\"address\"` section of the payload).\n\n- As it is a batch update, **for each film we expect you to send _all_ the sessions scheduled in the future**. Any missing session in subsequent calls will be considered as cancelled and soft deleted on our side.",
+                "description": "This endpoint allows for the batch update (update/insert/delete) of cinema sessions for a venue.\n\n**\u2139\ufe0fImportant information:**\n\n- On pass Culture side, a film corresponds to an offer and a session/show corresponds to a stock. Therefore, **for a given `\"filmId\"`, there can be only one offer in each location** (a location being the venue address or an address specified in the `\"address\"` section of the payload).\n\n- As it is a batch update, **for each film we expect you to send _all_ the sessions scheduled in the future**. Any missing session in subsequent calls will be considered as cancelled and soft deleted on our side.",
                 "operationId": "PutBatchUpdateCinemaSessions",
                 "parameters": [],
                 "requestBody": {
@@ -10976,7 +10975,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "summary": "(PREVIEW) Batch Update Cinema Sessions",
+                "summary": "(BETA) Batch Update Cinema Sessions",
                 "tags": [
                     "Event Offers"
                 ]

--- a/api/src/pcapi/celery_tasks/celery_worker.py
+++ b/api/src/pcapi/celery_tasks/celery_worker.py
@@ -14,7 +14,6 @@ import pcapi.core.mails.tasks  # noqa: F401
 import pcapi.core.offerers.tasks  # noqa: F401
 import pcapi.core.offers.tasks  # noqa: F401
 import pcapi.core.operations.tasks  # noqa: F401
-import pcapi.core.providers.batch_update_cinema_offers_task  # noqa: F401
 import pcapi.core.providers.tasks  # noqa: F401
 import pcapi.core.subscription.bonus.tasks  # noqa: F401
 import pcapi.core.subscription.ubble.tasks  # noqa: F401

--- a/api/src/pcapi/core/providers/etls/public_api_etl.py
+++ b/api/src/pcapi/core/providers/etls/public_api_etl.py
@@ -1,11 +1,9 @@
 import logging
 import typing
 
-import pydantic as pydantic_v2
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 
-from pcapi.celery_tasks.tasks import celery_async_task
 from pcapi.core.categories import subcategories
 from pcapi.core.finance import utils as finance_utils
 from pcapi.core.offerers import api as offerers_api
@@ -23,18 +21,9 @@ from pcapi.utils.repository import atomic
 logger = logging.getLogger(__name__)
 
 
-class TaskPayload(pydantic_v2.BaseModel):
-    provider_id: int
-    request_payload: events_serializers.PutCinemaSessions
-
-
-@celery_async_task(
-    name="tasks.providers.default.batch_update_cinema_offers",
-    model=TaskPayload,
-)
-def batch_update_cinema_offers_task(payload: TaskPayload) -> None:
-    extract_result = _extract(payload)
-    transform_result = _transform(payload.request_payload, extract_result)
+def batch_update_cinema_offers_etl(provider_id: int, request_payload: events_serializers.PutCinemaSessions) -> None:
+    extract_result = _extract(provider_id, request_payload)
+    transform_result = _transform(request_payload, extract_result)
     with atomic():
         _load(
             transform_result,
@@ -58,17 +47,17 @@ class _ExtractResult(typing.TypedDict):
     offers_by_id_at_provider: dict[str, offers_models.Offer]
 
 
-def _extract(task_payload: TaskPayload) -> _ExtractResult:
+def _extract(provider_id: int, request_payload: events_serializers.PutCinemaSessions) -> _ExtractResult:
     """Extract existing data from DB"""
-    allocine_ids, visas = task_payload.request_payload.get_film_ids_split_by_id_origin()
-    offers_addresses = task_payload.request_payload.get_offers_addresses()
+    allocine_ids, visas = request_payload.get_film_ids_split_by_id_origin()
+    offers_addresses = request_payload.get_offers_addresses()
     offers_computed_ids = set()
 
-    for offer in task_payload.request_payload.offers:
-        offers_computed_ids.add(_compute_offer_id_at_provider(task_payload.request_payload.venue_id, offer))
+    for offer in request_payload.offers:
+        offers_computed_ids.add(_compute_offer_id_at_provider(request_payload.venue_id, offer))
 
-    provider = db.session.query(providers_models.Provider).filter_by(id=task_payload.provider_id).one()
-    venue = db.session.query(offerers_models.Venue).filter_by(id=task_payload.request_payload.venue_id).one()
+    provider = db.session.query(providers_models.Provider).filter_by(id=provider_id).one()
+    venue = db.session.query(offerers_models.Venue).filter_by(id=request_payload.venue_id).one()
 
     return {
         "venue": venue,

--- a/api/src/pcapi/core/providers/tasks.py
+++ b/api/src/pcapi/core/providers/tasks.py
@@ -1,14 +1,17 @@
 import enum
 import logging
 
+import pydantic as pydantic_v2
 from pydantic import BaseModel as BaseModelV2
 
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.providers.repository as providers_repository
 from pcapi.celery_tasks.tasks import celery_async_task
+from pcapi.core.providers.etls.public_api_etl import batch_update_cinema_offers_etl
 from pcapi.core.providers.serialization import ExternalEventBookingRequest
 from pcapi.local_providers.provider_manager import synchronize_ems_venue_provider
 from pcapi.local_providers.provider_manager import synchronize_venue_provider
+from pcapi.routes.public.individual_offers.v1.serializers import events as events_serializers
 from pcapi.utils import requests
 
 
@@ -98,3 +101,16 @@ def external_api_booking_notification_task_with_built_in_rate_limit(
             exception,
             extra={"stock_id": payload.data.stock_id, "booking_creation_date": payload.data.booking_creation_date},
         )
+
+
+class BatchUpdateOffersTaskPayload(pydantic_v2.BaseModel):
+    provider_id: int
+    request_payload: events_serializers.PutCinemaSessions
+
+
+@celery_async_task(
+    name="tasks.providers.default.batch_update_cinema_offers",
+    model=BatchUpdateOffersTaskPayload,
+)
+def batch_update_cinema_offers_task(payload: BatchUpdateOffersTaskPayload) -> None:
+    batch_update_cinema_offers_etl(provider_id=payload.provider_id, request_payload=payload.request_payload)

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -20,6 +20,7 @@ from pcapi.core.offers import models as offers_models
 from pcapi.core.offers import repository as offers_repository
 from pcapi.core.offers import schemas as offers_schemas
 from pcapi.core.offers.validation import check_for_duplicated_price_categories
+from pcapi.core.providers import tasks as providers_tasks
 from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.routes.public import blueprints
@@ -835,10 +836,7 @@ def _get_existing_addresses_ids(addresses_ids: set[int]) -> set[int]:
 )
 def put_batch_update_cinema_sessions(body: events_serializers.PutCinemaSessions) -> None:
     """
-    (PREVIEW) Batch Update Cinema Sessions
-
-    **⚠️ WARNING: This endpoint is not yet functional (offers & stocks will not be created), this is an endpoint preview to test
-    its interface.**
+    (BETA) Batch Update Cinema Sessions
 
     This endpoint allows for the batch update (update/insert/delete) of cinema sessions for a venue.
 
@@ -850,9 +848,7 @@ def put_batch_update_cinema_sessions(body: events_serializers.PutCinemaSessions)
     - As it is a batch update, **for each film we expect you to send _all_ the sessions scheduled in the future**. Any missing session in subsequent calls
     will be considered as cancelled and soft deleted on our side.
     """
-    venue_provider = authorization.get_venue_provider_or_raise_404(body.venue_id)
-    venue = utils.get_venue_with_offerer_address(venue_provider.venueId)
-
+    authorization.get_venue_provider_or_raise_404(body.venue_id)
     addresses_ids = body.get_addresses_ids()
     if addresses_ids:
         existing_addresses_ids = _get_existing_addresses_ids(addresses_ids)
@@ -861,5 +857,8 @@ def put_batch_update_cinema_sessions(body: events_serializers.PutCinemaSessions)
             raise api_errors.ResourceNotFoundError(
                 {"global": [f"Addresse(s) not found. Missing ids: {list(missing_addresses_ids)}"]}
             )
-
-    logger.info("Update cinema sessions", extra={"venue_id": venue.id, "payload": body.model_dump()})
+    payload = providers_tasks.BatchUpdateOffersTaskPayload(
+        provider_id=current_api_key.provider.id,
+        request_payload=body,
+    )
+    providers_tasks.batch_update_cinema_offers_task.delay(payload.model_dump())

--- a/api/src/pcapi/routes/public/individual_offers/v1/serializers/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/serializers/events.py
@@ -406,7 +406,7 @@ class CinemaStock(serialization.HttpBodyModel):
             description='Show/session features. You must indicate the show/session language: either `"VF"` or `"VO"`.'
         ),
     ]
-    beginning_datetime: serialization_utils.future_tz_aware_datetime = fields_v2.BEGINNING_DATETIME
+    beginning_datetime: serialization_utils.future_tz_aware_datetime_to_utc_datetime = fields_v2.BEGINNING_DATETIME
 
 
 class CinemaPriceCategory(serialization.HttpBodyModel):
@@ -465,7 +465,7 @@ class CinemaOffer(serialization.HttpBodyModel):
     ]
     stocks: Annotated[
         list[CinemaStock],
-        pydantic_v2.Field(min_length=1, max_length=850, description="List of sessions/shows for given offer"),
+        pydantic_v2.Field(max_length=850, description="List of sessions/shows for given offer"),
         pydantic_v2.AfterValidator(_validate_ids_at_provider_are_unique),
     ]
     price_categories: Annotated[

--- a/api/src/pcapi/serialization/utils.py
+++ b/api/src/pcapi/serialization/utils.py
@@ -176,6 +176,14 @@ def check_date_in_future_and_remove_timezone(
     return no_tz_value
 
 
+def _check_datetime_in_future_and_format_to_utc_datetime(value: datetime.datetime) -> datetime.datetime:
+    if value.tzinfo is None:
+        raise PydanticError("The datetime must be timezone-aware.")
+    if value < datetime.datetime.now(datetime.timezone.utc):
+        raise PydanticError("The datetime must be in the future.")
+    return value.astimezone(datetime.timezone.utc)
+
+
 def validate_datetime(field_name: str, always: bool = False) -> classmethod:
     # TODO: (tcoudray-pass, 11/05/26) Should not accept `None` value
     def _check_if_not_none(value: datetime.datetime | NOW_LITERAL | None) -> datetime.datetime | None:
@@ -191,6 +199,10 @@ def _validate_datetime(value: datetime.datetime) -> datetime.datetime:
 
 
 future_tz_aware_datetime = Annotated[datetime.datetime, pydantic_v2.AfterValidator(_validate_datetime)]
+future_tz_aware_datetime_to_utc_datetime = Annotated[
+    datetime.datetime,
+    pydantic_v2.AfterValidator(_check_datetime_in_future_and_format_to_utc_datetime),
+]
 
 
 def validate_timezoned_datetime(field_name: str, always: bool = False) -> classmethod:

--- a/api/tests/core/providers/test_batch_update_cinema_offers_task.py
+++ b/api/tests/core/providers/test_batch_update_cinema_offers_task.py
@@ -11,9 +11,9 @@ from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
-from pcapi.core.providers import batch_update_cinema_offers_task
 from pcapi.core.providers import factories as provider_factories
 from pcapi.core.providers import models as provider_models
+from pcapi.core.providers import tasks
 from pcapi.models import db
 from pcapi.utils import date as date_utils
 
@@ -47,7 +47,7 @@ class BatchUpdateCinemaOffersTaskTest:
         film_id: str | None = None,
         data: dict | None = None,
         address: dict | None = None,
-    ) -> batch_update_cinema_offers_task.TaskPayload:
+    ) -> tasks.BatchUpdateOffersTaskPayload:
         two_weeks_from_now = date_utils.get_naive_utc_now().replace(
             hour=18, minute=30, second=0, microsecond=0
         ) + datetime.timedelta(weeks=2)
@@ -74,13 +74,13 @@ class BatchUpdateCinemaOffersTaskTest:
         if data:
             request_payload.update(**data)
 
-        return batch_update_cinema_offers_task.TaskPayload(provider_id=provider_id, request_payload=request_payload)
+        return tasks.BatchUpdateOffersTaskPayload(provider_id=provider_id, request_payload=request_payload)
 
     @time_machine.travel("2026-05-01", tick=False)
     def test_create_offers_and_stocks_with_allocine(self):
         venue, provider, allocine_product, _, _ = self.setup_base_resource()
         task_payload = self.generate_task_payload(provider_id=provider.id, venue_id=venue.id)
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)
+        tasks.batch_update_cinema_offers_task(task_payload)
         offers = db.session.query(offers_models.Offer).all()
         assert len(offers) == 1
         price_categories = db.session.query(offers_models.PriceCategory).all()
@@ -113,7 +113,7 @@ class BatchUpdateCinemaOffersTaskTest:
     def test_create_offer_with_visa(self):
         venue, provider, _, visa_product, _ = self.setup_base_resource()
         task_payload = self.generate_task_payload(provider_id=provider.id, venue_id=venue.id, film_id="visa:166715")
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)
+        tasks.batch_update_cinema_offers_task(task_payload)
         offers = db.session.query(offers_models.Offer).all()
         assert len(offers) == 1
         price_categories = db.session.query(offers_models.PriceCategory).all()
@@ -137,7 +137,7 @@ class BatchUpdateCinemaOffersTaskTest:
             venue_id=venue.id,
             address={"id": address.id, "label": "Somewhere out there"},
         )
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)
+        tasks.batch_update_cinema_offers_task(task_payload)
         offers = db.session.query(offers_models.Offer).all()
         assert len(offers) == 1
         price_categories = db.session.query(offers_models.PriceCategory).all()
@@ -173,8 +173,8 @@ class BatchUpdateCinemaOffersTaskTest:
             venue_id=venue.id,
             address={"id": address.id, "label": "Somewhere out there"},
         )
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)  # twice
+        tasks.batch_update_cinema_offers_task(task_payload)
+        tasks.batch_update_cinema_offers_task(task_payload)  # twice
         offers = db.session.query(offers_models.Offer).all()
         assert len(offers) == 1
         price_categories = db.session.query(offers_models.PriceCategory).all()
@@ -245,7 +245,7 @@ class BatchUpdateCinemaOffersTaskTest:
         stock_to_update.dnBookedQuantity = 1
         db.session.commit()
 
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)
+        tasks.batch_update_cinema_offers_task(task_payload)
         offers = db.session.query(offers_models.Offer).all()
         assert len(offers) == 1
         price_categories = db.session.query(offers_models.PriceCategory).all()
@@ -313,7 +313,7 @@ class BatchUpdateCinemaOffersTaskTest:
 
         db.session.commit()
 
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)
+        tasks.batch_update_cinema_offers_task(task_payload)
         offers = db.session.query(offers_models.Offer).all()
         assert len(offers) == 1
         price_categories = db.session.query(offers_models.PriceCategory).all()
@@ -354,7 +354,7 @@ class BatchUpdateCinemaOffersTaskTest:
             hour=18, minute=30, second=0, microsecond=0
         ) + datetime.timedelta(weeks=2)
 
-        task_payload = batch_update_cinema_offers_task.TaskPayload(
+        task_payload = tasks.BatchUpdateOffersTaskPayload(
             provider_id=provider.id,
             request_payload={
                 "venueId": venue.id,
@@ -390,7 +390,7 @@ class BatchUpdateCinemaOffersTaskTest:
             },
         )
 
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)
+        tasks.batch_update_cinema_offers_task(task_payload)
         offers = db.session.query(offers_models.Offer).order_by(offers_models.Offer.id).all()
         assert len(offers) == 2
         price_categories = db.session.query(offers_models.PriceCategory).all()
@@ -423,7 +423,7 @@ class BatchUpdateCinemaOffersTaskTest:
             hour=18, minute=30, second=0, microsecond=0
         ) + datetime.timedelta(weeks=2)
 
-        task_payload = batch_update_cinema_offers_task.TaskPayload(
+        task_payload = tasks.BatchUpdateOffersTaskPayload(
             provider_id=provider.id,
             request_payload={
                 "venueId": venue.id,
@@ -460,7 +460,7 @@ class BatchUpdateCinemaOffersTaskTest:
             },
         )
 
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)
+        tasks.batch_update_cinema_offers_task(task_payload)
         offers = db.session.query(offers_models.Offer).order_by(offers_models.Offer.id).all()
         assert len(offers) == 2
         offerer_addresses = (
@@ -479,7 +479,7 @@ class BatchUpdateCinemaOffersTaskTest:
             hour=18, minute=30, second=0, microsecond=0
         ) + datetime.timedelta(weeks=2)
 
-        task_payload = batch_update_cinema_offers_task.TaskPayload(
+        task_payload = tasks.BatchUpdateOffersTaskPayload(
             provider_id=provider.id,
             request_payload={
                 "venueId": venue.id,
@@ -524,7 +524,7 @@ class BatchUpdateCinemaOffersTaskTest:
             },
         )
 
-        batch_update_cinema_offers_task.batch_update_cinema_offers_task(task_payload)
+        tasks.batch_update_cinema_offers_task(task_payload)
         offers = db.session.query(offers_models.Offer).order_by(offers_models.Offer.id).all()
         assert len(offers) == 2
 

--- a/api/tests/routes/public/individual_offers/v1/events/put_batch_update_cinema_sessions_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/put_batch_update_cinema_sessions_test.py
@@ -1,9 +1,13 @@
 import datetime
+import decimal
 
 import pytest
 import time_machine
 
 from pcapi.core.geography import factories as geography_factories
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.offers import models as offers_models
+from pcapi.models import db
 from pcapi.utils import date as date_utils
 
 from tests.routes.public.helpers import PublicAPIVenueEndpointHelper
@@ -174,7 +178,6 @@ class PutCinemaSessionsTest(PublicAPIVenueEndpointHelper):
     @pytest.mark.parametrize(
         "stocks, expected_response_json",
         [
-            ([], {"offers.0.stocks": ["List should have at least 1 item after validation, not 0"]}),
             (
                 [{}],
                 {
@@ -453,3 +456,90 @@ class PutCinemaSessionsTest(PublicAPIVenueEndpointHelper):
         }
         response = self.make_request(plain_api_key, json_body=payload)
         assert response.status_code == 204, response.json
+
+    @time_machine.travel("2026-06-23", tick=False)
+    def test_should_return_204_and_run_task(self):
+        allocine_product = offers_factories.EventProductFactory(
+            name="Juste une illusion", extraData={"allocineId": 1000015954}
+        )
+        visa_product = offers_factories.EventProductFactory(name="Hamnet", extraData={"visa": "166715"})
+        plain_api_key, venue_provider = self.setup_active_venue_provider()
+        venue = venue_provider.venue
+        payload = {
+            "venueId": venue_provider.venue.id,
+            "offers": [
+                {
+                    "filmId": "visa:166715",
+                    "priceCategories": [
+                        {"price": 500, "label": "Tarif pass Culture", "idAtProvider": "PC"},
+                        {"price": 1000, "label": "Tarif PC 2", "idAtProvider": "PC_2"},
+                    ],
+                    "stocks": [
+                        {
+                            "beginningDatetime": "2026-07-07T20:30:00+02:00",
+                            "priceCategoryIdAtProvider": "PC",
+                            "quantity": 100,
+                            "idAtProvider": "film166715_session1",
+                            "features": ["VF"],
+                        },
+                        {
+                            "beginningDatetime": "2026-07-07T20:30:00+02:00",
+                            "priceCategoryIdAtProvider": "PC_2",
+                            "quantity": 200,
+                            "idAtProvider": "film166715_session2",
+                            "features": ["VO"],
+                        },
+                    ],
+                },
+                {
+                    "filmId": "allocine_id:1000015954",
+                    "priceCategories": [{"price": 600, "label": "Tarif pass Culture", "idAtProvider": "PC"}],
+                    "stocks": [
+                        {
+                            "beginningDatetime": "2026-07-07T20:30:00+02:00",
+                            "priceCategoryIdAtProvider": "PC",
+                            "quantity": 50,
+                            "idAtProvider": "film1000015954_session1",
+                            "features": ["VF"],
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.make_request(plain_api_key, json_body=payload)
+        assert response.status_code == 204, response.json
+
+        offers = db.session.query(offers_models.Offer).order_by(offers_models.Offer.id).all()
+        assert len(offers) == 2
+
+        offer_visa = offers[0]
+        offer_allocine = offers[1]
+
+        assert offer_visa.product == visa_product
+        assert offer_visa.idAtProvider == f"visa:166715%{venue.id}"
+        assert len(offer_visa.stocks) == 2
+        assert len(offer_visa.priceCategories) == 2
+        stock_vf = next(stock for stock in offer_visa.stocks if "VF" in stock.features)
+        assert stock_vf.quantity == 100
+        assert stock_vf.idAtProviders == "film166715_session1"
+        assert stock_vf.features == ["VF"]
+        assert stock_vf.priceCategory.price == decimal.Decimal("5.00")
+        assert stock_vf.priceCategory.label == "Tarif pass Culture"
+        assert stock_vf.bookingLimitDatetime == datetime.datetime(2026, 7, 7, 18, 30)
+        stock_vo = next(stock for stock in offer_visa.stocks if "VO" in stock.features)
+        assert stock_vo.quantity == 200
+        assert stock_vo.idAtProviders == "film166715_session2"
+        assert stock_vo.features == ["VO"]
+        assert stock_vo.priceCategory.price == decimal.Decimal("10.00")
+        assert stock_vo.priceCategory.label == "Tarif PC 2"
+        assert stock_vo.bookingLimitDatetime == datetime.datetime(2026, 7, 7, 18, 30)
+
+        assert offer_allocine.product == allocine_product
+        assert offer_allocine.idAtProvider == f"allocine_id:1000015954%{venue.id}"
+        assert len(offer_allocine.priceCategories) == 1
+        assert offer_allocine.priceCategories[0].label == "Tarif pass Culture"
+        assert offer_allocine.priceCategories[0].price == decimal.Decimal("6.00")
+        assert len(offer_allocine.stocks) == 1
+        assert offer_allocine.stocks[0].priceCategory == offer_allocine.priceCategories[0]
+        assert offer_allocine.stocks[0].quantity == 50
+        assert offer_allocine.stocks[0].features == ["VF"]


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41695)

Fait dans ce ticket :
- Rendre le endpoint cinéma fonctionnel en le liant à la tâche celery
- Ajouter la possibilité de n'indiquer aucun stock pour une offre (si le provider veut supprimer toutes les séances)
- Migrer `batch_update_cinema_offers_task ` dans `providers.tasks`

