### PR TITLE
(PC-43166)[API] fix: correctly validate query params in movie calendar native endpoints

### DIFF
--- a/api/src/pcapi/routes/native/v1/serialization/movies.py
+++ b/api/src/pcapi/routes/native/v1/serialization/movies.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 
 
 class MovieScreeningsRequest(HttpQueryParamsModel):
-    allocine_id: str | None = None
-    visa: str | None = None
+    allocine_id: str | None = pydantic_v2.Field(default=None, pattern=r"^\d+$")
+    visa: str | None = pydantic_v2.Field(default=None, pattern=r"^[a-zA-Z0-9]+$")
     latitude: float
     longitude: float
     around_radius: int = 50_000  # meters
@@ -41,6 +41,13 @@ class MovieScreeningsRequest(HttpQueryParamsModel):
             raise ValueError("Only one of allocine_id and visa must be provided")
 
         return self
+
+    @pydantic_v2.field_validator("allocine_id", mode="before")
+    @classmethod
+    def remove_leading_zeros(cls, value: str | None) -> str | None:
+        if isinstance(value, str) and value.isdigit():
+            return value.lstrip("0") or "0"
+        return value
 
 
 class VenueMovieScreeningsRequest(HttpBodyModel):

--- a/api/tests/files/native_openapi.json
+++ b/api/tests/files/native_openapi.json
@@ -4168,6 +4168,7 @@
                     "allocineId": {
                         "anyOf": [
                             {
+                                "pattern": "^\\d+$",
                                 "type": "string"
                             },
                             {
@@ -4203,6 +4204,7 @@
                     "visa": {
                         "anyOf": [
                             {
+                                "pattern": "^[a-zA-Z0-9]+$",
                                 "type": "string"
                             },
                             {
@@ -11536,6 +11538,7 @@
                         "schema": {
                             "anyOf": [
                                 {
+                                    "pattern": "^\\d+$",
                                     "type": "string"
                                 },
                                 {
@@ -11554,6 +11557,7 @@
                         "schema": {
                             "anyOf": [
                                 {
+                                    "pattern": "^[a-zA-Z0-9]+$",
                                     "type": "string"
                                 },
                                 {
@@ -11666,6 +11670,7 @@
                         "schema": {
                             "anyOf": [
                                 {
+                                    "pattern": "^\\d+$",
                                     "type": "string"
                                 },
                                 {
@@ -11684,6 +11689,7 @@
                         "schema": {
                             "anyOf": [
                                 {
+                                    "pattern": "^[a-zA-Z0-9]+$",
                                     "type": "string"
                                 },
                                 {

--- a/api/tests/routes/native/v1/movies_test.py
+++ b/api/tests/routes/native/v1/movies_test.py
@@ -428,6 +428,47 @@ class MovieCalendarTest:
         assert today_screenings[0]["dayScreenings"][0]["bookability"] == "STOCK_BOOKING_IS_DISABLED"
         assert today_screenings[0]["nextScreening"]["bookability"] == "STOCK_BOOKING_IS_DISABLED"
 
+    @pytest.mark.parametrize(
+        "field_name,value",
+        [
+            ("allocineId", "https://malware.0rg"),
+            ("allocineId", "&'@09839"),
+            ("visa", "https://malware.0rg"),
+            ("visa", "&'@09839"),
+        ],
+    )
+    def test_invalid_query_params(self, client, field_name, value):
+        params = {
+            "latitude": 48.85,
+            "longitude": 2.35,
+            "from": date.today(),
+            "to": date.today() + timedelta(days=1),
+            **{field_name: value},
+        }
+        response = client.get("/native/v1/movie/calendar", params=params)
+        assert response.status_code == 400
+        assert list(response.json) == [field_name]
+
+    @pytest.mark.parametrize(
+        "field_name,value",
+        [
+            ("allocineId", "09839"),
+            ("visa", "abc1234def"),
+            ("visa", "abc"),
+            ("visa", "1234"),
+        ],
+    )
+    def test_valid_query_params(self, client, field_name, value):
+        params = {
+            "latitude": 48.85,
+            "longitude": 2.35,
+            "from": date.today(),
+            "to": date.today() + timedelta(days=1),
+            **{field_name: value},
+        }
+        response = client.get("/native/v1/movie/calendar", params=params)
+        assert response.status_code == 404
+
 
 class MovieCalendarForUserTest:
     def test_get_movie_shows_for_user(self, client):
@@ -861,6 +902,58 @@ class MovieCalendarForUserTest:
 
         today_screenings = [e["screenings"] for e in response.json["calendar"] if e["date"] == today.isoformat()][0]
         assert today_screenings[0]["dayScreenings"][0]["bookability"] == "USER_HAS_APPLICATION_ERROR"
+
+    @pytest.mark.parametrize(
+        "field_name,value",
+        [
+            ("allocineId", "https://malware.0rg"),
+            ("allocineId", "&'@09839"),
+            ("allocineId", "abcdef"),
+            ("visa", "https://malware.0rg"),
+            ("visa", "&'@09839"),
+        ],
+    )
+    def test_invalid_query_params(self, client, field_name, value):
+        user = users_factories.UserFactory(
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+        )
+        params = {
+            "latitude": 48.85,
+            "longitude": 2.35,
+            "from": date.today(),
+            "to": date.today() + timedelta(days=1),
+            **{field_name: value},
+        }
+        client.with_token(user)
+        response = client.get("/native/v1/movie/calendar/me", params=params)
+        assert response.status_code == 400
+        assert list(response.json) == [field_name]
+
+    @pytest.mark.parametrize(
+        "field_name,value",
+        [
+            ("allocineId", "09839"),
+            ("visa", "abc1234def"),
+            ("visa", "abc"),
+            ("visa", "1234"),
+        ],
+    )
+    def test_valid_query_params(self, client, field_name, value):
+        user = users_factories.UserFactory(
+            dateOfBirth=date_utils.get_naive_utc_now() - relativedelta(years=18),
+            phoneValidationStatus=users_models.PhoneValidationStatusType.VALIDATED,
+        )
+        params = {
+            "latitude": 48.85,
+            "longitude": 2.35,
+            "from": date.today(),
+            "to": date.today() + timedelta(days=1),
+            **{field_name: value},
+        }
+        client.with_token(user)
+        response = client.get("/native/v1/movie/calendar/me", params=params)
+        assert response.status_code == 404
 
 
 class VenueMovieCalendarTest:


### PR DESCRIPTION

## 🎯 Related Ticket or 🔧 Changes Made

Validate fields format for `allocineId` and `visa` query params in `/native/v1/movie/calendar` and `/native/v1/movie/calendar/me` endpoints

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43166)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

- [ ] Travail pair testé en environnement de preview
