### PR TITLE
(PC-42430)[API] feat: expose chronicle club type in native offer seri…

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v1/serialization/offers.py
@@ -19,6 +19,7 @@ from pcapi.core.categories.genres.music import MUSIC_TYPES_LABEL_BY_CODE
 from pcapi.core.categories.genres.show import SHOW_SUB_TYPES_LABEL_BY_CODE
 from pcapi.core.categories.genres.show import SHOW_TYPES_LABEL_BY_CODE
 from pcapi.core.chronicles.api import get_offer_published_chronicles
+from pcapi.core.chronicles.models import ChronicleClubType
 from pcapi.core.geography.models import Address
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import models
@@ -447,6 +448,7 @@ class OfferChronicleAuthor(ConfiguredBaseModel):
 class OfferChronicle(ConfiguredBaseModel):
     id: int
     author: OfferChronicleAuthor | None
+    club_type: ChronicleClubType
     content: str
     date_created: datetime
 

--- a/api/src/pcapi/routes/native/v3/serialization/offers.py
+++ b/api/src/pcapi/routes/native/v3/serialization/offers.py
@@ -255,6 +255,7 @@ class ChronicleAuthor(HttpBodyModel):
 class ChroniclePreview(HttpBodyModel):
     id: int
     author: ChronicleAuthor | None = None
+    club_type: chronicle_models.ChronicleClubType
     content_preview: str
     date_created: datetime.datetime
 
@@ -271,6 +272,7 @@ class ChroniclePreview(HttpBodyModel):
         return cls(
             id=chronicle.id,
             author=author,
+            club_type=chronicle.clubType,
             content_preview=textwrap.shorten(chronicle.content, width=255, placeholder="…"),
             date_created=chronicle.dateCreated,
         )

--- a/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_chronicles.py
+++ b/api/src/pcapi/sandboxes/scripts/creators/industrial/create_industrial_chronicles.py
@@ -248,3 +248,27 @@ la convoitise.
             user=user,
             offers=([offers[i + 5]] if (i + 5) in offers else []),
         )
+
+    logger.info("Creating 'SCENE' type chronicles attached to a live show offer")
+    scene_offer = offers_factories.OfferFactory.create(
+        name="Spectacle avec chroniques",
+        subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
+    )
+    offers_factories.StockFactory.create(offer=scene_offer)
+    for user, i in zip(itertools.cycle(users), range(5)):
+        chronicles_factories.ChronicleFactory.create(
+            age=(15 + (i % 5)),
+            city=user.city,
+            content=f"Chronique SCÈNE sur l'offre {scene_offer.name} écrite par l'utilisateur {user.full_name} ({user.id}).",
+            identifierChoiceId=hashlib.sha256(str(scene_offer.id).encode()).hexdigest()[:20],
+            productIdentifier=str(scene_offer.id),
+            productIdentifierType=chronicles_models.ChronicleProductIdentifierType.OFFER_ID,
+            clubType=chronicles_models.ChronicleClubType.SCENE_CLUB,
+            email=user.email,
+            firstName=user.firstName,
+            isActive=bool(i < 4),
+            isIdentityDiffusible=bool(i % 2 == 0),
+            isSocialMediaDiffusible=bool(i < 3),
+            user=user,
+            offers=[scene_offer],
+        )

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -2365,6 +2365,17 @@
                 "title": "ChronicleAuthor",
                 "type": "object"
             },
+            "ChronicleClubType": {
+                "description": "An enumeration.",
+                "enum": [
+                    "CINE",
+                    "BOOK",
+                    "ALBUM",
+                    "CONCERT",
+                    "SCENE"
+                ],
+                "title": "ChronicleClubType"
+            },
             "ChroniclePreview": {
                 "additionalProperties": false,
                 "properties": {
@@ -2378,6 +2389,9 @@
                             }
                         ],
                         "default": null
+                    },
+                    "clubType": {
+                        "$ref": "#/components/schemas/ChronicleClubType"
                     },
                     "contentPreview": {
                         "title": "Contentpreview",
@@ -2395,6 +2409,7 @@
                 },
                 "required": [
                     "id",
+                    "clubType",
                     "contentPreview",
                     "dateCreated"
                 ],
@@ -4613,6 +4628,9 @@
                         "nullable": true,
                         "title": "OfferChronicleAuthor"
                     },
+                    "clubType": {
+                        "$ref": "#/components/schemas/ChronicleClubType"
+                    },
                     "content": {
                         "title": "Content",
                         "type": "string"
@@ -4629,6 +4647,7 @@
                 },
                 "required": [
                     "id",
+                    "clubType",
                     "content",
                     "dateCreated"
                 ],

--- a/api/tests/routes/native/v1/offers_test.py
+++ b/api/tests/routes/native/v1/offers_test.py
@@ -5,6 +5,7 @@ import pytest
 import time_machine
 
 import pcapi.core.chronicles.factories as chronicles_factories
+import pcapi.core.chronicles.models as chronicles_models
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.offers.factories as offers_factories
 import pcapi.local_providers.cinema_providers.constants as cinema_providers_constants
@@ -406,6 +407,31 @@ class OfferChroniclesTest:
         contents = [chronicle["content"] for chronicle in response.json["chronicles"]]
         assert "Test Chronicle 2" in contents
         assert "Test Chronicle" in contents
+        club_types = [chronicle["clubType"] for chronicle in response.json["chronicles"]]
+        assert club_types == ["BOOK", "BOOK"]
+
+    def test_get_offer_scene_club_chronicles(self, client):
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id)
+        chronicles_factories.ChronicleFactory(
+            offers=[offer],
+            content="Test Scene Chronicle",
+            clubType=chronicles_models.ChronicleClubType.SCENE_CLUB,
+            productIdentifierType=chronicles_models.ChronicleProductIdentifierType.OFFER_ID,
+            productIdentifier=str(offer.id),
+            isActive=True,
+            isSocialMediaDiffusible=True,
+        )
+
+        offer_id = offer.id
+        db.session.expire_all()
+        with assert_num_queries(self.expected_num_queries):
+            response = client.get(f"/native/v1/offer/{offer_id}/chronicles")
+        assert response.status_code == 200
+
+        chronicles = response.json["chronicles"]
+        assert len(chronicles) == 1
+        assert chronicles[0]["content"] == "Test Scene Chronicle"
+        assert chronicles[0]["clubType"] == "SCENE"
 
     def test_get_offer_chronicles_with_no_author(self, client):
         product = offers_factories.ProductFactory(name="Test Product")

--- a/api/tests/routes/native/v3/offers_test.py
+++ b/api/tests/routes/native/v3/offers_test.py
@@ -7,6 +7,7 @@ import time_machine
 
 import pcapi.core.artist.factories as artists_factories
 import pcapi.core.chronicles.factories as chronicles_factories
+import pcapi.core.chronicles.models as chronicles_models
 import pcapi.core.offers.factories as offers_factories
 import pcapi.core.providers.factories as providers_factories
 import pcapi.local_providers.cinema_providers.constants as cinema_providers_constants
@@ -702,11 +703,35 @@ class OffersV3Test:
         assert response.json["chronicles"] == [
             {
                 "id": chronicle.id,
+                "clubType": "BOOK",
                 "contentPreview": "a " * 126 + "a…",
                 "dateCreated": date_utils.format_into_utc_date(chronicle.dateCreated),
                 "author": {"firstName": chronicle.firstName, "age": chronicle.age, "city": chronicle.city},
             }
         ]
+
+    def test_offer_with_scene_club_chronicles(self, client):
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id)
+        chronicles_factories.ChronicleFactory(
+            offers=[offer],
+            content="Test Scene Chronicle",
+            clubType=chronicles_models.ChronicleClubType.SCENE_CLUB,
+            productIdentifierType=chronicles_models.ChronicleProductIdentifierType.OFFER_ID,
+            productIdentifier=str(offer.id),
+            isActive=True,
+            isSocialMediaDiffusible=True,
+        )
+
+        offer_id = offer.id
+        with assert_num_queries(self.base_num_queries):
+            response = client.get(f"/native/v3/offer/{offer_id}")
+
+        assert response.status_code == 200
+        assert response.json["chroniclesCount"] == 1
+        chronicles = response.json["chronicles"]
+        assert len(chronicles) == 1
+        assert chronicles[0]["contentPreview"] == "Test Scene Chronicle"
+        assert chronicles[0]["clubType"] == "SCENE"
 
     def test_offer_with_n_chronicles(self, client):
         product = offers_factories.ProductFactory()


### PR DESCRIPTION
…alizers

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42430)

Expose le type de club (`clubType`) des chroniques dans l'API native, afin que
l'app puisse distinguer les avis Scène club des autres clubs (Book, Ciné,
Concert…) sur les offres de spectacle vivant. Le champ existait en base
(`Chronicle.clubType`, enum `BOOK` / `CINE` / `ALBUM` / `CONCERT` / `SCENE`)
mais n'était exposé nulle part côté natif — l'app déduisait le club de la
sous-catégorie de l'offre, ce qui devient ambigu pour le spectacle vivant
(scène club vs concert club).

### Changements

- **v3** — `ChroniclePreview` (`GET /native/v3/offer/{offer_id}`) : ajout du
  champ `clubType` (aperçu des avis sur la page offre)
- **v1** — `OfferChronicle` (`GET /native/v1/offer/{offer_id}/chronicles`) :
  ajout du champ `clubType` (page « Tous les avis »)
- Snapshot OpenAPI natif régénéré (`flask generate_native_api_openapi_json`)
- Sandbox : ajout de chroniques `SCENE_CLUB` rattachées à une offre
  `SPECTACLE_REPRESENTATION` avec stock, pour le test manuel
