### PR TITLE
(PC-41903)[API] feat: to_many_retries for AAH/AEEH

### DIFF
--- a/api/src/pcapi/core/users/api.py
+++ b/api/src/pcapi/core/users/api.py
@@ -1465,7 +1465,7 @@ def get_user_is_eligible_for_qf_bonification(user: models.User, *, is_from_backo
             bonus_schemas.QFBonificationStatus.TOO_MANY_RETRIES,
             bonus_schemas.QFBonificationStatus.STARTED,
         }
-    return deposit_api.can_receive_bonus_credit(user) and get_user_qf_bonification_status(user) not in excluded_statuses
+    return get_user_qf_bonification_status(user) not in excluded_statuses
 
 
 def get_user_is_eligible_for_disability_bonification(user: models.User, *, is_from_backoffice: bool = False) -> bool:
@@ -1478,10 +1478,7 @@ def get_user_is_eligible_for_disability_bonification(user: models.User, *, is_fr
             bonus_schemas.DisabilityBonificationStatus.TOO_MANY_RETRIES,
             bonus_schemas.DisabilityBonificationStatus.STARTED,
         }
-    return (
-        deposit_api.can_receive_bonus_credit(user)
-        and get_user_disability_bonification_status(user) not in excluded_statuses
-    )
+    return get_user_disability_bonification_status(user) not in excluded_statuses
 
 
 def get_bonus_credit_fraud_checks(
@@ -1635,6 +1632,17 @@ def get_user_disability_bonification_status(user: models.User) -> bonus_schemas.
 
     if aah_fraud_check_status == subscription_models.FraudCheckStatus.KO:
         reason_codes = (aah_bonus_fraud_check.reasonCodes if aah_bonus_fraud_check else None) or []
+
+        if aah_bonus_fraud_check:
+            fraud_created_date_in_user_departement_tz = date_utils.utc_datetime_to_department_timezone(
+                aah_bonus_fraud_check.dateCreated, user.departementCode
+            ).date()
+            today_user_departement_tz = date_utils.utc_datetime_to_department_timezone(
+                date_utils.get_naive_utc_now(), user.departementCode
+            ).date()
+            # normally, fraud_created_date_in_user_departement_tz can't be > today, but you never know.
+            if fraud_created_date_in_user_departement_tz >= today_user_departement_tz:
+                return bonus_schemas.DisabilityBonificationStatus.TOO_MANY_RETRIES
 
         if subscription_models.FraudReasonCode.PERSON_NOT_FOUND in reason_codes:
             return bonus_schemas.DisabilityBonificationStatus.PERSON_NOT_FOUND

--- a/api/tests/routes/native/v1/account_test.py
+++ b/api/tests/routes/native/v1/account_test.py
@@ -672,17 +672,19 @@ class AccountTest:
     def test_get_user_profile_bonification_disability_status_ko(
         self, client, reason_code, expected_disability_bonification_status
     ):
-        user = users_factories.BeneficiaryFactory(age=18)
-        subscription_factories.AAHBonusCreditFraudCheckFactory(
-            status=subscription_models.FraudCheckStatus.KO,
-            reasonCodes=[reason_code],
-            user=user,
-        )
-        subscription_factories.AEEHBonusCreditFraudCheckFactory(
-            status=subscription_models.FraudCheckStatus.KO,
-            reasonCodes=[reason_code],
-            user=user,
-        )
+        # Need travel on yesterday to avoid too_many_retries
+        with time_machine.travel(date_utils.get_naive_utc_now() - relativedelta(days=1)):
+            user = users_factories.BeneficiaryFactory(age=18)
+            subscription_factories.AAHBonusCreditFraudCheckFactory(
+                status=subscription_models.FraudCheckStatus.KO,
+                reasonCodes=[reason_code],
+                user=user,
+            )
+            subscription_factories.AEEHBonusCreditFraudCheckFactory(
+                status=subscription_models.FraudCheckStatus.KO,
+                reasonCodes=[reason_code],
+                user=user,
+            )
         response = client.with_token(user).get("/native/v1/me")
         assert response.status_code == 200
         assert response.json["disabilityBonificationStatus"] == expected_disability_bonification_status.value
@@ -695,7 +697,7 @@ class AccountTest:
         assert response.json["qfBonificationStatus"] == bonus_schemas.QFBonificationStatus.GRANTED.value
         assert response.json["disabilityBonificationStatus"] == bonus_schemas.DisabilityBonificationStatus.GRANTED.value
 
-    def test_get_user_profile_bonification_status_too_many_retries(self, client):
+    def test_get_user_profile_bonification_qf_status_too_many_retries(self, client):
         user = users_factories.BeneficiaryFactory(age=18)
         subscription_factories.QFBonusCreditFraudCheckFactory.create_batch(
             size=users_constants.MAX_QF_BONUS_RETRIES,
@@ -706,6 +708,20 @@ class AccountTest:
         response = client.with_token(user).get("/native/v1/me")
         assert response.status_code == 200
         assert response.json["qfBonificationStatus"] == bonus_schemas.QFBonificationStatus.TOO_MANY_RETRIES.value
+
+    def test_get_user_profile_bonification_disability_status_too_many_retries(self, client):
+        user = users_factories.BeneficiaryFactory(age=18)
+        subscription_factories.AAHBonusCreditFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.KO, user=user
+        )
+        subscription_factories.AEEHBonusCreditFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.KO, user=user
+        )
+        response = client.with_token(user).get("/native/v1/me")
+        assert response.status_code == 200
+        assert (
+            response.json["disabilityBonificationStatus"] == bonus_schemas.QFBonificationStatus.TOO_MANY_RETRIES.value
+        )
 
     def test_get_user_profile_bonification_status_is_not_eligible_for_under_17(self, client):
         user = users_factories.BeneficiaryFactory(age=17)

--- a/api/tests/routes/native/v1/subscription_test.py
+++ b/api/tests/routes/native/v1/subscription_test.py
@@ -1270,16 +1270,42 @@ class DisabilityBonusTest:
         assert response.status_code == 400
         assert response.json["code"] == "BONUS_NOT_ELIGIBLE"
 
-    @patch("pcapi.core.subscription.bonus.tasks.apply_for_adult_disability_bonus_task.delay")
-    @patch("pcapi.core.subscription.bonus.tasks.apply_for_disabled_child_education_bonus_task.delay")
-    def test_create_bonus_fraud_check_eligible_after_one_failing_try(self, mocked_aeeh_task, mocked_aah_task, client):
+    def test_not_eligible_if_too_many_retries_after_one_failing_try_on_today(self, client):
         user = users_factories.BeneficiaryFactory()
         subscription_factories.AAHBonusCreditFraudCheckFactory(
             user=user, status=subscription_models.FraudCheckStatus.KO
         )
         subscription_factories.AEEHBonusCreditFraudCheckFactory(
-            user=user, status=subscription_models.FraudCheckStatus.KO
+            user=user,
+            status=subscription_models.FraudCheckStatus.KO,
         )
+
+        response = client.with_token(user).post(
+            "/native/v1/subscription/bonus/disability",
+            json={
+                "birthCountryCogCode": "99100",
+                "birthCityCogCode": "67482",  # Strasbourg
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json["code"] == "BONUS_NOT_ELIGIBLE"
+
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_adult_disability_bonus_task.delay")
+    @patch("pcapi.core.subscription.bonus.tasks.apply_for_disabled_child_education_bonus_task.delay")
+    def test_create_bonus_fraud_check_eligible_after_one_failing_try_on_previous_days(
+        self, mocked_aeeh_task, mocked_aah_task, client
+    ):
+
+        with time_machine.travel(date_utils.get_naive_utc_now() - relativedelta(days=1)):
+            user = users_factories.BeneficiaryFactory()
+            subscription_factories.AAHBonusCreditFraudCheckFactory(
+                user=user, status=subscription_models.FraudCheckStatus.KO
+            )
+            subscription_factories.AEEHBonusCreditFraudCheckFactory(
+                user=user,
+                status=subscription_models.FraudCheckStatus.KO,
+            )
 
         response = client.with_token(user).post(
             "/native/v1/subscription/bonus/disability",


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41903)

La condition sur la date c'est pas idéal car ça ne tient pas compte du fuseau horaire de l'utilisateur. 
On pourrait mettre 24h mais ce n'est pas terrible non plus....et en front c'est écrit "Prochaine demande possible demain". 

Déjà vu avec @dnguyen-pass, idéalement le too-many-retries devrait surement ne pas être un statut car il masque la raison du KO mais actuellement on est un peu coincé, on changera plus tard si besoin. 
