### PR TITLE
(BSR)[PRO] fix: unify feature-flag route filtering and remove duplicated wizard route

### DIFF
--- a/pro/src/app/AppRouter/AppRouter.tsx
+++ b/pro/src/app/AppRouter/AppRouter.tsx
@@ -10,6 +10,7 @@ import { noop } from '@/commons/utils/noop'
 import { ErrorBoundary } from './ErrorBoundary'
 import { redirectedRoutes } from './redirectedRoutes'
 import type { CustomRouteOrphan } from './types'
+import { filterRoutesByActiveFeatures } from './utils/filterRoutesByActiveFeatures'
 
 const sentryCreateBrowserRouter =
   Sentry.wrapCreateBrowserRouterV7(createBrowserRouter)
@@ -17,16 +18,8 @@ const sentryCreateBrowserRouter =
 export const AppRouter = () => {
   const activeFeatures = useAppSelector(selectActiveFeatures)
 
-  const activeRoutes = routes
-    .filter(
-      (route) =>
-        !route.disabledWithFeatureName ||
-        !activeFeatures.includes(route.disabledWithFeatureName)
-    )
-    .filter(
-      (route) =>
-        !route.featureName || activeFeatures.includes(route.featureName)
-    )
+  const activeRoutes = filterRoutesByActiveFeatures(routes, activeFeatures)
+
   const activeRedirections = redirectedRoutes.filter(
     (route) => !route.featureName || activeFeatures.includes(route.featureName)
   )

--- a/pro/src/app/AppRouter/subroutesIndividualOfferWizardMap.tsx
+++ b/pro/src/app/AppRouter/subroutesIndividualOfferWizardMap.tsx
@@ -79,18 +79,7 @@ export const routesIndividualOfferWizard: CustomRouteGroupChild[] = [
     },
     loader: withUserPermissions(mustBeOnboardedWithSelectedPartnerVenue),
   },
-  {
-    lazy: () =>
-      import(
-        '@/pages/IndividualOfferSummary/IndividualOfferSummaryDetails/IndividualOfferSummaryDetails'
-      ),
-    path: '/offre/individuelle/:offerId/recapitulatif/description',
-    handle: {
-      title: 'Description - Consulter une offre individuelle',
-    },
-    disabledWithFeatureName: 'WIP_OFFER_EXPOSURE',
-    loader: withUserPermissions(mustBeOnboardedWithSelectedPartnerVenue),
-  },
+
   //  Practical Informations
   {
     lazy: () =>

--- a/pro/src/app/AppRouter/utils/__specs__/filterRoutesByActiveFeatures.spec.ts
+++ b/pro/src/app/AppRouter/utils/__specs__/filterRoutesByActiveFeatures.spec.ts
@@ -1,0 +1,68 @@
+import type { RouteObject } from 'react-router'
+
+import { filterRoutesByActiveFeatures } from '../filterRoutesByActiveFeatures'
+
+type FeatureAwareRoute = RouteObject & {
+  featureName?: string
+  disabledWithFeatureName?: string
+}
+
+const buildRoutes = (): FeatureAwareRoute[] => [
+  { path: '/always' },
+  { path: '/gated', featureName: 'FF_1' },
+  { path: '/disabled', disabledWithFeatureName: 'FF_2' },
+  {
+    path: '/parent',
+    children: [
+      { path: 'child-always' },
+      { path: 'child-gated', featureName: 'FF_1' },
+      { path: 'child-disabled', disabledWithFeatureName: 'FF_2' },
+    ] as FeatureAwareRoute[],
+  },
+]
+
+const getPaths = (routes: RouteObject[]): string[] =>
+  routes.flatMap((route) => [
+    ...(route.path ? [route.path] : []),
+    ...(route.children ? getPaths(route.children) : []),
+  ])
+
+describe('filterRoutesByActiveFeatures', () => {
+  it('should keep routes without any feature flag', () => {
+    const result = filterRoutesByActiveFeatures(buildRoutes(), [])
+
+    expect(getPaths(result)).toContain('/always')
+    expect(getPaths(result)).toContain('child-always')
+  })
+
+  it('should remove routes gated behind an inactive featureName', () => {
+    const result = filterRoutesByActiveFeatures(buildRoutes(), [])
+
+    expect(getPaths(result)).not.toContain('/gated')
+  })
+
+  it('should keep routes gated behind an active featureName', () => {
+    const result = filterRoutesByActiveFeatures(buildRoutes(), ['FF_1'])
+
+    expect(getPaths(result)).toContain('/gated')
+  })
+
+  it('should remove routes disabled by an active disabledWithFeatureName', () => {
+    const result = filterRoutesByActiveFeatures(buildRoutes(), ['FF_2'])
+
+    expect(getPaths(result)).not.toContain('/disabled')
+  })
+
+  it('should filter nested children gated behind an inactive featureName', () => {
+    const result = filterRoutesByActiveFeatures(buildRoutes(), [])
+
+    expect(getPaths(result)).not.toContain('child-gated')
+    expect(getPaths(result)).not.toContain('deep-gated')
+  })
+
+  it('should remove nested children disabled by an active disabledWithFeatureName', () => {
+    const result = filterRoutesByActiveFeatures(buildRoutes(), ['FF_2'])
+
+    expect(getPaths(result)).not.toContain('child-disabled')
+  })
+})

--- a/pro/src/app/AppRouter/utils/filterRoutesByActiveFeatures.ts
+++ b/pro/src/app/AppRouter/utils/filterRoutesByActiveFeatures.ts
@@ -1,0 +1,36 @@
+import type { RouteObject } from 'react-router'
+
+import type { CustomRouteTree } from '../types'
+
+const isRouteActive = (
+  route: CustomRouteTree[number],
+  activeFeatures: string[]
+): boolean => {
+  if (
+    route.disabledWithFeatureName &&
+    activeFeatures.includes(route.disabledWithFeatureName)
+  ) {
+    return false
+  }
+
+  return !route.featureName || activeFeatures.includes(route.featureName)
+}
+
+// Filter routes based on active features recursively for nested children
+export const filterRoutesByActiveFeatures = (
+  routes: RouteObject[],
+  activeFeatures: string[]
+): CustomRouteTree =>
+  (routes as CustomRouteTree)
+    .filter((route) => isRouteActive(route, activeFeatures))
+    .map((route) =>
+      route.children
+        ? {
+            ...route,
+            children: filterRoutesByActiveFeatures(
+              route.children,
+              activeFeatures
+            ),
+          }
+        : route
+    )


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

> Corrige le filtrage des routes activées/désactivées par feature flags et supprime un doublon de route dans le wizard d’offre individuelle, pour éviter une gestion incohérente des routes et réduire le risque d’un chemin redondant.

### 🔧 Changements
- Ajoute `pro/src/app/AppRouter/utils/filterRoutesByActiveFeatures.ts` : extraction d’un helper réutilisable pour gérer `featureName` et `disabledWithFeatureName`
- Simplifie `pro/src/app/AppRouter/AppRouter.tsx` en remplaçant le filtrage inline par ce helper
- Supprime la route dupliquée `/offre/individuelle/:offerId/recapitulatif/description` dans `pro/src/app/AppRouter/subroutesIndividualOfferWizardMap.tsx`
- Ajoute des tests unitaires dans `pro/src/app/AppRouter/utils/__specs__/filterRoutesByActiveFeatures.spec.ts` pour couvrir les routes actives, désactivées et les enfants imbriqués

### 🧪 Comment tester
- Exécuter `pnpm test:unit -- pro/src/app/AppRouter/utils/__specs__/filterRoutesByActiveFeatures.spec.ts`
- Vérifier que le routeur continue à appliquer `featureName` et `disabledWithFeatureName` correctement
- Confirmer qu’il n’existe plus de doublon pour `/offre/individuelle/:offerId/recapitulatif/description`

---

**🧭 Review effort : 2/5** — petite refactorisation de routage avec un ajout de tests ciblés.