### PR TITLE
(PC-41608)[DS] feat: add Dropdown component in design-system

### DIFF
--- a/pro/src/design-system/Dropdown/Dropdown.module.scss
+++ b/pro/src/design-system/Dropdown/Dropdown.module.scss
@@ -49,8 +49,8 @@
   background-color: var(--color-background-default);
 
   &-icon {
-    width: rem.torem(16px);
-    height: rem.torem(16px);
+    width: var(--size-icon-s);
+    height: var(--size-icon-s);
     aspect-ratio: 1 / 1;
     margin-right: var(--size-spacing-m);
   }

--- a/pro/src/design-system/Dropdown/Dropdown.module.scss
+++ b/pro/src/design-system/Dropdown/Dropdown.module.scss
@@ -1,0 +1,102 @@
+@use "styles/mixins/_rem.scss" as rem;
+@use "styles/mixins/_fonts.scss" as fonts;
+
+.dropdown-width {
+  &-auto {
+    min-width: rem.torem(280px);
+    max-width: rem.torem(320px);
+    width: auto;
+  }
+
+  &-trigger {
+    width: var(--radix-dropdown-menu-trigger-width);
+  }
+}
+
+.dropdown-content {
+  border-radius: var(--size-spacing-xs);
+  border: rem.torem(1px) solid var(--color-border-subtle);
+  background-color: var(--color-background-default);
+  box-shadow: 0 1px 6px 0 var(--color-background-shadow-overlay);
+
+  &[data-side="top"] {
+    margin-bottom: var(--size-spacing-s);
+  }
+
+  &[data-side="bottom"] {
+    margin-top: var(--size-spacing-s);
+  }
+
+  &[data-side="left"] {
+    margin-right: var(--size-spacing-s);
+  }
+
+  &[data-side="right"] {
+    margin-left: var(--size-spacing-s);
+  }
+}
+
+.dropdown-item {
+  @include fonts.body-accent-s;
+
+  border-radius: var(--size-spacing-xs);
+  cursor: pointer;
+  padding: var(--size-spacing-s) var(--size-spacing-m);
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+  align-items: center;
+  background-color: var(--color-background-default);
+
+  &-icon {
+    width: rem.torem(16px);
+    height: rem.torem(16px);
+    aspect-ratio: 1 / 1;
+    margin-right: var(--size-spacing-m);
+  }
+
+  .tag-wrapper {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+  }
+
+  &-separator {
+    height: rem.torem(1px);
+    width: 100%;
+    background-color: var(--separator-color-subtle);
+  }
+
+  // Radix "highlighted" state that represents the "trusted" hover state
+  &[data-highlighted] {
+    background-color: var(--color-background-brand-primary-hover);
+    color: var(--color-text-inverted);
+
+    /* stylelint-disable-next-line selector-max-type */
+    .item-icon > svg {
+      fill: var(--color-icon-inverted);
+    }
+  }
+
+  // No need default outline focus because it's handled by Radix above
+  &:focus-visible {
+    outline: none;
+  }
+
+  // Disabled
+  &[data-disabled] {
+    color: var(--color-text-disabled);
+    pointer-events: none;
+  }
+
+  &-variant {
+    &-destructive {
+      color: var(--color-text-danger);
+
+      &[data-highlighted] {
+        background-color: var(--color-background-danger);
+        color: var(--color-text-inverted);
+      }
+    }
+  }
+}

--- a/pro/src/design-system/Dropdown/Dropdown.spec.tsx
+++ b/pro/src/design-system/Dropdown/Dropdown.spec.tsx
@@ -1,0 +1,361 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
+
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+import fullLinkIcon from '@/icons/full-link.svg'
+
+import { TagVariant } from '../Tag/Tag'
+import { DropDownItemVariant, Dropdown, type DropdownProps } from './Dropdown'
+
+const defaultItems: DropdownProps['items'] = [
+  [{ text: 'Item 1' }, { text: 'Item 2' }],
+]
+
+// The component renders `react-router` <Link> for link items and a design-system
+// <Button> as the default trigger, both of which need router/redux context, so
+// every test goes through `renderWithProviders`.
+function renderDropdown(props?: Partial<DropdownProps>) {
+  const mergedProps = {
+    label: 'Dropdown',
+    items: defaultItems,
+    ...props,
+  } as DropdownProps
+
+  return renderWithProviders(<Dropdown {...mergedProps} />)
+}
+
+// Opens the menu and returns the trigger, factored out because almost every
+// assertion needs the (portaled) content to be mounted first.
+async function openDropdown(triggerName = 'Dropdown') {
+  const trigger = screen.getByRole('button', { name: triggerName })
+  await userEvent.click(trigger)
+  return trigger
+}
+
+describe('<Dropdown />', () => {
+  describe('happy path', () => {
+    it('should render the default trigger button labelled with the `label` prop', () => {
+      renderDropdown()
+
+      expect(
+        screen.getByRole('button', { name: 'Dropdown' })
+      ).toBeInTheDocument()
+    })
+
+    it('should keep the menu closed until the trigger is clicked', () => {
+      renderDropdown()
+
+      expect(screen.queryByRole('menuitem')).not.toBeInTheDocument()
+    })
+
+    it('should open the menu and reveal items when the trigger is clicked', async () => {
+      renderDropdown()
+
+      await openDropdown()
+
+      expect(
+        screen.getByRole('menuitem', { name: 'Item 1' })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('menuitem', { name: 'Item 2' })
+      ).toBeInTheDocument()
+    })
+
+    it('should fire the item `onSelect` handler when an item is clicked', async () => {
+      const onSelect = vi.fn()
+      renderDropdown({
+        items: [[{ text: 'Item 1', onSelect }, { text: 'Item 2' }]],
+      })
+
+      await openDropdown()
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Item 1' }))
+
+      expect(onSelect).toHaveBeenCalledOnce()
+    })
+
+    it('should render an icon for each item when `icon` is provided', async () => {
+      renderDropdown({
+        items: [
+          [
+            { text: 'Item 1', icon: fullLinkIcon },
+            { text: 'Item 2', icon: fullLinkIcon },
+          ],
+        ],
+      })
+
+      await openDropdown()
+
+      // The icon is rendered as a decorative (aria-hidden) <svg> pointing at the
+      // provided sprite via <use xlink:href="...#icon">.
+      const item = screen.getByRole('menuitem', { name: 'Item 1' })
+      const svg = item.querySelector('svg')
+      expect(svg).toBeInTheDocument()
+      expect(svg).toHaveAttribute('aria-hidden', 'true')
+      expect(item.querySelector('use')).toHaveAttribute(
+        'xlink:href',
+        `${fullLinkIcon}#icon`
+      )
+    })
+
+    it('should render a tag alongside an item when `tag` is provided', async () => {
+      renderDropdown({
+        items: [
+          [{ text: 'Item 1', tag: { label: 'New', variant: TagVariant.NEW } }],
+        ],
+      })
+
+      await openDropdown()
+
+      expect(screen.getByText('New')).toBeInTheDocument()
+    })
+
+    it('should render a separator between item groups', async () => {
+      const { container } = renderDropdown({
+        items: [[{ text: 'Item 1' }], [{ text: 'Item 2' }]],
+      })
+
+      await openDropdown()
+
+      expect(
+        container.ownerDocument.querySelector('[role="separator"]')
+      ).toBeInTheDocument()
+    })
+
+    it('should NOT render a separator for a single group', async () => {
+      const { container } = renderDropdown({ items: [[{ text: 'Item 1' }]] })
+
+      await openDropdown()
+
+      expect(
+        container.ownerDocument.querySelector('[role="separator"]')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should render an item as a link when `link` is provided', async () => {
+      renderDropdown({
+        items: [[{ text: 'Go', link: { to: '/somewhere' } }]],
+      })
+
+      await openDropdown()
+
+      const link = screen.getByRole('menuitem', { name: 'Go' })
+      expect(link.tagName).toBe('A')
+      expect(link).toHaveAttribute('href', '/somewhere')
+    })
+
+    it('should use a custom trigger instead of the default button', () => {
+      renderDropdown({
+        label: 'Accessible name',
+        trigger: <button type="button">Custom content</button>,
+      })
+
+      // The custom node is rendered (its visible text is present) in place of the
+      // default design-system <Button>, which would have rendered the label text.
+      expect(screen.getByText('Custom content')).toBeInTheDocument()
+    })
+
+    it('should fall back the custom trigger `aria-label` to the `label` prop', () => {
+      renderDropdown({
+        label: 'Accessible name',
+        trigger: <button type="button">Icon</button>,
+      })
+
+      // The custom trigger has no aria-label, so the component injects `label` as
+      // the accessible name while keeping its own visible content.
+      expect(
+        screen.getByRole('button', { name: 'Accessible name' })
+      ).toBeInTheDocument()
+      expect(screen.getByText('Icon')).toBeInTheDocument()
+    })
+
+    it('should keep an explicit `aria-label` on the custom trigger (precedence)', () => {
+      renderDropdown({
+        label: 'Fallback label',
+        trigger: (
+          <button type="button" aria-label="Own label">
+            Icon
+          </button>
+        ),
+      })
+
+      expect(
+        screen.getByRole('button', { name: 'Own label' })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole('button', { name: 'Fallback label' })
+      ).not.toBeInTheDocument()
+    })
+
+    it('should call `onOpenChange` when the open state changes', async () => {
+      const onOpenChange = vi.fn()
+      renderDropdown({ onOpenChange })
+
+      await openDropdown()
+
+      expect(onOpenChange).toHaveBeenCalledWith(true)
+    })
+
+    it('should respect the `defaultOpen` prop (uncontrolled)', () => {
+      renderDropdown({ defaultOpen: true })
+
+      expect(
+        screen.getByRole('menuitem', { name: 'Item 1' })
+      ).toBeInTheDocument()
+    })
+
+    it('should respect the controlled `open` prop', () => {
+      renderDropdown({ open: true })
+
+      expect(
+        screen.getByRole('menuitem', { name: 'Item 1' })
+      ).toBeInTheDocument()
+    })
+
+    it('should not open on click when controlled `open` is false', async () => {
+      const onOpenChange = vi.fn()
+      renderDropdown({ open: false, onOpenChange })
+
+      await openDropdown()
+
+      // In controlled mode the parent owns the state: the menu stays closed
+      // until `open` is flipped, even though `onOpenChange` is requested.
+      expect(screen.queryByRole('menuitem')).not.toBeInTheDocument()
+      expect(onOpenChange).toHaveBeenCalledWith(true)
+    })
+
+    it('should disable an item flagged as `disabled`', async () => {
+      const onSelect = vi.fn()
+      renderDropdown({
+        items: [[{ text: 'Item 1', disabled: true, onSelect }]],
+      })
+
+      await openDropdown()
+
+      const item = screen.getByRole('menuitem', { name: 'Item 1' })
+      expect(item).toHaveAttribute('data-disabled')
+    })
+
+    it('should apply the destructive variant class to an item', async () => {
+      renderDropdown({
+        items: [[{ text: 'Delete', variant: DropDownItemVariant.DESTRUCTIVE }]],
+      })
+
+      await openDropdown()
+
+      expect(screen.getByRole('menuitem', { name: 'Delete' })).toHaveClass(
+        'dropdown-item-variant-destructive'
+      )
+    })
+  })
+
+  describe('width prop', () => {
+    it('should apply the auto-width class by default', async () => {
+      renderDropdown()
+
+      await openDropdown()
+
+      expect(screen.getByRole('menu')).toHaveClass('dropdown-width-auto')
+    })
+
+    it('should apply the trigger-width class when `width="trigger"`', async () => {
+      renderDropdown({ width: 'trigger' })
+
+      await openDropdown()
+
+      expect(screen.getByRole('menu')).toHaveClass('dropdown-width-trigger')
+    })
+
+    it('should apply an inline pixel width when `width` is a number', async () => {
+      renderDropdown({ width: 200 })
+
+      await openDropdown()
+
+      const menu = screen.getByRole('menu')
+      expect(menu).toHaveStyle({ width: '200px' })
+      // A numeric width must not also set the auto/trigger modifier classes.
+      expect(menu).not.toHaveClass('dropdown-width-auto')
+      expect(menu).not.toHaveClass('dropdown-width-trigger')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should render the trigger but no items for an empty `items` array', async () => {
+      renderDropdown({ items: [] })
+
+      await openDropdown()
+
+      expect(screen.queryByRole('menuitem')).not.toBeInTheDocument()
+    })
+
+    it('should handle `width` of 0 as an inline pixel width', async () => {
+      renderDropdown({ width: 0 })
+
+      await openDropdown()
+
+      const menu = screen.getByRole('menu')
+      // 0 is a valid number, so the inline style branch is taken (not the classes).
+      expect(menu).not.toHaveClass('dropdown-width-auto')
+      expect(menu).not.toHaveClass('dropdown-width-trigger')
+    })
+  })
+
+  describe('error cases', () => {
+    // These render with the bare `render()` (no router error boundary) so the
+    // synchronous render error propagates and can be asserted with `toThrow`.
+    // `console.error` is silenced because React logs the error before rethrowing,
+    // which would otherwise trip `vitest-fail-on-console`.
+    it('should throw when a group is empty (no item to derive the key from)', () => {
+      // `items.map` reads `itemGroup[0].text` for the React key; an empty group
+      // makes `itemGroup[0]` undefined, which throws at render time.
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      // Cast through the whole props object: an empty group does not satisfy the
+      // discriminated `items` union, which is exactly the invalid input under test.
+      const invalidProps = {
+        label: 'Dropdown',
+        open: true,
+        items: [[]],
+      } as unknown as DropdownProps
+
+      expect(() => render(<Dropdown {...invalidProps} />)).toThrow()
+    })
+
+    it('should throw when `trigger` is a non-element node (string)', () => {
+      // `DropdownMenu.Trigger` uses `asChild`, which slots onto a single React
+      // element. A plain string cannot be slotted, so rendering throws. This
+      // documents that the `return trigger` fallback for non-elements is unusable.
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect(() =>
+        render(
+          <Dropdown
+            label="Dropdown"
+            trigger="Plain text trigger"
+            items={defaultItems}
+          />
+        )
+      ).toThrow()
+    })
+  })
+
+  it('should render without accessibility violations (closed)', async () => {
+    const { container } = renderDropdown()
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('should render without accessibility violations (open)', async () => {
+    const { baseElement } = renderDropdown()
+
+    // Open via a real click so the state update is wrapped in `act`, then run
+    // axe on `baseElement` to cover the portaled menu. The `region` rule is
+    // disabled because the menu is portaled outside any landmark in test
+    // isolation (it lives inside page landmarks in the real app).
+    await openDropdown()
+
+    expect(
+      await axe(baseElement, { rules: { region: { enabled: false } } })
+    ).toHaveNoViolations()
+  })
+})

--- a/pro/src/design-system/Dropdown/Dropdown.spec.tsx
+++ b/pro/src/design-system/Dropdown/Dropdown.spec.tsx
@@ -144,6 +144,46 @@ describe('<Dropdown />', () => {
       expect(link).toHaveAttribute('href', '/somewhere')
     })
 
+    it('should not set `target`/`rel` for an internal link', async () => {
+      renderDropdown({
+        items: [[{ text: 'Go', link: { to: '/somewhere' } }]],
+      })
+
+      await openDropdown()
+
+      const link = screen.getByRole('menuitem', { name: 'Go' })
+      expect(link).not.toHaveAttribute('target')
+      expect(link).not.toHaveAttribute('rel')
+    })
+
+    it('should enforce `target`, `rel` and "Nouvelle fenêtre" on icon when `opensInNewTab` is set', async () => {
+      renderDropdown({
+        items: [
+          [
+            {
+              text: 'External',
+              icon: fullLinkIcon,
+              link: { to: '/out', opensInNewTab: true },
+            },
+          ],
+        ],
+      })
+
+      await openDropdown()
+
+      // The accessible name combines the text and the injected icon's alt, so
+      // the user is warned the link opens a new tab (WCAG 3.2.5).
+      const link = screen.getByRole('menuitem', {
+        name: 'Nouvelle fenêtre External',
+      })
+      expect(link).toHaveAttribute('target', '_blank')
+      // Security/privacy guard cannot be forgotten by the caller.
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+      expect(
+        screen.getByRole('img', { name: 'Nouvelle fenêtre' })
+      ).toBeInTheDocument()
+    })
+
     it('should use a custom trigger instead of the default button', () => {
       renderDropdown({
         label: 'Accessible name',
@@ -194,14 +234,6 @@ describe('<Dropdown />', () => {
       await openDropdown()
 
       expect(onOpenChange).toHaveBeenCalledWith(true)
-    })
-
-    it('should respect the `defaultOpen` prop (uncontrolled)', () => {
-      renderDropdown({ defaultOpen: true })
-
-      expect(
-        screen.getByRole('menuitem', { name: 'Item 1' })
-      ).toBeInTheDocument()
     })
 
     it('should respect the controlled `open` prop', () => {

--- a/pro/src/design-system/Dropdown/Dropdown.stories.tsx
+++ b/pro/src/design-system/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,393 @@
+import type { StoryObj } from '@storybook/react-vite'
+import { useRef, useState } from 'react'
+import { withRouter } from 'storybook-addon-remix-react-router'
+
+import fullClearIcon from '@/icons/full-clear.svg'
+import fullDownIcon from '@/icons/full-down.svg'
+import fullDownloadIcon from '@/icons/full-download.svg'
+import fullDuplicateIcon from '@/icons/full-duplicate.svg'
+import fullEditIcon from '@/icons/full-edit.svg'
+import fullLinkIcon from '@/icons/full-link.svg'
+import fullLogoutIcon from '@/icons/full-logout.svg'
+import fullPauseIcon from '@/icons/full-pause.svg'
+import fullPlusIcon from '@/icons/full-plus.svg'
+import fullShowIcon from '@/icons/full-show.svg'
+import fullStarIcon from '@/icons/full-star.svg'
+import fullThreeDotsIcon from '@/icons/full-three-dots.svg'
+import fullTrashIcon from '@/icons/full-trash.svg'
+import fullUpIcon from '@/icons/full-up.svg'
+
+import { Button } from '../Button/Button'
+import { ButtonVariant, IconPositionEnum } from '../Button/types'
+import { TagVariant } from '../Tag/Tag'
+import { DropDownItemVariant, Dropdown, type DropdownProps } from './Dropdown'
+
+export default {
+  title: '@/design-system/Dropdown',
+  decorators: [withRouter],
+  component: Dropdown,
+  argTypes: {
+    label: { control: 'text' },
+    align: { control: 'select', options: ['start', 'center', 'end'] },
+    items: { control: 'object' },
+    width: { control: 'select', options: ['auto', 'trigger', 650] },
+  },
+}
+
+const DEFAULT_ARGS = {
+  label: 'Dropdown',
+  align: 'start',
+  items: [
+    [
+      { text: 'Ajouter', icon: fullPlusIcon },
+      { text: 'Modifier', icon: fullEditIcon },
+      {
+        text: 'Supprimer',
+        icon: fullTrashIcon,
+        variant: DropDownItemVariant.DESTRUCTIVE,
+      },
+    ],
+  ],
+  width: 'auto',
+} satisfies DropdownProps
+
+export const Default: StoryObj<typeof Dropdown> = {
+  args: {
+    label: 'Dropdown',
+    align: 'start',
+    items: [
+      [
+        {
+          text: 'Mettre à la une',
+          icon: fullStarIcon,
+          tag: {
+            label: 'Nouveau',
+            variant: TagVariant.CINECLUB,
+          },
+        },
+      ],
+      [
+        {
+          text: 'Un texte super mega long et désactivé',
+          icon: fullShowIcon,
+          disabled: true,
+        },
+        {
+          text: 'Aller sur Google',
+          icon: fullLinkIcon,
+          link: {
+            target: '_blank',
+            to: '//google.fr',
+          },
+        },
+        { text: 'Dupliquer', icon: fullDuplicateIcon },
+      ],
+      [
+        {
+          text: 'Supprimer',
+          icon: fullTrashIcon,
+          variant: DropDownItemVariant.DESTRUCTIVE,
+        },
+      ],
+    ],
+  },
+}
+
+export const WithIcons: StoryObj<typeof Dropdown> = {
+  args: {
+    ...DEFAULT_ARGS,
+    items: [
+      [
+        { text: 'Ajouter', icon: fullPlusIcon },
+        { text: 'Modifier', icon: fullEditIcon },
+        {
+          text: 'Supprimer',
+          icon: fullTrashIcon,
+          variant: DropDownItemVariant.DESTRUCTIVE,
+        },
+      ],
+    ],
+  },
+}
+
+export const WithoutIcons: StoryObj<typeof Dropdown> = {
+  args: {
+    ...DEFAULT_ARGS,
+    items: [
+      [
+        { text: 'Ajouter' },
+        { text: 'Modifier' },
+        { text: 'Supprimer', variant: DropDownItemVariant.DESTRUCTIVE },
+      ],
+    ],
+  },
+}
+
+export const WithSeparators: StoryObj<typeof Dropdown> = {
+  args: {
+    ...DEFAULT_ARGS,
+    items: [
+      [{ text: 'Ajouter', icon: fullPlusIcon }],
+      [{ text: 'Modifier', icon: fullEditIcon }],
+      [
+        {
+          text: 'Supprimer',
+          icon: fullTrashIcon,
+          variant: DropDownItemVariant.DESTRUCTIVE,
+        },
+      ],
+    ],
+  },
+}
+
+export const ForcedSideRight: StoryObj<typeof Dropdown> = {
+  args: {
+    ...DEFAULT_ARGS,
+    side: 'right',
+  },
+}
+
+export const ForcedSideRightAndAlignedEnd: StoryObj<typeof Dropdown> = {
+  args: {
+    ...DEFAULT_ARGS,
+    side: 'right',
+    align: 'end',
+  },
+}
+
+export const WidthTrigger: StoryObj<typeof Dropdown> = {
+  args: {
+    ...DEFAULT_ARGS,
+    width: 'trigger',
+    label: "Trigger d'une certaine longueur",
+  },
+}
+
+export const WidthNumber: StoryObj<typeof Dropdown> = {
+  args: {
+    ...DEFAULT_ARGS,
+    width: 650,
+    label: 'Dropdown largeur fixe (650px)',
+  },
+}
+
+export const WithTags: StoryObj<typeof Dropdown> = {
+  args: {
+    ...DEFAULT_ARGS,
+    items: [
+      [
+        {
+          text: 'Pré-réserver',
+          tag: { label: 'Nouveau', variant: TagVariant.NEW },
+        },
+        {
+          text: 'Partager',
+          tag: { label: 'J’aime', variant: TagVariant.LIKE },
+        },
+        {
+          text: 'Transcription',
+          tag: { label: 'Pour les livres', variant: TagVariant.CINECLUB },
+        },
+      ],
+    ],
+  },
+}
+
+export const NavigationLinks: StoryObj<typeof Dropdown> = {
+  args: {
+    ...DEFAULT_ARGS,
+    items: [
+      [
+        {
+          text: 'Accueil Storybook',
+          link: {
+            to: 'https://pass-culture.github.io/pass-culture-main/',
+            target: '_blank',
+          },
+          icon: fullLogoutIcon,
+        },
+        {
+          text: 'Google',
+          link: { to: 'https://google.fr', target: '_blank' },
+          icon: fullLinkIcon,
+        },
+      ],
+    ],
+  },
+}
+
+export const OnOpenChangeExample: StoryObj<typeof Dropdown> = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    return (
+      <>
+        <pre style={{ marginBottom: '16px  ' }}>
+          isOpen: {isOpen ? 'true' : 'false'}
+        </pre>
+        <Dropdown
+          label="Dropdown"
+          trigger={
+            <Button
+              label="Dropdown"
+              variant={ButtonVariant.PRIMARY}
+              icon={isOpen ? fullUpIcon : fullDownIcon}
+              iconPosition={IconPositionEnum.RIGHT}
+            />
+          }
+          open={isOpen}
+          onOpenChange={setIsOpen}
+          items={[
+            [
+              { text: 'Ajouter', icon: fullPlusIcon },
+              { text: 'Modifier', icon: fullEditIcon },
+              {
+                text: 'Supprimer',
+                icon: fullTrashIcon,
+                variant: DropDownItemVariant.DESTRUCTIVE,
+              },
+            ],
+          ]}
+        />
+      </>
+    )
+  },
+}
+
+export const onSelectActions: StoryObj<typeof Dropdown> = {
+  render: () => {
+    const [isDownloading, setIsDownloading] = useState(false)
+    const [downloadProgress, setDownloadProgress] = useState(0)
+
+    const interval = useRef<NodeJS.Timeout | null>(null)
+
+    const startDownload = () => {
+      setIsDownloading(true)
+      interval.current = setInterval(() => {
+        setDownloadProgress((prev) => prev + 0.01)
+
+        if (downloadProgress >= 1) {
+          stopDownload()
+        }
+      }, 100)
+    }
+
+    const pauseDownload = () => {
+      setIsDownloading(false)
+      if (interval.current) {
+        clearInterval(interval.current)
+        interval.current = null
+      }
+    }
+
+    const stopDownload = () => {
+      pauseDownload()
+      setDownloadProgress(0)
+    }
+
+    const shouldSeeProgressBar = isDownloading || downloadProgress > 0
+
+    const itemsDefault = [
+      [
+        {
+          text: downloadProgress > 0 ? 'Reprendre' : 'Télécharger',
+          onSelect: startDownload,
+          icon: fullDownloadIcon,
+        },
+      ],
+    ]
+
+    const itemsWhenDownloading = [
+      [
+        {
+          text: 'Annuler',
+          onSelect: stopDownload,
+          icon: fullClearIcon,
+          variant: DropDownItemVariant.DESTRUCTIVE,
+        },
+      ],
+      [{ text: 'Pause', onSelect: pauseDownload, icon: fullPauseIcon }],
+    ]
+
+    return (
+      <>
+        <Dropdown
+          label="Choose an action"
+          side="top"
+          align="start"
+          items={isDownloading ? itemsWhenDownloading : itemsDefault}
+        />
+        <br />
+        <br />
+        {shouldSeeProgressBar ? (
+          <>
+            <p>Téléchargement en cours…</p>
+            <progress value={downloadProgress} max={1} />
+          </>
+        ) : (
+          <p>—</p>
+        )}
+      </>
+    )
+  },
+}
+
+export const WithCustomTriggerAndAriaLabel: StoryObj<typeof Dropdown> = {
+  render: () => {
+    const [color, setColor] = useState('red')
+    return (
+      <div
+        style={{
+          display: 'inline-flex',
+          gap: '10px',
+          alignItems: 'center',
+          justifyContent: 'space-around',
+        }}
+      >
+        <Dropdown
+          items={[
+            [
+              { text: 'Rouge', onSelect: () => setColor('red') },
+              { text: 'Vert', onSelect: () => setColor('green') },
+              { text: 'Bleu', onSelect: () => setColor('blue') },
+            ],
+          ]}
+          side="left"
+          align="start"
+          trigger={
+            <div
+              tabIndex={1}
+              style={{
+                backgroundColor: color,
+                borderRadius: '25px',
+                width: '50px',
+                height: '50px',
+                cursor: 'pointer',
+              }}
+            />
+          }
+          label="Custom trigger label"
+        />
+        <Dropdown
+          items={[
+            [
+              { text: 'Ajouter' },
+              { text: 'Modifier' },
+              { text: 'Supprimer', variant: DropDownItemVariant.DESTRUCTIVE },
+            ],
+          ]}
+          side="right"
+          align="start"
+          trigger={
+            <Button
+              tabIndex={2}
+              variant={ButtonVariant.SECONDARY}
+              icon={fullThreeDotsIcon}
+            />
+          }
+          label="Open options"
+        />
+      </div>
+    )
+  },
+}

--- a/pro/src/design-system/Dropdown/Dropdown.stories.tsx
+++ b/pro/src/design-system/Dropdown/Dropdown.stories.tsx
@@ -76,8 +76,8 @@ export const Default: StoryObj<typeof Dropdown> = {
           text: 'Aller sur Google',
           icon: fullLinkIcon,
           link: {
-            target: '_blank',
             to: '//google.fr',
+            opensInNewTab: true,
           },
         },
         { text: 'Dupliquer', icon: fullDuplicateIcon },
@@ -202,13 +202,13 @@ export const NavigationLinks: StoryObj<typeof Dropdown> = {
           text: 'Accueil Storybook',
           link: {
             to: 'https://pass-culture.github.io/pass-culture-main/',
-            target: '_blank',
+            opensInNewTab: true,
           },
           icon: fullLogoutIcon,
         },
         {
           text: 'Google',
-          link: { to: 'https://google.fr', target: '_blank' },
+          link: { to: 'https://google.fr', opensInNewTab: true },
           icon: fullLinkIcon,
         },
       ],

--- a/pro/src/design-system/Dropdown/Dropdown.tsx
+++ b/pro/src/design-system/Dropdown/Dropdown.tsx
@@ -1,0 +1,188 @@
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import cn from 'classnames'
+import React from 'react'
+import { Link, type LinkProps } from 'react-router'
+
+import { SvgIcon } from '@/ui-kit/SvgIcon/SvgIcon'
+
+import { Button } from '../Button/Button'
+import { Tag, type TagProps } from '../Tag/Tag'
+import styles from './Dropdown.module.scss'
+
+// biome-ignore lint/suspicious/noConstEnum: Prefer "const enum": inlines values at compile time, reduces bundle size and avoids runtime objects.
+export const enum DropDownItemVariant {
+  DESTRUCTIVE = 'destructive',
+}
+
+/**
+ * Base dropdown props for the component.
+ *
+ * @typedef {object} BaseProps
+ * @property {string} label - Accessible label for the dropdown trigger.
+ * @property {'auto' | 'trigger' | number} [width] - Width of the dropdown content. `'auto'` (default), `'trigger'` (match trigger width), or a specific px number.
+ * @property {'start' | 'center' | 'end'} [align] - Dropdown alignment relative to the trigger.
+ * @property {'top' | 'right' | 'bottom' | 'left'} [side] - Side on which dropdown content appears.
+ * @property {React.ReactNode} [trigger] - Custom trigger node (if not provided, a default button is used).
+ * @property {boolean} [open] - Controlled open state.
+ * @property {boolean} [defaultOpen] - Initial open state (uncontrolled).
+ * @property {(open: boolean) => void} [onOpenChange] - Called when the dropdown open state changes.
+ */
+type BaseProps = DropdownMenu.DropdownMenuProps & {
+  /** Accessible label for the dropdown trigger. */
+  label: string
+  /** Width of the dropdown content; 'auto' (default), 'trigger' (match trigger width), or a specific px number. */
+  width?: 'auto' | 'trigger' | number
+  /** Dropdown alignment relative to trigger ('start' | 'center' | 'end'). */
+  align?: DropdownMenu.DropdownMenuContentProps['align']
+  /** Side for dropdown content ('top', 'right', 'bottom', 'left'). */
+  side?: DropdownMenu.DropdownMenuContentProps['side']
+  /** Custom trigger node. */
+  trigger?: React.ReactNode
+  /** Controlled open state. */
+  open?: boolean
+  /** Initial open state (uncontrolled). */
+  defaultOpen?: boolean
+  /** Callback fired on open state change. */
+  onOpenChange?: (open: boolean) => void
+}
+
+/**
+ * Item definition for dropdown content.
+ *
+ * @typedef {object} Item
+ * @property {string} text - Item display text.
+ * @property {LinkProps} [link] - If present, the item becomes a link (remix-router/next/link-style).
+ * @property {string} [icon] - Optional icon (either all items have an icon, or none).
+ * @property {DropDownItemVariant} [variant] - Variant, e.g. 'destructive'.
+ * @property {boolean} [disabled] - Disables the item.
+ * @property {TagProps} [tag] - Optional badge/tag to display alongside.
+ */
+type Item = DropdownMenu.DropdownMenuItemProps & {
+  /** Item display text. */
+  text: string
+  /** If present, the item becomes a link. */
+  link?: LinkProps
+  /** Optional icon (all items must include icons if any do). */
+  icon?: string
+  /** Variant, e.g. 'destructive' for dangerous actions. */
+  variant?: DropDownItemVariant
+  /** Disabled state. */
+  disabled?: boolean
+  /** Optional tag/badge element shown next to the item. */
+  tag?: TagProps
+}
+
+// DS rule: either ALL items have an `icon` or NONE do. Discriminating the
+// array on `icon` only (required vs `never`) enforces that, while keeping the
+// other optional props (destructive, tag, …) free per item.
+export type DropdownProps =
+  | (BaseProps & { items: (Item & { icon: string })[][] })
+  | (BaseProps & { items: (Item & { icon?: never })[][] })
+
+export const Dropdown = ({
+  label,
+  width = 'auto',
+  align,
+  side,
+  trigger,
+  open,
+  defaultOpen,
+  onOpenChange,
+  items,
+}: Readonly<DropdownProps>): JSX.Element => {
+  // When a custom `trigger` is provided we force its `aria-label` *by default*
+  // to the `label` prop, so the trigger always exposes an accessible name.
+  // A `aria-label` already set on the trigger takes precedence (non-destructive).
+  const renderTrigger = (): React.ReactNode => {
+    if (!trigger) {
+      return <Button type="button" label={label} />
+    }
+
+    if (React.isValidElement(trigger)) {
+      const { 'aria-label': triggerAriaLabel } = trigger.props as {
+        'aria-label'?: string
+      }
+
+      return React.cloneElement(trigger, {
+        'aria-label': triggerAriaLabel ?? label,
+      } as React.HTMLAttributes<HTMLElement>)
+    }
+
+    return trigger
+  }
+
+  return (
+    <DropdownMenu.Root
+      open={open}
+      defaultOpen={defaultOpen}
+      onOpenChange={onOpenChange}
+    >
+      <DropdownMenu.Trigger asChild>{renderTrigger()}</DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align={align}
+          side={side}
+          className={cn(styles['dropdown-content'], {
+            [styles['dropdown-width-auto']]: width === 'auto',
+            [styles['dropdown-width-trigger']]: width === 'trigger',
+          })}
+          style={typeof width === 'number' ? { width } : undefined}
+        >
+          {items.map((itemGroup, index) => (
+            <React.Fragment key={itemGroup[0].text}>
+              {itemGroup.map(
+                ({
+                  text,
+                  link,
+                  icon,
+                  variant,
+                  disabled,
+                  tag,
+                  ...itemsProps
+                }) => {
+                  const itemBody = (
+                    <>
+                      {icon && (
+                        <div className={styles['dropdown-item-icon']}>
+                          <SvgIcon src={icon} aria-hidden="true" />
+                        </div>
+                      )}
+                      {text}
+                      {tag && (
+                        <div className={styles['tag-wrapper']}>
+                          <Tag {...tag} />
+                        </div>
+                      )}
+                    </>
+                  )
+
+                  return (
+                    <DropdownMenu.Item
+                      {...itemsProps}
+                      key={text}
+                      disabled={disabled}
+                      className={cn(styles['dropdown-item'], {
+                        [styles['dropdown-item-disabled']]: disabled,
+                        [styles[`dropdown-item-variant-${variant}`]]:
+                          variant !== undefined,
+                      })}
+                      asChild={!!link}
+                    >
+                      {link ? <Link {...link}>{itemBody}</Link> : itemBody}
+                    </DropdownMenu.Item>
+                  )
+                }
+              )}
+              {index < items.length - 1 && (
+                <DropdownMenu.Separator
+                  className={styles['dropdown-item-separator']}
+                />
+              )}
+            </React.Fragment>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}

--- a/pro/src/design-system/Dropdown/Dropdown.tsx
+++ b/pro/src/design-system/Dropdown/Dropdown.tsx
@@ -24,7 +24,6 @@ export const enum DropDownItemVariant {
  * @property {'top' | 'right' | 'bottom' | 'left'} [side] - Side on which dropdown content appears.
  * @property {React.ReactNode} [trigger] - Custom trigger node (if not provided, a default button is used).
  * @property {boolean} [open] - Controlled open state.
- * @property {boolean} [defaultOpen] - Initial open state (uncontrolled).
  * @property {(open: boolean) => void} [onOpenChange] - Called when the dropdown open state changes.
  */
 type BaseProps = DropdownMenu.DropdownMenuProps & {
@@ -40,8 +39,6 @@ type BaseProps = DropdownMenu.DropdownMenuProps & {
   trigger?: React.ReactNode
   /** Controlled open state. */
   open?: boolean
-  /** Initial open state (uncontrolled). */
-  defaultOpen?: boolean
   /** Callback fired on open state change. */
   onOpenChange?: (open: boolean) => void
 }
@@ -51,17 +48,24 @@ type BaseProps = DropdownMenu.DropdownMenuProps & {
  *
  * @typedef {object} Item
  * @property {string} text - Item display text.
- * @property {LinkProps} [link] - If present, the item becomes a link (remix-router/next/link-style).
+ * @property {ItemLink} [link] - If present, the item becomes a link. Use `opensInNewTab` instead of raw `target`/`rel`: external-link safety (rel + "Nouvelle fenêtre" icon) is then enforced by the component.
  * @property {string} [icon] - Optional icon (either all items have an icon, or none).
  * @property {DropDownItemVariant} [variant] - Variant, e.g. 'destructive'.
  * @property {boolean} [disabled] - Disables the item.
  * @property {TagProps} [tag] - Optional badge/tag to display alongside.
  */
+
+// Use `opensInNewTab` instead of `target`/`rel` to always enforce security and accessibility for external links.
+type ItemLink = Omit<LinkProps, 'target' | 'rel'> & {
+  /** Opens the link in a new tab, enforcing `rel` + alt text. */
+  opensInNewTab?: boolean
+}
+
 type Item = DropdownMenu.DropdownMenuItemProps & {
   /** Item display text. */
   text: string
   /** If present, the item becomes a link. */
-  link?: LinkProps
+  link?: ItemLink
   /** Optional icon (all items must include icons if any do). */
   icon?: string
   /** Variant, e.g. 'destructive' for dangerous actions. */
@@ -72,9 +76,7 @@ type Item = DropdownMenu.DropdownMenuItemProps & {
   tag?: TagProps
 }
 
-// DS rule: either ALL items have an `icon` or NONE do. Discriminating the
-// array on `icon` only (required vs `never`) enforces that, while keeping the
-// other optional props (destructive, tag, …) free per item.
+// Items either all have an icon or none at all.
 export type DropdownProps =
   | (BaseProps & { items: (Item & { icon: string })[][] })
   | (BaseProps & { items: (Item & { icon?: never })[][] })
@@ -86,7 +88,6 @@ export const Dropdown = ({
   side,
   trigger,
   open,
-  defaultOpen,
   onOpenChange,
   items,
 }: Readonly<DropdownProps>): JSX.Element => {
@@ -112,11 +113,7 @@ export const Dropdown = ({
   }
 
   return (
-    <DropdownMenu.Root
-      open={open}
-      defaultOpen={defaultOpen}
-      onOpenChange={onOpenChange}
-    >
+    <DropdownMenu.Root open={open} onOpenChange={onOpenChange}>
       <DropdownMenu.Trigger asChild>{renderTrigger()}</DropdownMenu.Trigger>
 
       <DropdownMenu.Portal>
@@ -141,11 +138,16 @@ export const Dropdown = ({
                   tag,
                   ...itemsProps
                 }) => {
+                  const opensInNewTab = link?.opensInNewTab ?? false
+
                   const itemBody = (
                     <>
                       {icon && (
                         <div className={styles['dropdown-item-icon']}>
-                          <SvgIcon src={icon} aria-hidden="true" />
+                          <SvgIcon
+                            src={icon}
+                            alt={opensInNewTab ? 'Nouvelle fenêtre' : ''}
+                          />
                         </div>
                       )}
                       {text}
@@ -157,6 +159,28 @@ export const Dropdown = ({
                     </>
                   )
 
+                  // Enforce external-link safety with rel="noopener noreferrer"
+                  const linkElement = link
+                    ? (() => {
+                        const {
+                          opensInNewTab: _opensInNewTab,
+                          ...routerProps
+                        } = link
+
+                        return (
+                          <Link
+                            {...routerProps}
+                            target={opensInNewTab ? '_blank' : undefined}
+                            rel={
+                              opensInNewTab ? 'noopener noreferrer' : undefined
+                            }
+                          >
+                            {itemBody}
+                          </Link>
+                        )
+                      })()
+                    : null
+
                   return (
                     <DropdownMenu.Item
                       {...itemsProps}
@@ -167,9 +191,10 @@ export const Dropdown = ({
                         [styles[`dropdown-item-variant-${variant}`]]:
                           variant !== undefined,
                       })}
-                      asChild={!!link}
+                      /* If the item is a link, we want the <DropdownMenu.Item> to be rendered as its child : <Link> component */
+                      asChild={!!linkElement}
                     >
-                      {link ? <Link {...link}>{itemBody}</Link> : itemBody}
+                      {linkElement ?? itemBody}
                     </DropdownMenu.Item>
                   )
                 }

--- a/pro/src/ui-kit/Dropdown/Dropdown.tsx
+++ b/pro/src/ui-kit/Dropdown/Dropdown.tsx
@@ -39,6 +39,7 @@ export type DropdownProps = {
   triggerTooltip?: boolean
 }
 
+/** @deprecated Use `<Dropdown />` from /design-system/ folder instead */
 export function Dropdown({
   title,
   trigger,

--- a/pro/src/ui-kit/Dropdown/DropdownItem.tsx
+++ b/pro/src/ui-kit/Dropdown/DropdownItem.tsx
@@ -55,6 +55,8 @@ type DropdownItemProps = DropdownMenu.DropdownMenuItemProps & {
  *
  * @accessibility
  * - If present, the `title` attribute provides additional context for the dropdown item.
+ *
+ * @deprecated Use `<Dropdown />` from /design-system/ folder instead
  */
 export function DropdownItem({
   title,


### PR DESCRIPTION
## 🎯 Related Ticket

[PC-41608](https://passculture.atlassian.net/browse/PC-41608)

> Création d'un composant `Dropdown` dans le design-system pour remplacer celui du `ui-kit` sur l'espace partenaire. L'objectif : une API déclarative, accessible et cohérente, et amorcer la dépréciation de l'ancien composant.

<p align="center"><img width="355" height="304" alt="image" src="https://github.com/user-attachments/assets/303731e1-a20d-42f0-b9c6-ada490ec1a8c" /></p>

### 🔧 Changements

#### Design-system
- Nouveau composant `Dropdown` (`@/design-system/Dropdown`) avec API **déclarative** : items passés en tableau de groupes (`items: Item[][]`), chaque groupe séparé visuellement par un `Separator`.
- Par item : `link` (rendu en `<Link>` react-router via `asChild`), `icon`, `tag` (badge), `variant` destructif et `disabled`.
- Typage strict : **tous les items ont une icône, ou aucun** (union discriminée sur `icon`) pour une UI homogène.
- Trigger : bouton par défaut, ou trigger custom dont l'`aria-label` est dérivé de `label` (sans écraser un `aria-label` déjà présent) → nom accessible garanti.
- Placement/dimension : `width` (`'auto'` | `'trigger'` | nombre px), `align`, `side` ; état **contrôlé** via `open` / `onOpenChange`.
- Styles dédiés (`Dropdown.module.scss`) + stories Storybook (`Dropdown.stories.tsx`).

#### UI-Kit
- Dépréciation de l'ancien composant : `@deprecated Use <Dropdown /> from /design-system/ folder instead` sur `ui-kit/Dropdown/Dropdown.tsx` et `DropdownItem.tsx`.

#### Tests
- Tests unitaires (`Dropdown.spec.tsx`) : rendu, groupes/séparateurs, liens, icônes, tags, variant destructif, états disabled/contrôlés et accessibilité (axe).

### 🧪 Comment tester
- `pnpm test:unit run src/design-system/Dropdown/Dropdown.spec.tsx`
- `pnpm storybook` → story **Dropdown** : groupes, icônes, tags, item destructif, largeurs (`auto`/`trigger`/px), navigation clavier.

---
**🧭 Review effort : 2/5** — nouveau composant isolé, sans impact sur l'existant (l'ancien est seulement marqué déprécié), bien couvert par les tests.

**🗂️ Walkthrough**

| Fichier(s) | Résumé |
|---|---|
| `pro/src/design-system/Dropdown/Dropdown.tsx` | Nouveau composant DS (API déclarative, a11y, variants) |
| `pro/src/design-system/Dropdown/Dropdown.module.scss` | Styles du composant |
| `pro/src/design-system/Dropdown/Dropdown.stories.tsx` | Stories Storybook |
| `pro/src/design-system/Dropdown/Dropdown.spec.tsx` | Tests unitaires + a11y |
| `pro/src/ui-kit/Dropdown/Dropdown.tsx`, `DropdownItem.tsx` | Notice de dépréciation vers le composant DS |

[PC-41608]: https://passculture.atlassian.net/browse/PC-41608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ