### PR TITLE
(PC-42726)[PRO] fix: orejime error getboundingclientrect

### DIFF
--- a/pro/src/app/App/analytics/orejime.ts
+++ b/pro/src/app/App/analytics/orejime.ts
@@ -14,6 +14,18 @@ import {
 // biome-ignore lint/suspicious/noExplicitAny: Orejime comes from a loaded script
 export const orejimeRef = { current: null as any }
 
+// TODO (smokhtari, 2026-07-24) Temporary workaround (pc-42726): remove when Orejime fixes
+// https://github.com/boscop-fr/orejime/issues/170.
+const blockInvalidFocusinTargets = (event: FocusEvent) => {
+  if (event.target instanceof Element) {
+    return
+  }
+
+  // Some mobile/webview flows can dispatch `focusin` with `Document` as target.
+  // Orejime 3.1.0 expects an Element and crashes on getBoundingClientRect.
+  event.stopImmediatePropagation()
+}
+
 function addListener(
   setConsentedToFirebase: Dispatch<SetStateAction<boolean>>,
   setConsentedToBeamer: Dispatch<SetStateAction<boolean>>
@@ -71,6 +83,14 @@ export const useOrejime = () => {
   const location = useLocation()
   const [consentedToFirebase, setConsentedToFirebase] = useState(false)
   const [consentedToBeamer, setConsentedToBeamer] = useState(false)
+
+  useEffect(() => {
+    document.addEventListener('focusin', blockInvalidFocusinTargets, true)
+
+    return () => {
+      document.removeEventListener('focusin', blockInvalidFocusinTargets, true)
+    }
+  }, [])
 
   useEffect(() => {
     if (location.pathname.includes('/adage-iframe')) {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42726)

Après une redirection orejime s'attend à avoir un focus sur un élément mais ce n'est pas toujours le cas, parfois le focus se met sur toute la page et orejime renvoie une erreur

Une issue a été ouverte sur le repo d'orejime pour corriger : https://github.com/boscop-fr/orejime/issues/170