### PR TITLE
(BSR)[PRO] fix: sonar - prefer set over arrays to check existence

### DIFF
--- a/pro/src/commons/utils/translate.ts
+++ b/pro/src/commons/utils/translate.ts
@@ -11,7 +11,7 @@ const translateObjectKeysAndValues = (
   translationsMap: Record<string, string>
 ) => {
   const nonTranlatedKeys = new Set(['nom-ou-isbn', 'nameOrIsbn', 'nom', 'name']) //  These keys should not have their values translated since it's user inputs
-  const keyShouldNotHaveEmptyValue = ['status']
+  const keyShouldNotHaveEmptyValue = new Set(['status'])
 
   const result: Record<string, string> = {}
   Object.entries(originalObject).forEach(([originalKey, originalValue]) => {
@@ -23,10 +23,7 @@ const translateObjectKeysAndValues = (
         ? translationsMap[originalValue]
         : originalValue
 
-    if (
-      !keyShouldNotHaveEmptyValue.includes(translatedKey) ||
-      translatedValue
-    ) {
+    if (!keyShouldNotHaveEmptyValue.has(translatedKey) || translatedValue) {
       result[translatedKey] = Array.isArray(translatedValue)
         ? translatedValue.map((value) => translationsMap[value])
         : translatedValue

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/CollectiveOfferEdition/utils/createPatchOfferPayload.ts
@@ -202,7 +202,7 @@ export const createPatchOfferTemplatePayload = (
   offer: OfferEducationalFormValues,
   initialValues: OfferEducationalFormValues
 ): PatchCollectiveOfferTemplateBodyModel => {
-  const keysToOmmit: (keyof OfferEducationalFormValues)[] = [
+  const keysToOmmit: Set<keyof OfferEducationalFormValues> = new Set([
     'imageUrl',
     'imageCredit',
     'beginningDate',
@@ -213,7 +213,7 @@ export const createPatchOfferTemplatePayload = (
     'contactFormType',
     'contactOptions',
     'addressAutocomplete',
-  ]
+  ])
 
   let changedValues: PatchCollectiveOfferTemplateBodyModel = {}
 
@@ -221,7 +221,7 @@ export const createPatchOfferTemplatePayload = (
 
   offerKeys.forEach((key) => {
     if (
-      !keysToOmmit.includes(key) &&
+      !keysToOmmit.has(key) &&
       !isEqual(offer[key], initialValues[key]) &&
       !key.startsWith('search-')
     ) {

--- a/pro/src/repository/pcapi/pcapiClient.ts
+++ b/pro/src/repository/pcapi/pcapiClient.ts
@@ -8,10 +8,10 @@ const HTTP_STATUS = {
   BAD_GATEWAY: 502,
   SERVICE_UNAVAILABLE: 503,
 }
-const NOT_JSON_BODY_RESPONSE_STATUS = [
+const NOT_JSON_BODY_RESPONSE_STATUS = new Set([
   HTTP_STATUS.NO_CONTENT,
   HTTP_STATUS.SERVICE_UNAVAILABLE,
-]
+])
 const GET_HTTP_METHOD = 'GET'
 const DELETE_HTTP_METHOD = 'DELETE'
 
@@ -34,7 +34,7 @@ const buildUrl = (path: string) => `${API_URL}${path}`
 const fetchWithErrorHandler = async (path: string, options: RequestInit) => {
   try {
     const response = await fetch(buildUrl(path), options)
-    const results = NOT_JSON_BODY_RESPONSE_STATUS.includes(response.status)
+    const results = NOT_JSON_BODY_RESPONSE_STATUS.has(response.status)
       ? null
       : await response.json()
     if (!response.ok) {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Fix sonar medium issues for this rule : [Arrays used only for existence checks should be Sets](https://sonarcloud.io/organizations/pass-culture/rules?open=typescript%3AS7776&rule_key=typescript%3AS7776)
