### PR TITLE
(PC-42730)[PRO] fix: remove double call to offerer id and stop logging out for network errors

### DIFF
--- a/pro/src/commons/store/StoreProvider/__specs__/StoreProvider.spec.tsx
+++ b/pro/src/commons/store/StoreProvider/__specs__/StoreProvider.spec.tsx
@@ -78,8 +78,7 @@ describe('src | App', () => {
     expect(api.getProfile).toHaveBeenCalledTimes(1)
     expect(api.listOfferersNames).toHaveBeenCalledTimes(1)
     expect(api.getVenuesLite).toHaveBeenCalledTimes(1)
-    // TODO (igabriele, 2026-05-11): Change back to `1` once `nextSelectedPartnerVenue` is removed from `setSelectedPartnerVenueById` (`WIP_SWITCH_VENUE`).
     expect(api.getVenue).toHaveBeenCalledTimes(1)
-    expect(api.getOfferer).toHaveBeenCalledTimes(2)
+    expect(api.getOfferer).toHaveBeenCalledTimes(1)
   })
 })

--- a/pro/src/commons/store/user/dispatchers/__specs__/setSelectedPartnerVenueById.spec.ts
+++ b/pro/src/commons/store/user/dispatchers/__specs__/setSelectedPartnerVenueById.spec.ts
@@ -24,7 +24,6 @@ vi.mock('@/apiClient/api', () => ({
   api: {
     getVenue: vi.fn(),
     signout: vi.fn(),
-    getOfferer: vi.fn(),
   },
 }))
 vi.mock('@/commons/errors/handleError', () => ({
@@ -89,25 +88,19 @@ describe('setSelectedPartnerVenueById', () => {
       .unwrap()
 
     expect(api.getVenue).not.toHaveBeenCalled()
-    expect(api.getOfferer).not.toHaveBeenCalled()
-
-    const state = store.getState()
-    expect(state.user.selectedPartnerVenue?.id).toBe(201)
 
     expect(localStorage.getItem(LOCAL_STORAGE_KEY.SELECTED_VENUE_ID)).toBe(
       '201'
     )
   })
 
-  it('should compute nextSelectedPartnerVenue, fetch its offerer, and persist it', async () => {
+  it('should compute nextSelectedPartnerVenue and persist it', async () => {
     vi.spyOn(api, 'getVenue').mockResolvedValue(
-      makeGetVenueResponseModel({ id: 101, managingOffererId: 100 })
+      makeGetVenueResponseModel({
+        id: 101,
+        managingOfferer: makeGetVenueManagingOffererResponseModel({ id: 100 }),
+      })
     )
-    vi.spyOn(api, 'getOfferer').mockResolvedValue({
-      ...defaultGetOffererResponseModel,
-      id: 100,
-      isOnboarded: true,
-    })
 
     const store = configureTestStore(storeDataBase)
 
@@ -121,7 +114,6 @@ describe('setSelectedPartnerVenueById', () => {
       .unwrap()
 
     expect(api.getVenue).toHaveBeenCalledTimes(1)
-    expect(api.getOfferer).toHaveBeenCalledTimes(1)
 
     const state = store.getState()
     expect(state.user.selectedPartnerVenue?.id).toBe(101)
@@ -131,7 +123,7 @@ describe('setSelectedPartnerVenueById', () => {
     )
   })
 
-  it('should not call getVenue and getOfferer when offerer is not attached', async () => {
+  it('should not call getVenue when offerer is not attached', async () => {
     const store = configureTestStore(storeDataBase)
 
     await store
@@ -144,7 +136,6 @@ describe('setSelectedPartnerVenueById', () => {
       .unwrap()
 
     expect(api.getVenue).toHaveBeenCalledTimes(0)
-    expect(api.getOfferer).toHaveBeenCalledTimes(0)
 
     const state = store.getState()
     expect(state.user.selectedPartnerVenue?.id).toBe(301)
@@ -184,22 +175,19 @@ describe('setSelectedPartnerVenueById', () => {
     expect(logoutSpy).toHaveBeenCalledTimes(1)
 
     expect(api.getVenue).not.toHaveBeenCalled()
-    expect(api.getOfferer).not.toHaveBeenCalled()
 
     expect(localStorage.getItem(LOCAL_STORAGE_KEY.SELECTED_VENUE_ID)).toBeNull()
   })
 
   it('should throw when nextSelectedOffererName is undefined', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
+    // The selected venue belongs to offerer 999, which is not in offererNames
     vi.spyOn(api, 'getVenue').mockResolvedValue(
-      makeGetVenueResponseModel({ id: 101, managingOffererId: 999 })
+      makeGetVenueResponseModel({
+        id: 101,
+        managingOfferer: makeGetVenueManagingOffererResponseModel({ id: 999 }),
+      })
     )
-    // The selected venue belongs to offerer 999, which is not validated in offererNames
-    vi.spyOn(api, 'getOfferer').mockResolvedValue({
-      ...defaultGetOffererResponseModel,
-      id: 999,
-      isOnboarded: true,
-    })
     const handleErrorSpy = vi.spyOn(handleErrorModule, 'handleError')
     const logoutSpy = vi.spyOn(logoutModule, 'logout')
 
@@ -248,7 +236,6 @@ describe('setSelectedPartnerVenueById', () => {
     expect(logoutSpy).toHaveBeenCalledTimes(1)
 
     expect(api.getVenue).toHaveBeenCalledTimes(1)
-    expect(api.getOfferer).toHaveBeenCalledTimes(1)
 
     expect(localStorage.getItem(LOCAL_STORAGE_KEY.SELECTED_VENUE_ID)).toBeNull()
   })
@@ -260,11 +247,6 @@ describe('setSelectedPartnerVenueById', () => {
         managingOfferer: makeGetVenueManagingOffererResponseModel({ id: 100 }),
       })
     )
-    vi.spyOn(api, 'getOfferer').mockResolvedValue({
-      ...defaultGetOffererResponseModel,
-      id: 100,
-      isOnboarded: true,
-    })
     const setSelectedAdminOffererByIdSpy = vi.spyOn(
       setSelectedAdminOffererByIdModule,
       'setSelectedAdminOffererById'
@@ -291,11 +273,6 @@ describe('setSelectedPartnerVenueById', () => {
         managingOfferer: makeGetVenueManagingOffererResponseModel({ id: 100 }),
       })
     )
-    vi.spyOn(api, 'getOfferer').mockResolvedValue({
-      ...defaultGetOffererResponseModel,
-      id: 100,
-      isOnboarded: true,
-    })
     const setSelectedAdminOffererByIdSpy = vi.spyOn(
       setSelectedAdminOffererByIdModule,
       'setSelectedAdminOffererById'
@@ -333,7 +310,6 @@ describe('setSelectedPartnerVenueById', () => {
       .unwrap()
 
     expect(api.getVenue).not.toHaveBeenCalled()
-    expect(api.getOfferer).not.toHaveBeenCalled()
     expect(setSelectedAdminOffererByIdSpy).toHaveBeenCalledExactlyOnceWith(300)
   })
 
@@ -358,7 +334,7 @@ describe('setSelectedPartnerVenueById', () => {
   })
 
   describe('shouldRefresh', () => {
-    it('should bypass the same-venue early-return and refetch venue + offerer when shouldRefresh is true', async () => {
+    it('should bypass the same-venue early-return and refetch venue when shouldRefresh is true', async () => {
       vi.spyOn(api, 'getVenue').mockResolvedValue(
         makeGetVenueResponseModel({
           id: 201,
@@ -368,11 +344,6 @@ describe('setSelectedPartnerVenueById', () => {
           isOnboarded: true,
         })
       )
-      vi.spyOn(api, 'getOfferer').mockResolvedValue({
-        ...defaultGetOffererResponseModel,
-        id: 200,
-        isOnboarded: true,
-      })
 
       const store = configureTestStore(storeDataBase)
 
@@ -389,9 +360,6 @@ describe('setSelectedPartnerVenueById', () => {
       expect(api.getVenue).toHaveBeenCalledExactlyOnceWith({
         path: { venue_id: 201 },
       })
-      expect(api.getOfferer).toHaveBeenCalledExactlyOnceWith({
-        path: { offerer_id: 200 },
-      })
 
       const state = store.getState()
       expect(state.user.selectedPartnerVenue?.id).toBe(201)
@@ -407,11 +375,6 @@ describe('setSelectedPartnerVenueById', () => {
           }),
         })
       )
-      vi.spyOn(api, 'getOfferer').mockResolvedValue({
-        ...defaultGetOffererResponseModel,
-        id: 200,
-        isOnboarded: true,
-      })
       const setSelectedAdminOffererByIdSpy = vi.spyOn(
         setSelectedAdminOffererByIdModule,
         'setSelectedAdminOffererById'
@@ -452,11 +415,6 @@ describe('setSelectedPartnerVenueById', () => {
           }),
         })
       )
-      vi.spyOn(api, 'getOfferer').mockResolvedValue({
-        ...defaultGetOffererResponseModel,
-        id: 200,
-        isOnboarded: true,
-      })
       const setSelectedAdminOffererByIdSpy = vi.spyOn(
         setSelectedAdminOffererByIdModule,
         'setSelectedAdminOffererById'

--- a/pro/src/commons/store/user/dispatchers/setSelectedAdminOffererById.ts
+++ b/pro/src/commons/store/user/dispatchers/setSelectedAdminOffererById.ts
@@ -65,7 +65,10 @@ export const setSelectedAdminOffererById = createAsyncThunk<
         err,
         "Une erreur est survenue lors du chargement de l'entité juridique."
       )
-      if (isErrorAPIError(err) || err instanceof FrontendError) {
+      if (
+        (isErrorAPIError(err) && err.status !== 0) ||
+        err instanceof FrontendError
+      ) {
         logout()
       }
     }

--- a/pro/src/commons/store/user/dispatchers/setSelectedPartnerVenueById.ts
+++ b/pro/src/commons/store/user/dispatchers/setSelectedPartnerVenueById.ts
@@ -1,10 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import { api } from '@/apiClient/api'
-import type {
-  GetOffererResponseModel,
-  GetVenueResponseModel,
-} from '@/apiClient/v1'
+import type { GetVenueResponseModel } from '@/apiClient/v1'
 import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { handleError } from '@/commons/errors/handleError'
 import {
@@ -58,7 +55,6 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
       const venuesWithPendingValidationIds =
         state.user.venuesWithPendingValidation?.map((v) => v.id)
       let nextSelectedPartnerVenue: GetVenueResponseModel
-      let nextSelectedOfferer: GetOffererResponseModel | undefined
       if (
         venuesWithPendingValidationIds?.length &&
         venuesWithPendingValidationIds.includes(nextSelectedPartnerVenueId)
@@ -70,15 +66,9 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
           id: nextSelectedPartnerVenueId,
           managingOfferer: { id: venue?.managingOffererId },
         } as GetVenueResponseModel
-        nextSelectedOfferer = {
-          id: venue?.managingOffererId,
-        } as GetOffererResponseModel
       } else {
         nextSelectedPartnerVenue = await api.getVenue({
           path: { venue_id: nextSelectedPartnerVenueId },
-        })
-        nextSelectedOfferer = await api.getOfferer({
-          path: { offerer_id: nextSelectedPartnerVenue.managingOfferer.id },
         })
       }
 
@@ -98,7 +88,7 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
       }
 
       const nextSelectedOffererName = offererNames.find(
-        (offerer) => offerer.id === nextSelectedOfferer.id
+        (offerer) => offerer.id === nextSelectedPartnerVenue.managingOfferer.id
       )
       assertOrFrontendError(
         nextSelectedOffererName,


### PR DESCRIPTION
Deux changements :

- Suppression de l'appel `api.getOfferer` dans `setSelectedPartnerVenueById`. L'offerer était fetché uniquement pour récupérer son `.id`, qui était déjà disponible via `nextSelectedPartnerVenue.managingOfferer.id`. Cela élimine le double appel à` /offerers/:id` : `setSelectedPartnerVenueById` faisait le 1er appel, puis `setSelectedAdminOffererById` refaisait le même 1 seconde après, et c'est ce 2e appel qui échouait avec status 0.
- Dans `setSelectedAdminOffererById`, le `logout()` ne se déclenche plus pour les `ApiError`avec status 0 car il s'agit d'une simple erreur réseau.