### PR TITLE
(BSR)[API] test: use ipdb as defauilt debugger in tests

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -254,6 +254,7 @@ addopts = [
   # Use network range 172.16.0.0/12 once pytest-socket supports it (https://github.com/miketheman/pytest-socket/pull/185)
   "--allow-hosts=127.0.0.1,::1,172.18.0.2,172.18.0.3,172.18.0.4,172.19.0.2,172.19.0.3,172.19.0.4,172.20.0.2,172.20.0.3,172.20.0.4,172.21.0.2,192.168.16.2", # allow connections to local Redis
   "-p no:warnings",
+  "--pdbcls=IPython.terminal.debugger:TerminalPdb", # use ipdb as default debugger in pytest
 ]
 filterwarnings = [
   # Mark warnings as errors


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Change  le debugger par defaut de pdb a ipdb dans les tests.

On pourrait aussi le faire au niveau de projet mais a voir ce que ça donne pour vscode
