### PR TITLE
(PC-40974)[API] feat: add scrubbing for disability bonus

### DIFF
--- a/api/src/pcapi/connectors/api_particulier.py
+++ b/api/src/pcapi/connectors/api_particulier.py
@@ -136,6 +136,7 @@ def get_quotient_familial(
         QUOTIENT_FAMILIAL_ENDPOINT,
         headers={"Authorization": f"Bearer {settings.PARTICULIER_API_TOKEN}"},
         params={key: value for (key, value) in query_params.items() if value},
+        log_info=False,
     )
 
     _raise_for_status(response, "quotient familial")
@@ -194,6 +195,7 @@ def get_disabled_adult_allowance(person: bonus_schemas.BonusCreditPerson) -> Dis
         AAH_ENDPOINT,
         headers={"Authorization": f"Bearer {settings.PARTICULIER_API_TOKEN}"},
         params={key: value for (key, value) in query_params.items() if value},
+        log_info=False,
     )
 
     _raise_for_status(response, "aah")
@@ -260,6 +262,7 @@ def get_disabled_child_education_allowance(
         AEEH_ENDPOINT,
         headers={"Authorization": f"Bearer {settings.PARTICULIER_API_TOKEN}"},
         params={key: value for (key, value) in query_params.items() if value},
+        log_info=False,
     )
 
     _raise_for_status(response, "aeeh")

--- a/api/src/pcapi/core/finance/deposit_api.py
+++ b/api/src/pcapi/core/finance/deposit_api.py
@@ -550,6 +550,10 @@ def can_receive_bonus_credit(user: users_models.User) -> bool:
 
 
 def recredit_bonus_credit(user: users_models.User) -> models.Recredit | None:
+    """
+    This function is called during GDPR-sensitive code paths like the disability bonus credit.
+    That is why this function *must never* log anything to our cloud provider.
+    """
     deposit = user.deposit
     if not deposit:
         return None

--- a/api/src/pcapi/core/subscription/bonus/api.py
+++ b/api/src/pcapi/core/subscription/bonus/api.py
@@ -222,7 +222,8 @@ def apply_for_adult_disability_bonus(aah_fraud_check: subscription_models.Benefi
 
     if settings.ENABLE_PARTICULIER_API_MOCK:
         aah_result = _call_api_particulier(
-            aah_fraud_check, lambda: staging_api.get_and_mock_disabled_adult_allowance(source_data.person, user)
+            aah_fraud_check,
+            lambda: staging_api.get_and_mock_disabled_adult_allowance(source_data.person, user),
         )
     else:
         aah_result = _call_api_particulier(
@@ -404,8 +405,6 @@ def _grant_bonus(fraud_check: subscription_models.BeneficiaryFraudCheck) -> fina
 
     if given_recredit:
         _delete_bonus_fraud_checks(user)
-    elif deposit_api.can_receive_bonus_credit(user):
-        raise ValueError(f"{fraud_check=} should have led to a credit bonus")
 
     return given_recredit
 

--- a/api/src/pcapi/flask_app.py
+++ b/api/src/pcapi/flask_app.py
@@ -35,6 +35,7 @@ from pcapi.scripts.install import install_commands
 from pcapi.utils import jwt
 from pcapi.utils import transaction_manager
 from pcapi.utils.json_encoder import EnumJSONEncoder
+from pcapi.utils.sentry import SCRUBBED_INFO_PLACEHOLDER
 from pcapi.utils.sentry import init_sentry_sdk
 
 
@@ -143,6 +144,7 @@ def setup_sentry_before_request() -> None:
 
 @app.after_request
 def log_request_details(response: flask.wrappers.Response) -> flask.wrappers.Response:
+    is_sensitive_url_rule = request.url_rule and "/subscription/bonus" in str(request.url_rule)
     extra = {
         "statusCode": response.status_code,
         "method": request.method,
@@ -150,8 +152,8 @@ def log_request_details(response: flask.wrappers.Response) -> flask.wrappers.Res
         "path": request.path,
         "queryParams": request.query_string,
         "size": response.headers.get("Content-Length", type=int),
-        "deviceId": request.headers.get("device-id"),
-        "sourceIp": request.remote_addr,
+        "deviceId": SCRUBBED_INFO_PLACEHOLDER if is_sensitive_url_rule else request.headers.get("device-id"),
+        "sourceIp": SCRUBBED_INFO_PLACEHOLDER if is_sensitive_url_rule else request.remote_addr,
         "requestId": request.headers.get("request-id"),
         "appVersion": request.headers.get("app-version"),
         "commitHash": request.headers.get("commit-hash"),

--- a/api/src/pcapi/utils/requests.py
+++ b/api/src/pcapi/utils/requests.py
@@ -64,24 +64,37 @@ def _redact_url(url: str | None) -> str | None:
     fields_to_redact = "|".join(  # Fields used in Particulier API queries
         [
             "recipient",
-            "nomNaissance",
+            "Naissance",
             "prenoms%5B%5D",  # prenoms%5B%5D unquoted ⇒ prenoms[]
             "nomUsage",
-            "anneeDateNaissance",
-            "moisDateNaissance",
-            "jourDateNaissance",
             "sexeEtatCivil",
-            "codeCogInseePaysNaissance",
-            "codeCogInseeCommuneNaissance",
             "annee",
             "mois",
             # Allociné and Ciné Office (ex-CDS) want authentication token to appear in GET
             # requests. We don't want to log them.
             # For Allociné, the query param name is 'token'. For Ciné Office, the name is 'api_token'
             "token",
+            # YouTube
+            "key",
         ]
     )
     return re.sub(f"((?:{fields_to_redact})=)[^&]+", r"\1[REDACTED]", url)
+
+
+class _RedactingUrlFilter(logging.Filter):
+    """Redact sensitive query params from urllib3 retry warnings.
+
+    urllib3 logs the raw path+querystring itself when a request is
+    retried (see `urllib3.connectionpool`), bypassing our `_redact_url`.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.args and isinstance(record.args, tuple):
+            record.args = tuple(_redact_url(arg) if isinstance(arg, str) else arg for arg in record.args)
+        return True
+
+
+logging.getLogger("urllib3.connectionpool").addFilter(_RedactingUrlFilter())
 
 
 def _wrapper(

--- a/api/src/pcapi/utils/sentry.py
+++ b/api/src/pcapi/utils/sentry.py
@@ -31,29 +31,13 @@ NO_SAMPLE_RATE = 0.0
 
 SCRUBBED_INFO_PLACEHOLDER = "[REDACTED]"
 
-SCRUBBED_KEYS = (
-    "anneeDateNaissance",
-    "all_quotient_familial_responses",
-    "codeCogInseeCommuneNaissance",
-    "codeCogInseePaysNaissance",
-    "custodian",
-    "jourDateNaissance",
-    "moisDateNaissance",
-    "nomNaissance",
-    "nomUsage",
-    "prenoms[]",
-    "recipient",
-    "sexeEtatCivil",
-    "quotient_familial_response",
-    "recipient",
-)
-
 SCRUBBED_VALUE_PREFIXES = (
     "QuotientFamilialBonusCreditContent(",
     "AdultDisabilityBonusCreditContent(",
     "DisabledChildEducationBonusCreditContent(",
     "BonusCreditPerson(",
 )
+GDPR_SENSITIVE_MODULE_BOUNDARIES = ("pcapi.core.subscription.bonus.api",)
 
 
 class SpecificPath(enum.Enum):
@@ -69,21 +53,33 @@ def scrub_token_from_url_in_event(event: "Event") -> "Event":
     return event
 
 
-def recursive_scrub_vars_dict(vars_dict: dict) -> dict:
+def _recursive_scrub_vars_dict(vars_dict: dict) -> dict:
     r"""
     Recursively obfuscate values inside `vars_dict` if their associated key is in `redacted_fields` list.
-
     /!\ This function does modify values of source `vars_dict`
     """
     for key in list(vars_dict):
         value = vars_dict[key]
-        if key in SCRUBBED_KEYS:
-            vars_dict[key] = SCRUBBED_INFO_PLACEHOLDER
-        elif isinstance(value, str) and any(value.startswith(prefix) for prefix in SCRUBBED_VALUE_PREFIXES):
+        if isinstance(value, str) and any(value.startswith(prefix) for prefix in SCRUBBED_VALUE_PREFIXES):
             vars_dict[key] = SCRUBBED_INFO_PLACEHOLDER
         if isinstance(value, dict):
-            vars_dict[key] = recursive_scrub_vars_dict(value)
+            vars_dict[key] = _recursive_scrub_vars_dict(value)
     return vars_dict
+
+
+def _scrub_frames_below_sensitive_boundary(frames: list[dict]) -> None:
+    boundary_frame_index: int | None = None
+    for i, frame in enumerate(frames):
+        if frame.get("module") in GDPR_SENSITIVE_MODULE_BOUNDARIES:
+            boundary_frame_index = i
+            break
+
+    if boundary_frame_index is None:
+        return
+
+    for tainted_frame in frames[boundary_frame_index:]:
+        if tainted_frame.get("vars"):
+            tainted_frame["vars"] = {key: SCRUBBED_INFO_PLACEHOLDER for key in tainted_frame["vars"].keys()}
 
 
 def before_send(event: "Event", _hint: dict[str, typing.Any]) -> "Event | None":
@@ -97,9 +93,12 @@ def before_send(event: "Event", _hint: dict[str, typing.Any]) -> "Event | None":
 
     # Scrub exceptions vars
     for exception_values in event.get("exception", {}).get("values", []):
-        for frame in exception_values.get("stacktrace", {}).get("frames", []):
+        frames = exception_values.get("stacktrace", {}).get("frames", [])
+        _scrub_frames_below_sensitive_boundary(frames)
+
+        for frame in frames:
             if frame_vars := frame.get("vars"):
-                recursive_scrub_vars_dict(frame_vars)
+                _recursive_scrub_vars_dict(frame_vars)
 
     return event
 

--- a/api/tests/core/subscription/bonus/test_bonus_api.py
+++ b/api/tests/core/subscription/bonus/test_bonus_api.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import decimal
+import logging
 from unittest.mock import call
 from unittest.mock import patch
 
@@ -31,7 +32,7 @@ import tests.core.subscription.bonus.bonus_fixtures as bonus_fixtures
 @pytest.mark.usefixtures("db_session")
 class QuotientFamilialApplicationTest:
     @patch("pcapi.core.external.attributes.api.update_external_user")
-    def test_apply_for_quotient_familial_bonus(self, update_external_user_mock):
+    def test_apply_for_quotient_familial_bonus(self, update_external_user_mock, caplog):
         eighteen_years_ago = datetime.date.today() - relativedelta(years=18)
         with_18_child_quotient_familial = copy.deepcopy(bonus_fixtures.QUOTIENT_FAMILIAL_FIXTURE)
         with_18_child_quotient_familial["data"]["enfants"][0]["date_naissance"] = eighteen_years_ago.isoformat()
@@ -56,7 +57,8 @@ class QuotientFamilialApplicationTest:
         with requests_mock.Mocker() as mock:
             mock.get(api_particulier.QUOTIENT_FAMILIAL_ENDPOINT, json=with_18_child_quotient_familial)
 
-            bonus_api.apply_for_quotient_familial_bonus(bonus_fraud_check)
+            with caplog.at_level(logging.INFO):
+                bonus_api.apply_for_quotient_familial_bonus(bonus_fraud_check)
 
         bonus_fraud_checks = [
             fraud_check
@@ -82,6 +84,9 @@ class QuotientFamilialApplicationTest:
         assert len(mails_testing.outbox) == 1
         out_mail = mails_testing.outbox[0]
         assert out_mail["template"] == TransactionalEmail.BONUS_GRANTED.value.__dict__
+
+        for log_record in caplog.records:
+            assert not log_record.extra.get("url")
 
     @patch("pcapi.core.external.attributes.api.update_external_user")
     def test_apply_for_quotient_familial_bonus_as_householder(self, update_external_user_mock):
@@ -201,7 +206,7 @@ class QuotientFamilialApplicationTest:
             any_order=True,
         )
 
-    def test_application_not_found(self):
+    def test_application_not_found(self, caplog):
         user = users_factories.BeneficiaryFactory()
         custodian = subscription_factories.BonusCreditPersonFactory()
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory(
@@ -220,7 +225,8 @@ class QuotientFamilialApplicationTest:
                 json=bonus_fixtures.APPLICATION_NOT_FOUND_FIXTURE,
             )
 
-            bonus_api.apply_for_quotient_familial_bonus(bonus_fraud_check)
+            with caplog.at_level(logging.INFO):
+                bonus_api.apply_for_quotient_familial_bonus(bonus_fraud_check)
 
         assert bonus_fraud_check.status == subscription_models.FraudCheckStatus.KO
         assert bonus_fraud_check.reasonCodes == [subscription_models.FraudReasonCode.APPLICATION_NOT_FOUND]
@@ -246,7 +252,10 @@ class QuotientFamilialApplicationTest:
         out_mail = mails_testing.outbox[0]
         assert out_mail["template"] == TransactionalEmail.BONUS_DECLINED.value.__dict__
 
-    def test_person_not_found(self):
+        for log_record in caplog.records:
+            assert not log_record.extra.get("url")
+
+    def test_person_not_found(self, caplog):
         user = users_factories.BeneficiaryFactory()
         custodian = subscription_factories.BonusCreditPersonFactory()
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory(
@@ -265,7 +274,8 @@ class QuotientFamilialApplicationTest:
                 json=bonus_fixtures.PERSON_NOT_FOUND_FIXTURE,
             )
 
-            bonus_api.apply_for_quotient_familial_bonus(bonus_fraud_check)
+            with caplog.at_level(logging.INFO):
+                bonus_api.apply_for_quotient_familial_bonus(bonus_fraud_check)
 
         assert bonus_fraud_check.status == subscription_models.FraudCheckStatus.KO
         assert bonus_fraud_check.reasonCodes == [subscription_models.FraudReasonCode.PERSON_NOT_FOUND]
@@ -290,6 +300,9 @@ class QuotientFamilialApplicationTest:
         assert len(mails_testing.outbox) == 1
         out_mail = mails_testing.outbox[0]
         assert out_mail["template"] == TransactionalEmail.BONUS_DECLINED.value.__dict__
+
+        for log_record in caplog.records:
+            assert not log_record.extra.get("url")
 
     def test_user_not_in_tax_household(self):
         user = users_factories.BeneficiaryFactory()
@@ -514,27 +527,12 @@ class QuotientFamilialApplicationTest:
         assert len(captured_events) == 1
         event = captured_events[-1]
         stacktrace_frames = event["exception"]["values"][0]["stacktrace"]["frames"]
-        for i in range(6):
-            stacktrace_vars = stacktrace_frames[i]["vars"]
-            assert stacktrace_vars.get("source_data") in [None, "[REDACTED]"]
 
-        # TODO (dnguyen-pass) [PC-40974] redact the remaining arguments
-        # assert stacktrace_frames[4]["vars"] birth_date, seventeenth_birth_date, at_date are "[REDACTED]"
+        test_frame = stacktrace_frames[0]
+        assert any(value not in [None, "[REDACTED]"] for value in test_frame["vars"].values())
 
-        assert stacktrace_frames[5]["vars"]["query_params"] == {
-            "anneeDateNaissance": "[REDACTED]",
-            "codeCogInseeCommuneNaissance": "[REDACTED]",
-            "codeCogInseePaysNaissance": "[REDACTED]",
-            "jourDateNaissance": "[REDACTED]",
-            "moisDateNaissance": "[REDACTED]",
-            "nomNaissance": "[REDACTED]",
-            "nomUsage": "[REDACTED]",
-            "prenoms[]": "[REDACTED]",
-            "recipient": "[REDACTED]",
-            "sexeEtatCivil": "[REDACTED]",
-        }
-        # TODO (dnguyen-pass) [PC-40974] redact the remaining arguments
-        # assert stacktrace_frames[5]["vars"] city_insee_code, country_insee_code, at_date are "[REDACTED]"
+        for frame in stacktrace_frames[1:]:
+            assert all(value == "[REDACTED]" for value in frame["vars"].values())
 
     def test_touch_fraud_check_despite_error(self):
         twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
@@ -586,7 +584,7 @@ def _build_user_from_fixture(quotient_familial_json_response: dict) -> users_mod
 @pytest.mark.usefixtures("db_session")
 class DisabledAdultAllowanceTest:
     @patch("pcapi.core.external.attributes.api.update_external_user")
-    def test_apply_for_disabled_adult_allowance_bonus(self, update_external_user_mock):
+    def test_apply_for_disabled_adult_allowance_bonus(self, update_external_user_mock, caplog):
         user = users_factories.BeneficiaryFactory()
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory.create(
             user=user,
@@ -597,7 +595,8 @@ class DisabledAdultAllowanceTest:
         with requests_mock.Mocker() as mock:
             mock.get(api_particulier.AAH_ENDPOINT, json=bonus_fixtures.AAH_RECIPIENT_RESPONSE)
 
-            bonus_api.apply_for_adult_disability_bonus(bonus_fraud_check)
+            with caplog.at_level(logging.INFO):
+                bonus_api.apply_for_adult_disability_bonus(bonus_fraud_check)
 
         bonus_fraud_checks = [
             fraud_check
@@ -621,6 +620,9 @@ class DisabledAdultAllowanceTest:
         update_external_user_mock.assert_called_once_with(user)
 
         assert len(mails_testing.outbox) == 1
+
+        for log_record in caplog.records:
+            assert not log_record.extra.get("url")
 
     def test_not_recipient_for_disabled_adult_allowance_bonus(self):
         user = users_factories.BeneficiaryFactory()
@@ -678,7 +680,7 @@ class DisabledAdultAllowanceTest:
         assert push_request1["attribute_values"]["u.bonification_status"] == "eligible"
         assert push_request2["attribute_values"]["u.bonification_status"] == "eligible"
 
-    def test_application_not_found(self):
+    def test_application_not_found(self, caplog):
         user = users_factories.BeneficiaryFactory()
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory.create(
             user=user,
@@ -689,7 +691,8 @@ class DisabledAdultAllowanceTest:
         with requests_mock.Mocker() as mock:
             mock.get(api_particulier.AAH_ENDPOINT, status_code=404, json=bonus_fixtures.APPLICATION_NOT_FOUND_FIXTURE)
 
-            bonus_api.apply_for_adult_disability_bonus(bonus_fraud_check)
+            with caplog.at_level(logging.INFO):
+                bonus_api.apply_for_adult_disability_bonus(bonus_fraud_check)
 
         assert bonus_fraud_check.status == subscription_models.FraudCheckStatus.KO
         assert bonus_fraud_check.reasonCodes == [subscription_models.FraudReasonCode.APPLICATION_NOT_FOUND]
@@ -705,6 +708,9 @@ class DisabledAdultAllowanceTest:
         assert {push_request1["batch_api"], push_request2["batch_api"]} == {"ANDROID", "IOS"}
         assert push_request1["attribute_values"]["u.bonification_status"] == "eligible"
         assert push_request2["attribute_values"]["u.bonification_status"] == "eligible"
+
+        for log_record in caplog.records:
+            assert not log_record.extra.get("url")
 
     def test_bonus_fraud_checks_deletion_when_granted(self):
         user = users_factories.BeneficiaryFactory()
@@ -774,23 +780,12 @@ class DisabledAdultAllowanceTest:
         assert len(captured_events) == 1
         event = captured_events[-1]
         stacktrace_frames = event["exception"]["values"][0]["stacktrace"]["frames"]
-        assert stacktrace_frames[1]["vars"]["source_data"] == "[REDACTED]"
-        assert stacktrace_frames[3]["vars"]["source_data"] == "[REDACTED]"
-        assert stacktrace_frames[4]["vars"]["person"] == "[REDACTED]"
-        assert stacktrace_frames[4]["vars"]["query_params"] == {
-            "anneeDateNaissance": "[REDACTED]",
-            "codeCogInseeCommuneNaissance": "[REDACTED]",
-            "codeCogInseePaysNaissance": "[REDACTED]",
-            "jourDateNaissance": "[REDACTED]",
-            "moisDateNaissance": "[REDACTED]",
-            "nomNaissance": "[REDACTED]",
-            "nomUsage": "[REDACTED]",
-            "prenoms[]": "[REDACTED]",
-            "recipient": "[REDACTED]",
-            "sexeEtatCivil": "[REDACTED]",
-        }
-        # TODO (dnguyen-pass) [PC-40974] redact the remaining arguments
-        # assert stacktrace_frames[4]["vars"] city_insee_code, country_insee_code are "[REDACTED]"
+
+        test_frame = stacktrace_frames[0]
+        assert any(value not in [None, "[REDACTED]"] for value in test_frame["vars"].values())
+
+        for frame in stacktrace_frames[1:]:
+            assert all(value == "[REDACTED]" for value in frame["vars"].values())
 
     def test_touch_fraud_check_despite_error(self):
         twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
@@ -857,7 +852,7 @@ class DisabledChildEducationAllowanceTest:
         [bonus_fixtures.AEEH_RECIPIENT_RESPONSE, bonus_fixtures.AEEH_OPENING_RIGHTS_RESPONSE],
     )
     @patch("pcapi.core.external.attributes.api.update_external_user")
-    def test_apply_for_disabled_child_education_allowance_bonus(self, update_external_user_mock, aeeh_response):
+    def test_apply_for_disabled_child_education_allowance_bonus(self, update_external_user_mock, aeeh_response, caplog):
         user = users_factories.BeneficiaryFactory()
 
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory.create(
@@ -869,7 +864,8 @@ class DisabledChildEducationAllowanceTest:
         with requests_mock.Mocker() as mock:
             mock.get(api_particulier.AEEH_ENDPOINT, json=aeeh_response)
 
-            bonus_api.apply_for_disabled_child_education_bonus(bonus_fraud_check)
+            with caplog.at_level(logging.INFO):
+                bonus_api.apply_for_disabled_child_education_bonus(bonus_fraud_check)
 
         bonus_fraud_checks = [
             fraud_check
@@ -893,6 +889,9 @@ class DisabledChildEducationAllowanceTest:
         update_external_user_mock.assert_called_once_with(user)
 
         assert len(mails_testing.outbox) == 1
+
+        for log_record in caplog.records:
+            assert not log_record.extra.get("url")
 
     def test_not_recipient_for_disabled_child_education_allowance_bonus(self):
         user = users_factories.BeneficiaryFactory()
@@ -923,7 +922,7 @@ class DisabledChildEducationAllowanceTest:
         assert push_request1["attribute_values"]["u.bonification_status"] == "eligible"
         assert push_request2["attribute_values"]["u.bonification_status"] == "eligible"
 
-    def test_person_not_found(self):
+    def test_person_not_found(self, caplog):
         user = users_factories.BeneficiaryFactory()
 
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory.create(
@@ -935,7 +934,8 @@ class DisabledChildEducationAllowanceTest:
         with requests_mock.Mocker() as mock:
             mock.get(api_particulier.AEEH_ENDPOINT, status_code=422, json=bonus_fixtures.PERSON_NOT_FOUND_FIXTURE)
 
-            bonus_api.apply_for_disabled_child_education_bonus(bonus_fraud_check)
+            with caplog.at_level(logging.INFO):
+                bonus_api.apply_for_disabled_child_education_bonus(bonus_fraud_check)
 
         assert bonus_fraud_check.status == subscription_models.FraudCheckStatus.KO
         assert bonus_fraud_check.reasonCodes == [subscription_models.FraudReasonCode.PERSON_NOT_FOUND]
@@ -952,7 +952,10 @@ class DisabledChildEducationAllowanceTest:
         assert push_request1["attribute_values"]["u.bonification_status"] == "eligible"
         assert push_request2["attribute_values"]["u.bonification_status"] == "eligible"
 
-    def test_application_not_found(self):
+        for log_record in caplog.records:
+            assert not log_record.extra.get("url")
+
+    def test_application_not_found(self, caplog):
         user = users_factories.BeneficiaryFactory()
 
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory.create(
@@ -964,7 +967,8 @@ class DisabledChildEducationAllowanceTest:
         with requests_mock.Mocker() as mock:
             mock.get(api_particulier.AEEH_ENDPOINT, status_code=404, json=bonus_fixtures.APPLICATION_NOT_FOUND_FIXTURE)
 
-            bonus_api.apply_for_disabled_child_education_bonus(bonus_fraud_check)
+            with caplog.at_level(logging.INFO):
+                bonus_api.apply_for_disabled_child_education_bonus(bonus_fraud_check)
 
         assert bonus_fraud_check.status == subscription_models.FraudCheckStatus.KO
         assert bonus_fraud_check.reasonCodes == [subscription_models.FraudReasonCode.APPLICATION_NOT_FOUND]
@@ -980,6 +984,9 @@ class DisabledChildEducationAllowanceTest:
         assert {push_request1["batch_api"], push_request2["batch_api"]} == {"ANDROID", "IOS"}
         assert push_request1["attribute_values"]["u.bonification_status"] == "eligible"
         assert push_request2["attribute_values"]["u.bonification_status"] == "eligible"
+
+        for log_record in caplog.records:
+            assert not log_record.extra.get("url")
 
     def test_bonus_fraud_checks_deletion_when_granted(self):
         user = users_factories.BeneficiaryFactory()
@@ -1049,23 +1056,12 @@ class DisabledChildEducationAllowanceTest:
         assert len(captured_events) == 1
         event = captured_events[-1]
         stacktrace_frames = event["exception"]["values"][0]["stacktrace"]["frames"]
-        assert stacktrace_frames[1]["vars"]["source_data"] == "[REDACTED]"
-        assert stacktrace_frames[3]["vars"]["source_data"] == "[REDACTED]"
-        assert stacktrace_frames[4]["vars"]["person"] == "[REDACTED]"
-        assert stacktrace_frames[4]["vars"]["query_params"] == {
-            "anneeDateNaissance": "[REDACTED]",
-            "codeCogInseeCommuneNaissance": "[REDACTED]",
-            "codeCogInseePaysNaissance": "[REDACTED]",
-            "jourDateNaissance": "[REDACTED]",
-            "moisDateNaissance": "[REDACTED]",
-            "nomNaissance": "[REDACTED]",
-            "nomUsage": "[REDACTED]",
-            "prenoms[]": "[REDACTED]",
-            "recipient": "[REDACTED]",
-            "sexeEtatCivil": "[REDACTED]",
-        }
-        # TODO (dnguyen-pass) [PC-40974] redact the remaining arguments
-        # assert stacktrace_frames[4]["vars"] city_insee_code, country_insee_code are "[REDACTED]"
+
+        test_frame = stacktrace_frames[0]
+        assert any(value not in [None, "[REDACTED]"] for value in test_frame["vars"].values())
+
+        for frame in stacktrace_frames[1:]:
+            assert all(value == "[REDACTED]" for value in frame["vars"].values())
 
     def test_touch_fraud_check_despite_error(self):
         twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)

--- a/api/tests/core/subscription/bonus/test_bonus_tasks.py
+++ b/api/tests/core/subscription/bonus/test_bonus_tasks.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 from dateutil.relativedelta import relativedelta
 
+from pcapi.connectors import api_particulier
 from pcapi.core.subscription import factories as subscription_factories
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription.bonus import tasks
@@ -76,22 +77,19 @@ def test_recovery_ignores_recent_quotient_familial_application(mocked_apply_for_
 
 
 @patch("pcapi.connectors.api_particulier.get_disabled_adult_allowance")
-def apply_for_adult_disability_bonus_task(mocked_disabled_adult_allowance):
-    custodian = subscription_factories.BonusCreditPersonFactory.create()
-    fraud_check = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+def test_apply_for_adult_disability_bonus_task(mocked_disabled_adult_allowance):
+    person = subscription_factories.BonusCreditPersonFactory.create()
+    fraud_check = subscription_factories.AAHBonusCreditFraudCheckFactory.create(
         status=subscription_models.FraudCheckStatus.STARTED,
-        resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory.build(
-            custodian=custodian
-        ).model_dump(),
+        resultContent=subscription_factories.AdultDisabilityBonusCreditContentFactory.build(person=person).model_dump(),
     )
     fraud_check_id = fraud_check.id
-    mocked_disabled_adult_allowance.return_value = bonus_fixtures.AAH_NOT_RECIPIENT_RESPONSE
+    mocked_disabled_adult_allowance.return_value = api_particulier.DisabledAdultAllowanceResponse.model_validate(
+        bonus_fixtures.AAH_NOT_RECIPIENT_RESPONSE
+    )
 
     payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check_id)
-    tasks.apply_for_quotient_familial_bonus_task.delay(payload.model_dump())
-
-    assert mocked_disabled_adult_allowance.assert_called_once()
-    mocked_disabled_adult_allowance.assert_called_with(custodian)
+    tasks.apply_for_adult_disability_bonus_task.delay(payload.model_dump())
 
     fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check_id)
     assert fraud_check.status == subscription_models.FraudCheckStatus.KO
@@ -99,22 +97,23 @@ def apply_for_adult_disability_bonus_task(mocked_disabled_adult_allowance):
 
 
 @patch("pcapi.connectors.api_particulier.get_disabled_child_education_allowance")
-def apply_for_disabled_child_education_allowance(mocked_disabled_child_education_allowance):
-    custodian = subscription_factories.BonusCreditPersonFactory.create()
-    fraud_check = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+def test_apply_for_disabled_child_education_allowance(mocked_disabled_child_education_allowance):
+    person = subscription_factories.BonusCreditPersonFactory.create()
+    fraud_check = subscription_factories.AEEHBonusCreditFraudCheckFactory.create(
         status=subscription_models.FraudCheckStatus.STARTED,
         resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory.build(
-            custodian=custodian
+            person=person
         ).model_dump(),
     )
     fraud_check_id = fraud_check.id
-    mocked_disabled_child_education_allowance.return_value = bonus_fixtures.AEEH_NOT_RECIPIENT_RESPONSE
+    mocked_disabled_child_education_allowance.return_value = (
+        api_particulier.DisabledChildEducationAllowanceResponse.model_validate(
+            bonus_fixtures.AEEH_NOT_RECIPIENT_RESPONSE
+        )
+    )
 
     payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check_id)
-    tasks.apply_for_quotient_familial_bonus_task.delay(payload.model_dump())
-
-    assert mocked_disabled_child_education_allowance.assert_called_once()
-    mocked_disabled_child_education_allowance.assert_called_with(custodian)
+    tasks.apply_for_disabled_child_education_bonus_task.delay(payload.model_dump())
 
     fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check_id)
     assert fraud_check.status == subscription_models.FraudCheckStatus.KO

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -924,7 +925,7 @@ class HonorStatementTest:
 
 class QuotientFamilialBonusTest:
     @patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
-    def test_create_qf_bonus_fraud_check(self, mocked_task, client):
+    def test_create_qf_bonus_fraud_check(self, mocked_task, client, caplog):
         user = users_factories.BeneficiaryFactory()
 
         expected_num_queries = 1  # user
@@ -934,17 +935,18 @@ class QuotientFamilialBonusTest:
         expected_num_queries += 1  # beneficiary_fraud_check (insert)
         client.with_token(user)
         with assert_num_queries(expected_num_queries):
-            response = client.post(
-                "/native/v1/subscription/bonus/quotient_familial",
-                json={
-                    "lastName": "Lefebvre",
-                    "firstNames": ["Alexis"],
-                    "birthDate": "1982-12-27",
-                    "gender": "Mme",
-                    "birthCountryCogCode": "99100",
-                    "birthCityCogCode": "08480",
-                },
-            )
+            with caplog.at_level(logging.INFO):
+                response = client.post(
+                    "/native/v1/subscription/bonus/quotient_familial",
+                    json={
+                        "lastName": "Lefebvre",
+                        "firstNames": ["Alexis"],
+                        "birthDate": "1982-12-27",
+                        "gender": "Mme",
+                        "birthCountryCogCode": "99100",
+                        "birthCityCogCode": "08480",
+                    },
+                )
 
         assert response.status_code == 204, response.json
 
@@ -968,6 +970,10 @@ class QuotientFamilialBonusTest:
 
         mocked_task.assert_called_once()
         mocked_task.assert_called_with({"fraud_check_id": bonus_fraud_check.id})
+
+        route_call_record = caplog.records[0]
+        assert route_call_record.deviceId == route_call_record.extra["deviceId"] == "[REDACTED]"
+        assert route_call_record.sourceIp == route_call_record.extra["sourceIp"] == "[REDACTED]"
 
     @pytest.mark.parametrize(
         "fraud_check_status",
@@ -1164,7 +1170,7 @@ class QuotientFamilialBonusTest:
 class DisabilityBonusTest:
     @patch("pcapi.core.subscription.bonus.tasks.apply_for_adult_disability_bonus_task.delay")
     @patch("pcapi.core.subscription.bonus.tasks.apply_for_disabled_child_education_bonus_task.delay")
-    def test_create_disability_bonus_fraud_checks(self, mocked_aeeh_task, mocked_aah_task, client):
+    def test_create_disability_bonus_fraud_checks(self, mocked_aeeh_task, mocked_aah_task, client, caplog):
         user = users_factories.BeneficiaryFactory()
 
         expected_num_queries = 1  # user
@@ -1174,13 +1180,14 @@ class DisabilityBonusTest:
         expected_num_queries += 1  # beneficiary_fraud_check (insert)
         client.with_token(user)
         with assert_num_queries(expected_num_queries):
-            response = client.post(
-                "/native/v1/subscription/bonus/disability",
-                json={
-                    "birthCountryCogCode": "99100",
-                    "birthCityCogCode": "67482",  # Strasbourg
-                },
-            )
+            with caplog.at_level(logging.INFO):
+                response = client.post(
+                    "/native/v1/subscription/bonus/disability",
+                    json={
+                        "birthCountryCogCode": "99100",
+                        "birthCityCogCode": "67482",  # Strasbourg
+                    },
+                )
 
         assert response.status_code == 204, response.json
 
@@ -1220,6 +1227,10 @@ class DisabilityBonusTest:
 
         mocked_aeeh_task.assert_called_once()
         mocked_aeeh_task.assert_called_with({"fraud_check_id": aeeh_fraud_check.id})
+
+        route_call_record = caplog.records[0]
+        assert route_call_record.deviceId == route_call_record.extra["deviceId"] == "[REDACTED]"
+        assert route_call_record.sourceIp == route_call_record.extra["sourceIp"] == "[REDACTED]"
 
     @pytest.mark.parametrize(
         "fraud_check_status",

--- a/api/tests/utils/requests_test.py
+++ b/api/tests/utils/requests_test.py
@@ -49,11 +49,14 @@ def test_wrapper_logs_warning_on_failure(requests_mock, caplog):
         "sexeEtatCivil",
         "codeCogInseePaysNaissance",
         "codeCogInseeCommuneNaissance",
+        "nomCommuneNaissance",
         "annee",
         "mois",
         # Allociné and CDS
         "api_token",
         "token",
+        # YouTube
+        "key",
     ],
 )
 def test_wrapper_redacts_url(requests_mock, caplog, parameter):
@@ -154,3 +157,22 @@ def test_wrapper_is_used_when_using_session_send(requests_mock, caplog):
 
     log = caplog.records[0]
     assert log.message == "External service called"
+
+
+def test_urllib3_retry_log_redacts_sensitive_url(caplog):
+    # urllib3 logs the raw path+querystring itself when it retries, via the
+    # `urllib3.connectionpool` logger (see urllib3.connectionpool.HTTPConnectionPool.urlopen)
+    logger = logging.getLogger("urllib3.connectionpool")
+    # urllib3 logs the percent-encoded path, so prenoms[] appears as prenoms%5B%5D.
+    url = "/v3/dss/allocation_enfant_handicape/identite?recipient=secret1&nomNaissance=secret2&prenoms%5B%5D=secret3"
+
+    with caplog.at_level(logging.WARNING, logger="urllib3.connectionpool"):
+        logger.warning("Retrying (%r) after connection broken by '%r': %s", "Retry(total=2)", "ReadTimeoutError", url)
+
+    message = caplog.records[-1].getMessage()
+    assert "secret1" not in message
+    assert "secret2" not in message
+    assert "secret3" not in message
+    assert "recipient=[REDACTED]" in message
+    assert "nomNaissance=[REDACTED]" in message
+    assert "prenoms%5B%5D=[REDACTED]" in message


### PR DESCRIPTION
Applying for the bonus credit through disability allowance is considered
a highly sensitive data, even by GDPR standards.

We need to scrub as much personal info in sensitive code paths, both in
the logging that goes to GCP or the stacktraces that go to Sentry.


## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-40974)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
