### PR TITLE
(DS-4154) feat: handle music platform IDs in artist synchronisation

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-22e9e95e4f11 (pre) (head)
+d4e5f6a7b8c9 (pre) (head)
 8499f0606e34 (post) (head)

--- a/api/src/pcapi/alembic/versions/20260717T000000_d4e5f6a7b8c9_add_music_ids_to_artist.py
+++ b/api/src/pcapi/alembic/versions/20260717T000000_d4e5f6a7b8c9_add_music_ids_to_artist.py
@@ -1,0 +1,36 @@
+"""add artist_music_platform table"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "d4e5f6a7b8c9"
+down_revision = "22e9e95e4f11"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "artist_music_platform",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, primary_key=True),
+        sa.Column(
+            "artist_id",
+            sa.Text(),
+            sa.ForeignKey("artist.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("spotify_id", sa.Text(), nullable=True),
+        sa.Column("isni_id", sa.Text(), nullable=True),
+        sa.Column("apple_music_id", sa.Text(), nullable=True),
+        sa.Column("deezer_id", sa.Text(), nullable=True),
+        sa.Column("genius_id", sa.Text(), nullable=True),
+        sa.Column("soundcloud_id", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("artist_music_platform", if_exists=True)

--- a/api/src/pcapi/connectors/big_query/importer/artist.py
+++ b/api/src/pcapi/connectors/big_query/importer/artist.py
@@ -173,7 +173,7 @@ class ArtistImporter:
                 file_id=model.mediation_uuid,
             )
 
-        return artist_models.Artist(
+        artist = artist_models.Artist(
             id=model.id,
             name=model.name,
             description=model.description,
@@ -185,6 +185,35 @@ class ArtistImporter:
             biography=model.biography,
             wikipedia_url=model.wikipedia_url,
             mediation_uuid=mediation_uuid,
+        )
+        if self._has_music_platform(model):
+            artist.music_platform = self._build_music_platform(model)
+        return artist
+
+    @staticmethod
+    def _has_music_platform(model: bq_artist_queries.ArtistModel) -> bool:
+        return any(
+            [
+                model.spotify_id,
+                model.isni_id,
+                model.apple_music_id,
+                model.deezer_id,
+                model.genius_id,
+                model.soundcloud_id,
+            ]
+        )
+
+    @staticmethod
+    def _build_music_platform(
+        model: bq_artist_queries.ArtistModel,
+    ) -> artist_models.ArtistMusicPlatform:
+        return artist_models.ArtistMusicPlatform(
+            spotify_id=model.spotify_id,
+            isni_id=model.isni_id,
+            apple_music_id=model.apple_music_id,
+            deezer_id=model.deezer_id,
+            genius_id=model.genius_id,
+            soundcloud_id=model.soundcloud_id,
         )
 
     @staticmethod
@@ -198,6 +227,18 @@ class ArtistImporter:
         artist.wikidata_id = delta_model.wikidata_id
         artist.biography = delta_model.biography
         artist.wikipedia_url = delta_model.wikipedia_url
+        if ArtistImporter._has_music_platform(delta_model):
+            if artist.music_platform:
+                artist.music_platform.spotify_id = delta_model.spotify_id
+                artist.music_platform.isni_id = delta_model.isni_id
+                artist.music_platform.apple_music_id = delta_model.apple_music_id
+                artist.music_platform.deezer_id = delta_model.deezer_id
+                artist.music_platform.genius_id = delta_model.genius_id
+                artist.music_platform.soundcloud_id = delta_model.soundcloud_id
+            else:
+                artist.music_platform = ArtistImporter._build_music_platform(delta_model)
+        else:
+            artist.music_platform = None
 
     def _apply_update_with_mediation(
         self, artist: artist_models.Artist, delta_model: bq_artist_queries.DeltaArtistModel

--- a/api/src/pcapi/connectors/big_query/queries/artist.py
+++ b/api/src/pcapi/connectors/big_query/queries/artist.py
@@ -24,6 +24,12 @@ class ArtistModel(BaseModelV2):
     biography: str | None = None
     wikipedia_url: str | None = None
     mediation_uuid: str | None = None
+    spotify_id: str | None = None
+    isni_id: str | None = None
+    apple_music_id: str | None = None
+    deezer_id: str | None = None
+    genius_id: str | None = None
+    soundcloud_id: str | None = None
 
 
 class DeltaArtistModel(ArtistModel):
@@ -44,6 +50,12 @@ class ArtistDeltaQuery(BaseQuery):
             artist_biography as biography,
             wikipedia_url,
             artist_mediation_uuid as mediation_uuid,
+            spotify_id,
+            isni_id,
+            apple_music_id,
+            deezer_id,
+            genius_id,
+            soundcloud_id,
             action
         FROM
             `{settings.BIG_QUERY_TABLE_BASENAME}.artist_delta`

--- a/api/src/pcapi/core/artist/factories.py
+++ b/api/src/pcapi/core/artist/factories.py
@@ -51,3 +51,16 @@ class ArtistOfferLinkFactory(BaseFactory):
         model = models.ArtistOfferLink
 
     artist_type = models.ArtistType.PERFORMER
+
+
+class ArtistMusicPlatformFactory(BaseFactory):
+    class Meta:
+        model = models.ArtistMusicPlatform
+
+    artist_id = factory.LazyAttribute(lambda o: o.artist.id if hasattr(o, "artist") else None)
+    spotify_id = None
+    isni_id = None
+    apple_music_id = None
+    deezer_id = None
+    genius_id = None
+    soundcloud_id = None

--- a/api/src/pcapi/core/artist/models.py
+++ b/api/src/pcapi/core/artist/models.py
@@ -97,6 +97,21 @@ class ArtistProductLink(PcObject, Model):
     )
 
 
+class ArtistMusicPlatform(PcObject, Model):
+    __tablename__ = "artist_music_platform"
+
+    artist_id: sa_orm.Mapped[str] = sa_orm.mapped_column(
+        sa.Text, sa.ForeignKey("artist.id", ondelete="CASCADE"), nullable=False, unique=True
+    )
+    artist: sa_orm.Mapped["Artist"] = sa_orm.relationship("Artist", back_populates="music_platform")
+    spotify_id: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
+    isni_id: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
+    apple_music_id: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
+    deezer_id: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
+    genius_id: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
+    soundcloud_id: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
+
+
 class Artist(Model):
     __tablename__ = "artist"
     aliases: sa_orm.Mapped[list["ArtistAlias"]] = sa_orm.relationship(
@@ -127,6 +142,9 @@ class Artist(Model):
     is_eligible_for_search: sa_orm.Mapped["bool"] = sa_orm.query_expression()
     # identifier of the artist image stored in object storage
     mediation_uuid: sa_orm.Mapped[str | None] = sa_orm.mapped_column(sa.Text, nullable=True)
+    music_platform: sa_orm.Mapped["ArtistMusicPlatform | None"] = sa_orm.relationship(
+        "ArtistMusicPlatform", back_populates="artist", uselist=False, cascade="all, delete-orphan"
+    )
     name: sa_orm.Mapped[str] = sa_orm.mapped_column(sa.Text, nullable=False, index=True)
     products: sa_orm.Mapped[list["Product"]] = sa_orm.relationship(
         "Product", back_populates="artists", secondary=ArtistProductLink.__table__

--- a/api/src/pcapi/db_utils.py
+++ b/api/src/pcapi/db_utils.py
@@ -74,6 +74,7 @@ tables_to_clean: list[type[Model]] = [
     highlights_models.HighlightRequest,
     highlights_models.Highlight,
     achievements_models.Achievement,
+    artist_models.ArtistMusicPlatform,
     artist_models.Artist,
     artist_models.ArtistAlias,
     artist_models.ArtistProductLink,

--- a/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/test_cases/__init__.py
@@ -336,6 +336,15 @@ def create_artists() -> None:
         image_license="CC BY 2.0",
         image_license_url="https://creativecommons.org/licenses/by/2.0",
     )
+    artist_factories.ArtistMusicPlatformFactory.create(
+        artist_id=artist_2.id,
+        spotify_id="0p4nmQO2msCgU4IF37Wi3j",
+        isni_id="0000000114946276",
+        apple_music_id="459885",
+        deezer_id="35",
+        genius_id="Avril-lavigne",
+        soundcloud_id="avrillavigne",
+    )
     for _ in range(10):
         product = offers_factories.ProductFactory.create(subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id)
         offer = offers_factories.OfferFactory.create(product=product, venue=venue)
@@ -382,6 +391,14 @@ def create_artists() -> None:
         image_license="CC BY 2.0",
         image_license_url="https://creativecommons.org/licenses/by/2.0",
     )
+    artist_factories.ArtistMusicPlatformFactory.create(
+        artist_id=artist_4.id,
+        spotify_id="7IlRNXHjoOCgEAWN5qYksg",
+        isni_id="0000000462953608",
+        apple_music_id="1042004371",
+        deezer_id="8909272",
+        genius_id="Aya-nakamura",
+    )
     _create_offers_for_artist(
         venue, artist_4, subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id, ArtistType.PERFORMER, count=2
     )
@@ -395,6 +412,15 @@ def create_artists() -> None:
         image="https://upload.wikimedia.org/wikipedia/commons/thumb/4/48/Clara_Luciani%2C_Singer_Songwriter%2C_at_82nd_Venice_International_Film_Festival_in_Venice%2C_Italy.-1.jpg/500px-Clara_Luciani%2C_Singer_Songwriter%2C_at_82nd_Venice_International_Film_Festival_in_Venice%2C_Italy.-1.jpg",
         image_license="CC BY-SA 4.0",
         image_license_url="https://creativecommons.org/licenses/by-sa/4.0",
+    )
+    artist_factories.ArtistMusicPlatformFactory.create(
+        artist_id=artist_5.id,
+        spotify_id="2oVrruuEI0Dr2I4NvLtQS0",
+        apple_music_id="1178021987",
+        isni_id="0000000466535577",
+        deezer_id="4889156",
+        genius_id="Clara-luciani",
+        soundcloud_id="claraluciani",
     )
     _create_offers_for_artist(
         venue, artist_5, subcategories.SUPPORT_PHYSIQUE_MUSIQUE_VINYLE.id, ArtistType.PERFORMER, count=2
@@ -415,6 +441,15 @@ def create_artists() -> None:
         image="https://commons.wikimedia.org/wiki/Special:FilePath/Le_chanteur_Stromae.jpg",
         image_license="CC BY-SA 2.0",
         image_license_url="https://creativecommons.org/licenses/by-sa/2.0",
+    )
+    artist_factories.ArtistMusicPlatformFactory.create(
+        artist_id=artist_6.id,
+        spotify_id="5j4HeCoUlzhfWtjAfM1acR",
+        isni_id="0000000084160095",
+        apple_music_id="270954369",
+        deezer_id="310260",
+        genius_id="Stromae",
+        soundcloud_id="STROMAE",
     )
     _create_offers_for_artist(
         venue, artist_6, subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id, ArtistType.PERFORMER, count=3

--- a/api/tests/core/artist/test_commands.py
+++ b/api/tests/core/artist/test_commands.py
@@ -46,6 +46,12 @@ class UpdateArtistsFromDeltaTest:
                 wikipedia_url="Wikipedia du nouvel artiste",
                 wikidata_id="Q123456",
                 mediation_uuid="new-uuid",
+                spotify_id="spotify_id_nouvel_artiste",
+                isni_id="isni_id_nouvel_artiste",
+                apple_music_id="apple_music_id_nouvel_artiste",
+                deezer_id="deezer_id_nouvel_artiste",
+                genius_id="genius_id_nouvel_artiste",
+                soundcloud_id="soundcloud_id_nouvel_artiste",
                 action=DeltaAction.ADD,
             ),
             DeltaArtistModel(id=artist_to_delete.id, action=DeltaAction.REMOVE, name="Artist to Delete"),
@@ -65,6 +71,13 @@ class UpdateArtistsFromDeltaTest:
         assert new_artist.wikipedia_url == "Wikipedia du nouvel artiste"
         assert new_artist.wikidata_id == "Q123456"
         assert new_artist.mediation_uuid == "new-uuid"
+        assert new_artist.music_platform is not None
+        assert new_artist.music_platform.spotify_id == "spotify_id_nouvel_artiste"
+        assert new_artist.music_platform.isni_id == "isni_id_nouvel_artiste"
+        assert new_artist.music_platform.apple_music_id == "apple_music_id_nouvel_artiste"
+        assert new_artist.music_platform.deezer_id == "deezer_id_nouvel_artiste"
+        assert new_artist.music_platform.genius_id == "genius_id_nouvel_artiste"
+        assert new_artist.music_platform.soundcloud_id == "soundcloud_id_nouvel_artiste"
 
     @patch("pcapi.connectors.big_query.queries.artist.ArtistProductLinkDeltaQuery.execute")
     def test_updates_and_creates_artist_product_links(self, mock_link_delta_query):
@@ -121,6 +134,12 @@ class UpdateArtistsFromDeltaTest:
                 wikipedia_url="https://fr.wikipedia.org/wiki/Rick_Astley",
                 biography="Rick Astley est un chanteur britannique né le 6 février 1966 à Newton-le-Willows...",
                 mediation_uuid=mediation_uuid,
+                spotify_id="spotify_id_rick_astley",
+                isni_id="isni_id_rick_astley",
+                apple_music_id="apple_music_id_rick_astley",
+                deezer_id="deezer_id_rick_astley",
+                genius_id="genius_id_rick_astley",
+                soundcloud_id="soundcloud_id_rick_astley",
                 action=DeltaAction.UPDATE,
             ),
         ]
@@ -137,6 +156,13 @@ class UpdateArtistsFromDeltaTest:
             == "Rick Astley est un chanteur britannique né le 6 février 1966 à Newton-le-Willows..."
         )
         assert artist_to_update.mediation_uuid == mediation_uuid
+        assert artist_to_update.music_platform is not None
+        assert artist_to_update.music_platform.spotify_id == "spotify_id_rick_astley"
+        assert artist_to_update.music_platform.isni_id == "isni_id_rick_astley"
+        assert artist_to_update.music_platform.apple_music_id == "apple_music_id_rick_astley"
+        assert artist_to_update.music_platform.deezer_id == "deezer_id_rick_astley"
+        assert artist_to_update.music_platform.genius_id == "genius_id_rick_astley"
+        assert artist_to_update.music_platform.soundcloud_id == "soundcloud_id_rick_astley"
 
     @patch("pcapi.connectors.big_query.queries.artist.ArtistDeltaQuery.execute")
     def test_update_action_does_nothing_for_non_existent_artist(self, mock_artist_delta_query):


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Notion](https://app.notion.com/p/passcultureapp/DS-ID-artistes-Cr-er-les-colonnes-c-t-back-end-et-Mettre-jour-la-synchronisation-32bad4e0ff98834f8c10014c16699c9c?v=21cad4e0ff9880bbb75b000ccde7bad7&source=copy_link)

> Les artistes peuvent être rattachés à plusieurs plateformes musicales (Spotify, Deezer, Apple Music, etc.). Cette PR ajoute une table dédiée `artist_music_platform` et branche sa synchronisation depuis le pipeline BigQuery (delta import).

### 🔧 Changements

#### `06ccd6e` feat: create alembic migration to add music platform IDs to artist
- Nouvelle table `artist_music_platform` (migration `pre`) : PK `id` BigInteger auto-incrémenté, FK `artist_id → artist.id CASCADE` avec contrainte `UNIQUE`, 6 colonnes nullable : `spotify_id`, `isni_id`, `apple_music_id`, `deezer_id`, `genius_id`, `soundcloud_id`
- Nouveau modèle SQLAlchemy `ArtistMusicPlatformIds` héritant de `PcObject` (relation 1-to-1 avec `Artist` via `artist_id unique`, `cascade="all, delete-orphan"`)
- Relation `music_platform_ids` ajoutée sur `Artist`

#### `20d29cb` feat: handle music platform IDs in artist synchronisation
- `ArtistModel` / `ArtistDeltaQuery` : ajout des 6 champs dans le modèle Pydantic et dans la requête SQL BigQuery
- `ArtistImporter` : nouvelles méthodes `_has_music_platform_ids` et `_build_music_platform_ids` ; gestion create/update/clear dans `_build_artist` et `_apply_update`
- `ArtistMusicPlatformIdsFactory` ajoutée dans `factories.py`
- Tests : vérification de la création et de la mise à jour de `music_platform_ids` dans `test_commands.py`

#### `7981743` feat: update sandbox with music platform IDs for artists
- 4 artistes de sandbox enrichis avec des IDs réels (Avril Lavigne, Aya Nakamura, Clara Luciani, Stromae)

### 🧪 Comment tester
- Lancer les tests existants : `pytest api/tests/core/artist/test_commands.py`
- Vérifier la migration en local : `alembic upgrade head` puis `alembic downgrade -1`
- En sandbox : `flask sandbox --name test_cases` et vérifier que les artistes ont bien des entrées dans `artist_music_platform`

---
**🧭 Review effort : 2/5** — _Diff modéré (184 lignes), logique de synchronisation avec 3 branches conditionnelles dans `_apply_update`, migration de schéma impliquant une nouvelle table._

**🗂️ Walkthrough**

| Fichier(s) | Résumé |
|---|---|
| `alembic/versions/20260717T000000_d4e5f6a7b8c9_add_music_ids_to_artist.py` | Migration `pre` : création/suppression de `artist_music_platform` |
| `core/artist/models.py` | Nouveau modèle `ArtistMusicPlatformIds` + relation sur `Artist` |
| `connectors/big_query/queries/artist.py` | Ajout des 6 champs plateforme dans `ArtistModel` et la requête SQL delta |
| `connectors/big_query/importer/artist.py` | Logique create/update/clear de `music_platform_ids` lors du delta import |
| `core/artist/factories.py` | `ArtistMusicPlatformIdsFactory` pour les tests |
| `tests/core/artist/test_commands.py` | Couverture ADD et UPDATE avec `music_platform_ids` |
| `sandboxes/.../test_cases/__init__.py` | 4 artistes sandbox avec des IDs plateforme réels |