### PR TITLE
(PC-41804)[API] feat: close venue: unlink bank accounts

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -36,6 +36,7 @@ import time
 import typing
 import zipfile
 from collections import defaultdict
+from functools import partial
 
 import pytz
 import sqlalchemy as sa
@@ -67,6 +68,7 @@ from pcapi.core.mails.transactional.finance_incidents.finance_incident_notificat
 from pcapi.core.mails.transactional.finance_incidents.finance_incident_notification import send_finance_incident_emails
 from pcapi.core.mails.transactional.pro.provider_reimbursement_csv import send_provider_reimbursement_email
 from pcapi.core.object_storage import store_public_object
+from pcapi.core.offerers import api as offerers_api
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.routes.serialization.reimbursement_csv_serialize import ReimbursementDetails
@@ -77,6 +79,7 @@ from pcapi.utils.repository import transaction
 from pcapi.utils.transaction_manager import atomic
 from pcapi.utils.transaction_manager import is_managed_transaction
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
+from pcapi.utils.transaction_manager import on_commit
 
 from . import conf
 from . import exceptions
@@ -3717,3 +3720,31 @@ def clean_duplicate_bank_accounts() -> None:
             synchronize_session=False
         )
         db.session.delete(bank_account)
+
+
+class CannotUnlinkBankAccount(Exception):
+    pass
+
+
+def unlink_venue_bank_accounts(venue: offerers_models.Venue) -> None:
+    if not venue.bankAccountLinks:
+        return
+
+    if offerers_api.venue_has_ongoing_bookings(venue):
+        raise CannotUnlinkBankAccount()
+
+    bank_account_link = venue.current_bank_account_link
+    if bank_account_link:
+        now = date_utils.get_naive_utc_now()
+        new_timespan = db_utils.make_timerange(start=bank_account_link.timespan.lower, end=now)
+        bank_account_link.timespan = new_timespan
+
+        db.session.flush()
+
+        on_commit(
+            partial(
+                logger.info,
+                "ending current venue bank account link",
+                extra={"venue_id": venue.id, "bank_account_id": bank_account_link.bankAccountId},
+            )
+        )

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -53,6 +53,7 @@ from pcapi.core.educational.api import booking as educational_booking_api
 from pcapi.core.educational.api import dms as dms_api
 from pcapi.core.external.attributes import api as external_attributes_api
 from pcapi.core.external.zendesk_sell import api as zendesk_sell_api
+from pcapi.core.finance import api as finance_api
 from pcapi.core.geography import constants as geography_constants
 from pcapi.core.geography import models as geography_models
 from pcapi.core.geography import utils as geography_utils
@@ -3452,6 +3453,8 @@ def close_venue(venue: models.Venue, author: users_models.User) -> None:
     venue.state = models.VenueState.CLOSING
     nullify_venue_emails(venue, author)
 
+    finance_api.unlink_venue_bank_accounts(venue)
+
     payload = tasks.FinalizeClosingVenuePayload(venue_id=venue.id)
     on_commit(
         functools.partial(
@@ -3557,3 +3560,16 @@ def deactivate_venue_offers(venue: models.Venue) -> None:
         log_extra = {"venue_id": venue.id, "offers_backup": backup_data}
         log_msg = "closing venue: offers deactivated, will be unindexed (added to queue)"
         logger.info(log_msg, extra=log_extra)
+
+
+def venue_has_ongoing_bookings(venue: models.Venue) -> bool:
+    return db.session.query(
+        db.session.query(bookings_models.Booking)
+        .filter_by(venueId=venue.id)
+        .filter(
+            bookings_models.Booking.status.not_in(
+                [bookings_models.BookingStatus.REIMBURSED, bookings_models.BookingStatus.CANCELLED]
+            )
+        )
+        .exists()
+    ).scalar()

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -5598,3 +5598,61 @@ class CleanDuplicateBankAccountsTest:
         api.clean_duplicate_bank_accounts()
 
         assert set(db.session.query(sa.func.array_agg(models.BankAccount.id)).scalar()) == {ba.id}
+
+
+class UnlinkVenueBankAccountsTest:
+    def test_venue_without_any_bank_account_nothing_is_done(self):
+        venue = offerers_factories.VenueFactory()
+        api.unlink_venue_bank_accounts(venue)
+
+        db.session.refresh(venue)
+        assert not venue.bankAccountLinks
+
+    def test_one_active_bank_account_link_is_ended(self, caplog):
+        bank_account_link = offerers_factories.VenueBankAccountLinkFactory()
+        venue = bank_account_link.venue
+        assert venue.current_bank_account_link
+
+        now = datetime.datetime.now(datetime.UTC)
+        with caplog.at_level("INFO"):
+            with time_machine.travel(now, tick=False):
+                api.unlink_venue_bank_accounts(venue)
+
+                db.session.refresh(venue)
+
+                assert len(venue.bankAccountLinks) == 1
+                assert datetime.datetime.fromisoformat(venue.bankAccountLinks[0].timespan.upper) == now
+
+            assert len(caplog.records) == 1
+            assert caplog.records[0].message == "ending current venue bank account link"
+            assert caplog.records[0].extra == {
+                "venue_id": venue.id,
+                "bank_account_id": bank_account_link.bankAccountId,
+            }
+
+    def test_already_ended_bank_account_link_stays_the_same(self):
+        now = datetime.datetime.now()
+        timespan = [now - datetime.timedelta(days=256), now]
+
+        venue = offerers_factories.VenueBankAccountLinkFactory(timespan=timespan).venue
+        assert not venue.current_bank_account_link
+
+        with time_machine.travel(now, tick=False):
+            api.unlink_venue_bank_accounts(venue)
+
+            db.session.refresh(venue)
+
+            assert len(venue.bankAccountLinks) == 1
+            assert venue.bankAccountLinks[0].timespan.upper == now
+
+    def test_cannot_unlink_if_venue_has_an_ongoing_booking(self):
+        venue = offerers_factories.VenueBankAccountLinkFactory().venue
+        assert venue.bankAccountLinks
+
+        bookings_factories.UsedBookingFactory(stock__offer__venue=venue)
+
+        with pytest.raises(api.CannotUnlinkBankAccount):
+            api.unlink_venue_bank_accounts(venue)
+
+        db.session.refresh(venue)
+        assert venue.current_bank_account_link

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -4039,7 +4039,9 @@ class CloseVenueTest:
     """
 
     def test_open_venue_becomes_closed(self):
-        venue = offerers_factories.VenueFactory(state=None, bookingEmail="some.email@test.com")
+        venue = offerers_factories.VenueBankAccountLinkFactory(
+            venue__state=None, venue__bookingEmail="some.email@test.com"
+        ).venue
         author = users_factories.BaseUserFactory()
 
         with atomic():
@@ -4049,6 +4051,8 @@ class CloseVenueTest:
 
         assert not venue.bookingEmail
         assert not venue.contact
+
+        assert not venue.current_bank_account_link
         assert venue.state == offerers_models.VenueState.CLOSED
 
     def test_closed_venue_stays_closed(self):
@@ -4209,3 +4213,36 @@ class NullifyVenueEmailsTest:
 
         # no update to track
         assert not venue.action_history
+
+
+class VenueHasOngoingBookingsTest:
+    def test_venue_without_any_bookings_is_false(self):
+        venue = offerers_factories.VenueFactory()
+        assert not offerers_api.venue_has_ongoing_bookings(venue)
+
+    def test_venue_with_only_cancelled_and_reimbursed_bookings_is_false(self):
+        venue = offerers_factories.VenueFactory()
+
+        bookings_factories.CancelledBookingFactory(stock__offer__venue=venue)
+        bookings_factories.ReimbursedBookingFactory(stock__offer__venue=venue)
+
+        assert not offerers_api.venue_has_ongoing_bookings(venue)
+
+    def test_venue_with_only_ongoing_bookings_is_true(self):
+        venue = offerers_factories.VenueFactory()
+
+        bookings_factories.UsedBookingFactory(stock__offer__venue=venue)
+        bookings_factories.PendingReimbursementBookingFactory(stock__offer__venue=venue)
+
+        assert offerers_api.venue_has_ongoing_bookings(venue)
+
+    def test_venue_with_mixed_ongoing_and_not_bookings_is_true(self):
+        venue = offerers_factories.VenueFactory()
+
+        bookings_factories.UsedBookingFactory(stock__offer__venue=venue)
+        bookings_factories.PendingReimbursementBookingFactory(stock__offer__venue=venue)
+
+        bookings_factories.CancelledBookingFactory(stock__offer__venue=venue)
+        bookings_factories.ReimbursedBookingFactory(stock__offer__venue=venue)
+
+        assert offerers_api.venue_has_ongoing_bookings(venue)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41804)

Dissocier les comptes bancaires d'un lieu lors de sa fermeture.

Cette opération n'est autorisée que si le lieu n'a aucune réservation en cours : toutes ses réservations doivent être déjà soit annulées, soit remboursées.