### PR TITLE
(PC-43172)[PRO] fix: remove leading zero to stepper digits + fix vertical alignment

### DIFF
--- a/pro/src/design-system/Stepper/Stepper.module.scss
+++ b/pro/src/design-system/Stepper/Stepper.module.scss
@@ -150,12 +150,8 @@ $connector-width: rem.torem(2px);
 
     .step-content {
       flex-direction: row;
-      align-items: flex-start;
+      align-items: center;
       gap: var(--size-spacing-m);
-    }
-
-    .text-container {
-      padding-top: var(--size-spacing-xxs);
     }
 
     .connector {

--- a/pro/src/design-system/Stepper/Stepper.spec.tsx
+++ b/pro/src/design-system/Stepper/Stepper.spec.tsx
@@ -49,9 +49,9 @@ describe('Stepper', () => {
       </MemoryRouter>
     )
 
-    expect(screen.getByText('01')).toBeInTheDocument()
-    expect(screen.getByText('02')).toBeInTheDocument()
-    expect(screen.getByText('03')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(screen.getByText('3')).toBeInTheDocument()
 
     expect(screen.getByText('Choisissez votre catégorie')).toBeInTheDocument()
     expect(screen.getByText('Définissez un tarif')).toBeInTheDocument()

--- a/pro/src/design-system/Stepper/Stepper.tsx
+++ b/pro/src/design-system/Stepper/Stepper.tsx
@@ -121,9 +121,7 @@ export const Stepper = ({
         const visualContent = (
           <div className={styles['step-content']} aria-hidden="true">
             <div className={styles.indicator}>
-              <span className={styles.number}>
-                {(index + 1).toString().padStart(2, '0')}
-              </span>
+              <span className={styles.number}>{(index + 1).toString()}</span>
               {
                 <div
                   className={cn(styles.connector, {


### PR DESCRIPTION
## 🎯 Related Ticket

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43172)

> Les numéros d'étapes du Stepper s'affichent maintenant sans zéro initial (`1`, `2`, `3` au lieu de `01`, `02`, `03`), avec un léger ajustement d'alignement vertical.

### 🔧 Changements
- Suppression du `padStart(2, '0')` sur les chiffres d'étape dans `Stepper.tsx`
- Ajustement CSS : centrage vertical du contenu d'étape (suppression du padding compensatoire)

## 🖼️ Before & After Images

Before | After
:---: | :---:
<img width="282" height="286" alt="image" src="https://github.com/user-attachments/assets/73166f9d-f8d0-4bf3-88b4-acc1693bc9d3" /> | <img width="282" height="286" alt="image" src="https://github.com/user-attachments/assets/fb1954e6-0d21-4770-9201-cfea65019078" />