### PR TITLE
(PC-39987)[API] fix: add restrictions on extra data

### DIFF
--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -3,7 +3,6 @@ import decimal
 import json
 import logging
 import re
-import typing
 import warnings
 from io import BytesIO
 
@@ -47,8 +46,8 @@ from pcapi.utils.string import to_camelcase
 
 MAX_EXTRA_DATA_SIZE_BYTES = 64 * 1024
 
-HTML_INJECTION_REGEX = re.compile(r"<[^>]*>|on\w+\s*=", re.IGNORECASE)
 # '<[^>]*>' to match <...> , 'on\w+\s*=' to match classic JS actions (onerror=, onload=...)
+HTML_INJECTION_REGEX = re.compile(r"<[^>]*>|on\w+\s*=", re.IGNORECASE)
 
 logger = logging.getLogger(__name__)
 
@@ -967,14 +966,11 @@ def check_artist_offer_links(
             )
 
 
-def validate_extra_data_size(extra_data: typing.Any) -> typing.Any:
+def validate_extra_data_size(extra_data: models.OfferExtraData | None) -> None:
     if len(json.dumps(extra_data).encode("utf-8")) > MAX_EXTRA_DATA_SIZE_BYTES:
         raise ValueError("extraData field is too big (maximum 64 Ko).")
 
-    return extra_data
 
-
-def validate_extra_data_content(extra_data: typing.Any) -> typing.Any:
+def validate_extra_data_content(extra_data: models.OfferExtraData | None) -> None:
     if HTML_INJECTION_REGEX.search(json.dumps(extra_data)):
         raise ValueError("extraData field includes forbidden caracters or scripts")
-    return extra_data

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -1,7 +1,9 @@
 import datetime
 import decimal
+import json
 import logging
 import re
+import typing
 import warnings
 from io import BytesIO
 
@@ -42,6 +44,11 @@ from pcapi.utils import date
 from pcapi.utils.string import is_canonical_integer
 from pcapi.utils.string import to_camelcase
 
+
+MAX_EXTRA_DATA_SIZE_BYTES = 64 * 1024
+
+HTML_INJECTION_REGEX = re.compile(r"<[^>]*>|on\w+\s*=", re.IGNORECASE)
+# '<[^>]*>' to match <...> , 'on\w+\s*=' to match classic JS actions (onerror=, onload=...)
 
 logger = logging.getLogger(__name__)
 
@@ -958,3 +965,16 @@ def check_artist_offer_links(
             raise api_errors.ApiErrors(
                 errors={"artistOfferLinks": ["Le type d'artiste n'est pas autorisé pour cette sous catégorie"]}
             )
+
+
+def validate_extra_data_size(extra_data: typing.Any) -> typing.Any:
+    if len(json.dumps(extra_data).encode("utf-8")) > MAX_EXTRA_DATA_SIZE_BYTES:
+        raise ValueError("extraData field is too big (maximum 64 Ko).")
+
+    return extra_data
+
+
+def validate_extra_data_content(extra_data: typing.Any) -> typing.Any:
+    if HTML_INJECTION_REGEX.search(json.dumps(extra_data)):
+        raise ValueError("extraData field includes forbidden caracters or scripts")
+    return extra_data

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -35,6 +35,7 @@ from pcapi.serialization.utils import validate_timezoned_datetime
 from pcapi.serialization.utils import validate_url
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
+from pcapi.utils.string import to_camelcase
 
 
 class SubcategoryGetterDict(GetterDict):
@@ -88,7 +89,7 @@ class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
     description: str | None
     isNational: bool | None
     name: str | None
-    extraData: Any
+    extraData: offers_models.OfferExtraData | None
     externalTicketOfficeUrl: HttpUrl | None
     url: HttpUrl | None
     withdrawalDetails: str | None
@@ -135,6 +136,30 @@ class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
 
         check_offer_subcategory_is_valid(subcategory_id)
         return subcategory_id
+
+    @validator("extraData", pre=True)
+    def format_extra_data(cls, extra_data: typing.Any) -> typing.Any:
+        if not isinstance(extra_data, dict):
+            return extra_data
+
+        formated_extra_data: dict[str, typing.Any] = {}
+        for key, value in extra_data.items():
+            if not isinstance(key, str):
+                continue
+
+            field_name = to_camelcase(key)
+            formated_extra_data[field_name] = value
+
+        return formated_extra_data
+
+    @validator("extraData")
+    def validate_extra_data(cls, extra_data: typing.Any) -> offers_models.OfferExtraData | None:
+        if extra_data is None:
+            return None
+
+        offers_validation.validate_extra_data_size(extra_data)
+        offers_validation.validate_extra_data_content(extra_data)
+        return extra_data
 
     class Config:
         alias_generator = to_camel

--- a/api/src/pcapi/routes/serialization/offers_serialize.py
+++ b/api/src/pcapi/routes/serialization/offers_serialize.py
@@ -145,6 +145,8 @@ class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
         formated_extra_data: dict[str, typing.Any] = {}
         for key, value in extra_data.items():
             if not isinstance(key, str):
+                # will raise during OfferExtraData validation
+                formated_extra_data[key] = value
                 continue
 
             field_name = to_camelcase(key)
@@ -153,7 +155,9 @@ class PatchOfferBodyModel(BaseModel, AccessibilityComplianceMixin):
         return formated_extra_data
 
     @validator("extraData")
-    def validate_extra_data(cls, extra_data: typing.Any) -> offers_models.OfferExtraData | None:
+    def validate_extra_data(
+        cls, extra_data: offers_models.OfferExtraData | None
+    ) -> offers_models.OfferExtraData | None:
         if extra_data is None:
             return None
 
@@ -520,7 +524,7 @@ class GetIndividualOfferResponseModel(BaseModel, AccessibilityComplianceMixin):
     bookingAllowedDatetime: datetime.datetime | None
     description: str | None
     durationMinutes: int | None
-    extraData: Any
+    extraData: offers_models.OfferExtraData | None
     hasBookingLimitDatetimesPassed: bool
     hasStocks: bool
     isActive: bool

--- a/api/tests/routes/pro/patch_offer_test.py
+++ b/api/tests/routes/pro/patch_offer_test.py
@@ -472,6 +472,28 @@ class Returns200Test:
         assert updated_offer.extraData == {}
         assert updated_offer.ean == "1111111111111"
 
+    def test_patch_offer_with_product_with_gtl_id(self, client):
+        user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
+        venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
+        offers_factories.ProductFactory(
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            ean="1111111111111",
+            name="New name",
+            description="description",
+        )
+        offer = offers_factories.OfferFactory(venue=venue)
+
+        data = {"extraData": {"gtl_id": "010101010"}}
+        response = client.with_session_auth("user@example.com").patch(
+            self.endpoint.format(offer_id=offer.id), json=data
+        )
+
+        assert response.status_code == 200, response.json
+        assert response.json["id"] == offer.id
+
+        updated_offer = db.session.get(Offer, offer.id)
+        assert updated_offer.extraData == {"gtl_id": "010101010"}
+
     def test_patch_offer_with_product_with_same_ean(self, client):
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
         venue = offerers_factories.VenueFactory(managingOfferer=user_offerer.offerer)
@@ -562,7 +584,7 @@ class Returns200Test:
             self.endpoint.format(offer_id=offer.id), json=data
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json
         assert response.json["id"] == offer.id
 
         updated_offer = db.session.get(Offer, offer.id)
@@ -1188,6 +1210,38 @@ class Returns400Test:
                     "durationMinutes": [
                         "La durée doit être inférieure à 24 heures. Pour les événements durant 24 heures ou plus (par exemple, un pass festival de 3 jours), veuillez laisser ce champ vide."
                     ]
+                },
+            ),
+            (
+                {"subcategoryId": subcategories.SUPPORT_PHYSIQUE_FILM.id, "url": None},
+                {
+                    "extraData": {
+                        "malicious_data": ["a", "very", "large", "dict"],
+                    },
+                },
+                {
+                    "extraData.maliciousData": ["Vous ne pouvez pas changer cette information"],
+                },
+            ),
+            (
+                {"subcategoryId": subcategories.SUPPORT_PHYSIQUE_FILM.id, "url": None},
+                {"extraData": {"cast": ["A" * 70000]}},
+                {
+                    "extraData": ["extraData field is too big (maximum 64 Ko)."],
+                },
+            ),
+            (
+                {"subcategoryId": subcategories.SUPPORT_PHYSIQUE_FILM.id, "url": None},
+                {"extraData": {"cast": ["><img+stc=x+oneerror=alert(document.cookie)>"]}},
+                {
+                    "extraData": ["extraData field includes forbidden caracters or scripts"],
+                },
+            ),
+            (
+                {"subcategoryId": subcategories.SUPPORT_PHYSIQUE_FILM.id, "url": None},
+                {"extraData": 1312},
+                {
+                    "extraData.__root__": ["OfferExtraData expected dict not int"],
                 },
             ),
         ],

--- a/pro/src/apiClient/v1/index.ts
+++ b/pro/src/apiClient/v1/index.ts
@@ -333,6 +333,7 @@ export {
   type NewPasswordBodyModel,
   OfferContactFormEnum,
   type OfferDomain,
+  type OfferExtraData,
   type OfferHomeResponseModel,
   type OfferImage,
   type OfferImageV2,

--- a/pro/src/apiClient/v1/types.gen.ts
+++ b/pro/src/apiClient/v1/types.gen.ts
@@ -4649,6 +4649,248 @@ export type OfferDomain = {
 };
 
 /**
+ * OfferExtraData
+ */
+export type OfferExtraData = {
+    /**
+     * Allocineid
+     */
+    allocineId?: number;
+    /**
+     * Artist
+     */
+    artist?: string;
+    /**
+     * Author
+     */
+    author?: string;
+    /**
+     * Backlink
+     */
+    backlink?: string;
+    /**
+     * Bookformat
+     */
+    bookFormat?: string;
+    /**
+     * Cast
+     */
+    cast?: Array<string>;
+    /**
+     * Certificate
+     */
+    certificate?: string;
+    /**
+     * Codeclil
+     */
+    codeClil?: string;
+    /**
+     * Collection
+     */
+    collection?: string;
+    /**
+     * Comicseries
+     */
+    comicSeries?: string;
+    /**
+     * Comment
+     */
+    comment?: string;
+    /**
+     * Companies
+     */
+    companies?: Array<{
+        [key: string]: unknown;
+    }>;
+    /**
+     * Contenuexplicite
+     */
+    contenuExplicite?: string;
+    /**
+     * Countries
+     */
+    countries?: Array<string>;
+    /**
+     * Credits
+     */
+    credits?: Array<{
+        [key: string]: unknown;
+    }>;
+    /**
+     * Csrid
+     */
+    csrId?: string;
+    /**
+     * Dateparution
+     */
+    dateParution?: string;
+    /**
+     * Dewey
+     */
+    dewey?: string;
+    /**
+     * Diffusionversion
+     */
+    diffusionVersion?: string;
+    /**
+     * Dispo
+     */
+    dispo?: number;
+    /**
+     * Dispolabel
+     */
+    dispoLabel?: string;
+    /**
+     * Distributeur
+     */
+    distributeur?: string;
+    /**
+     * Ean
+     */
+    ean?: string;
+    /**
+     * Editeur
+     */
+    editeur?: string;
+    /**
+     * Eidr
+     */
+    eidr?: string;
+    /**
+     * Genres
+     */
+    genres?: Array<string>;
+    /**
+     * Gtlid
+     */
+    gtlId?: string;
+    /**
+     * Langue
+     */
+    langue?: string;
+    /**
+     * Langueiso
+     */
+    langueiso?: string;
+    /**
+     * Musiclabel
+     */
+    musicLabel?: string;
+    /**
+     * Musicsubtype
+     */
+    musicSubType?: string;
+    /**
+     * Musictype
+     */
+    musicType?: string;
+    /**
+     * Nbgalettes
+     */
+    nbGalettes?: string;
+    /**
+     * Nbpages
+     */
+    nbPages?: string;
+    /**
+     * Numincollection
+     */
+    numInCollection?: string;
+    /**
+     * Originaltitle
+     */
+    originalTitle?: string;
+    /**
+     * Performer
+     */
+    performer?: string;
+    /**
+     * Posterurl
+     */
+    posterUrl?: string;
+    /**
+     * Prixlivre
+     */
+    prixLivre?: string;
+    /**
+     * Prixmusique
+     */
+    prixMusique?: string;
+    /**
+     * Productionyear
+     */
+    productionYear?: number;
+    /**
+     * Rayon
+     */
+    rayon?: string;
+    /**
+     * Releasedate
+     */
+    releaseDate?: string;
+    /**
+     * Releases
+     */
+    releases?: Array<{
+        [key: string]: unknown;
+    }>;
+    /**
+     * Runtime
+     */
+    runtime?: number;
+    /**
+     * Schoolbook
+     */
+    schoolbook?: boolean;
+    /**
+     * Showsubtype
+     */
+    showSubType?: string;
+    /**
+     * Showtype
+     */
+    showType?: string;
+    /**
+     * Speaker
+     */
+    speaker?: string;
+    /**
+     * Stagedirector
+     */
+    stageDirector?: string;
+    /**
+     * Synopsis
+     */
+    synopsis?: string;
+    /**
+     * Theater
+     */
+    theater?: {
+        [key: string]: unknown;
+    };
+    /**
+     * Titeliveregroup
+     */
+    titeliveRegroup?: string;
+    /**
+     * Title
+     */
+    title?: string;
+    /**
+     * Top
+     */
+    top?: string;
+    /**
+     * Type
+     */
+    type?: string;
+    /**
+     * Visa
+     */
+    visa?: string;
+};
+
+/**
  * OfferHomeResponseModel
  */
 export type OfferHomeResponseModel = {
@@ -5033,10 +5275,7 @@ export type PatchOfferBodyModel = {
      * Externalticketofficeurl
      */
     externalTicketOfficeUrl?: string;
-    /**
-     * Extradata
-     */
-    extraData?: unknown;
+    extraData?: OfferExtraData;
     /**
      * Hasculturaloutreachclaim
      */

--- a/pro/src/apiClient/v1/types.gen.ts
+++ b/pro/src/apiClient/v1/types.gen.ts
@@ -2570,10 +2570,7 @@ export type GetIndividualOfferResponseModel = {
      * Externalticketofficeurl
      */
     externalTicketOfficeUrl?: string;
-    /**
-     * Extradata
-     */
-    extraData?: unknown;
+    extraData?: OfferExtraData;
     /**
      * Hasbookinglimitdatetimespassed
      */
@@ -2737,10 +2734,7 @@ export type GetIndividualOfferWithAddressResponseModel = {
      * Externalticketofficeurl
      */
     externalTicketOfficeUrl?: string;
-    /**
-     * Extradata
-     */
-    extraData?: unknown;
+    extraData?: OfferExtraData;
     /**
      * Hasbookinglimitdatetimespassed
      */
@@ -4681,17 +4675,17 @@ export type OfferExtraData = {
      */
     certificate?: string;
     /**
-     * Codeclil
+     * Code Clil
      */
-    codeClil?: string;
+    code_clil?: string;
     /**
      * Collection
      */
     collection?: string;
     /**
-     * Comicseries
+     * Comic Series
      */
-    comicSeries?: string;
+    comic_series?: string;
     /**
      * Comment
      */
@@ -4703,9 +4697,9 @@ export type OfferExtraData = {
         [key: string]: unknown;
     }>;
     /**
-     * Contenuexplicite
+     * Contenu Explicite
      */
-    contenuExplicite?: string;
+    contenu_explicite?: string;
     /**
      * Countries
      */
@@ -4717,13 +4711,13 @@ export type OfferExtraData = {
         [key: string]: unknown;
     }>;
     /**
-     * Csrid
+     * Csr Id
      */
-    csrId?: string;
+    csr_id?: string;
     /**
-     * Dateparution
+     * Date Parution
      */
-    dateParution?: string;
+    date_parution?: string;
     /**
      * Dewey
      */
@@ -4737,9 +4731,9 @@ export type OfferExtraData = {
      */
     dispo?: number;
     /**
-     * Dispolabel
+     * Dispo Label
      */
-    dispoLabel?: string;
+    dispo_label?: string;
     /**
      * Distributeur
      */
@@ -4761,9 +4755,9 @@ export type OfferExtraData = {
      */
     genres?: Array<string>;
     /**
-     * Gtlid
+     * Gtl Id
      */
-    gtlId?: string;
+    gtl_id?: string;
     /**
      * Langue
      */
@@ -4773,10 +4767,6 @@ export type OfferExtraData = {
      */
     langueiso?: string;
     /**
-     * Musiclabel
-     */
-    musicLabel?: string;
-    /**
      * Musicsubtype
      */
     musicSubType?: string;
@@ -4785,17 +4775,21 @@ export type OfferExtraData = {
      */
     musicType?: string;
     /**
-     * Nbgalettes
+     * Music Label
      */
-    nbGalettes?: string;
+    music_label?: string;
     /**
-     * Nbpages
+     * Nb Galettes
      */
-    nbPages?: string;
+    nb_galettes?: string;
     /**
-     * Numincollection
+     * Nb Pages
      */
-    numInCollection?: string;
+    nb_pages?: string;
+    /**
+     * Num In Collection
+     */
+    num_in_collection?: string;
     /**
      * Originaltitle
      */
@@ -4809,13 +4803,13 @@ export type OfferExtraData = {
      */
     posterUrl?: string;
     /**
-     * Prixlivre
+     * Prix Livre
      */
-    prixLivre?: string;
+    prix_livre?: string;
     /**
-     * Prixmusique
+     * Prix Musique
      */
-    prixMusique?: string;
+    prix_musique?: string;
     /**
      * Productionyear
      */
@@ -4869,9 +4863,9 @@ export type OfferExtraData = {
         [key: string]: unknown;
     };
     /**
-     * Titeliveregroup
+     * Titelive Regroup
      */
-    titeliveRegroup?: string;
+    titelive_regroup?: string;
     /**
      * Title
      */

--- a/pro/src/commons/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
+++ b/pro/src/commons/context/IndividualOfferContext/__specs__/IndividualOfferContext.spec.tsx
@@ -168,7 +168,7 @@ describe('IndividualOfferContextProvider', () => {
     it('should check for EAN duplicate and set hasPublishedOfferWithSameEan to true when there is one', async () => {
       vi.spyOn(api, 'getOffer').mockResolvedValueOnce({
         ...offerBase,
-        extraData: { ean: 2 },
+        extraData: { ean: '2' },
         productId: 3,
         venue: getOfferVenueFactory({ id: 4 }),
       })
@@ -183,7 +183,7 @@ describe('IndividualOfferContextProvider', () => {
         path: { offer_id: 1 },
       })
       expect(api.getActiveVenueOfferByEan).toHaveBeenCalledExactlyOnceWith({
-        path: { venue_id: 4, ean: 2 },
+        path: { venue_id: 4, ean: '2' },
       })
 
       expect(result.current.hasPublishedOfferWithSameEan).toBe(true)
@@ -192,7 +192,7 @@ describe('IndividualOfferContextProvider', () => {
     it('should check for EAN duplicate and set hasPublishedOfferWithSameEan to false when there is none', async () => {
       vi.spyOn(api, 'getOffer').mockResolvedValueOnce({
         ...offerBase,
-        extraData: { ean: 2 },
+        extraData: { ean: '2' },
         productId: 3,
         venue: getOfferVenueFactory({ id: 4 }),
       })
@@ -206,7 +206,7 @@ describe('IndividualOfferContextProvider', () => {
         path: { offer_id: 1 },
       })
       expect(api.getActiveVenueOfferByEan).toHaveBeenCalledWith({
-        path: { venue_id: 4, ean: 2 },
+        path: { venue_id: 4, ean: '2' },
       })
 
       expect(result.current.hasPublishedOfferWithSameEan).toBe(false)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-39987)

~2 méthodes pour pouvoir utiliser les champs en `snake_case` **et** en `camelCase` des `OfferExtraData`:~ 
~- 2e commit : tout mettre en `camelCase` dans le modèle, et  supprimer le `to_camel` de la `Config`~
~- ou bien 3e commit: écrire une méthode qui va reprendre chaque attribut des `OfferExtraData` et les réécrire correctement lors d'un validateur `pre` (plus propre à mon sens)~

~à vous de me dire ce que vous préférez.~


~Bien sur, en fonction de la méthode choisie, je squash pour n'avoir qu'un seul commit avant de merge~

EDIT: on est parti sur le 3e commit (qui n'existe plus du coup). J'ai squash le code

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
