### PR TITLE
(PC-42480) fix: dependabot interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,4 +82,4 @@ updates:
       - 'app-engine/image-resizing'
     schedule:
       # Disable dependency graph for now
-      interval: 'never'
+      interval: 'yearly'


### PR DESCRIPTION
`interval: never` n'existe pas (plus ?)
-> `yearly`