### PR TITLE
Pc 43220/close venue minor fixes

### DIFF
--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -3730,7 +3730,7 @@ def unlink_venue_bank_accounts(venue: offerers_models.Venue) -> None:
     if not venue.bankAccountLinks:
         return
 
-    if offerers_api.venue_has_ongoing_bookings(venue):
+    if offerers_api.venue_has_incoming_reimbursements(venue):
         raise CannotUnlinkBankAccount()
 
     bank_account_link = venue.current_bank_account_link

--- a/api/src/pcapi/core/finance/api.py
+++ b/api/src/pcapi/core/finance/api.py
@@ -48,6 +48,8 @@ import pcapi.core.bookings.models as bookings_models
 import pcapi.core.educational.models as educational_models
 import pcapi.core.history.models as history_models
 import pcapi.core.mails.transactional as transactional_mails
+import pcapi.core.offerers.api as offerers_api
+import pcapi.core.offerers.exceptions as offerers_exceptions
 import pcapi.core.offerers.models as offerers_models
 import pcapi.core.offers.models as offers_models
 import pcapi.core.reference.models as reference_models
@@ -67,7 +69,6 @@ from pcapi.core.mails.transactional.finance_incidents.finance_incident_notificat
 from pcapi.core.mails.transactional.finance_incidents.finance_incident_notification import send_finance_incident_emails
 from pcapi.core.mails.transactional.pro.provider_reimbursement_csv import send_provider_reimbursement_email
 from pcapi.core.object_storage import store_public_object
-from pcapi.core.offerers import api as offerers_api
 from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
 from pcapi.routes.serialization.reimbursement_csv_serialize import ReimbursementDetails
@@ -3722,16 +3723,13 @@ def clean_duplicate_bank_accounts() -> None:
         db.session.delete(bank_account)
 
 
-class CannotUnlinkBankAccount(Exception):
-    pass
-
-
 def unlink_venue_bank_accounts(venue: offerers_models.Venue) -> None:
+    """Deactivate current venue bank account link"""
     if not venue.bankAccountLinks:
         return
 
     if offerers_api.venue_has_incoming_reimbursements(venue):
-        raise CannotUnlinkBankAccount()
+        raise offerers_exceptions.VenueHasIncomingReimbursements()
 
     bank_account_link = venue.current_bank_account_link
     if bank_account_link:

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -53,7 +53,6 @@ from pcapi.core.educational.api import booking as educational_booking_api
 from pcapi.core.educational.api import dms as dms_api
 from pcapi.core.external.attributes import api as external_attributes_api
 from pcapi.core.external.zendesk_sell import api as zendesk_sell_api
-from pcapi.core.finance import api as finance_api
 from pcapi.core.geography import constants as geography_constants
 from pcapi.core.geography import models as geography_models
 from pcapi.core.geography import utils as geography_utils
@@ -3506,11 +3505,12 @@ def close_venue(venue: models.Venue, author: users_models.User, comment: str | N
     if venue.is_closed:
         return
 
+    if venue_has_incoming_reimbursements(venue):
+        raise exceptions.VenueHasIncomingReimbursements()
+
     venue.state = models.VenueState.CLOSING
     nullify_venue_emails(venue, author)
     history_api.add_action(history_models.ActionType.VENUE_CLOSED, author=author, venue=venue, comment=comment)
-
-    finance_api.unlink_venue_bank_accounts(venue)
 
     payload = tasks.FinalizeClosingVenuePayload(venue_id=venue.id, author_id=author.id)
     on_commit(

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -3611,13 +3611,13 @@ def deactivate_venue_offers(venue: models.Venue) -> None:
         logger.info(log_msg, extra=log_extra)
 
 
-def venue_has_ongoing_bookings(venue: models.Venue) -> bool:
+def venue_has_incoming_reimbursements(venue: models.Venue) -> bool:
     return db.session.query(
         db.session.query(bookings_models.Booking)
         .filter_by(venueId=venue.id)
         .filter(
-            bookings_models.Booking.status.not_in(
-                [bookings_models.BookingStatus.REIMBURSED, bookings_models.BookingStatus.CANCELLED]
+            bookings_models.Booking.status.in_(
+                [bookings_models.BookingStatus.PENDING_REIMBURSEMENT, bookings_models.BookingStatus.USED]
             )
         )
         .exists()

--- a/api/src/pcapi/core/offerers/exceptions.py
+++ b/api/src/pcapi/core/offerers/exceptions.py
@@ -161,3 +161,7 @@ class InviteAgainImpossibleException(ClientError):
 class UserAlreadyAttachedToOffererException(ClientError):
     def __init__(self) -> None:
         super().__init__("UserAlreadyAttachedToOffererException", "Ce collaborateur est déjà membre de votre structure")
+
+
+class VenueHasIncomingReimbursements(OffererException):
+    pass

--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -3,6 +3,7 @@ import logging
 import sqlalchemy.orm as sa_orm
 from pydantic import BaseModel as BaseModelV2
 
+import pcapi.core.finance.api as finance_api
 from pcapi.celery_tasks.tasks import celery_async_task
 from pcapi.connectors.entreprise import api as entreprise_api
 from pcapi.connectors.entreprise import exceptions as entreprise_exceptions
@@ -110,6 +111,9 @@ def finalize_closing_venue_task(payload: FinalizeClosingVenuePayload) -> None:
         db.session.flush()
 
         logger.info("closing venue: pivots deleted", extra={"venue_id": venue.id})
+
+        finance_api.unlink_venue_bank_accounts(venue)
+        logger.info("closing venue: bank accounts unlinked", extra={"venue_id": venue.id})
 
         venue.state = offerers_models.VenueState.CLOSED
         db.session.flush()

--- a/api/tests/core/finance/test_api.py
+++ b/api/tests/core/finance/test_api.py
@@ -27,6 +27,7 @@ from pcapi.core.finance import utils
 from pcapi.core.history import models as history_models
 from pcapi.core.object_storage.testing import recursive_listdir
 from pcapi.core.offerers import api as offerers_api
+from pcapi.core.offerers import exceptions as offerers_exceptions
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import factories as offers_factories
@@ -5651,7 +5652,7 @@ class UnlinkVenueBankAccountsTest:
 
         bookings_factories.UsedBookingFactory(stock__offer__venue=venue)
 
-        with pytest.raises(api.CannotUnlinkBankAccount):
+        with pytest.raises(offerers_exceptions.VenueHasIncomingReimbursements):
             api.unlink_venue_bank_accounts(venue)
 
         db.session.refresh(venue)

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -4376,10 +4376,10 @@ class NullifyVenueEmailsTest:
         assert not venue.action_history
 
 
-class VenueHasOngoingBookingsTest:
+class VenueHasIncomingReimbursementsTest:
     def test_venue_without_any_bookings_is_false(self):
         venue = offerers_factories.VenueFactory()
-        assert not offerers_api.venue_has_ongoing_bookings(venue)
+        assert not offerers_api.venue_has_incoming_reimbursements(venue)
 
     def test_venue_with_only_cancelled_and_reimbursed_bookings_is_false(self):
         venue = offerers_factories.VenueFactory()
@@ -4387,26 +4387,28 @@ class VenueHasOngoingBookingsTest:
         bookings_factories.CancelledBookingFactory(stock__offer__venue=venue)
         bookings_factories.ReimbursedBookingFactory(stock__offer__venue=venue)
 
-        assert not offerers_api.venue_has_ongoing_bookings(venue)
+        assert not offerers_api.venue_has_incoming_reimbursements(venue)
 
-    def test_venue_with_only_ongoing_bookings_is_true(self):
+    def test_venue_with_only_ongoing_reimbursements_is_true(self):
         venue = offerers_factories.VenueFactory()
 
         bookings_factories.UsedBookingFactory(stock__offer__venue=venue)
         bookings_factories.PendingReimbursementBookingFactory(stock__offer__venue=venue)
 
-        assert offerers_api.venue_has_ongoing_bookings(venue)
+        assert offerers_api.venue_has_incoming_reimbursements(venue)
 
-    def test_venue_with_mixed_ongoing_and_not_bookings_is_true(self):
+    def test_venue_with_mixed_bookings_is_true(self):
         venue = offerers_factories.VenueFactory()
 
-        bookings_factories.UsedBookingFactory(stock__offer__venue=venue)
-        bookings_factories.PendingReimbursementBookingFactory(stock__offer__venue=venue)
+        bookings_factories.BookingFactory(stock__offer__venue=venue)
 
         bookings_factories.CancelledBookingFactory(stock__offer__venue=venue)
         bookings_factories.ReimbursedBookingFactory(stock__offer__venue=venue)
 
-        assert offerers_api.venue_has_ongoing_bookings(venue)
+        bookings_factories.UsedBookingFactory(stock__offer__venue=venue)
+        bookings_factories.PendingReimbursementBookingFactory(stock__offer__venue=venue)
+
+        assert offerers_api.venue_has_incoming_reimbursements(venue)
 
 
 class CancelIndividualBookingsOnVenueClosureTest:

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -4161,6 +4161,23 @@ class CloseVenueTest:
         assert not venue.contact
         assert venue.state == offerers_models.VenueState.CLOSED
 
+    @pytest.mark.parametrize(
+        "booking_factory",
+        [bookings_factories.UsedBookingFactory, bookings_factories.PendingReimbursementBookingFactory],
+    )
+    def test_cannot_close_venue_with_incoming_reimbursements(self, booking_factory):
+        venue = offerers_factories.VenueFactory()
+        author = users_factories.BaseUserFactory()
+
+        booking_factory(stock__offer__venue=venue)
+
+        with pytest.raises(offerers_exceptions.VenueHasIncomingReimbursements):
+            with atomic():
+                offerers_api.close_venue(venue, author)
+
+        db.session.refresh(venue)
+        assert not venue.is_closed
+
     def test_close_venue_with_external_ticket(self, requests_mock):
         venue = offerers_factories.VenueFactory()
 

--- a/api/tests/core/offerers/test_tasks.py
+++ b/api/tests/core/offerers/test_tasks.py
@@ -217,6 +217,20 @@ class FinalizeClosingVenueTaskTest:
 
         assert venue.state == offerers_models.VenueState.CLOSED
 
+    def test_bank_accounts_have_been_unlinked(self):
+        bank_account_link = offerers_factories.VenueBankAccountLinkFactory()
+        venue = bank_account_link.venue
+        assert venue.current_bank_account_link
+
+        author = users_factories.BaseUserFactory()
+
+        payload = offerers_tasks.FinalizeClosingVenuePayload(venue_id=venue.id, author_id=author.id)
+        offerers_tasks.finalize_closing_venue_task(payload.model_dump())
+
+        db.session.refresh(venue)
+        assert not venue.current_bank_account_link
+        assert venue.state == offerers_models.VenueState.CLOSED
+
     def create_synced_offers_with_bookings(self, venue):
         boost_pivot = providers_factories.BoostCinemaProviderPivotFactory(venue=venue)
         now = datetime.datetime.now(datetime.UTC)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43220)

Deux fixs, deux _commits_ :

1. On bloque la fermeture d'une structure (venue) uniquement s'il y a des réservations qui vont être remboursées à coup sûr. La tâche asynchrone se chargera d'annuler toutes celles qui peuvent l'être.
2. La dissociation des comptes bancaires se fait maintenant dans la tâche asynchrone, après l'annulation des réservations : ceci permet d'être certain qu'une fois arrivé à cette étape, il n'y a plus de réservations qui pourraient nécessiter un remboursement.