### PR TITLE
(PC-42534)[BO] fix: reduce collective bookiong query time by 5

### DIFF
--- a/api/src/pcapi/routes/backoffice/bookings/collective_bookings_blueprint.py
+++ b/api/src/pcapi/routes/backoffice/bookings/collective_bookings_blueprint.py
@@ -107,7 +107,7 @@ def _get_collective_bookings_query() -> sa_orm.Query:
                 offerers_models.Venue.name,
                 offerers_models.Venue.publicName,
             ),
-            sa_orm.joinedload(educational_models.CollectiveBooking.pricings)
+            sa_orm.selectinload(educational_models.CollectiveBooking.pricings)
             .load_only(
                 finance_models.Pricing.amount, finance_models.Pricing.status, finance_models.Pricing.creationDate
             )

--- a/api/tests/routes/backoffice/collective_bookings_test.py
+++ b/api/tests/routes/backoffice/collective_bookings_test.py
@@ -105,10 +105,11 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
     # by a field added in the jinja template.
     # - fetch session + user (1 query)
     # - fetch collective bookings with extra data (1 query)
-    expected_num_queries = 2
+    # - select in load for extra data (1 query)
+    expected_num_queries = 3
 
     def test_list_bookings_without_filter(self, authenticated_client, collective_bookings):
-        with assert_num_queries(self.expected_num_queries - 1):
+        with assert_num_queries(self.expected_num_queries - 2):
             response = authenticated_client.get(url_for(self.endpoint))
             assert response.status_code == 200
 
@@ -270,7 +271,7 @@ class ListCollectiveBookingsTest(GetEndpointHelper):
 
     def test_list_bookings_by_id_not_found(self, authenticated_client, collective_bookings):
         search_query = str(collective_bookings[-1].id * 1000)
-        with assert_num_queries(self.expected_num_queries):
+        with assert_num_queries(self.expected_num_queries - 1):  # no select in load
             response = authenticated_client.get(url_for(self.endpoint, q=search_query))
             assert response.status_code == 200
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42534)

ancien explain `Hash Left Join  (cost=670765.06..1615968.97 rows=5239 width=591)`
nouvel explain `Nested Loop Left Join  (cost=68636.08..367344.18 rows=68 width=577)`

l'ancienne requete était trop complexe pour la configuration actuelle du query planner


- [ ] Travail pair testé en environnement de preview
