### PR TITLE
(PC-42626)[API] fix: move check on status_code at the end of `_raise_for_status` function

### DIFF
--- a/api/src/pcapi/core/providers/clients/boost_client.py
+++ b/api/src/pcapi/core/providers/clients/boost_client.py
@@ -109,15 +109,18 @@ def _raise_for_status(response: requests.Response, cinema_api_token: str | None,
             extra={"message_content": message, "status_code": response.status_code, "request_detail": request_detail},
         )
 
-        if response.status_code == 401:
-            raise BoostInvalidTokenException(f"Boost: {message}")
-
         if regex.match(_BOOST_NOT_ENOUGH_SEAT_ERROR_PATTERN, message):
             remaining_seats = int(regex.findall(_BOOST_NOT_ENOUGH_SEAT_ERROR_PATTERN, message)[0])
             raise external_bookings_exceptions.ShowSoldOutException(remaining_seats)
 
         if "No showtime found" in message:
             raise external_bookings_exceptions.ShowRemovedException()
+
+        # we move this check at the end because Boost API can respond
+        # with incorrect status code (some error responses that should
+        # have a status code equal 400 have their status code equal to 401)
+        if response.status_code == 401:
+            raise BoostInvalidTokenException(f"Boost: {message}")
 
         raise BoostAPIException(f"Error on Boost API: {error_message} - {message}")
 

--- a/api/src/pcapi/core/providers/clients/boost_client.py
+++ b/api/src/pcapi/core/providers/clients/boost_client.py
@@ -118,7 +118,7 @@ def _raise_for_status(response: requests.Response, cinema_api_token: str | None,
 
         # we move this check at the end because Boost API can respond
         # with incorrect status code (some error responses that should
-        # have a status code equal 400 have their status code equal to 401)
+        # have a status code equal to 400 have their status code equal to 401)
         if response.status_code == 401:
             raise BoostInvalidTokenException(f"Boost: {message}")
 

--- a/api/src/pcapi/core/providers/clients/cgr_client.py
+++ b/api/src/pcapi/core/providers/clients/cgr_client.py
@@ -32,7 +32,8 @@ CGR_TIMEOUT = 10
 CGR_SHOWTIMES_STOCKS_CACHE_KEY = "api:cinema_provider:cgr:stocks:%s:%s"
 CGR_SHOWTIMES_STOCKS_CACHE_TIMEOUT = 60
 _CGR_NOT_ENOUGH_SEAT_ERROR_PATTERN = r"Impossible de délivrer \d places , il n'en reste que : (\d)"
-_CGR_SHOW_DOES_NOT_EXISTS_PATTERN = r"PASS CULTURE IMPOSSIBLE erreur création résa \(site\) : IdSeance\(\d+\) inconnu"
+# their error message is poorly formatted
+_CGR_SHOW_DOES_NOT_EXISTS_PATTERN = r" PASS CULTURE IMPOSSIBLE erreur création résa \(site\) : IdSeance\(\d+\) inconnu"
 
 
 class CGRAPIException(ExternalBookingException):

--- a/api/tests/core/providers/clients/test_boost_client.py
+++ b/api/tests/core/providers/clients/test_boost_client.py
@@ -421,8 +421,8 @@ class BookTicketTest:
         )
         requests_mock.post(
             "https://cinema-0.example.com/api/sale/complete",
-            status_code=400,
-            json={"code": 400, "message": error_message},
+            status_code=401,  # unfortunately Boost uses an inappropriate status code
+            json={"code": 401, "message": error_message},
             headers={"Content-Type": "application/json"},
             additional_matcher=lambda request: not request.json().get("idsBeforeSale"),
         )

--- a/api/tests/core/providers/clients/test_cgr_client.py
+++ b/api/tests/core/providers/clients/test_cgr_client.py
@@ -334,7 +334,8 @@ class BookTicketTest:
         "error_message",
         [
             "Séance inconnue.",
-            "PASS CULTURE IMPOSSIBLE erreur création résa (site) : IdSeance(528581) inconnu",
+            # the white space at the beginning is part of the actual error message sent by CGR
+            " PASS CULTURE IMPOSSIBLE erreur création résa (site) : IdSeance(528581) inconnu",
         ],
     )
     def test_should_raise_show_does_not_exist(self, error_message, requests_mock):

--- a/api/tests/routes/native/v1/bookings_test.py
+++ b/api/tests/routes/native/v1/bookings_test.py
@@ -616,7 +616,8 @@ class PostBookingTest:
         "error_message",
         [
             "Séance inconnue.",
-            "PASS CULTURE IMPOSSIBLE erreur création résa (site) : IdSeance(528581) inconnu",
+            # the white space at the beginning is part of the actual error message sent by CGR
+            " PASS CULTURE IMPOSSIBLE erreur création résa (site) : IdSeance(528581) inconnu",
         ],
     )
     def test_handle_cgr_showtime_does_not_exist_case(self, error_message, client, requests_mock):


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Corrige deux bugs liés à la réservation cinéma qui générent environ 1k erreurs / semaine : 
- https://passculture.atlassian.net/browse/PC-42626
- https://passculture.atlassian.net/browse/PC-42620


- [ ] Travail pair testé en environnement de preview
