### PR TITLE
(PC-43019)[API] fix: close venue: wrong history action template

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -3538,7 +3538,7 @@ def nullify_venue_emails(venue: models.Venue, author: users_models.User) -> None
             "social_medias": {},
         }
 
-        contact_snapshot.trace_update(data=changes, target=venue.contact, field_name_template="venue.contact.{}")
+        contact_snapshot.trace_update(data=changes, target=venue.contact, field_name_template="contact.{}")
         contact_snapshot.add_action()
 
         db.session.query(models.VenueContact).filter_by(venueId=venue.id).delete()

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -4193,10 +4193,10 @@ class NullifyVenueEmailsTest:
                 "bookingEmail": {"new_info": None, "old_info": old_booking_email},
             },
             {
-                "venue.contact.email": {"new_info": None, "old_info": old_contact_email},
-                "venue.contact.phone_number": {"new_info": None, "old_info": old_phone_number},
-                "venue.contact.website": {"new_info": None, "old_info": old_website},
-                "venue.contact.social_medias": {"new_info": None, "old_info": old_social_medias},
+                "contact.email": {"new_info": None, "old_info": old_contact_email},
+                "contact.phone_number": {"new_info": None, "old_info": old_phone_number},
+                "contact.website": {"new_info": None, "old_info": old_website},
+                "contact.social_medias": {"new_info": None, "old_info": old_social_medias},
             },
         ]
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43019)

Correction : le template passé en paramètre lors de la suppression des informations de contact d'un lieu, lors de sa fermeture, n'était pas bon. Le préfixe `venue` était en trop. 