### PR TITLE
(PC-42411)[API] feat: WIP on rewriting offer/id endpoint

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -475,6 +475,377 @@ def get_offers_details(offer_ids: list[int]) -> sa_orm.Query[models.Offer]:
     )
 
 
+def get_offer_main_data(offer_id: int) -> sa_orm.Query[models.Offer]:
+    """Critical header data: identity, stocks, artists, video and booking flags.
+
+    Excludes venue/address (-> /offerer), images & SEO metadata (-> /header) and
+    engagement counts (-> sub-routes). Only a minimal ``venue -> managingOfferer``
+    join is kept, required by ``Offer.isReleased``. ``Offer._durationMinutes`` is
+    eagerly loaded to avoid a lazy load on product-less offers.
+    """
+    return (
+        db.session.query(models.Offer)
+        .options(
+            sa_orm.load_only(
+                models.Offer.id,
+                models.Offer.name,
+                models.Offer.ean,
+                models.Offer._extraData,
+                models.Offer._durationMinutes,
+                models.Offer.subcategoryId,
+                models.Offer.url,
+                models.Offer.validation,  # required by Offer.isPublished (-> isReleased)
+                models.Offer.publicationDatetime,
+                models.Offer.bookingAllowedDatetime,
+                models.Offer.lastProviderId,
+                models.Offer.isDuo,
+                models.Offer.externalTicketOfficeUrl,
+                models.Offer.productId,
+                models.Offer.venueId,
+            )
+        )
+        .options(
+            sa_orm.selectinload(models.Offer.stocks)
+            .load_only(
+                models.Stock.idAtProviders,
+                models.Stock.beginningDatetime,
+                models.Stock.bookingLimitDatetime,
+                models.Stock.features,
+                models.Stock.price,
+                models.Stock.offerId,
+                models.Stock.isSoftDeleted,
+                models.Stock.quantity,
+                models.Stock.dnBookedQuantity,
+            )
+            .joinedload(models.Stock.priceCategory)
+            .joinedload(models.PriceCategory.priceCategoryLabel)
+        )
+        # minimal venue -> offerer, only for Offer.isReleased
+        .options(
+            sa_orm.joinedload(models.Offer.venue)
+            .load_only(offerers_models.Venue.id)
+            .joinedload(offerers_models.Venue.managingOfferer)
+            .load_only(
+                offerers_models.Offerer.isActive,
+                offerers_models.Offerer.validationStatus,
+            )
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.product).load_only(
+                models.Product.id,
+                models.Product.extraData,
+                models.Product.last_30_days_booking,
+                models.Product.durationMinutes,
+            )
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.product)
+            .selectinload(models.Product.artistLinks)
+            .joinedload(artist_models.ArtistProductLink.artist)
+        )
+        .options(sa_orm.joinedload(models.Offer.artistOfferLinks).joinedload(artist_models.ArtistOfferLink.artist))
+        .options(sa_orm.joinedload(models.Offer.headlineOffers))
+        .options(sa_orm.joinedload(models.Offer.metaData))
+        .outerjoin(models.Offer.lastProvider)
+        .options(sa_orm.contains_eager(models.Offer.lastProvider).load_only(providers_models.Provider.localClass))
+        .filter(
+            models.Offer.id == offer_id,
+            models.Offer.validation == offer_mixin.OfferValidationStatus.APPROVED,
+            models.Offer.isPublished,
+        )
+    )
+
+
+def get_offer_header(offer_id: int) -> sa_orm.Query[models.Offer]:
+    return (
+        db.session.query(models.Offer)
+        .options(
+            sa_orm.load_only(
+                models.Offer.id,
+                models.Offer.name,
+                models.Offer._extraData,
+                models.Offer._description,
+                models.Offer.ean,
+                models.Offer.url,
+                models.Offer.subcategoryId,
+                models.Offer.validation,
+                models.Offer.publicationDatetime,
+                models.Offer.productId,
+                models.Offer.venueId,
+                models.Offer.offererAddressId,
+            )
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.mediations).load_only(
+                models.Mediation.isActive,
+                models.Mediation.dateCreated,
+                models.Mediation.thumbCount,
+                models.Mediation.credit,
+            )
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.product)
+            .load_only(
+                models.Product.id,
+                models.Product.likesCount,
+                models.Product.thumbCount,
+                models.Product.description,
+                models.Product.extraData,  # accessed by get_metadata_from_offer via offer.extraData
+            )
+            .joinedload(models.Product.productMediations)
+            .load_only(
+                models.ProductMediation.imageType,
+                models.ProductMediation.uuid,
+            )
+        )
+        # stocks needed by get_metadata_from_offer: min_price, hasStocks, metadataFirstBeginningDatetime
+        .options(
+            sa_orm.selectinload(models.Offer.stocks).load_only(
+                models.Stock.offerId,
+                models.Stock.price,
+                models.Stock.isSoftDeleted,
+                models.Stock.beginningDatetime,
+                models.Stock.quantity,
+                models.Stock.dnBookedQuantity,
+                models.Stock.bookingLimitDatetime,
+            )
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.venue)
+            .load_only(offerers_models.Venue.id, offerers_models.Venue.name)
+            .joinedload(offerers_models.Venue.offererAddress)
+            .joinedload(offerers_models.OffererAddress.address)
+        )
+        # needed by Offer.isReleased, called via stock.isBookable in is_forbidden_to_underage
+        .options(
+            sa_orm.joinedload(models.Offer.venue)
+            .joinedload(offerers_models.Venue.managingOfferer)
+            .load_only(
+                offerers_models.Offerer.isActive,
+                offerers_models.Offerer.validationStatus,
+            )
+        )
+        .options(sa_orm.joinedload(models.Offer.offererAddress).joinedload(offerers_models.OffererAddress.address))
+        .filter(
+            models.Offer.id == offer_id,
+            models.Offer.validation == offer_mixin.OfferValidationStatus.APPROVED,
+            models.Offer.isPublished,
+        )
+    )
+
+
+def get_offer_offerer(offer_id: int) -> sa_orm.Query[models.Offer]:
+    return (
+        db.session.query(models.Offer)
+        .options(
+            sa_orm.load_only(
+                models.Offer.id,
+                models.Offer._description,
+                models.Offer.withdrawalDetails,
+                models.Offer.audioDisabilityCompliant,
+                models.Offer.mentalDisabilityCompliant,
+                models.Offer.motorDisabilityCompliant,
+                models.Offer.visualDisabilityCompliant,
+                models.Offer.validation,
+                models.Offer.publicationDatetime,
+                models.Offer.productId,
+                models.Offer.venueId,
+                models.Offer.offererAddressId,
+            )
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.venue)
+            .load_only(
+                offerers_models.Venue.id,
+                offerers_models.Venue.name,
+                offerers_models.Venue.publicName,
+                offerers_models.Venue.isPermanent,
+                offerers_models.Venue.isOpenToPublic,
+                offerers_models.Venue._bannerUrl,
+                offerers_models.Venue.venueTypeCode,
+                offerers_models.Venue.isSoftDeleted,
+            )
+            .joinedload(offerers_models.Venue.managingOfferer)
+            .load_only(offerers_models.Offerer.name)
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.venue)
+            .joinedload(offerers_models.Venue.googlePlacesInfo)
+            .load_only(offerers_models.GooglePlacesInfo.bannerUrl)
+        )
+        .options(
+            sa_orm.joinedload(models.Offer.venue)
+            .joinedload(offerers_models.Venue.offererAddress)
+            .joinedload(offerers_models.OffererAddress.address)
+        )
+        .options(sa_orm.joinedload(models.Offer.offererAddress).joinedload(offerers_models.OffererAddress.address))
+        .options(
+            sa_orm.joinedload(models.Offer.product).load_only(
+                models.Product.id,
+                models.Product.description,
+            )
+        )
+        .filter(
+            models.Offer.id == offer_id,
+            models.Offer.validation == offer_mixin.OfferValidationStatus.APPROVED,
+            models.Offer.isPublished,
+        )
+    )
+
+
+def get_offer_chronicles_data(
+    offer_id: int,
+    page: int,
+    limit: int,
+) -> tuple[list[chronicles_models.Chronicle], int] | None:
+    """Returns None when the offer does not exist or is not published."""
+    row = db.session.execute(
+        sa.select(models.Offer.productId, models.Product.chroniclesCount)
+        .outerjoin(models.Offer.product)
+        .where(
+            models.Offer.id == offer_id,
+            models.Offer.validation == offer_mixin.OfferValidationStatus.APPROVED,
+            models.Offer.isPublished,
+        )
+    ).one_or_none()
+
+    if row is None:
+        return None
+
+    product_id, chronicles_count = row
+    offset = (page - 1) * limit
+
+    if product_id:
+        chronicles_query = (
+            db.session.query(chronicles_models.Chronicle)
+            .join(chronicles_models.Chronicle.products)
+            .filter(
+                models.Product.id == product_id,
+                chronicles_models.Chronicle.isPublished,
+            )
+            .order_by(chronicles_models.Chronicle.id.desc())
+        )
+        total = chronicles_count if chronicles_count is not None else chronicles_query.count()
+    else:
+        chronicles_query = (
+            db.session.query(chronicles_models.Chronicle)
+            .join(chronicles_models.Chronicle.offers)
+            .filter(
+                models.Offer.id == offer_id,
+                chronicles_models.Chronicle.isPublished,
+            )
+            .order_by(chronicles_models.Chronicle.id.desc())
+        )
+        total = chronicles_query.count()
+
+    return chronicles_query.offset(offset).limit(limit).all(), total
+
+
+def get_offer_pro_advices_data(
+    offer_id: int,
+    latitude: float | None,
+    longitude: float | None,
+    page: int,
+    limit: int,
+    max_content_length: int | None = None,
+) -> tuple[list[tuple[models.ProAdvice, int | None]], int] | None:
+    """Returns None when the offer does not exist or is not published."""
+    row = db.session.execute(
+        sa.select(models.Offer.productId, models.Product.proAdvicesCount)
+        .outerjoin(models.Offer.product)
+        .where(
+            models.Offer.id == offer_id,
+            models.Offer.validation == offer_mixin.OfferValidationStatus.APPROVED,
+            models.Offer.isPublished,
+        )
+    ).one_or_none()
+
+    if row is None:
+        return None
+
+    product_id, pro_advices_count = row
+    offset = (page - 1) * limit
+
+    results = get_pro_advices(
+        offer_id=offer_id,
+        product_id=product_id,
+        latitude=latitude,
+        longitude=longitude,
+        offset=offset,
+        limit=limit,
+    )
+
+    if product_id:
+        if pro_advices_count is not None:
+            total = pro_advices_count
+        elif len(results) >= limit:
+            total = get_product_pro_advices_count(product_id)
+        else:
+            total = offset + len(results)
+    else:
+        total = offset + len(results)
+
+    return results, total
+
+
+def get_offer_stocks_data(
+    offer_id: int,
+    page: int,
+    limit: int,
+) -> tuple[list[models.Stock], int] | None:
+    """Returns None when the offer does not exist or is not published."""
+    row = db.session.execute(
+        sa.select(
+            models.Offer.id,
+            sa.func.count(models.Stock.id).filter(~models.Stock.isSoftDeleted).label("total"),
+        )
+        .outerjoin(models.Offer.stocks)
+        .where(
+            models.Offer.id == offer_id,
+            models.Offer.validation == offer_mixin.OfferValidationStatus.APPROVED,
+            models.Offer.isPublished,
+        )
+        .group_by(models.Offer.id)
+    ).one_or_none()
+
+    if row is None:
+        return None
+
+    _, total = row
+    offset = (page - 1) * limit
+
+    stocks = (
+        db.session.query(models.Stock)
+        .filter(
+            models.Stock.offerId == offer_id,
+            ~models.Stock.isSoftDeleted,
+        )
+        .options(sa_orm.joinedload(models.Stock.priceCategory).joinedload(models.PriceCategory.priceCategoryLabel))
+        .options(
+            sa_orm.joinedload(models.Stock.offer)
+            .load_only(
+                models.Offer.url,
+                models.Offer.subcategoryId,
+                models.Offer.validation,
+                models.Offer.publicationDatetime,
+            )
+            .joinedload(models.Offer.venue)
+            .load_only(offerers_models.Venue.id)
+            .joinedload(offerers_models.Venue.managingOfferer)
+            .load_only(
+                offerers_models.Offerer.isActive,
+                offerers_models.Offerer.validationStatus,
+            )
+        )
+        .order_by(models.Stock.beginningDatetime.asc().nullsfirst(), models.Stock.id.asc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+
+    return stocks, total
+
+
 def get_nearby_bookable_screenings_from_product(
     product: models.Product,
     latitude: float,

--- a/api/src/pcapi/routes/native/__init__.py
+++ b/api/src/pcapi/routes/native/__init__.py
@@ -5,7 +5,9 @@ def install_routes(app: Flask) -> None:
     from . import v1
     from . import v2
     from . import v3
+    from . import v4
 
     v1.install_routes(app)
     v2.install_routes(app)
     v3.install_routes(app)
+    v4.install_routes(app)

--- a/api/src/pcapi/routes/native/v4/__init__.py
+++ b/api/src/pcapi/routes/native/v4/__init__.py
@@ -1,0 +1,5 @@
+from flask import Flask
+
+
+def install_routes(app: Flask) -> None:
+    from . import offers

--- a/api/src/pcapi/routes/native/v4/offers.py
+++ b/api/src/pcapi/routes/native/v4/offers.py
@@ -1,0 +1,84 @@
+from pcapi.core.offers import repository
+from pcapi.models.api_errors import ResourceNotFoundError
+from pcapi.models.utils import first_or_404
+from pcapi.serialization.decorator import spectree_serialize
+from pcapi.utils.transaction_manager import atomic
+
+from .. import blueprint
+from .serialization import offers as serializers
+
+
+@blueprint.native_route("/offer/<int:offer_id>", version="v4", methods=["GET"])
+@spectree_serialize(response_model=serializers.OfferResponse, api=blueprint.api, on_error_statuses=[404])
+@atomic()
+def get_offer(offer_id: int) -> serializers.OfferResponse:
+    query = repository.get_offer_main_data(offer_id)
+    offer = first_or_404(query)
+    return serializers.OfferResponse.build(offer)
+
+
+@blueprint.native_route("/offer/<int:offer_id>/header", version="v4", methods=["GET"])
+@spectree_serialize(response_model=serializers.OfferHeaderResponse, api=blueprint.api, on_error_statuses=[404])
+@atomic()
+def get_offer_header(offer_id: int) -> serializers.OfferHeaderResponse:
+    query = repository.get_offer_header(offer_id)
+    offer = first_or_404(query)
+    return serializers.OfferHeaderResponse.build(offer)
+
+
+@blueprint.native_route("/offer/<int:offer_id>/offerer", version="v4", methods=["GET"])
+@spectree_serialize(response_model=serializers.OfferOffererResponse, api=blueprint.api, on_error_statuses=[404])
+@atomic()
+def get_offer_offerer(offer_id: int) -> serializers.OfferOffererResponse:
+    query = repository.get_offer_offerer(offer_id)
+    offer = first_or_404(query)
+    return serializers.OfferOffererResponse.build(offer)
+
+
+@blueprint.native_route("/offer/<int:offer_id>/chronicles", version="v4", methods=["GET"])
+@spectree_serialize(response_model=serializers.OfferChroniclesResponse, api=blueprint.api, on_error_statuses=[404])
+@atomic()
+def get_offer_chronicles(offer_id: int, query: serializers.OfferChroniclesQuery) -> serializers.OfferChroniclesResponse:
+    result = repository.get_offer_chronicles_data(offer_id, page=query.page, limit=query.limit)
+    if result is None:
+        raise ResourceNotFoundError()
+    chronicles, total = result
+    return serializers.OfferChroniclesResponse.build(chronicles, total)
+
+
+@blueprint.native_route("/offer/<int:offer_id>/stocks", version="v4", methods=["GET"])
+@spectree_serialize(response_model=serializers.OfferStocksResponse, api=blueprint.api, on_error_statuses=[404])
+@atomic()
+def get_offer_stocks(offer_id: int, query: serializers.OfferStocksQuery) -> serializers.OfferStocksResponse:
+    result = repository.get_offer_stocks_data(offer_id, page=query.page, limit=query.limit)
+    if result is None:
+        raise ResourceNotFoundError()
+    stocks, total = result
+    return serializers.OfferStocksResponse(
+        stocks=[serializers.v3_serializers.OfferStockResponse.build(stock) for stock in stocks],
+        stocks_count=total,
+    )
+
+
+@blueprint.native_route("/offer/<int:offer_id>/pro_advices", version="v4", methods=["GET"])
+@spectree_serialize(response_model=serializers.OfferProAdvicesResponse, api=blueprint.api, on_error_statuses=[404])
+def get_offer_pro_advices(
+    offer_id: int, query: serializers.OfferProAdvicesQuery
+) -> serializers.OfferProAdvicesResponse:
+    result = repository.get_offer_pro_advices_data(
+        offer_id=offer_id,
+        latitude=query.latitude,
+        longitude=query.longitude,
+        page=query.page,
+        limit=query.limit,
+    )
+    if result is None:
+        raise ResourceNotFoundError()
+    pro_advices, total = result
+    return serializers.OfferProAdvicesResponse(
+        pro_advices=[
+            serializers.OfferProAdviceResponse.build(pro_advice, distance, query.max_content_length)
+            for pro_advice, distance in pro_advices
+        ],
+        pro_advices_count=total,
+    )

--- a/api/src/pcapi/routes/native/v4/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v4/serialization/offers.py
@@ -1,0 +1,345 @@
+import datetime
+import logging
+import textwrap
+from typing import Any
+
+import pydantic as pydantic_v2
+
+from pcapi.core.chronicles import models as chronicle_models
+from pcapi.core.offers import models
+from pcapi.core.offers import offer_metadata
+from pcapi.core.offers.api import get_expense_domains
+from pcapi.core.providers import constants as provider_constants
+from pcapi.core.users.models import ExpenseDomain
+from pcapi.routes.native.v3.serialization import offers as v3_serializers
+from pcapi.routes.serialization import HttpBodyModel
+from pcapi.routes.serialization import HttpQueryParamsModel
+
+
+logger = logging.getLogger(__name__)
+
+
+def _serialize_offer_artists(offer: models.Offer) -> list[v3_serializers.OfferArtist]:
+    if offer.product:
+        return [
+            v3_serializers.OfferArtist(
+                id=artist_link.artist.id,
+                image=artist_link.artist.thumbUrl,
+                name=artist_link.artist.name,
+                role=artist_link.artist_type if artist_link.artist_type else None,
+            )
+            for artist_link in offer.product.artistLinks
+            if not artist_link.artist.is_blacklisted
+        ]
+
+    artists = []
+    for artist_link in offer.artistOfferLinks:
+        if artist_link.artist and not artist_link.artist.is_blacklisted:
+            artists.append(
+                v3_serializers.OfferArtist(
+                    id=artist_link.artist_id,
+                    image=artist_link.artist.thumbUrl,
+                    name=artist_link.artist.name,
+                    role=artist_link.artist_type,
+                )
+            )
+        elif artist_link.custom_name:
+            artists.append(
+                v3_serializers.OfferArtist(
+                    id=None,
+                    image=None,
+                    name=artist_link.custom_name,
+                    role=artist_link.artist_type,
+                )
+            )
+
+    return artists
+
+
+class OfferResponse(HttpBodyModel):
+    id: int
+    name: str
+    subcategory_id: str
+    artists: list[v3_serializers.OfferArtist]
+    booking_allowed_datetime: datetime.datetime | None
+    expense_domains: list[ExpenseDomain]
+    external_ticket_office_url: str | None = None
+    extra_data: v3_serializers.OfferExtraDataResponse | None = None
+    is_digital: bool
+    is_duo: bool
+    is_educational: bool
+    is_event: bool
+    is_expired: bool
+    is_external_bookings_disabled: bool
+    is_forbidden_to_underage: bool
+    is_headline: bool
+    is_released: bool
+    is_sold_out: bool
+    last_30_days_bookings: int | None = None
+    publication_date: datetime.datetime | None
+    video: v3_serializers.OfferVideo | None = None
+
+    @classmethod
+    def build(cls, offer: models.Offer) -> "OfferResponse":
+        product = offer.product
+
+        is_external_bookings_disabled = False
+        if offer.lastProvider and offer.lastProvider.localClass in provider_constants.PROVIDER_LOCAL_CLASS_TO_FF:
+            is_external_bookings_disabled = provider_constants.PROVIDER_LOCAL_CLASS_TO_FF[
+                offer.lastProvider.localClass
+            ].is_active()
+
+        raw_extra_data = (product.extraData if product else offer.extraData) or {}
+        extra_data = v3_serializers.OfferExtraDataResponse.model_validate(raw_extra_data)
+        extra_data.duration_minutes = offer.durationMinutes
+        gtl_id = raw_extra_data.get("gtl_id")
+        if gtl_id is not None:
+            extra_data.gtl_labels = v3_serializers.get_gtl_labels(gtl_id)
+        if offer.ean:
+            extra_data.ean = offer.ean
+
+        video = None
+        if offer.metaData and offer.metaData.videoUrl and not offer.metaData.videoExternalId:
+            logger.error(
+                "This offer has a video URL but no videoExternalId in its metaData, and this should not happen",
+                extra={"offer_id": offer.id},
+            )
+        if offer.metaData and offer.metaData.videoExternalId:
+            video = v3_serializers.OfferVideo(
+                id=offer.metaData.videoExternalId,
+                duration_seconds=offer.metaData.videoDuration,
+                thumb_url=offer.metaData.videoThumbnailUrl,
+                title=offer.metaData.videoTitle,
+            )
+
+        return cls(
+            id=offer.id,
+            name=offer.name,
+            subcategory_id=offer.subcategoryId,
+            artists=_serialize_offer_artists(offer),
+            booking_allowed_datetime=offer.bookingAllowedDatetime,
+            expense_domains=[domain.value for domain in get_expense_domains(offer)],
+            external_ticket_office_url=offer.externalTicketOfficeUrl,
+            extra_data=extra_data,
+            is_digital=offer.isDigital,
+            is_duo=offer.isDuo,
+            is_educational=offer.isEducational,
+            is_event=offer.isEvent,
+            is_expired=offer.hasBookingLimitDatetimesPassed,
+            is_external_bookings_disabled=is_external_bookings_disabled,
+            is_forbidden_to_underage=offer.is_forbidden_to_underage,
+            is_headline=offer.is_headline_offer,
+            is_released=offer.isReleased,
+            is_sold_out=offer.isSoldOut,
+            last_30_days_bookings=product.last_30_days_booking if product else None,
+            publication_date=offer.bookingAllowedDatetime,
+            video=video,
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GET /native/v4/offer/<id>/header  —  images + likes count + SEO metadata
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class OfferHeaderResponse(HttpBodyModel):
+    """Images, likes count and SEO metadata for the native v4 offer page header."""
+
+    images: dict[str, v3_serializers.OfferImageResponse] | None = None
+    likes_count: int
+    metadata: dict[str, Any]
+
+    @classmethod
+    def build(cls, offer: models.Offer) -> "OfferHeaderResponse":
+        product = offer.product
+
+        images = None
+        if offer.images:
+            images = {
+                image_type: v3_serializers.OfferImageResponse(url=img.url, credit=img.credit)
+                for image_type, img in offer.images.items()
+            }
+
+        likes_count = (product.likesCount if product else None) or 0
+
+        return cls(
+            images=images,
+            likes_count=likes_count,
+            metadata=offer_metadata.get_metadata_from_offer(offer),
+        )
+
+
+class OfferAccessibilityResponse(HttpBodyModel):
+    audio_disability: bool | None = None
+    mental_disability: bool | None = None
+    motor_disability: bool | None = None
+    visual_disability: bool | None = None
+
+
+class OfferVenueResponse(HttpBodyModel):
+    id: int
+    banner_url: str | None = None
+    is_open_to_public: bool
+    is_permanent: bool
+    name: str
+    public_name: str
+    venue_type_code: str
+
+
+class OfferOffererResponse(HttpBodyModel):
+    """Venue, offerer, address, accessibility and description for the native v4 offerer section."""
+
+    accessibility: OfferAccessibilityResponse
+    address: v3_serializers.OfferAddressResponse | None = None
+    description: str | None = None
+    offerer_name: str
+    venue: OfferVenueResponse
+    withdrawal_details: str | None = None
+
+    @classmethod
+    def build(cls, offer: models.Offer) -> "OfferOffererResponse":
+        venue = offer.venue
+
+        # address: offer-level override takes precedence over venue-level
+        address = None
+        offerer_address = offer.offererAddress or venue.offererAddress
+        if offerer_address and offerer_address.address:
+            addr = offerer_address.address
+            address = v3_serializers.OfferAddressResponse(
+                city=addr.city,
+                coordinates=v3_serializers.OfferVenueCoordinates(
+                    latitude=float(addr.latitude),
+                    longitude=float(addr.longitude),
+                ),
+                label=offerer_address.label,
+                postal_code=addr.postalCode,
+                street=addr.street,
+                timezone=addr.timezone,
+            )
+
+        return cls(
+            accessibility=OfferAccessibilityResponse(
+                audio_disability=offer.audioDisabilityCompliant,
+                mental_disability=offer.mentalDisabilityCompliant,
+                motor_disability=offer.motorDisabilityCompliant,
+                visual_disability=offer.visualDisabilityCompliant,
+            ),
+            address=address,
+            description=offer.description,
+            offerer_name=venue.managingOfferer.name,
+            venue=OfferVenueResponse(
+                id=venue.id,
+                banner_url=venue.bannerUrl,
+                is_open_to_public=venue.isOpenToPublic,
+                is_permanent=venue.isPermanent,
+                name=venue.name,
+                public_name=venue.publicName,
+                venue_type_code=venue.venueTypeCode.name,
+            ),
+            withdrawal_details=offer.withdrawalDetails,
+        )
+
+
+class OfferChroniclesQuery(HttpQueryParamsModel):
+    page: int = pydantic_v2.Field(default=1, ge=1, le=100)
+    limit: int = pydantic_v2.Field(default=10, ge=1, le=50)
+
+
+class OfferChronicleAuthorResponse(HttpBodyModel):
+    age: int | None = None
+    city: str | None = None
+    first_name: str | None = None
+
+
+class OfferChronicleResponse(HttpBodyModel):
+    id: int
+    author: OfferChronicleAuthorResponse | None = None
+    content: str
+    date_created: datetime.datetime
+
+    @classmethod
+    def build(cls, chronicle: chronicle_models.Chronicle) -> "OfferChronicleResponse":
+        author = None
+        if chronicle.isIdentityDiffusible:
+            author = OfferChronicleAuthorResponse(
+                age=chronicle.age,
+                city=chronicle.city,
+                first_name=chronicle.firstName,
+            )
+        return cls(
+            id=chronicle.id,
+            author=author,
+            content=chronicle.content,
+            date_created=chronicle.dateCreated,
+        )
+
+
+class OfferChroniclesResponse(HttpBodyModel):
+    chronicles: list[OfferChronicleResponse]
+    chronicles_count: int
+
+    @classmethod
+    def build(cls, chronicles: list[chronicle_models.Chronicle], total: int) -> "OfferChroniclesResponse":
+        return cls(
+            chronicles=[OfferChronicleResponse.build(c) for c in chronicles],
+            chronicles_count=total,
+        )
+
+
+class OfferProAdvicesQuery(HttpQueryParamsModel):
+    max_content_length: int | None = None
+    page: int = pydantic_v2.Field(default=1, ge=1, le=20)
+    limit: int = pydantic_v2.Field(default=20, ge=1, le=50)
+    latitude: float | None = pydantic_v2.Field(default=None, ge=-90, le=90)
+    longitude: float | None = pydantic_v2.Field(default=None, ge=-180, le=180)
+
+    @pydantic_v2.model_validator(mode="after")
+    def validate_params(self) -> "OfferProAdvicesQuery":
+        if (self.latitude and not self.longitude) or (not self.latitude and self.longitude):
+            raise ValueError("Latitude and longitude must be provided together")
+        return self
+
+
+class OfferProAdviceResponse(HttpBodyModel):
+    author: str | None = None
+    content: str
+    distance: int | None = None
+    publication_datetime: datetime.datetime
+    venue_id: int
+    venue_name: str
+    venue_thumb_url: str | None = None
+
+    @classmethod
+    def build(
+        cls,
+        pro_advice: models.ProAdvice,
+        distance: int | None,
+        max_content_length: int | None,
+    ) -> "OfferProAdviceResponse":
+        content = pro_advice.content
+        if max_content_length:
+            content = textwrap.shorten(content, width=max_content_length, placeholder="…")
+        return cls(
+            author=pro_advice.author,
+            content=content,
+            distance=distance if pro_advice.venue.isOpenToPublic else None,
+            venue_id=pro_advice.venue.id,
+            venue_name=pro_advice.venue.publicName,
+            venue_thumb_url=pro_advice.venue.bannerUrl,
+            publication_datetime=pro_advice.updatedAt,
+        )
+
+
+class OfferProAdvicesResponse(HttpBodyModel):
+    pro_advices: list[OfferProAdviceResponse]
+    pro_advices_count: int
+
+
+class OfferStocksQuery(HttpQueryParamsModel):
+    page: int = pydantic_v2.Field(default=1, ge=1, le=1000)
+    limit: int = pydantic_v2.Field(default=20, ge=1, le=50)
+
+
+class OfferStocksResponse(HttpBodyModel):
+    stocks: list[v3_serializers.OfferStockResponse]
+    stocks_count: int

--- a/api/tests/routes/native/v4/offers_test.py
+++ b/api/tests/routes/native/v4/offers_test.py
@@ -1,0 +1,554 @@
+import pytest
+
+import pcapi.core.artist.factories as artists_factories
+import pcapi.core.chronicles.factories as chronicles_factories
+import pcapi.core.offerers.factories as offerers_factories
+import pcapi.core.offers.factories as offers_factories
+from pcapi.core.artist.models import ArtistType
+from pcapi.core.categories import subcategories
+from pcapi.core.offers.models import ImageType
+from pcapi.core.testing import assert_num_queries
+from pcapi.models.offer_mixin import OfferValidationStatus
+from pcapi.utils import date as date_utils
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class OffersV4Test:
+    # 1. select offer (+ joined venue/offerer, product, artistOfferLinks, headlineOffers, metaData, provider)
+    # 2. select stocks (selectinload)
+    base_num_queries = 2
+    num_queries_with_product = 1  # select product.artistLinks (selectinload)
+
+    def test_get_thing_offer(self, client):
+        offer = offers_factories.OfferFactory(venue__isPermanent=True, subcategoryId=subcategories.CARTE_MUSEE.id)
+        offers_factories.ThingStockFactory(offer=offer, price=12.34)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["id"] == offer.id
+        assert response.json["name"] == offer.name
+        assert response.json["subcategoryId"] == "CARTE_MUSEE"
+        assert response.json["isEvent"] is False
+        assert response.json["isEducational"] is False
+
+    def test_response_is_slim(self, client):
+        # sections moved to dedicated sub-routes must NOT be in the main payload
+        offer = offers_factories.OfferFactory()
+        offers_factories.ThingStockFactory(offer=offer)
+
+        response = client.get(f"/native/v4/offer/{offer.id}")
+
+        assert response.status_code == 200
+        for moved_key in (
+            "venue",
+            "address",
+            "accessibility",
+            "description",
+            "withdrawalDetails",
+            "images",
+            "image",
+            "metadata",
+            "reactionsCount",
+            "chronicles",
+            "chroniclesCount",
+            "proAdvicesCount",
+            "stocks",
+        ):
+            assert moved_key not in response.json
+
+    def test_get_event_offer_flags(self, client):
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id, isDuo=True)
+        offers_factories.EventStockFactory(offer=offer, price=12.34, quantity=2)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["isDuo"] is True
+        assert response.json["isEvent"] is True
+
+    def test_get_offer_with_artists(self, client):
+        product = offers_factories.ProductFactory()
+        offer = offers_factories.OfferFactory(product=product)
+        offers_factories.ThingStockFactory(offer=offer)
+        artist = artists_factories.ArtistFactory()
+        blacklisted = artists_factories.ArtistFactory(is_blacklisted=True)
+        artists_factories.ArtistProductLinkFactory(
+            artist_id=artist.id, product_id=product.id, artist_type=ArtistType.PERFORMER
+        )
+        artists_factories.ArtistProductLinkFactory(artist_id=blacklisted.id, product_id=product.id)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries + self.num_queries_with_product):
+            response = client.get(f"/native/v4/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert len(response.json["artists"]) == 1
+        assert response.json["artists"][0]["id"] == artist.id
+        assert response.json["artists"][0]["name"] == artist.name
+        assert response.json["artists"][0]["role"] == ArtistType.PERFORMER.value
+
+    def test_product_less_offer_duration_minutes(self, client):
+        # _durationMinutes is eagerly loaded to avoid a lazy load on product-less offers
+        offer = offers_factories.OfferFactory(durationMinutes=33)
+        offers_factories.ThingStockFactory(offer=offer)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["extraData"]["durationMinutes"] == 33
+
+    def test_active_validated_offerer_offer_is_released(self, client):
+        offer = offers_factories.OfferFactory()
+        offers_factories.ThingStockFactory(offer=offer)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["isReleased"] is True
+
+    def test_closed_offerer_offer_is_not_released(self, client):
+        offer = offers_factories.EventOfferFactory(venue__managingOfferer=offerers_factories.ClosedOffererFactory())
+        offers_factories.EventStockFactory(offer=offer)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["isReleased"] is False
+
+    def test_get_offer_with_video(self, client):
+        metadata = offers_factories.OfferMetaDataFactory(
+            videoUrl="https://www.youtube.com/watch?v=fAkeV1ide0o",
+            videoExternalId="fAkeV1ide0o",
+            videoTitle="Test Video",
+            videoThumbnailUrl="https://example.com/thumb.jpg",
+            videoDuration=123,
+        )
+        offers_factories.ThingStockFactory(offer=metadata.offer)
+
+        offer_id = metadata.offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["video"] == {
+            "id": "fAkeV1ide0o",
+            "title": "Test Video",
+            "thumbUrl": "https://example.com/thumb.jpg",
+            "durationSeconds": 123,
+        }
+
+    def test_get_offer_not_found(self, client):
+        # 1. select offer / 2. rollback / 3. rollback
+        with assert_num_queries(3):
+            response = client.get("/native/v4/offer/1")
+
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize(
+        "validation",
+        [OfferValidationStatus.DRAFT, OfferValidationStatus.PENDING, OfferValidationStatus.REJECTED],
+    )
+    def test_get_non_approved_offer(self, client, validation):
+        offer = offers_factories.OfferFactory(validation=validation)
+
+        offer_id = offer.id
+        with assert_num_queries(3):
+            response = client.get(f"/native/v4/offer/{offer_id}")
+
+        assert response.status_code == 404
+
+
+class OfferHeaderV4Test:
+    # 1. main SELECT (offer + joined mediations, product+productMediations, venue+address chain)
+    # 2. stocks selectinload (needed for SEO metadata: min_price, hasStocks)
+    base_num_queries = 2
+
+    def test_get_offer_header_no_images(self, client):
+        offer = offers_factories.OfferFactory()
+        offers_factories.ThingStockFactory(offer=offer)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/header")
+
+        assert response.status_code == 200
+        assert response.json["images"] is None
+        assert response.json["likesCount"] == 0
+        assert "metadata" in response.json
+
+    def test_get_offer_header_with_mediation(self, client):
+        offer = offers_factories.OfferFactory()
+        offers_factories.ThingStockFactory(offer=offer)
+        offers_factories.MediationFactory(offer=offer, thumbCount=1, credit="Photo credit")
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/header")
+
+        assert response.status_code == 200
+        images = response.json["images"]
+        assert images is not None
+        assert "recto" in images
+        assert images["recto"]["credit"] == "Photo credit"
+
+    def test_get_offer_header_with_product_mediations(self, client):
+        product = offers_factories.ProductFactory(likesCount=42)
+        offer = offers_factories.OfferFactory(product=product)
+        offers_factories.ThingStockFactory(offer=offer)
+        offers_factories.ProductMediationFactory(product=product, imageType=ImageType.RECTO)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/header")
+
+        assert response.status_code == 200
+        assert response.json["likesCount"] == 42
+        images = response.json["images"]
+        assert images is not None
+        assert "recto" in images
+
+    def test_get_offer_header_metadata_name(self, client):
+        offer = offers_factories.OfferFactory(name="Mon Super Spectacle")
+        offers_factories.ThingStockFactory(offer=offer)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/header")
+
+        assert response.status_code == 200
+        assert response.json["metadata"]["name"] == "Mon Super Spectacle"
+
+    def test_get_offer_header_not_found(self, client):
+        # 1. SELECT offer / 2. rollback / 3. rollback
+        with assert_num_queries(3):
+            response = client.get("/native/v4/offer/99999/header")
+
+        assert response.status_code == 404
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# GET /native/v4/offer/<id>/offerer  —  venue + address + accessibility + desc
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class OfferOffererV4Test:
+    # all joinedloads → single SQL query
+    base_num_queries = 1
+
+    def test_get_offer_offerer(self, client):
+        offer = offers_factories.OfferFactory()
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/offerer")
+
+        assert response.status_code == 200
+        assert response.json["offererName"] == offer.venue.managingOfferer.name
+        assert "venue" in response.json
+        assert "address" in response.json
+        assert "accessibility" in response.json
+
+    def test_get_offer_offerer_address_from_venue(self, client):
+        offer = offers_factories.OfferFactory()
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/offerer")
+
+        assert response.status_code == 200
+        address = response.json["address"]
+        assert address is not None
+        venue_addr = offer.venue.offererAddress.address
+        assert address["city"] == venue_addr.city
+        assert address["postalCode"] == venue_addr.postalCode
+
+    def test_get_offer_offerer_description_from_product(self, client):
+        product = offers_factories.ProductFactory(description="Description du produit")
+        offer = offers_factories.OfferFactory(product=product)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/offerer")
+
+        assert response.status_code == 200
+        assert response.json["description"] == "Description du produit"
+
+    def test_get_offer_offerer_accessibility(self, client):
+        offer = offers_factories.OfferFactory(
+            audioDisabilityCompliant=True,
+            mentalDisabilityCompliant=False,
+            motorDisabilityCompliant=True,
+            visualDisabilityCompliant=None,
+        )
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/offerer")
+
+        assert response.status_code == 200
+        acc = response.json["accessibility"]
+        assert acc["audioDisability"] is True
+        assert acc["mentalDisability"] is False
+        assert acc["motorDisability"] is True
+        assert acc["visualDisability"] is None
+
+    def test_get_offer_offerer_venue_info(self, client):
+        offer = offers_factories.OfferFactory(venue__isPermanent=True)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/offerer")
+
+        assert response.status_code == 200
+        venue = response.json["venue"]
+        assert venue["id"] == offer.venue.id
+        assert venue["isPermanent"] is True
+        assert venue["name"] == offer.venue.name
+        assert venue["publicName"] == offer.venue.publicName
+
+    def test_get_offer_offerer_withdrawal_details(self, client):
+        offer = offers_factories.OfferFactory(withdrawalDetails="Retrait en magasin le lundi")
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/offerer")
+
+        assert response.status_code == 200
+        assert response.json["withdrawalDetails"] == "Retrait en magasin le lundi"
+
+    def test_get_offer_offerer_not_found(self, client):
+        # 1. SELECT offer / 2. rollback / 3. rollback
+        with assert_num_queries(3):
+            response = client.get("/native/v4/offer/99999/offerer")
+
+        assert response.status_code == 404
+
+
+class OfferChroniclesV4Test:
+    # query 1: resolve offer productId + chroniclesCount
+    # query 2: paginated chronicles
+    base_num_queries_with_product = 2
+    # query 1: resolve, query 2: COUNT (no denormalized counter), query 3: paginated list
+    base_num_queries_no_product = 3
+
+    def test_get_chronicles_with_product(self, client):
+        # Set chroniclesCount explicitly: the denormalized counter is not updated by factories
+        product = offers_factories.ProductFactory(chroniclesCount=2)
+        offer = offers_factories.OfferFactory(product=product)
+        chronicle_1 = chronicles_factories.ChronicleFactory(
+            products=[product],
+            isActive=True,
+            isSocialMediaDiffusible=True,
+            isIdentityDiffusible=True,
+            content="First chronicle content",
+        )
+        chronicles_factories.ChronicleFactory(
+            products=[product],
+            isActive=True,
+            isSocialMediaDiffusible=True,
+            isIdentityDiffusible=False,
+            content="Second chronicle content",
+        )
+        # inactive: must not appear
+        chronicles_factories.ChronicleFactory(products=[product], isActive=False, isSocialMediaDiffusible=True)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries_with_product):
+            response = client.get(f"/native/v4/offer/{offer_id}/chronicles")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 2  # from denormalized column
+        chronicles = response.json["chronicles"]
+        assert len(chronicles) == 2
+        # ordered by id desc → most recent first
+        assert chronicles[0]["content"] == "Second chronicle content"
+        assert chronicles[0]["author"] is None  # isIdentityDiffusible=False
+        assert chronicles[1]["content"] == "First chronicle content"
+        assert chronicles[1]["author"]["firstName"] == chronicle_1.firstName
+
+    def test_get_chronicles_without_product(self, client):
+        # Event offer with no product → no denormalized counter, uses COUNT query
+        offer = offers_factories.EventOfferFactory()
+        offers_factories.EventStockFactory(offer=offer)
+        chronicles_factories.ChronicleFactory(
+            offers=[offer],
+            isActive=True,
+            isSocialMediaDiffusible=True,
+            content="Event chronicle content",
+        )
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries_no_product):
+            response = client.get(f"/native/v4/offer/{offer_id}/chronicles")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 1
+        assert len(response.json["chronicles"]) == 1
+        assert response.json["chronicles"][0]["content"] == "Event chronicle content"
+
+    def test_get_chronicles_pagination(self, client):
+        product = offers_factories.ProductFactory(chroniclesCount=3)
+        offer = offers_factories.OfferFactory(product=product)
+        chronicles_factories.ChronicleFactory.create_batch(
+            3, products=[product], isActive=True, isSocialMediaDiffusible=True
+        )
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries_with_product):
+            response = client.get(f"/native/v4/offer/{offer_id}/chronicles?page=1&limit=2")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 3
+        assert len(response.json["chronicles"]) == 2
+
+    def test_get_chronicles_full_content_not_truncated(self, client):
+        long_content = ("mot " * 100).rstrip()  # ~400 chars, well above the 255 preview limit
+        product = offers_factories.ProductFactory(chroniclesCount=1)
+        offer = offers_factories.OfferFactory(product=product)
+        chronicles_factories.ChronicleFactory(
+            products=[product], isActive=True, isSocialMediaDiffusible=True, content=long_content
+        )
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries_with_product):
+            response = client.get(f"/native/v4/offer/{offer_id}/chronicles")
+
+        assert response.status_code == 200
+        assert response.json["chronicles"][0]["content"] == long_content
+
+    def test_get_chronicles_not_found(self, client):
+        # 1 resolve query returns None → ResourceNotFoundError + rollbacks
+        response = client.get("/native/v4/offer/99999/chronicles")
+        assert response.status_code == 404
+
+
+class OfferProAdvicesV4Test:
+    # query 1: resolve productId + proAdvicesCount
+    # query 2: get_pro_advices
+    base_num_queries = 2
+
+    def test_get_pro_advices_with_product(self, client):
+        product = offers_factories.ProductFactory(proAdvicesCount=1)
+        offer = offers_factories.OfferFactory(product=product)
+        pro_advice = offers_factories.ProAdviceFactory(offer=offer)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/pro_advices")
+
+        assert response.status_code == 200
+        assert response.json["proAdvicesCount"] == 1
+        advices = response.json["proAdvices"]
+        assert len(advices) == 1
+        assert advices[0]["content"] == pro_advice.content
+        assert advices[0]["venueId"] == offer.venue.id
+        assert advices[0]["venueName"] == offer.venue.publicName
+        assert advices[0]["publicationDatetime"] == date_utils.format_into_utc_date(pro_advice.updatedAt)
+
+    def test_get_pro_advices_without_product(self, client):
+        offer = offers_factories.OfferFactory()
+        offers_factories.ProAdviceFactory(offer=offer)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/pro_advices")
+
+        assert response.status_code == 200
+        # no product → total from offset + len(results)
+        assert response.json["proAdvicesCount"] == 1
+        assert len(response.json["proAdvices"]) == 1
+
+    def test_get_pro_advices_author_can_be_null(self, client):
+        offer = offers_factories.OfferFactory()
+        offers_factories.ProAdviceFactory(offer=offer, author=None)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/pro_advices")
+
+        assert response.status_code == 200
+        assert response.json["proAdvices"][0]["author"] is None
+
+    def test_get_pro_advices_not_found(self, client):
+        response = client.get("/native/v4/offer/99999/pro_advices")
+        assert response.status_code == 404
+
+
+class OfferStocksV4Test:
+    # 1. SELECT offer existence + COUNT active stocks
+    # 2. SELECT paginated stocks (+ joinedload priceCategory, priceCategoryLabel, offer.url)
+    base_num_queries = 2
+
+    def test_get_stocks_thing_offer(self, client):
+        offer = offers_factories.OfferFactory()
+        stock = offers_factories.ThingStockFactory(offer=offer, price=12.34)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/stocks")
+
+        assert response.status_code == 200
+        assert response.json["stocksCount"] == 1
+        assert len(response.json["stocks"]) == 1
+        assert response.json["stocks"][0]["id"] == stock.id
+        assert response.json["stocks"][0]["price"] == 1234
+
+    def test_get_stocks_event_offer_with_price_category(self, client):
+        offer = offers_factories.EventOfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
+        stock = offers_factories.EventStockFactory(
+            offer=offer, price=9.99, quantity=100, priceCategory__label="Tarif plein"
+        )
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/stocks")
+
+        assert response.status_code == 200
+        assert response.json["stocksCount"] == 1
+        assert response.json["stocks"][0]["id"] == stock.id
+        assert response.json["stocks"][0]["priceCategoryLabel"] == "Tarif plein"
+        assert response.json["stocks"][0]["beginningDatetime"] is not None
+
+    def test_get_stocks_excludes_soft_deleted(self, client):
+        offer = offers_factories.OfferFactory()
+        offers_factories.ThingStockFactory(offer=offer, isSoftDeleted=True)
+        active = offers_factories.ThingStockFactory(offer=offer)
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/stocks")
+
+        assert response.status_code == 200
+        assert response.json["stocksCount"] == 1
+        assert response.json["stocks"][0]["id"] == active.id
+
+    def test_get_stocks_pagination(self, client):
+        offer = offers_factories.OfferFactory()
+        stocks = [offers_factories.ThingStockFactory(offer=offer) for _ in range(5)]
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v4/offer/{offer_id}/stocks?page=2&limit=2")
+
+        assert response.status_code == 200
+        assert response.json["stocksCount"] == 5
+        assert len(response.json["stocks"]) == 2
+        returned_ids = {s["id"] for s in response.json["stocks"]}
+        assert returned_ids == {stocks[2].id, stocks[3].id}
+
+    def test_get_stocks_not_found(self, client):
+        response = client.get("/native/v4/offer/99999/stocks")
+        assert response.status_code == 404


### PR DESCRIPTION
Découpage de la route monolithique GET /offer/<id> en 6 routes v4 progressives pour le chargement de la page offre native.

Nouvelles routes

GET /native/v4/offer/<id> - payload critique allégé (identité, flags de réservation, artistes)
GET /native/v4/offer/<id>/header - images, likesCount, métadonnées SEO
GET /native/v4/offer/<id>/offerer - venue, adresse, accessibilité, description
GET /native/v4/offer/<id>/chronicles - avis des jeunes paginés + total
GET /native/v4/offer/<id>/pro_advices - avis des pros paginés + total
GET /native/v4/offer/<id>/stocks - stocks paginés 

Les routes v1/v2/v3 ne sont pas touchées pour ne pas casser l'existant

Point d'attention
La route principale charge encore tous les stocks en mémoire via selectinload pour calculer is_expired, is_sold_out et is_forbidden_to_underage. Ces propriétés nécessitent une réécriture en expressions SQL pour être vraiment soulagées => un ticket à part ?