### PR TITLE
(PC-42491)[API] fix: remove api key auth decorator from storage route

### DIFF
--- a/api/src/pcapi/routes/internal/storage.py
+++ b/api/src/pcapi/routes/internal/storage.py
@@ -5,11 +5,10 @@ from flask import send_file
 
 from pcapi.core.object_storage.backends.local import LocalBackend
 from pcapi.routes.apis import public_api
-from pcapi.routes.internal.auth import api_key_required
 
 
+# used locally only: auth is not needed.
 @public_api.route("/storage/<bucket_id>/<path:object_id>")
-@api_key_required
 def send_storage_file(bucket_id: str, object_id: str) -> Response:
     path = LocalBackend().local_path(bucket_id, object_id)
     type_path = path.parent / (path.name + ".type")


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42491)

Un précédent [_commit_](https://github.com/pass-culture/pass-culture-main/commit/f89bcaec5d17404eb4ef614af8580ef965020e43) avait ajouté un décorateur sur des routes utilisées par les tests e2e. Seulement, la route pour récupérer des images n'en avait pas besoin. Et cela pose maintenant un problème en local : les appels ne sont pas authentifiés, donc rejetés, et aucun media ne peut être affiché dans le portail pro.