### PR TITLE
(PC-41887)[PRO] feat: migrate TipsBanner to DS Banner in offer creation

### DIFF
--- a/pro/src/design-system/Banner/Banner.module.scss
+++ b/pro/src/design-system/Banner/Banner.module.scss
@@ -114,5 +114,5 @@
   max-width: 30%;
   border-radius: var(--size-border-radius-m);
   aspect-ratio: 208/315;
-  object-fit: cover;
+  object-fit: contain;
 }

--- a/pro/src/design-system/Banner/Banner.module.scss
+++ b/pro/src/design-system/Banner/Banner.module.scss
@@ -75,12 +75,13 @@
   flex-direction: column;
   color: var(--color-text-default);
 
-  &-large {
-    @include fonts.body;
+  .description {
+    @include fonts.body-s;
   }
 
-  .description * {
-    @include fonts.body-s;
+  &-large,
+  &-large .description {
+    @include fonts.body;
   }
 }
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/VideoUploaderOfferTips/VideoUploaderOfferTips.module.scss
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/VideoUploaderOfferTips/VideoUploaderOfferTips.module.scss
@@ -18,6 +18,8 @@
 }
 
 .list {
+  @include fonts.body-xs;
+
   list-style: inside;
   margin-top: var(--size-spacing-s);
 }

--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/VideoUploaderOfferTips/VideoUploaderOfferTips.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/VideoUploaderOfferTips/VideoUploaderOfferTips.tsx
@@ -1,22 +1,29 @@
-import { TipsBanner } from '@/ui-kit/TipsBanner/TipsBanner'
+import { Banner } from '@/design-system/Banner/Banner'
+import bulbIcon from '@/icons/full-bulb.svg'
 
 import styles from './VideoUploaderOfferTips.module.scss'
 import imageVideoTips from './video-tips.png'
 
 export const VideoUploaderTips = () => (
-  <TipsBanner
-    decorativeImage={imageVideoTips}
-    className={styles['video-uploader-tips']}
-  >
-    <p className={styles['hook']}>
-      "2 jeunes sur 3 aimeraient voir des vidéos sur les offres culturelles du
-      pass Culture."
-    </p>
-    <p className={styles['text']}>Quel type de vidéo ?</p>
-    <ul className={styles['list']}>
-      <li>Bande annonce de votre pièce, film...</li>
-      <li>Aftermovie d’une édition précédente </li>
-      <li>Témoignages de participante, auteure, metteuse en scène...</li>
-    </ul>
-  </TipsBanner>
+  <div className={styles['video-uploader-tips']}>
+    <Banner
+      title="À savoir"
+      icon={bulbIcon}
+      imageSrc={imageVideoTips}
+      description={
+        <>
+          <p className={styles['hook']}>
+            "2 jeunes sur 3 aimeraient voir des vidéos sur les offres
+            culturelles du pass Culture."
+          </p>
+          <p className={styles['text']}>Quel type de vidéo ?</p>
+          <ul className={styles['list']}>
+            <li>Bande annonce de votre pièce, film...</li>
+            <li>Aftermovie d’une édition précédente </li>
+            <li>Témoignages de participante, auteure, metteuse en scène...</li>
+          </ul>
+        </>
+      }
+    />
+  </div>
 )


### PR DESCRIPTION
## 🎯 Related Ticket

[PC-41887](https://passculture.atlassian.net/browse/PC-41887)

> Migration du composant legacy `TipsBanner` (ui-kit) vers le composant `Banner` du design-system dans le tunnel de création d'offre. Au passage, correction d'un sélecteur CSS global du `Banner` DS qui empêchait la description d'être stylée correctement.

### 🔧 Changements

#### `1b0a6c6` fix: change TipsBanner to DS Banner in offer creation
- Remplacement de `TipsBanner` par le `Banner` du design-system dans `VideoUploaderTips`, avec `title="À savoir"`, icône `full-bulb` et image décorative passée via `imageSrc`.
- Contenu (hook, question, liste des types de vidéo) déplacé dans la prop `description` du `Banner`.
- Wrapper `div` conservant la classe `video-uploader-tips` autour du `Banner`.
- SCSS : ajout de `fonts.body-xs` sur `.list` pour conserver la taille de texte attendue.

#### `b7a0c5e` fix: remove global CSS marker « * » that prevents description to be styled properly
- Suppression du sélecteur global `.description *` dans `Banner.module.scss` qui écrasait les styles des enfants passés en `description`.
- Application de `fonts.body-s` directement sur `.description`, et de `fonts.body` sur `&-large` + `&-large .description` pour la variante large.

### 🧪 Comment tester
- Aller sur la création d'une offre individuelle → étape média (upload vidéo).
- Vérifier que l'encart de conseils s'affiche avec l'icône ampoule, le titre « À savoir », l'image décorative et la liste correctement stylée.
- Contrôler qu'aucune régression visuelle n'apparaît sur les autres usages du `Banner` DS (notamment la variante `large`).

## 🖼️ Before & After

Before | After
:---: | :---:
<img width="527" height="274" alt="image" src="https://github.com/user-attachments/assets/212c11de-9653-4f3f-af6c-154446c4b0fc" /> | <img width="527" height="274" alt="image" src="https://github.com/user-attachments/assets/ff22c905-6ea1-4a74-86fa-5d6d5805d528" />

---
**🧭 Review effort : 2/5** — _petit diff localisé, mais touche un composant DS partagé (`Banner`) : à valider visuellement sur ses autres usages._

**🗂️ Walkthrough**

| Fichier(s) | Résumé |
|---|---|
| `pro/src/pages/IndividualOffer/IndividualOfferMedia/components/VideoUploaderOfferTips/VideoUploaderOfferTips.tsx` | Passage de `TipsBanner` au `Banner` DS |
| `pro/src/pages/.../VideoUploaderOfferTips/VideoUploaderOfferTips.module.scss` | `fonts.body-xs` sur `.list` |
| `pro/src/design-system/Banner/Banner.module.scss` | Retrait du sélecteur global `.description *`, styles de police recentrés |

[PC-41887]: https://passculture.atlassian.net/browse/PC-41887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ