### PR TITLE
(BSR)[PRO] feat: force sub-dependencies bump for security reasons

### DIFF
--- a/pro/pnpm-lock.yaml
+++ b/pro/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
   esbuild@>=0.27.3 <0.28.1: '>=0.28.1'
+  js-yaml@4.2.0: 4.3.0
+  fast-uri@3.1.3: 3.1.4
 
 importers:
 
@@ -2744,8 +2746,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -3049,10 +3051,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
-    hasBin: true
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
@@ -4901,7 +4899,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@hey-api/openapi-ts@0.99.0(magicast@0.5.3)(typescript@6.0.3)':
     dependencies:
@@ -6100,7 +6098,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6573,7 +6571,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -6871,10 +6869,6 @@ snapshots:
   jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.2.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:

--- a/pro/pnpm-workspace.yaml
+++ b/pro/pnpm-workspace.yaml
@@ -7,3 +7,7 @@ allowBuilds:
 overrides:
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
   esbuild@>=0.27.3 <0.28.1: '>=0.28.1'
+  # TODO: transitive DoS fix, remove once @hey-api/openapi-ts pulls js-yaml >= 4.3.0
+  js-yaml@4.2.0: 4.3.0
+  # TODO: transitive DoS fix, remove once stylelint pulls fast-uri >= 3.1.4
+  fast-uri@3.1.3: 3.1.4


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Traîtement de deux alertes de sécurité dependabot sur le repo front PRO :

[l'alerte 1](https://github.com/pass-culture/pass-culture-main/security/dependabot/677) concerne la sous-dépendance js-yaml@4.2.0 (dépendance de hey-api)
[l'alerte 2](https://github.com/pass-culture/pass-culture-main/security/dependabot/686) concerne la sous-dépendance fast-uri@3.1.3 (dépendance de stylelint)

Dans les deux cas la vulnérabilité (DoS) est corrigée dans une version supérieure (js-yaml 4.3.0 et fast-uri 3.1.4)

**Problème :** 

- les versions des sous-dépendances sont verrouillées par les dépendances parentes (hey-api et stylelint)
- J'ai essayé de mettre à jour les dépendances parentes, mais ça ne ne bump pas les sous-dépendances

**Solution :**

- override pnpm pour contourner le verrou + tests pour vérifier que les hey-api et stylelint fonctionnent avec 
- ajout d'un TODO pour supprimer l'override lorsque les versions parentes utiliseront les bonnes sous-dépendances