### PR TITLE
(PC-43207)[PRO] fix: 404 on connect as

### DIFF
--- a/pro/src/commons/store/user/utils/__specs__/getInitialAdminOffererId.spec.ts
+++ b/pro/src/commons/store/user/utils/__specs__/getInitialAdminOffererId.spec.ts
@@ -38,6 +38,18 @@ describe('getInitialAdminOffererId', () => {
 
       expect(result).toBe(100)
     })
+
+    it('should ignore offerer id from URL param when it is not in offererNames', () => {
+      vi.spyOn(localStorageManager, 'getItem').mockReturnValue('200')
+      window.history.pushState({}, '', '/?offerer=999')
+
+      const result = getInitialAdminOffererId({
+        offererNames,
+        selectedPartnerVenue: null,
+      })
+
+      expect(result).toBe(200)
+    })
   })
 
   describe('Priority 2: localStorage', () => {

--- a/pro/src/commons/store/user/utils/getInitialAdminOffererId.ts
+++ b/pro/src/commons/store/user/utils/getInitialAdminOffererId.ts
@@ -23,7 +23,13 @@ export const getInitialAdminOffererId = ({
   const urlSearchParams = new URLSearchParams(globalThis.location.search)
   const selectedOffererIdFromUrl = Number(urlSearchParams.get('offerer'))
   if (selectedOffererIdFromUrl) {
-    return selectedOffererIdFromUrl
+    const selectedOffererFromUrl = offererNames.find(
+      (offerer) => offerer.id === selectedOffererIdFromUrl
+    )
+
+    if (selectedOffererFromUrl) {
+      return selectedOffererFromUrl.id
+    }
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43207)

L'erreur venait d'une 404 sur le connect as en prod, pour un offerer non trouvé.
En effet, `getInitialAdminOffererId` récupérait l'id de l'offerer dans l'url comme prévu, mais ne contrôlait pas ci cet id existait dans la liste des offerers (comme c'est le cas pour les venues par exemple). Ce contrôle est désormais appliqué.

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
