### PR TITLE
(BSR)[API] refactor: rework secureToken api to replace all other tokens

### DIFF
--- a/api/src/pcapi/core/token/__init__.py
+++ b/api/src/pcapi/core/token/__init__.py
@@ -37,6 +37,7 @@ class TokenType(enum.Enum):
     OAUTH_STATE = "oauth_state"
     DISCORD_OAUTH = "discord_oauth"
     PASSWORDLESS_LOGIN = "passwordless_login"
+    CONNECT_AS = "connect_as"
 
 
 T = typing.TypeVar("T", bound="AbstractToken")
@@ -228,41 +229,46 @@ class UUIDToken(AbstractToken):
         return token
 
 
-class SecureToken:
-    """A "single use token" implementation that put emphasis on security over any other concerns"""
+def _get_token_key(token_type: TokenType, token: str) -> str:
+    return f"pcapi:token:{token_type.value}:{token}"
 
-    def __init__(self, token: str = "", ttl: int = 30, data: dict | None = None):
-        """
-        This object has two modes:
-        - If token is provided this class will try to retrieve the data from redis. If they are not found it will
-        raise a ValueError.
 
-        Warning retrieving a token from redis will destroy it (it is single use and this operation is atomic)
+def create_token(token_type: TokenType, ttl: timedelta | int, data: dict | None = None) -> str:
+    """
+    Create a single use secure token that emphasis on security over any other concerns
 
-        - If no token is provided this class will dump data in json, generate a token and store the data with the
-        ttl (in seconds) in redis.
+    ttl can be either a timedelta or an in in seconds
+    """
+    if isinstance(ttl, timedelta):
+        ttl = int(ttl.total_seconds())
 
-        Once the object has been instantiated you can retrieve the data with token.data and the token with
-        token.token.
-        """
-        if token:
-            self.token = token
-            raw_data = get_redis_client().getdel(self.key)
-            if not raw_data:
-                # add robustness against timing attacks
-                time.sleep(random.random())
-                raise users_exceptions.InvalidToken()
-            self.data = json.loads(raw_data)
-        else:
-            self.data = data or {}
-            # generate a 512 bits secure token
-            self.token = secrets.token_urlsafe(64)
-            raw_data = json.dumps(self.data)
-            get_redis_client().set(self.key, raw_data, ex=ttl)
+    if ttl <= 0:
+        raise ValueError("A strictly positive ttl value is mandatory when creating a token")
 
-    @property
-    def key(self) -> str:
-        return f"pcapi:token:SecureToken:{self.token}"
+    # generate a 512 bits secure token
+    token = secrets.token_urlsafe(64)
+    raw_data = json.dumps(data or {})
+    key = _get_token_key(token_type, token)
+    get_redis_client().set(key, raw_data, ex=ttl)
+    return token
+
+
+def load_token(token_type: TokenType, token: str) -> dict:
+    """
+    Retrieve a token's content and delete it
+
+    raises `InvalidToken` if the token is not found in redis
+    """
+    if not token:
+        raise ValueError("Cannot check an empty token")
+
+    key = _get_token_key(token_type, token)
+    raw_data = get_redis_client().getdel(key)
+    if not raw_data:
+        # add robustness against timing attacks
+        time.sleep(random.random())
+        raise users_exceptions.InvalidToken()
+    return json.loads(raw_data)
 
 
 PASSWORDLESS_REDIS_KEY_TEMPLATE = "pcapi:token:%(type_)s:%(key_suffix)s"

--- a/api/src/pcapi/routes/backoffice/pro/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/pro/blueprint.py
@@ -13,13 +13,13 @@ from sqlalchemy import func
 from werkzeug.exceptions import NotFound
 
 from pcapi import settings
+from pcapi.core import token as token_utils
 from pcapi.core.educational import models as educational_models
 from pcapi.core.finance import models as finance_models
 from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import models as offers_models
 from pcapi.core.permissions import models as perm_models
-from pcapi.core.token import SecureToken
 from pcapi.core.token.serialization import ConnectAsInternalModel
 from pcapi.core.users import api as users_api
 from pcapi.core.users import models as users_models
@@ -336,7 +336,8 @@ def connect_as() -> response_utils.BackofficeResponse:
         mark_transaction_as_invalid()
         return request_utils.safe_redirect_back(request)
 
-    token = SecureToken(
+    token = token_utils.create_token(
+        token_type=token_utils.TokenType.CONNECT_AS,
         data=ConnectAsInternalModel(
             user_id=user_id,
             internal_admin_id=current_user.id,
@@ -344,5 +345,5 @@ def connect_as() -> response_utils.BackofficeResponse:
             redirect_link=settings.PRO_URL + form.redirect.data,
         ).model_dump(),
         ttl=10,
-    ).token
+    )
     return redirect(urls.build_pc_pro_connect_as_link(token), code=303)

--- a/api/src/pcapi/routes/pro/users.py
+++ b/api/src/pcapi/routes/pro/users.py
@@ -18,7 +18,6 @@ from pcapi.core.finance import models as finance_models
 from pcapi.core.history import api as history_api
 from pcapi.core.history import models as history_models
 from pcapi.core.mails import transactional as transactional_mails
-from pcapi.core.token import SecureToken
 from pcapi.core.token.serialization import ConnectAsInternalModel
 from pcapi.core.users import api as users_api
 from pcapi.core.users import email as email_api
@@ -320,11 +319,11 @@ def cookies_consent(body: CookieConsentRequest) -> None:
 def connect_as(token: str) -> Response:
     # This route is not used by PRO but it is used by the Backoffice
     try:
-        secure_token = SecureToken(token=token)
+        token_redis_data = token_utils.load_token(token_type=token_utils.TokenType.CONNECT_AS, token=token)
     except users_exceptions.InvalidToken:
         raise ForbiddenError({"global": "Le token est invalide"})
 
-    token_data = ConnectAsInternalModel(**secure_token.data)
+    token_data = ConnectAsInternalModel(**token_redis_data)
     user = db.session.query(users_models.User).filter(users_models.User.id == token_data.user_id).one_or_none()
 
     if not user:

--- a/api/tests/core/token/test_token.py
+++ b/api/tests/core/token/test_token.py
@@ -157,47 +157,62 @@ class TokenTest:
 
 
 class SecureTokenTest:
-    def test_create_token_with_data(self, app):
+    def test_create_token_with_data(self, app, clear_redis):
         data = {"int": 12, "str": "Ça c'est pas de l'ascii 😉"}
 
-        token = token_tools.SecureToken(data=data)
+        token = token_tools.create_token(token_type=token_tools.TokenType.CONNECT_AS, data=data, ttl=30)
 
-        assert 29 < app.redis_client.ttl(f"pcapi:token:SecureToken:{token.token}") <= 30
-        assert len(token.token) == 86
-        assert token.data["int"] == data["int"]
-        assert token.data["str"] == data["str"]
+        redis_key = token_tools._get_token_key(token_type=token_tools.TokenType.CONNECT_AS, token=token)
+        assert 29 < app.redis_client.ttl(redis_key) <= 30
+        assert len(token) == 86
 
-    def test_create_token_without_data(self, app):
-        token = token_tools.SecureToken(ttl=10)
+    def test_create_token_without_data(self, app, clear_redis):
+        token = token_tools.create_token(token_type=token_tools.TokenType.CONNECT_AS, ttl=10)
 
-        assert 9 < app.redis_client.ttl(f"pcapi:token:SecureToken:{token.token}") <= 10
-        assert len(token.token) == 86
+        redis_key = token_tools._get_token_key(token_type=token_tools.TokenType.CONNECT_AS, token=token)
+        assert 9 < app.redis_client.ttl(redis_key) <= 10
+        assert len(token) == 86
 
-    def test_retrieve_token_with_data(self, app):
+    def test_retrieve_token_with_data(self, app, clear_redis):
         data = {"int": 12, "str": "Ça c'est pas de l'ascii 😉"}
-        original_token = token_tools.SecureToken(data=data)
+        original_token = token_tools.create_token(token_type=token_tools.TokenType.CONNECT_AS, data=data, ttl=3)
 
-        token = token_tools.SecureToken(token=original_token.token)
+        token_data = token_tools.load_token(token=original_token, token_type=token_tools.TokenType.CONNECT_AS)
 
-        assert app.redis_client.ttl(f"pcapi:token:SecureToken:{original_token.token}") == -2
-        assert token.data["int"] == data["int"]
-        assert token.data["str"] == data["str"]
+        redis_key = token_tools._get_token_key(token_type=token_tools.TokenType.CONNECT_AS, token=original_token)
+        assert app.redis_client.ttl(redis_key) == -2
+        assert token_data["int"] == data["int"]
+        assert token_data["str"] == data["str"]
 
-    def test_retrieve_token_without_data(self, app):
-        original_token = token_tools.SecureToken()
+    def test_retrieve_token_without_data(self, app, clear_redis):
+        original_token = token_tools.create_token(token_type=token_tools.TokenType.CONNECT_AS, ttl=3)
 
-        token = token_tools.SecureToken(token=original_token.token)
+        data = token_tools.load_token(token_type=token_tools.TokenType.CONNECT_AS, token=original_token)
 
-        assert app.redis_client.ttl(f"pcapi:token:SecureToken:{original_token.token}") == -2
-        assert token.data == {}
+        redis_key = token_tools._get_token_key(token_type=token_tools.TokenType.CONNECT_AS, token=original_token)
+        assert app.redis_client.ttl(redis_key) == -2
+        assert data == {}
 
-    def test_retrieve_unknown_token(self, app):
+    def test_retrieve_unknown_token(self, app, clear_redis):
         # create token
-        original_token = token_tools.SecureToken()
+        original_token = token_tools.create_token(token_type=token_tools.TokenType.CONNECT_AS, ttl=3)
+        redis_key = token_tools._get_token_key(token_type=token_tools.TokenType.CONNECT_AS, token=original_token)
+
         # remove token from redis
-        app.redis_client.delete(f"pcapi:token:SecureToken:{original_token.token}")
+        app.redis_client.delete(redis_key)
         with pytest.raises(InvalidToken):
-            token_tools.SecureToken(token=original_token.token)
+            token_tools.load_token(token_type=token_tools.TokenType.CONNECT_AS, token=original_token)
+
+    def test_negative_ttl(self, app, clear_redis):
+        with pytest.raises(ValueError):
+            token_tools.create_token(token_type=token_tools.TokenType.CONNECT_AS, ttl=-1)
+
+        redis_key = token_tools._get_token_key(token_type=token_tools.TokenType.CONNECT_AS, token="*")
+        assert app.redis_client.keys(redis_key) == []
+
+    def test_empty_token(self, app):
+        with pytest.raises(ValueError):
+            token_tools.load_token(token_type=token_tools.TokenType.CONNECT_AS, token="")
 
 
 class PasswordLessLoginTokenTest:

--- a/api/tests/routes/backoffice/pro_test.py
+++ b/api/tests/routes/backoffice/pro_test.py
@@ -7,6 +7,7 @@ import pytest
 from flask import url_for
 
 from pcapi import settings
+from pcapi.core import token as token_utils
 from pcapi.core.educational import factories as educational_factories
 from pcapi.core.finance import factories as finance_factories
 from pcapi.core.history import factories as history_factories
@@ -16,7 +17,6 @@ from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.permissions import models as perm_models
 from pcapi.core.testing import assert_num_queries
-from pcapi.core.token import SecureToken
 from pcapi.core.users import constants as users_constants
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
@@ -847,7 +847,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_user_invalid_redirect(self, authenticated_client, legit_user):
         user = users_factories.ProFactory()
@@ -968,7 +970,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_venue_without_user(self, authenticated_client):
         venue = offerers_factories.VenueFactory()
@@ -1081,7 +1085,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_offerer(self, authenticated_client, legit_user):
         user_offerer = offerers_factories.UserOffererFactory()
@@ -1102,7 +1108,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_offerer_without_user(self, authenticated_client):
         offerer = offerers_factories.OffererFactory()
@@ -1207,7 +1215,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_offer(self, authenticated_client, legit_user):
         user_offerer = offerers_factories.UserOffererFactory()
@@ -1231,7 +1241,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_offer_without_user(self, authenticated_client):
         offer = offers_factories.OfferFactory()
@@ -1342,7 +1354,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_bank_account(self, authenticated_client, legit_user):
         bank_account = finance_factories.BankAccountFactory(offerer=offerers_factories.UserOffererFactory().offerer)
@@ -1364,7 +1378,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_bank_account_without_user(self, authenticated_client):
         bank_account = finance_factories.BankAccountFactory()
@@ -1473,7 +1489,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_collective_offer(self, authenticated_client, legit_user):
         user_offerer = offerers_factories.UserOffererFactory()
@@ -1497,7 +1515,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_collective_offer_without_user(self, authenticated_client):
         offer = educational_factories.CollectiveOfferFactory()
@@ -1608,7 +1628,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_collective_offer_template(self, authenticated_client, legit_user):
         user_offerer = offerers_factories.UserOffererFactory()
@@ -1632,7 +1654,9 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )
 
     def test_connect_as_collective_offer_template_without_user(self, authenticated_client):
         offer = educational_factories.CollectiveOfferTemplateFactory()
@@ -1743,4 +1767,6 @@ class ConnectAsProUserTest(PostEndpointHelper):
         assert response.status_code == 303
         base_url, key_token = response.location.rsplit("/", 1)
         assert base_url + "/" == urls.build_pc_pro_connect_as_link("")
-        assert SecureToken(token=key_token).data == expected_token_data
+        assert (
+            token_utils.load_token(token=key_token, token_type=token_utils.TokenType.CONNECT_AS) == expected_token_data
+        )

--- a/api/tests/routes/pro/collective_bookings/patch_cancel_collective_offer_booking_test.py
+++ b/api/tests/routes/pro/collective_bookings/patch_cancel_collective_offer_booking_test.py
@@ -1,11 +1,11 @@
 import pytest
 
+from pcapi.core import token as token_utils
 from pcapi.core.educational import factories
 from pcapi.core.educational import models
 from pcapi.core.educational import testing
 from pcapi.core.educational.serialization.collective_booking import serialize_collective_booking
 from pcapi.core.offerers import factories as offerers_factories
-from pcapi.core.token import SecureToken
 from pcapi.core.token.serialization import ConnectAsInternalModel
 from pcapi.core.users import factories as user_factories
 from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
@@ -69,16 +69,18 @@ class Returns204Test:
             collectiveStock__collectiveOffer__venue__managingOfferer=offerer,
         )
         expected_redirect_link = "https://example.com"
-        secure_token = SecureToken(
+        token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=user.id,
                 internal_admin_email=admin.email,
                 internal_admin_id=admin.id,
             ).model_dump(),
+            ttl=20,
         )
 
-        response_token = client.get(f"/users/connect-as/{secure_token.token}")
+        response_token = client.get(f"/users/connect-as/{token}")
         assert response_token.status_code == 302
 
         offer_id = collective_booking.collectiveStock.collectiveOffer.id

--- a/api/tests/routes/pro/delete_stocks_test.py
+++ b/api/tests/routes/pro/delete_stocks_test.py
@@ -4,8 +4,8 @@ import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.offers.models as offer_models
 import pcapi.core.users.factories as users_factories
+from pcapi.core import token as token_utils
 from pcapi.core.bookings import factories as booking_factory
-from pcapi.core.token import SecureToken
 from pcapi.core.token.serialization import ConnectAsInternalModel
 from pcapi.models import db
 from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
@@ -44,16 +44,18 @@ class Returns200Test:
         booking_2 = booking_factory.BookingFactory(stock=batch_stocks[1])
         data = {"ids_to_delete": [stock.id for stock in batch_stocks]}
         admin = users_factories.AdminFactory(email="admin@example.com")
-        secure_token = SecureToken(
+        secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
             data=ConnectAsInternalModel(
                 redirect_link="https://example.com",
                 user_id=user_offerer.user.id,
                 internal_admin_email=admin.email,
                 internal_admin_id=admin.id,
             ).model_dump(),
+            ttl=20,
         )
 
-        response_token = client.get(f"/users/connect-as/{secure_token.token}")
+        response_token = client.get(f"/users/connect-as/{secure_token}")
         assert response_token.status_code == 302
 
         # When

--- a/api/tests/routes/pro/get_connect_as_test.py
+++ b/api/tests/routes/pro/get_connect_as_test.py
@@ -1,5 +1,5 @@
+from pcapi.core import token as token_utils
 from pcapi.core.testing import assert_num_queries
-from pcapi.core.token import SecureToken
 from pcapi.core.token.serialization import ConnectAsInternalModel
 from pcapi.core.users import factories as users_factories
 from pcapi.core.users import models as users_models
@@ -17,7 +17,9 @@ class Returns200Test:
         target = users_factories.ProFactory()
 
         expected_redirect_link = "https://example.com"
-        secure_token = SecureToken(
+        secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=target.id,
@@ -27,7 +29,7 @@ class Returns200Test:
         )
         # when
         with assert_num_queries(self.expected_num_queries):
-            response = client.get(f"/users/connect-as/{secure_token.token}")
+            response = client.get(f"/users/connect-as/{secure_token}")
             assert response.status_code == 302
 
         # then
@@ -45,7 +47,9 @@ class Returns200Test:
         target = users_factories.NonAttachedProFactory()
 
         expected_redirect_link = "https://example.com"
-        secure_token = SecureToken(
+        secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=target.id,
@@ -55,7 +59,7 @@ class Returns200Test:
         )
         # when
         with assert_num_queries(self.expected_num_queries):
-            response = client.get(f"/users/connect-as/{secure_token.token}")
+            response = client.get(f"/users/connect-as/{secure_token}")
             assert response.status_code == 302
 
         # then
@@ -74,7 +78,9 @@ class Returns200Test:
         real_target = users_factories.ProFactory()
 
         expected_redirect_link = "https://example.com"
-        intermediary_secure_token = SecureToken(
+        intermediary_secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=intermediary_target.id,
@@ -82,7 +88,9 @@ class Returns200Test:
                 internal_admin_id=admin.id,
             ).model_dump(),
         )
-        real_secure_token = SecureToken(
+        real_secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=real_target.id,
@@ -93,7 +101,7 @@ class Returns200Test:
 
         # use connect as to connect to a pro
         with assert_num_queries(self.expected_num_queries):
-            response = client.get(f"/users/connect-as/{intermediary_secure_token.token}")
+            response = client.get(f"/users/connect-as/{intermediary_secure_token}")
             assert response.status_code == 302
 
         assert response.location == expected_redirect_link
@@ -104,7 +112,7 @@ class Returns200Test:
         # +1 get admin user
         expected_num_queries = self.expected_num_queries + 3
         with assert_num_queries(expected_num_queries):
-            response = client.get(f"/users/connect-as/{real_secure_token.token}")
+            response = client.get(f"/users/connect-as/{real_secure_token}")
             assert response.status_code == 302
 
         assert response.location == expected_redirect_link
@@ -125,7 +133,9 @@ class Returns200Test:
         target = users_factories.ProFactory()
 
         expected_redirect_link = "https://example.com"
-        secure_token = SecureToken(
+        secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=target.id,
@@ -139,7 +149,7 @@ class Returns200Test:
         # +1 get current user
         # +1 get current session
         with assert_num_queries(self.expected_num_queries + 2):
-            response = client.get(f"/users/connect-as/{secure_token.token}")
+            response = client.get(f"/users/connect-as/{secure_token}")
             assert response.status_code == 302
 
         # then
@@ -180,7 +190,9 @@ class Returns403Test:
         target = users_factories.ProFactory(isActive=False)
 
         expected_redirect_link = "https://example.com"
-        secure_token = SecureToken(
+        secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=target.id,
@@ -190,7 +202,7 @@ class Returns403Test:
         )
         # when
         with assert_num_queries(self.expected_num_queries):
-            response = client.get(f"/users/connect-as/{secure_token.token}")
+            response = client.get(f"/users/connect-as/{secure_token}")
             assert response.status_code == 403
 
         # then
@@ -208,7 +220,9 @@ class Returns403Test:
         target = users_factories.AdminFactory()
 
         expected_redirect_link = "https://example.com"
-        secure_token = SecureToken(
+        secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=target.id,
@@ -218,7 +232,7 @@ class Returns403Test:
         )
         # when
         with assert_num_queries(self.expected_num_queries):
-            response = client.get(f"/users/connect-as/{secure_token.token}")
+            response = client.get(f"/users/connect-as/{secure_token}")
             assert response.status_code == 403
 
         # then
@@ -236,7 +250,9 @@ class Returns403Test:
         target = users_factories.ProFactory(roles=[users_models.UserRole.PRO, users_models.UserRole.ANONYMIZED])
 
         expected_redirect_link = "https://example.com"
-        secure_token = SecureToken(
+        secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=target.id,
@@ -246,7 +262,7 @@ class Returns403Test:
         )
         # when
         with assert_num_queries(self.expected_num_queries):
-            response = client.get(f"/users/connect-as/{secure_token.token}")
+            response = client.get(f"/users/connect-as/{secure_token}")
             assert response.status_code == 403
 
         # then
@@ -264,7 +280,9 @@ class Returns403Test:
         target = users_factories.BeneficiaryGrant18Factory()
 
         expected_redirect_link = "https://example.com"
-        secure_token = SecureToken(
+        secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=target.id,
@@ -274,7 +292,7 @@ class Returns403Test:
         )
         # when
         with assert_num_queries(self.expected_num_queries):
-            response = client.get(f"/users/connect-as/{secure_token.token}")
+            response = client.get(f"/users/connect-as/{secure_token}")
             assert response.status_code == 403
 
         # then
@@ -295,7 +313,9 @@ class Returns404Test:
         # given
         admin = users_factories.AdminFactory(email="admin@example.com")
         expected_redirect_link = "https://example.com"
-        secure_token = SecureToken(
+        secure_token = token_utils.create_token(
+            token_type=token_utils.TokenType.CONNECT_AS,
+            ttl=20,
             data=ConnectAsInternalModel(
                 redirect_link=expected_redirect_link,
                 user_id=0,
@@ -305,7 +325,7 @@ class Returns404Test:
         )
         # when
         with assert_num_queries(self.expected_num_queries):
-            response = client.get(f"/users/connect-as/{secure_token.token}")
+            response = client.get(f"/users/connect-as/{secure_token}")
             assert response.status_code == 404
 
         # then

--- a/api/tests/routes/pro/patch_offerer_bank_accounts_test.py
+++ b/api/tests/routes/pro/patch_offerer_bank_accounts_test.py
@@ -85,16 +85,18 @@ class OffererPatchBankAccountsTest:
         bank_account = finance_factories.BankAccountFactory(offerer=offerer)
         venue = offerers_factories.VenueFactory(managingOfferer=offerer, pricing_point="self")
         # impersonate pro user
-        secure_token = token.SecureToken(
+        secure_token = token.create_token(
+            token_type=token.TokenType.CONNECT_AS,
             data=token_serialization.ConnectAsInternalModel(
                 redirect_link="http://example.com",
                 user_id=pro_user.id,
                 internal_admin_email=impersonator.email,
                 internal_admin_id=impersonator.id,
             ).dict(),
+            ttl=20,
         )
 
-        client.get(f"/users/connect-as/{secure_token.token}")
+        client.get(f"/users/connect-as/{secure_token}")
 
         assert not bank_account.venueLinks
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Rework du `SecureToken` pour rendre son API plus facilement utilisable et gérer les types de tokens afin de remplacer tout les tokens par des `SecureToken` dans le futur