### PR TITLE
(PC-42573)[API] feat: only consider headline active if offer has active image

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -668,8 +668,7 @@ class HeadlineOffer(PcObject, Model):
     @hybrid_property
     def isActive(self) -> bool:
         now = date_utils.get_naive_utc_now()
-        has_images = self.offer.mediations or (self.offer.product.images if self.offer.product else None)
-        if now in self.timespan and self.offer.status == OfferStatus.ACTIVE and has_images:
+        if now in self.timespan and self.offer.status == OfferStatus.ACTIVE and self.offer.hasActiveImage:
             return True
         return False
 
@@ -681,10 +680,7 @@ class HeadlineOffer(PcObject, Model):
             cls.timespan.contains(sa.cast(sa.func.now(), sa.TIMESTAMP)),
             offer_alias.id == cls.offerId,
             offer_alias.status == OfferStatus.ACTIVE,
-            sa.or_(
-                sa.exists().where(Mediation.offerId == offer_alias.id),
-                sa.exists().where(ProductMediation.productId == offer_alias.productId),
-            ),
+            offer_alias.hasActiveImage,
         )
 
 
@@ -1012,6 +1008,19 @@ class Offer(PcObject, Model, ValidationMixin, AccessibilityMixin):
         sorted_by_date_desc = sorted(self.mediations, key=lambda m: m.dateCreated, reverse=True)
         only_active = list(filter(lambda m: m.isActive, sorted_by_date_desc))
         return only_active[0] if only_active else None
+
+    @hybrid_property
+    def hasActiveImage(self) -> bool:
+        # Whether the offer has an active offer mediation or a product mediation
+        return self.activeMediation is not None or bool(self.product and self.product.productMediations)
+
+    @hasActiveImage.inplace.expression
+    @classmethod
+    def _hasActiveImageExpression(cls) -> ColumnElement[bool]:
+        return sa.or_(
+            sa.exists().where(Mediation.offerId == cls.id, Mediation.isActive.is_(True)),
+            sa.exists().where(ProductMediation.productId == cls.productId),
+        )
 
     @hybrid_property
     def canExpire(self) -> bool:

--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -1197,19 +1197,10 @@ def get_inactive_headline_offers() -> list[models.HeadlineOffer]:
     return (
         db.session.query(models.HeadlineOffer)
         .join(models.Offer, models.HeadlineOffer.offerId == models.Offer.id)
-        .outerjoin(models.Mediation, models.Mediation.offerId == models.Offer.id)
-        .outerjoin(models.Product, models.Offer.productId == models.Product.id)
-        .outerjoin(
-            models.ProductMediation,
-            models.ProductMediation.productId == models.Product.id,
-        )
         .filter(
             sa.or_(
                 models.Offer.status != offer_mixin.OfferStatus.ACTIVE.name,
-                sa.and_(
-                    models.ProductMediation.id.is_(None),
-                    models.Mediation.id.is_(None),
-                ),
+                sa.not_(models.Offer.hasActiveImage),
             ),
             sa.or_(
                 # We don't want to fetch HeadlineOffers that have already been marked as finished

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -907,7 +907,7 @@ class OfferValidationError(Exception):
 def check_offer_is_eligible_to_be_headline(offer: models.Offer) -> None:
     if offer.status != OfferStatus.ACTIVE:
         raise exceptions.InactiveOfferCanNotBeHeadline()
-    if not offer.images:
+    if not offer.hasActiveImage:
         raise exceptions.OfferWithoutImageCanNotBeHeadline()
 
 

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_headline_offers.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_headline_offers.py
@@ -8,34 +8,19 @@ from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
 
 logger = logging.getLogger(__name__)
 
-HEADLINE_OFFER_LIMIT_PER_OFFERER = 1
-
 
 @log_func_duration
 def create_industrial_headline_offers(offers_by_name: dict[str, Offer]) -> None:
     logger.info("create_industrial_headline_offers")
 
-    headline_offer_limit_per_offerer = {}
-    offerers = {offer.venue.managingOfferer.name: offer.venue.managingOfferer for offer in offers_by_name.values()}
-    for offerer_name in offerers.keys():
-        headline_offer_limit_per_offerer[offerer_name] = HEADLINE_OFFER_LIMIT_PER_OFFERER
+    headlined_venue_ids: set[int] = set()
 
     headline_offers_by_name = {}
     for offer_name, offer in offers_by_name.items():
-        offerer_name = offer.venue.managingOfferer.name
-        if (
-            headline_offer_limit_per_offerer[offerer_name]
-            and offer.status == OfferStatus.ACTIVE
-            and not offer.venue.has_headline_offer
-        ):
+        if offer.status == OfferStatus.ACTIVE and offer.venue.id not in headlined_venue_ids and offer.hasActiveImage:
             headline_offers_by_name[offer_name] = offers_factories.HeadlineOfferFactory.create(
                 offer=offer, venue=offer.venue, without_mediation=True
             )
-
-            headline_offer_limit_per_offerer[offerer_name] = (
-                headline_offer_limit_per_offerer[offerer_name] - 1
-                if headline_offer_limit_per_offerer[offerer_name] > 0
-                else headline_offer_limit_per_offerer[offerer_name]
-            )
+            headlined_venue_ids.add(offer.venue.id)
 
     logger.info("created %d headline offers", len(headline_offers_by_name))

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_mediations.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_mediations.py
@@ -7,13 +7,14 @@ from shutil import copyfile
 import pcapi.core.offers.factories as offers_factories
 import pcapi.sandboxes
 from pcapi import settings
+from pcapi.connectors import thumb_storage
 from pcapi.core.categories import subcategories
 from pcapi.core.object_storage import delete_public_object_recursively
 from pcapi.core.offers.models import Offer
 from pcapi.models import db
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
 from pcapi.sandboxes.scripts.utils.select import remove_every
-from pcapi.sandboxes.scripts.utils.storage_utils import store_public_object_from_sandbox_assets
+from pcapi.sandboxes.scripts.utils.storage_utils import read_sandbox_mediation_asset
 
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,6 @@ def prepare_mediations_folders() -> None:
 def create_industrial_mediations(offers_by_name: dict[str, Offer]) -> None:
     logger.info("create_industrial_mediations")
 
-    mediations_with_asset = {}
     mediations_by_name = {}
 
     offer_items = list(offers_by_name.items())
@@ -59,11 +59,10 @@ def create_industrial_mediations(offers_by_name: dict[str, Offer]) -> None:
     db.session.commit()
 
     for mediation in mediations_by_name.values():
-        mediations_with_asset[mediation.id] = store_public_object_from_sandbox_assets(
-            "thumbs", mediation, mediation.offer.subcategoryId
-        )
+        image_as_bytes = read_sandbox_mediation_asset(mediation.offer.subcategoryId)
+        thumb_storage.create_thumb(mediation, image_as_bytes, keep_ratio=True)
 
-    db.session.add_all(mediations_with_asset.values())
+    db.session.add_all(mediations_by_name.values())
     db.session.commit()
 
     logger.info("created %d mediations", len(mediations_by_name))

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_offerer_providers_for_apis.py
@@ -3,6 +3,7 @@ import logging
 import random
 
 from pcapi import settings
+from pcapi.connectors import thumb_storage
 from pcapi.connectors.big_query.queries.offerer_stats import DAILY_CONSULT_PER_OFFERER_LAST_180_DAYS_TABLE
 from pcapi.connectors.big_query.queries.offerer_stats import TOP_3_MOST_CONSULTED_OFFERS_LAST_30_DAYS_TABLE
 from pcapi.core.bookings import factories as bookings_factories
@@ -17,6 +18,7 @@ from pcapi.core.providers import factories as providers_factories
 from pcapi.core.providers import models as providers_models
 from pcapi.core.users import factories as users_factories
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
+from pcapi.sandboxes.scripts.utils.storage_utils import read_sandbox_mediation_asset
 from pcapi.utils import date as date_utils
 
 
@@ -144,7 +146,10 @@ def create_offerer_provider_with_offers(name: str, user_email: str) -> None:
             total_views_last_30_days=total_views_last_30_days,
         ),
     )
-    offers_factories.HeadlineOfferFactory.create(offer=top_offer)
+    mediation = offers_factories.MediationFactory.create(offer=top_offer)
+    image_as_bytes = read_sandbox_mediation_asset(top_offer.subcategoryId)
+    thumb_storage.create_thumb(mediation, image_as_bytes, keep_ratio=True)
+    offers_factories.HeadlineOfferFactory.create(offer=top_offer, without_mediation=True)
 
     offers_factories.EventStockFactory.create(
         offer__name="Taylor à Besançon !",

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/utils.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/utils.py
@@ -1,10 +1,4 @@
-import itertools
-import pathlib
 from decimal import Decimal
-
-import pcapi.core.offers.models as offers_models
-import pcapi.sandboxes.thumbs.generic_pictures as generic_pictures_thumbs
-from pcapi.connectors import thumb_storage
 
 
 def get_occurrence_short_name_or_none(concatened_names_with_a_date: str) -> str | None:
@@ -29,11 +23,3 @@ def get_price_by_short_name(occurrence_short_name: str | None = None) -> Decimal
         return Decimal(0)
 
     return Decimal(str(sum(map(ord, occurrence_short_name)) % 50))
-
-
-def create_products_thumb(products: list[offers_models.Product]) -> None:
-    image_dir = pathlib.Path(generic_pictures_thumbs.__path__[0])
-    image_paths = image_dir.iterdir()
-
-    for product, image_path in zip(products, itertools.cycle(image_paths)):
-        thumb_storage.create_thumb(product, image_path.read_bytes(), keep_ratio=True)

--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -58,7 +58,7 @@ from pcapi.sandboxes.scripts.creators.industrial.create_venue_labels import crea
 from pcapi.sandboxes.scripts.creators.test_cases import pro_advices_mocks
 from pcapi.sandboxes.scripts.creators.test_cases import venues_mock
 from pcapi.sandboxes.scripts.utils.helpers import log_func_duration
-from pcapi.sandboxes.scripts.utils.storage_utils import store_public_object_from_sandbox_assets
+from pcapi.sandboxes.scripts.utils.storage_utils import read_sandbox_mediation_asset
 from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
 from pcapi.utils.transaction_manager import atomic
@@ -737,7 +737,8 @@ def create_offer_and_stocks_for_cinemas(
                 venue=venue,
             )
             mediation = offers_factories.MediationFactory.create(offer=movie_offer)
-            store_public_object_from_sandbox_assets("thumbs", mediation, movie_offer.subcategoryId)
+            image_as_bytes = read_sandbox_mediation_asset(movie_offer.subcategoryId)
+            thumb_storage.create_thumb(mediation, image_as_bytes, keep_ratio=True)
 
             product_stocks = []
             for daydelta in range(0, 20, 4):
@@ -957,11 +958,6 @@ def create_offers_interactions() -> None:
         isSocialMediaDiffusible=True,
     )
 
-    offers_factories.HeadlineOfferFactory.create(offer=offer_1_likes_headline)
-    offers_factories.HeadlineOfferFactory.create(offer=offer_2_likes_headline_1)
-    offers_factories.HeadlineOfferFactory.create(offer=offer_2_likes_headline_2)
-    offers_factories.HeadlineOfferFactory.create(offer=offer_5_likes_headline)
-
 
 @log_func_duration
 def create_offers_with_video_url() -> None:
@@ -1114,7 +1110,8 @@ def create_offers_for_each_subcategory() -> None:
                     quantity=i * 10,
                 )
             mediation = offers_factories.MediationFactory.create(offer=stock.offer)
-            store_public_object_from_sandbox_assets("thumbs", mediation, subcategory.id)
+            image_as_bytes = read_sandbox_mediation_asset(subcategory.id)
+            thumb_storage.create_thumb(mediation, image_as_bytes, keep_ratio=True)
 
 
 @log_func_duration
@@ -1242,7 +1239,10 @@ def create_pro_advices() -> None:
         offer__name=f"Offre à la une du lieu {venue_1.id} - sans avis",
         offer__subcategoryId=subcategories.SEANCE_CINE.id,
     ).offer
-    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_1)
+    mediation = offers_factories.MediationFactory.create(offer=headline_offer_1)
+    image_as_bytes = read_sandbox_mediation_asset(headline_offer_1.subcategoryId)
+    thumb_storage.create_thumb(mediation, image_as_bytes, keep_ratio=True)
+    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_1, without_mediation=True)
 
     # Cas 2 :
     # - ✔︎ Offre à la une
@@ -1261,7 +1261,10 @@ def create_pro_advices() -> None:
         offer__name=f"Offre à la une du lieu {venue_2.id}",
         offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
     ).offer
-    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_2)
+    mediation = offers_factories.MediationFactory.create(offer=headline_offer_2)
+    image_as_bytes = read_sandbox_mediation_asset(headline_offer_2.subcategoryId)
+    thumb_storage.create_thumb(mediation, image_as_bytes, keep_ratio=True)
+    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_2, without_mediation=True)
     offers_factories.ProAdviceFactory.create(offer=headline_offer_2, **pro_advices_mocks.advices["fully-featured"])
 
     # Cas 3 :
@@ -1281,7 +1284,10 @@ def create_pro_advices() -> None:
         offer__name=f"Offre à la une du lieu {venue_3.id} - sans avis",
         offer__subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
     ).offer
-    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_3)
+    mediation = offers_factories.MediationFactory.create(offer=headline_offer_3)
+    image_as_bytes = read_sandbox_mediation_asset(headline_offer_3.subcategoryId)
+    thumb_storage.create_thumb(mediation, image_as_bytes, keep_ratio=True)
+    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_3, without_mediation=True)
     offer_with_advice = offers_factories.StockFactory.create(
         offer__venue=venue_3,
         offer__name=f"Offre du lieu {venue_3.id} - avec avis",
@@ -1306,7 +1312,10 @@ def create_pro_advices() -> None:
         offer__name=f"Offre à la une du lieu {venue_4.id} - avec avis",
         offer__subcategoryId=subcategories.LIVRE_NUMERIQUE.id,
     ).offer
-    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_4)
+    mediation = offers_factories.MediationFactory.create(offer=headline_offer_4)
+    image_as_bytes = read_sandbox_mediation_asset(headline_offer_4.subcategoryId)
+    thumb_storage.create_thumb(mediation, image_as_bytes, keep_ratio=True)
+    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_4, without_mediation=True)
     offers_factories.ProAdviceFactory.create(offer=headline_offer_4, **pro_advices_mocks.advices["short"])
     offer_with_advice_1 = offers_factories.StockFactory.create(
         offer__venue=venue_4,
@@ -1344,7 +1353,10 @@ def create_pro_advices() -> None:
         offer__name=f"Offre à la une du lieu {venue_5.id} - sans avis",
         offer__subcategoryId=subcategories.LIVRE_PAPIER.id,
     ).offer
-    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_5)
+    mediation = offers_factories.MediationFactory.create(offer=headline_offer_5)
+    image_as_bytes = read_sandbox_mediation_asset(headline_offer_5.subcategoryId)
+    thumb_storage.create_thumb(mediation, image_as_bytes, keep_ratio=True)
+    offers_factories.HeadlineOfferFactory.create(offer=headline_offer_5, without_mediation=True)
     offer_with_advice_1 = offers_factories.StockFactory.create(
         offer__venue=venue_5,
         offer__name=f"Offre 1 du lieu {venue_5.id} - avec avis",
@@ -1621,16 +1633,11 @@ def create_product_with_multiple_images() -> None:
         product=product, name=product.name, subcategoryId=product.subcategoryId
     )
     offers_factories.StockFactory.create(offer=offer)
-    offers_factories.ProductMediationFactory.create(
-        product=product,
-        uuid="222A",
-        imageType=ImageType.RECTO,
-    )
-    offers_factories.ProductMediationFactory.create(
-        product=product,
-        uuid="222A_1",
-        imageType=ImageType.VERSO,
-    )
+
+    image_paths = itertools.cycle(pathlib.Path(generic_picture_thumbs.__path__[0]).iterdir())
+    for image_type in [ImageType.RECTO, ImageType.VERSO]:
+        mediation = offers_factories.ProductMediationFactory.create(product=product, imageType=image_type)
+        thumb_storage.create_thumb(product, next(image_paths).read_bytes(), keep_ratio=True, object_id=mediation.uuid)
 
 
 @log_func_duration

--- a/api/src/pcapi/sandboxes/scripts/utils/storage_utils.py
+++ b/api/src/pcapi/sandboxes/scripts/utils/storage_utils.py
@@ -1,27 +1,9 @@
 from pathlib import Path
 
 import pcapi.sandboxes
-from pcapi.connectors.thumb_storage import create_thumb
-from pcapi.core.object_storage import store_public_object
-from pcapi.core.offers.models import Mediation
-from pcapi.utils.human_ids import humanize
 
 
-def store_public_object_from_sandbox_assets(folder: str, model: Mediation, subcategory_id: str) -> Mediation:
-    mimes_by_folder = {"spreadsheets": "application/CSV", "thumbs": "image/jpeg", "zips": "application/zip"}
-    thumb_id = humanize(model.id)
-    assert thumb_id  # helps mypy
-    thumbs_folder_path = Path(pcapi.sandboxes.__path__[0]) / "thumbs"
-    picture_path = str(thumbs_folder_path / "mediations" / subcategory_id) + ".jpg"
+def read_sandbox_mediation_asset(subcategory_id: str) -> bytes:
+    picture_path = str(Path(pcapi.sandboxes.__path__[0]) / "thumbs" / "mediations" / subcategory_id) + ".jpg"
     with open(picture_path, mode="rb") as thumb_file:
-        if folder == "thumbs":
-            create_thumb(model, thumb_file.read(), keep_ratio=True)
-        else:
-            store_public_object(
-                folder,
-                model.thumb_path_component + "/" + thumb_id,
-                thumb_file.read(),
-                mimes_by_folder[folder],
-            )
-
-    return model
+        return thumb_file.read()

--- a/api/tests/core/offers/test_models.py
+++ b/api/tests/core/offers/test_models.py
@@ -756,14 +756,14 @@ class HeadlineOfferTest:
         )
         assert db.session.query(models.HeadlineOffer).filter(models.HeadlineOffer.isActive.is_(False)).first() == None
 
-    def test_headline_offer_is_not_active(self):
+    def test_headline_offer_with_ending_time_in_the_past_is_not_active(self):
         headline_offer = factories.HeadlineOfferFactory(timespan=(self.today, self.day_after_tomorrow))
         with time_machine.travel(self.next_month):
             assert not headline_offer.isActive
             # note: it is not possible to test the sql expression here
             # as time_machine affects only python time, not sql's
 
-    def test_headline_offer_without_mediation_is_not_active(self):
+    def test_headline_offer_without_any_mediation_is_not_active(self):
         headline_offer = factories.HeadlineOfferFactory(
             timespan=(self.today, self.day_after_tomorrow), without_mediation=True
         )
@@ -794,6 +794,30 @@ class HeadlineOfferTest:
         )
         assert db.session.query(models.HeadlineOffer).filter(models.HeadlineOffer.isActive.is_(False)).first() == None
 
+    def test_headline_offer_with_product_thumb_is_not_active(self):
+        product = factories.ProductFactory(thumbCount=1)
+        offer = factories.OfferFactory(product=product)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, without_mediation=True)
+
+        assert not headline_offer.isActive
+        assert db.session.query(models.HeadlineOffer).filter(models.HeadlineOffer.isActive.is_(True)).first() is None
+        assert (
+            db.session.query(models.HeadlineOffer).filter(models.HeadlineOffer.isActive.is_(False)).one()
+            == headline_offer
+        )
+
+    def test_headline_offer_with_inactive_mediation_is_not_active(self):
+        offer = factories.OfferFactory()
+        factories.MediationFactory(offer=offer, isActive=False)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, without_mediation=True)
+
+        assert not headline_offer.isActive
+        assert db.session.query(models.HeadlineOffer).filter(models.HeadlineOffer.isActive.is_(True)).first() is None
+        assert (
+            db.session.query(models.HeadlineOffer).filter(models.HeadlineOffer.isActive.is_(False)).one()
+            == headline_offer
+        )
+
     @pytest.mark.parametrize(
         "timespan,overlaping_timespan",
         [
@@ -816,6 +840,45 @@ class HeadlineOfferTest:
         factories.HeadlineOfferFactory(offer=offer)
         with pytest.raises(sa_exc.IntegrityError):
             factories.HeadlineOfferFactory(offer=another_offer_on_the_same_venue)
+
+
+class OfferHasActiveImageTest:
+    def test_active_offer_mediation(self):
+        offer = factories.MediationFactory().offer
+        assert offer.hasActiveImage is True
+
+        # hybrid property: also check SQL expression
+        assert db.session.query(models.Offer).filter(models.Offer.hasActiveImage.is_(True)).all() == [offer]
+
+    def test_inactive_offer_mediation(self):
+        offer = factories.MediationFactory(isActive=False).offer
+        assert offer.hasActiveImage is False
+
+        # hybrid property: also check SQL expression
+        assert db.session.query(models.Offer).filter(models.Offer.hasActiveImage.is_(False)).all() == [offer]
+
+    def test_product_mediation(self):
+        offer = factories.OfferFactory(product=factories.ProductFactory())
+        factories.ProductMediationFactory(product=offer.product)
+        assert offer.hasActiveImage is True
+
+        # hybrid property: also check SQL expression
+        assert db.session.query(models.Offer).filter(models.Offer.hasActiveImage.is_(True)).all() == [offer]
+
+    def test_product_thumb(self):
+        # product.thumbCount is a legacy column and no longer counts as a displayable image
+        offer = factories.OfferFactory(product=factories.ProductFactory(thumbCount=1))
+        assert offer.hasActiveImage is False
+
+        # hybrid property: also check SQL expression
+        assert db.session.query(models.Offer).filter(models.Offer.hasActiveImage.is_(False)).all() == [offer]
+
+    def test_no_image(self):
+        offer = factories.OfferFactory()
+        assert offer.hasActiveImage is False
+
+        # hybrid property: also check SQL expression
+        assert db.session.query(models.Offer).filter(models.Offer.hasActiveImage.is_(False)).all() == [offer]
 
 
 class OfferIsHeadlineTest:

--- a/api/tests/core/offers/test_repository.py
+++ b/api/tests/core/offers/test_repository.py
@@ -1999,6 +1999,21 @@ class GetHeadlineOfferFiltersTest:
         headline_offer_query_result = repository.get_inactive_headline_offers()
         assert headline_offer_query_result == [headline_offer_without_mediation]
 
+    def test_get_inactive_headline_offers_with_product_thumb(self):
+        offer = factories.OfferFactory(isActive=True, product=factories.ProductFactory(thumbCount=1))
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, without_mediation=True)
+
+        headline_offer_query_result = repository.get_inactive_headline_offers()
+        assert headline_offer_query_result == [headline_offer]
+
+    def test_get_inactive_headline_offers_with_inactive_mediation(self):
+        offer = factories.OfferFactory(isActive=True)
+        factories.MediationFactory(offer=offer, isActive=False)
+        headline_offer = factories.HeadlineOfferFactory(offer=offer, without_mediation=True)
+
+        headline_offer_query_result = repository.get_inactive_headline_offers()
+        assert headline_offer_query_result == [headline_offer]
+
     def test_get_venue_active_headline_offer_even_not_yet_disabled_by_cron_for_active_offer(
         self,
     ):

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -1090,7 +1090,7 @@ class CheckPublicationDateTest:
 
 
 class CheckOfferIsEligibleForHeadlineOffersTest:
-    def test_check_offer_is_eligible_to_be_headline(self):
+    def test_offer_with_mediation_is_eligible(self):
         offerer = offerers_factories.OffererFactory()
         permanent_venue = offerers_factories.VenueFactory(isPermanent=True, managingOfferer=offerer)
         offer = offers_factories.ThingOfferFactory(venue=permanent_venue)
@@ -1105,6 +1105,45 @@ class CheckOfferIsEligibleForHeadlineOffersTest:
             validation.check_offer_is_eligible_to_be_headline(offer_without_image)
             msg = "Offers without images can not be set to the headline"
             assert exc.value.errors["headlineOffer"] == [msg]
+
+    def test_offer_with_product_mediation_is_eligible(self):
+        permanent_venue = offerers_factories.VenueFactory(isPermanent=True)
+        product = offers_factories.ProductFactory()
+        offers_factories.ProductMediationFactory(product=product)
+        offer = offers_factories.OfferFactory(venue=permanent_venue, product=product)
+        offers_factories.StockFactory(offer=offer)
+
+        assert validation.check_offer_is_eligible_to_be_headline(offer) is None
+
+    def test_check_offer_without_any_mediation_is_not_eligible(self):
+        offerer = offerers_factories.OffererFactory()
+        permanent_venue = offerers_factories.VenueFactory(isPermanent=True, managingOfferer=offerer)
+        offer_without_image = offers_factories.OfferFactory(venue=permanent_venue)
+        offers_factories.StockFactory(offer=offer_without_image)
+
+        with pytest.raises(exceptions.OfferWithoutImageCanNotBeHeadline) as exc:
+            validation.check_offer_is_eligible_to_be_headline(offer_without_image)
+            msg = "Offers without images can not be set to the headline"
+            assert exc.value.errors["headlineOffer"] == [msg]
+
+    def test_offer_with_product_thumb_is_not_eligible(self):
+        permanent_venue = offerers_factories.VenueFactory(isPermanent=True)
+        offer = offers_factories.OfferFactory(
+            venue=permanent_venue, product=offers_factories.ProductFactory(thumbCount=1)
+        )
+        offers_factories.StockFactory(offer=offer)
+
+        with pytest.raises(exceptions.OfferWithoutImageCanNotBeHeadline):
+            validation.check_offer_is_eligible_to_be_headline(offer)
+
+    def test_offer_with_inactive_mediation_is_not_eligible(self):
+        permanent_venue = offerers_factories.VenueFactory(isPermanent=True)
+        offer = offers_factories.OfferFactory(venue=permanent_venue)
+        offers_factories.StockFactory(offer=offer)
+        offers_factories.MediationFactory(offer=offer, isActive=False)
+
+        with pytest.raises(exceptions.OfferWithoutImageCanNotBeHeadline):
+            validation.check_offer_is_eligible_to_be_headline(offer)
 
 
 class CheckOfferNameDoesNotContainEanTest:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/jira/software/c/projects/PC/boards/66?selectedIssue=PC-42573)

Une offre ne peut être mise `à la une` que si elle possède une image

La logique actuelle se base sur la property `offer.images` qui est très laxiste : 
- `offer.images` n'est pas vide si l'offre est reliée à une médiation `inactive`
- `offer.images` n'est pas vide si l'offres est reliée à un produit qui possède un `thumbCount > 0` (or ce n'est pas une source fiable)

**Commit 1** : J'introduis donc la nouvelle property `offer.hasActiveImage` pour faire correspondre la logique métier au besoin produit réel

**Commit 2** : je m'assure que toutes les headline offers dans la sandbox ont des images valides. J'en profite pour supprimer des vieux helpers.

- [x] Travail pair testé en environnement de preview
