### PR TITLE
(BSR)[API] refactor: refactor collective stock patch

### DIFF
--- a/api/src/pcapi/core/educational/api/stock.py
+++ b/api/src/pcapi/core/educational/api/stock.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import typing
 from functools import partial
@@ -116,13 +115,17 @@ def edit_collective_stock(stock: models.CollectiveStock, stock_data: dict) -> No
     booking_limit = stock_data.get("bookingLimitDatetime")
     booking_limit = serialization_utils.as_utc_without_timezone(booking_limit) if booking_limit else None
 
-    updatable_fields = _extract_updatable_fields_from_stock_data(
-        stock,
-        stock_data,
-        start_datetime=start_datetime,
-        end_datetime=end_datetime,
-        booking_limit_datetime=booking_limit,
-    )
+    updatable_fields: dict = {
+        "startDatetime": start_datetime,
+        "endDatetime": end_datetime,
+        "bookingLimitDatetime": booking_limit or stock.bookingLimitDatetime,
+        "price": stock_data.get("price"),
+        "servicePrice": stock_data.get("servicePrice"),
+        "collectiveAdditionalFees": stock_data.get("collectiveAdditionalFees"),
+        "numberOfTickets": stock_data.get("numberOfTickets"),
+        "numberOfTeachers": stock_data.get("numberOfTeachers"),
+        "priceDetail": stock_data.get("priceDetail"),
+    }
 
     check_start = start_datetime or stock.startDatetime
     check_booking_limit_datetime = booking_limit or stock.bookingLimitDatetime
@@ -227,33 +230,3 @@ def edit_collective_stock(stock: models.CollectiveStock, stock_data: dict) -> No
             list(stock_data.keys()),
         )
     )
-
-
-def _extract_updatable_fields_from_stock_data(
-    stock: models.CollectiveStock,
-    stock_data: dict,
-    *,
-    start_datetime: datetime.datetime | None,
-    end_datetime: datetime.datetime | None,
-    booking_limit_datetime: datetime.datetime | None,
-) -> dict:
-    # if booking_limit_datetime is provided but null, set it to default value which is event datetime
-    if "bookingLimitDatetime" in stock_data.keys() and booking_limit_datetime is None:
-        booking_limit_datetime = start_datetime if start_datetime else stock.startDatetime
-
-    if "bookingLimitDatetime" not in stock_data.keys():
-        booking_limit_datetime = stock.bookingLimitDatetime
-
-    updatable_fields = {
-        "startDatetime": start_datetime,
-        "endDatetime": end_datetime,
-        "bookingLimitDatetime": booking_limit_datetime,
-        "price": stock_data.get("price"),
-        "servicePrice": stock_data.get("servicePrice"),
-        "collectiveAdditionalFees": stock_data.get("collectiveAdditionalFees"),
-        "numberOfTickets": stock_data.get("numberOfTickets"),
-        "numberOfTeachers": stock_data.get("numberOfTeachers"),
-        "priceDetail": stock_data.get("priceDetail"),
-    }
-
-    return updatable_fields

--- a/api/src/pcapi/routes/serialization/collective_stock_serialize.py
+++ b/api/src/pcapi/routes/serialization/collective_stock_serialize.py
@@ -16,55 +16,28 @@ from pcapi.serialization.exceptions import PydanticError
 from pcapi.serialization.utils import DecimalPrice
 
 
-def validate_number_of_tickets(number_of_tickets: int | None) -> int:
-    if number_of_tickets is None:
-        raise PydanticError("Le nombre de places ne peut pas être nul.")
-    if number_of_tickets < 0:
-        raise PydanticError("Le nombre de places ne peut pas être négatif.")
-    if number_of_tickets > settings.EAC_NUMBER_OF_TICKETS_LIMIT:
-        raise PydanticError("Le nombre de places est trop élevé.")
-    return number_of_tickets
-
-
-def validate_price(price: float | None) -> float:
-    if price is None:
-        raise PydanticError("Le prix ne peut pas être nul.")
-    if price < 0:
-        raise PydanticError("Le prix ne peut pas être négatif.")
-    if price > settings.EAC_OFFER_PRICE_LIMIT:
-        raise PydanticError("Le prix est trop élevé.")
-    return price
-
-
-def validate_booking_limit_datetime(
-    booking_limit_datetime: datetime | None, info: pydantic_v2.ValidationInfo
-) -> datetime | None:
+def validate_booking_limit_datetime(booking_limit_datetime: datetime, info: pydantic_v2.ValidationInfo) -> datetime:
     start_datetime = info.data.get("startDatetime")
-    if booking_limit_datetime and start_datetime and booking_limit_datetime > start_datetime:
+    if start_datetime and booking_limit_datetime > start_datetime:
         raise PydanticError("La date limite de réservation ne peut être postérieure à la date de début de l'évènement")
+
     return booking_limit_datetime
 
 
-def validate_start_datetime(start_datetime: datetime | None) -> datetime:
-    if start_datetime is None:
-        raise PydanticError("La date de début de l'évènement ne peut pas être nulle.")
-
-    # we need a datetime with timezone information
-    if start_datetime and start_datetime < datetime.now(timezone.utc):
+def validate_start_datetime(start_datetime: datetime) -> datetime:
+    if start_datetime < datetime.now(timezone.utc):
         raise PydanticError("L'évènement ne peut commencer dans le passé.")
     return start_datetime
 
 
-def validate_end_datetime(end_datetime: datetime | None, info: pydantic_v2.ValidationInfo) -> datetime:
-    if end_datetime is None:
-        raise PydanticError("La date de fin de l'évènement ne peut pas être nulle.")
-
-    # we need a datetime with timezone information
-    start_datetime = info.data.get("startDatetime")
-    if end_datetime and end_datetime < datetime.now(timezone.utc):
+def validate_end_datetime(end_datetime: datetime, info: pydantic_v2.ValidationInfo) -> datetime:
+    if end_datetime < datetime.now(timezone.utc):
         raise PydanticError("L'évènement ne peut se terminer dans le passé.")
+
+    start_datetime = info.data.get("startDatetime")
     if start_datetime and end_datetime < start_datetime:
         raise PydanticError("La date de fin de l'évènement ne peut précéder la date de début.")
+
     return end_datetime
 
 
@@ -127,12 +100,12 @@ class CollectiveStockCreationBodyModel(HttpBodyModel):
     startDatetime: typing.Annotated[datetime, pydantic_v2.AfterValidator(validate_start_datetime)]
     endDatetime: typing.Annotated[datetime, pydantic_v2.AfterValidator(validate_end_datetime)]
     bookingLimitDatetime: typing.Annotated[datetime | None, pydantic_v2.AfterValidator(validate_booking_limit_datetime)]
-    price: typing.Annotated[DecimalPrice, pydantic_v2.AfterValidator(validate_price)]
+    price: DecimalPrice = pydantic_v2.Field(ge=0, le=settings.EAC_OFFER_PRICE_LIMIT)
     servicePrice: DecimalPrice | None = pydantic_v2.Field(default=None, ge=0)
     collectiveAdditionalFees: list[CollectiveAdditionalFeeModel] | None = pydantic_v2.Field(
         default=None, max_length=constants.MAX_COLLECTIVE_NUMBER_OF_ADDITIONAL_FEES
     )
-    numberOfTickets: typing.Annotated[int, pydantic_v2.AfterValidator(validate_number_of_tickets)]
+    numberOfTickets: int = pydantic_v2.Field(ge=0, le=settings.EAC_NUMBER_OF_TICKETS_LIMIT)
     numberOfTeachers: int | None = pydantic_v2.Field(default=None, ge=0, le=constants.MAX_COLLECTIVE_NUMBER_OF_TEACHERS)
     priceDetail: typing.Annotated[str | None, pydantic_v2.AfterValidator(validate_price_detail)] = None
 
@@ -176,14 +149,33 @@ class CollectiveStockEditionBodyModel(HttpBodyModel):
     bookingLimitDatetime: typing.Annotated[
         datetime | None, pydantic_v2.AfterValidator(validate_booking_limit_datetime)
     ] = None
-    price: typing.Annotated[DecimalPrice | None, pydantic_v2.AfterValidator(validate_price)] = None
+    price: DecimalPrice | None = pydantic_v2.Field(default=None, ge=0, le=settings.EAC_OFFER_PRICE_LIMIT)
     servicePrice: DecimalPrice | None = pydantic_v2.Field(default=None, ge=0)
     collectiveAdditionalFees: list[CollectiveAdditionalFeeModel] | None = pydantic_v2.Field(
         default=None, max_length=constants.MAX_COLLECTIVE_NUMBER_OF_ADDITIONAL_FEES
     )
-    numberOfTickets: typing.Annotated[int | None, pydantic_v2.AfterValidator(validate_number_of_tickets)] = None
+    numberOfTickets: int | None = pydantic_v2.Field(default=None, ge=0, le=settings.EAC_NUMBER_OF_TICKETS_LIMIT)
     numberOfTeachers: int | None = pydantic_v2.Field(default=None, ge=0, le=constants.MAX_COLLECTIVE_NUMBER_OF_TEACHERS)
     priceDetail: typing.Annotated[str | None, pydantic_v2.AfterValidator(validate_price_detail)] = None
+
+    NON_NULLABLE_FIELDS: typing.ClassVar = (
+        "startDatetime",
+        "endDatetime",
+        "bookingLimitDatetime",
+        "price",
+        "servicePrice",
+        "collectiveAdditionalFees",
+        "numberOfTickets",
+        "numberOfTeachers",
+    )
+
+    @pydantic_v2.field_validator(*NON_NULLABLE_FIELDS, mode="before")
+    @classmethod
+    def validate_not_none(cls, value: typing.Any) -> typing.Any:
+        if value is None:
+            raise PydanticError("Ce champ ne peut pas être null")
+
+        return value
 
     @pydantic_v2.model_validator(mode="after")
     def validate_model(self) -> typing.Self:
@@ -193,18 +185,11 @@ class CollectiveStockEditionBodyModel(HttpBodyModel):
         if new_price_ff_is_active and "priceDetail" in self.model_fields_set:
             raise_error_from_location(None, loc="priceDetail", msg="Ce champ ne peut pas être édité")
 
-        for field_name, field_value in (
-            ("numberOfTeachers", self.numberOfTeachers),
-            ("servicePrice", self.servicePrice),
-            ("collectiveAdditionalFees", self.collectiveAdditionalFees),
-        ):
-            # must not be None when FF is ON
-            if new_price_ff_is_active and field_name in self.model_fields_set and field_value is None:
-                raise_error_from_location(None, loc=field_name, msg="Ce champ est requis")
-
-            # must not be present when FF is OFF
-            if not new_price_ff_is_active and field_name in self.model_fields_set:
-                raise_error_from_location(None, loc=field_name, msg="Ce champ ne peut pas être édité")
+        if not new_price_ff_is_active:
+            # these fields must not be present when FF is OFF
+            for field_name in ("numberOfTeachers", "servicePrice", "collectiveAdditionalFees"):
+                if field_name in self.model_fields_set:
+                    raise_error_from_location(None, loc=field_name, msg="Ce champ ne peut pas être édité")
 
         if new_price_ff_is_active:
             # price, servicePrice and collectiveAdditionalFees must all be present or all absent

--- a/api/tests/core/educational/api/test_edit_collective_offer_stock.py
+++ b/api/tests/core/educational/api/test_edit_collective_offer_stock.py
@@ -18,7 +18,9 @@ from pcapi.routes.serialization import collective_stock_serialize
 from pcapi.utils import date as date_utils
 
 
-@pytest.mark.usefixtures("db_session")
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
 class EditCollectiveOfferStocksTest:
     def test_should_update_all_fields_when_all_changed(self) -> None:
         initial_event_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
@@ -74,49 +76,6 @@ class EditCollectiveOfferStocksTest:
         assert stock.bookingLimitDatetime == initial_booking_limit_date
         assert stock.price == 1200
         assert stock.numberOfTickets == 35
-
-    def test_should_replace_bookingLimitDatetime_with_new_event_datetime_if_provided_but_none(self) -> None:
-        initial_event_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
-        initial_booking_limit_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
-        factories.create_educational_year(initial_event_date)
-        stock_to_be_updated = factories.CollectiveStockFactory(
-            startDatetime=initial_event_date,
-            bookingLimitDatetime=initial_booking_limit_date,
-        )
-        new_event_datetime = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=7, hours=5)
-        new_stock_data = collective_stock_serialize.CollectiveStockEditionBodyModel(
-            startDatetime=new_event_datetime,
-            endDatetime=new_event_datetime,
-            bookingLimitDatetime=None,
-        )
-
-        educational_api_stock.edit_collective_stock(
-            stock=stock_to_be_updated, stock_data=new_stock_data.model_dump(exclude_unset=True)
-        )
-
-        stock = db.session.query(CollectiveStock).filter_by(id=stock_to_be_updated.id).one()
-        assert stock.bookingLimitDatetime == new_event_datetime.replace(tzinfo=None)
-
-    def test_should_replace_bookingLimitDatetime_with_old_event_datetime_if_provided_but_none_and_event_date_unchanged(
-        self,
-    ) -> None:
-        initial_event_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=5)
-        initial_booking_limit_date = date_utils.get_naive_utc_now() + datetime.timedelta(days=3)
-        factories.create_educational_year(initial_event_date)
-        stock_to_be_updated = factories.CollectiveStockFactory(
-            startDatetime=initial_event_date,
-            bookingLimitDatetime=initial_booking_limit_date,
-        )
-        new_stock_data = collective_stock_serialize.CollectiveStockEditionBodyModel(
-            bookingLimitDatetime=None,
-        )
-
-        educational_api_stock.edit_collective_stock(
-            stock=stock_to_be_updated, stock_data=new_stock_data.model_dump(exclude_unset=True)
-        )
-
-        stock = db.session.query(CollectiveStock).filter_by(id=stock_to_be_updated.id).one()
-        assert stock.bookingLimitDatetime == initial_event_date
 
     @time_machine.travel("2020-11-17 15:00:00")
     def should_update_bookings_cancellation_limit_date_if_event_postponed(self) -> None:
@@ -438,7 +397,6 @@ class EditCollectiveOfferStocksTest:
         assert stock.collectiveAdditionalFees == []
 
 
-@pytest.mark.usefixtures("db_session")
 class ReturnErrorTest:
     @time_machine.travel("2020-11-17 15:00:00")
     def test_should_not_allow_stock_edition_when_startDatetime_not_provided_and_bookingLimitDatetime_set_after_existing_event_datetime(

--- a/api/tests/routes/pro/collective_stocks/patch_collective_stock_test.py
+++ b/api/tests/routes/pro/collective_stocks/patch_collective_stock_test.py
@@ -21,6 +21,7 @@ from pcapi.core.providers import factories as providers_factories
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
+from pcapi.routes.serialization.collective_stock_serialize import CollectiveStockEditionBodyModel
 from pcapi.utils import date as date_utils
 
 
@@ -477,66 +478,20 @@ class Return400Test:
         assert edited_stock.bookingLimitDatetime == stock.bookingLimitDatetime
 
     @time_machine.travel("2020-11-17 15:00:00")
-    def should_not_allow_stock_edition_when_numberOfTickets_has_been_set_to_none(self, client):
+    @pytest.mark.parametrize("field", CollectiveStockEditionBodyModel.NON_NULLABLE_FIELDS)
+    def test_fields_not_null(self, client, field):
         stock = factories.CollectiveStockFactory()
         offerers_factories.UserOffererFactory(
             user__email="user@example.com",
             offerer=stock.collectiveOffer.venue.managingOfferer,
         )
 
-        stock_edition_payload = {"numberOfTickets": None}
-
+        stock_edition_payload = {field: None}
         client.with_session_auth("user@example.com")
         response = client.patch(f"/collective/stocks/{stock.id}", json=stock_edition_payload)
 
         assert response.status_code == 400
-        assert response.json == {"numberOfTickets": ["Le nombre de places ne peut pas être nul."]}
-
-    @time_machine.travel("2020-11-17 15:00:00")
-    def should_not_allow_stock_edition_when_price_has_been_set_to_none(self, client):
-        stock = factories.CollectiveStockFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com",
-            offerer=stock.collectiveOffer.venue.managingOfferer,
-        )
-
-        stock_edition_payload = {"price": None}
-
-        client.with_session_auth("user@example.com")
-        response = client.patch(f"/collective/stocks/{stock.id}", json=stock_edition_payload)
-
-        assert response.status_code == 400
-        assert response.json == {"price": ["Le prix ne peut pas être nul."]}
-
-    @time_machine.travel("2020-11-17 15:00:00")
-    def should_not_allow_stock_edition_when_startDatetime_has_been_set_to_none(self, client):
-        stock = factories.CollectiveStockFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com", offerer=stock.collectiveOffer.venue.managingOfferer
-        )
-
-        stock_edition_payload = {"startDatetime": None}
-
-        client.with_session_auth("user@example.com")
-        response = client.patch(f"/collective/stocks/{stock.id}", json=stock_edition_payload)
-
-        assert response.status_code == 400
-        assert response.json == {"startDatetime": ["La date de début de l'évènement ne peut pas être nulle."]}
-
-    @time_machine.travel("2020-11-17 15:00:00")
-    def should_not_allow_stock_edition_when_endDatetime_has_been_set_to_none(self, client):
-        stock = factories.CollectiveStockFactory()
-        offerers_factories.UserOffererFactory(
-            user__email="user@example.com", offerer=stock.collectiveOffer.venue.managingOfferer
-        )
-
-        stock_edition_payload = {"endDatetime": None}
-
-        client.with_session_auth("user@example.com")
-        response = client.patch(f"/collective/stocks/{stock.id}", json=stock_edition_payload)
-
-        assert response.status_code == 400
-        assert response.json == {"endDatetime": ["La date de fin de l'évènement ne peut pas être nulle."]}
+        assert response.json == {field: ["Ce champ ne peut pas être null"]}
 
     @time_machine.travel("2020-11-17 15:00:00")
     def should_raise_error_when_educational_price_detail_length_is_greater_than_1000(self, client):
@@ -777,9 +732,11 @@ class Return400Test:
     @pytest.mark.parametrize(
         "price_value,error",
         (
-            (None, "Le prix ne peut pas être nul."),
-            (-1, "Le prix ne peut pas être négatif."),
-            (settings.EAC_OFFER_PRICE_LIMIT + 1, "Le prix est trop élevé."),
+            (-1, "Saisissez un nombre supérieur ou égal à 0"),
+            (
+                settings.EAC_OFFER_PRICE_LIMIT + 1,
+                f"Saisissez un nombre inférieur ou égal à {settings.EAC_OFFER_PRICE_LIMIT}",
+            ),
         ),
     )
     def should_not_accept_payload_with_price_error(self, client, price_value, error):
@@ -799,9 +756,11 @@ class Return400Test:
     @pytest.mark.parametrize(
         "number_of_tickets_value,error",
         (
-            (None, "Le nombre de places ne peut pas être nul."),
-            (-1, "Le nombre de places ne peut pas être négatif."),
-            (settings.EAC_NUMBER_OF_TICKETS_LIMIT + 1, "Le nombre de places est trop élevé."),
+            (-1, "Saisissez un nombre supérieur ou égal à 0"),
+            (
+                settings.EAC_NUMBER_OF_TICKETS_LIMIT + 1,
+                f"Saisissez un nombre inférieur ou égal à {settings.EAC_NUMBER_OF_TICKETS_LIMIT}",
+            ),
         ),
     )
     def should_not_accept_payload_with_number_of_tickets_error(self, client, number_of_tickets_value, error):
@@ -835,7 +794,6 @@ class Return400Test:
     @pytest.mark.parametrize(
         "number_of_teachers,error",
         (
-            (None, "Ce champ est requis"),
             (-1, "Saisissez un nombre supérieur ou égal à 0"),
             (60, "Saisissez un nombre inférieur ou égal à 50"),
         ),
@@ -909,17 +867,17 @@ class Return400Test:
             # price = None
             (
                 {"price": None, "servicePrice": 10, "collectiveAdditionalFees": []},
-                {"price": ["Le prix ne peut pas être nul."]},
+                {"price": ["Ce champ ne peut pas être null"]},
             ),
             # servicePrice = None
             (
                 {"price": 10, "servicePrice": None, "collectiveAdditionalFees": []},
-                {"servicePrice": ["Ce champ est requis"]},
+                {"servicePrice": ["Ce champ ne peut pas être null"]},
             ),
             # collectiveAdditionalFees = None
             (
                 {"price": 10, "servicePrice": 10, "collectiveAdditionalFees": None},
-                {"collectiveAdditionalFees": ["Ce champ est requis"]},
+                {"collectiveAdditionalFees": ["Ce champ ne peut pas être null"]},
             ),
             # collectiveAdditionalFees invalid
             (
@@ -1011,7 +969,7 @@ class Return400Test:
                         {"type": CollectiveAdditionalFeeType.OTHER.name, "label": "hello", "amount": 5},
                     ],
                 },
-                {"price": ["Le prix est trop élevé."]},
+                {"price": [f"Saisissez un nombre inférieur ou égal à {settings.EAC_OFFER_PRICE_LIMIT}"]},
             ),
         ),
     )

--- a/api/tests/routes/pro/collective_stocks/post_collective_stock_test.py
+++ b/api/tests/routes/pro/collective_stocks/post_collective_stock_test.py
@@ -180,7 +180,7 @@ class Return400Test:
         response = client.with_session_auth("user@example.com").post("/collective/stocks/", json=stock_payload)
 
         assert response.status_code == 400
-        assert response.json == {"numberOfTickets": ["Le nombre de places ne peut pas être négatif."]}
+        assert response.json == {"numberOfTickets": ["Saisissez un nombre supérieur ou égal à 0"]}
 
     @time_machine.travel("2020-11-17 15:00:00")
     def test_should_not_allow_price_to_be_negative_on_creation(self, client):
@@ -195,7 +195,7 @@ class Return400Test:
         response = client.with_session_auth("user@example.com").post("/collective/stocks/", json=stock_payload)
 
         assert response.status_code == 400
-        assert response.json == {"price": ["Le prix ne peut pas être négatif."]}
+        assert response.json == {"price": ["Saisissez un nombre supérieur ou égal à 0"]}
 
     @time_machine.travel("2020-11-17 15:00:00")
     def test_should_not_allow_price_to_be_too_high(self, client):
@@ -210,7 +210,7 @@ class Return400Test:
         response = client.with_session_auth("user@example.com").post("/collective/stocks/", json=stock_payload)
 
         assert response.status_code == 400
-        assert response.json == {"price": ["Le prix est trop élevé."]}
+        assert response.json == {"price": [f"Saisissez un nombre inférieur ou égal à {settings.EAC_OFFER_PRICE_LIMIT}"]}
 
     @time_machine.travel("2020-11-17 15:00:00")
     def test_should_not_allow_too_many_tickets(self, client):
@@ -225,7 +225,9 @@ class Return400Test:
         response = client.with_session_auth("user@example.com").post("/collective/stocks/", json=stock_payload)
 
         assert response.status_code == 400
-        assert response.json == {"numberOfTickets": ["Le nombre de places est trop élevé."]}
+        assert response.json == {
+            "numberOfTickets": [f"Saisissez un nombre inférieur ou égal à {settings.EAC_NUMBER_OF_TICKETS_LIMIT}"]
+        }
 
     @time_machine.travel("2020-11-17 15:00:00")
     def test_should_not_accept_payload_with_bookingLimitDatetime_after_startDatetime(self, client):
@@ -572,7 +574,7 @@ class Return400Test:
                         {"type": CollectiveAdditionalFeeType.OTHER.name, "label": "hello", "amount": 5},
                     ],
                 },
-                {"price": ["Le prix est trop élevé."]},
+                {"price": [f"Saisissez un nombre inférieur ou égal à {settings.EAC_OFFER_PRICE_LIMIT}"]},
             ),
         ),
     )


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

- Remplacer la validation custom par `ge / le` de pydantic
- Valider les champs non-requis et non-nullable au niveau du modèle
- Suppression de `_extract_updatable_fields_from_stock_data` qui n'aide pas la lisibilité

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
