### PR TITLE
(PC-42958)[PRO] feat: ModalSimple in design system

### DIFF
--- a/pro/knip.json
+++ b/pro/knip.json
@@ -13,7 +13,7 @@
     "scripts/customRequest.ts",
     "scripts/format_generated_index_exports.js",
     "scripts/sanitize_enum_keys.js",
-    "src/ui-kit/BaseDialog/BaseDialog.tsx"
+    "src/design-system/SimpleModal/SimpleModal.tsx"
   ],
   "ignoreDependencies": ["openapi-typescript-codegen"],
   "ignoreUnresolved": ["typescript-plugin-css-modules"],

--- a/pro/knip.production.json
+++ b/pro/knip.production.json
@@ -27,7 +27,8 @@
     "scripts/format_generated_index_exports.js",
     "scripts/sanitize_enum_keys.js",
     "src/design-system/Dropdown/Dropdown.tsx",
-    "src/ui-kit/BaseDialog/BaseDialog.tsx"
+    "src/ui-kit/BaseDialog/BaseDialog.tsx",
+    "src/design-system/SimpleModal/SimpleModal.tsx"
   ],
   "ignoreDependencies": ["openapi-typescript-codegen"],
   "ignoreUnresolved": ["typescript-plugin-css-modules"],

--- a/pro/src/design-system/SimpleModal/SimpleModal.module.scss
+++ b/pro/src/design-system/SimpleModal/SimpleModal.module.scss
@@ -1,0 +1,41 @@
+@use "styles/mixins/_size.scss" as size;
+@use "styles/mixins/_fonts.scss" as fonts;
+@use "styles/mixins/_a11y.scss" as a11y;
+@use "styles/mixins/_rem.scss" as rem;
+
+.dialog-container {
+  display: flex;
+  gap: var(--size-spacing-xl);
+  flex-direction: column;
+  align-items: center;
+}
+
+.dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-spacing-l);
+  align-items: center;
+}
+
+.dialog-content-title {
+  @include fonts.title4;
+}
+
+.action-buttons {
+  display: flex;
+  gap: var(--size-spacing-l);
+  margin-top: auto;
+  flex-direction: column;
+  align-items: center;
+
+  @media (min-width: size.$tablet) {
+    flex-direction: row;
+  }
+}
+
+@keyframes simple-appear {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(-25px);
+  }
+}

--- a/pro/src/design-system/SimpleModal/SimpleModal.module.scss
+++ b/pro/src/design-system/SimpleModal/SimpleModal.module.scss
@@ -1,7 +1,41 @@
 @use "styles/mixins/_size.scss" as size;
 @use "styles/mixins/_fonts.scss" as fonts;
-@use "styles/mixins/_a11y.scss" as a11y;
 @use "styles/mixins/_rem.scss" as rem;
+
+.dialog-wrapper {
+  background-color: var(--color-background-default);
+  display: flex;
+  padding: var(--size-spacing-xxl);
+  border-radius: var(--size-border-radius-m);
+  flex-direction: column;
+  will-change: transform, opacity;
+  width: 100vw;
+  position: fixed;
+  bottom: 0;
+
+  @media screen and (prefers-reduced-motion: no-preference) and (max-width: size.$tablet) {
+    animation: slide-in-up 500ms;
+  }
+
+  @media (min-width: size.$tablet) {
+    max-width: rem.torem(512px);
+    margin: 0;
+    bottom: unset;
+    position: unset;
+  }
+
+  @keyframes slide-in-up {
+    from {
+      transform: translateY(100%);
+      opacity: 0;
+    }
+
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+}
 
 .dialog-container {
   display: flex;
@@ -38,4 +72,10 @@
     opacity: 0;
     transform: scale(0.95) translateY(-25px);
   }
+}
+
+.close-button {
+  display: flex;
+  align-self: flex-end;
+  margin-bottom: rem.torem(10px);
 }

--- a/pro/src/design-system/SimpleModal/SimpleModal.spec.tsx
+++ b/pro/src/design-system/SimpleModal/SimpleModal.spec.tsx
@@ -1,0 +1,71 @@
+import { screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+
+import { renderWithProviders } from '@/commons/utils/renderWithProviders'
+import fullLinkIcon from '@/icons/full-link.svg'
+
+import { Button } from '../Button/Button'
+import { ButtonVariant } from '../Button/types'
+import { SimpleModal, type SimpleModalProps } from './SimpleModal'
+
+const renderModalSimple = (props: SimpleModalProps) => {
+  return renderWithProviders(<SimpleModal {...props} />)
+}
+
+const props: SimpleModalProps = {
+  title: 'Modal Title',
+  iconPath: fullLinkIcon,
+  isOpen: true,
+  onClose: vi.fn(),
+  children: <p>Modal content.</p>,
+  actionButtons: (
+    <>
+      <Button label="Annuler" variant={ButtonVariant.SECONDARY} />
+      <Button label="Confirmer" variant={ButtonVariant.PRIMARY} />
+    </>
+  ),
+}
+
+describe('SimpleModal', () => {
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn()
+    HTMLDialogElement.prototype.close = vi.fn()
+  })
+
+  it('should have an accessible structure', async () => {
+    const { container } = renderModalSimple(props)
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('should display the title, children, icon, and buttons', () => {
+    renderModalSimple(props)
+    expect(screen.getByText('Modal Title')).toBeInTheDocument()
+    expect(screen.getByText('Modal content.')).toBeInTheDocument()
+    expect(screen.getByTestId('modal-icon')).toBeInTheDocument()
+    expect(screen.getByText('Annuler')).toBeInTheDocument()
+    expect(screen.getByText('Confirmer')).toBeInTheDocument()
+  })
+
+  it('should not display the image when not provided', () => {
+    renderModalSimple({
+      ...props,
+      iconPath: undefined,
+    })
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+
+  it('should call onClose when the modal is closed', () => {
+    const onCloseMock = vi.fn()
+    renderModalSimple({
+      ...props,
+      isOpen: true,
+      onClose: onCloseMock,
+    })
+
+    const closeButton = screen.getByLabelText('Fermer la modale')
+    closeButton.click()
+
+    expect(onCloseMock).toHaveBeenCalled()
+  })
+})

--- a/pro/src/design-system/SimpleModal/SimpleModal.stories.tsx
+++ b/pro/src/design-system/SimpleModal/SimpleModal.stories.tsx
@@ -1,0 +1,53 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+import { SimpleModal } from "./SimpleModal"
+
+import fullNextIcon from '@/icons/full-next.svg'
+import fullClearIcon from '@/icons/full-clear.svg'
+import { Button } from "../Button/Button"
+import { ButtonColor, ButtonVariant } from "../Button/types"
+import { useState } from "react"
+
+
+const SimpleModalWithOpenButton = (
+  args: React.ComponentProps<typeof SimpleModal>
+) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div style={{ minHeight: '240px' }}>
+      <Button
+        variant={ButtonVariant.PRIMARY}
+        label="Ouvrir la modale simple"
+        onClick={() => setIsOpen(true)}
+      />
+
+      <SimpleModal
+        {...args}
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+      />
+    </div>
+  )
+}
+
+
+const meta: Meta<typeof SimpleModal> = {
+  title: '@/design-system/SimpleModal',
+  component: SimpleModal,
+}
+
+
+export default meta
+type Story = StoryObj<typeof SimpleModal>
+
+export const Default: Story = {
+  render: () => <SimpleModalWithOpenButton title={"Titre très très très loong"} isOpen={true} iconPath={fullNextIcon} onClose={() => {}} actionButtons={
+  <>
+    <Button label="Annuler" variant={ButtonVariant.TERTIARY} color={ButtonColor.NEUTRAL} icon={fullClearIcon}/>
+    <Button label="Annuler" variant={ButtonVariant.SECONDARY}/>
+    <Button label="Confirmer" variant={ButtonVariant.PRIMARY}/>
+  </>
+  }>
+    <p style={{ textAlign: 'center' }}>Description de 2 à 3 lignes max Description de 2 à 3 lignes max Description de 2 à 3 lignes max</p>
+  </SimpleModalWithOpenButton>,
+}

--- a/pro/src/design-system/SimpleModal/SimpleModal.tsx
+++ b/pro/src/design-system/SimpleModal/SimpleModal.tsx
@@ -1,0 +1,72 @@
+import { useId } from 'react'
+
+import { BaseDialog } from '@/ui-kit/BaseDialog/BaseDialog'
+import { SvgIcon } from '@/ui-kit/SvgIcon/SvgIcon'
+
+import styles from './SimpleModal.module.scss'
+
+export interface SimpleModalProps {
+  /**
+   * The heading title of the dialog.
+   */
+  title: string
+  /**
+   * An icon path.
+   */
+  iconPath?: string
+  /**
+   * The content to be displayed inside the dialog.
+   */
+  children: React.ReactNode
+  /**
+   * Function called to close the modal.
+   */
+  onClose: () => void
+  /**
+   * Controls the open state of the dialog.
+   */
+  isOpen: boolean
+  /**
+   * Action buttons to be displayed at the bottom of the dialog. The dialog must not have more than 3 buttons.
+   */
+  actionButtons?: React.ReactNode
+  /**
+   * Identifier of the description element for screen readers (aria-describedby).
+   */
+  ariaDescribedBy?: string
+}
+
+export const SimpleModal = ({
+  title,
+  iconPath,
+  children,
+  onClose,
+  isOpen,
+  actionButtons,
+  ariaDescribedBy,
+}: Readonly<SimpleModalProps>) => {
+  const dialogTitleId = useId()
+
+  return (
+    <BaseDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabelledBy={dialogTitleId}
+      ariaDescribedBy={ariaDescribedBy}
+      variant="simple"
+    >
+      <div className={styles['dialog-container']}>
+        {iconPath && (
+          <SvgIcon alt="" src={iconPath} width="88" data-testid="modal-icon" />
+        )}
+        <div className={styles['dialog-content']}>
+          <h1 className={styles['dialog-content-title']} id={dialogTitleId}>
+            {title}
+          </h1>
+          <div>{children}</div>
+        </div>
+        <div className={styles['action-buttons']}>{actionButtons}</div>
+      </div>
+    </BaseDialog>
+  )
+}

--- a/pro/src/design-system/SimpleModal/SimpleModal.tsx
+++ b/pro/src/design-system/SimpleModal/SimpleModal.tsx
@@ -1,8 +1,11 @@
 import { useId } from 'react'
 
+import fullCloseIcon from '@/icons/full-close.svg'
 import { BaseDialog } from '@/ui-kit/BaseDialog/BaseDialog'
 import { SvgIcon } from '@/ui-kit/SvgIcon/SvgIcon'
 
+import { Button } from '../Button/Button'
+import { ButtonColor, ButtonVariant } from '../Button/types'
 import styles from './SimpleModal.module.scss'
 
 export interface SimpleModalProps {
@@ -53,19 +56,34 @@ export const SimpleModal = ({
       onClose={onClose}
       ariaLabelledBy={dialogTitleId}
       ariaDescribedBy={ariaDescribedBy}
-      variant="simple"
     >
-      <div className={styles['dialog-container']}>
-        {iconPath && (
-          <SvgIcon alt="" src={iconPath} width="88" data-testid="modal-icon" />
-        )}
-        <div className={styles['dialog-content']}>
-          <h1 className={styles['dialog-content-title']} id={dialogTitleId}>
-            {title}
-          </h1>
-          <div>{children}</div>
+      <div className={styles['dialog-wrapper']}>
+        <span className={styles['close-button']}>
+          <Button
+            icon={fullCloseIcon}
+            variant={ButtonVariant.TERTIARY}
+            color={ButtonColor.NEUTRAL}
+            onClick={onClose}
+            aria-label={'Fermer la modale'}
+          />
+        </span>
+        <div className={styles['dialog-container']}>
+          {iconPath && (
+            <SvgIcon
+              alt=""
+              src={iconPath}
+              width="88"
+              data-testid="modal-icon"
+            />
+          )}
+          <div className={styles['dialog-content']}>
+            <h1 className={styles['dialog-content-title']} id={dialogTitleId}>
+              {title}
+            </h1>
+            <div>{children}</div>
+          </div>
+          <div className={styles['action-buttons']}>{actionButtons}</div>
         </div>
-        <div className={styles['action-buttons']}>{actionButtons}</div>
       </div>
     </BaseDialog>
   )

--- a/pro/src/ui-kit/BaseDialog/BaseDialog.module.scss
+++ b/pro/src/ui-kit/BaseDialog/BaseDialog.module.scss
@@ -5,8 +5,11 @@
   // Reset the browser's default styles on the <dialog> tag
   border: none;
   background: transparent;
-  margin: auto;
   overflow: visible;
+
+  @media (min-width: size.$tablet) {
+    margin: auto;
+  }
 
   // Remove the browser's default outline (the outline will be handled by inner focusable elements)
   &:focus-visible {
@@ -26,10 +29,31 @@
     border-radius: var(--size-border-radius-m);
     flex-direction: column;
     will-change: transform, opacity;
-    max-width: rem.torem(512px);
+    width: 100vw;
+    position: fixed;
+    bottom: 0;
 
-    @media screen and (prefers-reduced-motion: no-preference) {
-      animation: simple-appear 100ms;
+    @media screen and (prefers-reduced-motion: no-preference) and (max-width: size.$tablet) {
+      animation: slide-in-up 500ms;
+    }
+
+    @media (min-width: size.$tablet) {
+      max-width: rem.torem(512px);
+      margin: 0;
+      bottom: unset;
+      position: unset;
+    }
+
+    @keyframes slide-in-up {
+      from {
+        transform: translateY(100%);
+        opacity: 0;
+      }
+
+      to {
+        transform: translateY(0);
+        opacity: 1;
+      }
     }
   }
 }

--- a/pro/src/ui-kit/BaseDialog/BaseDialog.module.scss
+++ b/pro/src/ui-kit/BaseDialog/BaseDialog.module.scss
@@ -1,4 +1,3 @@
-@use "styles/mixins/_rem.scss" as rem;
 @use "styles/mixins/_size.scss" as size;
 
 .base-dialog {
@@ -21,45 +20,4 @@
     background-color: var(--color-background-overlay);
     backdrop-filter: blur(4px); // Modern blur effect
   }
-
-  &-simple {
-    background-color: #fff;
-    display: flex;
-    padding: var(--size-spacing-xxl);
-    border-radius: var(--size-border-radius-m);
-    flex-direction: column;
-    will-change: transform, opacity;
-    width: 100vw;
-    position: fixed;
-    bottom: 0;
-
-    @media screen and (prefers-reduced-motion: no-preference) and (max-width: size.$tablet) {
-      animation: slide-in-up 500ms;
-    }
-
-    @media (min-width: size.$tablet) {
-      max-width: rem.torem(512px);
-      margin: 0;
-      bottom: unset;
-      position: unset;
-    }
-
-    @keyframes slide-in-up {
-      from {
-        transform: translateY(100%);
-        opacity: 0;
-      }
-
-      to {
-        transform: translateY(0);
-        opacity: 1;
-      }
-    }
-  }
-}
-
-.close-button {
-  display: flex;
-  align-self: flex-end;
-  margin-bottom: rem.torem(10px);
 }

--- a/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
+++ b/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
@@ -1,10 +1,6 @@
 import type React from 'react'
 import { useEffect, useRef } from 'react'
 
-import { Button } from '@/design-system/Button/Button'
-import { ButtonColor, ButtonVariant } from '@/design-system/Button/types'
-import fullCloseIcon from '@/icons/full-close.svg'
-
 import styles from './BaseDialog.module.scss'
 
 export interface BaseDialogProps {
@@ -29,10 +25,6 @@ export interface BaseDialogProps {
    * Modal content.
    */
   children: React.ReactNode
-  /**
-   * Variant of the modale : simple or detailed.
-   */
-  variant: 'simple' | 'detailed'
 }
 
 /**
@@ -49,7 +41,6 @@ export const BaseDialog = ({
   ariaLabelledBy,
   ariaDescribedBy,
   children,
-  variant,
 }: BaseDialogProps): JSX.Element => {
   const dialogRef = useRef<HTMLDialogElement>(null)
 
@@ -101,18 +92,7 @@ export const BaseDialog = ({
       aria-describedby={ariaDescribedBy}
       className={styles['base-dialog']}
     >
-      <div className={styles[`base-dialog-${variant}`]}>
-        <span className={styles['close-button']}>
-          <Button
-            icon={fullCloseIcon}
-            variant={ButtonVariant.TERTIARY}
-            color={ButtonColor.NEUTRAL}
-            onClick={onClose}
-            aria-label={'Fermer la modale'}
-          />
-        </span>
-        {children}
-      </div>
+      {children}
     </dialog>
   )
 }

--- a/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
+++ b/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
@@ -7,7 +7,6 @@ import fullCloseIcon from '@/icons/full-close.svg'
 
 import styles from './BaseDialog.module.scss'
 
-/** @lintignore Will be used later in future <ModalSimple> and <ModalDetailed> components */
 export interface BaseDialogProps {
   /**
    * Determines whether the modal is open or closed.


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42958)

Deux features n'ont pas étées implémentées :
- l'ordre des boutons inversés en taille mobile
- sur mobile, la fermeture via drag 


<img width="713" height="533" alt="image" src="https://github.com/user-attachments/assets/874cc220-a50b-4f3f-a84f-1b635c50699b" />



<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
