### PR TITLE
(BSR)[PRO] fix: sonar - a presence assertion should use getBy* query

### DIFF
--- a/pro/src/components/ActionsBarSticky/ActionsBarSticky.spec.tsx
+++ b/pro/src/components/ActionsBarSticky/ActionsBarSticky.spec.tsx
@@ -28,19 +28,19 @@ describe('ActionsBarSticky', () => {
   it('should render contents', () => {
     renderActionsBar({ dirtyForm: undefined, mode: Mode.EDITION })
 
-    expect(screen.queryByText('left content')).toBeInTheDocument()
-    expect(screen.queryByText('right content')).toBeInTheDocument()
+    expect(screen.getByText('left content')).toBeInTheDocument()
+    expect(screen.getByText('right content')).toBeInTheDocument()
   })
 
   it('should display the saved draft message', () => {
     renderActionsBar({ dirtyForm: false, mode: Mode.CREATION })
 
-    expect(screen.queryByText('Brouillon enregistré')).toBeInTheDocument()
+    expect(screen.getByText('Brouillon enregistré')).toBeInTheDocument()
   })
 
   it('should display draft unsaved information message', () => {
     renderActionsBar({ dirtyForm: true, mode: Mode.CREATION })
 
-    expect(screen.queryByText('Brouillon non enregistré')).toBeInTheDocument()
+    expect(screen.getByText('Brouillon non enregistré')).toBeInTheDocument()
   })
 })

--- a/pro/src/components/Bookings/Components/Header/Header.spec.tsx
+++ b/pro/src/components/Bookings/Components/Header/Header.spec.tsx
@@ -14,7 +14,7 @@ describe("bookings recap table's header", () => {
   it('should display the appropriate message when there is one booking', () => {
     renderHeader(defaultProps)
 
-    expect(screen.queryByText('1 réservation')).toBeInTheDocument()
+    expect(screen.getByText('1 réservation')).toBeInTheDocument()
   })
 
   it('should display the appropriate message when there is several booking', () => {
@@ -25,7 +25,7 @@ describe("bookings recap table's header", () => {
 
     renderHeader(props)
 
-    expect(screen.queryByText('2 réservations')).toBeInTheDocument()
+    expect(screen.getByText('2 réservations')).toBeInTheDocument()
   })
 
   it('should only display a specific message when data are still loading', () => {
@@ -49,7 +49,7 @@ describe("bookings recap table's header", () => {
 
     expect(screen.queryByText('1 réservation')).not.toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: 'Voir toutes les réservations' })
+      screen.getByRole('button', { name: 'Voir toutes les réservations' })
     ).toBeInTheDocument()
   })
 })

--- a/pro/src/components/Bookings/Components/PreFilters/PreFilters.spec.tsx
+++ b/pro/src/components/Bookings/Components/PreFilters/PreFilters.spec.tsx
@@ -107,7 +107,7 @@ describe('filter bookings by bookings period', () => {
     await user.click(bookingStatusFilterInput)
     await user.click(screen.getByText('Période de validation'))
 
-    expect(screen.queryByText('Période de validation')).toBeInTheDocument()
+    expect(screen.getByText('Période de validation')).toBeInTheDocument()
   })
 
   it('should filter with a combination of filters', async () => {

--- a/pro/src/components/ExternalAccessibility/ExternalAccessibilityCollapse/ExternalAccessibilityCollapse.spec.tsx
+++ b/pro/src/components/ExternalAccessibility/ExternalAccessibilityCollapse/ExternalAccessibilityCollapse.spec.tsx
@@ -34,6 +34,6 @@ describe('ExternalAccessibilityCollapse', () => {
     await userEvent.click(
       screen.getByLabelText('Voir les détails pour Handicap moteur')
     )
-    expect(screen.queryByText('Content')).toBeInTheDocument()
+    expect(screen.getByText('Content')).toBeInTheDocument()
   })
 })

--- a/pro/src/components/Footer/Footer.spec.tsx
+++ b/pro/src/components/Footer/Footer.spec.tsx
@@ -18,7 +18,7 @@ describe('Footer', () => {
     renderFooter(true)
 
     expect(
-      screen.queryByRole('link', { name: /CGU professionnels/ })
+      screen.getByRole('link', { name: /CGU professionnels/ })
     ).toBeInTheDocument()
   })
 
@@ -26,7 +26,7 @@ describe('Footer', () => {
     renderFooter(true)
 
     expect(
-      screen.queryByRole('link', {
+      screen.getByRole('link', {
         name: 'Accessibilité : partiellement conforme',
       })
     ).toBeInTheDocument()

--- a/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/__specs__/OffererAuthenticationScreen.spec.tsx
@@ -281,9 +281,9 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
     ).toBeInTheDocument()
 
     expect(
-      screen.queryByRole('button', { name: 'Continuer' })
+      screen.getByRole('button', { name: 'Continuer' })
     ).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Retour' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retour' })).toBeInTheDocument()
 
     expect(
       screen.getByRole('heading', {
@@ -302,7 +302,7 @@ describe('screens:SignupJourney::OffererAuthentication', () => {
       await screen.findByRole('button', { name: 'Continuer' })
     ).toBeInTheDocument()
 
-    expect(screen.queryByRole('button', { name: 'Retour' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retour' })).toBeInTheDocument()
   })
 
   it('should render component with empty adresss', async () => {

--- a/pro/src/components/SkipLinks/__specs__/SkipLinks.spec.tsx
+++ b/pro/src/components/SkipLinks/__specs__/SkipLinks.spec.tsx
@@ -59,7 +59,7 @@ const renderApp = ({
 describe('SkipLinks', () => {
   it('should render', () => {
     renderApp()
-    expect(screen.queryByText('Aller au contenu')).toBeInTheDocument()
+    expect(screen.getByText('Aller au contenu')).toBeInTheDocument()
     expect(screen.queryByText('Menu')).not.toBeInTheDocument()
   })
 

--- a/pro/src/components/SynchronisedProviderInformation/SynchronizedProviderInformation.spec.tsx
+++ b/pro/src/components/SynchronisedProviderInformation/SynchronizedProviderInformation.spec.tsx
@@ -19,7 +19,7 @@ describe('SynchronizedProviderInformation', () => {
       props: { providerName: 'unknown provider id' },
     })
     expect(
-      screen.queryByText('unknown provider id', { exact: false })
+      screen.getByText('unknown provider id', { exact: false })
     ).toBeInTheDocument()
   })
 

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/__specs__/AdageHeader.spec.tsx
@@ -79,10 +79,10 @@ describe('AdageHeader', () => {
     expect(
       screen.getByRole('link', { name: 'Pour mon établissement 0' })
     ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Découvrir' })).toBeInTheDocument()
     expect(
-      screen.queryByRole('link', { name: 'Découvrir' })
+      screen.getByRole('link', { name: /Solde prévisionnel/ })
     ).toBeInTheDocument()
-    screen.queryByRole('link', { name: /Solde prévisionnel/ })
   })
 
   it('should render adage header with link for discovery', async () => {
@@ -192,7 +192,7 @@ describe('AdageHeader', () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole('link', { name: /Mes Favoris/ })
+        screen.getByRole('link', { name: /Mes Favoris/ })
       ).toBeInTheDocument()
     })
   })
@@ -204,7 +204,7 @@ describe('AdageHeader', () => {
 
     await waitFor(() => {
       expect(
-        screen.queryByRole('link', { name: /Mes Favoris (10)/ })
+        screen.getByRole('link', { name: /Mes Favoris (10)/ })
       ).toBeInTheDocument()
     })
   })

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/CollectiveOfferSummary/CollectiveOfferSummary.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/CollectiveOfferSummary/CollectiveOfferSummary.spec.tsx
@@ -192,7 +192,7 @@ describe('CollectiveOfferSummary', () => {
       offerEditLink: '123',
     })
 
-    expect(screen.queryByRole('link', { name: 'Modifier' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Modifier' })).toBeInTheDocument()
   })
 
   it('should display two edition buttons when the offer description and price are editable', () => {
@@ -341,7 +341,7 @@ describe('CollectiveOfferSummary', () => {
         ffOverrides
       )
       expect(
-        screen.queryByRole('heading', { name: 'Dates et prix' })
+        screen.getByRole('heading', { name: 'Dates et prix' })
       ).toBeVisible()
       expect(screen.getByText('test-booking-email@example.com')).toBeVisible()
     })

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/CollectiveOfferSummary/components/__specs__/CollectiveOfferDateSection.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/CollectiveOfferSummary/components/__specs__/CollectiveOfferDateSection.spec.tsx
@@ -35,7 +35,7 @@ describe('CollectiveOfferDateSection', () => {
       offer,
     })
     expect(
-      screen.queryByText(
+      screen.getByText(
         'Tout au long de l’année scolaire (l’offre est permanente)'
       )
     ).toBeInTheDocument()

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferType/OfferType/OfferType.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferType/OfferType/OfferType.spec.tsx
@@ -176,7 +176,7 @@ describe('OfferType', () => {
     )
 
     expect(
-      screen.queryByRole('heading', {
+      screen.getByRole('heading', {
         name: 'Créer une nouvelle offre ou dupliquer une offre ?',
       })
     ).toBeInTheDocument()

--- a/pro/src/pages/CollectiveVenuePageEdition/CollectiveVenuePageEdition.spec.tsx
+++ b/pro/src/pages/CollectiveVenuePageEdition/CollectiveVenuePageEdition.spec.tsx
@@ -163,17 +163,17 @@ describe('CollectiveVenuePageEdition', () => {
       await userEvent.click(title)
 
       expect(
-        screen.queryByText(
+        screen.getByText(
           'Veuillez renseigner un numéro de téléphone valide, exemple : 6 12 34 56 78'
         )
       ).toBeInTheDocument()
       expect(
-        screen.queryByText(
+        screen.getByText(
           'Veuillez renseigner une URL valide. Ex : https://exemple.com'
         )
       ).toBeInTheDocument()
       expect(
-        screen.queryByText(
+        screen.getByText(
           'Veuillez renseigner un email valide, exemple : mail@exemple.com'
         )
       ).toBeInTheDocument()

--- a/pro/src/pages/IndividualBookings/IndividualBookings.spec.tsx
+++ b/pro/src/pages/IndividualBookings/IndividualBookings.spec.tsx
@@ -326,7 +326,7 @@ describe('components | BookingsRecap | Pro user', () => {
       ).toBeDisabled()
     })
     expect(
-      screen.queryByText(
+      screen.getByText(
         'Pour visualiser vos réservations, veuillez sélectionner un ou plusieurs des filtres précédents et cliquer sur « Rechercher »'
       )
     ).toBeInTheDocument()
@@ -733,7 +733,7 @@ describe('components | BookingsRecap | Pro user', () => {
     await screen.findAllByText(bookingRecap.stock.offerName)
 
     expect(
-      screen.queryByText(
+      screen.getByText(
         'Télécharger vos réservations dans l’onglet “Données d’activité” de votre Espace administration accessible en haut à droite.'
       )
     ).toBeInTheDocument()

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsEanSearch/DetailsEanSearch.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsEanSearch/DetailsEanSearch.spec.tsx
@@ -239,7 +239,7 @@ describe('DetailsEanSearch', () => {
         await userEvent.type(getInput(), '9781234567897')
         await userEvent.click(getButton())
 
-        expect(screen.queryByText(errorMessage)).toBeInTheDocument()
+        expect(screen.getByText(errorMessage)).toBeInTheDocument()
       })
 
       it('should disable the submit button', async () => {

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/DetailsSubForm/components/ArtistField/ArtistField.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/DetailsSubForm/components/ArtistField/ArtistField.spec.tsx
@@ -104,7 +104,7 @@ describe('ArtistField', () => {
 
     const props = apiSelectSpy.mock.calls[0][0]
 
-    expect(screen.queryByTestId('mock-api-select')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-api-select')).toBeInTheDocument()
     expect(props.label).toBe('Auteur')
     expect(props.name).toBe('artistOfferLinks.0')
     expect(props.minSearchLength).toBe(2)

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/IndividualOfferDescriptionScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/IndividualOfferDescriptionScreen.spec.tsx
@@ -351,7 +351,7 @@ describe('<IndividualOfferDescriptionScreen />', () => {
     renderDetailsScreen({ contextValue })
 
     expect(
-      screen.queryByRole('heading', { name: 'Modalités d’accessibilité' })
+      screen.getByRole('heading', { name: 'Modalités d’accessibilité' })
     ).toBeInTheDocument()
   })
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferSummary/components/IndividualOfferSummaryScreen.spec.tsx
@@ -313,7 +313,7 @@ describe('IndividualOfferSummaryScreen', () => {
       renderIndividualOfferSummaryScreen({ contextValues, path })
 
       await expectOfferFields()
-      expect(screen.queryByText('Visualiser dans l’app')).toBeInTheDocument()
+      expect(screen.getByText('Visualiser dans l’app')).toBeInTheDocument()
     })
 
     it('should render a media section', async () => {

--- a/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOffersActionsBar/IndividualOffersActionsBar.spec.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOffersActionsBar/IndividualOffersActionsBar.spec.tsx
@@ -105,13 +105,13 @@ describe('ActionsBar', () => {
 
     renderActionsBar(props)
 
-    expect(screen.queryByText('1 offre sélectionnée')).toBeInTheDocument()
+    expect(screen.getByText('1 offre sélectionnée')).toBeInTheDocument()
   })
 
   it('should say how many offers are selected when more than 1 offer are selected', () => {
     renderActionsBar(props)
 
-    expect(screen.queryByText('2 offres sélectionnées')).toBeInTheDocument()
+    expect(screen.getByText('2 offres sélectionnées')).toBeInTheDocument()
   })
 
   it('should show a generic count when more than 500 offers are selected', () => {
@@ -121,7 +121,7 @@ describe('ActionsBar', () => {
 
     renderActionsBar(props)
 
-    expect(screen.queryByText('100+ offres sélectionnées')).toBeInTheDocument()
+    expect(screen.getByText('100+ offres sélectionnées')).toBeInTheDocument()
   })
 
   it('should activate selected offers upon publication', async () => {

--- a/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.spec.tsx
+++ b/pro/src/pages/Onboarding/OnboardingOfferIndividual/OnboardingOfferIndividual.spec.tsx
@@ -120,7 +120,7 @@ describe('<OnboardingOfferIndividual />', () => {
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
     expect(
-      screen.queryByRole('heading', {
+      screen.getByRole('heading', {
         name: /Reprendre une offre déjà commencée/,
       })
     ).toBeInTheDocument()

--- a/pro/src/pages/Reimbursements/BankInformations/BankInformations.spec.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/BankInformations.spec.tsx
@@ -126,7 +126,7 @@ describe('BankInformations page', () => {
     )
 
     expect(
-      screen.queryByText(
+      screen.getByText(
         /Les informations non sauvegardées ne seront pas prises en compte/
       )
     ).toBeInTheDocument()
@@ -154,7 +154,7 @@ describe('BankInformations page', () => {
     )
 
     expect(
-      screen.queryByText(
+      screen.getByText(
         /Attention : la ou les structures désélectionnées ne seront plus remboursées sur ce compte bancaire/
       )
     ).toBeInTheDocument()
@@ -253,7 +253,7 @@ describe('BankInformations page', () => {
     renderBankInformations()
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-    expect(screen.queryByText('Ajouter un compte bancaire')).toBeInTheDocument()
+    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
 
     expect(
       screen.queryByText(
@@ -280,7 +280,7 @@ describe('BankInformations page', () => {
     renderBankInformations()
     await waitForElementToBeRemoved(() => screen.queryByTestId('spinner'))
 
-    expect(screen.queryByText('Ajouter un compte bancaire')).toBeInTheDocument()
+    expect(screen.getByText('Ajouter un compte bancaire')).toBeInTheDocument()
 
     expect(
       screen.queryByText(

--- a/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/StocksProviderForm/StocksProviderForm.spec.tsx
+++ b/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/StocksProviderForm/StocksProviderForm.spec.tsx
@@ -37,7 +37,7 @@ describe('StocksProviderForm', () => {
     renderStocksProviderForm(props)
 
     expect(
-      screen.queryByRole('button', { name: 'Lancer la synchronisation' })
+      screen.getByRole('button', { name: 'Lancer la synchronisation' })
     ).toBeInTheDocument()
   })
 

--- a/pro/src/ui-kit/SelectedValuesTags/SelectedValuesTags.spec.tsx
+++ b/pro/src/ui-kit/SelectedValuesTags/SelectedValuesTags.spec.tsx
@@ -74,7 +74,7 @@ describe('SelectedValuesTags', () => {
     render(<SelectedValuesTags {...defaultProps} />)
 
     // Check that the ellipsis tag is not displayed
-    expect(screen.queryByText('+')).toBeDefined()
+    expect(screen.queryByText('+')).not.toBeInTheDocument()
   })
 
   it('should disable the remove buttons when disabled prop is true', () => {

--- a/pro/src/ui-kit/Tabs/Tabs.spec.tsx
+++ b/pro/src/ui-kit/Tabs/Tabs.spec.tsx
@@ -32,7 +32,7 @@ describe('Tabs', () => {
       />
     )
 
-    expect(screen.queryByText(/NavLinkItems/)).toBeInTheDocument()
+    expect(screen.getByText(/NavLinkItems/)).toBeInTheDocument()
     expect(screen.queryByText(/TabItems/)).not.toBeInTheDocument()
   })
 
@@ -56,7 +56,7 @@ describe('Tabs', () => {
       />
     )
 
-    expect(screen.queryByText(/TabItems/)).toBeInTheDocument()
+    expect(screen.getByText(/TabItems/)).toBeInTheDocument()
     expect(screen.queryByText(/NavLinkItems/)).not.toBeInTheDocument()
   })
 })

--- a/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.spec.tsx
+++ b/pro/src/ui-kit/form/PhoneNumberInput/PhoneNumberInput.spec.tsx
@@ -63,7 +63,7 @@ describe('PhoneNumberInput', () => {
         'Veuillez renseigner un numéro de téléphone valide, exemple : 612345678',
     })
     expect(
-      screen.queryByText(
+      screen.getByText(
         'Veuillez renseigner un numéro de téléphone valide, exemple : 612345678'
       )
     ).toBeInTheDocument()


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Fix sonar medium issue "A presence assertion should use a `getBy*` query so a missing element produces Testing Library diagnostics."