### PR TITLE
(PC-42480) fix: dependabot graph for image-resizing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,3 +75,11 @@ updates:
     cooldown:
       # The property 'semver-major-days' is not supported for the package ecosystem 'github-actions'.
       default-days: 14
+
+  # App Engine
+  - package-ecosystem: 'pip'
+    directories:
+      - 'app-engine/image-resizing'
+    schedule:
+      # Disable dependency graph for now
+      interval: 'never'


### PR DESCRIPTION
PC-42480

Dependabot essaye de traiter les dépendances de `/app-engine/image-resizing` avec `uv`, mais on utilise `pip` dans ce folder -> on explicite le package manager