### PR TITLE
(DS-4274)[API] refactor: remove pre ingestion checks since they are done in Bigquery now

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/event_series.py
+++ b/api/src/pcapi/connectors/big_query/queries/event_series.py
@@ -70,17 +70,3 @@ class EventSeriesOfferLinkDeltaQuery(BaseQuery):
         offer_id;
     """
     model = DeltaEventSeriesOfferLinkModel
-
-
-class EventSeriesPreIngestionChecksModel(BaseModelV2):
-    ready_for_ingestion: bool
-
-
-class EventSeriesPreIngestionChecksQuery(BaseQuery):
-    raw_query = f"""
-        SELECT
-            ready_for_ingestion
-        FROM
-            `{settings.BIG_QUERY_TABLE_BASENAME}.event_series_pre_ingestion_checks`
-    """
-    model = EventSeriesPreIngestionChecksModel

--- a/api/src/pcapi/core/event_series/commands.py
+++ b/api/src/pcapi/core/event_series/commands.py
@@ -5,7 +5,6 @@ import click
 import pcapi.utils.cron as cron_decorators
 from pcapi.connectors.big_query.importer.event_series import EventSeriesImporter
 from pcapi.connectors.big_query.importer.event_series import EventSeriesOfferLinkImporter
-from pcapi.connectors.big_query.queries.event_series import EventSeriesPreIngestionChecksQuery
 from pcapi.models.feature import FeatureToggle
 from pcapi.utils.blueprint import Blueprint
 
@@ -19,13 +18,6 @@ logger = logging.getLogger(__name__)
 @cron_decorators.cron_require_feature(FeatureToggle.SYNCHRONIZE_EVENT_SERIES_FROM_BIGQUERY_TABLES)
 def update_event_series_from_delta(batch_size: int) -> None:
     logger.info("Starting event series update from delta tables...")
-
-    checks = next(EventSeriesPreIngestionChecksQuery().execute(), None)
-    if checks is None or not checks.ready_for_ingestion:
-        logger.warning("Data is not ready to be ingested. Skipping Event Series ingestion.")
-        return
-
-    logger.info("Event series data is ready to be ingested. Starting ingestion...")
     EventSeriesImporter().run_delta_update(batch_size)
     EventSeriesOfferLinkImporter().run_delta_update(batch_size)
     logger.info("Event series update from delta tables finished successfully.")

--- a/api/tests/core/event_series/test_commands.py
+++ b/api/tests/core/event_series/test_commands.py
@@ -143,62 +143,14 @@ class UpdateEventSeriesFromDeltaTest:
         assert series1.name == "New Name 1"
         assert series2.name == "New Name 2"
 
-    @patch("pcapi.core.event_series.commands.EventSeriesPreIngestionChecksQuery.execute")
     @patch("pcapi.core.event_series.commands.EventSeriesImporter.run_delta_update")
     @patch("pcapi.core.event_series.commands.EventSeriesOfferLinkImporter.run_delta_update")
-    def test_update_command_skips_ingestion_when_not_ready(
+    def test_update_command_runs_importers(
         self,
         mock_link_importer,
         mock_series_importer,
-        mock_pre_checks,
-        run_command,
-        caplog,
-    ):
-        from pcapi.connectors.big_query.queries.event_series import EventSeriesPreIngestionChecksModel
-
-        mock_pre_checks.return_value = iter([EventSeriesPreIngestionChecksModel(ready_for_ingestion=False)])
-
-        with caplog.at_level(logging.WARNING):
-            run_command("update_event_series_from_delta")
-
-        assert "not ready to be ingested" in caplog.text
-        mock_series_importer.assert_not_called()
-        mock_link_importer.assert_not_called()
-
-    @patch("pcapi.core.event_series.commands.EventSeriesPreIngestionChecksQuery.execute")
-    @patch("pcapi.core.event_series.commands.EventSeriesImporter.run_delta_update")
-    @patch("pcapi.core.event_series.commands.EventSeriesOfferLinkImporter.run_delta_update")
-    def test_update_command_skips_ingestion_when_no_checks_found(
-        self,
-        mock_link_importer,
-        mock_series_importer,
-        mock_pre_checks,
-        run_command,
-        caplog,
-    ):
-        mock_pre_checks.return_value = iter([])
-
-        with caplog.at_level(logging.WARNING):
-            run_command("update_event_series_from_delta")
-
-        assert "not ready to be ingested" in caplog.text
-        mock_series_importer.assert_not_called()
-        mock_link_importer.assert_not_called()
-
-    @patch("pcapi.core.event_series.commands.EventSeriesPreIngestionChecksQuery.execute")
-    @patch("pcapi.core.event_series.commands.EventSeriesImporter.run_delta_update")
-    @patch("pcapi.core.event_series.commands.EventSeriesOfferLinkImporter.run_delta_update")
-    def test_update_command_proceeds_when_ready(
-        self,
-        mock_link_importer,
-        mock_series_importer,
-        mock_pre_checks,
         run_command,
     ):
-        from pcapi.connectors.big_query.queries.event_series import EventSeriesPreIngestionChecksModel
-
-        mock_pre_checks.return_value = iter([EventSeriesPreIngestionChecksModel(ready_for_ingestion=True)])
-
         run_command("update_event_series_from_delta", "--batch-size", "50")
 
         mock_series_importer.assert_called_once_with(50)


### PR DESCRIPTION
## 🎯 Related Ticket

[DS-4274](https://app.notion.com/p/passcultureapp/880351701699470cb129e4e0ad6bbcba?v=2b1ad4e0ff9880b881b6000c2d6b48a0&p=39fad4e0ff9880aba416c2649bd90e1a&pm=s)

> Les checks de pré-ingestion des event series étaient dupliqués : ils sont maintenant effectués directement côté Bigquery en amont. On peut donc supprimer cette vérification côté API pour simplifier le flux d'ingestion.

### 🔧 Changements
- Suppression de `EventSeriesPreIngestionChecksQuery` / `EventSeriesPreIngestionChecksModel` (`event_series.py`)
- `update_event_series_from_delta` lance directement les imports (`EventSeriesImporter`, `EventSeriesOfferLinkImporter`) sans vérifier `ready_for_ingestion`
- Mise à jour des tests : suppression des scénarios "skip" (not ready / no checks found), le test restant vérifie simplement que les importers sont bien appelés

### 🧪 Comment tester
- `pytest api/tests/core/event_series/test_commands.py` doit passer
- Vérifier en preview que la commande `update_event_series_from_delta` s'exécute sans erreur

---
**🧭 Review effort : 1/5** — _suppression nette d'un check devenu redondant, diff petit et localisé, tests ajustés en conséquence._