### PR TITLE
(PC-42725)[PRO] fix: use same value from back width/height

### DIFF
--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
@@ -101,6 +101,34 @@ describe('ModalImageUpsertOrEdit', () => {
     expect(screen.getByRole('button', { name: 'Importer' })).toBeInTheDocument()
   })
 
+  it('should enforce 400x600 minimum dimensions in collective offer mode', async () => {
+    renderModalImageCrop({
+      mode: UploaderModeEnum.OFFER_COLLECTIVE,
+      initialValues: {},
+    })
+
+    await waitForRender()
+
+    const imageFile = Object.assign(
+      new File(['test'], 'test-image.jpg', { type: 'image/jpeg' }),
+      {
+        width: 500,
+        height: 500,
+      }
+    )
+
+    await userEvent.upload(screen.getByLabelText('Importez une image'), [
+      imageFile,
+    ])
+
+    expect(
+      await screen.findByText('L’image doit faire au moins 600 pixels de haut')
+    ).toBeVisible()
+    expect(
+      screen.queryByText('L’image doit faire au moins 400 pixels de large')
+    ).not.toBeInTheDocument()
+  })
+
   it('should render a spinner until the image is loaded', async () => {
     const mockImageUrl = 'http://example.com/image.jpg'
     renderModalImageCrop({

--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.tsx
@@ -363,14 +363,14 @@ export const ModalImageUpsertOrEdit = ({
           {!isLoadingImage && !image && (
             <ImageDragAndDrop
               onDropOrSelected={onImageReplacementDropOrSelected}
-              {...(mode === UploaderModeEnum.OFFER
-                ? {}
-                : {
+              {...(mode === UploaderModeEnum.OFFER_COLLECTIVE
+                ? {
                     minSizes: {
-                      width: 600,
-                      height: 400,
+                      width: 400,
+                      height: 600,
                     },
-                  })}
+                  }
+                : {})}
             />
           )}
         </div>


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42725)

Les vérifications sur la taille de l'image ne sont pas les mêmes que côté back donc on aligne côté front 

<img width="2360" height="1052" alt="image" src="https://github.com/user-attachments/assets/f8967dbf-2857-424c-9f84-72e237ce7203" />
