### PR TITLE
(PC-41913)[API] feat: remove esperluette and rename search group

### DIFF
--- a/api/src/pcapi/core/categories/app_search_tree.py
+++ b/api/src/pcapi/core/categories/app_search_tree.py
@@ -323,7 +323,7 @@ SEARCH_GROUP_ARTS_LOISIRS_CREATIFS = SearchGroup(
         NATIVE_CATEGORY_PRATIQUE_ARTISTIQUE_EN_LIGNE,
     ],
     search_value="ARTS_LOISIRS_CREATIFS",
-    label="Arts & loisirs créatifs",
+    label="Arts et loisirs créatifs",
     included_subcategories=[
         "ABO_PRATIQUE_ART",
         "ATELIER_PRATIQUE_ART",
@@ -347,7 +347,7 @@ SEARCH_GROUP_CONCERTS_FESTIVALS = SearchGroup(
         NATIVE_CATEGORY_FESTIVALS,
     ],
     search_value="CONCERTS_FESTIVALS",
-    label="Concerts & festivals",
+    label="Concerts et festivals",
     included_subcategories=["ABO_CONCERT", "CONCERT", "EVENEMENT_MUSIQUE", "FESTIVAL_MUSIQUE"],
 )
 SEARCH_GROUP_EVENEMENTS_EN_LIGNE = SearchGroup(
@@ -400,7 +400,7 @@ SEARCH_GROUP_JEUX_JEUX_VIDEOS = SearchGroup(
         NATIVE_CATEGORY_RENCONTRES_EVENEMENTS,
     ],
     search_value="JEUX_JEUX_VIDEOS",
-    label="Jeux & jeux vidéos",
+    label="Jeux et jeux vidéos",
     included_subcategories=[
         "ABO_JEU_VIDEO",
         "ABO_LUDOTHEQUE",
@@ -434,7 +434,7 @@ SEARCH_GROUP_LIVRES = SearchGroup(
 SEARCH_GROUP_MEDIA_PRESSE = SearchGroup(
     children=[NATIVE_CATEGORY_AUTRES_MEDIAS, NATIVE_CATEGORY_PODCAST, NATIVE_CATEGORY_PRESSE_EN_LIGNE],
     search_value="MEDIA_PRESSE",
-    label="Médias & presse",
+    label="Médias et presse",
     included_subcategories=["ABO_PRESSE_EN_LIGNE", "APP_CULTURELLE", "PODCAST"],
 )
 SEARCH_GROUP_MUSEES_VISITES_CULTURELLES = SearchGroup(
@@ -445,7 +445,7 @@ SEARCH_GROUP_MUSEES_VISITES_CULTURELLES = SearchGroup(
         NATIVE_CATEGORY_VISITES_CULTURELLES_EN_LIGNE,
     ],
     search_value="MUSEES_VISITES_CULTURELLES",
-    label="Musées & visites culturelles",
+    label="Musées et visites",
     included_subcategories=[
         "CARTE_MUSEE",
         "EVENEMENT_PATRIMOINE",
@@ -499,7 +499,7 @@ SEARCH_GROUP_RENCONTRES_CONFERENCES = SearchGroup(
         NATIVE_CATEGORY_SALONS_ET_METIERS,
     ],
     search_value="RENCONTRES_CONFERENCES",
-    label="Conférences & rencontres",
+    label="Conférences et rencontres",
     included_subcategories=["CONFERENCE", "DECOUVERTE_METIERS", "RENCONTRE_EN_LIGNE", "RENCONTRE", "SALON"],
 )
 SEARCH_GROUP_SPECTACLES = SearchGroup(

--- a/api/tests/routes/native/v1/categories_test.py
+++ b/api/tests/routes/native/v1/categories_test.py
@@ -47,19 +47,19 @@ class SubcategoriesTest:
         search_groups = response.json["searchGroups"]
 
         assert search_groups == [
-            {"name": "ARTS_LOISIRS_CREATIFS", "value": "Arts & loisirs créatifs"},
+            {"name": "ARTS_LOISIRS_CREATIFS", "value": "Arts et loisirs créatifs"},
             {"name": "CARTES_JEUNES", "value": "Cartes jeunes"},
-            {"name": "CONCERTS_FESTIVALS", "value": "Concerts & festivals"},
+            {"name": "CONCERTS_FESTIVALS", "value": "Concerts et festivals"},
             {"name": "EVENEMENTS_EN_LIGNE", "value": "Évènements en ligne"},
             {"name": "CINEMA", "value": "Cinéma"},
             {"name": "FILMS_DOCUMENTAIRES_SERIES", "value": "Films, séries et documentaires"},
-            {"name": "JEUX_JEUX_VIDEOS", "value": "Jeux & jeux vidéos"},
+            {"name": "JEUX_JEUX_VIDEOS", "value": "Jeux et jeux vidéos"},
             {"name": "LIVRES", "value": "Livres"},
-            {"name": "MEDIA_PRESSE", "value": "Médias & presse"},
-            {"name": "MUSEES_VISITES_CULTURELLES", "value": "Musées & visites culturelles"},
+            {"name": "MEDIA_PRESSE", "value": "Médias et presse"},
+            {"name": "MUSEES_VISITES_CULTURELLES", "value": "Musées et visites"},
             {"name": "MUSIQUE", "value": "Musique"},
             {"name": "NONE", "value": "None"},
-            {"name": "RENCONTRES_CONFERENCES", "value": "Conférences & rencontres"},
+            {"name": "RENCONTRES_CONFERENCES", "value": "Conférences et rencontres"},
             {"name": "SPECTACLES", "value": "Spectacles"},
         ]
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41913)

- Remplacement de l'esperluette par des "et" pour les search group
- Suppression de "culturelles" pour "Musées et visites culturelles"

| Case | Before | After |
|--------|--------|--------|
| Cat sup |<img width="509" height="460" alt="Capture d’écran 2026-06-23 à 11 01 06" src="https://github.com/user-attachments/assets/81e2b539-3c30-4544-b8f8-b25f7a04c86e" />|<img width="512" height="459" alt="Capture d’écran 2026-06-23 à 11 00 08" src="https://github.com/user-attachments/assets/bddedfa3-b29f-413b-901b-ebfd6701324d" />|
| Cat inf |<img width="514" height="345" alt="Capture d’écran 2026-06-23 à 11 01 13" src="https://github.com/user-attachments/assets/657afe79-ef4e-46c2-8f2c-04ee439c143f" />|<img width="507" height="342" alt="Capture d’écran 2026-06-23 à 12 10 23" src="https://github.com/user-attachments/assets/9e5ca333-4b1d-42bf-8468-6ec9725d90c4" />|

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
