### PR TITLE
(PC-41151)[API] feat: add more screening bookability values related to user's status in movie calendar endpoint

### DIFF
--- a/api/src/pcapi/routes/native/v1/movies.py
+++ b/api/src/pcapi/routes/native/v1/movies.py
@@ -4,7 +4,9 @@ from werkzeug.exceptions import BadRequest
 from pcapi.core.bookings import repository as bookings_repository
 from pcapi.core.offers import repository
 from pcapi.core.offers.models import Product
+from pcapi.core.subscription import api as subscription_api
 from pcapi.core.users import api as users_api
+from pcapi.core.users.young_status import Eligible
 from pcapi.models import db
 from pcapi.models.utils import first_or_404
 from pcapi.routes.native.security import authenticated_and_active_user_required
@@ -87,8 +89,12 @@ def get_movie_screenings_for_user(query: serializers.MovieScreeningsRequest) -> 
         bookings_repository.get_bookings_from_deposit(current_user.deposit.id) if current_user.deposit else []
     )
     booked_offers = [booking.stock.offer.id for booking in user_bookings]
+    booked_stocks = [booking.stock.id for booking in user_bookings]
     user_domains_credit = users_api.get_domains_credit(current_user, user_bookings)
     remaining_credit = user_domains_credit.all.remaining if user_domains_credit else 0
+    user_subscription_state = subscription_api.get_user_subscription_state(current_user)
+    young_status = user_subscription_state.young_status
+
     raw_screenings = [
         serializers.RawScreening(
             beginning_datetime=row["beginning_datetime"],
@@ -100,9 +106,11 @@ def get_movie_screenings_for_user(query: serializers.MovieScreeningsRequest) -> 
             stock_id=row["stock_id"],
             thumb_url=row["thumb_url"],
             user_data=serializers.ScreeningUserData(
-                has_already_booked_offer=row["offer_id"] in booked_offers,
+                has_already_booked_offer=row["stock_id"] in booked_stocks,
+                has_already_booked_related_offer=row["offer_id"] in booked_offers,
                 has_enough_credit=row["price"] <= remaining_credit,
                 is_allowed_to_book=current_user.is_beneficiary,
+                subscription_status=young_status.subscription_status if type(young_status) is Eligible else None,
             ),
             venue_data=serializers.ScreeningVenueData(
                 city=row["city"],
@@ -172,8 +180,11 @@ def get_movie_screenings_by_venue_for_user(
         bookings_repository.get_bookings_from_deposit(current_user.deposit.id) if current_user.deposit else []
     )
     booked_offers = [booking.stock.offer.id for booking in user_bookings]
+    booked_stocks = [booking.stock.id for booking in user_bookings]
     user_domains_credit = users_api.get_domains_credit(current_user, user_bookings)
     remaining_credit = user_domains_credit.all.remaining if user_domains_credit else 0
+    user_subscription_state = subscription_api.get_user_subscription_state(current_user)
+    young_status = user_subscription_state.young_status
 
     raw_screenings = [
         serializers.RawScreening(
@@ -192,9 +203,11 @@ def get_movie_screenings_by_venue_for_user(
                 movie_name=offer.name,
             ),
             user_data=serializers.ScreeningUserData(
-                has_already_booked_offer=offer.id in booked_offers,
+                has_already_booked_offer=stock.id in booked_stocks,
+                has_already_booked_related_offer=offer.id in booked_offers,
                 has_enough_credit=stock.price <= remaining_credit,
                 is_allowed_to_book=current_user.is_beneficiary,
+                subscription_status=young_status.subscription_status if type(young_status) is Eligible else None,
             ),
         )
         for offer in offers

--- a/api/src/pcapi/routes/native/v1/serialization/movies.py
+++ b/api/src/pcapi/routes/native/v1/serialization/movies.py
@@ -12,6 +12,7 @@ import pydantic as pydantic_v2
 
 from pcapi.core.categories.genres.movie import get_movie_label
 from pcapi.core.providers import api as providers_api
+from pcapi.core.users.young_status import SubscriptionStatus
 from pcapi.routes.serialization import HttpBodyModel
 from pcapi.routes.serialization import HttpQueryParamsModel
 from pcapi.utils import date as date_utils
@@ -57,8 +58,12 @@ class Bookability(enum.Enum):
     STOCK_IS_SOLD_OUT = "STOCK_IS_SOLD_OUT"
     USER_CANNOT_BOOK = "USER_CANNOT_BOOK"
     USER_HAS_ALREADY_BOOKED_OFFER = "USER_HAS_ALREADY_BOOKED_OFFER"
+    USER_HAS_ALREADY_BOOKED_RELATED_OFFER = "USER_HAS_ALREADY_BOOKED_RELATED_OFFER"
     USER_HAS_INSUFFICIENT_CREDIT = "USER_HAS_INSUFFICIENT_CREDIT"
     AUTHENTICATION_REQUIRED = "AUTHENTICATION_REQUIRED"
+    FINISH_SUBSCRIPTION_REQUIRED = "FINISH_SUBSCRIPTION_REQUIRED"
+    USER_APPLICATION_STILL_PROCESSING = "USER_APPLICATION_STILL_PROCESSING"
+    USER_HAS_APPLICATION_ERROR = "USER_HAS_APPLICATION_ERROR"
 
 
 @dataclass
@@ -82,8 +87,10 @@ class ScreeningVenueData:
 @dataclass
 class ScreeningUserData:
     has_already_booked_offer: bool
+    has_already_booked_related_offer: bool
     has_enough_credit: bool
     is_allowed_to_book: bool
+    subscription_status: SubscriptionStatus | None
 
 
 @dataclass
@@ -116,8 +123,16 @@ class Screening(HttpBodyModel):
         if raw_screening.is_sold_out:
             return Bookability.STOCK_IS_SOLD_OUT
         if raw_screening.user_data:
+            if raw_screening.user_data.subscription_status == SubscriptionStatus.HAS_TO_COMPLETE_SUBSCRIPTION:
+                return Bookability.FINISH_SUBSCRIPTION_REQUIRED
+            if raw_screening.user_data.subscription_status == SubscriptionStatus.HAS_SUBSCRIPTION_PENDING:
+                return Bookability.USER_APPLICATION_STILL_PROCESSING
+            if raw_screening.user_data.subscription_status == SubscriptionStatus.HAS_SUBSCRIPTION_ISSUES:
+                return Bookability.USER_HAS_APPLICATION_ERROR
             if raw_screening.user_data.has_already_booked_offer:
                 return Bookability.USER_HAS_ALREADY_BOOKED_OFFER
+            if raw_screening.user_data.has_already_booked_related_offer:
+                return Bookability.USER_HAS_ALREADY_BOOKED_RELATED_OFFER
             if not raw_screening.user_data.is_allowed_to_book:
                 return Bookability.USER_CANNOT_BOOK
             if not raw_screening.user_data.has_enough_credit:

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -699,8 +699,12 @@
                     "STOCK_IS_SOLD_OUT",
                     "USER_CANNOT_BOOK",
                     "USER_HAS_ALREADY_BOOKED_OFFER",
+                    "USER_HAS_ALREADY_BOOKED_RELATED_OFFER",
                     "USER_HAS_INSUFFICIENT_CREDIT",
-                    "AUTHENTICATION_REQUIRED"
+                    "AUTHENTICATION_REQUIRED",
+                    "FINISH_SUBSCRIPTION_REQUIRED",
+                    "USER_APPLICATION_STILL_PROCESSING",
+                    "USER_HAS_APPLICATION_ERROR"
                 ],
                 "title": "Bookability",
                 "type": "string"

--- a/api/tests/routes/native/v1/movies_test.py
+++ b/api/tests/routes/native/v1/movies_test.py
@@ -4,6 +4,7 @@ from datetime import time
 from datetime import timedelta
 
 import pytest
+from dateutil.relativedelta import relativedelta
 
 import pcapi.core.offers.factories as offers_factories
 from pcapi.core.bookings.factories import BookingFactory
@@ -11,8 +12,11 @@ from pcapi.core.categories import subcategories
 from pcapi.core.geography.factories import AddressFactory
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.providers.repository import get_provider_by_local_class
+from pcapi.core.subscription import factories as subscription_factories
+from pcapi.core.subscription import models as subscription_models
 from pcapi.core.testing import assert_num_queries
 from pcapi.core.users import factories as users_factories
+from pcapi.core.users import models as users_models
 from pcapi.utils import date as date_utils
 
 
@@ -655,6 +659,41 @@ class MovieCalendarForUserTest:
             offer__venue__offererAddress__label="Cinéma Parisien",
             beginningDatetime=datetime.now() + timedelta(hours=1),
         )
+        offers_factories.StockFactory(offer=stock.offer)
+        _user_booking = BookingFactory(user=user, stock=stock)
+        today = date.today()
+        tomorrow = date.today() + timedelta(days=1)
+        params = {
+            "allocineId": "12345",
+            "latitude": 48.85,
+            "longitude": 2.35,
+            "from": today,
+            "to": tomorrow,
+        }
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # product
+        expected_num_queries += 1  # product stocks
+        expected_num_queries += 1  # screenings
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # user bookings
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.get("/native/v1/movie/calendar/me", params=params)
+            assert response.status_code == 200
+
+        today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_HAS_ALREADY_BOOKED_OFFER"
+
+    def test_when_user_has_already_booked_related_offer(self, client):
+        user = users_factories.BeneficiaryFactory()
+        product = offers_factories.ProductFactory(extraData={"allocineId": 12345})
+        address = AddressFactory(latitude=48.85, longitude=2.35)
+        stock = offers_factories.EventStockFactory(
+            offer__product=product,
+            offer__venue__offererAddress__address=address,
+            offer__venue__offererAddress__label="Cinéma Parisien",
+            beginningDatetime=datetime.now() + timedelta(hours=1),
+        )
         another_stock = offers_factories.StockFactory(offer=stock.offer)
         _user_booking = BookingFactory(user=user, stock=another_stock)
         today = date.today()
@@ -678,7 +717,150 @@ class MovieCalendarForUserTest:
             assert response.status_code == 200
 
         today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
-        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_HAS_ALREADY_BOOKED_OFFER"
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_HAS_ALREADY_BOOKED_RELATED_OFFER"
+
+    def test_bookability_finish_subscription_required(self, client):
+        user = users_factories.UserFactory(dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18))
+        product = offers_factories.ProductFactory(extraData={"allocineId": 12345})
+        address = AddressFactory(latitude=48.85, longitude=2.35)
+        offers_factories.EventStockFactory(
+            offer__product=product,
+            offer__venue__offererAddress__address=address,
+            beginningDatetime=datetime.now() + timedelta(hours=1),
+        )
+        today = date.today()
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # product
+        expected_num_queries += 1  # product stocks
+        expected_num_queries += 1  # screenings
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # beneficiary_fraud_review
+        expected_num_queries += 1  # beneficiary_fraud_check
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.get(
+                "/native/v1/movie/calendar/me",
+                params={
+                    "allocineId": "12345",
+                    "latitude": 48.85,
+                    "longitude": 2.35,
+                    "from": today,
+                    "to": today + timedelta(days=1),
+                },
+            )
+            assert response.status_code == 200
+
+        today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "FINISH_SUBSCRIPTION_REQUIRED"
+
+    def test_bookability_user_application_still_processing(self, client):
+        user = users_factories.UserFactory(
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.OK,
+            type=subscription_models.FraudCheckType.PROFILE_COMPLETION,
+            user=user,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.PENDING,
+            type=subscription_models.FraudCheckType.DMS,
+            user=user,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.OK,
+            type=subscription_models.FraudCheckType.HONOR_STATEMENT,
+            user=user,
+        )
+
+        product = offers_factories.ProductFactory(extraData={"allocineId": 12345})
+        address = AddressFactory(latitude=48.85, longitude=2.35)
+        offers_factories.EventStockFactory(
+            offer__product=product,
+            offer__venue__offererAddress__address=address,
+            beginningDatetime=datetime.now() + timedelta(hours=1),
+        )
+        today = date.today()
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # product
+        expected_num_queries += 1  # product stocks
+        expected_num_queries += 1  # screenings
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # beneficiary_fraud_review
+        expected_num_queries += 1  # beneficiary_fraud_check
+        expected_num_queries += 1  # action_history
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.get(
+                "/native/v1/movie/calendar/me",
+                params={
+                    "allocineId": "12345",
+                    "latitude": 48.85,
+                    "longitude": 2.35,
+                    "from": today,
+                    "to": today + timedelta(days=1),
+                },
+            )
+            assert response.status_code == 200
+
+        today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_APPLICATION_STILL_PROCESSING"
+
+    def test_bookability_user_application_has_error(self, client):
+        user = users_factories.UserFactory(
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            type=subscription_models.FraudCheckType.PROFILE_COMPLETION,
+            status=subscription_models.FraudCheckStatus.OK,
+            user=user,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.KO,
+            reasonCodes=[subscription_models.FraudReasonCode.INVALID_ID_PIECE_NUMBER],
+            type=subscription_models.FraudCheckType.UBBLE,
+            user=user,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.OK,
+            type=subscription_models.FraudCheckType.HONOR_STATEMENT,
+            user=user,
+        )
+
+        product = offers_factories.ProductFactory(extraData={"allocineId": 12345})
+        address = AddressFactory(latitude=48.85, longitude=2.35)
+        offers_factories.EventStockFactory(
+            offer__product=product,
+            offer__venue__offererAddress__address=address,
+            beginningDatetime=datetime.now() + timedelta(hours=1),
+        )
+        today = date.today()
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # product
+        expected_num_queries += 1  # product stocks
+        expected_num_queries += 1  # screenings
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # beneficiary_fraud_review
+        expected_num_queries += 1  # beneficiary_fraud_check
+        expected_num_queries += 1  # action_history
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.get(
+                "/native/v1/movie/calendar/me",
+                params={
+                    "allocineId": "12345",
+                    "latitude": 48.85,
+                    "longitude": 2.35,
+                    "from": today,
+                    "to": today + timedelta(days=1),
+                },
+            )
+            assert response.status_code == 200
+
+        today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_HAS_APPLICATION_ERROR"
 
 
 class VenueMovieCalendarTest:
@@ -1068,3 +1250,170 @@ class VenueMovieCalendarForUserTest:
         today_screenings = [e["screenings"] for e in calendar if e["date"] == today.isoformat()][0]
         assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_CANNOT_BOOK"
         assert today_screenings[0]["nextScreening"]["bookability"] == "USER_CANNOT_BOOK"
+
+    def test_bookability_finish_subscription_required(self, client):
+        user = users_factories.UserFactory(dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18))
+        product = offers_factories.ProductFactory(subcategoryId=subcategories.SEANCE_CINE.id, durationMinutes=116)
+        stock = offers_factories.EventStockFactory(
+            offer__product=product, beginningDatetime=datetime.now() + timedelta(hours=1)
+        )
+        today = date.today()
+        tomorrow = date.today() + timedelta(days=1)
+        venue_id = stock.offer.venue.id
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # offers
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # beneficiary_fraud_review
+        expected_num_queries += 1  # beneficiary_fraud_check
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.get(
+                f"/native/v1/venue/{venue_id}/movie/calendar/me", params={"from": today, "to": tomorrow}
+            )
+            assert response.status_code == 200
+
+        calendar = response.json["calendar"]
+        today_screenings = [e["screenings"] for e in calendar if e["date"] == today.isoformat()][0]
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "FINISH_SUBSCRIPTION_REQUIRED"
+
+    def test_bookability_user_application_still_processing(self, client):
+        user = users_factories.UserFactory(
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.OK,
+            type=subscription_models.FraudCheckType.PROFILE_COMPLETION,
+            user=user,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.PENDING,
+            type=subscription_models.FraudCheckType.DMS,
+            user=user,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.OK,
+            type=subscription_models.FraudCheckType.HONOR_STATEMENT,
+            user=user,
+        )
+
+        product = offers_factories.ProductFactory(subcategoryId=subcategories.SEANCE_CINE.id, durationMinutes=116)
+        stock = offers_factories.EventStockFactory(
+            offer__product=product, beginningDatetime=datetime.now() + timedelta(hours=1)
+        )
+        today = date.today()
+        tomorrow = date.today() + timedelta(days=1)
+        venue_id = stock.offer.venue.id
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # offers
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # beneficiary_fraud_review
+        expected_num_queries += 1  # beneficiary_fraud_check
+        expected_num_queries += 1  # action_history
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.get(
+                f"/native/v1/venue/{venue_id}/movie/calendar/me", params={"from": today, "to": tomorrow}
+            )
+            assert response.status_code == 200
+
+        today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_APPLICATION_STILL_PROCESSING"
+
+    def test_bookability_user_application_has_error(self, client):
+        user = users_factories.UserFactory(
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            type=subscription_models.FraudCheckType.PROFILE_COMPLETION,
+            status=subscription_models.FraudCheckStatus.OK,
+            user=user,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.KO,
+            reasonCodes=[subscription_models.FraudReasonCode.INVALID_ID_PIECE_NUMBER],
+            type=subscription_models.FraudCheckType.UBBLE,
+            user=user,
+        )
+        subscription_factories.BeneficiaryFraudCheckFactory(
+            status=subscription_models.FraudCheckStatus.OK,
+            type=subscription_models.FraudCheckType.HONOR_STATEMENT,
+            user=user,
+        )
+        product = offers_factories.ProductFactory(subcategoryId=subcategories.SEANCE_CINE.id, durationMinutes=116)
+        stock = offers_factories.EventStockFactory(
+            offer__product=product, beginningDatetime=datetime.now() + timedelta(hours=1)
+        )
+        today = date.today()
+        tomorrow = date.today() + timedelta(days=1)
+        venue_id = stock.offer.venue.id
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # offers
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # beneficiary_fraud_review
+        expected_num_queries += 1  # beneficiary_fraud_check
+        expected_num_queries += 1  # action_history
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.get(
+                f"/native/v1/venue/{venue_id}/movie/calendar/me", params={"from": today, "to": tomorrow}
+            )
+            assert response.status_code == 200
+
+        today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_HAS_APPLICATION_ERROR"
+
+    def test_bookability_user_has_already_booked_offer(self, client):
+        user = users_factories.BeneficiaryFactory()
+        product = offers_factories.ProductFactory(subcategoryId=subcategories.SEANCE_CINE.id, durationMinutes=116)
+        stock = offers_factories.EventStockFactory(
+            offer__product=product,
+            beginningDatetime=datetime.now() + timedelta(hours=1),
+        )
+        offers_factories.EventStockFactory(offer=stock.offer)
+        _user_booking = BookingFactory(user=user, stock=stock)
+        today = date.today()
+        tomorrow = date.today() + timedelta(days=1)
+        venue_id = stock.offer.venue.id
+
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # offers
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # user bookings
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.get(
+                f"/native/v1/venue/{venue_id}/movie/calendar/me", params={"from": today, "to": tomorrow}
+            )
+            assert response.status_code == 200
+
+        today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_HAS_ALREADY_BOOKED_OFFER"
+
+    def test_bookability_user_has_already_booked_related_offer(self, client):
+        user = users_factories.BeneficiaryFactory()
+        product = offers_factories.ProductFactory(subcategoryId=subcategories.SEANCE_CINE.id, durationMinutes=116)
+        stock = offers_factories.EventStockFactory(
+            offer__product=product,
+            beginningDatetime=datetime.now() + timedelta(hours=1),
+        )
+        another_stock = offers_factories.EventStockFactory(offer=stock.offer)
+        _user_booking = BookingFactory(user=user, stock=another_stock)
+        today = date.today()
+        tomorrow = date.today() + timedelta(days=1)
+        venue_id = stock.offer.venue.id
+
+        expected_num_queries = 1  # user
+        expected_num_queries += 1  # offers
+        expected_num_queries += 1  # deposit
+        expected_num_queries += 1  # user bookings
+        client.with_token(user)
+        with assert_num_queries(expected_num_queries):
+            response = client.get(
+                f"/native/v1/venue/{venue_id}/movie/calendar/me", params={"from": today, "to": tomorrow}
+            )
+            assert response.status_code == 200
+
+        today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
+        assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_HAS_ALREADY_BOOKED_RELATED_OFFER"


### PR DESCRIPTION

## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-41151)

Add the following bookability values to movie calendar endpoints:
 - `AUTHENTICATION_REQUIRED`
 - `FINISH_SUBSCRIPTION_REQUIRED`
 - `USER_APPLICATION_STILL_PROCESSING`
 - `USER_HAS_APPLICATION_ERROR`
