### PR TITLE
(PC-42559)[API] feat: serve artist image from bucket via mediation_uu…

### DIFF
--- a/api/src/pcapi/core/artist/models.py
+++ b/api/src/pcapi/core/artist/models.py
@@ -152,9 +152,21 @@ class Artist(Model):
         ),
     )
 
+    # Artists expose several image sources, by descending priority for the native app (see thumbUrl):
+    #  - mediationImageUrl: full public bucket URL, used directly as <img src> (same format as offers)
+    #  - image:             DEPRECATED Wikimedia URL, kept as fallback during data migration
+    #  - computed_image:    URL of a linked product image, last-resort fallback (set by a cron)
+    # mediationUrl is NOT a URL: it is the bucket object path (bucket name + path) consumed by the
+    # pro frontend's image resizing service as its `filename` query param. Hence two distinct properties.
     @property
     def thumbUrl(self) -> str | None:
-        return self.image or self.computed_image
+        return self.mediationImageUrl or self.image or self.computed_image
+
+    @property
+    def mediationImageUrl(self) -> str | None:
+        if self.mediation_uuid:
+            return f"{settings.OBJECT_STORAGE_URL}/{settings.ARTIST_THUMBS_FOLDER_NAME}/{self.mediation_uuid}"
+        return None
 
     @property
     def mediationUrl(self) -> str | None:

--- a/api/src/pcapi/core/search/__init__.py
+++ b/api/src/pcapi/core/search/__init__.py
@@ -619,6 +619,7 @@ def get_base_query_for_offer_indexation() -> sa_orm.Query:
                     artist_models.Artist.image,
                     artist_models.Artist.is_blacklisted,
                     artist_models.Artist.computed_image,
+                    artist_models.Artist.mediation_uuid,
                 )
             )
         )
@@ -631,6 +632,7 @@ def get_base_query_for_offer_indexation() -> sa_orm.Query:
                 artist_models.Artist.image,
                 artist_models.Artist.is_blacklisted,
                 artist_models.Artist.computed_image,
+                artist_models.Artist.mediation_uuid,
             )
         )
     )

--- a/api/tests/routes/native/v1/artists_tests.py
+++ b/api/tests/routes/native/v1/artists_tests.py
@@ -1,6 +1,7 @@
 import pytest
 
 import pcapi.core.artist.factories as artist_factories
+from pcapi import settings
 from pcapi.core.testing import assert_num_queries
 
 
@@ -20,6 +21,30 @@ class GetArtistsTest:
         assert response.json["id"] == artist.id
         assert response.json["name"] == artist.name
         assert response.json["description"] == artist.description
+        assert response.json["image"] == artist.image
+
+    def test_get_artist_image_uses_bucket_url_when_mediation_uuid_is_set(self, client):
+        artist = artist_factories.ArtistFactory(mediation_uuid="some-mediation-uuid")
+
+        artist_id = artist.id
+        nb_queries = 1  # artist
+        with assert_num_queries(nb_queries):
+            response = client.get(f"/native/v1/artists/{artist_id}")
+
+        assert response.status_code == 200
+        expected_url = f"{settings.OBJECT_STORAGE_URL}/{settings.ARTIST_THUMBS_FOLDER_NAME}/{artist.mediation_uuid}"
+        assert response.json["image"] == expected_url
+        assert response.json["image"] != artist.image
+
+    def test_get_artist_image_falls_back_to_image_when_mediation_uuid_is_none(self, client):
+        artist = artist_factories.ArtistFactory(mediation_uuid=None)
+
+        artist_id = artist.id
+        nb_queries = 1  # artist
+        with assert_num_queries(nb_queries):
+            response = client.get(f"/native/v1/artists/{artist_id}")
+
+        assert response.status_code == 200
         assert response.json["image"] == artist.image
 
     def test_get_artist_with_none_fields(self, client):

--- a/api/tests/routes/native/v1/similar_artists_test.py
+++ b/api/tests/routes/native/v1/similar_artists_test.py
@@ -4,6 +4,7 @@ import pytest
 
 import pcapi.core.artist.factories as artist_factories
 import pcapi.core.offers.factories as offers_factories
+from pcapi import settings
 from pcapi.core.testing import assert_num_queries
 
 
@@ -56,6 +57,24 @@ class GetSimilarArtistsTest:
                 {"id": second.id, "name": second.name, "image": second.thumbUrl},
             ]
         }
+
+    def test_similar_artist_image_uses_bucket_url_when_mediation_uuid_is_set(self, client, requests_mock):
+        similar = artist_factories.ArtistFactory(name="Similar", mediation_uuid="some-mediation-uuid")
+        _link_artist_to_bookable_offer(similar)
+        source_id = "00000000-0000-0000-0000-000000000001"
+
+        requests_mock.get(
+            DS_SIMILAR_ARTISTS_URL.format(artist_id=source_id),
+            content=_ds_response([similar.id]),
+        )
+
+        with assert_num_queries(1):
+            response = client.get(f"/native/v1/artists/{source_id}/similar")
+
+        assert response.status_code == 200
+        expected_url = f"{settings.OBJECT_STORAGE_URL}/{settings.ARTIST_THUMBS_FOLDER_NAME}/{similar.mediation_uuid}"
+        assert response.json["artists"][0]["image"] == expected_url
+        assert response.json["artists"][0]["image"] != similar.image
 
     def test_skips_blacklisted_similar(self, client, requests_mock):
         blacklisted = artist_factories.ArtistFactory(is_blacklisted=True)


### PR DESCRIPTION
…id in native routes

https://passculture.atlassian.net/browse/PC-42559

## Contexte

Sur la fiche artiste de l'app (`GET /native/v1/artists/<id>`) et les artistes similaires (`GET /native/v1/artists/<id>/similar`), l'image renvoyée était l'URL **Wikimedia** (champ `image`, déprécié) au lieu de l'image hébergée dans notre bucket, alors qu'on dispose déjà du `mediation_uuid` (nom du fichier dans le bucket, alimenté par l'import BigQuery).

C'était incohérent avec les **offres**, qui renvoient déjà des URLs publiques complètes du bucket (`https://storage.googleapis.com/.../thumbs/<uuid>`).

## Changements

- Ajout de la propriété `Artist.mediationImageUrl` qui construit l'URL publique complète de l'image du bucket, sur le même modèle que les offres :
  `OBJECT_STORAGE_URL/ARTIST_THUMBS_FOLDER_NAME/<mediation_uuid>` → `https://storage.googleapis.com/.../thumbs/artist/<mediation_uuid>`
- `Artist.thumbUrl` priorise désormais l'image du bucket, avec repli sur l'existant :
  `mediationImageUrl` → `image` (Wikimedia) → `computed_image` (image produit).
- Les routes natives qui utilisent `thumbUrl` bénéficient toutes du correctif sans modification : fiche artiste, artistes similaires, et image artiste dans les offres v3.

## Hors périmètre (volontairement non modifié)

- `Artist.mediationUrl` (format chemin bucket `GCP_BUCKET_NAME/...`) reste **inchangé** : il est consommé par le **pro**, qui le passe à un service de redimensionnement d'images (`?filename=...`). Le natif, lui, utilise l'URL directement dans un `<img src>`, d'où la propriété dédiée `mediationImageUrl`.

## Notes

- Le repli vers l'URL Wikimedia / l'image produit est conservé tant que `mediation_uuid` n'est pas renseigné, pour éviter les images vides pendant la propagation de la donnée.

## Tests

- Nouveau test : un artiste avec `mediation_uuid` renvoie bien l'URL bucket (et plus l'URL Wikimedia) sur `GET /artists/<id>`.
- Nouveau test équivalent sur `GET /artists/<id>/similar`.
- Les tests existants restent valides (la factory ne définit pas `mediation_uuid` → repli sur `image`).
