### PR TITLE
(BSR)[API] refactor: the nullable migrations generator for semgrep

### DIFF
--- a/api/bin/alembic_add_not_null_constraint.py
+++ b/api/bin/alembic_add_not_null_constraint.py
@@ -76,7 +76,11 @@ from pcapi import settings
     with op.get_context().autocommit_block():
         op.execute("SET SESSION statement_timeout = '300s'")
         op.execute('ALTER TABLE "$table" VALIDATE CONSTRAINT "$constraint"')
-        op.execute(f"SET SESSION statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT}")
+        op.execute(
+            text("SET SESSION statement_timeout=:statement_timeout").bindparams(
+                statement_timeout=settings.DATABASE_STATEMENT_TIMEOUT,
+            )
+        )
     """,
     "downgrade": """
     pass


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Améliore le script de génération des migrations en nullable afin d'être compatible avec semgrep.