### PR TITLE
(BSR) exclude image files from sonar analysis

### DIFF
--- a/pro/sonar-project.properties
+++ b/pro/sonar-project.properties
@@ -37,4 +37,5 @@ sonar.exclusions=\
     src/apiClient/adage/**,\
     src/apiClient/compat.ts,\
     src/apiClient/clientConfig*,\
-    src/apiClient/v1/**
+    src/apiClient/v1/** \
+    **/*.jpg, **/*.jpeg, **/*.png, **/*.svg, **/*.gif,  **/*.ico


### PR DESCRIPTION
Sonar essaye de parse le projet selon la conf
https://github.com/pass-culture/pass-culture-main/blob/01c30265ff92c207d6848c1c9ec1fa0092e607f2/pro/sonar-project.properties#L21

et se casse les dents sur les images

```
09:26:17.255 WARN  Invalid character encountered in file /home/runner/work/pass-culture-main/pass-culture-main/pro/src/pages/Homepage/components/OffersEmptyStateCard/assets/bookable-offers.png at line 1 for encoding UTF-8. Please fix file content or configure the encoding to be used using property 'sonar.sourceEncoding'.
```

NB: voici [la syntaxe](https://docs.sonarsource.com/sonarqube-server/project-administration/adjusting-analysis/setting-analysis-scope/defining-matching-patterns#for-files) à utiliser pour un pattern.