### PR TITLE
(PC-41968)[API] feat: add bonus credit cron

### DIFF
--- a/api/.env.development
+++ b/api/.env.development
@@ -18,6 +18,7 @@ BACKOFFICE_URL=http://localhost:5002
 BATCH_ANDROID_API_KEY=DEV5F8E91B93C7956094EEE3A0666C # Batch public key # ggignore
 BATCH_IOS_API_KEY=DEV5F8EF34DD60B3437F8CF0318079     # Batch public key # ggignore
 BEAMER_BACKEND=LoggerBackend
+BONUS_CREDIT_DELAY=0
 CAN_RUN_SANDBOX=1
 CGR_API_USER=""
 CLICKHOUSE_BACKEND=pcapi.connectors.clickhouse.testing_backend.TestingBackend

--- a/api/.env.testauto
+++ b/api/.env.testauto
@@ -7,6 +7,7 @@ BATCH_IOS_API_KEY=fake_ios_api_key         # ggignore
 BEAMER_BACKEND=LoggerBackend
 BOOST_API_PASSWORD=fake_password
 BOOST_API_USERNAME=fake_user
+BONUS_CREDIT_DELAY=300
 BREVO_WEBHOOK_SECRET_QUERY_PARAM=brevo_token_test
 CATCH_INDEXATION_EXCEPTIONS=0
 CDS_API_URL=test_cds_url/vad/

--- a/api/src/pcapi/core/finance/deposit_api.py
+++ b/api/src/pcapi/core/finance/deposit_api.py
@@ -12,8 +12,11 @@ import pcapi.core.users.constants as users_constants
 import pcapi.core.users.models as users_models
 from pcapi.core.categories.models import ReimbursementRuleChoices
 from pcapi.core.external.batch import trigger_events
+from pcapi.core.subscription.bonus import constants as bonus_constants
+from pcapi.core.subscription.bonus import fraud_check_api
 from pcapi.core.users import utils as users_utils
 from pcapi.models import db
+from pcapi.models.feature import FeatureToggle
 from pcapi.utils import date as date_utils
 from pcapi.utils.repository import transaction
 
@@ -143,9 +146,14 @@ def _recredit_user_if_no_missing_step(user: users_models.User) -> None:
     recredit = _recredit_user(user)
     if not recredit:
         raise exceptions.UserCannotBeRecredited("Failed to recredit user")
+
     if recredit.recreditType == models.RecreditType.RECREDIT_18:
-        user.remove_underage_beneficiary_role()
         user.add_beneficiary_role()
+
+        if FeatureToggle.ENABLE_BONUS_CREDIT.is_active():
+            fraud_check_api.create_disability_bonus_credit_fraud_checks(
+                user, origin=f"{bonus_constants.AUTOMATIC_ORIGIN} through recredit cron"
+            )
 
     user.recreditAmountToShow = recredit.amount if recredit.amount > 0 else None
     db.session.add(user)

--- a/api/src/pcapi/core/subscription/api.py
+++ b/api/src/pcapi/core/subscription/api.py
@@ -20,6 +20,8 @@ from pcapi.core.subscription import messages as subscription_messages
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription import repository as subscription_repository
 from pcapi.core.subscription import schemas as subscription_schemas
+from pcapi.core.subscription.bonus import constants as bonus_constants
+from pcapi.core.subscription.bonus import fraud_check_api as bonus_fraud_check_api
 from pcapi.core.subscription.dms import schemas as dms_schemas
 from pcapi.core.users import api as users_api
 from pcapi.core.users import constants as users_constants
@@ -110,6 +112,11 @@ def activate_beneficiary_for_eligibility(
     activated_eligibility = eligibility_api.get_activated_eligibility(deposit.type)
     eligibility_api.add_eligibility_role(user, activated_eligibility)
     logger.info("Activated beneficiary and created deposit", extra={"user": user.id, "source": deposit.source})
+
+    if FeatureToggle.ENABLE_BONUS_CREDIT.is_active() and user.received_pass_18_v3:
+        bonus_fraud_check_api.create_disability_bonus_credit_fraud_checks(
+            user, origin=f"{bonus_constants.AUTOMATIC_ORIGIN} through beneficiary activation"
+        )
 
     transactional_mails.send_accepted_as_beneficiary_email(user=user)
     external_attributes_api.update_external_user(user)

--- a/api/src/pcapi/core/subscription/bonus/api.py
+++ b/api/src/pcapi/core/subscription/bonus/api.py
@@ -47,7 +47,7 @@ def apply_for_quotient_familial_bonus(quotient_familial_fraud_check: subscriptio
     """
     user = quotient_familial_fraud_check.user
     if not deposit_api.can_receive_bonus_credit(user):
-        logger.error("trying to apply for bonus when not able to receive said bonus")
+        logger.warning("trying to apply for bonus when not able to receive said bonus")
         return
 
     source_data = quotient_familial_fraud_check.source_data()
@@ -342,7 +342,6 @@ def _call_api_particulier[
 ) -> _ApiParticulierResult[ResponseT]:
     """
     Run fetch() and format the API Particulier errors into a result.
-    Re-raises unexpected errors after bumping updatedAt so the recovery cron doesn't loop.
     """
     response: ResponseT | None = None
     reason_codes = []
@@ -360,17 +359,10 @@ def _call_api_particulier[
         http_status_code, error_code = e.status_code, e.error_code
     except api_particulier.ParticulierApiException as e:
         with atomic():
-            fraud_check.updatedAt = datetime.datetime.now(tz=None)
-
             if not fraud_check.resultContent:
                 fraud_check.resultContent = {}
             fraud_check.resultContent["http_status_code"] = e.status_code
             fraud_check.resultContent["error_code"] = e.error_code
-
-        raise
-    except Exception:
-        with atomic():
-            fraud_check.updatedAt = datetime.datetime.now(tz=None)
 
         raise
 

--- a/api/src/pcapi/core/subscription/bonus/constants.py
+++ b/api/src/pcapi/core/subscription/bonus/constants.py
@@ -2,3 +2,5 @@ QUOTIENT_FAMILIAL_THRESHOLD = 700
 
 BACKOFFICE_ORIGIN_START = "backoffice"
 DISABILITY_ENDPOINT_ORIGIN = "enrolled from /subscription/bonus/disability endpoint"
+QUOTIENT_FAMILIAL_ENDPOINT_ORIGIN = "enrolled from /subscription/bonus/quotient_familial endpoint"
+AUTOMATIC_ORIGIN = "automatic attempt"

--- a/api/src/pcapi/core/subscription/bonus/fraud_check_api.py
+++ b/api/src/pcapi/core/subscription/bonus/fraud_check_api.py
@@ -1,9 +1,15 @@
 import datetime
+import random
 
+from dateutil.relativedelta import relativedelta
+
+from pcapi import settings
 from pcapi.core.subscription import models as subscription_models
+from pcapi.core.subscription.bonus import constants as bonus_constants
 from pcapi.core.subscription.bonus import schemas as bonus_schemas
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 def create_qf_bonus_credit_fraud_check(
@@ -27,7 +33,10 @@ def create_qf_bonus_credit_fraud_check(
         birth_country_cog_code=birth_country_cog_code,
         birth_city_cog_code=birth_city_cog_code,
     )
-    fraud_check_content = bonus_schemas.QuotientFamilialBonusCreditContent(custodian=custodian)
+    next_retry_at = _get_next_bonus_credit_retry_date(origin)
+    fraud_check_content = bonus_schemas.QuotientFamilialBonusCreditContent(
+        custodian=custodian, next_retry_at=next_retry_at
+    )
 
     fraud_check = subscription_models.BeneficiaryFraudCheck(
         user=user,
@@ -40,6 +49,7 @@ def create_qf_bonus_credit_fraud_check(
     )
     db.session.add(fraud_check)
     db.session.flush()
+
     return fraud_check
 
 
@@ -50,8 +60,12 @@ def create_disability_bonus_credit_fraud_checks(
     birth_city_cog_code: str | None = None,
     origin: str,
 ) -> tuple[subscription_models.BeneficiaryFraudCheck, subscription_models.BeneficiaryFraudCheck]:
+    eligibility = user.eligibility
     person = _build_bonus_credit_person_for_disability(user, birth_country_cog_code, birth_city_cog_code)
-    aah_fraud_check_content = bonus_schemas.AdultDisabilityBonusCreditContent(person=person)
+    next_retry_at = _get_next_bonus_credit_retry_date(origin)
+    aah_fraud_check_content = bonus_schemas.AdultDisabilityBonusCreditContent(
+        person=person, next_retry_at=next_retry_at
+    )
 
     aah_fraud_check = subscription_models.BeneficiaryFraudCheck(
         user=user,
@@ -60,11 +74,13 @@ def create_disability_bonus_credit_fraud_checks(
         reason=origin,
         thirdPartyId=f"aah-bonus-credit-{user.id}",
         resultContent=aah_fraud_check_content.model_dump(exclude_unset=True),
-        eligibilityType=user.eligibility,
+        eligibilityType=eligibility,
     )
     db.session.add(aah_fraud_check)
 
-    aeeh_fraud_check_content = bonus_schemas.DisabledChildEducationBonusCreditContent(person=person)
+    aeeh_fraud_check_content = bonus_schemas.DisabledChildEducationBonusCreditContent(
+        person=person, next_retry_at=next_retry_at
+    )
     aeeh_fraud_check = subscription_models.BeneficiaryFraudCheck(
         user=user,
         type=subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
@@ -72,13 +88,26 @@ def create_disability_bonus_credit_fraud_checks(
         reason=origin,
         thirdPartyId=f"aeeh-bonus-credit-{user.id}",
         resultContent=aeeh_fraud_check_content.model_dump(exclude_unset=True),
-        eligibilityType=user.eligibility,
+        eligibilityType=eligibility,
     )
     db.session.add(aeeh_fraud_check)
-
     db.session.flush()
 
     return aah_fraud_check, aeeh_fraud_check
+
+
+def _get_next_bonus_credit_retry_date(bonus_credit_origin: str) -> datetime.datetime:
+    """
+    A next retry date is mandatory to ensure recovery in any edge cases.
+    """
+    is_bonus_automatic = bonus_credit_origin.startswith(bonus_constants.AUTOMATIC_ORIGIN)
+    if not is_bonus_automatic:
+        return date_utils.get_naive_utc_now() + relativedelta(days=1)
+
+    # since only disability bonus credit attempts are created automatically, we need to add
+    # a jitter to prevent guessing the origin of the bonus credit through its creation timing.
+    jitter = random.randint(0, settings.BONUS_CREDIT_DELAY_JITTER)
+    return date_utils.get_naive_utc_now() + relativedelta(seconds=settings.BONUS_CREDIT_DELAY + jitter)
 
 
 def _build_bonus_credit_person_for_disability(
@@ -100,3 +129,34 @@ def _build_bonus_credit_person_for_disability(
         gender=user.gender or users_models.GenderEnum.F,
         **{key: value for key, value in birth_location_kwargs.items() if value},
     )
+
+
+def accelerate_automatic_disability_bonus_fraud_checks(
+    fraud_checks: list[subscription_models.BeneficiaryFraudCheck], new_origin: str
+) -> list[subscription_models.BeneficiaryFraudCheck]:
+    accelerated_fraud_checks = []
+    for fraud_check in fraud_checks:
+        if fraud_check.reason is None:
+            continue
+
+        disability_bonus_types = [
+            subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+            subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+        ]
+        is_pending_automatic_fraud_check = (
+            fraud_check.type in disability_bonus_types
+            and fraud_check.status == subscription_models.FraudCheckStatus.STARTED
+            and fraud_check.reason.startswith(bonus_constants.AUTOMATIC_ORIGIN)
+        )
+        if not is_pending_automatic_fraud_check:
+            continue
+
+        fraud_check.reason = fraud_check.reason + f", accelerated by {new_origin}"
+
+        if not fraud_check.resultContent:
+            fraud_check.resultContent = {}
+        fraud_check.resultContent["next_retry_at"] = date_utils.get_naive_utc_now() + relativedelta(days=1)
+
+        accelerated_fraud_checks.append(fraud_check)
+
+    return accelerated_fraud_checks

--- a/api/src/pcapi/core/subscription/bonus/schemas.py
+++ b/api/src/pcapi/core/subscription/bonus/schemas.py
@@ -70,6 +70,7 @@ class QuotientFamilialBonusCreditContent(BaseModelV2):
     children: list[BonusCreditPerson] | None = None
     http_status_code: int | None = None
     error_code: str | None = None
+    next_retry_at: datetime.datetime
 
 
 class AdultDisabilityBonusCreditContent(BaseModelV2):
@@ -77,6 +78,7 @@ class AdultDisabilityBonusCreditContent(BaseModelV2):
     is_disability_recipient: bool | None = None
     http_status_code: int | None = None
     error_code: str | None = None
+    next_retry_at: datetime.datetime
 
 
 class DisabledChildEducationRecipientStatus(enum.StrEnum):
@@ -90,6 +92,7 @@ class DisabledChildEducationBonusCreditContent(BaseModelV2):
     disability_recipient_status: DisabledChildEducationRecipientStatus | None = None
     http_status_code: int | None = None
     error_code: str | None = None
+    next_retry_at: datetime.datetime
 
 
 class QFBonificationStatus(enum.Enum):

--- a/api/src/pcapi/core/subscription/bonus/tasks.py
+++ b/api/src/pcapi/core/subscription/bonus/tasks.py
@@ -13,6 +13,9 @@ from pcapi.core.subscription.bonus.api import apply_for_adult_disability_bonus
 from pcapi.core.subscription.bonus.api import apply_for_disabled_child_education_bonus
 from pcapi.core.subscription.bonus.api import apply_for_quotient_familial_bonus
 from pcapi.models import db
+from pcapi.models.feature import FeatureToggle
+from pcapi.utils import date as date_utils
+from pcapi.utils.transaction_manager import atomic
 
 
 logger = logging.getLogger(__name__)
@@ -33,6 +36,10 @@ class BonusTaskPayload(BaseModelV2):
     rate_limit="200/m",
 )
 def apply_for_quotient_familial_bonus_task(payload: BonusTaskPayload) -> None:
+    if not FeatureToggle.ENABLE_BONUS_CREDIT.is_active():
+        logger.error("Trying to call apply_for_quotient_familial_bonus_task with disabled FF")
+        return
+
     fraud_check = (
         db.session.query(subscription_models.BeneficiaryFraudCheck)
         .filter(
@@ -56,30 +63,17 @@ def apply_for_quotient_familial_bonus_task(payload: BonusTaskPayload) -> None:
         logger.warning("Trying to handle already processed bonus fraud check #%s", payload.fraud_check_id)
         return
 
-    apply_for_quotient_familial_bonus(fraud_check)
+    try:
+        apply_for_quotient_familial_bonus(fraud_check)
+    except Exception:
+        with atomic():
+            if not fraud_check.resultContent:
+                fraud_check.resultContent = {}
 
+            tomorrow = date_utils.get_naive_utc_now() + relativedelta(hours=24)
+            fraud_check.resultContent["next_retry_at"] = tomorrow
 
-def recover_started_quotient_familial_application() -> None:
-    """
-    Recovers the `page_size` first started Quotient Familial fraud checks.
-    This function only recovers the first page, and is meant to be called as often as needed by recovery workers.
-    """
-    twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
-    started_qf_fraud_check_stmt = (
-        sa.select(subscription_models.BeneficiaryFraudCheck.id)
-        .filter(
-            subscription_models.BeneficiaryFraudCheck.type == subscription_models.FraudCheckType.QF_BONUS_CREDIT,
-            subscription_models.BeneficiaryFraudCheck.status == subscription_models.FraudCheckStatus.STARTED,
-            subscription_models.BeneficiaryFraudCheck.updatedAt <= twelve_hours_ago,
-        )
-        .order_by(subscription_models.BeneficiaryFraudCheck.id)
-        .limit(QUOTIENT_FAMILIAL_TASK_RATE_LIMIT)
-    )
-    started_qf_fraud_check_ids = db.session.scalars(started_qf_fraud_check_stmt).all()
-
-    for fraud_check_id in started_qf_fraud_check_ids:
-        payload = BonusTaskPayload(fraud_check_id=fraud_check_id)
-        apply_for_quotient_familial_bonus_task.delay(payload=payload.model_dump())
+        raise
 
 
 @celery_async_task(
@@ -89,6 +83,10 @@ def recover_started_quotient_familial_application() -> None:
     rate_limit="200/m",
 )
 def apply_for_adult_disability_bonus_task(payload: BonusTaskPayload) -> None:
+    if not FeatureToggle.ENABLE_BONUS_CREDIT.is_active():
+        logger.error("Trying to call apply_for_adult_disability_bonus_task with disabled FF")
+        return
+
     fraud_check = (
         db.session.query(subscription_models.BeneficiaryFraudCheck)
         .filter(
@@ -112,7 +110,17 @@ def apply_for_adult_disability_bonus_task(payload: BonusTaskPayload) -> None:
         logger.warning("Trying to handle already processed bonus fraud check #%s", payload.fraud_check_id)
         return
 
-    apply_for_adult_disability_bonus(fraud_check)
+    try:
+        apply_for_adult_disability_bonus(fraud_check)
+    except Exception:
+        with atomic():
+            if not fraud_check.resultContent:
+                fraud_check.resultContent = {}
+
+            tomorrow = date_utils.get_naive_utc_now() + relativedelta(hours=24)
+            fraud_check.resultContent["next_retry_at"] = tomorrow
+
+        raise
 
 
 @celery_async_task(
@@ -122,6 +130,10 @@ def apply_for_adult_disability_bonus_task(payload: BonusTaskPayload) -> None:
     rate_limit="200/m",
 )
 def apply_for_disabled_child_education_bonus_task(payload: BonusTaskPayload) -> None:
+    if not FeatureToggle.ENABLE_BONUS_CREDIT.is_active():
+        logger.error("Trying to call apply_for_disabled_child_education_bonus_task with disabled FF")
+        return
+
     fraud_check = (
         db.session.query(subscription_models.BeneficiaryFraudCheck)
         .filter(
@@ -145,4 +157,92 @@ def apply_for_disabled_child_education_bonus_task(payload: BonusTaskPayload) -> 
         logger.warning("Trying to handle already processed bonus fraud check #%s", payload.fraud_check_id)
         return
 
-    apply_for_disabled_child_education_bonus(fraud_check)
+    try:
+        apply_for_disabled_child_education_bonus(fraud_check)
+    except Exception:
+        with atomic():
+            if not fraud_check.resultContent:
+                fraud_check.resultContent = {}
+
+            tomorrow = date_utils.get_naive_utc_now() + relativedelta(hours=24)
+            fraud_check.resultContent["next_retry_at"] = tomorrow
+
+        raise
+
+
+def recover_started_bonus_credit_applications(
+    user_id: int | None = None, cutoff_time: datetime.datetime | None = None, page_size: int = 200
+) -> list[subscription_models.BeneficiaryFraudCheck]:
+    """
+    Recovers the `page_size` first started QF/AAH/AEEH fraud checks.
+    This function only recovers the first page, and is meant to be called as often as needed by recovery workers,
+    but no more than once per minute for rate limit reasons.
+    """
+    if not FeatureToggle.ENABLE_BONUS_CREDIT.is_active():
+        logger.warning("Trying to call recover_started_bonus_credit_applications with disabled FF")
+        return []
+
+    started_bonus_fraud_check_stmt = sa.select(subscription_models.BeneficiaryFraudCheck).filter(
+        subscription_models.BeneficiaryFraudCheck.type.in_(
+            [
+                subscription_models.FraudCheckType.QF_BONUS_CREDIT,
+                subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+                subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+            ]
+        ),
+        subscription_models.BeneficiaryFraudCheck.status == subscription_models.FraudCheckStatus.STARTED,
+    )
+    if user_id:
+        started_bonus_fraud_check_stmt = started_bonus_fraud_check_stmt.filter(
+            subscription_models.BeneficiaryFraudCheck.userId == user_id
+        )
+    if cutoff_time:
+        started_bonus_fraud_check_stmt = started_bonus_fraud_check_stmt.filter(
+            subscription_models.BeneficiaryFraudCheck.resultContent.is_not(None),
+            subscription_models.BeneficiaryFraudCheck.resultContent["next_retry_at"].astext.cast(sa.DateTime)
+            <= cutoff_time,
+        )
+
+    keyset_paginated_stmt = started_bonus_fraud_check_stmt.order_by(subscription_models.BeneficiaryFraudCheck.id).limit(
+        page_size
+    )
+    started_bonus_credit_fraud_checks = db.session.scalars(keyset_paginated_stmt).all()
+
+    handled_fraud_checks: list[subscription_models.BeneficiaryFraudCheck] = []
+    expected_api_particulier_calls = 0
+    for fraud_check in started_bonus_credit_fraud_checks:
+        match fraud_check.type:
+            case subscription_models.FraudCheckType.QF_BONUS_CREDIT:
+                expected_api_particulier_calls += 12
+
+                if expected_api_particulier_calls > page_size:
+                    return handled_fraud_checks
+
+                payload = BonusTaskPayload(fraud_check_id=fraud_check.id)
+                apply_for_quotient_familial_bonus_task.delay(payload=payload.model_dump())
+                handled_fraud_checks.append(fraud_check)
+
+            case subscription_models.FraudCheckType.AAH_BONUS_CREDIT:
+                expected_api_particulier_calls += 1
+
+                if expected_api_particulier_calls > page_size:
+                    return handled_fraud_checks
+
+                payload = BonusTaskPayload(fraud_check_id=fraud_check.id)
+                apply_for_adult_disability_bonus_task.delay(payload=payload.model_dump())
+                handled_fraud_checks.append(fraud_check)
+
+            case subscription_models.FraudCheckType.AEEH_BONUS_CREDIT:
+                expected_api_particulier_calls += 1
+
+                if expected_api_particulier_calls > page_size:
+                    return handled_fraud_checks
+
+                payload = BonusTaskPayload(fraud_check_id=fraud_check.id)
+                apply_for_disabled_child_education_bonus_task.delay(payload=payload.model_dump())
+                handled_fraud_checks.append(fraud_check)
+
+            case _:
+                logger.error("Unexpected %s fraud check %s was queried", fraud_check.type, fraud_check.id)
+
+    return handled_fraud_checks

--- a/api/src/pcapi/core/subscription/commands.py
+++ b/api/src/pcapi/core/subscription/commands.py
@@ -127,10 +127,10 @@ def ubble_archive_past_identifications_automation() -> None:
     archive_past_identification_pictures(start_date, end_date, picture_storage_status=False)
 
 
-@blueprint.cli.command("recover_started_quotient_familial_applications")
+@blueprint.cli.command("recover_started_bonus_credit_applications")
 @cron_decorators.log_cron
-def recover_started_quotient_familial_applications() -> None:
-    bonus_tasks.recover_started_quotient_familial_application()
+def recover_started_bonus_credit_applications() -> None:
+    bonus_tasks.recover_started_bonus_credit_applications(cutoff_time=date_utils.get_naive_utc_now())
 
 
 @blueprint.cli.command("recover_incomplete_ubble_id_verification")

--- a/api/src/pcapi/core/subscription/factories.py
+++ b/api/src/pcapi/core/subscription/factories.py
@@ -178,6 +178,7 @@ class QuotientFamilialBonusCreditContentFactory(factory.Factory):
 
     custodian = factory.SubFactory(BonusCreditPersonFactory)
     quotient_familial = factory.SubFactory(QuotientFamilialContentFactory)
+    next_retry_at = factory.LazyFunction(date_utils.get_naive_utc_now)
 
 
 class AdultDisabilityBonusCreditContentFactory(factory.Factory):
@@ -185,6 +186,7 @@ class AdultDisabilityBonusCreditContentFactory(factory.Factory):
         model = bonus_schemas.AdultDisabilityBonusCreditContent
 
     person = factory.SubFactory(BonusCreditPersonFactory)
+    next_retry_at = factory.LazyFunction(date_utils.get_naive_utc_now)
 
 
 class DisabledChildEducationBonusCreditContentFactory(factory.Factory):
@@ -192,6 +194,7 @@ class DisabledChildEducationBonusCreditContentFactory(factory.Factory):
         model = bonus_schemas.DisabledChildEducationBonusCreditContent
 
     person = factory.SubFactory(BonusCreditPersonFactory)
+    next_retry_at = factory.LazyFunction(date_utils.get_naive_utc_now)
 
 
 FRAUD_CHECK_TYPE_MODEL_ASSOCIATION: dict[subscription_models.FraudCheckType, type[factory.Factory] | None] = {

--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1612,13 +1612,19 @@ def get_user_disability_bonification_status(user: models.User) -> bonus_schemas.
     aah_bonus_credit_fraud_checks = get_bonus_credit_fraud_checks(
         user, subscription_models.FraudCheckType.AAH_BONUS_CREDIT
     )
-    aah_bonus_fraud_check = aah_bonus_credit_fraud_checks[-1] if aah_bonus_credit_fraud_checks else None
-    aah_fraud_check_status = aah_bonus_fraud_check.status if aah_bonus_fraud_check is not None else None
+    if not aah_bonus_credit_fraud_checks:
+        return bonus_schemas.DisabilityBonificationStatus.ELIGIBLE
 
-    if aah_fraud_check_status in (
+    aah_bonus_fraud_check = aah_bonus_credit_fraud_checks[-1]
+    aah_fraud_check_status = aah_bonus_fraud_check.status
+    is_pending_fraud_check = aah_fraud_check_status in (
         subscription_models.FraudCheckStatus.STARTED,
         subscription_models.FraudCheckStatus.PENDING,
-    ):
+    )
+    is_automatic_fraud_check = aah_bonus_fraud_check.reason is not None and aah_bonus_fraud_check.reason.startswith(
+        bonus_constants.AUTOMATIC_ORIGIN
+    )
+    if is_pending_fraud_check and not is_automatic_fraud_check:
         return bonus_schemas.DisabilityBonificationStatus.STARTED
 
     has_never_completely_tried = aah_fraud_check_status in (
@@ -1626,8 +1632,7 @@ def get_user_disability_bonification_status(user: models.User) -> bonus_schemas.
         subscription_models.FraudCheckStatus.CANCELED,
         subscription_models.FraudCheckStatus.ERROR,
     )
-
-    if has_never_completely_tried:
+    if has_never_completely_tried or (is_pending_fraud_check and is_automatic_fraud_check):
         return bonus_schemas.DisabilityBonificationStatus.ELIGIBLE
 
     if aah_fraud_check_status == subscription_models.FraudCheckStatus.KO:

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.sql import text
 
+from pcapi import settings
 from pcapi.models import Model
 from pcapi.models import db
 from pcapi.models.deactivable_mixin import DeactivableMixin
@@ -55,6 +56,7 @@ class FeatureToggle(enum.Enum):
         "Active la synchronisation des comptes bancaires avec l'outil finance externe (Cegid XRP Flex)"
     )
     ENABLE_BEAMER = "Active Beamer, le système de notifs du portail pro"
+    ENABLE_BONUS_CREDIT = "Active la bonification des jeunes via Quotient Familial ou allocations handicap"
     ENABLE_CDS_IMPLEMENTATION = "Permet la réservation de place de cinéma avec l'API Ciné Office (ex-CDS)"
     ENABLE_CRON_TO_UPDATE_OFFERER_STATS = "Active la mise à jour des statistiques des entités juridiques avec un cron"
     ENABLE_CHRONICLES_SYNC = "Activer la synchronisation des chroniques"
@@ -216,6 +218,9 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.WIP_PRE_SIGNUP_SIMULATION,
     # Please keep alphabetic order
 )
+
+if settings.IS_PROD:
+    FEATURES_DISABLED_BY_DEFAULT += (FeatureToggle.ENABLE_BONUS_CREDIT,)
 
 
 def install_feature_flags() -> None:

--- a/api/src/pcapi/routes/backoffice/accounts/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/accounts/blueprint.py
@@ -58,6 +58,7 @@ from pcapi.models import db
 from pcapi.models.beneficiary_import import BeneficiaryImport
 from pcapi.models.beneficiary_import_status import BeneficiaryImportStatus
 from pcapi.models.feature import DisabledFeatureError
+from pcapi.models.feature import FeatureToggle
 from pcapi.routes.backoffice import autocomplete
 from pcapi.routes.backoffice import blueprint as backoffice_blueprint
 from pcapi.routes.backoffice.bookings import helpers as booking_helpers
@@ -1896,10 +1897,17 @@ def request_qf_bonus_credit(user_id: int) -> response_utils.BackofficeResponse:
         origin=f"{bonus_constants.BACKOFFICE_ORIGIN_START}, User ID {current_user.id}",
     )
 
-    payload = bonus_tasks.BonusTaskPayload(fraud_check_id=fraud_check.id).model_dump()
-    on_commit(partial(bonus_tasks.apply_for_quotient_familial_bonus_task.delay, payload))
+    if FeatureToggle.ENABLE_BONUS_CREDIT.is_active():
+        payload = bonus_tasks.BonusTaskPayload(fraud_check_id=fraud_check.id).model_dump()
+        on_commit(partial(bonus_tasks.apply_for_quotient_familial_bonus_task.delay, payload))
 
-    flash("La demande de bonification QF est en cours.", "success")
+        flash("La demande de bonification QF est en cours.", "success")
+    else:
+        flash(
+            "La demande de bonification QF a été créée mais ne sera pas traitée tant que le FF ENABLE_BONUS_CREDIT est désactivé.",
+            "warning",
+        )
+
     return redirect(get_public_account_link(user_id), code=303)
 
 
@@ -1978,13 +1986,20 @@ def request_disability_bonus_credit(user_id: int) -> response_utils.BackofficeRe
         origin=f"{bonus_constants.BACKOFFICE_ORIGIN_START}, User ID {current_user.id}",
     )
 
-    aah_payload = bonus_tasks.BonusTaskPayload(fraud_check_id=aah_fraud_check.id).model_dump()
-    on_commit(partial(bonus_tasks.apply_for_adult_disability_bonus_task.delay, aah_payload))
+    if FeatureToggle.ENABLE_BONUS_CREDIT.is_active():
+        aah_payload = bonus_tasks.BonusTaskPayload(fraud_check_id=aah_fraud_check.id).model_dump()
+        on_commit(partial(bonus_tasks.apply_for_adult_disability_bonus_task.delay, aah_payload))
 
-    aeeh_payload = bonus_tasks.BonusTaskPayload(fraud_check_id=aeeh_fraud_check.id).model_dump()
-    on_commit(partial(bonus_tasks.apply_for_disabled_child_education_bonus_task.delay, aeeh_payload))
+        aeeh_payload = bonus_tasks.BonusTaskPayload(fraud_check_id=aeeh_fraud_check.id).model_dump()
+        on_commit(partial(bonus_tasks.apply_for_disabled_child_education_bonus_task.delay, aeeh_payload))
 
-    flash("La demande de bonification AAH/AEEH est en cours.", "success")
+        flash("La demande de bonification AAH/AEEH est en cours.", "success")
+    else:
+        flash(
+            "La demande de bonification AAH/AEEH a été créée mais ne sera pas traitée tant que le FF ENABLE_BONUS_CREDIT est désactivé.",
+            "warning",
+        )
+
     return redirect(get_public_account_link(user_id), code=303)
 
 

--- a/api/src/pcapi/routes/internal/e2e_account.py
+++ b/api/src/pcapi/routes/internal/e2e_account.py
@@ -1,6 +1,8 @@
 import datetime
+import itertools
 
 from pcapi.core import token as token_utils
+from pcapi.core.subscription.bonus import tasks as bonus_tasks
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import generator as users_generator
 from pcapi.core.users import models as users_models
@@ -111,3 +113,19 @@ def configure_api_disabled_child_education_allowance_response(user_id: int) -> t
     create_disabled_child_education_allowance_fraud_check_mock(user, form)
 
     return {}, 200
+
+
+@private_api.route("/e2e/bonus_credit/<user_id>/recover", methods=["POST"])
+@transaction_manager.atomic()
+@api_key_required
+def recover_started_bonus_credit_applications(user_id: int) -> tuple[dict[str, list[int]], int]:
+    handled_fraud_checks = bonus_tasks.recover_started_bonus_credit_applications(user_id=user_id)
+    handled_fraud_checks.sort(key=lambda fraud_check: fraud_check.type.value)
+
+    fraud_check_ids_by_type: dict[str, list[int]] = {}
+    for fraud_check_type, fraud_check_group in itertools.groupby(
+        handled_fraud_checks, key=lambda fraud_check: fraud_check.type.value
+    ):
+        fraud_check_ids_by_type[fraud_check_type] = [fraud_check.id for fraud_check in fraud_check_group]
+
+    return fraud_check_ids_by_type, 200

--- a/api/src/pcapi/routes/native/v1/subscription.py
+++ b/api/src/pcapi/routes/native/v1/subscription.py
@@ -10,6 +10,7 @@ from pcapi.core.external.attributes import api as external_attributes_api
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import exceptions
 from pcapi.core.subscription import fraud_check_api as fraud_api
+from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription import profile_options
 from pcapi.core.subscription import schemas as subscription_schemas
 from pcapi.core.subscription.bonus import constants as bonus_constants
@@ -21,7 +22,9 @@ from pcapi.core.subscription.ubble import schemas as ubble_schemas
 from pcapi.core.users import api as users_api
 from pcapi.core.users import models as users_models
 from pcapi.models import api_errors
+from pcapi.models.feature import FeatureToggle
 from pcapi.routes.native.security import authenticated_and_active_user_required
+from pcapi.serialization.decorator import feature_flag_required
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.utils import phone_number as phone_number_utils
 from pcapi.utils.transaction_manager import atomic
@@ -170,6 +173,7 @@ def start_identification_session(
         raise api_errors.ApiErrors({"code": code, "message": message}, status_code=return_status)
 
 
+@feature_flag_required(FeatureToggle.ENABLE_BONUS_CREDIT)
 @blueprint.native_route("/subscription/bonus/quotient_familial", methods=["POST"])
 @atomic()
 @authenticated_and_active_user_required
@@ -189,12 +193,26 @@ def create_quotient_familial_bonus_credit_fraud_check(body: serializers.Quotient
         gender=body.gender,
         birth_country_cog_code=body.birth_country_cog_code,
         birth_city_cog_code=body.birth_city_cog_code,
-        origin="enrolled from /subscription/bonus/quotient_familial endpoint",
+        origin=bonus_constants.QUOTIENT_FAMILIAL_ENDPOINT_ORIGIN,
     )
+
     payload = bonus_tasks.BonusTaskPayload(fraud_check_id=fraud_check.id).model_dump()
     on_commit(partial(bonus_tasks.apply_for_quotient_familial_bonus_task.delay, payload))
 
+    disability_fraud_checks = bonus_fraud_api.accelerate_automatic_disability_bonus_fraud_checks(
+        current_user.beneficiaryFraudChecks, new_origin="/subscription/bonus/quotient_familial endpoint"
+    )
+    for fraud_check in disability_fraud_checks:
+        if fraud_check.type == subscription_models.FraudCheckType.AAH_BONUS_CREDIT:
+            aah_payload = bonus_tasks.BonusTaskPayload(fraud_check_id=fraud_check.id).model_dump()
+            on_commit(partial(bonus_tasks.apply_for_adult_disability_bonus_task.delay, aah_payload))
 
+        if fraud_check.type == subscription_models.FraudCheckType.AEEH_BONUS_CREDIT:
+            aeeh_payload = bonus_tasks.BonusTaskPayload(fraud_check_id=fraud_check.id).model_dump()
+            on_commit(partial(bonus_tasks.apply_for_disabled_child_education_bonus_task.delay, aeeh_payload))
+
+
+@feature_flag_required(FeatureToggle.ENABLE_BONUS_CREDIT)
 @blueprint.native_route("/subscription/bonus/disability", methods=["POST"])
 @atomic()
 @authenticated_and_active_user_required

--- a/api/src/pcapi/settings.py
+++ b/api/src/pcapi/settings.py
@@ -689,3 +689,5 @@ DIGITAL_CAP_V2_DATETIME = datetime.fromisoformat(os.environ.get("DIGITAL_CAP_V2_
 EXTENDED_BIRTHDAY_BONUS_CUTOFF_DATETIME = datetime.fromisoformat(
     os.environ.get("EXTENDED_BIRTHDAY_BONUS_CUTOFF_DATETIME", "2026-01-01")
 )
+BONUS_CREDIT_DELAY = int(os.environ.get("BONUS_CREDIT_DELAY", "300"))
+BONUS_CREDIT_DELAY_JITTER = int(os.environ.get("BONUS_CREDIT_DELAY_JITTER", "0"))

--- a/api/tests/core/finance/test_deposit_api.py
+++ b/api/tests/core/finance/test_deposit_api.py
@@ -504,13 +504,20 @@ class UserRecreditTest:
     @time_machine.travel("2025-03-03")
     def test_user_cannot_be_recredited(self, age):
         before_decree = pcapi_settings.CREDIT_V3_DECREE_DATETIME - relativedelta(days=1)
-        users_factories.BeneficiaryFactory(age=age, dateCreated=before_decree)
+        user = users_factories.BeneficiaryFactory(age=age, dateCreated=before_decree)
 
         before_recredit_number = db.session.query(models.Recredit.id).count()
         api.recredit_users()
         after_recredit_number = db.session.query(models.Recredit.id).count()
 
         assert before_recredit_number == after_recredit_number
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     @time_machine.travel("2025-03-03")
     def test_user_already_received_pre_decree_17yo_recredit(self):
@@ -523,6 +530,13 @@ class UserRecreditTest:
         after_recredit_number = db.session.query(models.Recredit.id).count()
 
         assert before_recredit_number == after_recredit_number
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     def test_user_recredited_at_18(self):
         user = users_factories.BeneficiaryFactory(age=17, phoneNumber="0123456789")
@@ -540,6 +554,16 @@ class UserRecreditTest:
             assert len(user.deposits) == 1
             assert len(user.deposit.recredits) == 2
 
+            bonus_fraud_check_types = [
+                fraud_check.type
+                for fraud_check in user.beneficiaryFraudChecks
+                if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+            ]
+            assert set(bonus_fraud_check_types) == {
+                subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+                subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+            }
+
     def test_user_not_recredited_at_18_if_missing_step(self):
         user = users_factories.BeneficiaryFactory(age=17, phoneNumber="0123456789")
         with time_machine.travel(date_utils.get_naive_utc_now() + relativedelta(years=1)):
@@ -549,16 +573,25 @@ class UserRecreditTest:
             api.recredit_users()
             assert len(user.deposit.recredits) == 1
 
-    def test_users_recredited_once(self):
-        user = users_factories.BeneficiaryFactory(age=17, phoneNumber="0123456789")
-        with time_machine.travel(date_utils.get_naive_utc_now() + relativedelta(years=1)):
-            assert user.age == 18
-            subscription_factories.PhoneValidationFraudCheckFactory(user=user)
-            subscription_factories.BeneficiaryFraudCheckFactory(
-                user=user, type=subscription_models.FraudCheckType.UBBLE, status=subscription_models.FraudCheckStatus.OK
-            )
-            subscription_factories.HonorStatementFraudCheckFactory(user=user)
-            subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
+            bonus_fraud_checks = [
+                fraud_check
+                for fraud_check in user.beneficiaryFraudChecks
+                if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+            ]
+            assert not bonus_fraud_checks
+
+        def test_users_recredited_once(self):
+            user = users_factories.BeneficiaryFactory(age=17, phoneNumber="0123456789")
+            with time_machine.travel(date_utils.get_naive_utc_now() + relativedelta(years=1)):
+                assert user.age == 18
+                subscription_factories.PhoneValidationFraudCheckFactory(user=user)
+                subscription_factories.BeneficiaryFraudCheckFactory(
+                    user=user,
+                    type=subscription_models.FraudCheckType.UBBLE,
+                    status=subscription_models.FraudCheckStatus.OK,
+                )
+                subscription_factories.HonorStatementFraudCheckFactory(user=user)
+                subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
 
             api.recredit_users()
 
@@ -568,6 +601,16 @@ class UserRecreditTest:
             api.recredit_users()
             assert len(user.deposits) == 1
             assert len(user.deposit.recredits) == 2
+
+            bonus_fraud_check_types = [
+                fraud_check.type
+                for fraud_check in user.beneficiaryFraudChecks
+                if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+            ]
+            assert set(bonus_fraud_check_types) == {
+                subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+                subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+            }
 
     def test_user_with_missing_steps_is_not_recredited(self):
         user = users_factories.BeneficiaryFactory(age=17, deposit__type=models.DepositType.GRANT_17_18)
@@ -578,6 +621,13 @@ class UserRecreditTest:
             api.recredit_users()
             assert len(user.deposits) == 1
             assert len(user.deposit.recredits) == 1
+
+            bonus_fraud_checks = [
+                fraud_check
+                for fraud_check in user.beneficiaryFraudChecks
+                if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+            ]
+            assert not bonus_fraud_checks
 
             # Finish missing steps
             subscription_factories.ProfileCompletionFraudCheckFactory(user=user)
@@ -590,6 +640,16 @@ class UserRecreditTest:
 
         assert len(user.deposits) == 1
         assert len(user.deposit.recredits) == 2
+
+        bonus_fraud_check_types = [
+            fraud_check.type
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert set(bonus_fraud_check_types) == {
+            subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+            subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+        }
 
     def test_create_new_deposit_when_recrediting_underage_deposit(self):
         one_year_before_decree = pcapi_settings.CREDIT_V3_DECREE_DATETIME - relativedelta(years=1)
@@ -618,11 +678,28 @@ class UserRecreditTest:
             user_1.deposit.amount == 12 + 50
         )  #  12 (remaining credit 16 before decree) + 50 (for 17 year old after decree)
 
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user_1.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
+
         # User 2 is 18, and was recredited with RECREDIT_18 on its new deposit
         assert len(user_2.deposits) == 2
         assert user_2.deposit.type == models.DepositType.GRANT_17_18
         assert user_2.deposit.recredits[0].recreditType == models.RecreditType.RECREDIT_18
         assert user_2.deposit.amount == 30 + 150  #  30 (credit 17 before decree) + 150 (for 18 year old after decree)
+
+        bonus_fraud_check_types = [
+            fraud_check.type
+            for fraud_check in user_2.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert set(bonus_fraud_check_types) == {
+            subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+            subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+        }
 
     def test_booking_transfer_when_recrediting_underage_deposit(self):
         one_year_before_decree = pcapi_settings.CREDIT_V3_DECREE_DATETIME - relativedelta(years=1)
@@ -673,6 +750,13 @@ class UserRecreditTest:
         api.recredit_users()
 
         assert models.RecreditType.RECREDIT_18 not in [recredit.recreditType for recredit in user.deposit.recredits]
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     @pytest.mark.skip(
         reason="This test is very long and must be executed in a flask shell, outside of db_session fixture"

--- a/api/tests/core/subscription/bonus/test_bonus_api.py
+++ b/api/tests/core/subscription/bonus/test_bonus_api.py
@@ -21,6 +21,7 @@ import pcapi.core.subscription.factories as subscription_factories
 import pcapi.core.subscription.models as subscription_models
 import pcapi.core.users.factories as users_factories
 import pcapi.core.users.models as users_models
+import pcapi.utils.date as date_utils
 from pcapi.core.external.batch import models as batch_models
 from pcapi.core.mails.transactional.brevo_template_ids import TransactionalEmail
 from pcapi.core.subscription.bonus import constants as bonus_constants
@@ -209,12 +210,13 @@ class QuotientFamilialApplicationTest:
     def test_application_not_found(self, caplog):
         user = users_factories.BeneficiaryFactory()
         custodian = subscription_factories.BonusCreditPersonFactory()
+        now = date_utils.get_naive_utc_now()
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
             type=subscription_models.FraudCheckType.QF_BONUS_CREDIT,
             status=subscription_models.FraudCheckStatus.STARTED,
-            resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory(
-                custodian=custodian, quotient_familial=None
+            resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory.create(
+                custodian=custodian, quotient_familial=None, next_retry_at=now
             ).model_dump(),
         )
 
@@ -237,6 +239,7 @@ class QuotientFamilialApplicationTest:
             children=None,
             http_status_code=404,
             error_code="37003",
+            next_retry_at=now,
         )
         assert finance_models.RecreditType.BONUS_CREDIT not in [
             recredit.recreditType for recredit in user.deposit.recredits
@@ -258,12 +261,13 @@ class QuotientFamilialApplicationTest:
     def test_person_not_found(self, caplog):
         user = users_factories.BeneficiaryFactory()
         custodian = subscription_factories.BonusCreditPersonFactory()
+        now = date_utils.get_naive_utc_now()
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
             type=subscription_models.FraudCheckType.QF_BONUS_CREDIT,
             status=subscription_models.FraudCheckStatus.STARTED,
             resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory(
-                custodian=custodian, quotient_familial=None
+                custodian=custodian, quotient_familial=None, next_retry_at=now
             ).model_dump(),
         )
 
@@ -286,6 +290,7 @@ class QuotientFamilialApplicationTest:
             children=None,
             http_status_code=422,
             error_code="00355",
+            next_retry_at=now,
         )
         assert finance_models.RecreditType.BONUS_CREDIT not in [
             recredit.recreditType for recredit in user.deposit.recredits
@@ -307,12 +312,13 @@ class QuotientFamilialApplicationTest:
     def test_user_not_in_tax_household(self):
         user = users_factories.BeneficiaryFactory()
         custodian = subscription_factories.BonusCreditPersonFactory()
+        now = date_utils.get_naive_utc_now()
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
             type=subscription_models.FraudCheckType.QF_BONUS_CREDIT,
             status=subscription_models.FraudCheckStatus.STARTED,
             resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory(
-                custodian=custodian, quotient_familial=None
+                custodian=custodian, quotient_familial=None, next_retry_at=now
             ).model_dump(),
         )
 
@@ -355,6 +361,7 @@ class QuotientFamilialApplicationTest:
                 )
             ],
             http_status_code=200,
+            next_retry_at=now,
         )
 
         assert finance_models.RecreditType.BONUS_CREDIT not in [
@@ -378,12 +385,13 @@ class QuotientFamilialApplicationTest:
         high_quotient_familial["data"]["quotient_familial"]["valeur"] = 9_999_999
         user = _build_user_from_fixture(high_quotient_familial)
         custodian = subscription_factories.BonusCreditPersonFactory()
+        now = date_utils.get_naive_utc_now()
         bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
             type=subscription_models.FraudCheckType.QF_BONUS_CREDIT,
             status=subscription_models.FraudCheckStatus.STARTED,
             resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory(
-                custodian=custodian, quotient_familial=None
+                custodian=custodian, quotient_familial=None, next_retry_at=now
             ).model_dump(),
         )
 
@@ -428,6 +436,7 @@ class QuotientFamilialApplicationTest:
                 )
             ],
             http_status_code=200,
+            next_retry_at=now,
         )
 
         assert finance_models.RecreditType.BONUS_CREDIT not in [
@@ -533,22 +542,6 @@ class QuotientFamilialApplicationTest:
 
         for frame in stacktrace_frames[1:]:
             assert all(value == "[REDACTED]" for value in frame["vars"].values())
-
-    def test_touch_fraud_check_despite_error(self):
-        twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
-        bonus_fraud_check = subscription_factories.QFBonusCreditFraudCheckFactory.create(
-            status=subscription_models.FraudCheckStatus.STARTED, updatedAt=twelve_hours_ago
-        )
-
-        with requests_mock.Mocker() as mock:
-            mock.get(
-                api_particulier.QUOTIENT_FAMILIAL_ENDPOINT, status_code=502, json=bonus_fixtures.DATA_PROVIDER_ERROR
-            )
-
-            with pytest.raises(api_particulier.ParticulierApiException):
-                bonus_api.apply_for_quotient_familial_bonus(bonus_fraud_check)
-
-        assert bonus_fraud_check.updatedAt > twelve_hours_ago
 
     @patch("pcapi.core.finance.deposit_api.recredit_bonus_credit")
     def test_has_already_received_bonus_credit(self, mock_recredit):
@@ -786,22 +779,6 @@ class DisabledAdultAllowanceTest:
 
         for frame in stacktrace_frames[1:]:
             assert all(value == "[REDACTED]" for value in frame["vars"].values())
-
-    def test_touch_fraud_check_despite_error(self):
-        twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
-        bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory(
-            type=subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
-            status=subscription_models.FraudCheckStatus.STARTED,
-            updatedAt=twelve_hours_ago,
-        )
-
-        with requests_mock.Mocker() as mock:
-            mock.get(api_particulier.AAH_ENDPOINT, status_code=502, json=bonus_fixtures.DATA_PROVIDER_ERROR)
-
-            with pytest.raises(api_particulier.ParticulierApiException):
-                bonus_api.apply_for_adult_disability_bonus(bonus_fraud_check)
-
-        assert bonus_fraud_check.updatedAt > twelve_hours_ago
 
     @pytest.mark.parametrize(
         "fraud_check_origin,nb_mails_send",
@@ -1062,22 +1039,6 @@ class DisabledChildEducationAllowanceTest:
 
         for frame in stacktrace_frames[1:]:
             assert all(value == "[REDACTED]" for value in frame["vars"].values())
-
-    def test_touch_fraud_check_despite_error(self):
-        twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
-        bonus_fraud_check = subscription_factories.BeneficiaryFraudCheckFactory(
-            type=subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
-            status=subscription_models.FraudCheckStatus.STARTED,
-            updatedAt=twelve_hours_ago,
-        )
-
-        with requests_mock.Mocker() as mock:
-            mock.get(api_particulier.AEEH_ENDPOINT, status_code=502, json=bonus_fixtures.DATA_PROVIDER_ERROR)
-
-            with pytest.raises(api_particulier.ParticulierApiException):
-                bonus_api.apply_for_disabled_child_education_bonus(bonus_fraud_check)
-
-        assert bonus_fraud_check.updatedAt > twelve_hours_ago
 
     @pytest.mark.parametrize(
         "fraud_check_origin,nb_mails_send",

--- a/api/tests/core/subscription/bonus/test_bonus_staging_api.py
+++ b/api/tests/core/subscription/bonus/test_bonus_staging_api.py
@@ -1,7 +1,4 @@
-import datetime
-
 import pytest
-from dateutil.relativedelta import relativedelta
 
 from pcapi.connectors import api_particulier
 from pcapi.core.finance import models as finance_models
@@ -243,7 +240,6 @@ class StagingQuotientFamilialTest:
         ]
 
     def test_mock_data_provider_error(self, requests_mock):
-        twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
         user = users_factories.BeneficiaryFactory()
         subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
@@ -258,7 +254,6 @@ class StagingQuotientFamilialTest:
             type=subscription_models.FraudCheckType.QF_BONUS_CREDIT,
             status=subscription_models.FraudCheckStatus.STARTED,
             resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory().model_dump(),
-            updatedAt=twelve_hours_ago,
         )
         requests_mock.get(
             api_particulier.QUOTIENT_FAMILIAL_ENDPOINT,
@@ -271,8 +266,6 @@ class StagingQuotientFamilialTest:
 
         query_string = requests_mock.request_history[0].qs
         assert query_string["nomNaissance"] == [staging_api.DATA_PROVIDER_ERROR.last_name.upper()]
-
-        assert qf_fraud_check.updatedAt > twelve_hours_ago
 
         assert finance_models.RecreditType.BONUS_CREDIT not in [
             recredit.recreditType for recredit in user.deposit.recredits
@@ -411,7 +404,6 @@ class StagingDisabledAdultAllowanceTest:
         ]
 
     def test_mock_disabled_adult_allowance_data_provider_error(self, requests_mock):
-        twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
         user = users_factories.BeneficiaryFactory()
         subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
@@ -426,7 +418,6 @@ class StagingDisabledAdultAllowanceTest:
             type=subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
             status=subscription_models.FraudCheckStatus.STARTED,
             resultContent=subscription_factories.AdultDisabilityBonusCreditContentFactory().model_dump(),
-            updatedAt=twelve_hours_ago,
         )
         requests_mock.get(
             api_particulier.AAH_ENDPOINT,
@@ -439,8 +430,6 @@ class StagingDisabledAdultAllowanceTest:
 
         query_string = requests_mock.request_history[0].qs
         assert query_string["nomNaissance"] == [staging_api.DATA_PROVIDER_ERROR.last_name.upper()]
-
-        assert aah_fraud_check.updatedAt > twelve_hours_ago
 
         assert finance_models.RecreditType.BONUS_CREDIT not in [
             recredit.recreditType for recredit in user.deposit.recredits
@@ -611,7 +600,6 @@ class StagingDisabledChildEducationAllowanceTest:
         ]
 
     def test_mock_disabled_adult_allowance_data_provider_error(self, requests_mock):
-        twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
         user = users_factories.BeneficiaryFactory()
         subscription_factories.BeneficiaryFraudCheckFactory(
             user=user,
@@ -626,7 +614,6 @@ class StagingDisabledChildEducationAllowanceTest:
             type=subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
             status=subscription_models.FraudCheckStatus.STARTED,
             resultContent=subscription_factories.AdultDisabilityBonusCreditContentFactory().model_dump(),
-            updatedAt=twelve_hours_ago,
         )
         requests_mock.get(
             api_particulier.AEEH_ENDPOINT,
@@ -639,8 +626,6 @@ class StagingDisabledChildEducationAllowanceTest:
 
         query_string = requests_mock.request_history[0].qs
         assert query_string["nomNaissance"] == [staging_api.DISABLED_CHILD_DATA_PROVIDER_ERROR.last_name.upper()]
-
-        assert aeeh_fraud_check.updatedAt > twelve_hours_ago
 
         assert finance_models.RecreditType.BONUS_CREDIT not in [
             recredit.recreditType for recredit in user.deposit.recredits

--- a/api/tests/core/subscription/bonus/test_bonus_tasks.py
+++ b/api/tests/core/subscription/bonus/test_bonus_tasks.py
@@ -10,6 +10,7 @@ from pcapi.core.subscription import factories as subscription_factories
 from pcapi.core.subscription import models as subscription_models
 from pcapi.core.subscription.bonus import tasks
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 from tests.core.subscription.bonus import bonus_fixtures
 
@@ -17,104 +18,212 @@ from tests.core.subscription.bonus import bonus_fixtures
 pytestmark = pytest.mark.usefixtures("db_session")
 
 
-@patch("pcapi.connectors.api_particulier.get_quotient_familial")
-def test_apply_for_quotient_familial_bonus_task(mocked_get_quotient_familial):
-    custodian = subscription_factories.BonusCreditPersonFactory.create()
-    fraud_check = subscription_factories.QFBonusCreditFraudCheckFactory.create(
-        status=subscription_models.FraudCheckStatus.STARTED,
-        resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory.build(
-            custodian=custodian
-        ).model_dump(),
-    )
-    fraud_check_id = fraud_check.id
-    birth_date = fraud_check.user.validatedBirthDate
-    mocked_get_quotient_familial.return_value = bonus_fixtures.QF_DESERIALIZED_RESPONSE
-
-    payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check_id)
-    tasks.apply_for_quotient_familial_bonus_task.delay(payload.model_dump())
-
-    assert len(mocked_get_quotient_familial.mock_calls) == 12
-    mocked_get_quotient_familial.assert_called_with(
-        custodian, birth_date + relativedelta(years=17) + relativedelta(months=11)
-    )
-
-    fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check_id)
-    assert fraud_check.status == subscription_models.FraudCheckStatus.KO
-    assert fraud_check.reasonCodes == [subscription_models.FraudReasonCode.NOT_IN_TAX_HOUSEHOLD]
-
-
-@patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
-def test_recover_started_quotient_familial_application(mocked_apply_for_qf_task):
-    twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
-    started_fraud_check_1 = subscription_factories.QFBonusCreditFraudCheckFactory.create(
-        status=subscription_models.FraudCheckStatus.STARTED, updatedAt=twelve_hours_ago
-    )
-    started_fraud_check_2 = subscription_factories.QFBonusCreditFraudCheckFactory.create(
-        status=subscription_models.FraudCheckStatus.STARTED, updatedAt=twelve_hours_ago - relativedelta(seconds=1)
-    )
-
-    tasks.recover_started_quotient_familial_application()
-
-    mocked_apply_for_qf_task.assert_has_calls(
-        [
-            call(payload={"fraud_check_id": started_fraud_check_1.id}),
-            call(payload={"fraud_check_id": started_fraud_check_2.id}),
-        ],
-        any_order=True,
-    )
-
-
-@patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
-def test_recovery_ignores_recent_quotient_familial_application(mocked_apply_for_qf_task):
-    twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
-    subscription_factories.QFBonusCreditFraudCheckFactory.create(
-        status=subscription_models.FraudCheckStatus.STARTED, updatedAt=twelve_hours_ago + relativedelta(minutes=1)
-    )
-
-    tasks.recover_started_quotient_familial_application()
-
-    mocked_apply_for_qf_task.assert_not_called()
-
-
-@patch("pcapi.connectors.api_particulier.get_disabled_adult_allowance")
-def test_apply_for_adult_disability_bonus_task(mocked_disabled_adult_allowance):
-    person = subscription_factories.BonusCreditPersonFactory.create()
-    fraud_check = subscription_factories.AAHBonusCreditFraudCheckFactory.create(
-        status=subscription_models.FraudCheckStatus.STARTED,
-        resultContent=subscription_factories.AdultDisabilityBonusCreditContentFactory.build(person=person).model_dump(),
-    )
-    fraud_check_id = fraud_check.id
-    mocked_disabled_adult_allowance.return_value = api_particulier.DisabledAdultAllowanceResponse.model_validate(
-        bonus_fixtures.AAH_NOT_RECIPIENT_RESPONSE
-    )
-
-    payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check_id)
-    tasks.apply_for_adult_disability_bonus_task.delay(payload.model_dump())
-
-    fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check_id)
-    assert fraud_check.status == subscription_models.FraudCheckStatus.KO
-    assert fraud_check.reasonCodes == [subscription_models.FraudReasonCode.NOT_RECIPIENT]
-
-
-@patch("pcapi.connectors.api_particulier.get_disabled_child_education_allowance")
-def test_apply_for_disabled_child_education_allowance(mocked_disabled_child_education_allowance):
-    person = subscription_factories.BonusCreditPersonFactory.create()
-    fraud_check = subscription_factories.AEEHBonusCreditFraudCheckFactory.create(
-        status=subscription_models.FraudCheckStatus.STARTED,
-        resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory.build(
-            person=person
-        ).model_dump(),
-    )
-    fraud_check_id = fraud_check.id
-    mocked_disabled_child_education_allowance.return_value = (
-        api_particulier.DisabledChildEducationAllowanceResponse.model_validate(
-            bonus_fixtures.AEEH_NOT_RECIPIENT_RESPONSE
+class QuotientFamilialBonusTaskTest:
+    @patch("pcapi.connectors.api_particulier.get_quotient_familial")
+    def test_apply_for_quotient_familial_bonus_task(self, mocked_get_quotient_familial):
+        custodian = subscription_factories.BonusCreditPersonFactory.create()
+        fraud_check = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED,
+            resultContent=subscription_factories.QuotientFamilialBonusCreditContentFactory.build(
+                custodian=custodian
+            ).model_dump(),
         )
-    )
+        fraud_check_id = fraud_check.id
+        birth_date = fraud_check.user.validatedBirthDate
+        mocked_get_quotient_familial.return_value = bonus_fixtures.QF_DESERIALIZED_RESPONSE
 
-    payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check_id)
-    tasks.apply_for_disabled_child_education_bonus_task.delay(payload.model_dump())
+        payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check_id)
+        tasks.apply_for_quotient_familial_bonus_task.delay(payload.model_dump())
 
-    fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check_id)
-    assert fraud_check.status == subscription_models.FraudCheckStatus.KO
-    assert fraud_check.reasonCodes == [subscription_models.FraudReasonCode.NOT_RECIPIENT]
+        assert len(mocked_get_quotient_familial.mock_calls) == 12
+        mocked_get_quotient_familial.assert_called_with(
+            custodian, birth_date + relativedelta(years=17) + relativedelta(months=11)
+        )
+
+        fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check_id)
+        assert fraud_check.status == subscription_models.FraudCheckStatus.KO
+        assert fraud_check.reasonCodes == [subscription_models.FraudReasonCode.NOT_IN_TAX_HOUSEHOLD]
+
+    @patch("pcapi.connectors.api_particulier.get_quotient_familial")
+    def test_replan_fraud_check_on_exception(self, mocked_get_quotient_familial):
+        fraud_check = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED,
+        )
+        mocked_get_quotient_familial.side_effect = RuntimeError
+
+        payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check.id)
+        tasks.apply_for_quotient_familial_bonus_task.delay(payload.model_dump())
+
+        fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check.id)
+        assert fraud_check.status == subscription_models.FraudCheckStatus.STARTED
+        assert (
+            datetime.datetime.fromisoformat(fraud_check.resultContent["next_retry_at"]) > date_utils.get_naive_utc_now()
+        )
+
+
+class AdultDisabilityBonusTaskTest:
+    @patch("pcapi.connectors.api_particulier.get_disabled_adult_allowance")
+    def test_apply_for_adult_disability_bonus_task(self, mocked_disabled_adult_allowance):
+        person = subscription_factories.BonusCreditPersonFactory.create()
+        fraud_check = subscription_factories.AAHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED,
+            resultContent=subscription_factories.AdultDisabilityBonusCreditContentFactory.build(
+                person=person
+            ).model_dump(),
+        )
+        fraud_check_id = fraud_check.id
+        mocked_disabled_adult_allowance.return_value = api_particulier.DisabledAdultAllowanceResponse.model_validate(
+            bonus_fixtures.AAH_NOT_RECIPIENT_RESPONSE
+        )
+
+        payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check_id)
+        tasks.apply_for_adult_disability_bonus_task.delay(payload.model_dump())
+
+        fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check_id)
+        assert fraud_check.status == subscription_models.FraudCheckStatus.KO
+        assert fraud_check.reasonCodes == [subscription_models.FraudReasonCode.NOT_RECIPIENT]
+
+    @patch("pcapi.connectors.api_particulier.get_disabled_adult_allowance")
+    def test_replan_fraud_check_on_exception(self, mocked_disabled_adult_allowance):
+        fraud_check = subscription_factories.AAHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED,
+        )
+        mocked_disabled_adult_allowance.side_effect = RuntimeError
+
+        payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check.id)
+        tasks.apply_for_adult_disability_bonus_task.delay(payload.model_dump())
+
+        fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check.id)
+        assert fraud_check.status == subscription_models.FraudCheckStatus.STARTED
+        assert (
+            datetime.datetime.fromisoformat(fraud_check.resultContent["next_retry_at"]) > date_utils.get_naive_utc_now()
+        )
+
+
+class DisabledChildEducationBonusTaskTest:
+    @patch("pcapi.connectors.api_particulier.get_disabled_child_education_allowance")
+    def test_apply_for_disabled_child_education_allowance(self, mocked_disabled_child_education_allowance):
+        person = subscription_factories.BonusCreditPersonFactory.create()
+        fraud_check = subscription_factories.AEEHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED,
+            resultContent=subscription_factories.DisabledChildEducationBonusCreditContentFactory.build(
+                person=person
+            ).model_dump(),
+        )
+        fraud_check_id = fraud_check.id
+        mocked_disabled_child_education_allowance.return_value = (
+            api_particulier.DisabledChildEducationAllowanceResponse.model_validate(
+                bonus_fixtures.AEEH_NOT_RECIPIENT_RESPONSE
+            )
+        )
+
+        payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check_id)
+        tasks.apply_for_disabled_child_education_bonus_task.delay(payload.model_dump())
+
+        fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check_id)
+        assert fraud_check.status == subscription_models.FraudCheckStatus.KO
+        assert fraud_check.reasonCodes == [subscription_models.FraudReasonCode.NOT_RECIPIENT]
+
+    @patch("pcapi.connectors.api_particulier.get_disabled_child_education_allowance")
+    def test_replan_fraud_check_on_exception(self, mocked_disabled_child_education_allowance):
+        fraud_check = subscription_factories.AEEHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED,
+        )
+        mocked_disabled_child_education_allowance.side_effect = RuntimeError
+
+        payload = tasks.BonusTaskPayload(fraud_check_id=fraud_check.id)
+        tasks.apply_for_disabled_child_education_bonus_task.delay(payload.model_dump())
+
+        fraud_check = db.session.query(subscription_models.BeneficiaryFraudCheck).get(fraud_check.id)
+        assert fraud_check.status == subscription_models.FraudCheckStatus.STARTED
+        assert (
+            datetime.datetime.fromisoformat(fraud_check.resultContent["next_retry_at"]) > date_utils.get_naive_utc_now()
+        )
+
+
+class RecoverStartedBonusCreditApplicationsTest:
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_adult_disability_bonus_task.delay")
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_disabled_child_education_bonus_task.delay")
+    def test_recover_started_bonus_credit_applications_full_page(
+        self, mocked_apply_for_aeeh_task, mocked_apply_for_aah_task, mocked_apply_for_qf_task
+    ):
+        twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
+        started_fraud_check_1 = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, resultContent={"next_retry_at": twelve_hours_ago}
+        )
+        started_fraud_check_2 = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, resultContent={"next_retry_at": twelve_hours_ago}
+        )
+        aah_fraud_check = subscription_factories.AAHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, resultContent={"next_retry_at": twelve_hours_ago}
+        )
+        aeeh_fraud_check = subscription_factories.AEEHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, resultContent={"next_retry_at": twelve_hours_ago}
+        )
+
+        tasks.recover_started_bonus_credit_applications(
+            cutoff_time=twelve_hours_ago + relativedelta(minutes=1), page_size=12 + 12 + 1 + 1
+        )
+
+        mocked_apply_for_qf_task.assert_has_calls(
+            [
+                call(payload={"fraud_check_id": started_fraud_check_1.id}),
+                call(payload={"fraud_check_id": started_fraud_check_2.id}),
+            ],
+            any_order=True,
+        )
+        mocked_apply_for_aah_task.assert_has_calls([call(payload={"fraud_check_id": aah_fraud_check.id})])
+        mocked_apply_for_aeeh_task.assert_has_calls([call(payload={"fraud_check_id": aeeh_fraud_check.id})])
+
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
+    def test_recover_started_bonus_credit_applications_for_a_user(self, mocked_apply_for_qf_task):
+        twelve_hours_ago = datetime.datetime.now(tz=None) - relativedelta(hours=12)
+        started_fraud_check_1 = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, resultContent={"next_retry_at": twelve_hours_ago}
+        )
+        _started_fraud_check_2 = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, resultContent={"next_retry_at": twelve_hours_ago}
+        )
+
+        tasks.recover_started_bonus_credit_applications(user_id=started_fraud_check_1.userId)
+
+        mocked_apply_for_qf_task.assert_has_calls(
+            [
+                call(payload={"fraud_check_id": started_fraud_check_1.id}),
+            ]
+        )
+
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_adult_disability_bonus_task.delay")
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_disabled_child_education_bonus_task.delay")
+    def test_recovery_ignores_date_planned_too_late(
+        self, mocked_apply_for_aeeh_task, mocked_apply_for_aah_task, mocked_apply_for_qf_task
+    ):
+        cutoff_date = datetime.datetime.now(tz=None)
+        too_late = cutoff_date + relativedelta(minutes=1)
+        subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, resultContent={"next_retry_at": too_late}
+        )
+        subscription_factories.AAHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, resultContent={"next_retry_at": too_late}
+        )
+        subscription_factories.AEEHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, resultContent={"next_retry_at": too_late}
+        )
+
+        tasks.recover_started_bonus_credit_applications(cutoff_time=cutoff_date)
+
+        mocked_apply_for_qf_task.assert_not_called()
+        mocked_apply_for_aah_task.assert_not_called()
+        mocked_apply_for_aeeh_task.assert_not_called()
+
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
+    def test_recovery_does_not_overflow_page_size(self, mocked_apply_for_qf_task):
+        subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED
+        )
+
+        tasks.recover_started_bonus_credit_applications(page_size=11)
+
+        mocked_apply_for_qf_task.assert_not_called()

--- a/api/tests/core/subscription/dms/test_api.py
+++ b/api/tests/core/subscription/dms/test_api.py
@@ -1475,7 +1475,7 @@ class RunIntegrationTest:
         assert user.dateOfBirth.date() == self.BENEFICIARY_BIRTH_DATE
         assert user.validatedBirthDate == dms_validated_birth_date
 
-        assert len(user.beneficiaryFraudChecks) == 3  # DMS, HONOR_STATEMENT, PROFILE_COMPLETION
+        assert len(user.beneficiaryFraudChecks) == 5  # DMS, HONOR_STATEMENT, PROFILE_COMPLETION, AAH, AEEH
 
         dms_fraud_check = next(
             fraud_check
@@ -1809,7 +1809,7 @@ class GraphQLSourceProcessApplicationTest:
 
         dms_subscription_api.import_all_updated_dms_applications(6712558)
 
-        assert len(user.beneficiaryFraudChecks) == 3  # profile, DMS, honor statement
+        assert len(user.beneficiaryFraudChecks) == 5  # DMS, HONOR_STATEMENT, PROFILE_COMPLETION, AAH, AEEH
         assert user.roles == [users_models.UserRole.BENEFICIARY]
 
     @patch.object(api_dms.DMSGraphQLClient, "get_applications_with_details")
@@ -1839,7 +1839,7 @@ class GraphQLSourceProcessApplicationTest:
 
         dms_subscription_api.import_all_updated_dms_applications(6712558)
 
-        assert len(user.beneficiaryFraudChecks) == 3  # profile, DMS, honor statement
+        assert len(user.beneficiaryFraudChecks) == 5  # DMS, HONOR_STATEMENT, PROFILE_COMPLETION, AAH, AEEH
         assert user.roles == [users_models.UserRole.BENEFICIARY]
 
     @patch.object(api_dms.DMSGraphQLClient, "get_applications_with_details")

--- a/api/tests/core/subscription/test_api.py
+++ b/api/tests/core/subscription/test_api.py
@@ -1776,7 +1776,16 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         )
 
         is_success = subscription_api.activate_beneficiary_if_no_missing_step(user)
+
         assert not is_success
+        assert not user.is_beneficiary
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     def test_admin_review_ko(self):
         user = users_factories.UserFactory(
@@ -1819,6 +1828,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert not is_success
         assert not user.is_beneficiary
 
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
+
     def test_missing_step(self):
         user = users_factories.UserFactory(
             dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
@@ -1845,6 +1861,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert not user.is_beneficiary
         assert user.firstName is None
         assert user.lastName is None
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     def test_duplicate_detected(self):
         first_name = "Alain"
@@ -1889,6 +1912,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert to_invalidate_check.reasonCodes == [subscription_models.FraudReasonCode.DUPLICATE_USER]
         assert user.firstName is None
         assert user.lastName is None
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     AGE18_ELIGIBLE_BIRTH_DATE = date_utils.get_naive_utc_now() - relativedelta(years=18, months=4)
     UNDERAGE_ELIGIBLE_BIRTH_DATE = date_utils.get_naive_utc_now() - relativedelta(years=17, months=4)
@@ -1940,6 +1970,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.amount == 50
         assert user.recreditAmountToShow == 50
 
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
+
     def test_rejected_identity(self):
         user = self.eligible_user(validate_phone=False)
 
@@ -1956,6 +1993,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert not subscription_api.activate_beneficiary_if_no_missing_step(user)
         assert not user.is_beneficiary
 
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
+
     def test_missing_profile_after_dms_application(self):
         user = self.eligible_user(validate_phone=True, city=None)
         subscription_factories.BeneficiaryFraudCheckFactory(
@@ -1969,6 +2013,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
 
         assert not subscription_api.activate_beneficiary_if_no_missing_step(user)
         assert not user.is_beneficiary
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     def test_underage_ubble_valid_for_18(self):
         identity_firstname = "Yolan"
@@ -2128,6 +2179,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.amount == 30
         assert user.recreditAmountToShow == 30
 
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
+
     @time_machine.travel("2025-03-03")
     def test_pre_decree_at_17_when_registration_started_at_15(self):
         before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(days=1)
@@ -2145,6 +2203,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.type == finance_models.DepositType.GRANT_17_18
         assert user.deposit.amount == 20 + 0 + 50
         assert user.recreditAmountToShow == 70
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     @time_machine.travel("2025-03-03")
     def test_pre_decree_at_17_when_registration_started_at_16(self):
@@ -2164,6 +2229,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.amount == 30 + 50
         assert user.recreditAmountToShow == 80
 
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
+
     @time_machine.travel("2025-03-03")
     def test_pre_decree_at_16_when_registration_started_at_15(self):
         before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(days=1)
@@ -2182,6 +2254,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.amount == 20
         assert user.recreditAmountToShow == 20
 
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
+
     @time_machine.travel("2025-03-03")
     def test_pre_decree_18_eligibility(self):
         before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(days=1)
@@ -2196,6 +2275,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.is_beneficiary
         assert user.deposit.type == finance_models.DepositType.GRANT_18
         assert user.recreditAmountToShow == 300
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     @time_machine.travel("2025-03-03")
     def test_pre_decree_18_eligibility_at_19_year_old(self):
@@ -2212,6 +2298,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert is_user_activated
         assert user.is_beneficiary
         assert user.deposit.type == finance_models.DepositType.GRANT_18
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     @time_machine.travel("2025-03-03")
     def test_pre_decree_underage_transition_to_18(self):
@@ -2233,6 +2326,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.is_beneficiary
         assert user.deposit.type == finance_models.DepositType.GRANT_18
         assert user.recreditAmountToShow == 300
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     @time_machine.travel("2025-03-03")
     def test_pre_decree_underage_transition_to_18_ignores_false_age_18_fraud_checks(self):
@@ -2264,6 +2364,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.type == finance_models.DepositType.GRANT_18
         assert user.recreditAmountToShow == 300
 
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
+
     @time_machine.travel("2025-03-03")
     def test_underage_transition_to_18_after_decree(self):
         before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(days=1)
@@ -2285,6 +2392,16 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.type == finance_models.DepositType.GRANT_17_18
         assert user.recreditAmountToShow == 150
 
+        bonus_fraud_check_types = [
+            fraud_check.type
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert set(bonus_fraud_check_types) == {
+            subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+            subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+        }
+
     @pytest.mark.parametrize("age", [18, 19, 20])
     def test_post_decree_18_eligibility(self, age):
         user = users_factories.HonorStatementValidatedUserFactory(age=18)
@@ -2300,6 +2417,16 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         [recredit] = user.deposit.recredits
         assert recredit.recreditType == finance_models.RecreditType.RECREDIT_18
         assert user.recreditAmountToShow == 150
+
+        bonus_fraud_check_types = [
+            fraud_check.type
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert set(bonus_fraud_check_types) == {
+            subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+            subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+        }
 
     def test_post_decree_when_registration_started_at_16_before_decree(self):
         before_decree = settings.CREDIT_V3_DECREE_DATETIME - relativedelta(weeks=1)
@@ -2322,6 +2449,16 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.amount == 50 + 150
         assert user.recreditAmountToShow == 50 + 150
 
+        bonus_fraud_check_types = [
+            fraud_check.type
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert set(bonus_fraud_check_types) == {
+            subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+            subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+        }
+
     @pytest.mark.parametrize("age", [18, 19, 20])
     def test_post_decree_when_registration_started_at_17_after_decree(self, age):
         starting_age = 17
@@ -2342,6 +2479,37 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert set(recredit_types) == {finance_models.RecreditType.RECREDIT_17, finance_models.RecreditType.RECREDIT_18}
         assert user.recreditAmountToShow == 200
 
+        bonus_fraud_check_types = [
+            fraud_check.type
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert set(bonus_fraud_check_types) == {
+            subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+            subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+        }
+
+    @pytest.mark.features(ENABLE_BONUS_CREDIT=False)
+    def test_beneficiary_activation_respects_feature_flag(self):
+        user = users_factories.HonorStatementValidatedUserFactory(age=18)
+
+        is_user_activated = subscription_api.activate_beneficiary_if_no_missing_step(user)
+
+        assert is_user_activated
+        assert user.is_beneficiary
+        assert user.deposit.type == finance_models.DepositType.GRANT_17_18
+
+        [recredit] = user.deposit.recredits
+        assert recredit.recreditType == finance_models.RecreditType.RECREDIT_18
+        assert user.recreditAmountToShow == 150
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
+
     def test_free_eligibility(self):
         user = users_factories.ProfileCompletedUserFactory(age=16)
 
@@ -2352,6 +2520,13 @@ class ActivateBeneficiaryIfNoMissingStepTest:
         assert user.deposit.type == finance_models.DepositType.GRANT_FREE
         assert not user.deposit.recredits
         assert not mails_testing.outbox
+
+        bonus_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in subscription_models.BONUS_CREDIT_CHECK_TYPES
+        ]
+        assert not bonus_fraud_checks
 
     def test_user_with_old_fraud_checks_get_correct_deposit_and_role(self):
         """

--- a/api/tests/core/users/test_api.py
+++ b/api/tests/core/users/test_api.py
@@ -31,6 +31,7 @@ from pcapi.core.offers import factories as offers_factories
 from pcapi.core.subscription import api as subscription_api
 from pcapi.core.subscription import factories as subscription_factories
 from pcapi.core.subscription import models as subscription_models
+from pcapi.core.subscription.bonus import constants as bonus_constants
 from pcapi.core.subscription.bonus import schemas as bonus_schemas
 from pcapi.core.subscription.dms import schemas as dms_schemas
 from pcapi.core.testing import assert_num_queries
@@ -2102,3 +2103,16 @@ class DisabilityBonusCreditEligibilityTest:
             disability_bonification_status = users_api.get_user_disability_bonification_status(user)
 
         assert disability_bonification_status == bonus_schemas.DisabilityBonificationStatus.NOT_ELIGIBLE
+
+    def test_started_automatic_fraud_check_ignored(self):
+        user = users_factories.BeneficiaryFactory()
+        subscription_factories.AAHBonusCreditFraudCheckFactory(
+            user=user, status=subscription_models.FraudCheckStatus.STARTED, reason=f"{bonus_constants.AUTOMATIC_ORIGIN}"
+        )
+        subscription_factories.AEEHBonusCreditFraudCheckFactory(
+            user=user, status=subscription_models.FraudCheckStatus.STARTED, reason=f"{bonus_constants.AUTOMATIC_ORIGIN}"
+        )
+
+        disability_bonification_status = users_api.get_user_disability_bonification_status(user)
+
+        assert disability_bonification_status == bonus_schemas.DisabilityBonificationStatus.ELIGIBLE

--- a/api/tests/routes/internal/account_test.py
+++ b/api/tests/routes/internal/account_test.py
@@ -1,12 +1,17 @@
 import datetime
 import decimal
+from unittest.mock import call
+from unittest.mock import patch
 
 import pytest
 from dateutil.relativedelta import relativedelta
 
+from pcapi.core.subscription import factories as subscription_factories
+from pcapi.core.subscription import models as subscription_models
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
 from pcapi.models import db
+from pcapi.utils import date as date_utils
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -158,3 +163,55 @@ class E2EAccountAEEHConfigTest:
         user = users_factories.BeneficiaryFactory()
         response = auth_client.post(f"/e2e/account/{user.id}/aeeh", json={"mock_type": "RECIPIENT"})
         assert response.status_code == 200, response.json
+
+
+class E2EAccountBonusCreditRecoveryTest:
+    def test_recover_started_bonus_credit_applications_unauthorized(self, client):
+        response = client.post("/e2e/bonus_credit/1/recover")
+
+        assert response.status_code == 401
+
+    @pytest.mark.usefixtures("db_session")
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_adult_disability_bonus_task.delay")
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_disabled_child_education_bonus_task.delay")
+    def test_recover_started_bonus_credit_applications_full_page(
+        self, mocked_apply_for_aeeh_task, mocked_apply_for_aah_task, mocked_apply_for_qf_task, auth_client
+    ):
+        user = users_factories.BeneficiaryFactory()
+        next_year = date_utils.get_naive_utc_now() + relativedelta(years=1)
+        started_fraud_check_1 = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, user=user, resultContent={"next_retry_at": next_year}
+        )
+        started_fraud_check_2 = subscription_factories.QFBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, user=user, resultContent={"next_retry_at": next_year}
+        )
+        aah_fraud_check = subscription_factories.AAHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, user=user, resultContent={"next_retry_at": next_year}
+        )
+        aeeh_fraud_check = subscription_factories.AEEHBonusCreditFraudCheckFactory.create(
+            status=subscription_models.FraudCheckStatus.STARTED, user=user, resultContent={"next_retry_at": next_year}
+        )
+
+        response = auth_client.post(f"/e2e/bonus_credit/{user.id}/recover")
+
+        assert response.status_code == 200
+        assert response.json == {
+            "aah_bonus_credit": [aah_fraud_check.id],
+            "aeeh_bonus_credit": [aeeh_fraud_check.id],
+            "qf_bonus_credit": [started_fraud_check_1.id, started_fraud_check_2.id],
+        } or response.json == {
+            "aah_bonus_credit": [aah_fraud_check.id],
+            "aeeh_bonus_credit": [aeeh_fraud_check.id],
+            "qf_bonus_credit": [started_fraud_check_2.id, started_fraud_check_1.id],
+        }
+
+        mocked_apply_for_qf_task.assert_has_calls(
+            [
+                call(payload={"fraud_check_id": started_fraud_check_1.id}),
+                call(payload={"fraud_check_id": started_fraud_check_2.id}),
+            ],
+            any_order=True,
+        )
+        mocked_apply_for_aah_task.assert_has_calls([call(payload={"fraud_check_id": aah_fraud_check.id})])
+        mocked_apply_for_aeeh_task.assert_has_calls([call(payload={"fraud_check_id": aeeh_fraud_check.id})])

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -294,6 +294,7 @@ class UpdateProfileTest:
         expected_num_queries += 1  # recredit
         expected_num_queries += 1  # deposit (update)
         expected_num_queries += 1  # recredit (insert)
+        expected_num_queries += 1  # beneficiary_fraud_checks (insert)
         expected_num_queries += 1  # booking
         expected_num_queries += 1  # favorite
         expected_num_queries += 1  # achievement
@@ -924,39 +925,78 @@ class HonorStatementTest:
 
 
 class QuotientFamilialBonusTest:
+    @patch("pcapi.core.subscription.bonus.fraud_check_api._get_next_bonus_credit_retry_date")
     @patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
-    def test_create_qf_bonus_fraud_check(self, mocked_task, client, caplog):
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_adult_disability_bonus_task.delay")
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_disabled_child_education_bonus_task.delay")
+    def test_create_qf_bonus_fraud_check(
+        self,
+        mocked_apply_for_aeeh_task,
+        mocked_apply_for_aah_task,
+        mocked_apply_for_qf_task,
+        mocked_get_retry_date,
+        caplog,
+        client,
+    ):
         user = users_factories.BeneficiaryFactory()
+        result_content = {
+            "person": {
+                "last_name": user.lastName,
+                "first_names": [user.firstName],
+                "birth_date": user.birth_date.isoformat(),
+                "gender": "M.",
+            },
+        }
+        subscription_factories.AAHBonusCreditFraudCheckFactory(
+            user=user,
+            status=subscription_models.FraudCheckStatus.STARTED,
+            reason=bonus_constants.AUTOMATIC_ORIGIN,
+            resultContent=result_content,
+        )
+        subscription_factories.AEEHBonusCreditFraudCheckFactory(
+            user=user,
+            status=subscription_models.FraudCheckStatus.STARTED,
+            reason=bonus_constants.AUTOMATIC_ORIGIN,
+            resultContent=result_content,
+        )
+
+        now = date_utils.get_naive_utc_now()
+        tomorrow = now + relativedelta(days=1)
+        mocked_get_retry_date.return_value = tomorrow
 
         expected_num_queries = 1  # user
         expected_num_queries += 1  # deposit
         expected_num_queries += 1  # recredit
         expected_num_queries += 1  # beneficiary_fraud_check
-        expected_num_queries += 1  # beneficiary_fraud_check (insert)
+        expected_num_queries += 1  # beneficiary_fraud_check (insert qf)
+        expected_num_queries += 1  # beneficiary_fraud_check (update aah & aeeh)
         client.with_token(user)
-        with assert_num_queries(expected_num_queries):
-            with caplog.at_level(logging.INFO):
-                response = client.post(
-                    "/native/v1/subscription/bonus/quotient_familial",
-                    json={
-                        "lastName": "Lefebvre",
-                        "firstNames": ["Alexis"],
-                        "birthDate": "1982-12-27",
-                        "gender": "Mme",
-                        "birthCountryCogCode": "99100",
-                        "birthCityCogCode": "08480",
-                    },
-                )
+        with (
+            assert_num_queries(expected_num_queries),
+            caplog.at_level(logging.INFO),
+            time_machine.travel(now, tick=False),
+        ):
+            response = client.post(
+                "/native/v1/subscription/bonus/quotient_familial",
+                json={
+                    "lastName": "Lefebvre",
+                    "firstNames": ["Alexis"],
+                    "birthDate": "1982-12-27",
+                    "gender": "Mme",
+                    "birthCountryCogCode": "99100",
+                    "birthCityCogCode": "08480",
+                },
+            )
 
         assert response.status_code == 204, response.json
 
-        (bonus_fraud_check,) = [
+        (qf_fraud_check,) = [
             fraud_check
             for fraud_check in user.beneficiaryFraudChecks
             if fraud_check.type == subscription_models.FraudCheckType.QF_BONUS_CREDIT
         ]
-        assert bonus_fraud_check.status == subscription_models.FraudCheckStatus.STARTED
-        assert bonus_fraud_check.resultContent == {
+        assert qf_fraud_check.status == subscription_models.FraudCheckStatus.STARTED
+        assert qf_fraud_check.resultContent == {
             "custodian": {
                 "last_name": "Lefebvre",
                 "common_name": None,
@@ -966,10 +1006,37 @@ class QuotientFamilialBonusTest:
                 "birth_country_cog_code": "99100",
                 "birth_city_cog_code": "08480",
             },
+            "next_retry_at": tomorrow.isoformat(),
         }
+        mocked_apply_for_qf_task.assert_called_once_with({"fraud_check_id": qf_fraud_check.id})
 
-        mocked_task.assert_called_once()
-        mocked_task.assert_called_with({"fraud_check_id": bonus_fraud_check.id})
+        DISABILITY_FRAUD_CHECK_TYPES = [
+            subscription_models.FraudCheckType.AAH_BONUS_CREDIT,
+            subscription_models.FraudCheckType.AEEH_BONUS_CREDIT,
+        ]
+        disability_fraud_checks = [
+            fraud_check
+            for fraud_check in user.beneficiaryFraudChecks
+            if fraud_check.type in DISABILITY_FRAUD_CHECK_TYPES
+        ]
+        aah_fraud_check, aeeh_fraud_check = sorted(
+            disability_fraud_checks, key=lambda fraud_check: DISABILITY_FRAUD_CHECK_TYPES.index(fraud_check.type)
+        )
+        assert aah_fraud_check.type == subscription_models.FraudCheckType.AAH_BONUS_CREDIT
+        assert aeeh_fraud_check.type == subscription_models.FraudCheckType.AEEH_BONUS_CREDIT
+        assert aah_fraud_check.status == aeeh_fraud_check.status == subscription_models.FraudCheckStatus.STARTED
+        assert (
+            aah_fraud_check.reason
+            == aeeh_fraud_check.reason
+            == "automatic attempt, accelerated by /subscription/bonus/quotient_familial endpoint"
+        )
+        assert (
+            aah_fraud_check.resultContent["next_retry_at"]
+            == aeeh_fraud_check.resultContent["next_retry_at"]
+            == tomorrow.isoformat()
+        )
+        mocked_apply_for_aah_task.assert_called_once_with({"fraud_check_id": aah_fraud_check.id})
+        mocked_apply_for_aeeh_task.assert_called_once_with({"fraud_check_id": aeeh_fraud_check.id})
 
         route_call_record = caplog.records[0]
         assert route_call_record.deviceId == route_call_record.extra["deviceId"] == "[REDACTED]"
@@ -1038,8 +1105,7 @@ class QuotientFamilialBonusTest:
         assert response.status_code == 400
         assert response.json["code"] == "BONUS_NOT_ELIGIBLE"
 
-    @patch("pcapi.core.subscription.bonus.tasks.apply_for_quotient_familial_bonus_task.delay")
-    def test_create_bonus_fraud_check_eligible_after_one_failing_try(self, mocked_task, client):
+    def test_create_bonus_fraud_check_eligible_after_one_failing_try(self, client):
         user = users_factories.BeneficiaryFactory()
         subscription_factories.QFBonusCreditFraudCheckFactory(user=user, status=subscription_models.FraudCheckStatus.KO)
 
@@ -1170,8 +1236,12 @@ class QuotientFamilialBonusTest:
 class DisabilityBonusTest:
     @patch("pcapi.core.subscription.bonus.tasks.apply_for_adult_disability_bonus_task.delay")
     @patch("pcapi.core.subscription.bonus.tasks.apply_for_disabled_child_education_bonus_task.delay")
-    def test_create_disability_bonus_fraud_checks(self, mocked_aeeh_task, mocked_aah_task, client, caplog):
+    def test_create_disability_bonus_fraud_checks(
+        self, mocked_apply_for_aeeh_task, mocked_apply_for_aah_task, client, caplog
+    ):
         user = users_factories.BeneficiaryFactory()
+        now = date_utils.get_naive_utc_now()
+        tomorrow = now + relativedelta(days=1)
 
         expected_num_queries = 1  # user
         expected_num_queries += 1  # deposit
@@ -1179,15 +1249,18 @@ class DisabilityBonusTest:
         expected_num_queries += 1  # beneficiary_fraud_check
         expected_num_queries += 1  # beneficiary_fraud_check (insert)
         client.with_token(user)
-        with assert_num_queries(expected_num_queries):
-            with caplog.at_level(logging.INFO):
-                response = client.post(
-                    "/native/v1/subscription/bonus/disability",
-                    json={
-                        "birthCountryCogCode": "99100",
-                        "birthCityCogCode": "67482",  # Strasbourg
-                    },
-                )
+        with (
+            assert_num_queries(expected_num_queries),
+            caplog.at_level(logging.INFO),
+            time_machine.travel(now, tick=False),
+        ):
+            response = client.post(
+                "/native/v1/subscription/bonus/disability",
+                json={
+                    "birthCountryCogCode": "99100",
+                    "birthCityCogCode": "67482",  # Strasbourg
+                },
+            )
 
         assert response.status_code == 204, response.json
 
@@ -1219,14 +1292,11 @@ class DisabilityBonusTest:
                     "birth_country_cog_code": "99100",
                     "birth_city_cog_code": "67482",
                 },
+                "next_retry_at": tomorrow.isoformat(),
             }
         )
-
-        mocked_aah_task.assert_called_once()
-        mocked_aah_task.assert_called_with({"fraud_check_id": aah_fraud_check.id})
-
-        mocked_aeeh_task.assert_called_once()
-        mocked_aeeh_task.assert_called_with({"fraud_check_id": aeeh_fraud_check.id})
+        mocked_apply_for_aah_task.assert_called_once_with({"fraud_check_id": aah_fraud_check.id})
+        mocked_apply_for_aeeh_task.assert_called_once_with({"fraud_check_id": aeeh_fraud_check.id})
 
         route_call_record = caplog.records[0]
         assert route_call_record.deviceId == route_call_record.extra["deviceId"] == "[REDACTED]"


### PR DESCRIPTION
A single cron recovers all the ways to the bonus credit: through quotient familial or disability allowance. The cron will only be active during a few hours during the day, and there is a delay to prevent guessing the source of the bonus credit.

See RFC 34 for further info

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41968)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
