### PR TITLE
(BSR)[PRO] fix: add refToFocusOnClose prop to BaseDialog and SimpleMo…

### DIFF
--- a/pro/src/design-system/SimpleModal/SimpleModal.spec.tsx
+++ b/pro/src/design-system/SimpleModal/SimpleModal.spec.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { createRef } from 'react'
 import { axe } from 'vitest-axe'
 
 import { renderWithProviders } from '@/commons/utils/renderWithProviders'
@@ -65,5 +66,32 @@ describe('SimpleModal', () => {
     await user.click(closeButton)
 
     expect(onCloseMock).toHaveBeenCalled()
+  })
+
+  it('should focus refToFocusOnClose when the dialog closes', () => {
+    const refToFocusOnClose = createRef<HTMLButtonElement>()
+    const { rerender } = renderWithProviders(
+      <>
+        <button ref={refToFocusOnClose} type="button">
+          Outside
+        </button>
+        <SimpleModal {...props} refToFocusOnClose={refToFocusOnClose} />
+      </>
+    )
+
+    rerender(
+      <>
+        <button ref={refToFocusOnClose} type="button">
+          Outside
+        </button>
+        <SimpleModal
+          {...props}
+          isOpen={false}
+          refToFocusOnClose={refToFocusOnClose}
+        />
+      </>
+    )
+
+    expect(screen.getByRole('button', { name: 'Outside' })).toHaveFocus()
   })
 })

--- a/pro/src/design-system/SimpleModal/SimpleModal.tsx
+++ b/pro/src/design-system/SimpleModal/SimpleModal.tsx
@@ -37,6 +37,12 @@ export interface SimpleModalProps {
    * Identifier of the description element for screen readers (aria-describedby).
    */
   ariaDescribedBy?: string
+  /**
+   * Element to focus after the dialog has closed.
+   * Native `<dialog>` already restores focus to the opener; use this to
+   * override that target (e.g. a dropdown trigger instead of a menu item).
+   */
+  refToFocusOnClose?: React.RefObject<HTMLElement | null>
 }
 
 export const SimpleModal = ({
@@ -47,6 +53,7 @@ export const SimpleModal = ({
   isOpen,
   actionButtons,
   ariaDescribedBy,
+  refToFocusOnClose,
 }: Readonly<SimpleModalProps>) => {
   const dialogTitleId = useId()
 
@@ -56,6 +63,7 @@ export const SimpleModal = ({
       onClose={onClose}
       ariaLabelledBy={dialogTitleId}
       ariaDescribedBy={ariaDescribedBy}
+      refToFocusOnClose={refToFocusOnClose}
     >
       <div className={styles['dialog-wrapper']}>
         <span className={styles['close-button']}>

--- a/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOfferColumns/components/HeadlineOfferImageDialogs.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOfferColumns/components/HeadlineOfferImageDialogs.tsx
@@ -30,6 +30,7 @@ type HeadlineOfferImageDialogsProps = {
   offerId: number
   setIsFirstDialogOpen: (state: boolean) => void
   isInOfferJourney?: boolean
+  refToFocusOnClose?: React.RefObject<HTMLButtonElement | null>
 }
 
 export const HeadlineOfferImageDialogs = ({
@@ -37,6 +38,7 @@ export const HeadlineOfferImageDialogs = ({
   setIsFirstDialogOpen,
   offerId,
   isInOfferJourney = false,
+  refToFocusOnClose,
 }: HeadlineOfferImageDialogsProps) => {
   const { mutate } = useSWRConfig()
 
@@ -115,6 +117,7 @@ export const HeadlineOfferImageDialogs = ({
         title="Ajoutez une image pour mettre votre offre à la une"
         isOpen={isFirstDialogOpen}
         onClose={() => setIsFirstDialogOpen(false)}
+        refToFocusOnClose={refToFocusOnClose}
         actionButtons={
           <>
             <Button

--- a/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOfferColumns/components/IndividualActionsCells/IndividualActionsCells.tsx
+++ b/pro/src/pages/IndividualOffers/IndividualOffersContainer/components/IndividualOfferColumns/components/IndividualActionsCells/IndividualActionsCells.tsx
@@ -336,12 +336,16 @@ export const IndividualActionsCells = ({
             />
           </>
         }
+        refToFocusOnClose={dropdownTriggerRef}
       />
       <SimpleModal
         iconPath={strokeStarIcon}
         title="Vous êtes sur le point de remplacer votre offre à la une par une nouvelle offre."
         isOpen={isConfirmDialogReplaceHeadlineOfferOpen}
         onClose={closeReplaceHeadlineOfferDialog}
+        refToFocusOnClose={
+          isNewProAdviceAccess ? headlineButtonTriggerRef : dropdownTriggerRef
+        }
         actionButtons={
           <>
             <Button
@@ -358,6 +362,9 @@ export const IndividualActionsCells = ({
         offerId={offer.id}
         isFirstDialogOpen={isDialogForHeadlineOfferWithoutImageOpen}
         setIsFirstDialogOpen={setIsDialogForHeadlineOfferWithoutImageOpen}
+        refToFocusOnClose={
+          isNewProAdviceAccess ? headlineButtonTriggerRef : dropdownTriggerRef
+        }
       />
     </>
   )

--- a/pro/src/ui-kit/BaseDialog/BaseDialog.spec.tsx
+++ b/pro/src/ui-kit/BaseDialog/BaseDialog.spec.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import { createRef } from 'react'
+import { axe } from 'vitest-axe'
+
+import { BaseDialog } from './BaseDialog'
+
+describe('<BaseDialog />', () => {
+  it('should render without accessibility violations', async () => {
+    const { container } = render(
+      <BaseDialog isOpen onClose={() => {}} ariaLabelledBy="title">
+        <h2 id="title">Title</h2>
+      </BaseDialog>
+    )
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('should focus refToFocusOnClose when the dialog closes', () => {
+    const refToFocusOnClose = createRef<HTMLButtonElement>()
+    const { rerender } = render(
+      <>
+        <button ref={refToFocusOnClose} type="button">
+          Outside
+        </button>
+        <BaseDialog
+          isOpen
+          onClose={() => {}}
+          ariaLabelledBy="title"
+          refToFocusOnClose={refToFocusOnClose}
+        >
+          <h2 id="title">Title</h2>
+        </BaseDialog>
+      </>
+    )
+
+    rerender(
+      <>
+        <button ref={refToFocusOnClose} type="button">
+          Outside
+        </button>
+        <BaseDialog
+          isOpen={false}
+          onClose={() => {}}
+          ariaLabelledBy="title"
+          refToFocusOnClose={refToFocusOnClose}
+        >
+          <h2 id="title">Title</h2>
+        </BaseDialog>
+      </>
+    )
+
+    expect(screen.getByRole('button', { name: 'Outside' })).toHaveFocus()
+  })
+})

--- a/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
+++ b/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
@@ -25,6 +25,12 @@ export interface BaseDialogProps {
    * Modal content.
    */
   children: React.ReactNode
+  /**
+   * Element to focus after the dialog has closed.
+   * Native `<dialog>` already restores focus to the opener; use this to
+   * override that target (e.g. a dropdown trigger instead of a menu item).
+   */
+  refToFocusOnClose?: React.RefObject<HTMLElement | null>
 }
 
 /**
@@ -41,6 +47,7 @@ export const BaseDialog = ({
   ariaLabelledBy,
   ariaDescribedBy,
   children,
+  refToFocusOnClose,
 }: BaseDialogProps): JSX.Element => {
   const dialogRef = useRef<HTMLDialogElement>(null)
 
@@ -82,12 +89,18 @@ export const BaseDialog = ({
     }
   }
 
+  // Native `close` is queued after dialog.close() (focus trap already gone).
+  const handleNativeClose = () => {
+    refToFocusOnClose?.current?.focus()
+  }
+
   return (
     // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click is pointer-only; keyboard dismissal is handled via onCancel (Escape)
     <dialog
       ref={dialogRef}
       onCancel={handleCancel}
       onClick={handleBackdropClick}
+      onClose={handleNativeClose}
       aria-labelledby={ariaLabelledBy}
       aria-describedby={ariaDescribedBy}
       className={styles['base-dialog']}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

(BSR)

> Après fermeture d’une modale ouverte depuis un dropdown, le focus clavier retombait sur l’item du menu (déjà démonté). On le replace sur le trigger.

### 🔧 Changements
- `BaseDialog` / `SimpleModal` : nouvelle prop `refToFocusOnClose`, appliquée sur l’événement natif `close` (après disparition du focus trap)
- Offres individuelles : les modales « offre à la une » passent `dropdownTriggerRef`
- Tests unitaires `BaseDialog` + `SimpleModal`

### 🧪 Comment tester
1. Offres individuelles → Voir les actions → Ouvrir une modale « mettre à la une » (image manquante ou remplacement)
2. Fermer (Escape, backdrop ou bouton) → le focus revient sur le bouton du dropdown, pas dans le vide