### PR TITLE
(PC-43163)[PRO] fix: avoid error selectedvenue is null

### DIFF
--- a/pro/src/app/AppRouter/routes/partnerRouteGroup.tsx
+++ b/pro/src/app/AppRouter/routes/partnerRouteGroup.tsx
@@ -11,6 +11,7 @@ export const partnerRouteGroup: CustomRouteGroup = {
   children: [
     {
       path: 'accueil',
+      loader: withUserPermissions(mustBeOnboardedWithSelectedPartnerVenue),
       lazy: () => import('@/pages/Homepage/Homepage'),
       handle: {
         title: 'Espace acteurs culturels',

--- a/pro/src/commons/store/user/dispatchers/__specs__/setSelectedPartnerVenueById.spec.ts
+++ b/pro/src/commons/store/user/dispatchers/__specs__/setSelectedPartnerVenueById.spec.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
 
 import { api } from '@/apiClient/api'
+import { ApiError } from '@/apiClient/compat'
 import { FrontendError } from '@/commons/errors/FrontendError'
 import * as handleErrorModule from '@/commons/errors/handleError'
 import type { RootState } from '@/commons/store/store'
@@ -237,6 +238,35 @@ describe('setSelectedPartnerVenueById', () => {
 
     expect(api.getVenue).toHaveBeenCalledTimes(1)
 
+    expect(localStorage.getItem(LOCAL_STORAGE_KEY.SELECTED_VENUE_ID)).toBeNull()
+  })
+
+  it('should not call handleError when getVenue fails with ApiError', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(api, 'getVenue').mockRejectedValue(
+      new ApiError('/venues/922', 503, 'Service Unavailable', {
+        global: 'failed',
+      })
+    )
+    const handleErrorSpy = vi.spyOn(handleErrorModule, 'handleError')
+    const logoutSpy = vi.spyOn(logoutModule, 'logout')
+
+    const store = configureTestStore(storeDataBase)
+
+    await store
+      .dispatch(
+        setSelectedPartnerVenueById({
+          nextSelectedPartnerVenueId: 101,
+          shouldAlignSelectedAdminOfferer: false,
+        })
+      )
+      .unwrap()
+
+    expect(handleErrorSpy).not.toHaveBeenCalled()
+    expect(logoutSpy).not.toHaveBeenCalled()
+
+    const state = store.getState()
+    expect(state.user.selectedPartnerVenue).toBeNull()
     expect(localStorage.getItem(LOCAL_STORAGE_KEY.SELECTED_VENUE_ID)).toBeNull()
   })
 

--- a/pro/src/commons/store/user/dispatchers/setSelectedPartnerVenueById.ts
+++ b/pro/src/commons/store/user/dispatchers/setSelectedPartnerVenueById.ts
@@ -1,13 +1,16 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import { api } from '@/apiClient/api'
+import { isErrorAPIError } from '@/apiClient/helpers'
 import type { GetVenueResponseModel } from '@/apiClient/v1'
 import { assertOrFrontendError } from '@/commons/errors/assertOrFrontendError'
 import { handleError } from '@/commons/errors/handleError'
+import { addSnackBar } from '@/commons/store/snackBar/reducer'
 import {
   LOCAL_STORAGE_KEY,
   localStorageManager,
 } from '@/commons/utils/localStorageManager'
+import { SnackBarVariant } from '@/design-system/SnackBar/SnackBar'
 
 import type { AppThunkApiConfig } from '../../store'
 import { setSelectedPartnerVenue } from '../reducer'
@@ -15,7 +18,7 @@ import { logout } from './logout'
 import { setSelectedAdminOffererById } from './setSelectedAdminOffererById'
 
 type SetSelectedPartnerVenueByIdReturn = {
-  selectedPartnerVenue: GetVenueResponseModel
+  selectedPartnerVenue: GetVenueResponseModel | null
 }
 
 export const setSelectedPartnerVenueById = createAsyncThunk<
@@ -103,12 +106,28 @@ export const setSelectedPartnerVenueById = createAsyncThunk<
         selectedPartnerVenue: nextSelectedPartnerVenue,
       }
     } catch (err) {
-      handleError(
-        err,
-        'Une erreur est survenue lors du changement de la structure.'
-      )
+      if (isErrorAPIError(err)) {
+        dispatch(
+          addSnackBar({
+            description:
+              'Une erreur est survenue lors du changement de la structure.',
+            variant: SnackBarVariant.ERROR,
+          })
+        )
+        dispatch(setSelectedPartnerVenue(null))
+        localStorageManager.removeItem(LOCAL_STORAGE_KEY.SELECTED_VENUE_ID)
 
-      return await logout()
+        return {
+          selectedPartnerVenue: null,
+        }
+      } else {
+        handleError(
+          err,
+          'Une erreur est survenue lors du changement de la structure.'
+        )
+
+        return await logout()
+      }
     }
   }
 )

--- a/pro/src/pages/Homepage/Homepage.tsx
+++ b/pro/src/pages/Homepage/Homepage.tsx
@@ -1,10 +1,7 @@
 import { addDays, isBefore } from 'date-fns'
 import { useId, useState } from 'react'
 
-import {
-  DMSApplicationstatus,
-  type GetVenueResponseModel,
-} from '@/apiClient/v1'
+import { DMSApplicationstatus } from '@/apiClient/v1'
 import { MainHeading } from '@/app/App/layouts/components/MainHeading/MainHeading'
 import { useAppSelector } from '@/commons/hooks/useAppSelector'
 import { ensureSelectedPartnerVenue } from '@/commons/store/user/selectors'
@@ -41,9 +38,7 @@ import { WebinarCard } from './components/WebinarCard/WebinarCard'
 import styles from './Homepage.module.scss'
 
 export const Homepage = (): JSX.Element => {
-  const selectedPartnerVenue: GetVenueResponseModel = useAppSelector(
-    ensureSelectedPartnerVenue
-  )
+  const selectedPartnerVenue = useAppSelector(ensureSelectedPartnerVenue)
 
   const collectiveDmsApplication =
     selectedPartnerVenue.lastCollectiveDmsApplication

--- a/pro/src/pages/Hub/Hub.spec.tsx
+++ b/pro/src/pages/Hub/Hub.spec.tsx
@@ -3,6 +3,7 @@ import { userEvent } from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
 
 import { api } from '@/apiClient/api'
+import { ApiError } from '@/apiClient/compat'
 import { type VenueListItemLiteResponseModel, VenueState } from '@/apiClient/v1'
 import {
   defaultGetOffererResponseModel,
@@ -211,6 +212,28 @@ describe('Hub', () => {
         screen.getByText('Chargement de la structure en cours…')
       ).toBeInTheDocument()
     })
+  })
+
+  it('should stop showing spinner when venue selection fails', async () => {
+    vi.spyOn(api, 'getVenue').mockRejectedValue(
+      new ApiError('/venues/922', 503, 'Service Unavailable', {
+        global: 'failed',
+      })
+    )
+
+    renderHub({ venues: venuesBase })
+
+    await userEvent.click(screen.getByRole('button', { name: /Café des Arts/ }))
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Chargement de la structure en cours…')
+      ).not.toBeInTheDocument()
+    })
+
+    expect(
+      screen.getByRole('button', { name: /Café des Arts/ })
+    ).toBeInTheDocument()
   })
 
   describe('search functionality', () => {

--- a/pro/src/pages/Hub/Hub.tsx
+++ b/pro/src/pages/Hub/Hub.tsx
@@ -63,14 +63,23 @@ export const Hub = () => {
     nextSelectedVenueId: number
   ) => {
     setIsLoading(true)
-    await dispatch(
-      setSelectedPartnerVenueById({
-        nextSelectedPartnerVenueId: nextSelectedVenueId,
-        shouldAlignSelectedAdminOfferer: true,
-      })
-    ).unwrap()
+    try {
+      const { selectedPartnerVenue } = await dispatch(
+        setSelectedPartnerVenueById({
+          nextSelectedPartnerVenueId: nextSelectedVenueId,
+          shouldAlignSelectedAdminOfferer: true,
+        })
+      ).unwrap()
 
-    navigate('/accueil')
+      if (!selectedPartnerVenue) {
+        setIsLoading(false)
+        return
+      }
+
+      navigate('/accueil')
+    } catch {
+      setIsLoading(false)
+    }
   }
 
   if (isLoading) {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43163)

- Ajout d'un guard sur la route `accueil` pour éviter d'arriver sur la page d'accueil sans venue selectionnée (déjà en place au niveau du dessus, sécurité supplémentaire si accès direct)
- En cas d'erreur API/réseau, snackbar d'erreur et retour sur le hub plutôt que throw

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
