### PR TITLE
(PC-42906)[PRO] fix: dont ensure selectedpartnervenue in lateralmenu

### DIFF
--- a/pro/src/app/App/layouts/BasicLayout/LateralPanel/LateralMenu/LateralMenu.tsx
+++ b/pro/src/app/App/layouts/BasicLayout/LateralPanel/LateralMenu/LateralMenu.tsx
@@ -10,7 +10,6 @@ import {
 } from '@/commons/core/Offers/constants'
 import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
 import { useAppSelector } from '@/commons/hooks/useAppSelector'
-import { ensureSelectedPartnerVenue } from '@/commons/store/user/selectors'
 import { withVenueHelpers } from '@/commons/utils/withVenueHelpers'
 import { Button } from '@/design-system/Button/Button'
 import {
@@ -134,9 +133,13 @@ const generateNavItems = (): NavItem[] => {
 }
 
 export const LateralMenu = ({ isLateralPanelOpen }: SideNavLinksProps) => {
-  const selectedPartnerVenue = useAppSelector(ensureSelectedPartnerVenue)
-
   const [isOpen, setIsOpen] = useState(false)
+  const selectedPartnerVenue = useAppSelector(
+    (state) => state.user.selectedPartnerVenue
+  )
+  if (!selectedPartnerVenue) {
+    return null
+  }
 
   const navItems = generateNavItems()
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42906)

`LateralMenu` (rendu sur toutes les routes connectées) utilisait `ensureSelectedPartnerVenue` qui lance une `FrontendError` quand la valeur est null.

Lors de l'initialisation `updateUser` est dispatché en premier, ce qui marque l'utilisateur comme authentifié dans le store,  puis `setSelectedPartnerVenueById` est awaité. Pendant cette fenêtre, React peut re-rendre `LateralMenu` avec `selectedPartnerVenue = null`, ce qui provoque une erreur.

Fix : utiliser un selector nullable et retourner `null`, ce qui n'affichera pas le composant `LateralMenu` qui était d'ailleurs prévu mais jamais utilisé car `ensureSelectedPartnerVenue` ne retournait jamais `null`. 

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
