### PR TITLE
(PC-42789)[API] close venue: add venue.state to pydantic model

### DIFF
--- a/api/src/pcapi/routes/serialization/venue_serialize.py
+++ b/api/src/pcapi/routes/serialization/venue_serialize.py
@@ -130,6 +130,7 @@ class GetVenueResponseModel(HttpBodyModel):
     mentalDisabilityCompliant: bool | None
     motorDisabilityCompliant: bool | None
     visualDisabilityCompliant: bool | None
+    state: offerers_models.VenueState | None
 
     @classmethod
     def build(
@@ -223,6 +224,7 @@ class GetVenueResponseModel(HttpBodyModel):
             mentalDisabilityCompliant=venue.mentalDisabilityCompliant,
             motorDisabilityCompliant=venue.motorDisabilityCompliant,
             visualDisabilityCompliant=venue.visualDisabilityCompliant,
+            state=venue.state,
         )
 
 

--- a/api/tests/routes/pro/get_venue_test.py
+++ b/api/tests/routes/pro/get_venue_test.py
@@ -248,6 +248,7 @@ class Returns200Test:
             "hasPartnerPage": True,
             "hasNonDraftOffers": True,
             "volunteeringUrl": "https://www.jeveuxaider.gouv.fr/organisations/structure-name",
+            "state": None,
         }
         db.session.expire_all()
 

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -409,6 +409,7 @@ export {
   type VenueListItemLiteResponseModel,
   type VenueOfOffererFromSiretResponseModel,
   type VenueProviderResponse,
+  VenueState,
   type VenueStatsDataModel,
   type VenuesEducationalStatusResponseModel,
   type VenuesEducationalStatusesResponseModel,

--- a/pro/src/apiClient/v1/types.gen.ts
+++ b/pro/src/apiClient/v1/types.gen.ts
@@ -3707,6 +3707,7 @@ export type GetVenueResponseModel = {
      * Siret
      */
     siret: string | null;
+    state: VenueState | null;
     /**
      * Visualdisabilitycompliant
      */
@@ -6650,6 +6651,14 @@ export type VenueProviderResponse = {
      */
     venueIdAtOfferProvider: string | null;
 };
+
+/**
+ * VenueState
+ */
+export enum VenueState {
+    CLOSED = 'CLOSED',
+    CLOSING = 'CLOSING'
+}
 
 /**
  * VenueStatsDataModel

--- a/pro/src/commons/utils/factories/collectiveApiFactories.ts
+++ b/pro/src/commons/utils/factories/collectiveApiFactories.ts
@@ -367,6 +367,7 @@ export const defaultGetVenue: GetVenueResponseModel = {
   hasNonDraftOffers: true,
   volunteeringUrl: null,
   openingHours: null,
+  state: null,
 }
 
 export const defaultGetCollectiveOfferRequest: GetCollectiveOfferRequestResponseModel =

--- a/pro/src/commons/utils/factories/individualApiFactories.ts
+++ b/pro/src/commons/utils/factories/individualApiFactories.ts
@@ -458,6 +458,7 @@ export const defaultGetVenueResponseModel: GetVenueResponseModel = {
   hasNonDraftOffers: true,
   volunteeringUrl: null,
   openingHours: null,
+  state: null,
 }
 
 export const defaultGetBookingResponse: GetBookingResponse = {

--- a/pro/src/commons/utils/factories/venueFactories.ts
+++ b/pro/src/commons/utils/factories/venueFactories.ts
@@ -104,6 +104,7 @@ export const makeGetVenueResponseModel = <
     volunteeringUrl: null,
     withdrawalDetails: null,
     openingHours: null,
+    state: null,
   }
 
   return {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42789)

Ajouter l'information `venue.state` dans un modèle de sérialisation _pydantic_ de la route pro qui renvoie les détails d'un lieu (_venue_)