### PR TITLE
(PC-43056)[PRO] refactor: update Button signature to remove unclear i…

### DIFF
--- a/pro/src/app/App/layouts/BasicLayout/LateralPanel/AdminSideNav/AdminSideNav.tsx
+++ b/pro/src/app/App/layouts/BasicLayout/LateralPanel/AdminSideNav/AdminSideNav.tsx
@@ -55,7 +55,7 @@ export const AdminSideNavLinks = () => {
     <nav className={styles['nav-links']}>
       <div className={styles['back-to-admin']}>
         <Button
-          as="a"
+          as="router-link"
           variant={ButtonVariant.SECONDARY}
           to="/accueil"
           iconPosition={IconPositionEnum.LEFT}

--- a/pro/src/app/App/layouts/BasicLayout/LateralPanel/LateralMenu/LateralMenu.tsx
+++ b/pro/src/app/App/layouts/BasicLayout/LateralPanel/LateralMenu/LateralMenu.tsx
@@ -151,7 +151,7 @@ export const LateralMenu = ({ isLateralPanelOpen }: SideNavLinksProps) => {
     >
       <div className={styles['back-to-admin']}>
         <Button
-          as="a"
+          as="router-link"
           variant={ButtonVariant.SECONDARY}
           to="/remboursements"
           iconPosition={IconPositionEnum.LEFT}
@@ -164,7 +164,7 @@ export const LateralMenu = ({ isLateralPanelOpen }: SideNavLinksProps) => {
       <div className={styles['nav-links-group-switch-venue']}>
         <div className={styles['nav-links-switch-venue-button']}>
           <Button
-            as="a"
+            as="router-link"
             aria-label={`Changer de structure (actuellement sélectionnée : ${selectedPartnerVenue.publicName})`}
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}

--- a/pro/src/app/App/layouts/BasicLayout/LateralPanel/LateralPanel.tsx
+++ b/pro/src/app/App/layouts/BasicLayout/LateralPanel/LateralPanel.tsx
@@ -103,7 +103,6 @@ export const LateralPanel = ({
           <Button
             as="a"
             to={skipLinkTarget}
-            isExternal
             icon={fullNextIcon}
             label="Aller au menu"
             size={ButtonSize.SMALL}
@@ -146,7 +145,7 @@ export const LateralPanel = ({
         {isHubPage && (
           <div className={styles['back-to-admin']}>
             <Button
-              as="a"
+              as="router-link"
               variant={ButtonVariant.SECONDARY}
               to="/administration/remboursements"
               iconPosition={IconPositionEnum.LEFT}

--- a/pro/src/app/App/layouts/ErrorLayout/ErrorLayout.tsx
+++ b/pro/src/app/App/layouts/ErrorLayout/ErrorLayout.tsx
@@ -45,7 +45,7 @@ export const ErrorLayout = ({
           {/** biome-ignore lint/correctness/useUniqueElementIds: This is always
           rendered once per page, so there cannot be id duplications.> */}
           <Button
-            as="a"
+            as="router-link"
             id="error-return-link"
             variant={ButtonVariant.SECONDARY}
             to={redirect}

--- a/pro/src/app/App/layouts/components/Header/Header.tsx
+++ b/pro/src/app/App/layouts/components/Header/Header.tsx
@@ -124,7 +124,7 @@ export const Header = forwardRef(
               <>
                 {!hideAdminButton && (
                   <Button
-                    as="a"
+                    as="router-link"
                     variant={ButtonVariant.SECONDARY}
                     color={ButtonColor.BRAND}
                     size={ButtonSize.SMALL}
@@ -150,8 +150,7 @@ export const Header = forwardRef(
               <Button
                 as="a"
                 to="https://aide.passculture.app/hc/fr"
-                opensInNewTab={true}
-                isExternal={true}
+                opensInNewTab
                 color={ButtonColor.NEUTRAL}
                 variant={ButtonVariant.SECONDARY}
                 label="Besoin d’aide ?"

--- a/pro/src/app/App/layouts/components/Header/components/HeaderDropdown/HeaderDropdown.tsx
+++ b/pro/src/app/App/layouts/components/Header/components/HeaderDropdown/HeaderDropdown.tsx
@@ -62,7 +62,7 @@ export const HeaderDropdown = () => {
           {!IN_STRUCTURE_CREATION_FUNNEL && (
             <DropdownMenu.Item className={styles['menu-item']}>
               <Button
-                as="a"
+                as="router-link"
                 variant={ButtonVariant.TERTIARY}
                 color={ButtonColor.NEUTRAL}
                 icon={fullProfilIcon}

--- a/pro/src/components/AlreadyHasAccount/AlreadyHasAccount.tsx
+++ b/pro/src/components/AlreadyHasAccount/AlreadyHasAccount.tsx
@@ -12,7 +12,7 @@ export const AlreadyHasAccount = (): JSX.Element => {
       </p>
 
       <Button
-        as="a"
+        as="router-link"
         to="/connexion"
         icon={iconFullNext}
         variant={ButtonVariant.TERTIARY}

--- a/pro/src/components/CollectiveDmsTimeline/CollectiveAdagePendingStatus.tsx
+++ b/pro/src/components/CollectiveDmsTimeline/CollectiveAdagePendingStatus.tsx
@@ -22,7 +22,6 @@ export const CollectiveAdagePendingStatus = () => {
           color={ButtonColor.NEUTRAL}
           icon={fullInfoIcon}
           to="https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires"
-          isExternal
           opensInNewTab
           label="En savoir plus sur le pass Culture à destination des scolaires"
         />

--- a/pro/src/components/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
+++ b/pro/src/components/CollectiveDmsTimeline/CollectiveDmsTimeline.tsx
@@ -97,7 +97,6 @@ export const CollectiveDmsTimeline = ({
           color={ButtonColor.NEUTRAL}
           icon={fullLinkIcon}
           to={collectiveDmsApplicationLink}
-          isExternal
           onClick={() =>
             logClickOnDmsLink(DMSApplicationstatus.EN_CONSTRUCTION)
           }
@@ -109,7 +108,6 @@ export const CollectiveDmsTimeline = ({
           color={ButtonColor.NEUTRAL}
           icon={fullLinkIcon}
           to={collectiveDmsContactSupport}
-          isExternal
           label="Contacter les services des ministères de l’Éducation nationale et de la Culture"
         />
       </>
@@ -138,7 +136,6 @@ export const CollectiveDmsTimeline = ({
           color={ButtonColor.NEUTRAL}
           icon={fullLinkIcon}
           to={collectiveDmsApplicationLink}
-          isExternal
           onClick={() => logClickOnDmsLink(DMSApplicationstatus.EN_INSTRUCTION)}
           label="Consulter ma messagerie sur Démarche Numérique"
         />
@@ -180,7 +177,6 @@ export const CollectiveDmsTimeline = ({
           color={ButtonColor.NEUTRAL}
           icon={fullLinkIcon}
           to={collectiveDmsApplicationLink}
-          isExternal
           onClick={() => logClickOnDmsLink(DMSApplicationstatus.ACCEPTE)}
           label="Consulter ma messagerie sur Démarche Numérique"
         />

--- a/pro/src/components/DisplayOfferInAppLink/DisplayOfferInAppLink.tsx
+++ b/pro/src/components/DisplayOfferInAppLink/DisplayOfferInAppLink.tsx
@@ -4,10 +4,10 @@ import { useAnalytics } from '@/app/App/analytics/firebase'
 import { Events } from '@/commons/core/FirebaseEvents/constants'
 import { WEBAPP_URL } from '@/commons/utils/config'
 import { Button } from '@/design-system/Button/Button'
-import type { ButtonAsLinkProps } from '@/design-system/Button/types'
+import type { ButtonAsAnchorProps } from '@/design-system/Button/types'
 
 interface DisplayOfferInAppLinkProps
-  extends Partial<Omit<ButtonAsLinkProps, 'id'>> {
+  extends Partial<Omit<ButtonAsAnchorProps, 'id'>> {
   id: number
   onClick?: () => void
 }
@@ -23,7 +23,6 @@ export const DisplayOfferInAppLink: FunctionComponent<
       {...originalProps}
       as="a"
       to={offerPreviewUrl}
-      isExternal
       onClick={() => {
         logEvent(Events.CLICKED_VIEW_APP_OFFER, {
           offerId: id,

--- a/pro/src/components/EductionalRedactorDetails/EducationalRedactorDetails.tsx
+++ b/pro/src/components/EductionalRedactorDetails/EducationalRedactorDetails.tsx
@@ -49,7 +49,6 @@ export const EducationalRedactorDetails = ({
           <Button
             as="a"
             to={`mailto:${contact.email}`}
-            isExternal
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             label={contact.email ?? ''}

--- a/pro/src/components/EductionalRedactorDetailsForBooking/EducationalRedactorDetailsForBooking.tsx
+++ b/pro/src/components/EductionalRedactorDetailsForBooking/EducationalRedactorDetailsForBooking.tsx
@@ -35,7 +35,6 @@ export const EducationalRedactorDetailsForBooking = ({
           <Button
             as="a"
             to={`mailto:${contact.email}`}
-            isExternal
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             label={contact.email ?? ''}

--- a/pro/src/components/Footer/Footer.tsx
+++ b/pro/src/components/Footer/Footer.tsx
@@ -44,7 +44,6 @@ export const Footer = ({ layout }: FooterProps) => {
           <Button
             as="a"
             to="#pied-de-page"
-            isExternal
             icon={fullNextIcon}
             label="Aller au pied de page"
             size={ButtonSize.SMALL}
@@ -61,7 +60,6 @@ export const Footer = ({ layout }: FooterProps) => {
             color={ButtonColor.NEUTRAL}
             size={ButtonSize.SMALL}
             to="https://pass.culture.fr/cgu-professionnels/"
-            isExternal
             opensInNewTab
             label="CGU professionnels"
           />
@@ -73,14 +71,13 @@ export const Footer = ({ layout }: FooterProps) => {
             color={ButtonColor.NEUTRAL}
             size={ButtonSize.SMALL}
             to="https://pass.culture.fr/donnees-personnelles/"
-            isExternal
             opensInNewTab
             label="Charte des Données Personnelles"
           />
         </li>
         <li className={styles['footer-list-item']}>
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             size={ButtonSize.SMALL}
@@ -90,7 +87,7 @@ export const Footer = ({ layout }: FooterProps) => {
         </li>
         <li className={styles['footer-list-item']}>
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             size={ButtonSize.SMALL}
@@ -101,7 +98,7 @@ export const Footer = ({ layout }: FooterProps) => {
         {currentUser && (
           <li className={styles['footer-list-item']}>
             <Button
-              as="a"
+              as="router-link"
               variant={ButtonVariant.TERTIARY}
               color={ButtonColor.NEUTRAL}
               size={ButtonSize.SMALL}

--- a/pro/src/components/IndividualOfferLayout/components/OfferRecommendationCard/OfferRecommendationForm.tsx
+++ b/pro/src/components/IndividualOfferLayout/components/OfferRecommendationCard/OfferRecommendationForm.tsx
@@ -194,7 +194,6 @@ export function OfferRecommendationForm({
                   <Button
                     as="a"
                     variant={ButtonVariant.TERTIARY}
-                    isExternal
                     opensInNewTab
                     to={CGU_LINK}
                     color={ButtonColor.NEUTRAL}

--- a/pro/src/components/Newsletter/Newsletter.tsx
+++ b/pro/src/components/Newsletter/Newsletter.tsx
@@ -12,7 +12,6 @@ export const Newsletter = () => {
         variant={ButtonVariant.TERTIARY}
         color={ButtonColor.NEUTRAL}
         to="https://04a7f3c7.sibforms.com/serve/MUIFAPpqRUKo_nexWvrSwpAXBv-P4ips11dOuqZz5d5FnAbtVD5frxeX6yLHjJcPwiiYAObkjhhcOVTlTkrd7XZDk6Mb2pbWTeaI-BUB6GK-G1xdra_mo-D4xAQsX5afUNHKIs3E279tzr9rDkHn3zVhIHZhcY14BiXhobwL6aFlah1-oXmy_RbznM0dtxVdaWHBPe2z0rYudrUw"
-        isExternal
         opensInNewTab
         label="Inscrivez-vous à notre newsletter pour recevoir les actualités du pass
         Culture"

--- a/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
+++ b/pro/src/components/OnboardingOffersChoice/OnboardingOffersChoice.tsx
@@ -56,7 +56,7 @@ export const OnboardingOffersChoice = ({
           </Card.Content>
           <Card.Footer>
             <Button
-              as="a"
+              as="router-link"
               variant={ButtonVariant.PRIMARY}
               to="/onboarding/individuel"
               aria-label="Commencer la création d’offre sur l’application mobile"

--- a/pro/src/components/OnboardingOffersChoice/components/OnboardingCollectiveModal/OnboardingCollectiveModal.tsx
+++ b/pro/src/components/OnboardingOffersChoice/components/OnboardingCollectiveModal/OnboardingCollectiveModal.tsx
@@ -104,7 +104,6 @@ export const OnboardingCollectiveModal = ({
       <div className={styles['onboarding-collective-actions']}>
         <Button
           as="a"
-          isExternal
           opensInNewTab
           variant={ButtonVariant.PRIMARY}
           color={ButtonColor.BRAND}

--- a/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
+++ b/pro/src/components/SignupJourneyForm/Authentication/OffererAuthentication.tsx
@@ -259,7 +259,7 @@ export const OffererAuthentication = (): JSX.Element => {
                   Informations
                 </h2>
                 <Button
-                  as="a"
+                  as="router-link"
                   to="/inscription/structure/recherche"
                   variant={ButtonVariant.SECONDARY}
                   color={ButtonColor.NEUTRAL}

--- a/pro/src/components/SignupJourneyForm/Offerers/Offerers.tsx
+++ b/pro/src/components/SignupJourneyForm/Offerers/Offerers.tsx
@@ -234,7 +234,7 @@ export const Offerers = (): JSX.Element => {
       <div className={styles['next-actions']}>
         {isSignupSimulationEnabled && (
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.SECONDARY}
             onClick={() => {
               setOfferer(null)

--- a/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
+++ b/pro/src/components/SignupJourneyForm/Validation/Validation.tsx
@@ -254,7 +254,7 @@ export const Validation = (): JSX.Element | undefined => {
                 : 'Vos informations'}
             </h2>
             <Button
-              as="a"
+              as="router-link"
               to="/inscription/structure/identification"
               onClick={() => {
                 logEvent(Events.CLICKED_ONBOARDING_FORM_NAVIGATION, {
@@ -281,7 +281,7 @@ export const Validation = (): JSX.Element | undefined => {
           <div className={styles['validation-screen-subtitle']}>
             <h2 className={styles['subtitle']}>Votre activité</h2>
             <Button
-              as="a"
+              as="router-link"
               to="/inscription/structure/activite"
               onClick={() => {
                 logEvent(Events.CLICKED_ONBOARDING_FORM_NAVIGATION, {

--- a/pro/src/components/SkipLinks/SkipLinks.tsx
+++ b/pro/src/components/SkipLinks/SkipLinks.tsx
@@ -26,7 +26,6 @@ export const SkipLinks = (): JSX.Element => {
               as="a"
               id="go-to-content"
               to="#content"
-              isExternal
               icon={fullNextIcon}
               label="Aller au contenu"
               size={ButtonSize.SMALL}

--- a/pro/src/design-system/Banner/Banner.tsx
+++ b/pro/src/design-system/Banner/Banner.tsx
@@ -94,7 +94,11 @@ export const Banner = ({
                   <li key={a.label} className={styles.link}>
                     {a.type === 'link' ? (
                       <Button
-                        as="a"
+                        as={
+                          a.isExternal || a.href.startsWith('#')
+                            ? 'a'
+                            : 'router-link'
+                        }
                         variant={ButtonVariant.TERTIARY}
                         color={ButtonColor.NEUTRAL}
                         size={
@@ -106,9 +110,7 @@ export const Banner = ({
                         icon={a.icon}
                         iconAlt={a.iconAlt}
                         opensInNewTab={a.isExternal}
-                        isExternal={a.isExternal}
                         onClick={() => a.onClick?.()}
-                        isSectionLink={a.href.startsWith('#')}
                         label={a.label}
                       />
                     ) : (

--- a/pro/src/design-system/Banner/Banner.tsx
+++ b/pro/src/design-system/Banner/Banner.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import { Button } from '@/design-system/Button/Button'
 import {
   ButtonColor,
+  type ButtonProps,
   ButtonSize,
   ButtonVariant,
 } from '@/design-system/Button/types'
@@ -63,6 +64,26 @@ export const Banner = ({
   closable = false,
   onClose,
 }: BannerProps): JSX.Element => {
+  const actionButtonProps: ButtonProps[] = actions.map((a) => {
+    const { type, href, isExternal, ...btnProps } = a
+    const baseProps = {
+      ...btnProps,
+      onClick: () => btnProps.onClick?.(),
+      size: size === 'default' ? ButtonSize.SMALL : ButtonSize.DEFAULT,
+      variant: ButtonVariant.TERTIARY,
+      color: ButtonColor.NEUTRAL,
+    }
+
+    if (type !== 'link') {
+      return { ...baseProps }
+    }
+
+    if (isExternal || href.startsWith('#')) {
+      return { ...baseProps, as: 'a', to: href, opensInNewTab: isExternal }
+    }
+
+    return { ...baseProps, as: 'router-link', to: href }
+  })
   return (
     <div
       className={cx(styles.banner, styles[variant])}
@@ -90,43 +111,9 @@ export const Banner = ({
             )}
             {actions.length > 0 && (
               <ul className={styles['actions-list']}>
-                {actions.map((a) => (
-                  <li key={a.label} className={styles.link}>
-                    {a.type === 'link' ? (
-                      <Button
-                        as={
-                          a.isExternal || a.href.startsWith('#')
-                            ? 'a'
-                            : 'router-link'
-                        }
-                        variant={ButtonVariant.TERTIARY}
-                        color={ButtonColor.NEUTRAL}
-                        size={
-                          size === 'default'
-                            ? ButtonSize.SMALL
-                            : ButtonSize.DEFAULT
-                        }
-                        to={a.href}
-                        icon={a.icon}
-                        iconAlt={a.iconAlt}
-                        opensInNewTab={a.isExternal}
-                        onClick={() => a.onClick?.()}
-                        label={a.label}
-                      />
-                    ) : (
-                      <Button
-                        variant={ButtonVariant.TERTIARY}
-                        color={ButtonColor.NEUTRAL}
-                        icon={a.icon}
-                        onClick={() => a.onClick?.()}
-                        label={a.label}
-                        size={
-                          size === 'default'
-                            ? ButtonSize.SMALL
-                            : ButtonSize.DEFAULT
-                        }
-                      />
-                    )}
+                {actionButtonProps.map((btnProps) => (
+                  <li key={btnProps.label} className={styles.link}>
+                    <Button {...btnProps} />
                   </li>
                 ))}
               </ul>

--- a/pro/src/design-system/Button/Button.spec.tsx
+++ b/pro/src/design-system/Button/Button.spec.tsx
@@ -364,7 +364,7 @@ describe('Button', () => {
   describe('Link rendering', () => {
     it('should render as Link component when to is provided', () => {
       renderButton({
-        as: 'a',
+        as: 'router-link',
         label: 'Link Button',
         to: '/test-path',
       })
@@ -379,7 +379,6 @@ describe('Button', () => {
         as: 'a',
         label: 'External Link',
         to: 'https://example.com',
-        isExternal: true,
       })
 
       const link = screen.getByRole('link', { name: 'External Link' })
@@ -394,7 +393,6 @@ describe('Button', () => {
         as: 'a',
         label: 'Section Link',
         to: '#section',
-        isSectionLink: true,
       })
 
       const link = screen.getByRole('link', { name: 'Section Link' })
@@ -409,7 +407,6 @@ describe('Button', () => {
         as: 'a',
         label: 'New Tab Link',
         to: 'https://example.com',
-        isExternal: true,
         opensInNewTab: true,
       })
 
@@ -422,7 +419,6 @@ describe('Button', () => {
         as: 'a',
         label: 'Same Tab Link',
         to: 'https://example.com',
-        isExternal: true,
         opensInNewTab: false,
       })
 
@@ -433,7 +429,7 @@ describe('Button', () => {
     it('should handle onClick on link', async () => {
       const handleClick = vi.fn()
       renderButton({
-        as: 'a',
+        as: 'router-link',
         label: 'Clickable Link',
         to: '/test',
         onClick: handleClick,
@@ -446,7 +442,7 @@ describe('Button', () => {
 
     it('should render a disabled link as an anchor without href', () => {
       renderButton({
-        as: 'a',
+        as: 'router-link',
         label: 'Disabled Link',
         to: '/test',
         disabled: true,
@@ -461,7 +457,7 @@ describe('Button', () => {
     it('should not call onClick on a disabled link', async () => {
       const handleClick = vi.fn()
       renderButton({
-        as: 'a',
+        as: 'router-link',
         label: 'Disabled Clickable Link',
         to: '/test',
         disabled: true,
@@ -476,7 +472,7 @@ describe('Button', () => {
     it('should handle onBlur on link', () => {
       const handleBlur = vi.fn()
       renderButton({
-        as: 'a',
+        as: 'router-link',
         label: 'Blur Link',
         to: '/test',
         onBlur: handleBlur,
@@ -490,7 +486,7 @@ describe('Button', () => {
 
     it('should pass aria-label to link', () => {
       renderButton({
-        as: 'a',
+        as: 'router-link',
         label: 'Aria Link',
         to: '/test',
         'aria-label': 'Custom aria label',

--- a/pro/src/design-system/Button/Button.stories.tsx
+++ b/pro/src/design-system/Button/Button.stories.tsx
@@ -46,7 +46,7 @@ const meta: Meta<typeof ButtonComponent> = {
   argTypes: {
     as: {
       control: 'select',
-      options: ['button', 'a'],
+      options: ['button', 'a', 'router-link'],
     },
     type: {
       control: 'select',
@@ -100,15 +100,7 @@ const meta: Meta<typeof ButtonComponent> = {
     opensInNewTab: {
       control: 'boolean',
       if: { arg: 'as', eq: 'a' },
-    },
-    isExternal: {
-      control: 'boolean',
-      if: { arg: 'as', eq: 'a' },
-    },
-    isSectionLink: {
-      control: 'boolean',
-      if: { arg: 'as', eq: 'a' },
-    },
+    }
   },
 }
 
@@ -283,7 +275,7 @@ export const ButtonTransparent: Story = {
 export const ButtonWithExternalLink: Story = {
   render: () => (
     <div style={styles}>
-      <Button as='a' to="https://pass-culture.github.io/pass-culture-main/" label="Lien externe" isExternal />
+      <Button as='a' to="https://pass-culture.github.io/pass-culture-main/" label="Lien externe" />
     </div>
   ),
 }
@@ -294,7 +286,7 @@ export const ButtonWithExternalLink: Story = {
 export const ButtonWithExternalLinkAndTargetBlank: Story = {
   render: () => (
     <div style={styles}>
-      <Button as="a" to="https://pass-culture.github.io/pass-culture-main/" label="Lien externe avec nouvelle fenêtre" isExternal opensInNewTab />
+      <Button as="a" to="https://pass-culture.github.io/pass-culture-main/" label="Lien externe avec nouvelle fenêtre" opensInNewTab />
     </div>
   ),
 }
@@ -327,7 +319,7 @@ export const ButtonVariants: Story = {
           <Button label="Secondary" variant={ButtonVariant.SECONDARY} />
           <Button label="Secondary Hovered" variant={ButtonVariant.SECONDARY} hovered />
           <Button label="Secondary Disabled" variant={ButtonVariant.SECONDARY} disabled />
-          
+
         </div>
         <div style={columnStyles}>
           <Button label="Tertiary" variant={ButtonVariant.TERTIARY} />

--- a/pro/src/design-system/Button/Button.tsx
+++ b/pro/src/design-system/Button/Button.tsx
@@ -44,8 +44,6 @@ export const Button = forwardRef<
       /***** Link props *****/
       opensInNewTab = false,
       to = '',
-      isExternal = false,
-      isSectionLink = false,
       ...props
     }: ButtonProps,
     ref
@@ -67,14 +65,10 @@ export const Button = forwardRef<
     )
 
     const absoluteUrl =
-      isSectionLink || isExternal || to.startsWith('/') ? to : `/${to}`
+      as !== 'router-link' || to.startsWith('/') ? to : `/${to}`
 
-    const Component = getComponentType({
-      as,
-      disabled,
-      isExternal,
-      isSectionLink,
-    })
+    const Component = getComponentType({ as, disabled })
+
     const componentProps = getComponentProps({
       Component,
       type,

--- a/pro/src/design-system/Button/Button.tsx
+++ b/pro/src/design-system/Button/Button.tsx
@@ -65,7 +65,7 @@ export const Button = forwardRef<
     )
 
     const absoluteUrl =
-      as !== 'router-link' || to.startsWith('/') ? to : `/${to}`
+      as === 'router-link' && !to.startsWith('/') ? `/${to}` : to
 
     const Component = getComponentType({ as, disabled })
 

--- a/pro/src/design-system/Button/types.ts
+++ b/pro/src/design-system/Button/types.ts
@@ -131,7 +131,7 @@ type ButtonAsRouterLinkProps = ButtonBaseProps & {
   as: 'router-link'
   type?: never
   to: string
-  opensInNewTab?: boolean
+  opensInNewTab?: never
 } & Omit<
     React.AnchorHTMLAttributes<HTMLAnchorElement>,
     'className' | 'href' | 'style'

--- a/pro/src/design-system/Button/types.ts
+++ b/pro/src/design-system/Button/types.ts
@@ -105,23 +105,33 @@ type ButtonAsButtonProps = ButtonBaseProps & {
   type?: NonNullable<ButtonTypeAttribute>
   to?: never
   opensInNewTab?: never
-  isExternal?: never
-  isSectionLink?: never
 } & Omit<
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     'className' | 'disabled' | 'style'
   >
 
 /**
- * ******************* Link props *******************
+ * ******************* Anchor props *******************
  */
-export type ButtonAsLinkProps = ButtonBaseProps & {
+type ButtonAsAnchorProps = ButtonBaseProps & {
   as: 'a'
   type?: never
   to: string
   opensInNewTab?: boolean
-  isExternal?: boolean
-  isSectionLink?: boolean
+} & Omit<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    'className' | 'href' | 'style'
+  >
+
+/**
+ * ******************* Link props *******************
+ */
+
+type ButtonAsRouterLinkProps = ButtonBaseProps & {
+  as: 'router-link'
+  type?: never
+  to: string
+  opensInNewTab?: boolean
 } & Omit<
     React.AnchorHTMLAttributes<HTMLAnchorElement>,
     'className' | 'href' | 'style'
@@ -131,4 +141,7 @@ export type ButtonTypeAttribute = NonNullable<
   React.ButtonHTMLAttributes<HTMLButtonElement>['type']
 >
 
-export type ButtonProps = ButtonAsButtonProps | ButtonAsLinkProps
+export type ButtonProps =
+  | ButtonAsButtonProps
+  | ButtonAsAnchorProps
+  | ButtonAsRouterLinkProps

--- a/pro/src/design-system/Button/types.ts
+++ b/pro/src/design-system/Button/types.ts
@@ -113,7 +113,7 @@ type ButtonAsButtonProps = ButtonBaseProps & {
 /**
  * ******************* Anchor props *******************
  */
-type ButtonAsAnchorProps = ButtonBaseProps & {
+export type ButtonAsAnchorProps = ButtonBaseProps & {
   as: 'a'
   type?: never
   to: string

--- a/pro/src/design-system/Button/utils/helpers.spec.ts
+++ b/pro/src/design-system/Button/utils/helpers.spec.ts
@@ -14,30 +14,15 @@ describe('getComponentType', () => {
       getComponentType({
         as: 'button',
         disabled: undefined,
-        isExternal: false,
-        isSectionLink: false,
       })
     ).toBe('button')
   })
 
-  it('should return "a" when as is "a" and isExternal is true', () => {
+  it('should return "a" when as is "a"', () => {
     expect(
       getComponentType({
         as: 'a',
         disabled: undefined,
-        isExternal: true,
-        isSectionLink: false,
-      })
-    ).toBe('a')
-  })
-
-  it('should return "a" when as is "a" and isSectionLink is true', () => {
-    expect(
-      getComponentType({
-        as: 'a',
-        disabled: undefined,
-        isExternal: false,
-        isSectionLink: true,
       })
     ).toBe('a')
   })
@@ -47,19 +32,24 @@ describe('getComponentType', () => {
       getComponentType({
         as: 'a',
         disabled: true,
-        isExternal: false,
-        isSectionLink: false,
       })
     ).toBe('a')
   })
 
-  it('should return Link when as is "a" and neither isExternal nor isSectionLink', () => {
+  it('should return "a" when as is "router-link" and disabled is true', () => {
     expect(
       getComponentType({
-        as: 'a',
+        as: 'router-link',
+        disabled: true,
+      })
+    ).toBe('a')
+  })
+
+  it('should return Link when as is "router-link" and not disabled', () => {
+    expect(
+      getComponentType({
+        as: 'router-link',
         disabled: undefined,
-        isExternal: false,
-        isSectionLink: false,
       })
     ).toBe(Link)
   })

--- a/pro/src/design-system/Button/utils/helpers.ts
+++ b/pro/src/design-system/Button/utils/helpers.ts
@@ -5,19 +5,15 @@ import type { ButtonProps, ButtonTypeAttribute } from '../types'
 export const getComponentType = ({
   as,
   disabled,
-  isExternal,
-  isSectionLink,
 }: {
-  as: 'button' | 'a'
+  as: 'button' | 'a' | 'router-link'
   disabled: boolean | undefined
-  isExternal: boolean
-  isSectionLink: boolean
 }): React.ElementType => {
   if (as === 'button') {
     return 'button'
   }
   // A disabled <Link> is treated as an <a> to remove its `href` and inherit proper a11y from `getAnchorProps`.
-  if (isExternal || isSectionLink || disabled) {
+  if (as === 'a' || disabled) {
     return 'a'
   }
 

--- a/pro/src/design-system/DetailedModal/DetailedModal.stories.tsx
+++ b/pro/src/design-system/DetailedModal/DetailedModal.stories.tsx
@@ -145,9 +145,8 @@ export const WithLinkAndIconActions: Story = {
   args: {
     tertiaryAction: (
       <Button
-        as="a"
+        as="router-link"
         to="/offres"
-        isExternal={false}
         variant={ButtonVariant.TERTIARY}
         color={ButtonColor.NEUTRAL}
         label="Voir les offres"

--- a/pro/src/layouts/CollectiveVenuePageLayout/components/Header.tsx
+++ b/pro/src/layouts/CollectiveVenuePageLayout/components/Header.tsx
@@ -102,7 +102,6 @@ export const Header = ({ context }: Readonly<HeaderProps>) => {
                 color={ButtonColor.NEUTRAL}
                 size={ButtonSize.SMALL}
                 to={`${WEBAPP_URL}/lieu/${selectedPartnerVenue.id}`}
-                isExternal
                 opensInNewTab
                 label="Visualiser votre page"
               />

--- a/pro/src/layouts/CollectiveVenuePageLayout/components/PartnerPageCollectiveSection.tsx
+++ b/pro/src/layouts/CollectiveVenuePageLayout/components/PartnerPageCollectiveSection.tsx
@@ -62,7 +62,6 @@ export const PartnerPageCollectiveSection = () => {
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}
             to="https://demarche.numerique.gouv.fr/commencer/demande-de-referencement-sur-adage"
-            isExternal
             opensInNewTab
             onClick={logDMSApplicationLinkClick}
             label="Déposer un dossier ADAGE"
@@ -119,7 +118,6 @@ export const PartnerPageCollectiveSection = () => {
           variant={ButtonVariant.TERTIARY}
           color={ButtonColor.NEUTRAL}
           to="https://aide.passculture.app/hc/fr/categories/4410482280977--Acteurs-Culturels-Tout-savoir-sur-le-pass-Culture-collectif-%C3%A0-destination-des-groupes-scolaires"
-          isExternal
           opensInNewTab
           onClick={logCollectiveHelpLinkClick}
           label="En savoir plus sur le pass Culture à destination des scolaires"

--- a/pro/src/pages/Accessibility/AccessibilityMenu.tsx
+++ b/pro/src/pages/Accessibility/AccessibilityMenu.tsx
@@ -36,7 +36,7 @@ export function AccessibilityMenu() {
         />
         <div className={styles['pages-buttons-container']}>
           <Button
-            as="a"
+            as="router-link"
             to="/accessibilite/engagements"
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}
@@ -45,7 +45,7 @@ export function AccessibilityMenu() {
             label="Les engagements du pass Culture"
           />
           <Button
-            as="a"
+            as="router-link"
             to="/accessibilite/declaration"
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}

--- a/pro/src/pages/Accessibility/Commitment.tsx
+++ b/pro/src/pages/Accessibility/Commitment.tsx
@@ -14,7 +14,7 @@ export const Commitment = () => {
         <div className={styles['back-link']}>
           <Button
             to="/accessibilite/"
-            as="a"
+            as="router-link"
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             icon={fullBackIcon}
@@ -99,7 +99,6 @@ export const Commitment = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://acceslibre.beta.gouv.fr/"
-            isExternal
             label="acceslibre"
           />{' '}
           afin d’enrichir plus largement les informations d’accessibilité des

--- a/pro/src/pages/Accessibility/Declaration.tsx
+++ b/pro/src/pages/Accessibility/Declaration.tsx
@@ -13,7 +13,7 @@ export const Declaration = () => {
       <div className={styles['page-content']}>
         <div className={styles['back-link']}>
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="/accessibilite/"

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeader.tsx
@@ -73,7 +73,6 @@ export const AdageHeader = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to={`${document.referrer}adage/index/docGet/format/pptx/doc/PRESENTATION_J_UTILISE_PASS_CULTURE`}
-            isExternal
             download
             icon={fullDownloadIcon}
             target="_top"

--- a/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
+++ b/pro/src/pages/AdageIframe/app/components/AdageHeader/AdageHeaderBudget/AdageHeaderBudget.tsx
@@ -21,7 +21,6 @@ export const AdageHeaderBudget = ({
           variant={ButtonVariant.TERTIARY}
           color={ButtonColor.NEUTRAL}
           to={`${document.referrer}adage/passculture/index`}
-          isExternal
           opensInNewTab
           onClick={() => logAdageLinkClick(AdageHeaderLink.ADAGE_LINK)}
           label="Solde prévisionnel"

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/AdageOffer/AdageOfferPartnerPanel/AdageOfferPartnerPanel.tsx
@@ -80,7 +80,6 @@ export function AdageOfferPartnerPanel({
           {venue.adageId && !isPreview && (
             <Button
               as="a"
-              isExternal
               to={`${document.referrer}adage/ressource/partenaires/id/${venue.adageId}`}
               opensInNewTab
               variant={ButtonVariant.TERTIARY}

--- a/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OfferInfos/OfferInfos.tsx
@@ -64,7 +64,6 @@ export const OfferInfos = () => {
     recherche: {
       title: 'Recherche',
       link: {
-        isExternal: false,
         to: `/adage-iframe/recherche?token=${adageAuthToken}`,
       },
       icon: strokeSearchIcon,
@@ -72,7 +71,6 @@ export const OfferInfos = () => {
     decouverte: {
       title: 'Découvrir',
       link: {
-        isExternal: false,
         to: `/adage-iframe/decouverte?token=${adageAuthToken}`,
       },
       icon: strokePassIcon,
@@ -80,7 +78,6 @@ export const OfferInfos = () => {
     ['mes-favoris']: {
       title: 'Mes favoris',
       link: {
-        isExternal: false,
         to: `/adage-iframe/mes-favoris?token=${adageAuthToken}`,
       },
       icon: strokeStarIcon,
@@ -88,7 +85,6 @@ export const OfferInfos = () => {
     ['mon-etablissement']: {
       title: 'Pour mon établissement',
       link: {
-        isExternal: false,
         to: `/adage-iframe/mon-etablissement?token=${adageAuthToken}`,
       },
       icon: strokeVenueIcon,
@@ -119,7 +115,6 @@ export const OfferInfos = () => {
                 {
                   title: offer.name,
                   link: {
-                    isExternal: true,
                     to: '#',
                   },
                 },
@@ -150,7 +145,7 @@ export const OfferInfos = () => {
             Cette offre est introuvable
           </h1>
           <Button
-            as="a"
+            as="router-link"
             to={`/adage-iframe/recherche?token=${adageAuthToken}`}
             variant={ButtonVariant.PRIMARY}
             label="Explorer le catalogue"

--- a/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavoritesNoResult/OffersFavoritesNoResult.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersFavorites/OffersFavoritesNoResult/OffersFavoritesNoResult.tsx
@@ -27,7 +27,7 @@ export const OffersFavoritesNoResult = () => {
           retrouver facilement !
         </p>
         <Button
-          as="a"
+          as="router-link"
           to={`/adage-iframe/recherche?token=${adageAuthToken}`}
           variant={ButtonVariant.PRIMARY}
           label="Explorer le catalogue"

--- a/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersForInstitution/OffersForMyInstitution.tsx
@@ -84,7 +84,7 @@ export const OffersForMyInstitution = () => {
               Vous n’avez pas d’offre à préréserver
             </h2>
             <Button
-              as="a"
+              as="router-link"
               to={`/adage-iframe/recherche?token=${adageAuthToken}`}
               variant={ButtonVariant.PRIMARY}
               label="Explorer le catalogue"

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/ContactButton/RequestFormDialog/RequestFormDialog.tsx
@@ -211,7 +211,6 @@ export const RequestFormDialog = ({
                   variant={ButtonVariant.TERTIARY}
                   color={ButtonColor.BRAND}
                   to={contactUrl}
-                  isExternal
                   opensInNewTab
                   label="Aller sur le site"
                 />
@@ -261,7 +260,6 @@ export const RequestFormDialog = ({
           variant={ButtonVariant.TERTIARY}
           color={ButtonColor.BRAND}
           to={contactUrl}
-          isExternal
           opensInNewTab
           label="Aller sur le site"
         />

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/NoResultsPage.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/NoResultsPage/NoResultsPage.tsx
@@ -37,7 +37,6 @@ export const NoResultsPage = ({
       {venue?.adageId && (
         <Button
           as="a"
-          isExternal
           to={`${document.referrer}adage/ressource/partenaires/id/${venue.adageId}`}
           opensInNewTab
           variant={ButtonVariant.TERTIARY}

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferShareLink/OfferShareLink.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/OfferShareLink/OfferShareLink.tsx
@@ -39,7 +39,6 @@ Bonjour, \n\nJe partage avec vous l’offre pass Culture “${offer.name}”. \n
       to={`mailto:?subject=Partage d’offre sur ADAGE - ${encodeURIComponent(offer.name)}&body=${encodeURIComponent(mailBody)}`}
       icon={strokeShareIcon}
       onClick={handleShareButtonClicked}
-      isExternal
       tooltip={'Partager par email'}
     />
   )

--- a/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
+++ b/pro/src/pages/AdageIframe/app/components/OffersInstantSearch/OffersSearch/Offers/Offers.tsx
@@ -289,7 +289,6 @@ export const Offers = ({
                         as="a"
                         variant={ButtonVariant.PRIMARY}
                         to="https://passculture.docsend.com/view/nn7q3isav3dmhue2/d/pkhf9bba2ft4myz8"
-                        isExternal
                         opensInNewTab
                         onClick={() => logOpenHighlightBanner('TFD-2025')}
                         label="en savoir plus"

--- a/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
+++ b/pro/src/pages/AdageIframe/app/components/SurveySatisfaction/SurveySatisfaction.tsx
@@ -87,7 +87,6 @@ export const SurveySatisfaction = ({
             as="a"
             variant={ButtonVariant.PRIMARY}
             to={VITE_ADAGE_SURVEY_SATISFACTION_URL}
-            isExternal
             opensInNewTab
             onClick={logOpenSatisfactionSurvey}
             label="Je donne mon avis"

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormContactTemplate/FormContactTemplateCustomForm/FormContactTemplateCustomForm.tsx
@@ -34,7 +34,6 @@ export const FormContactTemplateCustomForm = ({
                   as="a"
                   variant={ButtonVariant.TERTIARY}
                   color={ButtonColor.NEUTRAL}
-                  isExternal
                   to="https://aide.passculture.app/hc/fr/articles/12957173606940--Acteurs-Culturels-Comment-paramétrer-les-options-de-contact-pour-les-enseignants-dans-le-cadre-d-une-offre-vitrine"
                   opensInNewTab
                   label="FAQ : À quoi ressemble le formulaire standard ?"

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -219,7 +219,6 @@ export const FormOfferType = ({
                     label="Voir des exemples d’offres vitrines"
                     onClick={logHasClickedSeeTemplateOfferExample}
                     to="https://aide.passculture.app/hc/fr/articles/17467449038876--Acteurs-Culturels-Consulter-des-exemples-d-offres-vitrine"
-                    isExternal
                     opensInNewTab
                   />
                 </TipsBanner>

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/OfferEducationalForm.tsx
@@ -176,7 +176,7 @@ export const OfferEducationalForm = ({
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}
             to={computeCollectiveOffersUrl({})}

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferConfirmation/CollectiveOfferConfirmation.tsx
@@ -177,13 +177,13 @@ const CollectiveOfferConfirmation = ({
           <div>{confirmationData.description}</div>
           <div className={styles['confirmation-actions']}>
             <Button
-              as="a"
+              as="router-link"
               variant={ButtonVariant.SECONDARY}
               to={isShowcase ? '/offres/vitrines' : '/offres/collectives'}
               label="Voir mes offres"
             />
             <Button
-              as="a"
+              as="router-link"
               variant={ButtonVariant.PRIMARY}
               to={creationUrl}
               label="Créer une nouvelle offre"

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferInformation/components/CollectiveOfferInformationForm/CollectiveOfferInformationForm.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferInformation/components/CollectiveOfferInformationForm/CollectiveOfferInformationForm.tsx
@@ -257,7 +257,7 @@ export const CollectiveOfferInformationForm = ({
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}
             to={stepUrls.previous}

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferTemplateNavigation/CollectiveOfferTemplateEditionNavigation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferLayout/CollectiveOfferTemplateNavigation/CollectiveOfferTemplateEditionNavigation.tsx
@@ -139,7 +139,7 @@ export const CollectiveOfferTemplateEditionNavigation = ({
     <div className={styles['actions-container']}>
       {canPreviewOffer && (
         <Button
-          as="a"
+          as="router-link"
           variant={ButtonVariant.SECONDARY}
           color={ButtonColor.NEUTRAL}
           size={ButtonSize.SMALL}

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferPreview/CollectiveOfferPreviewCreation/components/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreationScreen.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferPreview/CollectiveOfferPreviewCreation/components/CollectiveOfferPreviewCreation/CollectiveOfferPreviewCreationScreen.tsx
@@ -130,7 +130,7 @@ export const CollectiveOfferPreviewCreationScreen = ({
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.SECONDARY}
             to={backRedirectionUrl}
             label="Retour"
@@ -138,7 +138,7 @@ export const CollectiveOfferPreviewCreationScreen = ({
         </ActionsBarSticky.Left>
         <ActionsBarSticky.Right dirtyForm={false} mode={Mode.CREATION}>
           <Button
-            as="a"
+            as="router-link"
             to="/offres/collectives"
             variant={ButtonVariant.SECONDARY}
             onClick={() => {

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferPreview/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferPreview/CollectiveOfferPreviewEdition/CollectiveOfferPreviewEdition.tsx
@@ -24,7 +24,11 @@ export const CollectiveOfferPreviewEdition = ({
       <AdagePreviewLayout offer={offer} />
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
-          <Button as="a" to={backRedirectionUrl} label="Retour vers l’offre" />
+          <Button
+            as="router-link"
+            to={backRedirectionUrl}
+            label="Retour vers l’offre"
+          />
         </ActionsBarSticky.Left>
       </ActionsBarSticky>
     </BasicLayout>

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/CollectiveOfferStockForm/CollectiveOfferStockForm.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/CollectiveOfferStockForm/CollectiveOfferStockForm.tsx
@@ -356,7 +356,7 @@ export const CollectiveOfferStockForm = ({
           <ActionsBarSticky>
             <ActionsBarSticky.Left>
               <Button
-                as="a"
+                as="router-link"
                 color={
                   mode === Mode.CREATION
                     ? ButtonColor.BRAND

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/OfferEducationalStock/OfferEducationalStock.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferStock/components/OfferEducationalStock/OfferEducationalStock.tsx
@@ -235,7 +235,7 @@ export const OfferEducationalStock = ({
             <ActionsBarSticky>
               <ActionsBarSticky.Left>
                 <Button
-                  as="a"
+                  as="router-link"
                   variant={ButtonVariant.SECONDARY}
                   color={
                     mode === Mode.CREATION

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/BookableOfferSummary/BookableOfferSummary.tsx
@@ -269,7 +269,7 @@ export const BookableOfferSummary = ({ offer }: BookableOfferSummaryProps) => {
               {canEditOffer && !isVenueClosed && (
                 <li className={styles['header-actions-item']}>
                   <Button
-                    as="a"
+                    as="router-link"
                     variant={ButtonVariant.SECONDARY}
                     color={ButtonColor.NEUTRAL}
                     size={ButtonSize.SMALL}
@@ -284,7 +284,7 @@ export const BookableOfferSummary = ({ offer }: BookableOfferSummaryProps) => {
               {canPreviewOffer && (
                 <li className={styles['header-actions-item']}>
                   <Button
-                    as="a"
+                    as="router-link"
                     variant={ButtonVariant.SECONDARY}
                     color={ButtonColor.NEUTRAL}
                     size={ButtonSize.SMALL}
@@ -393,7 +393,7 @@ export const BookableOfferSummary = ({ offer }: BookableOfferSummaryProps) => {
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
           <Button
-            as="a"
+            as="router-link"
             to={computeCollectiveOffersUrl({})}
             label="Retour à la liste des offres"
           />

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryCreation/CollectiveOfferSummaryCreation.tsx
@@ -46,7 +46,7 @@ export const CollectiveOfferSummaryCreation = ({
         <ActionsBarSticky>
           <ActionsBarSticky.Left>
             <Button
-              as="a"
+              as="router-link"
               variant={ButtonVariant.SECONDARY}
               to={backRedirectionUrl}
               label="Retour"
@@ -54,7 +54,7 @@ export const CollectiveOfferSummaryCreation = ({
           </ActionsBarSticky.Left>
           <ActionsBarSticky.Right dirtyForm={false} mode={Mode.CREATION}>
             <Button
-              as="a"
+              as="router-link"
               to={nextRedirectionUrl}
               label="Enregistrer et continuer"
             />

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/CollectiveOfferSummaryEdition/CollectiveOfferSummaryEdition.tsx
@@ -69,7 +69,7 @@ export const CollectiveOfferSummaryEdition = ({
       <ActionsBarSticky>
         <ActionsBarSticky.Left>
           <Button
-            as="a"
+            as="router-link"
             to={computeCollectiveOffersUrl({}, undefined, offer.isTemplate)}
             label="Retour à la liste des offres"
           />

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/BookableOfferTimeline/banners/DraftBanner.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferSummary/components/BookableOfferTimeline/banners/DraftBanner.tsx
@@ -13,7 +13,7 @@ export const DraftBanner = ({ offerId }: { offerId: number }) => {
             iconAlt: 'Modifier',
             href: `/offre/collectif/${offerId}/creation`,
             label: 'Reprendre mon brouillon',
-            type: 'button',
+            type: 'link',
           },
         ]}
         description="Finalisez et envoyez votre brouillon à un établissement quand vous le souhaitez."

--- a/pro/src/pages/CollectiveOffer/CollectiveOfferType/ActionsBar/ActionsBar.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOfferType/ActionsBar/ActionsBar.tsx
@@ -27,7 +27,7 @@ export const ActionsBar = ({
     <ActionsBarSticky hasSideNav={!isOnboarding}>
       <ActionsBarSticky.Left>
         <Button
-          as="a"
+          as="router-link"
           to={
             isOnboarding
               ? '/onboarding/individuel'

--- a/pro/src/pages/CollectiveOfferInstitution/components/CollectiveOfferInstitution/CollectiveOfferInstitution.tsx
+++ b/pro/src/pages/CollectiveOfferInstitution/components/CollectiveOfferInstitution/CollectiveOfferInstitution.tsx
@@ -444,7 +444,7 @@ export const CollectiveOfferInstitutionScreen = ({
               <ActionsBarSticky>
                 <ActionsBarSticky.Left>
                   <Button
-                    as="a"
+                    as="router-link"
                     variant={ButtonVariant.SECONDARY}
                     color={
                       mode === Mode.CREATION

--- a/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.tsx
+++ b/pro/src/pages/CollectiveOfferSelectionDuplication/CollectiveOfferSelectionDuplication.tsx
@@ -194,7 +194,7 @@ export const CollectiveOfferSelectionDuplication = (): JSX.Element => {
                 <ActionsBarSticky>
                   <ActionsBarSticky.Left>
                     <Button
-                      as="a"
+                      as="router-link"
                       variant={ButtonVariant.SECONDARY}
                       to={computeCollectiveOffersUrl({})}
                       label="Retour à la liste des offres"

--- a/pro/src/pages/CollectiveVenuePageEdition/CollectiveVenuePageEdition.tsx
+++ b/pro/src/pages/CollectiveVenuePageEdition/CollectiveVenuePageEdition.tsx
@@ -281,7 +281,7 @@ export const CollectiveVenuePageEdition = (): JSX.Element | null => {
 
         <div className={styles['action-bar']}>
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}
             to={`/partenaire/page-collective`}

--- a/pro/src/pages/EcoDesign/Declaration.tsx
+++ b/pro/src/pages/EcoDesign/Declaration.tsx
@@ -23,7 +23,7 @@ export const EcoDesignDeclaration = () => {
       <div className={styles['page-content']}>
         <div className={styles['back-link']}>
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="/ecoconception"
@@ -43,7 +43,6 @@ export const EcoDesignDeclaration = () => {
             to={`${ASSETS_BUCKET_URL}/assets/declaration-rgesn-pass-culture.pdf`}
             icon={fullDownloadIcon}
             label="Télécharger la déclaration RGESN de l'espace partenaire"
-            isExternal
             opensInNewTab
           />
         </div>
@@ -159,7 +158,6 @@ export const EcoDesignDeclaration = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="mailto:eco-conception@passculture.app"
-            isExternal
             label="eco-conception@passculture.app"
           />
         </p>
@@ -200,7 +198,6 @@ export const EcoDesignDeclaration = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://github.com/pass-culture/pass-culture-main"
-            isExternal
             opensInNewTab
             label="https://github.com/pass-culture/pass-culture-main"
           />
@@ -272,7 +269,6 @@ export const EcoDesignDeclaration = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://passculture.pro"
-            isExternal
             label="passculture.pro"
           />{' '}
           n'a pas procédé à une revue de code et de conception pour réduire le
@@ -520,7 +516,6 @@ export const EcoDesignDeclaration = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://passculture.pro"
-            isExternal
             label="passculture.pro"
           />{' '}
           à raison de 2 ou 3 informations mensuelles.
@@ -697,7 +692,6 @@ export const EcoDesignDeclaration = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://sustainability.google/intl/fr_fr/operations/net-zero-carbon/"
-            isExternal
             opensInNewTab
             label="https://sustainability.google/intl/fr_fr/operations/net-zero-carbon/"
           />
@@ -885,7 +879,6 @@ export const EcoDesignDeclaration = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://passculture.pro"
-            isExternal
             label="passculture.pro"
           />{' '}
           a été envisagée et n'a pas été jugée nécessaire.

--- a/pro/src/pages/EcoDesign/EcoDesignMenu.tsx
+++ b/pro/src/pages/EcoDesign/EcoDesignMenu.tsx
@@ -36,7 +36,7 @@ export const EcoDesignMenu = () => {
         />
         <div className={styles['pages-buttons-container']}>
           <Button
-            as="a"
+            as="router-link"
             to="/ecoconception/politique"
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}
@@ -45,7 +45,7 @@ export const EcoDesignMenu = () => {
             label="Politique d'écoconception au pass Culture"
           />
           <Button
-            as="a"
+            as="router-link"
             to="/ecoconception/declaration"
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}

--- a/pro/src/pages/EcoDesign/Policy.tsx
+++ b/pro/src/pages/EcoDesign/Policy.tsx
@@ -11,7 +11,7 @@ export const EcoDesignPolicy = () => {
       <div className={styles['page-content']}>
         <div className={styles['back-link']}>
           <Button
-            as="a"
+            as="router-link"
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="/ecoconception"
@@ -27,7 +27,6 @@ export const EcoDesignPolicy = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://passculture.pro"
-            isExternal
             label="passculture.pro"
           />{' '}
           s'inscrit dans une démarche d'écoconception visant à réduire ses
@@ -44,7 +43,6 @@ export const EcoDesignPolicy = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://www.arcep.fr/demarches-et-services/professionnels/referentiel-general-ecoconception-services-numeriques.html"
-            isExternal
             label="site web de l’Arcep"
           />
         </p>
@@ -79,7 +77,6 @@ export const EcoDesignPolicy = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://passculture.pro"
-            isExternal
             label="passculture.pro"
           />{' '}
           s'inscrit dans la continuité de tout le travail qui a été fait et qui
@@ -91,7 +88,6 @@ export const EcoDesignPolicy = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://passculture.pro/accessibilite/declaration"
-            isExternal
             label="https://passculture.pro/accessibilite/declaration"
           />
           .
@@ -105,7 +101,6 @@ export const EcoDesignPolicy = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="mailto:eco-conception@passculture.app"
-            isExternal
             label="eco-conception@passculture.app"
           />
           .
@@ -122,7 +117,6 @@ export const EcoDesignPolicy = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="https://passculture.pro"
-            isExternal
             label="passculture.pro"
           />{' '}
           vise une amélioration de ce score sur les prochaines années. Pour ce
@@ -197,7 +191,6 @@ export const EcoDesignPolicy = () => {
             variant={ButtonVariant.TERTIARY}
             color={ButtonColor.NEUTRAL}
             to="mailto:eco-conception@passculture.app"
-            isExternal
             label="eco-conception@passculture.app"
           />
         </p>

--- a/pro/src/pages/EmailChangeValidation/EmailChangeValidation.tsx
+++ b/pro/src/pages/EmailChangeValidation/EmailChangeValidation.tsx
@@ -60,7 +60,7 @@ export const EmailChangeValidation = () => {
           <p className={styles['subtitle']}>
             Connectez-vous avec votre ancienne adresse email.
           </p>
-          <Button as="a" to="/" label="Se connecter" />
+          <Button as="router-link" to="/" label="Se connecter" />
         </>
       )}
     </LoggedOutLayout>

--- a/pro/src/pages/Homepage/components/CollectiveOffersBookableCard/CollectiveOffersBookableCard.tsx
+++ b/pro/src/pages/Homepage/components/CollectiveOffersBookableCard/CollectiveOffersBookableCard.tsx
@@ -39,7 +39,7 @@ export const CollectiveOffersBookableCard = ({
       </Card.Content>
       <Card.Footer>
         <Button
-          as="a"
+          as="router-link"
           to="/offres/collectives"
           label="Voir toutes les offres"
           variant={ButtonVariant.SECONDARY}

--- a/pro/src/pages/Homepage/components/CollectiveOffersBookableCard/components/CollectiveOffersBookableCTA/CollectiveOffersBookableCTA.tsx
+++ b/pro/src/pages/Homepage/components/CollectiveOffersBookableCard/components/CollectiveOffersBookableCTA/CollectiveOffersBookableCTA.tsx
@@ -32,7 +32,7 @@ export const CollectiveOffersBookableCTA = ({
         <Button
           variant={ButtonVariant.SECONDARY}
           label="Modifier la date limite"
-          as="a"
+          as="router-link"
           to={stockEditionLink}
           disabled={isReadOnly}
         />
@@ -44,7 +44,7 @@ export const CollectiveOffersBookableCTA = ({
     <Button
       variant={ButtonVariant.SECONDARY}
       label="Voir l'offre"
-      as="a"
+      as="router-link"
       to={offerLink}
     />
   )

--- a/pro/src/pages/Homepage/components/CollectiveOffersTemplateCard/CollectiveOffersTemplateCard.tsx
+++ b/pro/src/pages/Homepage/components/CollectiveOffersTemplateCard/CollectiveOffersTemplateCard.tsx
@@ -40,7 +40,7 @@ export const CollectiveOffersTemplateCard = ({
       </Card.Content>
       <Card.Footer>
         <Button
-          as="a"
+          as="router-link"
           to="/offres/vitrines"
           label="Voir toutes les offres"
           variant={ButtonVariant.SECONDARY}

--- a/pro/src/pages/Homepage/components/CollectiveOffersTemplateCard/components/CollectiveOffersTemplateLine/CollectiveOffersTemplateLine.tsx
+++ b/pro/src/pages/Homepage/components/CollectiveOffersTemplateCard/components/CollectiveOffersTemplateLine/CollectiveOffersTemplateLine.tsx
@@ -101,7 +101,7 @@ export const CollectiveOffersTemplateLine = ({
         <Button
           variant={ButtonVariant.SECONDARY}
           label="Voir l'offre"
-          as="a"
+          as="router-link"
           to={offerLink}
         />
       )}

--- a/pro/src/pages/Homepage/components/EditoCard/EditoCard.tsx
+++ b/pro/src/pages/Homepage/components/EditoCard/EditoCard.tsx
@@ -56,7 +56,7 @@ export const EditoCard = ({
               color={ButtonColor.NEUTRAL}
               disabled={isReadOnly}
               size={ButtonSize.SMALL}
-              fullWidth={true}
+              fullWidth
               onClick={() =>
                 logEvent(EngagementEvents.HAS_REQUESTED_HIGHLIGHTS, {
                   action: 'discover',
@@ -81,9 +81,8 @@ export const EditoCard = ({
           variant={ButtonVariant.SECONDARY}
           color={ButtonColor.NEUTRAL}
           size={ButtonSize.SMALL}
-          isExternal={true}
-          opensInNewTab={true}
-          fullWidth={true}
+          opensInNewTab
+          fullWidth
           as="a"
           to="https://pass.culture.fr/ressources/references-culturelles-best-of-2025"
           onClick={logCulturalSurveyClick}
@@ -104,9 +103,9 @@ export const EditoCard = ({
           color={ButtonColor.NEUTRAL}
           disabled={isReadOnly}
           size={ButtonSize.SMALL}
-          fullWidth={true}
+          fullWidth
           to="/offres"
-          as="a"
+          as="router-link"
           onClick={logHeadlineOfferClick}
         />
       }
@@ -125,9 +124,9 @@ export const EditoCard = ({
           color={ButtonColor.NEUTRAL}
           disabled={isReadOnly}
           size={ButtonSize.SMALL}
-          fullWidth={true}
+          fullWidth
           to="/offres"
-          as="a"
+          as="router-link"
           onClick={logRecommendationClick}
         />
       }

--- a/pro/src/pages/Homepage/components/HighlightHome/ModalHighlight/ModalHighlight.tsx
+++ b/pro/src/pages/Homepage/components/HighlightHome/ModalHighlight/ModalHighlight.tsx
@@ -95,7 +95,6 @@ export const ModalHighlight = ({
         <Button
           as="a"
           to="https://aide.passculture.app/hc/fr/articles/20587966046748--Acteurs-Culturels-Comment-et-pourquoi-proposer-des-offres-dans-le-cadre-des-temps-forts-et-zooms-th%C3%A9matiques"
-          isExternal
           opensInNewTab
           onClick={() =>
             logEvent(EngagementEvents.HAS_REQUESTED_HIGHLIGHTS, {
@@ -109,7 +108,6 @@ export const ModalHighlight = ({
         <Button
           as="a"
           to="https://passcultureapp.notion.site/1cfad4e0ff9880288df4c80eebfe3ca0?v=1cfad4e0ff9880f3bbfd000c6f5023f3"
-          isExternal
           opensInNewTab
           onClick={() =>
             logEvent(EngagementEvents.HAS_REQUESTED_HIGHLIGHTS, {
@@ -131,7 +129,7 @@ export const ModalHighlight = ({
             />
           </Dialog.Close>
           <Button
-            as="a"
+            as="router-link"
             to="/offres"
             variant={ButtonVariant.PRIMARY}
             onClick={() =>

--- a/pro/src/pages/Homepage/components/IncomeCard/IncomeCard.tsx
+++ b/pro/src/pages/Homepage/components/IncomeCard/IncomeCard.tsx
@@ -194,7 +194,7 @@ export const IncomeCard = ({
       {bankAccountStatus === SimplifiedBankAccountStatus.VALID && total > 0 && (
         <Card.Footer>
           <Button
-            as="a"
+            as="router-link"
             to="/administration/remboursements/revenus"
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}

--- a/pro/src/pages/Homepage/components/IndividualOffersCard/IndividualOffersCard.tsx
+++ b/pro/src/pages/Homepage/components/IndividualOffersCard/IndividualOffersCard.tsx
@@ -65,7 +65,7 @@ export const IndividualOffersCard = ({
       </Card.Content>
       <Card.Footer>
         <Button
-          as="a"
+          as="router-link"
           to="/offres"
           label="Voir toutes les offres"
           variant={ButtonVariant.SECONDARY}

--- a/pro/src/pages/Homepage/components/IndividualOffersCard/components/IndividualOffersCTA/IndividualOffersCTA.tsx
+++ b/pro/src/pages/Homepage/components/IndividualOffersCard/components/IndividualOffersCTA/IndividualOffersCTA.tsx
@@ -29,7 +29,7 @@ export const IndividualOffersCTA = ({
       <Button
         variant={ButtonVariant.SECONDARY}
         label="Ajouter du stock"
-        as="a"
+        as="router-link"
         to={offerLink}
       />
     )
@@ -48,7 +48,7 @@ export const IndividualOffersCTA = ({
     <Button
       variant={ButtonVariant.SECONDARY}
       label="Voir l'offre"
-      as="a"
+      as="router-link"
       to={offerLink}
     />
   )

--- a/pro/src/pages/Homepage/components/NewsletterCard/NewsletterCard.tsx
+++ b/pro/src/pages/Homepage/components/NewsletterCard/NewsletterCard.tsx
@@ -40,7 +40,6 @@ export const NewsletterCard = () => {
           size={ButtonSize.SMALL}
           to="https://04a7f3c7.sibforms.com/serve/MUIFAPpqRUKo_nexWvrSwpAXBv-P4ips11dOuqZz5d5FnAbtVD5frxeX6yLHjJcPwiiYAObkjhhcOVTlTkrd7XZDk6Mb2pbWTeaI-BUB6GK-G1xdra_mo-D4xAQsX5afUNHKIs3E279tzr9rDkHn3zVhIHZhcY14BiXhobwL6aFlah1-oXmy_RbznM0dtxVdaWHBPe2z0rYudrUw"
           as="a"
-          isExternal
           opensInNewTab
           onClick={logNewsletterClick}
         />

--- a/pro/src/pages/Homepage/components/OffersEmptyStateCard/OffersEmptyStateCard.tsx
+++ b/pro/src/pages/Homepage/components/OffersEmptyStateCard/OffersEmptyStateCard.tsx
@@ -71,7 +71,7 @@ export const OffersEmptyStateCard = ({
           variant={ButtonVariant.SECONDARY}
           color={ButtonColor.NEUTRAL}
           to={cardContent.to}
-          as="a"
+          as="router-link"
           onClick={logCreateOfferClick}
           disabled={isReadOnly}
         />

--- a/pro/src/pages/Homepage/components/OffersRetentionCard/OffersRetentionCard.tsx
+++ b/pro/src/pages/Homepage/components/OffersRetentionCard/OffersRetentionCard.tsx
@@ -63,14 +63,14 @@ export const OffersRetentionCard = ({
           label={'Voir toutes les offres'}
           variant={ButtonVariant.PRIMARY}
           to={config.toOffersList}
-          as="a"
+          as="router-link"
           onClick={logSeeAllOffersClick}
         />
         <Button
           label={config.buttonLabel}
           variant={ButtonVariant.SECONDARY}
           to={config.to}
-          as="a"
+          as="router-link"
           onClick={logCreateOfferClick}
           disabled={isReadOnly}
         />

--- a/pro/src/pages/Homepage/components/PartnerPageCard/PartnerPageCard.tsx
+++ b/pro/src/pages/Homepage/components/PartnerPageCard/PartnerPageCard.tsx
@@ -89,7 +89,7 @@ export const PartnerPageCard = ({
           color={ButtonColor.NEUTRAL}
           size={ButtonSize.SMALL}
           to={venueEditionLink}
-          as="a"
+          as="router-link"
           onClick={logFillPartnerPageClick}
           disabled={isReadOnly}
         />
@@ -99,7 +99,6 @@ export const PartnerPageCard = ({
             variant={ButtonVariant.SECONDARY}
             color={ButtonColor.NEUTRAL}
             size={ButtonSize.SMALL}
-            isExternal
             to={venuePreviewLink}
             as="a"
             opensInNewTab

--- a/pro/src/pages/Homepage/components/StatsCard/components/CumulatedViewsEmptyState.tsx
+++ b/pro/src/pages/Homepage/components/StatsCard/components/CumulatedViewsEmptyState.tsx
@@ -30,7 +30,6 @@ export const CumulatedViewsEmptyState = () => {
       <Button
         as="a"
         to={BEST_PRACTICES_URL}
-        isExternal
         opensInNewTab
         variant={ButtonVariant.TERTIARY}
         color={ButtonColor.NEUTRAL}

--- a/pro/src/pages/Homepage/components/WebinarCard/WebinarCard.tsx
+++ b/pro/src/pages/Homepage/components/WebinarCard/WebinarCard.tsx
@@ -60,7 +60,6 @@ export const WebinarCard = ({ variant }: Readonly<WebinarCardProps>) => {
           size={ButtonSize.SMALL}
           to={buttonLink}
           as="a"
-          isExternal
           opensInNewTab
           onClick={logWebinarClick}
         />

--- a/pro/src/pages/Hub/Hub.tsx
+++ b/pro/src/pages/Hub/Hub.tsx
@@ -140,7 +140,7 @@ export const Hub = () => {
 
       <div className={styles['venue-actions']}>
         <Button
-          as="a"
+          as="router-link"
           icon={fullMoreIcon}
           to="/inscription/structure/recherche"
           variant={ButtonVariant.SECONDARY}

--- a/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/components/IndividualOfferConfirmationScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/components/IndividualOfferConfirmationScreen.tsx
@@ -139,7 +139,11 @@ export const IndividualOfferConfirmationScreen = ({
             label="Créer une nouvelle offre"
           />
 
-          <Button as="router-link" to="/offres" label="Accéder à la liste des offres" />
+          <Button
+            as="router-link"
+            to="/offres"
+            label="Accéder à la liste des offres"
+          />
         </div>
       </div>
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/components/IndividualOfferConfirmationScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferConfirmation/components/IndividualOfferConfirmationScreen.tsx
@@ -133,14 +133,13 @@ export const IndividualOfferConfirmationScreen = ({
         )}
         <div className={styles['preview-actions']}>
           <Button
-            as="a"
+            as="router-link"
             to={offerCreationUrl}
-            isExternal
             variant={ButtonVariant.SECONDARY}
             label="Créer une nouvelle offre"
           />
 
-          <Button as="a" to="/offres" label="Accéder à la liste des offres" />
+          <Button as="router-link" to="/offres" label="Accéder à la liste des offres" />
         </div>
       </div>
 

--- a/pro/src/pages/IndividualOffer/IndividualOfferExposure/components/OfferExposureCards/OfferExposureCards.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferExposure/components/OfferExposureCards/OfferExposureCards.tsx
@@ -105,7 +105,7 @@ export const OfferExposureCards = ({
           <Card.Content>
             <div className={styles['bookings-button']}>
               <Button
-                as="a"
+                as="router-link"
                 to={`${getIndividualOfferUrl({
                   offerId: offer.id,
                   step: INDIVIDUAL_OFFER_WIZARD_STEP_IDS.BOOKINGS,

--- a/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPracticalInfos/components/IndividualOfferPracticalInfosForm/IndividualOfferPracticalInfosForm.tsx
@@ -85,7 +85,7 @@ export function IndividualOfferPracticalInfosForm({
                 title="Validation obligatoire"
                 variant={BannerVariants.WARNING}
                 description={`Sans validation de la contremarque, la réservation sera annulée et remise en vente après ${reimbursmentDelay} jours. ${offerWillBeReimbursed ? 'Vous ne serez pas remboursé.' : ''}`}
-              ></Banner>
+              />
             </FormLayout.Row>
           )}
           <FormLayout.Row mdSpaceAfter>

--- a/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/PriceTableForm/ActivationCodeFormDialog/AddActivationCodeForm.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferPriceTable/components/PriceTableForm/ActivationCodeFormDialog/AddActivationCodeForm.tsx
@@ -49,7 +49,6 @@ export const AddActivationCodeForm = ({
         <p className={styles['activation-codes-upload-gabarit']}>Gabarits</p>
         <Button
           as="a"
-          isExternal
           to="/csvtemplates/CodesActivations-Gabarit.csv"
           // type="text/csv" // TODO: jclery-pass: Refactor <Button as="a"> polymorphic component to accept "string | undefined"
           opensInNewTab

--- a/pro/src/pages/IndividualOffer/components/ActionBar/ActionBarLeft.tsx
+++ b/pro/src/pages/IndividualOffer/components/ActionBar/ActionBarLeft.tsx
@@ -65,7 +65,7 @@ export const ActionBarLeft = ({
     const backOfferUrl = computeIndividualOffersUrl({})
 
     return (
-      <Button as="a" to={backOfferUrl} label="Retour à la liste des offres" />
+      <Button as="router-link" to={backOfferUrl} label="Retour à la liste des offres" />
     )
   }
 

--- a/pro/src/pages/IndividualOffer/components/ActionBar/ActionBarLeft.tsx
+++ b/pro/src/pages/IndividualOffer/components/ActionBar/ActionBarLeft.tsx
@@ -65,7 +65,11 @@ export const ActionBarLeft = ({
     const backOfferUrl = computeIndividualOffersUrl({})
 
     return (
-      <Button as="router-link" to={backOfferUrl} label="Retour à la liste des offres" />
+      <Button
+        as="router-link"
+        to={backOfferUrl}
+        label="Retour à la liste des offres"
+      />
     )
   }
 

--- a/pro/src/pages/IndividualOffer/components/ActionBar/ActionBarRight.tsx
+++ b/pro/src/pages/IndividualOffer/components/ActionBar/ActionBarRight.tsx
@@ -38,7 +38,7 @@ export const ActionBarRight = ({
         <>
           {!isDisabled && (
             <Button
-              as="a"
+              as="router-link"
               to={isOnboarding ? '/accueil' : '/offres'}
               variant={ButtonVariant.SECONDARY}
               onClick={() => {

--- a/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/HeadlineOffer/HeadlineOffer.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/HeadlineOffer/HeadlineOffer.tsx
@@ -62,7 +62,6 @@ export function HeadlineOffer() {
           variant={ButtonVariant.TERTIARY}
           color={ButtonColor.NEUTRAL}
           to={venuePreviewLink}
-          isExternal
           opensInNewTab
           onClick={() => {
             logEvent(EngagementEvents.CLICKED_CONFIRMED_ADD_HEADLINE_OFFER, {

--- a/pro/src/pages/IndividualVenuePageEdition/components/VenueEditionForm.tsx
+++ b/pro/src/pages/IndividualVenuePageEdition/components/VenueEditionForm.tsx
@@ -230,7 +230,6 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
                     <Button
                       as="a"
                       variant={ButtonVariant.TERTIARY}
-                      isExternal
                       opensInNewTab
                       to="https://www.jeveuxaider.gouv.fr/"
                       color={ButtonColor.NEUTRAL}

--- a/pro/src/pages/LostPassword/LostPassword.tsx
+++ b/pro/src/pages/LostPassword/LostPassword.tsx
@@ -102,7 +102,7 @@ export const LostPassword = (): JSX.Element => {
               </FormLayout.Row>
               <FormLayout.Row>
                 <Button
-                  as="a"
+                  as="router-link"
                   to="/connexion"
                   variant={ButtonVariant.TERTIARY}
                   color={ButtonColor.NEUTRAL}

--- a/pro/src/pages/Reimbursements/BankInformations/AddBankInformationsDialog/AddBankInformationsDialog.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/AddBankInformationsDialog/AddBankInformationsDialog.tsx
@@ -41,7 +41,6 @@ export const AddBankInformationsDialog = ({
               ? DS_NEW_CALEDONIA_BANK_ACCOUNT_PROCEDURE_ID
               : DS_BANK_ACCOUNT_PROCEDURE_ID
           }
-          isExternal={true}
           opensInNewTab={true}
           variant={ButtonVariant.PRIMARY}
           onClick={() => {

--- a/pro/src/pages/Reimbursements/Income/IncomeNoData/IncomeNoData.tsx
+++ b/pro/src/pages/Reimbursements/Income/IncomeNoData/IncomeNoData.tsx
@@ -34,7 +34,6 @@ export const IncomeNoData = ({ type }: IncomeNoDataProps) => {
               >
                 <Button
                   as="a"
-                  isExternal
                   opensInNewTab
                   to="https://passcultureapp.notion.site/pass-Culture-Documentation-323b1a0ec309406192d772e7d803fbd0"
                   variant={ButtonVariant.TERTIARY}

--- a/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/pro/src/pages/ResetPassword/ChangePasswordForm/ChangePasswordForm.tsx
@@ -60,7 +60,7 @@ export const ChangePasswordForm = ({
             Vous n’êtes pas à l’origine de cette demande ?
           </p>
           <Button
-            as="a"
+            as="router-link"
             to="/connexion"
             icon={iconFullNext}
             variant={ButtonVariant.TERTIARY}

--- a/pro/src/pages/SignIn/SigninForm.tsx
+++ b/pro/src/pages/SignIn/SigninForm.tsx
@@ -61,7 +61,7 @@ export const SigninForm = ({ onSubmit }: SigninFormProps): JSX.Element => {
           />
         </div>
         <Button
-          as="a"
+          as="router-link"
           icon={fullKeyIcon}
           variant={ButtonVariant.TERTIARY}
           color={ButtonColor.NEUTRAL}
@@ -81,7 +81,7 @@ export const SigninForm = ({ onSubmit }: SigninFormProps): JSX.Element => {
             Vous n’avez pas encore de compte ?
           </p>
           <Button
-            as="a"
+            as="router-link"
             to={accountCreationUrl}
             icon={iconFullNext}
             variant={ButtonVariant.TERTIARY}

--- a/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
+++ b/pro/src/pages/Signup/SignupContainer/SignupForm.tsx
@@ -128,7 +128,7 @@ export const SignupForm = (): JSX.Element => {
           {isSignupSimulationEnabled ? (
             <>
               <Button
-                as="a"
+                as="router-link"
                 to="/inscription/preparation/resultats"
                 isLoading={isSubmitting}
                 disabled={isSubmitting}

--- a/pro/src/pages/Simulator/SimulatorActivity/SimulatorActivity.tsx
+++ b/pro/src/pages/Simulator/SimulatorActivity/SimulatorActivity.tsx
@@ -91,7 +91,7 @@ export const SimulatorActivity = (): JSX.Element => {
           </FormLayout.Row>
           <div className={commonStyles['action-bar']}>
             <Button
-              as="a"
+              as="router-link"
               to="/inscription/preparation/accueil-public"
               variant={ButtonVariant.SECONDARY}
               label="Retour"

--- a/pro/src/pages/Simulator/SimulatorOpenToPublic/SimulatorOpenToPublic.tsx
+++ b/pro/src/pages/Simulator/SimulatorOpenToPublic/SimulatorOpenToPublic.tsx
@@ -80,7 +80,7 @@ export const SimulatorOpenToPublic = (): JSX.Element => {
 
             <div className={commonStyles['action-bar']}>
               <Button
-                as="a"
+                as="router-link"
                 to="/inscription/preparation/siret"
                 variant={ButtonVariant.SECONDARY}
                 label="Retour"

--- a/pro/src/pages/Simulator/SimulatorResults/SimulatorResults.tsx
+++ b/pro/src/pages/Simulator/SimulatorResults/SimulatorResults.tsx
@@ -145,12 +145,12 @@ export const SimulatorResults = (): JSX.Element => {
       </div>
       <div className={commonStyles['action-bar']}>
         <Button
-          as="a"
+          as="router-link"
           to="/inscription/preparation/publics"
           variant={ButtonVariant.SECONDARY}
           label="Retour"
         />
-        <Button as="a" to="/inscription/compte/creation" label="Continuer" />
+        <Button as="router-link" to="/inscription/compte/creation" label="Continuer" />
       </div>
     </>
   )

--- a/pro/src/pages/Simulator/SimulatorResults/SimulatorResults.tsx
+++ b/pro/src/pages/Simulator/SimulatorResults/SimulatorResults.tsx
@@ -150,7 +150,11 @@ export const SimulatorResults = (): JSX.Element => {
           variant={ButtonVariant.SECONDARY}
           label="Retour"
         />
-        <Button as="router-link" to="/inscription/compte/creation" label="Continuer" />
+        <Button
+          as="router-link"
+          to="/inscription/compte/creation"
+          label="Continuer"
+        />
       </div>
     </>
   )

--- a/pro/src/pages/Simulator/SimulatorSiret/SimulatorSiret.tsx
+++ b/pro/src/pages/Simulator/SimulatorSiret/SimulatorSiret.tsx
@@ -34,7 +34,7 @@ export const SimulatorSiret = (): JSX.Element => {
   const submitElement = (isSubmitting: boolean): JSX.Element => (
     <div className={commonStyles['action-bar']}>
       <Button
-        as="a"
+        as="router-link"
         to="/bienvenue/prochaines-etapes"
         variant={ButtonVariant.SECONDARY}
         label="Retour"

--- a/pro/src/pages/Simulator/SimulatorTarget/SimulatorTarget.tsx
+++ b/pro/src/pages/Simulator/SimulatorTarget/SimulatorTarget.tsx
@@ -108,7 +108,7 @@ export const SimulatorTarget = (): JSX.Element => {
 
             <div className={commonStyles['action-bar']}>
               <Button
-                as="a"
+                as="router-link"
                 to="/inscription/preparation/activite"
                 variant={ButtonVariant.SECONDARY}
                 label="Retour"

--- a/pro/src/pages/User/UserProfile/UserAnonymization/components/UserAnonymizationUneligibility.tsx
+++ b/pro/src/pages/User/UserProfile/UserAnonymization/components/UserAnonymizationUneligibility.tsx
@@ -28,7 +28,6 @@ export const UserAnonymizationUneligibility = ({
         <Button
           as="a"
           to={PERSONAL_DATA_CHARTER_URL}
-          isExternal
           opensInNewTab
           variant={ButtonVariant.TERTIARY}
           color={ButtonColor.NEUTRAL}

--- a/pro/src/pages/VenueSettings/GeneralInformation/components/ComplementaryInfosDrawer/ComplementaryInfosDrawer.tsx
+++ b/pro/src/pages/VenueSettings/GeneralInformation/components/ComplementaryInfosDrawer/ComplementaryInfosDrawer.tsx
@@ -153,7 +153,7 @@ export const ComplementaryInfosDrawer = ({
                   variant={BannerVariants.WARNING}
                   title="Vos offres existantes ne sont pas mises à jour"
                   description="La modification de cette adresse ne change pas automatiquement la localisation de vos offres déjà créées. Pensez à les modifier individuellement."
-                ></Banner>
+                />
               )}
             </FormLayout.Section>
           </FormLayout>

--- a/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/StocksProviderForm/StocksProviderForm.tsx
+++ b/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/StocksProviderForm/StocksProviderForm.tsx
@@ -103,7 +103,6 @@ export const StocksProviderForm = ({
         </p>
         <Button
           as="a"
-          isExternal
           to="https://aide.passculture.app/hc/fr/articles/10616916478236"
           opensInNewTab
           aria-label="Nouvelle fenêtre"

--- a/pro/src/pages/WelcomeCarousel/WelcomeStepAdvantages/WelcomeStepAdvantages.tsx
+++ b/pro/src/pages/WelcomeCarousel/WelcomeStepAdvantages/WelcomeStepAdvantages.tsx
@@ -52,7 +52,7 @@ export const WelcomeStepAdvantages = (): JSX.Element => {
       </div>
       <div className={commonStyles['actionbar-container']}>
         <Button
-          as="a"
+          as="router-link"
           to="/bienvenue/offres-scolaires"
           variant={ButtonVariant.SECONDARY}
           label="Précédent"
@@ -63,7 +63,7 @@ export const WelcomeStepAdvantages = (): JSX.Element => {
           className={commonStyles['actionbar-container-stepper']}
         />
         <Button
-          as="a"
+          as="router-link"
           to="/bienvenue/prochaines-etapes"
           variant={ButtonVariant.PRIMARY}
           label="Suivant"

--- a/pro/src/pages/WelcomeCarousel/WelcomeStepCollective/WelcomeStepCollective.tsx
+++ b/pro/src/pages/WelcomeCarousel/WelcomeStepCollective/WelcomeStepCollective.tsx
@@ -43,7 +43,6 @@ const WelcomeStepCollective = (): JSX.Element => {
             label="Exemple d’offres pour les groupes scolaires"
             variant={ButtonVariant.TERTIARY}
             size={ButtonSize.SMALL}
-            isExternal
             onClick={() => {
               logEvent(WelcomeCarouselEvents.CLICKED_SEE_COLLECTIVE_OFFERS)
             }}
@@ -54,7 +53,7 @@ const WelcomeStepCollective = (): JSX.Element => {
       </div>
       <div className={commonStyles['actionbar-container']}>
         <Button
-          as="a"
+          as="router-link"
           to="/bienvenue/offres-jeunes"
           variant={ButtonVariant.SECONDARY}
           label="Précédent"
@@ -65,7 +64,7 @@ const WelcomeStepCollective = (): JSX.Element => {
           className={commonStyles['actionbar-container-stepper']}
         />
         <Button
-          as="a"
+          as="router-link"
           to="/bienvenue/avantages"
           variant={ButtonVariant.PRIMARY}
           label="Suivant"

--- a/pro/src/pages/WelcomeCarousel/WelcomeStepHub/WelcomeStepHub.spec.tsx
+++ b/pro/src/pages/WelcomeCarousel/WelcomeStepHub/WelcomeStepHub.spec.tsx
@@ -111,13 +111,13 @@ describe('<WelcomeStepHub />', () => {
       await userEvent.click(screen.getByRole('button', { name: 'Continuer' }))
 
       expect(
-        screen.getByRole('link', { name: 'Accéder à ADAGE' })
+        screen.getByRole('link', { name: /Accéder à ADAGE/ })
       ).toHaveAttribute(
         'href',
         'https://adage-pr.phm.education.gouv.fr/ds/?entityID=https%3A%2F%2Fadage-pr.phm.education.gouv.fr%2Fsp%2Fmdp&return=https%3A%2F%2Fadage-pr.phm.education.gouv.fr%2Fmdp%2FShibboleth.sso%2FLogin%3FSAMLDS%3D1%26target%3Dss%253Amem%253Af7ae5c254ceec3841749f8747ba4ff685aa80d7e05b232b3d8902796e9d36bab%26authnContextClassRef%3Durn%253Aoasis%253Anames%253Atc%253ASAML%253A2.0%253Aac%253Aclasses%253APasswordProtectedTransport%2520urn%253Aoasis%253Anames%253Atc%253ASAML%253A2.0%253Aac%253Aclasses%253ATimeSyncToken'
       )
       await userEvent.click(
-        screen.getByRole('link', { name: 'Accéder à ADAGE' })
+        screen.getByRole('link', { name: /Accéder à ADAGE/ })
       )
 
       expect(mockLogEvent).toHaveBeenCalledWith(

--- a/pro/src/pages/WelcomeCarousel/WelcomeStepHub/WelcomeStepHub.tsx
+++ b/pro/src/pages/WelcomeCarousel/WelcomeStepHub/WelcomeStepHub.tsx
@@ -57,7 +57,7 @@ export const WelcomeStepHub = (): JSX.Element => {
             <Button
               as="a"
               to="https://adage-pr.phm.education.gouv.fr/ds/?entityID=https%3A%2F%2Fadage-pr.phm.education.gouv.fr%2Fsp%2Fmdp&return=https%3A%2F%2Fadage-pr.phm.education.gouv.fr%2Fmdp%2FShibboleth.sso%2FLogin%3FSAMLDS%3D1%26target%3Dss%253Amem%253Af7ae5c254ceec3841749f8747ba4ff685aa80d7e05b232b3d8902796e9d36bab%26authnContextClassRef%3Durn%253Aoasis%253Anames%253Atc%253ASAML%253A2.0%253Aac%253Aclasses%253APasswordProtectedTransport%2520urn%253Aoasis%253Anames%253Atc%253ASAML%253A2.0%253Aac%253Aclasses%253ATimeSyncToken"
-              isExternal={true}
+              opensInNewTab
               variant={ButtonVariant.PRIMARY}
               label="Accéder à ADAGE"
               onClick={() =>

--- a/pro/src/pages/WelcomeCarousel/WelcomeStepIndividual/WelcomeStepIndividual.tsx
+++ b/pro/src/pages/WelcomeCarousel/WelcomeStepIndividual/WelcomeStepIndividual.tsx
@@ -45,7 +45,6 @@ const WelcomeStepIndividual = (): JSX.Element => {
             }}
             variant={ButtonVariant.TERTIARY}
             size={ButtonSize.SMALL}
-            isExternal
             opensInNewTab
           />
         </div>
@@ -53,7 +52,7 @@ const WelcomeStepIndividual = (): JSX.Element => {
 
       <div className={commonStyles['actionbar-container']}>
         <Button
-          as="a"
+          as="router-link"
           to="/bienvenue/publics"
           variant={ButtonVariant.SECONDARY}
           label="Précédent"
@@ -64,7 +63,7 @@ const WelcomeStepIndividual = (): JSX.Element => {
           className={commonStyles['actionbar-container-stepper']}
         />
         <Button
-          as="a"
+          as="router-link"
           to="/bienvenue/offres-scolaires"
           variant={ButtonVariant.PRIMARY}
           label="Suivant"

--- a/pro/src/pages/WelcomeCarousel/WelcomeStepNextSteps/WelcomeStepNextSteps.tsx
+++ b/pro/src/pages/WelcomeCarousel/WelcomeStepNextSteps/WelcomeStepNextSteps.tsx
@@ -81,7 +81,7 @@ const WelcomeStepNextSteps = (): JSX.Element => {
         )}
       >
         <Button
-          as="a"
+          as="router-link"
           to={
             isPreSignupSimulatorFeatureActive
               ? '/inscription/preparation/siret'

--- a/pro/src/pages/WelcomeCarousel/WelcomeStepTarget/WelcomeStepTarget.tsx
+++ b/pro/src/pages/WelcomeCarousel/WelcomeStepTarget/WelcomeStepTarget.tsx
@@ -55,7 +55,7 @@ const WelcomeStepTarget = (): JSX.Element => {
 
         <div className={commonStyles['actionbar-container']}>
           <Button
-            as="a"
+            as="router-link"
             to="/bienvenue"
             variant={ButtonVariant.SECONDARY}
             label="Précédent"
@@ -66,7 +66,7 @@ const WelcomeStepTarget = (): JSX.Element => {
             className={commonStyles['actionbar-container-stepper']}
           />
           <Button
-            as="a"
+            as="router-link"
             to="/bienvenue/offres-jeunes"
             variant={ButtonVariant.PRIMARY}
             label="Suivant"

--- a/pro/src/ui-kit/Breadcrumb/Breadcrumb.tsx
+++ b/pro/src/ui-kit/Breadcrumb/Breadcrumb.tsx
@@ -7,7 +7,7 @@ import styles from './Breadcrumb.module.scss'
 
 export type Crumb = {
   title: string
-  link: { to: string; isExternal: boolean }
+  link: { to: string; }
   icon?: string
 }
 
@@ -29,7 +29,7 @@ export const Breadcrumb = ({ crumbs }: BreadcrumbProps) => {
                 </span>
               ) : (
                 <Button
-                  as="a"
+                  as="router-link"
                   {...crumb.link}
                   variant={ButtonVariant.TERTIARY}
                   color={ButtonColor.BRAND}

--- a/pro/src/ui-kit/Breadcrumb/Breadcrumb.tsx
+++ b/pro/src/ui-kit/Breadcrumb/Breadcrumb.tsx
@@ -7,7 +7,7 @@ import styles from './Breadcrumb.module.scss'
 
 export type Crumb = {
   title: string
-  link: { to: string; }
+  link: { to: string }
   icon?: string
 }
 

--- a/pro/src/ui-kit/Breadcrumb/__specs__/Breadcrumb.spec.tsx
+++ b/pro/src/ui-kit/Breadcrumb/__specs__/Breadcrumb.spec.tsx
@@ -6,13 +6,9 @@ import { renderWithProviders } from '@/commons/utils/renderWithProviders'
 import { Breadcrumb, type Crumb } from '../Breadcrumb'
 
 const crumbs: Crumb[] = [
-  { title: 'Link 1', link: { to: './link1', isExternal: false } },
-  {
-    title: 'Link 2',
-    link: { to: './link2', isExternal: false },
-    icon: 'icon_url',
-  },
-  { title: 'Link 3', link: { to: './link3', isExternal: false } },
+  { title: 'Link 1', link: { to: './link1' } },
+  { title: 'Link 2', link: { to: './link2' }, icon: 'icon_url' },
+  { title: 'Link 3', link: { to: './link3' } },
 ]
 
 describe('Breadcrumb', () => {

--- a/pro/src/ui-kit/Card/Card.stories.tsx
+++ b/pro/src/ui-kit/Card/Card.stories.tsx
@@ -62,7 +62,7 @@ export const InfoVariant: Story = {
         </p>
       </Card.Content>
       <Card.Footer>
-        <Button as="a" to="#" isExternal opensInNewTab label="En savoir plus" size={ButtonSize.SMALL} variant={ButtonVariant.SECONDARY} color={ButtonColor.NEUTRAL} transparent/>
+        <Button as="a" to="#" opensInNewTab label="En savoir plus" size={ButtonSize.SMALL} variant={ButtonVariant.SECONDARY} color={ButtonColor.NEUTRAL} transparent/>
       </Card.Footer>
     </Card>
   ),

--- a/pro/src/ui-kit/SummaryLayout/SummarySection.tsx
+++ b/pro/src/ui-kit/SummaryLayout/SummarySection.tsx
@@ -46,7 +46,7 @@ export const SummarySection = ({
 
       {typeof editLink === 'string' ? (
         <Button
-          as="a"
+          as="router-link"
           variant={ButtonVariant.SECONDARY}
           color={ButtonColor.NEUTRAL}
           size={ButtonSize.SMALL}


### PR DESCRIPTION
…sExternal and isSectionLink props

# 🚀 Refactor: Simplification de la signature du composant `Button`

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43056)

## 1. Le problème

Jusqu'à présent, l'utilisation du composant Button manquait de clarté en ce qui concerne la gestion de la navigation, principalement en raison de props redondantes et d'une responsabilité mal découpée :

* **Manque de clarté & chevauchement de scope :** Les props `isExternal` et `openInNewTab` laissaient une ambiguïté récurrente (*"Est-ce que `isExternal={true}` implique automatiquement `openInNewTab={true}` ?"*).
* **Incohérence dans la sémantique de la prop `as` :** Avant cette PR, la prop `as` se basait sur _l'élément HTML_ final rendu (un `<Link>` de React Router rendant in fine une balise `<a>`, on passait `as="a"` dans tous les cas). Dans l'écosystème React, la convention pour la prop `as` (polymorphisme) est plutôt de cibler le _composant React_ sous-jacent à instancier (`button`, `a` ou `Link`). 
* **Doublons & dette technique :** `isSectionLink` et `isExternal` avaient exactement le même comportement interne (forcer le rendu d'un composant/balise native `<a>` au lieu d'un `Link` React Router pour éviter d'intercepter la navigation). `isExternal` était d'ailleurs souvent utilisé à la place de `isSectionLink`.


## 2. La solution implémentée par cette PR

1. **Rework de la prop `as` basée sur le composant React rendu :**
    * `as="button"` *(défaut)* : Rend le composant natif React `<button>`.
    * `as="a"` : Rend le composant natif React `<a>` (pour les liens externes, liens de section `#...`, téléchargements).
    * `as="router-link"` : Rend le composant React Router `<Link>` (pour la navigation interne SPA).
2. **Suppression des props ambiguës `isExternal` et `isSectionLink` :** Le composant à rendre étant désormais explicitement déclaré via `as`, ces deux flags n'ont plus lieu d'être.
3. **Maintien du comportement de `openInNewTab` :** La prop reste inchangée dans son fonctionnement, mais son rôle devient beaucoup plus clair maintenant que la confusion avec `isExternal` a disparu. 
    * _NB: Pour rappel, cette prop gère à la fois le `target="_blank"` et l'ajout de l'icône sur le lien_
4. **Mise à jour du typage discriminant (`ButtonProps`) :** Alignement des types TypeScript pour prendre en compte le nouveau contrat d'interface amené par `as: 'router-link'`.


## 3. Exemples d'utilisation (AVANT / APRÈS)

### 📌 Cas 1 : Lien interne à l'application (Navigation SPA React Router)

```tsx
// AVANT : L'intention était ambiguë, as="a" rendait en réalité un <Link> React Router
<Button as="a" to="/accueil">
  Retour à la super Home
</Button>

// APRÈS : On indique explicitement qu'on veut utiliser React Router
<Button as="router-link" to="/accueil">
  Retour à la super Home
</Button>
```

### 📌 Cas 2 : Lien externe vers un autre domaine

```tsx
// AVANT : Confusion sur le rôle respectif de isExternal et openInNewTab
<Button as="a" to="https://demarche.numerique.gouv.fr/" isExternal openInNewTab>
  Site pour créer un dossier ADAGE
</Button>

// APRÈS : as="a" indique clairement l'utilisation de la balise <a> native, isExternal disparaît
<Button as="a" to="https://demarche.numerique.gouv.fr/" openInNewTab>
  Site pour créer un dossier ADAGE
</Button>
```

### 📌 Cas 3 : Lien de section / ancre sur la même page

```tsx
// AVANT : on avait à la fois du isSectionLink et du isExternal  qui faisaient exactement la même chose
<Button as="a" to="#eac-section" isSectionLink>
   Partie EAC
</Button>
<Button as="a" to="#eac-section" isExternal>
  Partie EAC
</Button>

// APRÈS : Une ancre est simplement une navigation native <a>
<Button as="a" to="#eac-section">
  Partie EAC
</Button>
```

## ❓ Question en suspend

* **`openInNewTab` avec `as="router-link"` :** Faut-il interdire l'usage de la prop `openInNewTab` lorsque `as="router-link"` (via `openInNewTab?: never` dans le typage TypeScript) ?

### ⚠️ Impact & Consignes de test (QA / Non-régression)

⚠️ Le composant `Button` étant très largement utilisé, ces modifs impactent de nombreux fichiers : 
* plus on attend, plus il y aura de conflits
* il faudra prévoir une sessions un peu générale de tests de l'app
