### PR TITLE
(BSR)[PRO] fix: add BaseDialog to production ignore files

### DIFF
--- a/pro/knip.production.json
+++ b/pro/knip.production.json
@@ -26,7 +26,8 @@
     "scripts/customRequest.ts",
     "scripts/format_generated_index_exports.js",
     "scripts/sanitize_enum_keys.js",
-    "src/design-system/Dropdown/Dropdown.tsx"
+    "src/design-system/Dropdown/Dropdown.tsx",
+    "src/ui-kit/BaseDialog/BaseDialog.tsx"
   ],
   "ignoreDependencies": ["openapi-typescript-codegen"],
   "ignoreUnresolved": ["typescript-plugin-css-modules"],


### PR DESCRIPTION
## 🔧 Changes Made

> Aligner `knip.production.json` sur `knip.json` pour que le lint dead-code en mode production n’échoue plus sur `BaseDialog`, déjà ignoré en config standard.

### 🔧 Changements
- Ajout de `src/ui-kit/BaseDialog/BaseDialog.tsx` dans `ignoreFiles` de `knip.production.json`

### 🧪 Comment tester
```bash
pnpm lint:dead-code
# ou la commande CI qui utilise knip.production.json
```
- Vérifier que Knip ne remonte plus `BaseDialog` comme fichier inutilisé en mode production

---
**🧭 Review effort : 1/5** — _1 fichier config, +1 ligne, pas de logique produit._

**🗂️ Walkthrough**

| Fichier(s) | Résumé |
|---|---|
| `pro/knip.production.json` | Ignore `BaseDialog.tsx` comme dans `knip.json` |