### PR TITLE
(PC-42810)[API] feat: add hasProAdvice to GET /offers

### DIFF
--- a/api/src/pcapi/core/offers/repository.py
+++ b/api/src/pcapi/core/offers/repository.py
@@ -165,6 +165,7 @@ def get_capped_offers_for_filters(
             )
             .joinedload(models.Product.productMediations)
         )
+        .options(sa_orm.with_expression(models.Offer.hasProAdvice, get_offer_has_pro_advice_subquery()))
         .options(sa_orm.joinedload(models.Offer.lastProvider).load_only(providers_models.Provider.localClass))
         .options(sa_orm.joinedload(models.Offer.offererAddress).joinedload(offerers_models.OffererAddress.address))
         .limit(offers_limit)

--- a/api/src/pcapi/routes/serialization/offers_serialize/__init__.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize/__init__.py
@@ -220,6 +220,8 @@ class ListOffersOfferResponseModelsGetterDict(GetterDict):
             return offer_location_getter_dict_helper(self._obj)
         if key == "bookingsCount":
             return sum([stock.dnBookedQuantity for stock in self._obj.stocks])
+        if key == "hasProAdvice":
+            return bool(self._obj.hasProAdvice)
         if key == "highlightRequests":
             return [
                 highlight_request.highlight
@@ -244,6 +246,7 @@ class ListOffersOfferResponseModel(BaseModel):
     bookingsCount: int | None
     productId: int | None
     highlightRequests: list[highlight_serialize.ShortHighlightResponseModel]
+    hasProAdvice: bool
 
     class Config:
         json_encoders = {datetime.datetime: format_into_utc_date}

--- a/api/tests/routes/pro/get_offers_test.py
+++ b/api/tests/routes/pro/get_offers_test.py
@@ -304,6 +304,7 @@ class Returns200Test:
                 "publicationDatetime": "2022-10-21T13:19:00Z",
                 "bookingAllowedDatetime": "2022-11-21T13:19:00Z",
                 "bookingsCount": 50,
+                "hasProAdvice": False,
                 "productId": product.id,
                 "highlightRequests": [{"id": highlight_id, "name": highlight_name}],
             }
@@ -352,6 +353,7 @@ class Returns200Test:
                 "publicationDatetime": None,
                 "bookingAllowedDatetime": None,
                 "bookingsCount": 0,
+                "hasProAdvice": False,
                 "productId": None,
                 "highlightRequests": [],
             }
@@ -406,6 +408,7 @@ class Returns200Test:
                 "publicationDatetime": "2022-10-21T13:19:00Z",
                 "bookingAllowedDatetime": None,
                 "bookingsCount": 0,
+                "hasProAdvice": False,
                 "productId": None,
                 "highlightRequests": [],
             }
@@ -516,6 +519,7 @@ class Returns200Test:
                 "publicationDatetime": "2022-11-21T13:19:00Z",
                 "bookingAllowedDatetime": None,
                 "bookingsCount": 0,
+                "hasProAdvice": False,
                 "productId": None,
                 "highlightRequests": [],
             },
@@ -545,6 +549,7 @@ class Returns200Test:
                 "publicationDatetime": "2022-10-21T13:19:00Z",
                 "bookingAllowedDatetime": None,
                 "bookingsCount": 0,
+                "hasProAdvice": False,
                 "productId": None,
                 "highlightRequests": [],
             },
@@ -604,6 +609,7 @@ class Returns200Test:
                 "publicationDatetime": "2022-11-21T13:19:00Z",
                 "bookingAllowedDatetime": None,
                 "bookingsCount": 0,
+                "hasProAdvice": False,
                 "productId": None,
                 "highlightRequests": [],
             }
@@ -649,10 +655,27 @@ class Returns200Test:
                 "publicationDatetime": "2022-11-21T13:19:00Z",
                 "bookingAllowedDatetime": None,
                 "bookingsCount": 0,
+                "hasProAdvice": False,
                 "productId": None,
                 "highlightRequests": [],
             }
         ]
+
+    def should_return_has_pro_advice_true_when_offer_has_pro_advice(self, client):
+        pro = users_factories.ProFactory()
+        offerer = offerers_factories.OffererFactory()
+        offerers_factories.UserOffererFactory(user=pro, offerer=offerer)
+        venue = offerers_factories.VenueFactory(managingOfferer=offerer)
+
+        offer_with_advice = offers_factories.ThingOfferFactory(venue=venue)
+        offers_factories.ProAdviceFactory(offer=offer_with_advice, venue=venue)
+
+        authenticated_client = client.with_session_auth(email=pro.email)
+        response = authenticated_client.get(f"/offers?venueId={venue.id}")
+
+        assert response.status_code == 200
+        has_pro_advice_by_offer_id = {offer["id"]: offer["hasProAdvice"] for offer in response.json}
+        assert has_pro_advice_by_offer_id[offer_with_advice.id] is True
 
     def should_return_no_offers_when_user_has_no_rights_on_requested_venue(self, client, db_session):
         pro = users_factories.ProFactory()

--- a/pro/src/apiClient/v1/types.gen.ts
+++ b/pro/src/apiClient/v1/types.gen.ts
@@ -4088,6 +4088,10 @@ export type ListOffersOfferResponseModel = {
      */
     bookingsCount?: number;
     /**
+     * Hasproadvice
+     */
+    hasProAdvice: boolean;
+    /**
      * Highlightrequests
      */
     highlightRequests: Array<ShortHighlightResponseModel>;

--- a/pro/src/commons/utils/factories/individualApiFactories.ts
+++ b/pro/src/commons/utils/factories/individualApiFactories.ts
@@ -59,6 +59,7 @@ export const listOffersOfferFactory = (
     isEvent: true,
     stocks: [],
     highlightRequests: [],
+    hasProAdvice: false,
     ...customListOffersOffer,
   }
 }


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42810)

Ajouter un champ hasProAdvice dans `ListOffersOfferResponseModel` et avoir la valeur qui remonte dans le GET /offers