### PR TITLE
(BSR)[PRO] fix: add group for sentry libs in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,11 @@ updates:
       semver-major-days: 14
     ignore:
       - dependency-name: "openapi-typescript-codegen"
+    groups:
+      sentry/*:
+        patterns:
+          - "@sentry/browser"
+          - "@sentry/react"
 
   # Public API doc
   - package-ecosystem: 'npm'


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Création d'un groupe "sentry/*" dans la configuration dependabot pour forcer l'upgrade des libs de Sentry dans une même PR, évitant ainsi que les PRs échouent chacune de leur côté.
