### PR TITLE
(PC-43135)[API] feat: rework batch_update_offers

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -95,6 +95,8 @@ from . import validation
 logger = logging.getLogger(__name__)
 
 AnyOffer = educational_models.CollectiveOffer | educational_models.CollectiveOfferTemplate | models.Offer
+type OfferIds = tuple[int]
+type VenueIds = tuple[int]
 
 
 OFFER_LIKE_MODELS = {
@@ -537,40 +539,15 @@ def update_offer(
     return offer
 
 
-def batch_update_offers(
-    query: sa_orm.Query,
-    update_fields: dict | None = None,
-    activate: bool | None = None,
-    send_email_notification: bool = False,
+def batch_activate_offers(
+    query: sa_orm.Query[models.Offer],
+    activate: bool,
 ) -> set[int]:
     query = query.filter(models.Offer.validation == models.OfferValidationStatus.APPROVED)
-    query = query.with_entities(models.Offer.id, models.Offer.venueId).yield_per(2_500)
 
-    updated_offer_ids = set()
-    found_venue_ids = set()
+    update_fields = {"publicationDatetime": get_naive_utc_now() if activate else None}
 
-    if update_fields is None:
-        update_fields = {}
-
-    if activate is not None:
-        update_fields["publicationDatetime"] = None
-        if activate:
-            update_fields["publicationDatetime"] = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
-
-    logger.info("Batch update of offers: start", extra={"updated_fields": update_fields})
-
-    for chunk in get_chunks(query, chunk_size=settings.BATCH_UPDATE_OFFERS_CHUNK_SIZE):
-        raw_offer_ids, raw_venue_ids = zip(*chunk)
-        offer_ids = set(raw_offer_ids)
-        venue_ids = set(raw_venue_ids)
-
-        updated_offer_ids |= offer_ids
-        found_venue_ids |= venue_ids
-
-        query_to_update = db.session.query(models.Offer).filter(models.Offer.id.in_(offer_ids))
-        query_to_update.update(update_fields, synchronize_session=False)
-        db.session.flush()
-
+    def log_processed_chunk(offer_ids: OfferIds, venue_ids: VenueIds) -> None:
         if activate is not None:
             on_commit(
                 partial(
@@ -581,26 +558,66 @@ def batch_update_offers(
                 )
             )
 
-        on_commit(
-            partial(
-                search.async_index_offer_ids,
-                offer_ids,
-                reason=IndexationReason.OFFER_BATCH_UPDATE,
-                log_extra={"changes": set(update_fields.keys())},
-            ),
-        )
+    return batch_update_offers(
+        query=query,
+        update_fields=update_fields,
+        chunk_processed_callback=log_processed_chunk,
+    )
 
-        withdrawal_updated = {"withdrawalDetails", "withdrawalType", "withdrawalDelay"}.intersection(
-            update_fields.keys()
-        )
-        if send_email_notification and withdrawal_updated:
-            for offer in query_to_update.all():
-                transactional_mails.send_email_for_each_ongoing_booking(offer)
 
-    if is_managed_transaction():
-        db.session.flush()
-    else:
-        db.session.commit()
+def batch_update_offers(
+    query: sa_orm.Query[models.Offer],
+    update_fields: dict,
+    send_email_notification: bool = False,
+    chunk_processed_callback: typing.Callable[[OfferIds, VenueIds], None] | None = None,
+    chunk_size: int = settings.BATCH_UPDATE_OFFERS_CHUNK_SIZE,
+) -> set[int]:
+    results = query.with_entities(models.Offer.id, models.Offer.venueId).yield_per(2_500).tuples()
+
+    updated_offer_ids = set()
+    found_venue_ids = set()
+
+    logger.info("Batch update of offers: start", extra={"updated_fields": update_fields})
+
+    with atomic():
+        for chunk in get_chunks(results, chunk_size=chunk_size):
+            raw_offer_ids, raw_venue_ids = zip(*chunk)
+            offer_ids = set(raw_offer_ids)
+            venue_ids = set(raw_venue_ids)
+
+            updated_offer_ids |= offer_ids
+            found_venue_ids |= venue_ids
+
+            query_to_update = db.session.query(models.Offer).filter(models.Offer.id.in_(offer_ids))
+            try:
+                with atomic():
+                    query_to_update.update(update_fields, synchronize_session=False)
+                    db.session.flush()
+            except sa_exc.OperationalError:
+                # Batch failed, likely timeout. Let's fallback on a one by one basis.
+                for offer_id in offer_ids:
+                    db.session.query(models.Offer).filter(models.Offer.id == offer_id).update(
+                        update_fields, synchronize_session=False
+                    )
+
+            if chunk_processed_callback:
+                chunk_processed_callback(raw_offer_ids, raw_venue_ids)
+
+            on_commit(
+                partial(
+                    search.async_index_offer_ids,
+                    offer_ids,
+                    reason=IndexationReason.OFFER_BATCH_UPDATE,
+                    log_extra={"changes": set(update_fields.keys())},
+                ),
+            )
+
+            withdrawal_updated = {"withdrawalDetails", "withdrawalType", "withdrawalDelay"}.intersection(
+                update_fields.keys()
+            )
+            if send_email_notification and withdrawal_updated:
+                for offer in query_to_update.all():
+                    transactional_mails.send_email_for_each_ongoing_booking(offer)
 
     log_extra = {
         "updated_fields": update_fields,

--- a/api/src/pcapi/core/offers/generator.py
+++ b/api/src/pcapi/core/offers/generator.py
@@ -196,4 +196,4 @@ def deactivate_offer(offer: offers_models.Offer) -> None:
     from pcapi.core.offers import api as offers_api
 
     query = db.session.query(offers_models.Offer).filter(offers_models.Offer.id.in_([offer.id]))
-    offers_api.batch_update_offers(query, activate=False)
+    offers_api.batch_activate_offers(query, activate=False)

--- a/api/src/pcapi/core/offers/tasks.py
+++ b/api/src/pcapi/core/offers/tasks.py
@@ -65,7 +65,7 @@ def update_all_offers_active_status_task(payload: UpdateAllOffersActiveStatusPay
     query = offers_repository.get_offers_by_filters(name_keywords_or_ean=name_or_ean, **payload_dict)
     query = offers_repository.exclude_offers_from_inactive_venue_provider(query)
 
-    offers_api.batch_update_offers(query, activate=is_active)
+    offers_api.batch_activate_offers(query, activate=is_active)
 
 
 class UpdateVenueOffersActiveStatusPayload(BaseModelV2):
@@ -80,7 +80,7 @@ class UpdateVenueOffersActiveStatusPayload(BaseModelV2):
 )
 def update_venue_offers_active_status_task(payload: UpdateVenueOffersActiveStatusPayload) -> None:
     query = offers_repository.get_synchronized_offers_with_provider_for_venue(payload.venue_id, payload.provider_id)
-    offers_api.batch_update_offers(query, activate=payload.is_active)
+    offers_api.batch_activate_offers(query, activate=payload.is_active)
 
 
 class UpdateAllVenueOffersEmailPayload(BaseModelV2):

--- a/api/src/pcapi/routes/backoffice/offers/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/offers/blueprint.py
@@ -2239,7 +2239,7 @@ def get_batch_deactivate_offers_form() -> response_utils.BackofficeResponse:
 
 def _batch_update_activation_offers(offer_ids: list[int], *, is_active: bool) -> None:
     query = db.session.query(offers_models.Offer).filter(offers_models.Offer.id.in_(offer_ids))
-    offers_api.batch_update_offers(query, activate=is_active)
+    offers_api.batch_activate_offers(query, activate=is_active)
 
 
 @list_offers_blueprint.route("/<int:offer_id>/activate", methods=["POST"])

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -446,7 +446,7 @@ def patch_offers_active_status(body: offers_serialize.PatchOfferActiveStatusBody
     if body.is_active:
         query = offers_repository.exclude_offers_from_inactive_venue_provider(query)
 
-    offers_api.batch_update_offers(query, activate=body.is_active)
+    offers_api.batch_activate_offers(query, activate=body.is_active)
 
 
 @private_api.route("/offers/all-active-status", methods=["PATCH"])

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -2355,7 +2355,7 @@ yesterday_datetime_without_tz = yesterday_datetime_with_tz.replace(tzinfo=None)
 
 
 @pytest.mark.usefixtures("db_session")
-class BatchUpdateOffersTest:
+class BatchActivateOffersTest:
     @time_machine.travel(now_datetime_with_tz, tick=False)
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_activate_empty_list(self, mocked_async_index_offer_ids, caplog):
@@ -2364,7 +2364,7 @@ class BatchUpdateOffersTest:
         query = db.session.query(models.Offer).filter(models.Offer.id.in_({pending_offer.id}))
 
         with caplog.at_level(logging.INFO):
-            api.batch_update_offers(query, activate=True)
+            api.batch_activate_offers(query, activate=True)
 
         db.session.refresh(pending_offer)
         assert not pending_offer.isActive
@@ -2403,7 +2403,7 @@ class BatchUpdateOffersTest:
         )
 
         with caplog.at_level(logging.INFO):
-            api.batch_update_offers(query, activate=True)
+            api.batch_activate_offers(query, activate=True)
 
         db.session.refresh(offer1)
         db.session.refresh(offer2)
@@ -2442,7 +2442,7 @@ class BatchUpdateOffersTest:
         assert second_record.message == "Offers has been activated"
         assert second_record.extra.keys() == {"offer_ids", "venue_ids"}
         assert set(second_record.extra["offer_ids"]) == {offer1.id, offer2.id}
-        assert second_record.extra["venue_ids"] == {offer1.venueId, offer2.venueId}
+        assert set(second_record.extra["venue_ids"]) == {offer1.venueId, offer2.venueId}
 
         assert third_record.message == "Batch update of offers: end"
         assert third_record.extra == {
@@ -2464,7 +2464,7 @@ class BatchUpdateOffersTest:
 
         query = db.session.query(models.Offer).filter(models.Offer.id.in_({offer1.id, offer2.id}))
         with caplog.at_level(logging.INFO):
-            api.batch_update_offers(query, activate=False)
+            api.batch_activate_offers(query, activate=False)
 
         db.session.refresh(offer1)
         db.session.refresh(offer2)
@@ -2493,7 +2493,7 @@ class BatchUpdateOffersTest:
         assert second_record.message == "Offers has been deactivated"
         assert second_record.extra.keys() == {"offer_ids", "venue_ids"}
         assert set(second_record.extra["offer_ids"]) == {offer1.id, offer2.id}
-        assert second_record.extra["venue_ids"] == {offer1.venueId, offer2.venueId}
+        assert set(second_record.extra["venue_ids"]) == {offer1.venueId, offer2.venueId}
 
         assert last_record.message == "Batch update of offers: end"
         assert last_record.extra == {
@@ -2501,6 +2501,65 @@ class BatchUpdateOffersTest:
             "nb_offers": 2,
             "nb_venues": 2,
         }
+
+
+@pytest.mark.usefixtures("db_session")
+class BatchUpdateOffersTest:
+    @time_machine.travel(now_datetime_with_tz, tick=False)
+    @mock.patch("pcapi.core.search.async_index_offer_ids")
+    def test_update(self, mocked_async_index_offer_ids, caplog):
+        offer1 = factories.OfferFactory(publicationDatetime=None)
+        offer2 = factories.OfferFactory(publicationDatetime=None)
+        offer3 = factories.OfferFactory(publicationDatetime=None)
+
+        query = db.session.query(models.Offer).filter(models.Offer.id.in_({offer1.id, offer2.id}))
+
+        callback_called: int = 0
+
+        def callback(offer_ids, venue_ids):
+            nonlocal callback_called
+            callback_called = callback_called + 1
+            assert set(offer_ids) == set([offer1.id, offer2.id])
+            assert set(venue_ids) == set([offer1.venueId, offer2.venueId])
+
+        with caplog.at_level(logging.INFO):
+            api.batch_update_offers(
+                query, update_fields={"publicationDatetime": datetime.now()}, chunk_processed_callback=callback
+            )
+
+        db.session.refresh(offer1)
+        db.session.refresh(offer2)
+        db.session.refresh(offer3)
+
+        assert offer1.isActive
+        assert offer1.publicationDatetime == now_datetime_with_tz
+
+        assert offer2.isActive
+        assert offer2.publicationDatetime == now_datetime_with_tz
+
+        assert not offer3.isActive
+        assert not offer3.publicationDatetime
+
+        mocked_async_index_offer_ids.assert_called_once()
+        assert set(mocked_async_index_offer_ids.call_args[0][0]) == set([offer1.id, offer2.id])
+
+        assert len(caplog.records) == 2
+        first_record = caplog.records[0]
+        second_record = caplog.records[1]
+
+        assert first_record.message == "Batch update of offers: start"
+        assert first_record.extra == {
+            "updated_fields": {"publicationDatetime": now_datetime_with_tz.replace(tzinfo=None)}
+        }
+
+        assert second_record.message == "Batch update of offers: end"
+        assert second_record.extra == {
+            "updated_fields": {"publicationDatetime": now_datetime_with_tz.replace(tzinfo=None)},
+            "nb_offers": 2,
+            "nb_venues": 2,
+        }
+
+        assert callback_called == 1
 
 
 @pytest.mark.usefixtures("db_session")


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43135)

Make batch_update_offers more generic and add a fallback to process offers one by one if the batch times out.
Add batch_activate_offers to keep the offer activation/deactivation logic still in one place and make batch_update_offers really generic

- [ ] Travail pair testé en environnement de preview
