### PR TITLE
(PC-42864)[PRO] feat: add aria-describedby to tips banners

### DIFF
--- a/pro/docs/a11y/audits/following.md
+++ b/pro/docs/a11y/audits/following.md
@@ -56,6 +56,32 @@ Texte
 
 <details>
 
+<summary> ⏳ Critère 11.10 - RGAA - Dans chaque formulaire, le contrôle de saisie est-il utilisé de manière pertinente ?</summary>
+
+**RGAA** : [Critère 11.10](https://accessibilite.public.lu/fr/raweb1.1/criteres.html#crit-11-10)
+**Ticket** : [PC-42864](https://passculture.atlassian.net/browse/PC-42864)  
+**PR** : [#23850](https://github.com/pass-culture/pass-culture-main/pull/23850)
+
+**Problème** 😱  
+P05 → Création offre réservable (5 étapes et confirmation)
+P06 → Création offre individuelle (7 étapes et confirmation)
+
+Le contrôle de saisie n'est pas pertinent :
+
+Les messages d'indication ne sont pas correctement reliés à leur champ respectif. (les blocs "À savoir")
+
+**Correction** 💡  
+Relier tous les messages d'aides qui apparaissent à proximité des champs par la relation aria-describedby="id".
+
+**Retours audit** 🔥  
+Texte
+
+</details>
+
+<br>
+
+<details>
+
 <summary> ⏳ Critère 1.3 - Pour chaque image porteuse d'information ayant une alternative textuelle, cette alternative est-elle pertinente ?</summary>
 
 **RAWeb** : [Critère 1.3](https://accessibilite.public.lu/fr/raweb1.1/criteres.html#crit-1-3)
@@ -66,8 +92,6 @@ Texte
 Au moins une alternative d'image porteuse d'information n'est pas pertinente.
 
 Le composant <canvas aria-label="Editeur d’image"> dans la fenêtre modale « Modifier une image » (suite à l’import d’une image) dispose d’un aria-label insuffisamment précis. Celui-ci ne décrit pas de manière explicite la fonction réelle du composant, à savoir un éditeur de cadrage permettant de repositionner et recadrer l’image.
-
-Egalement, 
 
 **Correction** 💡  
 Modifier le aria-label afin de décrire plus précisément la fonctionnalité réelle du composant par "Editeur de cadrage et de zoom de l'image".

--- a/pro/src/commons/context/FormLayoutSideComponentContext/FormLayoutSideComponentContext.tsx
+++ b/pro/src/commons/context/FormLayoutSideComponentContext/FormLayoutSideComponentContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react'
+
+const FormLayoutSideComponentContext = createContext<string | undefined>(
+  undefined
+)
+
+type FormLayoutSideComponentContextProviderProps = {
+  children: React.ReactNode
+  describedById: string
+}
+
+export const FormLayoutSideComponentContextProvider = ({
+  children,
+  describedById,
+}: Readonly<FormLayoutSideComponentContextProviderProps>) => {
+  return (
+    <FormLayoutSideComponentContext.Provider value={describedById}>
+      {children}
+    </FormLayoutSideComponentContext.Provider>
+  )
+}
+
+export const useFormLayoutSideComponentDescribedBy = () => {
+  return useContext(FormLayoutSideComponentContext)
+}

--- a/pro/src/components/FormLayout/FormLayoutRow.tsx
+++ b/pro/src/components/FormLayout/FormLayoutRow.tsx
@@ -13,6 +13,7 @@ interface FormLayoutRowProps {
   smSpaceAfter?: boolean
   sideComponent?: JSX.Element | null
   testId?: string
+  describedById?: string
 }
 
 export const Row = ({
@@ -24,6 +25,7 @@ export const Row = ({
   smSpaceAfter,
   sideComponent,
   testId,
+  describedById,
 }: FormLayoutRowProps): JSX.Element => {
   return sideComponent !== undefined ? (
     <RowWithInfo
@@ -46,6 +48,7 @@ export const Row = ({
         [style['small-space-after']]: smSpaceAfter,
       })}
       data-testid={testId}
+      aria-describedby={describedById}
     >
       {children}
     </div>

--- a/pro/src/components/FormLayout/FormLayoutRowWithInfo.tsx
+++ b/pro/src/components/FormLayout/FormLayoutRowWithInfo.tsx
@@ -1,5 +1,8 @@
 import cn from 'classnames'
 import type React from 'react'
+import { useId } from 'react'
+
+import { FormLayoutSideComponentContextProvider } from '@/commons/context/FormLayoutSideComponentContext/FormLayoutSideComponentContext'
 
 import style from './FormLayout.module.scss'
 import { Row } from './FormLayoutRow'
@@ -25,6 +28,7 @@ export const RowWithInfo = ({
   sideComponent,
   testId,
 }: FormLayoutRowWithInfoProps): JSX.Element => {
+  const sideComponentId = useId()
   return (
     <Row
       className={cn(className, style['form-layout-row-info'])}
@@ -33,10 +37,16 @@ export const RowWithInfo = ({
       smSpaceAfter={smSpaceAfter}
       testId={testId}
     >
-      <Row className={style['form-layout-row-info-field']} inline={inline}>
-        {children}
-      </Row>
-      <div className={style['form-layout-row-info-info']}>
+      <FormLayoutSideComponentContextProvider describedById={sideComponentId}>
+        <Row
+          className={style['form-layout-row-info-field']}
+          inline={inline}
+          describedById={sideComponentId}
+        >
+          {children}
+        </Row>
+      </FormLayoutSideComponentContextProvider>
+      <div className={style['form-layout-row-info-info']} id={sideComponentId}>
         <div className={style['form-layout-row-info-info-inner']}>
           {sideComponent}
         </div>

--- a/pro/src/components/MarkdownInfoBox/MarkdownInfoBox.tsx
+++ b/pro/src/components/MarkdownInfoBox/MarkdownInfoBox.tsx
@@ -1,8 +1,8 @@
 import { TipsBanner } from '@/ui-kit/TipsBanner/TipsBanner'
 
-export const MarkdownInfoBox = () => {
+export const MarkdownInfoBox = ({ id }: { id?: string }) => {
   return (
-    <TipsBanner>
+    <TipsBanner id={id}>
       Vous pouvez modifier la mise en forme de votre texte.
       <br />
       Utilisez des doubles astérisques pour mettre en <strong>gras</strong> :

--- a/pro/src/design-system/CheckboxGroup/CheckboxGroup.tsx
+++ b/pro/src/design-system/CheckboxGroup/CheckboxGroup.tsx
@@ -3,6 +3,8 @@ import fullError from 'icons/full-error.svg'
 import { useId } from 'react'
 import { SvgIcon } from 'ui-kit/SvgIcon/SvgIcon'
 
+import { useFormLayoutSideComponentDescribedBy } from '@/commons/context/FormLayoutSideComponentContext/FormLayoutSideComponentContext'
+
 import { Checkbox, type CheckboxProps } from '../Checkbox/Checkbox'
 import styles from './CheckboxGroup.module.scss'
 
@@ -23,6 +25,7 @@ export type CheckboxGroupProps = {
   variant?: 'default' | 'detailed'
   /** If the checkbox group is disabled, making all options unselectable */
   disabled?: boolean
+  describedBy?: string
 }
 
 export const CheckboxGroup = ({
@@ -33,16 +36,25 @@ export const CheckboxGroup = ({
   display = 'vertical',
   variant = 'default',
   disabled = false,
+  describedBy,
 }: CheckboxGroupProps) => {
+  const formLayoutDescribedBy = useFormLayoutSideComponentDescribedBy()
   const errorId = useId()
   const descriptionId = useId()
-  const describedBy = `${error ? errorId : ''} ${description ? descriptionId : ''}`
+  const describedByIds = [
+    error ? errorId : '',
+    description ? descriptionId : '',
+    describedBy ?? '',
+    formLayoutDescribedBy ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   const isStringLabel = typeof label === 'string'
 
   return (
     <fieldset
-      aria-describedby={describedBy}
+      aria-describedby={describedByIds || undefined}
       className={classNames(
         styles['checkbox-group'],
         styles[`display-${display}`],

--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.tsx
@@ -1,6 +1,7 @@
 import cn from 'classnames'
 import { useId } from 'react'
 
+import { useFormLayoutSideComponentDescribedBy } from '@/commons/context/FormLayoutSideComponentContext/FormLayoutSideComponentContext'
 import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import {
   RadioButton,
@@ -40,6 +41,7 @@ export type RadioButtonGroupProps = {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   /** Event handler for blur */
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
+  describedBy?: string
 }
 
 export const RadioButtonGroup = ({
@@ -56,10 +58,17 @@ export const RadioButtonGroup = ({
   asset,
   onChange,
   onBlur,
+  describedBy,
 }: RadioButtonGroupProps): JSX.Element => {
+  const formLayoutDescribedBy = useFormLayoutSideComponentDescribedBy()
   const errorId = useId()
   const descriptionId = useId()
-  const describedBy = [error && errorId, description && descriptionId]
+  const describedByIds = [
+    error ? errorId : '',
+    description ? descriptionId : '',
+    describedBy ?? '',
+    formLayoutDescribedBy ?? '',
+  ]
     .filter(Boolean)
     .join(' ')
 
@@ -75,7 +84,7 @@ export const RadioButtonGroup = ({
 
   return (
     <fieldset
-      aria-describedby={describedBy}
+      aria-describedby={describedByIds || undefined}
       className={cn(styles['radio-button-group'], {
         [styles['label-as-text']]: isStringLabel,
       })}

--- a/pro/src/design-system/TextInput/TextInput.tsx
+++ b/pro/src/design-system/TextInput/TextInput.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from 'react'
 
+import { useFormLayoutSideComponentDescribedBy } from '@/commons/context/FormLayoutSideComponentContext/FormLayoutSideComponentContext'
 import { SvgIcon } from '@/ui-kit/SvgIcon/SvgIcon'
 
 import { FieldFooter } from '../common/FieldFooter/FieldFooter'
@@ -78,13 +79,22 @@ export const TextInput = forwardRef(
     }: TextInputProps,
     ref: ForwardedRef<HTMLInputElement>
   ) => {
+    const formLayoutDescribedBy = useFormLayoutSideComponentDescribedBy()
     const inputId = useId()
     const descriptionId = useId()
     const errorId = useId()
     const charactersCountId = useId()
     const inputRef = useRef<HTMLInputElement>(null)
 
-    const describedByIds = `${description ? descriptionId : ''} ${error ? errorId : ''} ${maxCharactersCount ? charactersCountId : ''} ${describedBy ?? ''}`
+    const describedByIds = [
+      description ? descriptionId : '',
+      error ? errorId : '',
+      maxCharactersCount ? charactersCountId : '',
+      describedBy ?? '',
+      formLayoutDescribedBy ?? '',
+    ]
+      .filter(Boolean)
+      .join(' ')
 
     useImperativeHandle(ref, () => inputRef.current as HTMLInputElement)
 
@@ -116,7 +126,7 @@ export const TextInput = forwardRef(
             id={inputId}
             type={type}
             disabled={disabled}
-            aria-describedby={describedByIds}
+            aria-describedby={describedByIds || undefined}
             aria-invalid={Boolean(error)}
             aria-required={required}
             ref={inputRef}

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/FormOfferType/FormOfferType.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useId, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 
 import { EacFormat } from '@/apiClient/v1'
@@ -43,6 +43,8 @@ export const FormOfferType = ({
 
   const { logEvent } = useAnalytics()
 
+  const offerTitleId = useId()
+
   const getAssociatedPrograms = (selectedDomainIds: string[]) => {
     const selectedDomains = domainsOptions.filter((domain) =>
       selectedDomainIds.includes(domain.id)
@@ -78,7 +80,7 @@ export const FormOfferType = ({
     logEvent(Events.CLICKED_GENERATE_TEMPLATE_DESCRIPTION, {
       ...(domainsValue &&
         domainsValue.length > 0 && {
-          domainIds: domainsValue.map((id) => Number(id)),
+          domainIds: domainsValue.map(Number),
         }),
     })
   })
@@ -87,7 +89,7 @@ export const FormOfferType = ({
     logEvent(Events.CLICKED_SEE_TEMPLATE_OFFER_EXAMPLE, {
       ...(domainsValue &&
         domainsValue.length > 0 && {
-          domainIds: domainsValue.map((id) => Number(id)),
+          domainIds: domainsValue.map(Number),
         }),
     })
   }
@@ -199,6 +201,7 @@ export const FormOfferType = ({
             {...register('title')}
             error={getFieldState('title').error?.message}
             disabled={disableForm}
+            describedBy={offerTitleId}
           />
         </FormLayout.Row>
         <FormLayout.Row

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/Subcategories/Subcategories.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/components/DetailsForm/Subcategories/Subcategories.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent } from 'react'
+import { type ChangeEvent, useId } from 'react'
 import { useFormContext } from 'react-hook-form'
 
 import type {
@@ -43,6 +43,7 @@ export function Subcategories({
 
   const categoryId = watch('categoryId')
   const subcategoryId = watch('subcategoryId')
+  const subcategoryBannerId = useId()
 
   const categoryOptions = buildCategoryOptions(filteredCategories)
   const subcategoryOptions = buildSubcategoryOptions(
@@ -159,9 +160,13 @@ export function Subcategories({
               subcategoryOptions.length === 1
             }
             error={errors.subcategoryId?.message}
+            describedBy={subcategoryBannerId}
           />
           {!readOnlyFields.includes('categoryId') && (
-            <div className={styles['subcategory-callout']}>
+            <div
+              className={styles['subcategory-callout']}
+              id={subcategoryBannerId}
+            >
               <Banner
                 title="Étapes adaptatives"
                 description="Le formulaire s'adaptera automatiquement selon la sous-catégorie sélectionnée."

--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/IndividualOfferMediaScreen.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/IndividualOfferMediaScreen.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useLocation, useNavigate } from 'react-router'
 import { useSWRConfig } from 'swr'
@@ -53,6 +54,7 @@ export const IndividualOfferMediaScreen = ({
   const isOfferExposureEnabled = useActiveFeature('WIP_OFFER_EXPOSURE')
   const selectedPartnerVenue = useAppSelector(ensureSelectedPartnerVenue)
   const isVenueClosed = withVenueHelpers(selectedPartnerVenue).isClosed
+  const tipsVideoUploaderId = useId()
 
   const initialImageOffer = getIndividualOfferImage(offer)
   const {
@@ -239,8 +241,12 @@ export const IndividualOfferMediaScreen = ({
                   title="Ajoutez une vidéo"
                   className={styles['media-sub-section']}
                 >
-                  <VideoUploader />
-                  {!videoData?.videoThumbnailUrl && <VideoUploaderTips />}
+                  <VideoUploader aria-describedby={tipsVideoUploaderId} />
+                  {!videoData?.videoThumbnailUrl && (
+                    <div id={tipsVideoUploaderId}>
+                      <VideoUploaderTips />
+                    </div>
+                  )}
                 </FormLayout.SubSection>
               </FormLayout.Row>
             </FormLayout.Section>

--- a/pro/src/pages/IndividualVenuePageEdition/components/WithdrawalDetails/WithdrawalDetails.tsx
+++ b/pro/src/pages/IndividualVenuePageEdition/components/WithdrawalDetails/WithdrawalDetails.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { useFormContext } from 'react-hook-form'
 
 import { FormLayout } from '@/components/FormLayout/FormLayout'
@@ -11,6 +12,7 @@ import styles from './WithdrawalDetails.module.scss'
 export const WithdrawalDetails = () => {
   const methods = useFormContext<VenueSettingsFormValues>()
   const { register } = methods
+  const bannerInfoId = useId()
 
   return (
     <FormLayout.SubSection
@@ -24,15 +26,18 @@ export const WithdrawalDetails = () => {
           label="Informations de retrait"
           maxLength={500}
           description="Par exemple : une autre adresse, un horaire d’accès, un délai de retrait, un guichet spécifique, un code d’accès, une communication par email..."
+          describedBy={bannerInfoId}
         />
       </FormLayout.Row>
       <FormLayout.Row>
-        <Banner
-          title="À savoir"
-          description="Ces indications s’appliqueront par défaut à toutes vos prochaines offres."
-          variant={BannerVariants.DEFAULT}
-          icon={fullInfoIcon}
-        />
+        <div id={bannerInfoId}>
+          <Banner
+            title="À savoir"
+            description="Ces indications s'appliqueront par défaut à toutes vos prochaines offres."
+            variant={BannerVariants.DEFAULT}
+            icon={fullInfoIcon}
+          />
+        </div>
       </FormLayout.Row>
     </FormLayout.SubSection>
   )

--- a/pro/src/pages/VenueSettings/Notifications/Notifications.tsx
+++ b/pro/src/pages/VenueSettings/Notifications/Notifications.tsx
@@ -1,4 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup'
+import { useId } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 
 import { useAppSelector } from '@/commons/hooks/useAppSelector'
@@ -58,6 +59,8 @@ const Notifications = () => {
   const { navigationGuardDialog, navigationGuardedSubmitHandler } =
     useFormNavigationGuard({ form, onSubmit })
 
+  const notificationId = useId()
+
   return (
     <>
       <FormProvider {...form}>
@@ -73,10 +76,11 @@ const Notifications = () => {
                   description="Format : email@exemple.com"
                   error={errors.bookingEmail?.message}
                   disabled={isVenueClosed}
+                  describedBy={notificationId}
                 />
               </FormLayout.Row>
               <FormLayout.Row>
-                <TipsBanner>
+                <TipsBanner id={notificationId}>
                   Cette adresse s’applique par défaut à toutes vos offres, vous
                   pouvez la modifier à l’échelle de chaque offre.
                 </TipsBanner>

--- a/pro/src/ui-kit/TipsBanner/TipsBanner.tsx
+++ b/pro/src/ui-kit/TipsBanner/TipsBanner.tsx
@@ -18,15 +18,20 @@ export interface TipsBannerProps {
    * Extra classnames to apply to the TipsBanner.
    */
   className?: string
+  /**
+   * The id attribute for the TipsBanner.
+   */
+  id?: string
 }
 
 export const TipsBanner = ({
   decorativeImage,
   children,
   className,
+  id,
 }: TipsBannerProps): JSX.Element => {
   return (
-    <div className={cn(className, styles['tips-banner'])}>
+    <div className={cn(className, styles['tips-banner'])} id={id}>
       <div className={styles['tips-banner-text']}>
         <div className={styles['tips-banner-header']}>
           <SvgIcon src={fullBulbIcon} className={styles['tips-banner-icon']} />À

--- a/pro/src/ui-kit/form/Select/Select.tsx
+++ b/pro/src/ui-kit/form/Select/Select.tsx
@@ -1,6 +1,7 @@
 import cn from 'classnames'
 import { type ForwardedRef, forwardRef, useId } from 'react'
 
+import { useFormLayoutSideComponentDescribedBy } from '@/commons/context/FormLayoutSideComponentContext/FormLayoutSideComponentContext'
 import type { SelectOption } from '@/commons/custom_types/form'
 import { FieldFooter } from '@/design-system/common/FieldFooter/FieldFooter'
 import { FieldHeader } from '@/design-system/common/FieldHeader/FieldHeader'
@@ -27,6 +28,7 @@ export interface SelectProps<T extends number | string = string> {
   error?: string
   value?: string
   ariaLabel?: string
+  describedBy?: string
 }
 
 export const Select = forwardRef(
@@ -45,9 +47,11 @@ export const Select = forwardRef(
       value,
       onChange,
       onBlur,
+      describedBy,
     }: Readonly<SelectProps<string | number>>,
     ref: ForwardedRef<HTMLSelectElement>
   ) => {
+    const formLayoutDescribedBy = useFormLayoutSideComponentDescribedBy()
     const fieldId = useId()
     const errorId = useId()
 
@@ -70,7 +74,11 @@ export const Select = forwardRef(
             aria-label={ariaLabel}
             aria-required={required}
             aria-invalid={Boolean(error)}
-            aria-describedby={error ? errorId : undefined}
+            aria-describedby={
+              [error ? errorId : '', describedBy ?? '', formLayoutDescribedBy]
+                .filter(Boolean)
+                .join(' ') || undefined
+            }
             className={cn(styles['select-input'], {
               [styles['has-error']]: Boolean(error),
               [styles['select-input-placeholder']]: value === '',

--- a/pro/src/ui-kit/form/TextArea/TextArea.tsx
+++ b/pro/src/ui-kit/form/TextArea/TextArea.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from 'react'
 
+import { useFormLayoutSideComponentDescribedBy } from '@/commons/context/FormLayoutSideComponentContext/FormLayoutSideComponentContext'
 import { Button } from '@/design-system/Button/Button'
 import { FieldFooter } from '@/design-system/common/FieldFooter/FieldFooter'
 import type { RequiredIndicator } from '@/design-system/common/types'
@@ -65,6 +66,7 @@ export type TextAreaProps = {
   onChange?: (e: { target: { value: string; name?: string } }) => void
   onBlur?: (e: React.FocusEvent<HTMLTextAreaElement>) => void
   value?: string
+  describedBy?: string
 } & (
   | {
       /**
@@ -81,7 +83,7 @@ export type TextAreaProps = {
       onPressTemplateButton: () => void
     }
   | {
-      hasTemplateButton?: false | undefined
+      hasTemplateButton?: false
       wordingTemplate?: never
       onPressTemplateButton?: never
     }
@@ -119,9 +121,11 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       onChange,
       onBlur,
       value,
+      describedBy,
     }: TextAreaProps,
     ref: ForwardedRef<HTMLTextAreaElement>
   ) => {
+    const formLayoutDescribedBy = useFormLayoutSideComponentDescribedBy()
     const textAreaRef = useRef<HTMLTextAreaElement>(null)
 
     const [textValue, setTextValue] = useState(value)
@@ -155,12 +159,15 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       updateTextAreaHeight()
     }, [updateTextAreaHeight])
 
-    // Constructing aria-describedby attribute
-    const describedBy = [charactersCountId, errorId]
-
-    if (description) {
-      describedBy.unshift(descriptionId)
-    }
+    const describedByIds = [
+      description ? descriptionId : '',
+      error ? errorId : '',
+      charactersCountId,
+      describedBy ?? '',
+      formLayoutDescribedBy ?? '',
+    ]
+      .filter(Boolean)
+      .join(' ')
 
     const generateTemplate = () => {
       wordingTemplate && setTextValue(wordingTemplate)
@@ -200,7 +207,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
           <textarea
             ref={textAreaRef}
             aria-invalid={!!error}
-            aria-describedby={describedBy.join(' ')}
+            aria-describedby={describedByIds || undefined}
             className={cn(styles['text-area'], {
               [styles['has-error']]: !!error,
             })}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-42864)

Ajout de `FormLayoutSideComponentContextProvider` afin d'automatiquement lier les `sideComponent` à leurs champs respectifs sans avoir à passer un id à chaque fois.
Ajout "manuel" d'ids + aria-describedBy pour les blocs "A savoir" qui ne sont pas dans les `sideComponent`.

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
