### PR TITLE
POC : fix stacktrace sentry + grouping

### DIFF
--- a/pro/src/apiClient/__specs__/callSite.spec.ts
+++ b/pro/src/apiClient/__specs__/callSite.spec.ts
@@ -1,0 +1,84 @@
+import { withCallSites } from '../callSite'
+
+describe('withCallSites', () => {
+  it('should forward the resolved value of an operation', async () => {
+    const sdk = withCallSites({
+      getOffer: () => Promise.resolve({ id: 1 }),
+    })
+
+    await expect(sdk.getOffer()).resolves.toStrictEqual({ id: 1 })
+  })
+
+  it('should forward the arguments of an operation', async () => {
+    const getOffer = vi.fn((options: { id: number }) =>
+      Promise.resolve(options)
+    )
+    const sdk = withCallSites({ getOffer })
+
+    await sdk.getOffer({ id: 42 })
+
+    expect(getOffer).toHaveBeenCalledWith({ id: 42 })
+  })
+
+  it('should replace the error own frames with those of the caller', async () => {
+    const sdk = withCallSites({
+      getOffer: async () => {
+        // Stands for the generated client: the error is built several awaits
+        // away from the caller, so its own stack does not mention it.
+        await Promise.resolve()
+
+        const apiError = new Error('500 GET /offers/{id}')
+        apiError.name = 'ApiError'
+        apiError.stack =
+          'ApiError: 500 GET /offers/{id}\n    at request (client.gen.ts:141:25)'
+
+        throw apiError
+      },
+    })
+
+    const theCallingComponent = async () => {
+      try {
+        await sdk.getOffer()
+
+        return null
+      } catch (error) {
+        return error as Error
+      }
+    }
+
+    const error = await theCallingComponent()
+
+    expect(error?.stack).not.toContain('client.gen.ts')
+    expect(error?.stack).toContain('theCallingComponent')
+  })
+
+  it('should keep the header line consistent with the error it rethrows', async () => {
+    const apiError = new Error('500 GET /offers/{id}')
+    apiError.name = 'ApiError'
+
+    const sdk = withCallSites({
+      getOffer: () => Promise.reject(apiError),
+    })
+
+    const error = await sdk.getOffer().catch((rejected: Error) => rejected)
+
+    expect(error.stack).toMatch(/^ApiError: 500 GET \/offers\/\{id\}/)
+  })
+
+  it('should rethrow values that are not errors untouched', async () => {
+    const sdk = withCallSites({
+      getOffer: () => Promise.reject('not an error'),
+    })
+
+    await expect(sdk.getOffer()).rejects.toBe('not an error')
+  })
+
+  it('should copy the properties that are not operations as-is', () => {
+    const sdk = withCallSites({
+      getOffer: () => Promise.resolve(null),
+      SOME_CONSTANT: 'unchanged',
+    })
+
+    expect(sdk.SOME_CONSTANT).toBe('unchanged')
+  })
+})

--- a/pro/src/apiClient/api.ts
+++ b/pro/src/apiClient/api.ts
@@ -1,4 +1,4 @@
-import { ApiError } from '@/apiClient/compat'
+import { ApiError, normalizeApiPath } from '@/apiClient/compat'
 
 import { client as adageClient } from './adage/client.gen'
 import { client as v1Client } from './v1/client.gen'
@@ -13,8 +13,9 @@ function createApiErrorInterceptor() {
       ? new ApiError(
           request.url,
           response.status,
-          response.statusText ?? '',
-          error
+          response.statusText,
+          error,
+          `${request.method} ${normalizeApiPath(request.url)}`
         )
       : error
 }
@@ -22,13 +23,56 @@ function createApiErrorInterceptor() {
 v1Client.interceptors.error.use(createApiErrorInterceptor())
 adageClient.interceptors.error.use(createApiErrorInterceptor())
 
+import * as adageSdk from '@/apiClient/adage/sdk.gen'
 import * as v1Sdk from '@/apiClient/v1/sdk.gen'
 
-export * as apiAdage from '@/apiClient/adage/sdk.gen'
 export {
   getDataFromAddress,
   getDataFromAddressParts,
 } from '@/apiClient/adresse/apiAdresse'
+
+// biome-ignore lint/suspicious/noExplicitAny: the generated SDK signatures are restored by the cast in `withCallSites`
+type AsyncFn = (...args: any[]) => Promise<unknown>
+
+/**
+ * Records where an API call was made from, so the information survives to Sentry.
+ *
+ * Once the request is awaited, the caller's frames are gone: Firefox only
+ * reconstructs async frames when DevTools is attached (the
+ * `javascript.options.asyncstack_capture_debuggee_only` pref, on by default),
+ * so in the field an ApiError's own stack stops at the first `await` inside the
+ * generated client — three frames, identical for every endpoint.
+ *
+ * Building the Error on entry, before any await, captures the caller's real
+ * stack synchronously, which every engine reports. It is attached as `cause` so
+ * that Sentry's linkedErrors integration reports it as a chained exception.
+ */
+function withCallSite<T extends AsyncFn>(fn: T, name: string): T {
+  return ((...args: Parameters<T>) => {
+    const callSite = new Error(`api.${name}()`)
+    callSite.name = 'ApiCallSite'
+
+    return fn(...args).catch((error: unknown) => {
+      // `cause` is ES2022 and this project targets es2021, hence the cast.
+      const withCause = error as { cause?: unknown }
+      if (error instanceof Error && withCause.cause === undefined) {
+        withCause.cause = callSite
+      }
+      throw error
+    })
+  }) as T
+}
+
+function withCallSites<T extends object>(sdk: T): T {
+  return Object.fromEntries(
+    Object.entries(sdk).map(([name, value]) => [
+      name,
+      typeof value === 'function'
+        ? withCallSite(value as AsyncFn, name)
+        : value,
+    ])
+  ) as T
+}
 
 /**
  * Plain object wrapper around the generated v1 SDK so consumers can spy on it via `vi.spyOn(api, '...')`.
@@ -36,4 +80,5 @@ export {
  */
 // Careful here:
 // The originally frozen ES module namespace objects prevented any accidental mutation, which we lose with this spread.
-export const api = { ...v1Sdk }
+export const api = withCallSites({ ...v1Sdk })
+export const apiAdage = withCallSites({ ...adageSdk })

--- a/pro/src/apiClient/api.ts
+++ b/pro/src/apiClient/api.ts
@@ -1,4 +1,5 @@
-import { ApiError } from '@/apiClient/compat'
+import { withCallSites } from '@/apiClient/callSite'
+import { ApiError, normalizeApiPath } from '@/apiClient/compat'
 
 import { client as adageClient } from './adage/client.gen'
 import { client as v1Client } from './v1/client.gen'
@@ -13,8 +14,9 @@ function createApiErrorInterceptor() {
       ? new ApiError(
           request.url,
           response.status,
-          response.statusText ?? '',
-          error
+          response.statusText,
+          error,
+          `${request.method} ${normalizeApiPath(request.url)}`
         )
       : error
 }
@@ -22,18 +24,20 @@ function createApiErrorInterceptor() {
 v1Client.interceptors.error.use(createApiErrorInterceptor())
 adageClient.interceptors.error.use(createApiErrorInterceptor())
 
+import * as adageSdk from '@/apiClient/adage/sdk.gen'
 import * as v1Sdk from '@/apiClient/v1/sdk.gen'
 
-export * as apiAdage from '@/apiClient/adage/sdk.gen'
 export {
   getDataFromAddress,
   getDataFromAddressParts,
 } from '@/apiClient/adresse/apiAdresse'
 
 /**
- * Plain object wrapper around the generated v1 SDK so consumers can spy on it via `vi.spyOn(api, '...')`.
- * ES module namespace objects are frozen which prevents spying on them directly.
+ * Plain object wrappers around the generated SDKs:
+ *  - Recording call sites (see `withCallSites`)
+ *  - Spreading the module namespace so consumers can spy on these via `vi.spyOn(api, '...')`.
  */
 // Careful here:
 // The originally frozen ES module namespace objects prevented any accidental mutation, which we lose with this spread.
-export const api = { ...v1Sdk }
+export const api = withCallSites({ ...v1Sdk })
+export const apiAdage = withCallSites({ ...adageSdk })

--- a/pro/src/apiClient/callSite.ts
+++ b/pro/src/apiClient/callSite.ts
@@ -1,0 +1,48 @@
+function adoptCallSiteStack(error: unknown, callSite: Error): void {
+  if (!(error instanceof Error)) {
+    return
+  }
+
+  callSite.name = error.name
+  callSite.message = error.message
+
+  if (callSite.stack) {
+    error.stack = callSite.stack
+  }
+}
+
+type SdkOperation = (...args: never[]) => Promise<unknown>
+
+/**
+ * Wraps one operation so that its failures carry the stack of their caller.
+ */
+function recordCallSite<Operation extends SdkOperation>(
+  operation: Operation
+): Operation {
+  const wrapped = async (...args: Parameters<Operation>) => {
+    // Captured synchronously, before the operation is entered
+    const callSite = new Error()
+
+    try {
+      return await operation(...args)
+    } catch (error) {
+      adoptCallSiteStack(error, callSite)
+      throw error
+    }
+  }
+
+  return wrapped as Operation
+}
+
+/**
+ * Returns a copy of a generated SDK whose every operation records its call site.
+ */
+export function withCallSites<Sdk extends object>(sdk: Sdk): Sdk {
+  const operations = Object.entries(sdk).map(([name, value]) => {
+    const isOperation = typeof value === 'function'
+    return [name, isOperation ? recordCallSite(value) : value] as const
+  })
+
+  // the cast restores the generated signatures
+  return Object.fromEntries(operations) as Sdk
+}

--- a/pro/src/apiClient/compat.ts
+++ b/pro/src/apiClient/compat.ts
@@ -1,5 +1,17 @@
 type OnCancel = (handler: () => void) => void
 
+/**
+ * Numeric path segments are replaced by a placeholder so that every call to an
+ * endpoint produces the same label, instead of one Sentry issue per resource id.
+ */
+export function normalizeApiPath(url: string): string {
+  try {
+    return new URL(url).pathname.replace(/\/\d+/g, '/{id}')
+  } catch {
+    return url
+  }
+}
+
 export type ApiRequestOptions = {
   readonly method:
     | 'GET'
@@ -42,16 +54,21 @@ export class ApiError extends Error {
     url: string,
     status: number,
     statusText: string,
-    originalError: unknown
+    originalError: unknown,
+    requestLabel?: string
   )
   constructor(
     urlOrRequest: string | ApiRequestOptions,
     statusOrResponse: number | ApiResult,
     statusTextOrMessage: string,
-    originalError?: unknown
+    originalError?: unknown,
+    requestLabel?: string
   ) {
     if (typeof urlOrRequest === 'string') {
-      super(`${statusOrResponse} ${statusTextOrMessage}`)
+      // `requestLabel` describes the endpoint ("POST /offers/{id}/stocks/delete").
+      // It is preferred over `statusText`, which is always empty over HTTP/2 —
+      // the protocol dropped the reason phrase — leaving an unreadable "500 ".
+      super(`${statusOrResponse} ${requestLabel || statusTextOrMessage}`)
       this.url = urlOrRequest
       this.status = statusOrResponse as number
       this.statusText = statusTextOrMessage

--- a/pro/src/apiClient/compat.ts
+++ b/pro/src/apiClient/compat.ts
@@ -1,5 +1,13 @@
 type OnCancel = (handler: () => void) => void
 
+export function normalizeApiPath(url: string): string {
+  try {
+    return new URL(url).pathname.replace(/\/\d+/g, '/{id}')
+  } catch {
+    return url
+  }
+}
+
 export type ApiRequestOptions = {
   readonly method:
     | 'GET'
@@ -33,6 +41,7 @@ export class ApiError extends Error {
   public readonly url: string
   public readonly status: number
   public readonly statusText: string
+  public readonly requestLabel: string
   // biome-ignore lint/suspicious/noExplicitAny: matches original openapi-typescript-codegen signature
   public readonly body: Record<string, any>
   public readonly originalError: unknown
@@ -42,30 +51,36 @@ export class ApiError extends Error {
     url: string,
     status: number,
     statusText: string,
-    originalError: unknown
+    originalError: unknown,
+    requestLabel?: string
   )
   constructor(
     urlOrRequest: string | ApiRequestOptions,
     statusOrResponse: number | ApiResult,
     statusTextOrMessage: string,
-    originalError?: unknown
+    originalError?: unknown,
+    requestLabel?: string
   ) {
     if (typeof urlOrRequest === 'string') {
-      super(`${statusOrResponse} ${statusTextOrMessage}`)
+      // `requestLabel` is preferred over `statusText`, which is always empty over HTTP/2
+      super(`${statusOrResponse} ${requestLabel || statusTextOrMessage}`)
       this.url = urlOrRequest
       this.status = statusOrResponse as number
       this.statusText = statusTextOrMessage
+      this.requestLabel = requestLabel || normalizeApiPath(urlOrRequest)
       this.body =
         typeof originalError === 'object' && originalError !== null
           ? originalError
           : {}
       this.originalError = originalError
     } else {
+      const request = urlOrRequest
       const response = statusOrResponse as ApiResult
       super(statusTextOrMessage)
       this.url = response.url
       this.status = response.status
       this.statusText = response.statusText
+      this.requestLabel = `${request.method} ${normalizeApiPath(response.url)}`
       this.body =
         typeof response.body === 'object' && response.body !== null
           ? response.body

--- a/pro/src/app/App/analytics/__specs__/sentry.spec.tsx
+++ b/pro/src/app/App/analytics/__specs__/sentry.spec.tsx
@@ -1,0 +1,216 @@
+import type { BrowserOptions, ErrorEvent, EventHint } from '@sentry/browser'
+import * as Sentry from '@sentry/browser'
+
+import { makeApiError } from '@/commons/utils/factories/errorFactories'
+import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+
+import { initializeSentry, useSentry } from '../sentry'
+
+vi.mock('@sentry/browser', () => ({
+  init: vi.fn(),
+  setUser: vi.fn(),
+}))
+
+vi.mock('@sentry/react', () => ({
+  reactRouterV7BrowserTracingIntegration: vi.fn(),
+}))
+
+const SIGNUP_URL =
+  'https://pro.example.com/inscription/compte/confirmation/A1B2'
+const SCRUBBED_SIGNUP_URL =
+  'https://pro.example.com/inscription/compte/confirmation/[TOKEN]'
+
+type TransactionEvent = Awaited<
+  ReturnType<NonNullable<BrowserOptions['beforeSendTransaction']>>
+>
+
+function getSentryOption<Key extends keyof BrowserOptions>(
+  key: Key
+): NonNullable<BrowserOptions[Key]> {
+  initializeSentry()
+
+  const option = vi.mocked(Sentry.init).mock.calls[0]?.[0]?.[key]
+  if (!option) {
+    throw new Error(`Sentry.init got no \`${String(key)}\` option.`)
+  }
+
+  return option
+}
+
+function send(
+  event: Omit<ErrorEvent, 'type'> = {},
+  hint: EventHint = {}
+): ErrorEvent | null {
+  const beforeSend = getSentryOption('beforeSend')
+
+  // `type: undefined` is what tells an error event apart from a transaction one
+  return beforeSend({ ...event, type: undefined }, hint) as ErrorEvent | null
+}
+
+describe('initializeSentry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('beforeSend', () => {
+    it('should scrub the signup token from the event tags, request and transaction', () => {
+      const event = send({
+        tags: { url: SIGNUP_URL },
+        request: { url: SIGNUP_URL },
+        transaction: SIGNUP_URL,
+      })
+
+      expect(event?.tags?.['url']).toBe(SCRUBBED_SIGNUP_URL)
+      expect(event?.request?.url).toBe(SCRUBBED_SIGNUP_URL)
+      expect(event?.transaction).toBe(SCRUBBED_SIGNUP_URL)
+    })
+
+    it('should scrub the signup token from the normalized request metadata', () => {
+      const event = send({
+        sdkProcessingMetadata: { normalizedRequest: { url: SIGNUP_URL } },
+      })
+
+      expect(event?.sdkProcessingMetadata?.normalizedRequest?.url).toBe(
+        SCRUBBED_SIGNUP_URL
+      )
+    })
+
+    it.each(['Timeout', 'Timeout (u)'])(
+      'should drop the recaptcha and analytics "%s" error',
+      (originalException) => {
+        expect(send({}, { originalException })).toBeNull()
+      }
+    )
+
+    it('should attach an API error context when the exception is an ApiError', () => {
+      const apiError = makeApiError({
+        status: 500,
+        url: 'https://api.example.com/offers/123/stocks',
+        body: { global: ['Une erreur technique est survenue'] },
+      })
+
+      const event = send({}, { originalException: apiError })
+
+      expect(event?.contexts?.['API error']).toStrictEqual({
+        endpoint: 'GET /offers/{id}/stocks',
+        status: 500,
+        url: 'https://api.example.com/offers/123/stocks',
+        body: { global: ['Une erreur technique est survenue'] },
+      })
+    })
+
+    it('should scrub the signup token from the API error context url', () => {
+      const apiError = makeApiError({
+        status: 400,
+        url: 'https://api.example.com/users/validate_signup/A1B2',
+      })
+
+      const event = send({}, { originalException: apiError })
+
+      expect(event?.contexts?.['API error']?.['url']).toBe(
+        'https://api.example.com/users/validate_signup/[TOKEN]'
+      )
+    })
+
+    it('should keep the contexts already set on the event', () => {
+      const event = send(
+        { contexts: { default: { isUserImpersonated: true } } },
+        { originalException: makeApiError() }
+      )
+
+      expect(event?.contexts?.default).toStrictEqual({
+        isUserImpersonated: true,
+      })
+    })
+
+    it('should not attach an API error context for other errors', () => {
+      const event = send({}, { originalException: new Error('Oops') })
+
+      expect(event?.contexts?.['API error']).toBeUndefined()
+    })
+
+    it('should not set a fingerprint, so that Sentry groups the event itself', () => {
+      const event = send({}, { originalException: makeApiError() })
+
+      expect(event?.fingerprint).toBeUndefined()
+    })
+  })
+
+  describe('beforeSendTransaction', () => {
+    it('should scrub the signup token from the transaction event', () => {
+      const beforeSendTransaction = getSentryOption('beforeSendTransaction')
+
+      const transactionEvent = beforeSendTransaction(
+        {
+          type: 'transaction',
+          request: { url: SIGNUP_URL },
+          transaction: SIGNUP_URL,
+          sdkProcessingMetadata: { normalizedRequest: { url: SIGNUP_URL } },
+        },
+        {}
+      ) as TransactionEvent
+
+      expect(transactionEvent?.request?.url).toBe(SCRUBBED_SIGNUP_URL)
+      expect(transactionEvent?.transaction).toBe(SCRUBBED_SIGNUP_URL)
+      expect(
+        transactionEvent?.sdkProcessingMetadata?.normalizedRequest?.url
+      ).toBe(SCRUBBED_SIGNUP_URL)
+    })
+  })
+
+  describe('beforeBreadcrumb', () => {
+    it('should scrub the signup token from the breadcrumb url', () => {
+      const beforeBreadcrumb = getSentryOption('beforeBreadcrumb')
+
+      const breadcrumb = beforeBreadcrumb(
+        { data: { url: 'https://api.example.com/users/validate_signup/A1B2' } },
+        {}
+      )
+
+      expect(breadcrumb?.data?.url).toBe(
+        'https://api.example.com/users/validate_signup/[TOKEN]'
+      )
+    })
+  })
+
+  describe('beforeSendSpan', () => {
+    it('should scrub the signup token from the span description', () => {
+      const beforeSendSpan = getSentryOption('beforeSendSpan')
+
+      const span = beforeSendSpan({
+        description: 'GET https://api.example.com/users/validate_signup/A1B2',
+      } as Parameters<typeof beforeSendSpan>[0])
+
+      expect(span.description).toBe(
+        'GET https://api.example.com/users/validate_signup/[TOKEN]'
+      )
+    })
+  })
+})
+
+describe('useSentry', () => {
+  const TestComponent = (): null => {
+    useSentry()
+
+    return null
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should identify the current user to Sentry', () => {
+    renderWithProviders(<TestComponent />, {
+      user: sharedCurrentUserFactory({ id: 42 }),
+    })
+
+    expect(Sentry.setUser).toHaveBeenCalledWith({ id: '42' })
+  })
+
+  it('should not identify anyone when nobody is logged in', () => {
+    renderWithProviders(<TestComponent />)
+
+    expect(Sentry.setUser).not.toHaveBeenCalled()
+  })
+})

--- a/pro/src/app/App/analytics/sentry.ts
+++ b/pro/src/app/App/analytics/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/browser'
+import { extraErrorDataIntegration } from '@sentry/browser'
 import { reactRouterV7BrowserTracingIntegration } from '@sentry/react'
 import { useEffect } from 'react'
 import {
@@ -8,6 +9,7 @@ import {
   useNavigationType,
 } from 'react-router'
 
+import { ApiError, normalizeApiPath } from '@/apiClient/compat'
 import { useAppSelector } from '@/commons/hooks/useAppSelector'
 import { selectCurrentUser } from '@/commons/store/user/selectors'
 import {
@@ -23,6 +25,10 @@ export const initializeSentry = () => {
     environment: ENVIRONMENT_NAME,
     release: VITE_APP_VERSION,
     integrations: [
+      // Serialises the non-standard properties of custom errors (for ApiError:
+      // `url`, `status` and `body`, which holds the payload returned by the
+      // backend). Without it they are dropped from the event.
+      extraErrorDataIntegration({ depth: 3 }),
       reactRouterV7BrowserTracingIntegration({
         useEffect: useEffect,
         useLocation,
@@ -57,6 +63,20 @@ export const initializeSentry = () => {
         hint.originalException === 'Timeout (u)'
       ) {
         return null
+      }
+      // Group API errors by endpoint and by the screen they were called from.
+      // Their stack is unreliable for grouping: it holds only the generated
+      // client's frames, and it is shorter on Firefox — which drops async
+      // frames outside DevTools — than on Chrome, so one failing endpoint would
+      // otherwise be split across issues.
+      if (hint.originalException instanceof ApiError) {
+        const { status, url } = hint.originalException
+        event.fingerprint = [
+          'ApiError',
+          String(status),
+          normalizeApiPath(url),
+          apiErrorOrigin(event.transaction),
+        ]
       }
       return event
     },
@@ -168,6 +188,28 @@ export const useSentry = () => {
       Sentry.setUser({ id: currentUser.id.toString() })
     }
   }, [currentUser])
+}
+
+/**
+ * Identifies the screen an API call was made from, so that the same endpoint
+ * failing on two different pages produces two issues instead of one.
+ *
+ * `event.transaction` is the parameterized route set by the React Router
+ * integration ("/offre/:offerId/individuel/horaires"): stable across releases
+ * and already stripped of its tokens earlier in `beforeSend`. The call site
+ * captured on the error is deliberately not used — `beforeSend` runs in the
+ * browser, before Sentry applies source maps server-side, so its frames still
+ * point at minified chunks whose content hash changes on every deploy, which
+ * would create a new issue at each release.
+ */
+function apiErrorOrigin(transaction: string | undefined): string {
+  if (transaction) {
+    return transaction
+  }
+  // No active route span: fall back to the current location, scrubbed the same
+  // way, rather than lumping every routeless error together.
+  const path = normalizeApiPath(window.location.href)
+  return removeTokenFromFrontURL(path) ?? path
 }
 
 function createURLRewriter(

--- a/pro/src/app/App/analytics/sentry.ts
+++ b/pro/src/app/App/analytics/sentry.ts
@@ -8,6 +8,7 @@ import {
   useNavigationType,
 } from 'react-router'
 
+import { ApiError } from '@/apiClient/compat'
 import { useAppSelector } from '@/commons/hooks/useAppSelector'
 import { selectCurrentUser } from '@/commons/store/user/selectors'
 import {
@@ -57,6 +58,20 @@ export const initializeSentry = () => {
         hint.originalException === 'Timeout (u)'
       ) {
         return null
+      }
+      if (hint.originalException instanceof ApiError) {
+        const { body, requestLabel, status, url } = hint.originalException
+
+        // Serialises properties of an Api Error for better debug
+        event.contexts = {
+          ...event.contexts,
+          'API error': {
+            endpoint: requestLabel,
+            status,
+            url: removeTokenFromBackURL(url) ?? url,
+            body,
+          },
+        }
       }
       return event
     },

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.tsx
@@ -112,15 +112,26 @@ export function StocksCalendar({ offer, mode }: StocksCalendarProps) {
     }
   )
 
+  async function deleteStock(ids: number[]) {
+    // call the API many times to test an error in local
+    // await concurrently with a limit of 10,000 times to test the error in local
+    const promises = []
+
+    let i = 0
+    while (i < 100) {
+      promises.push(
+        api.deleteStocks({
+          path: { offer_id: offer.id },
+          body: { ids_to_delete: ids },
+        })
+      )
+      i++
+    }
+    await Promise.all(promises)
+  }
+
   async function deleteStocks(ids: number[]) {
-    await mutate(
-      stockQueryKeys,
-      api.deleteStocks({
-        path: { offer_id: offer.id },
-        body: { ids_to_delete: ids },
-      }),
-      { revalidate: true }
-    )
+    await mutate(stockQueryKeys, deleteStock(ids), { revalidate: true })
 
     if (
       page > 1 &&


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-XXXXX)

Avant :

````markdown
### Firefox

ApiError: 500 INTERNAL SERVER ERROR
    at ApiError (/apiClient/compat.ts:4:4)
    at createApiErrorInterceptor/< (/apiClient/api.ts:5:75)
    at request (/apiClient/v1/client/client.gen.ts:141:25)

### Chrome

ApiError: 500 INTERNAL SERVER ERROR
    at ? (/apiClient/api.ts:5:75)
    at request (/apiClient/v1/client/client.gen.ts:141:25)
    at async createOfferFromTemplate (/commons/core/OfferEducational/utils/createOfferFromTemplate.ts:10:33)
````

Après :

````markdown
### Firefox

ApiError: 500 GET /collective/offers-template/{id}
    at wrapped (/apiClient/callSite.ts:17:20)
    at createOfferFromTemplate (/commons/core/OfferEducational/utils/createOfferFromTemplate.ts:10:43)
    at onClickCreateBookableOffer (/pages/Homepage/components/CollectiveOffersTemplateCard/components/CollectiveOffersTemplateLine/CollectiveOffersTemplateLine.tsx:44:26)
    at executeDispatch (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:9139:13)
    at runWithFiberInDEV (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:850:123)
    at processDispatchQueue (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:9165:27)
    at require_react_dom_client_development</dispatchEventForPluginEventSystem/< (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:9452:25)
    at batchedUpdates$1 (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:2042:12)
    at dispatchEventForPluginEventSystem (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:9238:20)
    at dispatchEvent (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:11317:62)
    at dispatchDiscreteEvent (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:11299:56)

### Chrome

ApiError: 500 GET /collective/offers-template/{id}
    at Object.wrapped [as getCollectiveOfferTemplate] (/apiClient/callSite.ts:17:20)
    at createOfferFromTemplate (/commons/core/OfferEducational/utils/createOfferFromTemplate.ts:10:43)
    at onClickCreateBookableOffer (/pages/Homepage/components/CollectiveOffersTemplateCard/components/CollectiveOffersTemplateLine/CollectiveOffersTemplateLine.tsx:44:3)
    at executeDispatch (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:9139:5)
    at runWithFiberInDEV (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:850:66)
    at processDispatchQueue (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:9165:27)
    at ? (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:9452:5)
    at batchedUpdates$1 (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:2042:12)
    at dispatchEventForPluginEventSystem (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:9238:4)
    at dispatchEvent (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:11317:29)
    at dispatchDiscreteEvent (/@fs/Users/passculture/Documents/pass-culture-main/pro/node_modules/.vite/deps/react-dom_client.js:11299:56)

````


