### PR TITLE
(PC-42732)[PRO] fix: keep canvas ratio on mobile image editor and align image weight validation

### DIFF
--- a/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.spec.tsx
+++ b/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.spec.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
+import { MAX_FILE_SIZE } from './constants'
 import { ImageDragAndDrop } from './ImageDragAndDrop'
 
 function mockData(files: File[]) {
@@ -122,7 +123,7 @@ describe('ImageDragAndDrop', () => {
         height: 600,
       }
     )
-    Object.defineProperty(file, 'size', { value: 11 * 1024 * 1024 })
+    Object.defineProperty(file, 'size', { value: MAX_FILE_SIZE + 1 })
     const data = mockData([file])
 
     const onError = vi.fn()

--- a/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
+++ b/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
@@ -8,6 +8,7 @@ import { SvgIcon } from '@/ui-kit/SvgIcon/SvgIcon'
 
 import {
   ALLOWED_IMAGE_TYPES_TO_EXTENSIONS,
+  MAX_FILE_SIZE,
   UPLOAD_IMAGE_MAX_RESOLUTION,
 } from './constants'
 import { getImageDimensions } from './getImageDimensions'
@@ -107,7 +108,7 @@ export const ImageDragAndDrop = forwardRef(
     const { getRootProps, getInputProps, fileRejections } = useDropzone({
       accept: ALLOWED_IMAGE_TYPES_TO_EXTENSIONS,
       maxFiles: 1,
-      maxSize: 10 * 1024 * 1024,
+      maxSize: MAX_FILE_SIZE,
       onDragEnter: () => {
         setCustomErrors([])
         setIsDraggedOver(true)

--- a/pro/src/components/ImageDragAndDrop/constants.ts
+++ b/pro/src/components/ImageDragAndDrop/constants.ts
@@ -22,3 +22,5 @@ export const ALLOWED_IMAGE_TYPES_TO_EXTENSIONS = Object.fromEntries(
 )
 
 export const UPLOAD_IMAGE_MAX_RESOLUTION = 80_000_000
+
+export const MAX_FILE_SIZE = 10_000_000

--- a/pro/src/components/ModalImageUpsertOrEdit/components/ImageEditor/ImageEditor.spec.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/components/ImageEditor/ImageEditor.spec.tsx
@@ -10,6 +10,11 @@ vi.mock('use-debounce', async () => ({
 
 describe('ImageEditor', () => {
   const mockImage = new File(['image'], 'image.jpg', { type: 'image/jpeg' })
+  const initialInnerWidth = global.innerWidth
+
+  afterEach(() => {
+    global.innerWidth = initialInnerWidth
+  })
 
   const defaultProps = {
     image: mockImage,
@@ -66,6 +71,35 @@ describe('ImageEditor', () => {
     expect(
       screen.getByText('L’image est trop petite pour utiliser le zoom.')
     ).toBeInTheDocument()
+  })
+
+  it.each([
+    { name: 'portrait', canvasHeight: 297, canvasWidth: 198, ratio: 2 / 3 },
+    { name: 'landscape', canvasHeight: 138, canvasWidth: 207, ratio: 3 / 2 },
+  ])('keeps the $name canvas ratio when it is shrunk on a mobile screen', ({
+    canvasHeight,
+    canvasWidth,
+    ratio,
+  }) => {
+    // Mobile screen width in the sentry issue : https://pass-culture.sentry.io/issues/127987982
+    global.innerWidth = 384
+
+    // No crop border, so that the canvas dimensions are the crop area ones
+    render(
+      <ImageEditor
+        {...defaultProps}
+        canvasHeight={canvasHeight}
+        canvasWidth={canvasWidth}
+        cropBorderHeight={0}
+        cropBorderWidth={0}
+      />
+    )
+
+    const canvas = screen.getByLabelText("Editeur d'image")
+    const width = Number(canvas.getAttribute('width'))
+    const height = Number(canvas.getAttribute('height'))
+
+    expect(width / height).toBeCloseTo(ratio)
   })
 })
 

--- a/pro/src/components/ModalImageUpsertOrEdit/components/ImageEditor/ImageEditor.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/components/ImageEditor/ImageEditor.tsx
@@ -89,13 +89,9 @@ export const ImageEditor = forwardRef<AvatarEditorRef, ImageEditorProps>(
       100,
       canvasHeight
     )
-    const responsiveCanvasWidth = map(
-      windowWidth,
-      0,
-      CANVAS_MOBILE_BREAKPOINT,
-      100,
-      canvasWidth
-    )
+    // Derived from the height so that the crop area always keeps the same aspect ratio
+    const responsiveCanvasWidth =
+      responsiveCanvasHeight * (canvasWidth / canvasHeight)
     const responsiveCropBorderWidth = map(
       windowWidth,
       0,


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/jira/software/c/projects/PC/boards/66?selectedIssue=PC-42732)

commit 1 : respecter le ratio imposer par le backend dans l'éditeur d'image sur mobile ([erreur sentry](https://pass-culture.sentry.io/issues/127987982/events/86019b2aea98427c9ffe11584b409b01))
commit 2 : aligner la validation back/front sur le poids de l'image ([erreur sentry](https://pass-culture.sentry.io/issues/127987982/events/9d7020684f474f7ea6047d19c64772ee))

## 🖼️ Before & After Images

Before | After
:---: | :---:
<img width="360" height="739" alt="Screenshot 2026-07-23 at 11 33 25" src="https://github.com/user-attachments/assets/00852ca1-50c3-4878-b01d-dcb77bae85c9" /> | <img width="358" height="739" alt="Screenshot 2026-07-23 at 11 33 46" src="https://github.com/user-attachments/assets/65c6717d-90b1-4171-b81b-4be69736e978" />
<img width="358" height="740" alt="Screenshot 2026-07-23 at 11 31 23" src="https://github.com/user-attachments/assets/8132188a-f49f-481e-ad93-8918fd0e6679" /> | <img width="361" height="742" alt="Screenshot 2026-07-23 at 11 30 55" src="https://github.com/user-attachments/assets/33a172f1-6cff-4e2d-a870-40c3138711ee" />










