### PR TITLE
(BSR)[PRO] feat: BaseDialog implementation

### DIFF
--- a/pro/knip.json
+++ b/pro/knip.json
@@ -13,7 +13,7 @@
     "scripts/customRequest.ts",
     "scripts/format_generated_index_exports.js",
     "scripts/sanitize_enum_keys.js",
-    "src/design-system/Dropdown/Dropdown.tsx"
+    "src/ui-kit/BaseDialog/BaseDialog.tsx"
   ],
   "ignoreDependencies": ["openapi-typescript-codegen"],
   "ignoreUnresolved": ["typescript-plugin-css-modules"],

--- a/pro/src/ui-kit/BaseDialog/BaseDialog.module.scss
+++ b/pro/src/ui-kit/BaseDialog/BaseDialog.module.scss
@@ -1,0 +1,20 @@
+@use "styles/mixins/_rem.scss" as rem;
+
+.base-dialog {
+  // Reset the browser's default styles on the <dialog> tag
+  border: none;
+  background: transparent;
+  margin: auto;
+  overflow: visible;
+
+  // Remove the browser's default outline (the outline will be handled by inner focusable elements)
+  &:focus-visible {
+    outline: none;
+  }
+
+  // Default backdrop configuration (the darkened background)
+  &::backdrop {
+    background-color: var(--color-background-overlay);
+    backdrop-filter: blur(4px); // Modern blur effect
+  }
+}

--- a/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
+++ b/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
@@ -1,0 +1,99 @@
+import type React from 'react'
+import { useEffect, useRef } from 'react'
+
+import styles from './BaseDialog.module.scss'
+
+/** @lintignore Will be used later in future <ModalSimple> and <ModalDetailed> components */
+export interface BaseDialogProps {
+  /**
+   * Determines whether the modal is open or closed.
+   */
+  isOpen: boolean
+  /**
+   * Callback triggered to close the modal (Escape key, backdrop click, etc.).
+   * It is up to the parent to update the `isOpen` state in return.
+   */
+  onClose: () => void
+  /**
+   * Identifier of the modal's title element for screen readers (aria-labelledby).
+   */
+  ariaLabelledBy?: string
+  /**
+   * Identifier of the description element for screen readers (aria-describedby).
+   */
+  ariaDescribedBy?: string
+  /**
+   * Modal content.
+   */
+  children: React.ReactNode
+}
+
+/**
+ * Base component wrapping the native HTML5 `<dialog>` element.
+ * It handles open state synchronization, keyboard accessibility (Escape),
+ * the native focus trap, and closing on backdrop click.
+ *
+ * This component does not embed any complex visual style (borders, backgrounds, paddings)
+ * so as to provide a neutral base for specialized modals (SimpleModal, DetailedModal).
+ */
+export const BaseDialog = ({
+  isOpen,
+  onClose,
+  ariaLabelledBy,
+  ariaDescribedBy,
+  children,
+}: BaseDialogProps): JSX.Element => {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  // Synchronizes React's open/closed state with the imperative APIs of the <dialog> tag
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    if (isOpen) {
+      if (!dialog.open) {
+        dialog.showModal()
+      }
+    } else if (dialog.open) {
+      dialog.close()
+    }
+  }, [isOpen])
+
+  // Prevents the browser's default auto-close behavior
+  // so that React controls the state via the `onClose` callback
+  const handleCancel = (e: React.SyntheticEvent<HTMLDialogElement>) => {
+    e.preventDefault()
+    onClose()
+  }
+
+  // Close on backdrop click (Light Dismiss)
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
+    const dialog = dialogRef.current
+    if (!dialog || e.target !== dialog) return
+
+    const rect = dialog.getBoundingClientRect()
+    const isClickInside =
+      rect.top <= e.clientY &&
+      e.clientY <= rect.top + rect.height &&
+      rect.left <= e.clientX &&
+      e.clientX <= rect.left + rect.width
+
+    if (!isClickInside) {
+      onClose()
+    }
+  }
+
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click is pointer-only; keyboard dismissal is handled via onCancel (Escape)
+    <dialog
+      ref={dialogRef}
+      onCancel={handleCancel}
+      onClick={handleBackdropClick}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+      className={styles['base-dialog']}
+    >
+      {children}
+    </dialog>
+  )
+}


### PR DESCRIPTION
## 🔧 Changes Made

> Introduction d'un composant de base `<BaseDialog>` s'appuyant sur l'élément natif HTML5 `<dialog>`, pour préparer la migration des modales actuellement basées sur Radix (`DialogBuilder`, `Dialog`, etc.) vers une implémentation native plus légère, avec focus trap et fermeture Escape/backdrop gérés par le navigateur.

> [!NOTE]
> **Exemple d'implémentation** sur cette PR en draft : https://github.com/pass-culture/pass-culture-main/pull/23669


### 🔧 Changements
- Nouveau composant `BaseDialog` (`ui-kit/BaseDialog/BaseDialog.tsx`) : synchronisation `isOpen` ↔ `showModal()`/`close()`, fermeture via Escape (`onCancel`) et clic sur le backdrop (light dismiss), props ARIA (`aria-labelledby`, `aria-describedby`)
- Styles minimaux (`BaseDialog.module.scss`) : reset des styles navigateur, fond transparent, backdrop avec overlay et blur — volontairement neutre pour servir de base à des modales spécialisées (`SimpleModal`, `DetailedModal`, etc.)
- Composant autonome, pas encore branché dans l'existant (Radix reste en place)

### 🧪 Comment tester
- Aucun usage en prod pour l'instant — vérification manuelle via un rendu temporaire ou une future story :
  - `isOpen={true}` → la modale s'ouvre, le backdrop apparaît (overlay + blur)
  - `Escape` ou clic hors contenu → `onClose` est appelé
  - Tabulation → le focus reste piégé dans la modale (comportement natif `<dialog>`)

---
**🧭 Review effort : 2/5** — _composant isolé, logique claire, pas de tests ni de consommateurs pour l'instant._

**🗂️ Walkthrough**

| Fichier(s) | Résumé |
|---|---|
| `pro/src/ui-kit/BaseDialog/BaseDialog.tsx` | Wrapper contrôlé autour de `<dialog>` natif |
| `pro/src/ui-kit/BaseDialog/BaseDialog.module.scss` | Reset + backdrop overlay/blur |