### PR TITLE
(PC-42938)[API] feat: duplicate and refactor update_offer (public path only)

### DIFF
--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -583,44 +583,19 @@ def update_offer(
     if offerer_address:
         fields["offererAddress"] = offerer_address
 
+    updates = {key: value for key, value in fields.items() if getattr(offer, key) != value}
+
     validation.check_can_update_offer(
         offer,
-        fields,
+        updates,
         mandatory_extra_data_fields=mandatory_extra_data_fields,
         venue_provider=venue_provider,
     )
-
-    updates = {key: value for key, value in fields.items() if getattr(offer, key) != value}
 
     if not updates:
         return offer
 
     updates_set = set(updates)
-
-    if "bookingAllowedDatetime" in updates:
-        new_booking_allowed_datetime = updates["bookingAllowedDatetime"]
-        if not new_booking_allowed_datetime or (new_booking_allowed_datetime <= datetime.datetime.now(datetime.UTC)):
-            reminders_notifications.notify_users_offer_is_bookable(offer)
-
-    try:
-        updates["ean"] = updates["extraData"].pop("ean")
-
-        # TODO(jbaudet - 11/2025): remove this whole try/except in a
-        # couple of weeks, after checking that this warning never
-        # appears.
-        # Caller should use the `ean` argument instead of extra_data["ean"]
-        # This seems to be ok today, but... lets wait a little bit before
-        # doing anything stupid.
-        # update 06/08/2026 : found warning https://console.cloud.google.com/logs/query;cursorTimestamp=2026-06-26T06:36:36.808331953Z;endTime=2026-08-06T09:51:01.625Z;query=jsonPayload.message:%22extracting%20EAN%20from%20extraData%20%2528use%20body.ean%20instead%2529%22%0Atimestamp%3D%222026-06-26T06:29:13.144607099Z%22%0AinsertId%3D%226l39mh05fg1z3sn9%22;startTime=2026-01-07T10:51:01.625Z?project=pc-backend-prd
-        logger.warning(
-            "update_offer: extracting EAN from extraData (use body.ean instead)",
-            extra={"offer": offer.id, "ean": updates["ean"]},
-        )
-    except (KeyError, AttributeError):
-        pass
-
-    if offer.is_soft_deleted():
-        raise pc_object.DeletedRecordException()
 
     changes = {}
     for key, value in updates.items():
@@ -630,6 +605,11 @@ def update_offer(
         setattr(offer, key, value)
 
     db.session.add(offer)
+
+    if "bookingAllowedDatetime" in updates:
+        new_booking_allowed_datetime = updates["bookingAllowedDatetime"]
+        if not new_booking_allowed_datetime or (new_booking_allowed_datetime <= datetime.datetime.now(datetime.UTC)):
+            reminders_notifications.notify_users_offer_is_bookable(offer)
 
     # This log is used for analytics purposes.
     # If you need to make a 'breaking change' of this log, please contact the data team.

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -316,6 +316,227 @@ def get_or_create_offerer_address_from_address_body(
     return offerers_api.get_offer_location_from_address(venue.managingOffererId, address_body, venue_id=venue.id)
 
 
+def old_update_offer(
+    offer: models.Offer,
+    body: schemas.UpdateOffer,
+    venue: offerers_models.Venue | None = None,
+    offerer_address: offerers_models.OffererAddress | None = None,
+    is_from_private_api: bool = False,
+) -> models.Offer:
+    validation.check_validation_status(offer)
+
+    aliases = set(body.dict(by_alias=True))
+    fields = body.dict(by_alias=True, exclude_unset=True)
+    fields.pop("artistOfferLinks", None)
+    fields.pop("hasCulturalOutreachClaim", None)
+    artist_offer_links = body.artist_offer_links
+    has_cultural_outreach_claim = body.has_cultural_outreach_claim
+
+    # updated using the pro interface
+    if body.location:
+        offerer_address_from_body = get_or_create_offerer_address_from_address_body(
+            address_body=body.location, venue=offer.venue
+        )
+
+        if offerer_address_from_body is not None:
+            fields["offererAddress"] = offerer_address_from_body
+            fields.pop("location", None)
+
+    should_send_mail = fields.pop("shouldSendMail", False)
+
+    if venue:
+        fields["venue"] = venue
+
+    if offerer_address:
+        fields["offererAddress"] = offerer_address
+
+    updates = {key: value for key, value in fields.items() if getattr(offer, key) != value}
+    updates_set = set(updates)
+
+    subcategory_id = updates.get("subcategoryId", offer.subcategoryId)
+    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
+
+    if artist_offer_links is not None:
+        validation.check_artist_offer_links(artist_offer_links, subcategory)
+        created_links, deleted_links = artist_api.upsert_artist_offer_links(artist_offer_links, offer)
+        db.session.expire(offer, ["artistOfferLinks"])
+
+        if deleted_links:
+            on_commit(
+                partial(
+                    logger.info,
+                    "Artist offer links have been deleted",
+                    extra={"offer_id": offer.id, "venue_id": offer.venueId, "links": [str(k) for k in deleted_links]},
+                    technical_message_id="offer.artistOfferLinks.deleted",
+                )
+            )
+        if created_links:
+            on_commit(
+                partial(
+                    logger.info,
+                    "Artist offer links have been created",
+                    extra={"offer_id": offer.id, "venue_id": offer.venueId, "links": [str(k) for k in created_links]},
+                    technical_message_id="offer.artistOfferLinks.created",
+                )
+            )
+
+    if has_cultural_outreach_claim is not None:
+        outreach = offer.culturalOutreach
+        is_currently_claimed = outreach is not None and outreach.claimedDatetime is not None
+        if has_cultural_outreach_claim != is_currently_claimed:
+            if outreach is None:
+                cultural_outreach_api.create_cultural_outreach_claim(offer)
+            else:
+                claim_datetime = get_naive_utc_now() if has_cultural_outreach_claim else None
+                cultural_outreach_api.update_cultural_outreach_claim(claim_datetime, offer)
+
+    if not updates:
+        return offer
+
+    if "bookingAllowedDatetime" in updates:
+        bookingAllowedDatetime = get_field(offer, updates, "bookingAllowedDatetime", aliases=aliases)
+        if not bookingAllowedDatetime or (bookingAllowedDatetime <= datetime.datetime.now(datetime.UTC)):
+            reminders_notifications.notify_users_offer_is_bookable(offer)
+
+    if (
+        "audioDisabilityCompliant" in updates
+        or "mentalDisabilityCompliant" in updates
+        or "motorDisabilityCompliant" in updates
+        or "visualDisabilityCompliant" in updates
+    ):
+        validation.check_accessibility_compliance(
+            audio_disability_compliant=get_field(offer, updates, "audioDisabilityCompliant", aliases=aliases),
+            mental_disability_compliant=get_field(offer, updates, "mentalDisabilityCompliant", aliases=aliases),
+            motor_disability_compliant=get_field(offer, updates, "motorDisabilityCompliant", aliases=aliases),
+            visual_disability_compliant=get_field(offer, updates, "visualDisabilityCompliant", aliases=aliases),
+        )
+
+    if "extraData" in updates or "ean" in updates:
+        formatted_extra_data = _format_extra_data(subcategory_id, body.extra_data) or {}
+        validation.check_offer_extra_data(
+            subcategory_id, formatted_extra_data, offer.venue, is_from_private_api, offer=offer, ean=body.ean
+        )
+
+    if "isDuo" in updates:
+        is_duo = get_field(offer, updates, "isDuo", aliases=aliases)
+        validation.check_is_duo_compliance(is_duo, subcategory)
+
+    if "idAtProvider" in updates:
+        id_at_provider = get_field(offer, updates, "idAtProvider", aliases=aliases)
+        validation.check_can_input_id_at_provider(offer.lastProvider, id_at_provider)
+        validation.check_can_input_id_at_provider_for_this_venue(offer.venueId, id_at_provider, offer.id)
+
+    if "name" in updates:
+        name = get_field(offer, updates, "name", aliases=aliases)
+        if name is None:
+            raise exceptions.OfferException({"name": ["cannot be null"]})
+        validation.check_offer_name_does_not_contain_ean(name)
+
+    if (
+        "withdrawalType" in updates
+        or "withdrawalDelay" in updates
+        or "withdrawalDetails" in updates
+        or "bookingContact" in updates
+    ):
+        booking_contact = get_field(offer, updates, "bookingContact", aliases=aliases)
+        withdrawal_delay = get_field(offer, updates, "withdrawalDelay", aliases=aliases)
+        withdrawal_type = get_field(offer, updates, "withdrawalType", aliases=aliases)
+        validation.check_offer_withdrawal(
+            withdrawal_type=withdrawal_type,
+            withdrawal_delay=withdrawal_delay,
+            subcategory_id=subcategory_id,
+            booking_contact=booking_contact,
+            provider=offer.lastProvider,
+        )
+
+    try:
+        updates["ean"] = updates["extraData"].pop("ean")
+
+        # TODO(jbaudet - 11/2025): remove this whole try/except in a
+        # couple of weeks, after checking that this warning never
+        # appears.
+        # Caller should use body.ean instead of body.extra_data["ean"]
+        # This seems to be ok today, but... lets wait a little bit before
+        # doing anything stupid.
+        logger.warning(
+            "update_offer: extracting EAN from extraData (use body.ean instead)",
+            extra={"offer": offer.id, "ean": updates["ean"]},
+        )
+    except (KeyError, AttributeError):
+        pass
+
+    # - The offer URL must not be removed if the offer has an online subcategory.
+    if offer.url and "url" in body.__fields_set__ and body.url is None:
+        offer_subcategory = subcategories.ALL_SUBCATEGORIES_DICT[offer.subcategoryId]
+        validation.check_url_is_coherent_with_subcategory(offer_subcategory, None)
+
+    if "subcategoryId" in updates and offer.status != models.OfferStatus.DRAFT:
+        raise exceptions.UnallowedUpdate("subcategoryId")
+
+    if "durationMinutes" in updates:
+        duration_minutes = get_field(offer, updates, "durationMinutes", aliases=aliases)
+        validation.check_duration_minutes(duration_minutes, is_from_private_api)
+
+    if offer.lastProvider is not None:
+        validation.check_update_only_allowed_fields_for_offer_from_provider(updates_set, offer.lastProvider)
+    if offer.is_soft_deleted():
+        raise pc_object.DeletedRecordException()
+
+    changes = {}
+    for key, value in updates.items():
+        if key == "extraData":
+            if offer.product:
+                continue
+        changes[key] = {"oldValue": getattr(offer, key), "newValue": value}
+        setattr(offer, key, value)
+
+    with db.session.no_autoflush:
+        # the creation process is splitted into several steps. URL and
+        # address might be set only in the end. Therefore, this
+        # validation is meaningless until the offer has been finalized.
+        if offer.status != models.OfferStatus.DRAFT:
+            validation.check_url_is_coherent_with_subcategory(offer.subcategory, offer.url)
+            validation.check_url_and_offererAddress_are_not_both_set(offer.url, offer.offererAddress)
+
+    if offer.isFromAllocine:
+        offer.fieldsUpdated = list(set(offer.fieldsUpdated) | updates_set)
+    db.session.add(offer)
+
+    # This log is used for analytics purposes.
+    # If you need to make a 'breaking change' of this log, please contact the data team.
+    # Otherwise, you will break some dashboards
+    on_commit(
+        partial(
+            logger.info,
+            "Offer has been updated",
+            extra={
+                "offer_id": offer.id,
+                "venue_id": offer.venueId,
+                "product_id": offer.productId,
+                "changes": {**changes},
+            },
+            technical_message_id="offer.updated",
+        )
+    )
+
+    withdrawal_fields = {"bookingContact", "withdrawalDelay", "withdrawalDetails", "withdrawalType"}
+    withdrawal_updated = updates_set & withdrawal_fields
+    oa_updated = "offererAddress" in updates
+    if should_send_mail and (withdrawal_updated or oa_updated):
+        transactional_mails.send_email_for_each_ongoing_booking(offer)
+
+    on_commit(
+        partial(
+            search.async_index_offer_ids,
+            [offer.id],
+            reason=IndexationReason.OFFER_UPDATE,
+            log_extra={"changes": updates_set},
+        )
+    )
+
+    return offer
+
+
 def update_offer(
     offer: models.Offer,
     body: schemas.UpdateOffer,

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -561,9 +561,9 @@ def update_offer(
     withdrawal_delay: int | None | T_UNCHANGED = UNCHANGED,
     withdrawal_details: str | None | T_UNCHANGED = UNCHANGED,
     withdrawal_type: models.WithdrawalTypeEnum | None | T_UNCHANGED = UNCHANGED,
+    mandatory_extra_data_fields: typing.Collection[str],
     venue: offerers_models.Venue | None = None,
     offerer_address: offerers_models.OffererAddress | None = None,
-    is_from_private_api: bool = False,
 ) -> models.Offer:
     validation.check_validation_status(offer)
 
@@ -627,8 +627,12 @@ def update_offer(
 
     if "extraData" in updates or "ean" in updates:
         formatted_extra_data = _format_extra_data(subcategory.id, fields.get("extraData")) or {}
-        validation.check_offer_extra_data(
-            subcategory.id, formatted_extra_data, offer.venue, is_from_private_api, offer=offer, ean=fields.get("ean")
+        validation.check_extra_data(
+            formatted_extra_data,
+            offer.venue,
+            mandatory_extra_data_fields,
+            offer=offer,
+            ean=fields.get("ean"),
         )
 
     if "isDuo" in updates:
@@ -684,7 +688,7 @@ def update_offer(
         raise exceptions.UnallowedUpdate("subcategoryId")
 
     if "durationMinutes" in updates:
-        validation.check_duration_minutes(get_field(offer, updates, "durationMinutes"), is_from_private_api)
+        validation.check_offer_duration(get_field(offer, updates, "durationMinutes"))
 
     if offer.lastProvider is not None:
         validation.check_update_only_allowed_fields_for_offer_from_provider(updates_set, offer.lastProvider)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -166,20 +166,6 @@ def deserialize_extra_data(initial_extra_data: typing.Any, subcategoryId: str) -
     return extra_data
 
 
-def _format_extra_data(subcategory_id: str, extra_data: dict[str, typing.Any] | None) -> models.OfferExtraData | None:
-    """Keep only the fields that are defined in the subcategory conditional fields"""
-    if extra_data is None:
-        return None
-
-    formatted_extra_data: models.OfferExtraData = {}
-
-    for field_name in subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id].conditional_fields:
-        if extra_data.get(field_name):
-            formatted_extra_data[field_name] = extra_data.get(field_name)  # type: ignore[literal-required]
-
-    return formatted_extra_data
-
-
 def create_offer(
     body: schemas.CreateOffer,
     *,
@@ -198,7 +184,7 @@ def create_offer(
         Both should use the same entrypoint but this is still a work in
         progress since some rules are slightly different.
     """
-    body.extra_data = _format_extra_data(body.subcategory_id, body.extra_data) or {}
+    body.extra_data = validation.format_extra_data(body.subcategory_id, body.extra_data) or {}
 
     validation.check_offer_subcategory_is_valid(body.subcategory_id)
     subcategory = subcategories.ALL_SUBCATEGORIES_DICT[body.subcategory_id]
@@ -316,6 +302,7 @@ def get_or_create_offerer_address_from_address_body(
     return offerers_api.get_offer_location_from_address(venue.managingOffererId, address_body, venue_id=venue.id)
 
 
+# TODO (@tpommellet): replace by `update_offer`
 def old_update_offer(
     offer: models.Offer,
     body: schemas.UpdateOffer,
@@ -412,7 +399,7 @@ def old_update_offer(
         )
 
     if "extraData" in updates or "ean" in updates:
-        formatted_extra_data = _format_extra_data(subcategory_id, body.extra_data) or {}
+        formatted_extra_data = validation.format_extra_data(subcategory_id, body.extra_data) or {}
         validation.check_offer_extra_data(
             subcategory_id, formatted_extra_data, offer.venue, is_from_private_api, offer=offer, ean=body.ean
         )
@@ -564,9 +551,8 @@ def update_offer(
     mandatory_extra_data_fields: typing.Collection[str],
     venue: offerers_models.Venue | None = None,
     offerer_address: offerers_models.OffererAddress | None = None,
+    venue_provider: providers_models.VenueProvider | None = None,
 ) -> models.Offer:
-    validation.check_validation_status(offer)
-
     fields: dict[str, typing.Any] = {
         "audioDisabilityCompliant": audio_disability_compliant,
         "bookingAllowedDatetime": booking_allowed_datetime,
@@ -592,76 +578,29 @@ def update_offer(
         "withdrawalType": withdrawal_type,
     }
     fields = {key: value for key, value in fields.items() if value is not UNCHANGED}
-
     if venue:
         fields["venue"] = venue
-
     if offerer_address:
         fields["offererAddress"] = offerer_address
 
-    updates = {key: value for key, value in fields.items() if getattr(offer, key) != value}
-    updates_set = set(updates)
+    validation.check_can_update_offer(
+        offer,
+        fields,
+        mandatory_extra_data_fields=mandatory_extra_data_fields,
+        venue_provider=venue_provider,
+    )
 
-    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[updates.get("subcategoryId", offer.subcategoryId)]
+    updates = {key: value for key, value in fields.items() if getattr(offer, key) != value}
 
     if not updates:
         return offer
 
+    updates_set = set(updates)
+
     if "bookingAllowedDatetime" in updates:
-        bookingAllowedDatetime = get_field(offer, updates, "bookingAllowedDatetime")
-        if not bookingAllowedDatetime or (bookingAllowedDatetime <= datetime.datetime.now(datetime.UTC)):
+        new_booking_allowed_datetime = updates["bookingAllowedDatetime"]
+        if not new_booking_allowed_datetime or (new_booking_allowed_datetime <= datetime.datetime.now(datetime.UTC)):
             reminders_notifications.notify_users_offer_is_bookable(offer)
-
-    if (
-        "audioDisabilityCompliant" in updates
-        or "mentalDisabilityCompliant" in updates
-        or "motorDisabilityCompliant" in updates
-        or "visualDisabilityCompliant" in updates
-    ):
-        validation.check_accessibility_compliance(
-            audio_disability_compliant=get_field(offer, updates, "audioDisabilityCompliant"),
-            mental_disability_compliant=get_field(offer, updates, "mentalDisabilityCompliant"),
-            motor_disability_compliant=get_field(offer, updates, "motorDisabilityCompliant"),
-            visual_disability_compliant=get_field(offer, updates, "visualDisabilityCompliant"),
-        )
-
-    if "extraData" in updates or "ean" in updates:
-        formatted_extra_data = _format_extra_data(subcategory.id, fields.get("extraData")) or {}
-        validation.check_extra_data(
-            formatted_extra_data,
-            offer.venue,
-            mandatory_extra_data_fields,
-            offer=offer,
-            ean=fields.get("ean"),
-        )
-
-    if "isDuo" in updates:
-        validation.check_is_duo_compliance(get_field(offer, updates, "isDuo"), subcategory)
-
-    if "idAtProvider" in updates:
-        updated_id_at_provider = get_field(offer, updates, "idAtProvider")
-        validation.check_can_input_id_at_provider(offer.lastProvider, updated_id_at_provider)
-        validation.check_can_input_id_at_provider_for_this_venue(offer.venueId, updated_id_at_provider, offer.id)
-
-    if "name" in updates:
-        updated_name = get_field(offer, updates, "name")
-        if updated_name is None:
-            raise exceptions.OfferException({"name": ["cannot be null"]})
-        validation.check_offer_name_does_not_contain_ean(updated_name)
-
-    if (
-        "withdrawalType" in updates
-        or "withdrawalDelay" in updates
-        or "withdrawalDetails" in updates
-        or "bookingContact" in updates
-    ):
-        validation.check_offer_withdrawal(
-            withdrawal_type=get_field(offer, updates, "withdrawalType"),
-            withdrawal_delay=get_field(offer, updates, "withdrawalDelay"),
-            subcategory_id=subcategory.id,
-            booking_contact=get_field(offer, updates, "bookingContact"),
-            provider=offer.lastProvider,
-        )
 
     try:
         updates["ean"] = updates["extraData"].pop("ean")
@@ -672,6 +611,7 @@ def update_offer(
         # Caller should use the `ean` argument instead of extra_data["ean"]
         # This seems to be ok today, but... lets wait a little bit before
         # doing anything stupid.
+        # update 06/08/2026 : found warning https://console.cloud.google.com/logs/query;cursorTimestamp=2026-06-26T06:36:36.808331953Z;endTime=2026-08-06T09:51:01.625Z;query=jsonPayload.message:%22extracting%20EAN%20from%20extraData%20%2528use%20body.ean%20instead%2529%22%0Atimestamp%3D%222026-06-26T06:29:13.144607099Z%22%0AinsertId%3D%226l39mh05fg1z3sn9%22;startTime=2026-01-07T10:51:01.625Z?project=pc-backend-prd
         logger.warning(
             "update_offer: extracting EAN from extraData (use body.ean instead)",
             extra={"offer": offer.id, "ean": updates["ean"]},
@@ -679,19 +619,6 @@ def update_offer(
     except (KeyError, AttributeError):
         pass
 
-    # - The offer URL must not be removed if the offer has an online subcategory.
-    if offer.url and "url" in fields and fields["url"] is None:
-        offer_subcategory = subcategories.ALL_SUBCATEGORIES_DICT[offer.subcategoryId]
-        validation.check_url_is_coherent_with_subcategory(offer_subcategory, None)
-
-    if "subcategoryId" in updates and offer.status != models.OfferStatus.DRAFT:
-        raise exceptions.UnallowedUpdate("subcategoryId")
-
-    if "durationMinutes" in updates:
-        validation.check_offer_duration(get_field(offer, updates, "durationMinutes"))
-
-    if offer.lastProvider is not None:
-        validation.check_update_only_allowed_fields_for_offer_from_provider(updates_set, offer.lastProvider)
     if offer.is_soft_deleted():
         raise pc_object.DeletedRecordException()
 
@@ -702,16 +629,6 @@ def update_offer(
         changes[key] = {"oldValue": getattr(offer, key), "newValue": value}
         setattr(offer, key, value)
 
-    with db.session.no_autoflush:
-        # the creation process is splitted into several steps. URL and
-        # address might be set only in the end. Therefore, this
-        # validation is meaningless until the offer has been finalized.
-        if offer.status != models.OfferStatus.DRAFT:
-            validation.check_url_is_coherent_with_subcategory(offer.subcategory, offer.url)
-            validation.check_url_and_offererAddress_are_not_both_set(offer.url, offer.offererAddress)
-
-    if offer.isFromAllocine:
-        offer.fieldsUpdated = list(set(offer.fieldsUpdated) | updates_set)
     db.session.add(offer)
 
     # This log is used for analytics purposes.

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -539,31 +539,59 @@ def old_update_offer(
 
 def update_offer(
     offer: models.Offer,
-    body: schemas.UpdateOffer,
+    *,
+    audio_disability_compliant: bool | None | T_UNCHANGED = UNCHANGED,
+    booking_allowed_datetime: datetime.datetime | None | T_UNCHANGED = UNCHANGED,
+    booking_contact: str | None | T_UNCHANGED = UNCHANGED,
+    booking_email: str | None | T_UNCHANGED = UNCHANGED,
+    description: str | None | T_UNCHANGED = UNCHANGED,
+    duration_minutes: int | None | T_UNCHANGED = UNCHANGED,
+    ean: str | None | T_UNCHANGED = UNCHANGED,
+    external_ticket_office_url: str | None | T_UNCHANGED = UNCHANGED,
+    extra_data: models.OfferExtraData | dict[str, typing.Any] | None | T_UNCHANGED = UNCHANGED,
+    id_at_provider: str | None | T_UNCHANGED = UNCHANGED,
+    is_duo: bool | None | T_UNCHANGED = UNCHANGED,
+    mental_disability_compliant: bool | None | T_UNCHANGED = UNCHANGED,
+    motor_disability_compliant: bool | None | T_UNCHANGED = UNCHANGED,
+    name: str | None | T_UNCHANGED = UNCHANGED,
+    publication_datetime: datetime.datetime | None | T_UNCHANGED = UNCHANGED,
+    subcategory_id: str | T_UNCHANGED = UNCHANGED,
+    url: str | None | T_UNCHANGED = UNCHANGED,
+    visual_disability_compliant: bool | None | T_UNCHANGED = UNCHANGED,
+    withdrawal_delay: int | None | T_UNCHANGED = UNCHANGED,
+    withdrawal_details: str | None | T_UNCHANGED = UNCHANGED,
+    withdrawal_type: models.WithdrawalTypeEnum | None | T_UNCHANGED = UNCHANGED,
     venue: offerers_models.Venue | None = None,
     offerer_address: offerers_models.OffererAddress | None = None,
     is_from_private_api: bool = False,
 ) -> models.Offer:
     validation.check_validation_status(offer)
 
-    aliases = set(body.dict(by_alias=True))
-    fields = body.dict(by_alias=True, exclude_unset=True)
-    fields.pop("artistOfferLinks", None)
-    fields.pop("hasCulturalOutreachClaim", None)
-    artist_offer_links = body.artist_offer_links
-    has_cultural_outreach_claim = body.has_cultural_outreach_claim
-
-    # updated using the pro interface
-    if body.location:
-        offerer_address_from_body = get_or_create_offerer_address_from_address_body(
-            address_body=body.location, venue=offer.venue
-        )
-
-        if offerer_address_from_body is not None:
-            fields["offererAddress"] = offerer_address_from_body
-            fields.pop("location", None)
-
-    should_send_mail = fields.pop("shouldSendMail", False)
+    fields: dict[str, typing.Any] = {
+        "audioDisabilityCompliant": audio_disability_compliant,
+        "bookingAllowedDatetime": booking_allowed_datetime,
+        "bookingContact": booking_contact,
+        "bookingEmail": booking_email,
+        "description": description,
+        "durationMinutes": duration_minutes,
+        "ean": ean,
+        "externalTicketOfficeUrl": external_ticket_office_url,
+        "extraData": extra_data,
+        "idAtProvider": id_at_provider,
+        # an explicit `null` disables double bookings rather than clearing the field
+        "isDuo": bool(is_duo) if is_duo is not UNCHANGED else UNCHANGED,
+        "mentalDisabilityCompliant": mental_disability_compliant,
+        "motorDisabilityCompliant": motor_disability_compliant,
+        "name": name,
+        "publicationDatetime": publication_datetime,
+        "subcategoryId": subcategory_id,
+        "url": url,
+        "visualDisabilityCompliant": visual_disability_compliant,
+        "withdrawalDelay": withdrawal_delay,
+        "withdrawalDetails": withdrawal_details,
+        "withdrawalType": withdrawal_type,
+    }
+    fields = {key: value for key, value in fields.items() if value is not UNCHANGED}
 
     if venue:
         fields["venue"] = venue
@@ -574,48 +602,13 @@ def update_offer(
     updates = {key: value for key, value in fields.items() if getattr(offer, key) != value}
     updates_set = set(updates)
 
-    subcategory_id = updates.get("subcategoryId", offer.subcategoryId)
-    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
-
-    if artist_offer_links is not None:
-        validation.check_artist_offer_links(artist_offer_links, subcategory)
-        created_links, deleted_links = artist_api.upsert_artist_offer_links(artist_offer_links, offer)
-        db.session.expire(offer, ["artistOfferLinks"])
-
-        if deleted_links:
-            on_commit(
-                partial(
-                    logger.info,
-                    "Artist offer links have been deleted",
-                    extra={"offer_id": offer.id, "venue_id": offer.venueId, "links": [str(k) for k in deleted_links]},
-                    technical_message_id="offer.artistOfferLinks.deleted",
-                )
-            )
-        if created_links:
-            on_commit(
-                partial(
-                    logger.info,
-                    "Artist offer links have been created",
-                    extra={"offer_id": offer.id, "venue_id": offer.venueId, "links": [str(k) for k in created_links]},
-                    technical_message_id="offer.artistOfferLinks.created",
-                )
-            )
-
-    if has_cultural_outreach_claim is not None:
-        outreach = offer.culturalOutreach
-        is_currently_claimed = outreach is not None and outreach.claimedDatetime is not None
-        if has_cultural_outreach_claim != is_currently_claimed:
-            if outreach is None:
-                cultural_outreach_api.create_cultural_outreach_claim(offer)
-            else:
-                claim_datetime = get_naive_utc_now() if has_cultural_outreach_claim else None
-                cultural_outreach_api.update_cultural_outreach_claim(claim_datetime, offer)
+    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[updates.get("subcategoryId", offer.subcategoryId)]
 
     if not updates:
         return offer
 
     if "bookingAllowedDatetime" in updates:
-        bookingAllowedDatetime = get_field(offer, updates, "bookingAllowedDatetime", aliases=aliases)
+        bookingAllowedDatetime = get_field(offer, updates, "bookingAllowedDatetime")
         if not bookingAllowedDatetime or (bookingAllowedDatetime <= datetime.datetime.now(datetime.UTC)):
             reminders_notifications.notify_users_offer_is_bookable(offer)
 
@@ -626,32 +619,31 @@ def update_offer(
         or "visualDisabilityCompliant" in updates
     ):
         validation.check_accessibility_compliance(
-            audio_disability_compliant=get_field(offer, updates, "audioDisabilityCompliant", aliases=aliases),
-            mental_disability_compliant=get_field(offer, updates, "mentalDisabilityCompliant", aliases=aliases),
-            motor_disability_compliant=get_field(offer, updates, "motorDisabilityCompliant", aliases=aliases),
-            visual_disability_compliant=get_field(offer, updates, "visualDisabilityCompliant", aliases=aliases),
+            audio_disability_compliant=get_field(offer, updates, "audioDisabilityCompliant"),
+            mental_disability_compliant=get_field(offer, updates, "mentalDisabilityCompliant"),
+            motor_disability_compliant=get_field(offer, updates, "motorDisabilityCompliant"),
+            visual_disability_compliant=get_field(offer, updates, "visualDisabilityCompliant"),
         )
 
     if "extraData" in updates or "ean" in updates:
-        formatted_extra_data = _format_extra_data(subcategory_id, body.extra_data) or {}
+        formatted_extra_data = _format_extra_data(subcategory.id, fields.get("extraData")) or {}
         validation.check_offer_extra_data(
-            subcategory_id, formatted_extra_data, offer.venue, is_from_private_api, offer=offer, ean=body.ean
+            subcategory.id, formatted_extra_data, offer.venue, is_from_private_api, offer=offer, ean=fields.get("ean")
         )
 
     if "isDuo" in updates:
-        is_duo = get_field(offer, updates, "isDuo", aliases=aliases)
-        validation.check_is_duo_compliance(is_duo, subcategory)
+        validation.check_is_duo_compliance(get_field(offer, updates, "isDuo"), subcategory)
 
     if "idAtProvider" in updates:
-        id_at_provider = get_field(offer, updates, "idAtProvider", aliases=aliases)
-        validation.check_can_input_id_at_provider(offer.lastProvider, id_at_provider)
-        validation.check_can_input_id_at_provider_for_this_venue(offer.venueId, id_at_provider, offer.id)
+        updated_id_at_provider = get_field(offer, updates, "idAtProvider")
+        validation.check_can_input_id_at_provider(offer.lastProvider, updated_id_at_provider)
+        validation.check_can_input_id_at_provider_for_this_venue(offer.venueId, updated_id_at_provider, offer.id)
 
     if "name" in updates:
-        name = get_field(offer, updates, "name", aliases=aliases)
-        if name is None:
+        updated_name = get_field(offer, updates, "name")
+        if updated_name is None:
             raise exceptions.OfferException({"name": ["cannot be null"]})
-        validation.check_offer_name_does_not_contain_ean(name)
+        validation.check_offer_name_does_not_contain_ean(updated_name)
 
     if (
         "withdrawalType" in updates
@@ -659,14 +651,11 @@ def update_offer(
         or "withdrawalDetails" in updates
         or "bookingContact" in updates
     ):
-        booking_contact = get_field(offer, updates, "bookingContact", aliases=aliases)
-        withdrawal_delay = get_field(offer, updates, "withdrawalDelay", aliases=aliases)
-        withdrawal_type = get_field(offer, updates, "withdrawalType", aliases=aliases)
         validation.check_offer_withdrawal(
-            withdrawal_type=withdrawal_type,
-            withdrawal_delay=withdrawal_delay,
-            subcategory_id=subcategory_id,
-            booking_contact=booking_contact,
+            withdrawal_type=get_field(offer, updates, "withdrawalType"),
+            withdrawal_delay=get_field(offer, updates, "withdrawalDelay"),
+            subcategory_id=subcategory.id,
+            booking_contact=get_field(offer, updates, "bookingContact"),
             provider=offer.lastProvider,
         )
 
@@ -676,7 +665,7 @@ def update_offer(
         # TODO(jbaudet - 11/2025): remove this whole try/except in a
         # couple of weeks, after checking that this warning never
         # appears.
-        # Caller should use body.ean instead of body.extra_data["ean"]
+        # Caller should use the `ean` argument instead of extra_data["ean"]
         # This seems to be ok today, but... lets wait a little bit before
         # doing anything stupid.
         logger.warning(
@@ -687,7 +676,7 @@ def update_offer(
         pass
 
     # - The offer URL must not be removed if the offer has an online subcategory.
-    if offer.url and "url" in body.__fields_set__ and body.url is None:
+    if offer.url and "url" in fields and fields["url"] is None:
         offer_subcategory = subcategories.ALL_SUBCATEGORIES_DICT[offer.subcategoryId]
         validation.check_url_is_coherent_with_subcategory(offer_subcategory, None)
 
@@ -695,8 +684,7 @@ def update_offer(
         raise exceptions.UnallowedUpdate("subcategoryId")
 
     if "durationMinutes" in updates:
-        duration_minutes = get_field(offer, updates, "durationMinutes", aliases=aliases)
-        validation.check_duration_minutes(duration_minutes, is_from_private_api)
+        validation.check_duration_minutes(get_field(offer, updates, "durationMinutes"), is_from_private_api)
 
     if offer.lastProvider is not None:
         validation.check_update_only_allowed_fields_for_offer_from_provider(updates_set, offer.lastProvider)
@@ -705,9 +693,8 @@ def update_offer(
 
     changes = {}
     for key, value in updates.items():
-        if key == "extraData":
-            if offer.product:
-                continue
+        if key == "extraData" and offer.product:
+            continue
         changes[key] = {"oldValue": getattr(offer, key), "newValue": value}
         setattr(offer, key, value)
 
@@ -739,12 +726,6 @@ def update_offer(
             technical_message_id="offer.updated",
         )
     )
-
-    withdrawal_fields = {"bookingContact", "withdrawalDelay", "withdrawalDetails", "withdrawalType"}
-    withdrawal_updated = updates_set & withdrawal_fields
-    oa_updated = "offererAddress" in updates
-    if should_send_mail and (withdrawal_updated or oa_updated):
-        transactional_mails.send_email_for_each_ongoing_booking(offer)
 
     on_commit(
         partial(

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -623,76 +623,77 @@ def check_booking_limit_datetime(
 
 def check_can_update_offer(
     offer: models.Offer,
-    fields: dict[str, typing.Any],
+    updates: dict[str, typing.Any],
     *,
     mandatory_extra_data_fields: typing.Collection[str],
     venue_provider: providers_models.VenueProvider | None = None,
 ) -> None:
     check_validation_status(offer)
 
-    updates = {key for key, value in fields.items() if getattr(offer, key) != value}
     if not updates:
         return
 
+    updated_fields = set(updates)
+
     if offer.lastProvider is not None:
-        check_update_only_allowed_fields_for_offer_from_provider(updates, offer.lastProvider)
+        check_update_only_allowed_fields_for_offer_from_provider(updated_fields, offer.lastProvider)
 
     if "subcategoryId" in updates and offer.status != OfferStatus.DRAFT:
         raise exceptions.UnallowedUpdate("subcategoryId")
 
-    subcategory_id = get_field(offer, fields, "subcategoryId")
+    subcategory_id = get_field(offer, updates, "subcategoryId")
     subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
 
-    if updates & {
+    if updated_fields & {
         "audioDisabilityCompliant",
         "mentalDisabilityCompliant",
         "motorDisabilityCompliant",
         "visualDisabilityCompliant",
     }:
         check_accessibility_compliance(
-            audio_disability_compliant=get_field(offer, fields, "audioDisabilityCompliant"),
-            mental_disability_compliant=get_field(offer, fields, "mentalDisabilityCompliant"),
-            motor_disability_compliant=get_field(offer, fields, "motorDisabilityCompliant"),
-            visual_disability_compliant=get_field(offer, fields, "visualDisabilityCompliant"),
+            audio_disability_compliant=get_field(offer, updates, "audioDisabilityCompliant"),
+            mental_disability_compliant=get_field(offer, updates, "mentalDisabilityCompliant"),
+            motor_disability_compliant=get_field(offer, updates, "motorDisabilityCompliant"),
+            visual_disability_compliant=get_field(offer, updates, "visualDisabilityCompliant"),
         )
 
-    if updates & {"extraData", "ean"}:
+    if updated_fields & {"extraData", "ean"}:
         check_extra_data(
-            format_extra_data(subcategory_id, get_field(offer, fields, "extraData")) or {},
+            format_extra_data(subcategory_id, get_field(offer, updates, "extraData")) or {},
             offer.venue,
             mandatory_extra_data_fields,
             offer=offer,
-            ean=get_field(offer, fields, "ean"),
+            ean=get_field(offer, updates, "ean"),
         )
 
     if "isDuo" in updates:
-        check_is_duo_compliance(get_field(offer, fields, "isDuo"), subcategory)
+        check_is_duo_compliance(get_field(offer, updates, "isDuo"), subcategory)
 
     if "idAtProvider" in updates:
-        id_at_provider = get_field(offer, fields, "idAtProvider")
+        id_at_provider = get_field(offer, updates, "idAtProvider")
         check_can_input_id_at_provider(offer.lastProvider, id_at_provider)
         check_can_input_id_at_provider_for_this_venue(offer.venueId, id_at_provider, offer.id)
 
     if "name" in updates:
-        name = get_field(offer, fields, "name")
+        name = get_field(offer, updates, "name")
         if name is None:
             raise exceptions.OfferException({"name": ["cannot be null"]})
         check_offer_name_does_not_contain_ean(name)
 
-    if updates & {"withdrawalType", "withdrawalDelay", "withdrawalDetails", "bookingContact"}:
+    if updated_fields & {"withdrawalType", "withdrawalDelay", "withdrawalDetails", "bookingContact"}:
         check_offer_withdrawal(
-            withdrawal_type=get_field(offer, fields, "withdrawalType"),
-            withdrawal_delay=get_field(offer, fields, "withdrawalDelay"),
+            withdrawal_type=get_field(offer, updates, "withdrawalType"),
+            withdrawal_delay=get_field(offer, updates, "withdrawalDelay"),
             subcategory_id=subcategory_id,
-            booking_contact=get_field(offer, fields, "bookingContact"),
+            booking_contact=get_field(offer, updates, "bookingContact"),
             provider=offer.lastProvider,
             venue_provider=venue_provider,
         )
 
     if "durationMinutes" in updates:
-        check_offer_duration(get_field(offer, fields, "durationMinutes"))
+        check_offer_duration(get_field(offer, updates, "durationMinutes"))
 
-    resulting_url = get_field(offer, fields, "url")
+    resulting_url = get_field(offer, updates, "url")
 
     # the creation process is splitted into several steps. URL and
     # address might be set only in the end. Therefore, this validation is
@@ -700,7 +701,7 @@ def check_can_update_offer(
     # of an online offer, which can never be removed.
     if offer.status != OfferStatus.DRAFT:
         check_url_is_coherent_with_subcategory(subcategory, resulting_url)
-        check_url_and_offererAddress_are_not_both_set(resulting_url, get_field(offer, fields, "offererAddress"))
+        check_url_and_offererAddress_are_not_both_set(resulting_url, get_field(offer, updates, "offererAddress"))
     elif offer.url and resulting_url is None:
         check_url_is_coherent_with_subcategory(subcategory, None)
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -40,6 +40,7 @@ from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.routes.serialization import artist_serialize
 from pcapi.routes.serialization import stock_serialize as serialization
 from pcapi.utils import date
+from pcapi.utils.custom_keys import get_field
 from pcapi.utils.string import is_canonical_integer
 from pcapi.utils.string import to_camelcase
 
@@ -620,6 +621,104 @@ def check_booking_limit_datetime(
     return [beginning, booking_limit_datetime]
 
 
+def check_can_update_offer(
+    offer: models.Offer,
+    fields: dict[str, typing.Any],
+    *,
+    mandatory_extra_data_fields: typing.Collection[str],
+    venue_provider: providers_models.VenueProvider | None = None,
+) -> None:
+    check_validation_status(offer)
+
+    updates = {key for key, value in fields.items() if getattr(offer, key) != value}
+    if not updates:
+        return
+
+    if offer.lastProvider is not None:
+        check_update_only_allowed_fields_for_offer_from_provider(updates, offer.lastProvider)
+
+    if "subcategoryId" in updates and offer.status != OfferStatus.DRAFT:
+        raise exceptions.UnallowedUpdate("subcategoryId")
+
+    subcategory_id = get_field(offer, fields, "subcategoryId")
+    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
+
+    if updates & {
+        "audioDisabilityCompliant",
+        "mentalDisabilityCompliant",
+        "motorDisabilityCompliant",
+        "visualDisabilityCompliant",
+    }:
+        check_accessibility_compliance(
+            audio_disability_compliant=get_field(offer, fields, "audioDisabilityCompliant"),
+            mental_disability_compliant=get_field(offer, fields, "mentalDisabilityCompliant"),
+            motor_disability_compliant=get_field(offer, fields, "motorDisabilityCompliant"),
+            visual_disability_compliant=get_field(offer, fields, "visualDisabilityCompliant"),
+        )
+
+    if updates & {"extraData", "ean"}:
+        check_extra_data(
+            format_extra_data(subcategory_id, get_field(offer, fields, "extraData")) or {},
+            offer.venue,
+            mandatory_extra_data_fields,
+            offer=offer,
+            ean=get_field(offer, fields, "ean"),
+        )
+
+    if "isDuo" in updates:
+        check_is_duo_compliance(get_field(offer, fields, "isDuo"), subcategory)
+
+    if "idAtProvider" in updates:
+        id_at_provider = get_field(offer, fields, "idAtProvider")
+        check_can_input_id_at_provider(offer.lastProvider, id_at_provider)
+        check_can_input_id_at_provider_for_this_venue(offer.venueId, id_at_provider, offer.id)
+
+    if "name" in updates:
+        name = get_field(offer, fields, "name")
+        if name is None:
+            raise exceptions.OfferException({"name": ["cannot be null"]})
+        check_offer_name_does_not_contain_ean(name)
+
+    if updates & {"withdrawalType", "withdrawalDelay", "withdrawalDetails", "bookingContact"}:
+        check_offer_withdrawal(
+            withdrawal_type=get_field(offer, fields, "withdrawalType"),
+            withdrawal_delay=get_field(offer, fields, "withdrawalDelay"),
+            subcategory_id=subcategory_id,
+            booking_contact=get_field(offer, fields, "bookingContact"),
+            provider=offer.lastProvider,
+            venue_provider=venue_provider,
+        )
+
+    if "durationMinutes" in updates:
+        check_offer_duration(get_field(offer, fields, "durationMinutes"))
+
+    resulting_url = get_field(offer, fields, "url")
+
+    # the creation process is splitted into several steps. URL and
+    # address might be set only in the end. Therefore, this validation is
+    # meaningless until the offer has been finalized, apart from the URL
+    # of an online offer, which can never be removed.
+    if offer.status != OfferStatus.DRAFT:
+        check_url_is_coherent_with_subcategory(subcategory, resulting_url)
+        check_url_and_offererAddress_are_not_both_set(resulting_url, get_field(offer, fields, "offererAddress"))
+    elif offer.url and resulting_url is None:
+        check_url_is_coherent_with_subcategory(subcategory, None)
+
+
+def format_extra_data(subcategory_id: str, extra_data: dict[str, typing.Any] | None) -> models.OfferExtraData | None:
+    """Keep only the fields that are defined in the subcategory conditional fields"""
+    if extra_data is None:
+        return None
+
+    formatted_extra_data: models.OfferExtraData = {}
+
+    for field_name in subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id].conditional_fields:
+        if extra_data.get(field_name):
+            formatted_extra_data[field_name] = extra_data.get(field_name)  # type: ignore[literal-required]
+
+    return formatted_extra_data
+
+
 def check_offer_extra_data(
     subcategory_id: str,
     extra_data: models.OfferExtraData | None,
@@ -736,8 +835,6 @@ def check_offer_duration(duration_minutes: int | None) -> None:
 
 
 def check_duration_minutes(duration_minutes: int | None, is_from_private_api: bool) -> None:
-    # TODO: only used when an offer is created. Drop this flag once offer
-    # creation translates the error at route level, as edition does.
     if is_from_private_api:
         check_offer_duration(duration_minutes)
         return

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 import logging
 import re
+import typing
 import warnings
 from io import BytesIO
 
@@ -627,11 +628,6 @@ def check_offer_extra_data(
     offer: models.Offer | None = None,
     ean: str | None = None,
 ) -> None:
-    errors = api_errors.ApiErrors()
-
-    if extra_data is None:
-        extra_data = {}
-
     subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
     mandatory_fields = [
         name
@@ -639,6 +635,21 @@ def check_offer_extra_data(
         if (is_from_private_api and conditional_field.is_required_in_internal_form)
         or (not is_from_private_api and conditional_field.is_required_in_external_form)
     ]
+    check_extra_data(extra_data, venue, mandatory_fields, offer=offer, ean=ean)
+
+
+def check_extra_data(
+    extra_data: models.OfferExtraData | None,
+    venue: offerers_models.Venue,
+    mandatory_fields: typing.Collection[str],
+    offer: models.Offer | None = None,
+    ean: str | None = None,
+) -> None:
+    errors = api_errors.ApiErrors()
+
+    if extra_data is None:
+        extra_data = {}
+
     for field in mandatory_fields:
         if field == "ean":
             if not ean:
@@ -709,24 +720,30 @@ def check_offer_name_does_not_contain_ean(offer_name: str) -> None:
         raise exceptions.OfferException({"name": ["Le titre d'une offre ne peut contenir l'EAN"]})
 
 
-def check_duration_minutes(duration_minutes: int | None, is_from_private_api: bool) -> None:
+DURATION_MINUTES_ERROR_MESSAGE = (
+    "La durée doit être inférieure à 24 heures. Pour les événements durant 24 heures ou plus "
+    "(par exemple, un pass festival de 3 jours), veuillez laisser ce champ vide."
+)
+EVENT_DURATION_ERROR_MESSAGE = (
+    "The duration must be under 1440 minutes (24 hours). For events lasting 24 hours or more "
+    "(e.g., a 3-day festival pass), please leave this field empty."
+)
+
+
+def check_offer_duration(duration_minutes: int | None) -> None:
     if duration_minutes and duration_minutes >= 24 * 60:
-        if is_from_private_api:
-            raise exceptions.OfferException(
-                {
-                    "durationMinutes": [
-                        "La durée doit être inférieure à 24 heures. Pour les événements durant 24 heures ou plus (par exemple, un pass festival de 3 jours), veuillez laisser ce champ vide."
-                    ]
-                }
-            )
-        else:
-            raise exceptions.OfferException(
-                {
-                    "eventDuration": [
-                        "The duration must be under 1440 minutes (24 hours). For events lasting 24 hours or more (e.g., a 3-day festival pass), please leave this field empty."
-                    ]
-                }
-            )
+        raise exceptions.OfferException({"durationMinutes": [DURATION_MINUTES_ERROR_MESSAGE]})
+
+
+def check_duration_minutes(duration_minutes: int | None, is_from_private_api: bool) -> None:
+    # TODO: only used when an offer is created. Drop this flag once offer
+    # creation translates the error at route level, as edition does.
+    if is_from_private_api:
+        check_offer_duration(duration_minutes)
+        return
+
+    if duration_minutes and duration_minutes >= 24 * 60:
+        raise exceptions.OfferException({"eventDuration": [EVENT_DURATION_ERROR_MESSAGE]})
 
 
 def _check_offer_has_product(offer: models.Offer | None) -> None:

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -477,7 +477,7 @@ def patch_offer(
         if "ean" in body_extra_data:
             updates["ean"] = body_extra_data.pop("ean")
         updates["extraData"] = body_extra_data
-    offers_api.update_offer(offer, offers_schemas.UpdateOffer(**updates), is_from_private_api=True)
+    offers_api.old_update_offer(offer, offers_schemas.UpdateOffer(**updates), is_from_private_api=True)
     db.session.flush()
     offer = offers_repository.get_offer_by_id(
         offer_id,

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -31,7 +31,6 @@ from pcapi.routes.public.services.authentication import api_key_required
 from pcapi.routes.public.services.authentication import current_api_key
 from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
-from pcapi.utils.custom_keys import get_field
 from pcapi.utils.transaction_manager import atomic
 
 from . import serialization
@@ -277,45 +276,39 @@ def edit_event(event_id: int, body: events_serializers.EventOfferEdition) -> eve
 
     try:
         updates = body.dict(by_alias=True, exclude_unset=True)
-        dc = updates.get("accessibility", {})
+        accessibility = updates.get("accessibility", {})
         extra_data = copy.deepcopy(offer.extraData)
 
-        publication_datetime = get_field(offer, updates, "publicationDatetime")
-        is_active = get_field(offer, updates, "isActive")
-
+        publication_datetime = updates.get("publicationDatetime", offer.publicationDatetime)
         # TODO(jbaudet): remove this part, do not use isActive once
         # the public API does not allow it anymore
         if "publicationDatetime" not in updates and updates.get("isActive") is not None:
-            publication_datetime = datetime.now(UTC) if is_active else None
+            publication_datetime = datetime.now(UTC) if updates["isActive"] else None
 
         offer = offers_api.update_offer(
             offer,
-            offers_schemas.UpdateOffer(
-                audioDisabilityCompliant=get_field(offer, dc, "audioDisabilityCompliant"),
-                mentalDisabilityCompliant=get_field(offer, dc, "mentalDisabilityCompliant"),
-                motorDisabilityCompliant=get_field(offer, dc, "motorDisabilityCompliant"),
-                visualDisabilityCompliant=get_field(offer, dc, "visualDisabilityCompliant"),
-                bookingContact=get_field(offer, updates, "bookingContact"),
-                bookingEmail=get_field(offer, updates, "bookingEmail"),
-                description=get_field(offer, updates, "description"),
-                durationMinutes=get_field(offer, updates, "eventDuration", col="durationMinutes"),
-                externalTicketOfficeUrl=get_field(offer, updates, "externalTicketOfficeUrl"),
-                ean=get_field(offer, updates, "ean"),
-                extraData=(
-                    serialization.deserialize_extra_data(
-                        body.category_related_fields, extra_data, venue_id=offer.venueId
-                    )
-                    if "categoryRelatedFields" in updates
-                    else extra_data
-                ),
-                publicationDatetime=publication_datetime,
-                idAtProvider=get_field(offer, updates, "idAtProvider"),
-                isDuo=get_field(offer, updates, "enableDoubleBookings", col="isDuo"),
-                withdrawalDetails=get_field(offer, updates, "itemCollectionDetails", col="withdrawalDetails"),
-                name=get_field(offer, updates, "name"),
-                url=body.location.url if isinstance(body.location, serialization.DigitalLocation) else None,
-                bookingAllowedDatetime=get_field(offer, updates, "bookingAllowedDatetime"),
-            ),  # type: ignore[call-arg]
+            audio_disability_compliant=accessibility.get("audioDisabilityCompliant", offers_api.UNCHANGED),
+            mental_disability_compliant=accessibility.get("mentalDisabilityCompliant", offers_api.UNCHANGED),
+            motor_disability_compliant=accessibility.get("motorDisabilityCompliant", offers_api.UNCHANGED),
+            visual_disability_compliant=accessibility.get("visualDisabilityCompliant", offers_api.UNCHANGED),
+            booking_allowed_datetime=updates.get("bookingAllowedDatetime", offers_api.UNCHANGED),
+            booking_contact=updates.get("bookingContact", offers_api.UNCHANGED),
+            booking_email=updates.get("bookingEmail", offers_api.UNCHANGED),
+            description=updates.get("description", offers_api.UNCHANGED),
+            duration_minutes=updates.get("eventDuration", offers_api.UNCHANGED),
+            ean=offer.ean,
+            external_ticket_office_url=updates.get("externalTicketOfficeUrl", offers_api.UNCHANGED),
+            extra_data=(
+                serialization.deserialize_extra_data(body.category_related_fields, extra_data, venue_id=offer.venueId)
+                if "categoryRelatedFields" in updates
+                else extra_data
+            ),
+            id_at_provider=updates.get("idAtProvider", offers_api.UNCHANGED),
+            is_duo=updates.get("enableDoubleBookings", offers_api.UNCHANGED),
+            name=updates.get("name", offers_api.UNCHANGED),
+            publication_datetime=publication_datetime,
+            url=body.location.url if isinstance(body.location, serialization.DigitalLocation) else None,
+            withdrawal_details=updates.get("itemCollectionDetails", offers_api.UNCHANGED),
             venue=venue,
             offerer_address=offerer_address,
         )

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -309,6 +309,7 @@ def edit_event(event_id: int, body: events_serializers.EventOfferEdition) -> eve
             publication_datetime=publication_datetime,
             url=body.location.url if isinstance(body.location, serialization.DigitalLocation) else None,
             withdrawal_details=updates.get("itemCollectionDetails", offers_api.UNCHANGED),
+            mandatory_extra_data_fields=utils.mandatory_extra_data_fields(offer.subcategoryId),
             venue=venue,
             offerer_address=offerer_address,
         )
@@ -319,7 +320,7 @@ def edit_event(event_id: int, body: events_serializers.EventOfferEdition) -> eve
             utils.update_or_delete_video(body.video_url, offer, current_api_key.provider.id)
 
     except offers_exceptions.OfferException as error:
-        raise api_errors.ApiErrors(error.errors)
+        raise api_errors.ApiErrors(utils.translate_offer_errors(error.errors))
 
     return events_serializers.EventOfferResponse.build_event_offer(offer)
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -269,8 +269,7 @@ def edit_event(event_id: int, body: events_serializers.EventOfferEdition) -> eve
     utils.log_offer_edition_without_last_provider(offer, body)
 
     venue, offerer_address = utils.extract_venue_and_offerer_address_from_location(body.location)
-    if venue:
-        authorization.get_venue_provider_or_raise_404(venue.id)
+    venue_provider = authorization.get_venue_provider_or_raise_404(venue.id if venue else offer.venueId)
 
     utils.check_offer_subcategory(body, offer.subcategoryId)
 
@@ -296,7 +295,6 @@ def edit_event(event_id: int, body: events_serializers.EventOfferEdition) -> eve
             booking_email=updates.get("bookingEmail", offers_api.UNCHANGED),
             description=updates.get("description", offers_api.UNCHANGED),
             duration_minutes=updates.get("eventDuration", offers_api.UNCHANGED),
-            ean=offer.ean,
             external_ticket_office_url=updates.get("externalTicketOfficeUrl", offers_api.UNCHANGED),
             extra_data=(
                 serialization.deserialize_extra_data(body.category_related_fields, extra_data, venue_id=offer.venueId)
@@ -312,6 +310,7 @@ def edit_event(event_id: int, body: events_serializers.EventOfferEdition) -> eve
             mandatory_extra_data_fields=utils.mandatory_extra_data_fields(offer.subcategoryId),
             venue=venue,
             offerer_address=offerer_address,
+            venue_provider=venue_provider,
         )
 
         if body.image:

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -551,8 +551,7 @@ def edit_product(body: products_serializers.ProductOfferEdition) -> serializatio
     utils.check_offer_subcategory(body, offer.subcategoryId)
 
     venue, offerer_address = utils.extract_venue_and_offerer_address_from_location(body.location)
-    if venue:
-        authorization.get_venue_provider_or_raise_404(venue.id)
+    venue_provider = authorization.get_venue_provider_or_raise_404(venue.id if venue else offer.venueId)
 
     updates = body.dict(by_alias=True, exclude_unset=True)
     accessibility = updates.get("accessibility", {})
@@ -590,6 +589,7 @@ def edit_product(body: products_serializers.ProductOfferEdition) -> serializatio
         mandatory_extra_data_fields=utils.mandatory_extra_data_fields(offer.subcategoryId),
         venue=venue,
         offerer_address=offerer_address,
+        venue_provider=venue_provider,
     )
     db.session.flush()
 

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -33,7 +33,6 @@ from pcapi.serialization.decorator import spectree_serialize
 from pcapi.serialization.spec_tree import ExtendResponse as SpectreeResponse
 from pcapi.utils import chunks as chunks_utils
 from pcapi.utils import image_conversion
-from pcapi.utils.custom_keys import get_field
 from pcapi.utils.transaction_manager import atomic
 
 from . import constants
@@ -556,41 +555,41 @@ def edit_product(body: products_serializers.ProductOfferEdition) -> serializatio
         authorization.get_venue_provider_or_raise_404(venue.id)
 
     updates = body.dict(by_alias=True, exclude_unset=True)
-    dc = updates.get("accessibility", {})
+    accessibility = updates.get("accessibility", {})
     extra_data = copy.deepcopy(offer.extraData)
 
-    publication_datetime = get_field(offer, updates, "publicationDatetime")
-    is_active = get_field(offer, updates, "isActive")
-
+    publication_datetime = updates.get("publicationDatetime", offer.publicationDatetime)
     # TODO(jbaudet): remove this part, do not use isActive once
     # the public API does not allow it anymore
     if "publicationDatetime" not in updates and updates.get("isActive") is not None:
-        publication_datetime = datetime.now(UTC) if is_active else None
+        publication_datetime = datetime.now(UTC) if updates["isActive"] else None
 
-    offer_body = offers_schemas.UpdateOffer(
-        name=get_field(offer, updates, "name"),
-        audioDisabilityCompliant=get_field(offer, dc, "audioDisabilityCompliant"),
-        mentalDisabilityCompliant=get_field(offer, dc, "mentalDisabilityCompliant"),
-        motorDisabilityCompliant=get_field(offer, dc, "motorDisabilityCompliant"),
-        visualDisabilityCompliant=get_field(offer, dc, "visualDisabilityCompliant"),
-        bookingContact=get_field(offer, updates, "bookingContact"),
-        bookingEmail=get_field(offer, updates, "bookingEmail"),
-        description=get_field(offer, updates, "description"),
-        externalTicketOfficeUrl=get_field(offer, updates, "externalTicketOfficeUrl"),
-        extraData=(
+    updated_offer = offers_api.update_offer(
+        offer,
+        audio_disability_compliant=accessibility.get("audioDisabilityCompliant", offers_api.UNCHANGED),
+        mental_disability_compliant=accessibility.get("mentalDisabilityCompliant", offers_api.UNCHANGED),
+        motor_disability_compliant=accessibility.get("motorDisabilityCompliant", offers_api.UNCHANGED),
+        visual_disability_compliant=accessibility.get("visualDisabilityCompliant", offers_api.UNCHANGED),
+        booking_allowed_datetime=updates.get("bookingAllowedDatetime", offers_api.UNCHANGED),
+        booking_contact=updates.get("bookingContact", offers_api.UNCHANGED),
+        booking_email=updates.get("bookingEmail", offers_api.UNCHANGED),
+        description=updates.get("description", offers_api.UNCHANGED),
+        external_ticket_office_url=updates.get("externalTicketOfficeUrl", offers_api.UNCHANGED),
+        extra_data=(
             serialization.deserialize_extra_data(
                 body.category_related_fields, extra_data, venue_id=venue.id if venue else None
             )
             if "categoryRelatedFields" in updates
             else extra_data
         ),
-        idAtProvider=get_field(offer, updates, "idAtProvider"),
-        isDuo=get_field(offer, updates, "enableDoubleBookings", col="isDuo"),
-        withdrawalDetails=get_field(offer, updates, "itemCollectionDetails", col="withdrawalDetails"),
-        publicationDatetime=publication_datetime,
-        bookingAllowedDatetime=get_field(offer, updates, "bookingAllowedDatetime"),
-    )  # type: ignore[call-arg]
-    updated_offer = offers_api.update_offer(offer, offer_body, venue=venue, offerer_address=offerer_address)
+        id_at_provider=updates.get("idAtProvider", offers_api.UNCHANGED),
+        is_duo=updates.get("enableDoubleBookings", offers_api.UNCHANGED),
+        name=updates.get("name", offers_api.UNCHANGED),
+        publication_datetime=publication_datetime,
+        withdrawal_details=updates.get("itemCollectionDetails", offers_api.UNCHANGED),
+        venue=venue,
+        offerer_address=offerer_address,
+    )
     db.session.flush()
 
     if body.image:

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -587,6 +587,7 @@ def edit_product(body: products_serializers.ProductOfferEdition) -> serializatio
         name=updates.get("name", offers_api.UNCHANGED),
         publication_datetime=publication_datetime,
         withdrawal_details=updates.get("itemCollectionDetails", offers_api.UNCHANGED),
+        mandatory_extra_data_fields=utils.mandatory_extra_data_fields(offer.subcategoryId),
         venue=venue,
         offerer_address=offerer_address,
     )

--- a/api/src/pcapi/routes/public/individual_offers/v1/utils.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/utils.py
@@ -1,8 +1,10 @@
 import logging
+import typing
 
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 
+from pcapi.core.categories import subcategories
 from pcapi.core.offerers import api as offerers_api
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers import schemas as offerers_schemas
@@ -301,3 +303,30 @@ def extract_venue_and_offerer_address_from_location(
         )
 
     return venue, offerer_address
+
+
+def mandatory_extra_data_fields(subcategory_id: str) -> set[str]:
+    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
+    return {
+        name
+        for name, conditional_field in subcategory.conditional_fields.items()
+        if conditional_field.is_required_in_external_form
+    }
+
+
+OFFER_ERRORS_TRANSLATIONS: dict[str, tuple[str, str]] = {
+    "durationMinutes": ("eventDuration", offers_validation.EVENT_DURATION_ERROR_MESSAGE),
+}
+
+
+def translate_offer_errors(errors: dict[str, typing.Any]) -> dict[str, typing.Any]:
+    """Reword the errors raised by `core` for the public API."""
+    translated = {}
+
+    for key, messages in errors.items():
+        if key in OFFER_ERRORS_TRANSLATIONS:
+            key, message = OFFER_ERRORS_TRANSLATIONS[key]
+            messages = [message]
+        translated[key] = messages
+
+    return translated

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -4,6 +4,7 @@ import decimal
 import logging
 import os
 import pathlib
+from unittest.mock import Mock
 from unittest.mock import call as mock_call
 from unittest.mock import patch
 
@@ -14,6 +15,7 @@ import time_machine
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.search.testing as search_testing
 from pcapi.connectors import acceslibre as acceslibre_connector
+from pcapi.connectors import api_adresse
 from pcapi.connectors.entreprise import models as sirene_models
 from pcapi.core import search
 from pcapi.core.bookings import factories as bookings_factories
@@ -3826,46 +3828,6 @@ class GetOffererConfidenceLevelTest:
 
 
 class OffererAddressTest:
-    @pytest.mark.parametrize(
-        "same_label,same_address, same_venue,",
-        [
-            [True, False, True],
-            [True, False, False],
-            [False, True, True],
-            [False, True, False],
-            [True, True, True],
-            [True, True, False],
-            [False, False, True],
-            [False, False, False],
-        ],
-    )
-    def test_get_or_create_offer_location(self, same_label, same_address, same_venue):
-        venue = offerers_factories.VenueFactory()
-        oa_1 = offerers_factories.OfferLocationFactory(
-            offerer=venue.managingOfferer, venue=venue, address=venue.offererAddress.address
-        )
-        other_address = geography_factories.AddressFactory(
-            street="1 rue de la paix",
-        )
-        other_venue = offerers_factories.VenueFactory()
-
-        oa_doppleganger = offerers_factories.OfferLocationFactory(
-            offerer=venue.managingOfferer, address=other_address, label="somethingdifferent"
-        )
-
-        oa_return = offerers_api.get_or_create_offer_location(
-            offerer_id=venue.managingOfferer.id,
-            venue_id=venue.id if same_venue else other_venue.id,
-            address_id=oa_1.address.id if same_address else other_address.id,
-            label=oa_1.label if same_label else "somethingdifferent",
-        )
-        if same_label and same_address and same_venue:
-            assert oa_return == oa_1
-        else:
-            assert oa_return.offerer == venue.managingOfferer
-            assert oa_return != oa_1
-        assert oa_return not in (venue.offererAddress, oa_doppleganger)
-
     @pytest.mark.parametrize("existant_address", [True, False])
     def test_get_or_create_address(self, existant_address):
         if existant_address:
@@ -3915,6 +3877,229 @@ class OffererAddressTest:
         offerers_factories.OfferLocationFactory(venue=venue, address=address, label=label)
         with pytest.raises(sa.exc.IntegrityError):
             offerers_factories.OfferLocationFactory(venue=venue, address=address, label=label)
+
+
+class GetOrCreateOfferLocationTest:
+    LABEL = "Salle Jean Vilar"
+
+    def create_offer_location(self, venue, **overrides):
+        defaults = {
+            "offerer": venue.managingOfferer,
+            "venue": venue,
+            "address": venue.offererAddress.address,
+            "label": self.LABEL,
+        }
+        return offerers_factories.OfferLocationFactory(**{**defaults, **overrides})
+
+    def test_should_reuse_the_location_matching_the_venue_the_address_and_the_label(self):
+        venue = offerers_factories.VenueFactory()
+        offer_location = self.create_offer_location(venue)
+
+        offerer_address = offerers_api.get_or_create_offer_location(
+            offerer_id=venue.managingOffererId,
+            venue_id=venue.id,
+            address_id=offer_location.addressId,
+            label=self.LABEL,
+        )
+
+        assert offerer_address == offer_location
+
+    def test_should_reuse_the_location_that_has_no_label(self):
+        venue = offerers_factories.VenueFactory()
+        offer_location = self.create_offer_location(venue, label=None)
+
+        offerer_address = offerers_api.get_or_create_offer_location(
+            offerer_id=venue.managingOffererId,
+            venue_id=venue.id,
+            address_id=offer_location.addressId,
+            label=None,
+        )
+
+        assert offerer_address == offer_location
+
+    def test_should_never_reuse_the_location_of_the_venue_itself(self):
+        venue = offerers_factories.VenueFactory()
+        assert venue.offererAddress.label is None
+
+        offerer_address = offerers_api.get_or_create_offer_location(
+            offerer_id=venue.managingOffererId,
+            venue_id=venue.id,
+            address_id=venue.offererAddress.addressId,
+            label=None,
+        )
+
+        assert offerer_address != venue.offererAddress
+        assert offerer_address.type == offerers_models.LocationType.OFFER_LOCATION
+
+    @pytest.mark.parametrize("differing_field", ["label", "address", "venue"])
+    def test_should_create_a_location_when_one_field_differs(self, differing_field):
+        venue = offerers_factories.VenueFactory()
+        offer_location = self.create_offer_location(venue)
+        kwargs = {
+            "offerer_id": venue.managingOffererId,
+            "venue_id": venue.id,
+            "address_id": offer_location.addressId,
+            "label": self.LABEL,
+        }
+
+        if differing_field == "label":
+            kwargs["label"] = "Petite salle"
+            expected_attr, expected_value = "label", "Petite salle"
+        elif differing_field == "address":
+            other_address = geography_factories.AddressFactory()
+            kwargs["address_id"] = other_address.id
+            expected_attr, expected_value = "addressId", other_address.id
+        else:
+            other_venue = offerers_factories.VenueFactory(managingOfferer=venue.managingOfferer)
+            kwargs["venue_id"] = other_venue.id
+            expected_attr, expected_value = "venueId", other_venue.id
+
+        offerer_address = offerers_api.get_or_create_offer_location(**kwargs)
+
+        assert offerer_address != offer_location
+        assert getattr(offerer_address, expected_attr) == expected_value
+
+    def test_should_create_the_location_with_the_requested_attributes(self):
+        venue = offerers_factories.VenueFactory()
+        address = geography_factories.AddressFactory()
+
+        offerer_address = offerers_api.get_or_create_offer_location(
+            offerer_id=venue.managingOffererId, venue_id=venue.id, address_id=address.id, label=self.LABEL
+        )
+
+        assert offerer_address.id
+        assert offerer_address.offererId == venue.managingOffererId
+        assert offerer_address.venueId == venue.id
+        assert offerer_address.addressId == address.id
+        assert offerer_address.label == self.LABEL
+        assert offerer_address.type == offerers_models.LocationType.OFFER_LOCATION
+
+
+class CreateOffererAddressFromAddressApiTest:
+    def build_address_body(self, **overrides):
+        defaults = {
+            "street": "1 rue de la Paix",
+            "city": "Paris",
+            "postalCode": "75002",
+            "inseeCode": "75102",
+            "banId": "75102_7560_00001",
+            "latitude": "48.8691",
+            "longitude": "2.3316",
+        }
+        return offerers_schemas.LocationModel(**{**defaults, **overrides})
+
+    @patch("pcapi.core.offerers.api.get_or_create_address")
+    def test_should_build_the_location_data_from_the_body(self, get_or_create_address):
+        address = offerers_api.create_offerer_address_from_address_api(self.build_address_body())
+
+        get_or_create_address.assert_called_once_with(
+            {
+                "city": "Paris",
+                "postal_code": "75002",
+                # the body carries them as strings, the address stores them as floats
+                "latitude": 48.8691,
+                "longitude": 2.3316,
+                "street": "1 rue de la Paix",
+                "insee_code": "75102",
+                "ban_id": "75102_7560_00001",
+            },
+            is_manual_edition=False,
+        )
+        assert address == get_or_create_address.return_value
+
+    @patch("pcapi.connectors.api_adresse.get_municipality_centroid")
+    @patch("pcapi.core.offerers.api.get_or_create_address")
+    def test_should_look_the_insee_code_up_when_the_address_is_manually_edited(
+        self, get_or_create_address, get_municipality_centroid
+    ):
+        get_municipality_centroid.return_value = Mock(citycode="75102")
+
+        offerers_api.create_offerer_address_from_address_api(
+            self.build_address_body(isManualEdition=True, inseeCode=None)
+        )
+
+        get_municipality_centroid.assert_called_once_with(city="Paris", postcode="75002")
+        assert get_or_create_address.call_args.args[0]["insee_code"] == "75102"
+
+    @patch("pcapi.core.offerers.api.get_or_create_address")
+    def test_should_drop_the_ban_id_when_the_address_is_manually_edited(self, get_or_create_address):
+        offerers_api.create_offerer_address_from_address_api(self.build_address_body(isManualEdition=True))
+
+        assert get_or_create_address.call_args.args[0]["ban_id"] is None
+        assert get_or_create_address.call_args.kwargs["is_manual_edition"] is True
+
+    @patch("pcapi.connectors.api_adresse.get_municipality_centroid")
+    @patch("pcapi.core.offerers.api.get_or_create_address")
+    def test_should_leave_the_insee_code_empty_when_the_municipality_cannot_be_found(
+        self, get_or_create_address, get_municipality_centroid
+    ):
+        get_municipality_centroid.side_effect = api_adresse.NoResultException()
+
+        offerers_api.create_offerer_address_from_address_api(self.build_address_body(isManualEdition=True))
+
+        assert get_or_create_address.call_args.args[0]["insee_code"] is None
+
+
+class GetOfferLocationFromAddressTest:
+    def build_address_body(self, **overrides):
+        defaults = {
+            "street": "1 rue de la Paix",
+            "city": "Paris",
+            "postalCode": "75002",
+            "latitude": 48.8691,
+            "longitude": 2.3316,
+            "label": "Salle Jean Vilar",
+        }
+
+        return offerers_schemas.LocationModel(**{**defaults, **overrides})
+
+    @patch("pcapi.core.offerers.api.create_offerer_address_from_address_api")
+    def test_should_create_the_address_from_the_body(self, create_offerer_address_from_address_api):
+        venue = offerers_factories.VenueFactory()
+        address_body = self.build_address_body()
+        create_offerer_address_from_address_api.return_value = geography_factories.AddressFactory()
+
+        offerers_api.get_offer_location_from_address(venue.managingOffererId, address_body, venue_id=venue.id)
+
+        create_offerer_address_from_address_api.assert_called_once_with(address_body)
+
+    @patch("pcapi.core.offerers.api.get_or_create_offer_location")
+    @patch("pcapi.core.offerers.api.create_offerer_address_from_address_api")
+    def test_should_create_an_offer_location_for_the_created_address(
+        self, create_offerer_address_from_address_api, get_or_create_offer_location
+    ):
+        venue = offerers_factories.VenueFactory()
+        address = geography_factories.AddressFactory()
+        create_offerer_address_from_address_api.return_value = address
+
+        offerer_address = offerers_api.get_offer_location_from_address(
+            venue.managingOffererId, self.build_address_body(), venue_id=venue.id
+        )
+
+        get_or_create_offer_location.assert_called_once_with(
+            offerer_id=venue.managingOffererId,
+            venue_id=venue.id,
+            address_id=address.id,
+            label="Salle Jean Vilar",
+        )
+        assert offerer_address == get_or_create_offer_location.return_value
+
+    @patch("pcapi.core.offerers.api.get_or_create_offer_location")
+    def test_should_turn_an_empty_label_into_no_label(self, get_or_create_offer_location):
+        venue = offerers_factories.VenueFactory()
+        address_body = self.build_address_body(label="")
+
+        offerers_api.get_offer_location_from_address(venue.managingOffererId, address_body, venue_id=venue.id)
+
+        assert get_or_create_offer_location.call_args.kwargs["label"] is None
+        # the body is edited in place, not copied
+        assert address_body.label is None
+
+    def test_should_refuse_a_missing_offerer(self):
+        venue = offerers_factories.VenueFactory()
+
+        with pytest.raises(AssertionError):
+            offerers_api.get_offer_location_from_address(0, self.build_address_body(), venue_id=venue.id)
 
 
 class SendReminderEmailToIndividualOfferersTest:

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1731,7 +1731,7 @@ class UpdateOfferTest:
 
         body = offers_schemas.UpdateOffer(isDuo=True, bookingEmail="new@example.com")
         with caplog.at_level(logging.DEBUG):
-            offer = api.update_offer(offer, body)
+            offer = api.old_update_offer(offer, body)
         db.session.flush()
 
         assert offer.isDuo
@@ -1760,7 +1760,7 @@ class UpdateOfferTest:
         offer = factories.OfferFactory(subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id)
         body = offers_schemas.UpdateOffer(extraData={"author": "Asimov"})
         with pytest.raises(api_errors.ApiErrors) as error:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         assert error.value.errors == {
             "showType": ["Ce champ est obligatoire"],
@@ -1773,7 +1773,7 @@ class UpdateOfferTest:
         )
         body = offers_schemas.UpdateOffer(extraData=None)
         with pytest.raises(api_errors.ApiErrors) as error:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
         assert error.value.errors == {
             "showType": ["Ce champ est obligatoire"],
             "showSubType": ["Ce champ est obligatoire"],
@@ -1787,7 +1787,7 @@ class UpdateOfferTest:
             subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
         )
         body = offers_schemas.UpdateOffer(name="New name", description="new Description")
-        offer = api.update_offer(offer, body)
+        offer = api.old_update_offer(offer, body)
         db.session.flush()
 
         assert offer.name == "New name"
@@ -1797,7 +1797,7 @@ class UpdateOfferTest:
         offer = factories.OfferFactory(name="Old name", ean="1234567890124")
         body = offers_schemas.UpdateOffer(name="Luftballons 1234567890124")
         with pytest.raises(exceptions.OfferException) as error:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         assert error.value.errors == {"name": ["Le titre d'une offre ne peut contenir l'EAN"]}
         assert db.session.query(models.Offer).one().name == "Old name"
@@ -1808,7 +1808,7 @@ class UpdateOfferTest:
             lastProvider=provider, name="Old name", subcategoryId=subcategories.SEANCE_CINE.id
         )
         body = offers_schemas.UpdateOffer(name="Old name", isDuo=True)
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         offer = db.session.query(models.Offer).one()
         assert offer.name == "Old name"
@@ -1821,7 +1821,7 @@ class UpdateOfferTest:
         )
         body = offers_schemas.UpdateOffer(durationMinutes=120, isDuo=True)
         with pytest.raises(api_errors.ApiErrors) as error:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         assert error.value.errors == {"durationMinutes": ["Vous ne pouvez pas modifier ce champ"]}
         offer = db.session.query(models.Offer).one()
@@ -1837,7 +1837,7 @@ class UpdateOfferTest:
             ean="1234567890124",
         )
         body = offers_schemas.UpdateOffer(externalTicketOfficeUrl="https://example.com")
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         offer = db.session.query(models.Offer).one()
         assert offer.name == "Old name"
@@ -1860,7 +1860,7 @@ class UpdateOfferTest:
             motorDisabilityCompliant=True,
             mentalDisabilityCompliant=False,
         )
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         offer = db.session.query(models.Offer).one()
         assert offer.name == "Old name"
@@ -1892,7 +1892,7 @@ class UpdateOfferTest:
             motorDisabilityCompliant=True,
             mentalDisabilityCompliant=False,
         )
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         offer = db.session.query(models.Offer).one()
         assert offer.name == "Old name"
@@ -1916,7 +1916,7 @@ class UpdateOfferTest:
             audioDisabilityCompliant=False,
         )
         with pytest.raises(api_errors.ApiErrors) as error:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         assert error.value.errors == {
             "durationMinutes": ["Vous ne pouvez pas modifier ce champ"],
@@ -1935,7 +1935,7 @@ class UpdateOfferTest:
         body = offers_schemas.UpdateOffer(name="Monologue")
 
         with pytest.raises(exceptions.OfferException) as error:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         assert error.value.errors == {
             "global": ["Les offres refusées ou en attente de validation ne sont pas modifiables"]
@@ -1953,7 +1953,7 @@ class UpdateOfferTest:
             ean="1234567890124",
         )
         body = offers_schemas.UpdateOffer(idAtProvider="some_id_at_provider")
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         offer = db.session.query(models.Offer).one()
         assert offer.name == "Offer linked to a provider"
@@ -1969,7 +1969,7 @@ class UpdateOfferTest:
             ean="1234567890124",
         )
         body = offers_schemas.UpdateOffer(ean="1234567890125")
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         offer = db.session.query(models.Offer).one()
         assert offer.ean == "1234567890125"
@@ -1980,7 +1980,7 @@ class UpdateOfferTest:
         providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
         offer = factories.EventOfferFactory(lastProvider=provider, name="Offer linked to a provider", ean=None)
         body = offers_schemas.UpdateOffer(ean=None)
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         offer = db.session.query(models.Offer).one()
         assert offer.ean == None
@@ -1993,7 +1993,7 @@ class UpdateOfferTest:
         )
         body = offers_schemas.UpdateOffer(idAtProvider="some_id_at_provider")
         with pytest.raises(exceptions.OfferException) as error:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         assert error.value.errors["idAtProvider"] == [
             "Une offre ne peut être créée ou éditée avec un idAtProvider si elle n'a pas de provider"
@@ -2022,7 +2022,7 @@ class UpdateOfferTest:
 
         body = offers_schemas.UpdateOffer(idAtProvider=id_at_provider)
         with pytest.raises(exceptions.OfferException) as error:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         assert error.value.errors["idAtProvider"] == ["`rolalala` is already taken by another venue offer"]
 
@@ -2043,10 +2043,10 @@ class UpdateOfferTest:
         body = offers_schemas.UpdateOffer(name="New name", offererAddress=offerer_address)
         if hasUrl:
             with pytest.raises(api_errors.ApiErrors) as error:
-                api.update_offer(offer, body)
+                api.old_update_offer(offer, body)
                 assert error.value.errors["offerUrl"] == ["Une offre numérique ne peut pas avoir d'adresse"]
         else:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
             offer = db.session.query(models.Offer).one()
             assert offer.offererAddress == offerer_address
 
@@ -2060,7 +2060,7 @@ class UpdateOfferTest:
         offer = factories.OfferFactory()
         body = offers_schemas.UpdateOffer()
 
-        updated_offer = api.update_offer(offer, body, offerer_address=new_offerer_address)
+        updated_offer = api.old_update_offer(offer, body, offerer_address=new_offerer_address)
 
         db.session.commit()
         db.session.refresh(updated_offer)
@@ -2081,7 +2081,7 @@ class UpdateOfferTest:
         )
         body = offers_schemas.UpdateOffer()
 
-        updated_offer = api.update_offer(offer, body, venue=new_venue, offerer_address=new_offerer_address)
+        updated_offer = api.old_update_offer(offer, body, venue=new_venue, offerer_address=new_offerer_address)
 
         db.session.commit()
         db.session.refresh(updated_offer)
@@ -2106,7 +2106,7 @@ class UpdateOfferTest:
 
         body = offers_schemas.UpdateOffer(bookingAllowedDatetime=bookingAllowedDatetime)
 
-        updated_offer = api.update_offer(offer, body)
+        updated_offer = api.old_update_offer(offer, body)
         assert len(notify_users_offer_is_bookable_mock.mock_calls) == expected_calls_count
         assert updated_offer.bookingAllowedDatetime == bookingAllowedDatetime
 
@@ -2128,7 +2128,7 @@ class UpdateOfferTest:
             withdrawalType=models.WithdrawalTypeEnum.IN_APP,
         )
 
-        api.update_offer(draft_offer, body)
+        api.old_update_offer(draft_offer, body)
 
         mock_check_is_duo.assert_called_once()
         call_args = mock_check_is_duo.call_args
@@ -2147,7 +2147,7 @@ class UpdateOfferTest:
         offer = factories.OfferFactory()
         body = offers_schemas.UpdateOffer(name="Updated Name")
 
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         mock_upsert_artist_offer_links.assert_not_called()
 
@@ -2164,7 +2164,7 @@ class UpdateOfferTest:
         ]
         body = offers_schemas.UpdateOffer(artistOfferLinks=artist_offer_links)
 
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         mock_upsert_artist_offer_links.assert_called_once_with(
             [
@@ -2188,7 +2188,7 @@ class UpdateOfferTest:
         body = offers_schemas.UpdateOffer(artistOfferLinks=artist_offer_links)
 
         with pytest.raises(api_errors.ApiErrors) as error:
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         assert error.value.errors == {
             "artistOfferLinks": ["Le type d'artiste n'est pas autorisé pour cette sous catégorie"]
@@ -2209,10 +2209,10 @@ class UpdateOfferTest:
             }
         ]
         body = offers_schemas.UpdateOffer(artistOfferLinks=artist_offer_links)
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         with caplog.at_level(logging.INFO):
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         deletion_logs = [
             record for record in caplog.records if "Artist offer links have been deleted" in record.message
@@ -2243,10 +2243,10 @@ class UpdateOfferTest:
             }
         ]
         body = offers_schemas.UpdateOffer(artistOfferLinks=artist_offer_links)
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         with caplog.at_level(logging.INFO):
-            api.update_offer(offer, body)
+            api.old_update_offer(offer, body)
 
         creation_logs = [
             record for record in caplog.records if "Artist offer links have been created" in record.message
@@ -2269,7 +2269,7 @@ class UpdateOfferTest:
         cultural_outreach_factories.CulturalOutreachFactory(offer=offer)
 
         body = offers_schemas.UpdateOffer(hasCulturalOutreachClaim=True)
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         mocked_update_claim.assert_called_once_with(datetime(2026, 4, 21, 12, 0, 0), offer)
 
@@ -2280,7 +2280,7 @@ class UpdateOfferTest:
         cultural_outreach_factories.ClaimedCulturalOutreachFactory(offer=offer)
 
         body = offers_schemas.UpdateOffer(hasCulturalOutreachClaim=True)
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         mocked_update_claim.assert_not_called()
 
@@ -2290,7 +2290,7 @@ class UpdateOfferTest:
         cultural_outreach_factories.ClaimedCulturalOutreachFactory(offer=offer)
 
         body = offers_schemas.UpdateOffer(hasCulturalOutreachClaim=False)
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         mocked_update_claim.assert_called_once_with(None, offer)
 
@@ -2299,7 +2299,7 @@ class UpdateOfferTest:
         offer = factories.OfferFactory(subcategoryId=subcategories.ESCAPE_GAME.id)
 
         body = offers_schemas.UpdateOffer(hasCulturalOutreachClaim=True)
-        api.update_offer(offer, body)
+        api.old_update_offer(offer, body)
 
         mocked_create_claim.assert_called_once_with(offer)
 

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -1722,7 +1722,7 @@ class CreateOfferTest:
 
 
 @pytest.mark.usefixtures("db_session")
-class UpdateOfferTest:
+class OldUpdateOfferTest:
     @mock.patch("pcapi.core.search.async_index_offer_ids")
     def test_basics(self, mocked_async_index_offer_ids, caplog):
         offer = factories.OfferFactory(
@@ -2302,6 +2302,209 @@ class UpdateOfferTest:
         api.old_update_offer(offer, body)
 
         mocked_create_claim.assert_called_once_with(offer)
+
+
+@pytest.mark.usefixtures("db_session")
+class UpdateOfferTest:
+    FROZEN_NOW = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
+
+    @pytest.fixture(name="venue_provider")
+    def venue_provider_fixture(self):
+        return providers_factories.VenueProviderFactory()
+
+    def build_offer(self, **overrides):
+        """approved, provider-less, physical offer that passes every check."""
+        defaults = {
+            "subcategoryId": subcategories.ESCAPE_GAME.id,
+            "name": "Les Quatre Cents Coups",
+            "bookingEmail": "old@example.com",
+            "isDuo": False,
+        }
+        # `overrides` always win including when it passes `None`
+        return factories.OfferFactory(**{**defaults, **overrides})
+
+    @mock.patch("pcapi.core.offers.validation.check_can_update_offer")
+    def test_should_delegate_the_validation(self, check_can_update_offer, venue_provider):
+        offer = self.build_offer()
+
+        api.update_offer(
+            offer,
+            name="Jules et Jim",
+            booking_email="new@example.com",
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        check_can_update_offer.assert_called_once_with(
+            offer,
+            {"bookingEmail": "new@example.com", "name": "Jules et Jim"},
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+    def test_should_write_the_fields_that_change(self, venue_provider):
+        offer = self.build_offer()
+
+        api.update_offer(
+            offer,
+            name="Jules et Jim",
+            booking_email="new@example.com",
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+        db.session.flush()
+
+        assert offer.name == "Jules et Jim"
+        assert offer.bookingEmail == "new@example.com"
+
+    def test_should_write_a_field_explicitly_set_to_none(self, venue_provider):
+        offer = self.build_offer(withdrawalDetails="À retirer à la caisse")
+
+        api.update_offer(
+            offer, withdrawal_details=None, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+        db.session.flush()
+
+        assert offer.withdrawalDetails is None
+
+    @pytest.mark.parametrize("is_duo,expected", [(False, False), (None, False)])
+    def test_should_coerce_is_duo_to_a_boolean(self, venue_provider, is_duo, expected):
+        # `null` disables double bookings rather than clearing the column
+        offer = self.build_offer(isDuo=True)
+
+        api.update_offer(offer, is_duo=is_duo, mandatory_extra_data_fields=set(), venue_provider=venue_provider)
+        db.session.flush()
+
+        assert offer.isDuo is expected
+
+    def test_should_move_the_offer_to_another_venue(self, venue_provider):
+        offer = self.build_offer()
+        other_venue = offerers_factories.VenueFactory()
+
+        api.update_offer(offer, venue=other_venue, mandatory_extra_data_fields=set(), venue_provider=venue_provider)
+        db.session.flush()
+
+        assert offer.venueId == other_venue.id
+
+    def test_should_not_clear_venue_and_offerer_address(self, venue_provider):
+        offer = self.build_offer()
+        venue_id = offer.venueId
+
+        api.update_offer(
+            offer,
+            venue=None,
+            offerer_address=None,
+            name="Jules et Jim",
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+        db.session.flush()
+
+        assert offer.venueId == venue_id
+        assert offer.offererAddress is not None
+
+    @mock.patch("pcapi.core.search.async_index_offer_ids")
+    def test_should_return_early_when_no_field_changes(self, mocked_async_index_offer_ids, venue_provider, caplog):
+        offer = self.build_offer()
+        date_updated = offer.dateUpdated
+
+        with caplog.at_level(logging.INFO):
+            api.update_offer(offer, name=offer.name, mandatory_extra_data_fields=set(), venue_provider=venue_provider)
+        db.session.flush()
+
+        assert offer.dateUpdated == date_updated
+        mocked_async_index_offer_ids.assert_not_called()
+        update_logs = [
+            record for record in caplog.records if getattr(record, "technical_message_id", None) == "offer.updated"
+        ]
+        assert not update_logs
+
+    @pytest.mark.parametrize(
+        "booking_allowed_datetime",
+        [None, FROZEN_NOW - timedelta(days=1)],
+        ids=["cleared", "in the past"],
+    )
+    @time_machine.travel(FROZEN_NOW, tick=False)
+    @mock.patch("pcapi.core.reminders.external.reminders_notifications.notify_users_offer_is_bookable")
+    def test_should_notify_users_when_bookings_open_immediately(
+        self, notify_users, venue_provider, booking_allowed_datetime
+    ):
+        offer = self.build_offer(bookingAllowedDatetime=self.FROZEN_NOW.replace(tzinfo=None) + timedelta(days=1))
+
+        api.update_offer(
+            offer,
+            booking_allowed_datetime=booking_allowed_datetime,
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        notify_users.assert_called_once_with(offer)
+
+    @time_machine.travel(FROZEN_NOW, tick=False)
+    @mock.patch("pcapi.core.reminders.external.reminders_notifications.notify_users_offer_is_bookable")
+    def test_should_not_notify_users_when_bookings_open_later(self, notify_users, venue_provider):
+        offer = self.build_offer()
+
+        api.update_offer(
+            offer,
+            booking_allowed_datetime=self.FROZEN_NOW + timedelta(days=1),
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        notify_users.assert_not_called()
+
+    def test_should_move_an_ean_found_in_extra_data_to_its_own_column(self, venue_provider):
+        offer = self.build_offer(subcategoryId=subcategories.LIVRE_PAPIER.id, extraData={"author": "Truffaut"})
+
+        api.update_offer(
+            offer,
+            extra_data={"author": "Truffaut", "ean": "9782070100002"},
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+        db.session.flush()
+
+        assert offer.ean == "9782070100002"
+        assert "ean" not in offer.extraData
+
+    def test_should_log_the_changed_fields(self, venue_provider, caplog):
+        offer = self.build_offer()
+
+        with caplog.at_level(logging.INFO):
+            api.update_offer(
+                offer,
+                name="Jules et Jim",
+                booking_email="new@example.com",
+                mandatory_extra_data_fields=set(),
+                venue_provider=venue_provider,
+            )
+
+        [update_log] = [
+            record for record in caplog.records if getattr(record, "technical_message_id", None) == "offer.updated"
+        ]
+        assert update_log.extra["changes"] == {
+            "name": {"oldValue": "Les Quatre Cents Coups", "newValue": "Jules et Jim"},
+            "bookingEmail": {"oldValue": "old@example.com", "newValue": "new@example.com"},
+        }
+
+    @mock.patch("pcapi.core.search.async_index_offer_ids")
+    def test_should_reindex_the_offer(self, mocked_async_index_offer_ids, venue_provider):
+        offer = self.build_offer()
+
+        api.update_offer(
+            offer,
+            name="Jules et Jim",
+            booking_email="new@example.com",
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        mocked_async_index_offer_ids.assert_called_once_with(
+            [offer.id],
+            reason=IndexationReason.OFFER_UPDATE,
+            log_extra={"changes": {"name", "bookingEmail"}},
+        )
 
 
 now_datetime_with_tz = datetime.now(UTC)
@@ -3969,22 +4172,6 @@ class DeleteStocksTest:
         # This call should not have modified the stock deletion because another process should
         # have updated them already.
         assert all(not stock.isSoftDeleted for stock in stocks)
-
-
-class FormatExtraDataTest:
-    def test_format_extra_data(self):
-        extra_data = {
-            "musicType": "-1",  # applicable and filled
-            "musicSubType": "100",  # applicable and filled
-            "gtl_id": "19000000",  # applicable and filled in deserializer
-            "other": "value",  # not applicable field
-            "performer": "",  # applicable but empty
-        }
-        assert api._format_extra_data(subcategories.FESTIVAL_MUSIQUE.id, extra_data) == {
-            "musicType": "-1",
-            "musicSubType": "100",
-            "gtl_id": "19000000",
-        }
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -2332,6 +2332,7 @@ class UpdateOfferTest:
             offer,
             name="Jules et Jim",
             booking_email="new@example.com",
+            is_duo=False,
             mandatory_extra_data_fields=set(),
             venue_provider=venue_provider,
         )
@@ -2404,8 +2405,11 @@ class UpdateOfferTest:
         assert offer.venueId == venue_id
         assert offer.offererAddress is not None
 
+    @mock.patch("pcapi.core.offers.validation.check_can_update_offer")
     @mock.patch("pcapi.core.search.async_index_offer_ids")
-    def test_should_return_early_when_no_field_changes(self, mocked_async_index_offer_ids, venue_provider, caplog):
+    def test_should_return_early_when_no_field_changes(
+        self, mocked_async_index_offer_ids, check_can_update_offer, venue_provider, caplog
+    ):
         offer = self.build_offer()
         date_updated = offer.dateUpdated
 
@@ -2414,6 +2418,9 @@ class UpdateOfferTest:
         db.session.flush()
 
         assert offer.dateUpdated == date_updated
+        check_can_update_offer.assert_called_once_with(
+            offer, {}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
         mocked_async_index_offer_ids.assert_not_called()
         update_logs = [
             record for record in caplog.records if getattr(record, "technical_message_id", None) == "offer.updated"
@@ -2454,20 +2461,6 @@ class UpdateOfferTest:
         )
 
         notify_users.assert_not_called()
-
-    def test_should_move_an_ean_found_in_extra_data_to_its_own_column(self, venue_provider):
-        offer = self.build_offer(subcategoryId=subcategories.LIVRE_PAPIER.id, extraData={"author": "Truffaut"})
-
-        api.update_offer(
-            offer,
-            extra_data={"author": "Truffaut", "ean": "9782070100002"},
-            mandatory_extra_data_fields=set(),
-            venue_provider=venue_provider,
-        )
-        db.session.flush()
-
-        assert offer.ean == "9782070100002"
-        assert "ean" not in offer.extraData
 
     def test_should_log_the_changed_fields(self, venue_provider, caplog):
         offer = self.build_offer()

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -34,6 +34,7 @@ import pcapi.core.finance.models as finance_models
 import pcapi.core.mails.testing as mails_testing
 import pcapi.core.offerers.factories as offerers_factories
 import pcapi.core.offerers.models as offerers_models
+import pcapi.core.offerers.schemas as offerers_schemas
 import pcapi.core.providers.factories as providers_factories
 import pcapi.core.providers.repository as providers_repository
 import pcapi.core.reactions.factories as reactions_factories
@@ -2505,6 +2506,45 @@ class UpdateOfferTest:
             reason=IndexationReason.OFFER_UPDATE,
             log_extra={"changes": {"name", "bookingEmail"}},
         )
+
+
+@pytest.mark.usefixtures("db_session")
+class GetOrCreateOffererAddressFromAddressBodyTest:
+    @mock.patch("pcapi.core.offerers.api.get_or_create_offer_location")
+    def test_should_reuse_the_venue_address_when_the_offer_is_located_on_the_venue(self, get_or_create_offer_location):
+        venue = offerers_factories.VenueFactory()
+
+        offerer_address = api.get_or_create_offerer_address_from_address_body(
+            offerers_schemas.LocationOnlyOnVenueModel(), venue
+        )
+
+        # no label, so the offer is not tied to the venue location itself
+        get_or_create_offer_location.assert_called_once_with(
+            offerer_id=venue.managingOffererId,
+            venue_id=venue.id,
+            address_id=venue.offererAddress.addressId,
+            label=None,
+        )
+        assert offerer_address == get_or_create_offer_location.return_value
+
+    @mock.patch("pcapi.core.offerers.api.get_offer_location_from_address")
+    def test_should_build_a_location_from_the_address_when_one_is_sent(self, get_offer_location_from_address):
+        venue = offerers_factories.VenueFactory()
+        address_body = offerers_schemas.LocationModel(
+            street="1 rue de la Paix",
+            city="Paris",
+            postalCode="75002",
+            latitude=48.8691,
+            longitude=2.3316,
+            label="Salle Jean Vilar",
+        )
+
+        offerer_address = api.get_or_create_offerer_address_from_address_body(address_body, venue)
+
+        get_offer_location_from_address.assert_called_once_with(
+            venue.managingOffererId, address_body, venue_id=venue.id
+        )
+        assert offerer_address == get_offer_location_from_address.return_value
 
 
 now_datetime_with_tz = datetime.now(UTC)

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -1553,20 +1553,10 @@ class CheckCanUpdateOfferTest:
 
         check_validation_status.assert_called_once_with(offer)
 
-    @pytest.mark.parametrize(
-        "fields",
-        [
-            {},
-            {"name": "Les Quatre Cents Coups", "durationMinutes": 99},
-        ],
-        ids=["empty body", "values equal to the offer's"],
-    )
-    def test_should_return_early_when_no_field_changes(self, fields, venue_provider):
+    def test_should_return_early_when_there_is_no_update(self, venue_provider):
         offer = self.build_offer(offererAddress=None)
 
-        validation.check_can_update_offer(
-            offer, fields, mandatory_extra_data_fields=set(), venue_provider=venue_provider
-        )
+        validation.check_can_update_offer(offer, {}, mandatory_extra_data_fields=set(), venue_provider=venue_provider)
 
     @pytest.mark.parametrize(
         "changed_field,expected_key",
@@ -1646,16 +1636,6 @@ class CheckCanUpdateOfferTest:
         )
 
         assert check_extra_data.call_args.args[0] == {}
-
-    @mock.patch("pcapi.core.offers.validation.check_extra_data")
-    def test_should_not_check_extra_data_when_it_does_not_change(self, check_extra_data, venue_provider):
-        offer = self.build_offer()
-
-        validation.check_can_update_offer(
-            offer, {"extraData": offer.extraData}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
-        )
-
-        check_extra_data.assert_not_called()
 
     @mock.patch("pcapi.core.offers.validation.check_is_duo_compliance")
     def test_should_check_duo_compliance_against_the_offer_subcategory(self, check_is_duo_compliance, venue_provider):

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -2,6 +2,7 @@ import datetime
 import pathlib
 import types
 from decimal import Decimal
+from unittest import mock
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -1267,3 +1268,532 @@ class CheckArtistOfferLinksTest:
         assert exc.value.errors == {
             "artistOfferLinks": ["Le type d'artiste n'est pas autorisé pour cette sous catégorie"]
         }
+
+
+class CheckAccessibilityComplianceTest:
+    @pytest.mark.parametrize(
+        "missing_field",
+        [
+            "audio_disability_compliant",
+            "mental_disability_compliant",
+            "motor_disability_compliant",
+            "visual_disability_compliant",
+        ],
+    )
+    def test_should_raise_when_any_single_field_is_none(self, missing_field):
+        fields = {
+            "audio_disability_compliant": True,
+            "mental_disability_compliant": True,
+            "motor_disability_compliant": True,
+            "visual_disability_compliant": True,
+        }
+        fields[missing_field] = None
+
+        with pytest.raises(exceptions.OfferException) as error:
+            validation.check_accessibility_compliance(**fields)
+
+        assert error.value.errors == {"global": ["L’accessibilité de l’offre doit être définie"]}
+
+
+class CheckIsDuoComplianceTest:
+    @pytest.mark.parametrize("is_duo", [False, None])
+    def test_should_accept_a_falsy_value_on_a_category_that_refuses_duo(self, is_duo):
+        assert not subcategories.ABO_BIBLIOTHEQUE.can_be_duo
+
+        validation.check_is_duo_compliance(is_duo, subcategories.ABO_BIBLIOTHEQUE)
+
+    def test_should_accept_duo_on_a_category_that_allows_it(self):
+        assert subcategories.SEANCE_CINE.can_be_duo
+
+        validation.check_is_duo_compliance(True, subcategories.SEANCE_CINE)
+
+    def test_should_raise_on_a_category_that_refuses_duo(self):
+        with pytest.raises(exceptions.OfferException) as error:
+            validation.check_is_duo_compliance(True, subcategories.ABO_BIBLIOTHEQUE)
+
+        assert error.value.errors == {"enableDoubleBookings": ["the category chosen does not allow double bookings"]}
+
+
+class CheckDurationMinutesTest:
+    @pytest.mark.parametrize("duration_minutes", [None, 0, 1439])
+    @pytest.mark.parametrize("is_from_private_api", [True, False])
+    def test_should_accept_a_duration_under_24_hours(self, duration_minutes, is_from_private_api):
+        validation.check_duration_minutes(duration_minutes, is_from_private_api)
+
+    def test_should_raise_in_french_for_the_private_api(self):
+        with pytest.raises(exceptions.OfferException) as error:
+            validation.check_duration_minutes(1440, True)
+
+        assert list(error.value.errors) == ["durationMinutes"]
+
+    def test_should_raise_in_english_for_the_public_api(self):
+        with pytest.raises(exceptions.OfferException) as error:
+            validation.check_duration_minutes(1440, False)
+
+        assert error.value.errors == {
+            "eventDuration": [
+                (
+                    "The duration must be under 1440 minutes (24 hours). For events lasting 24 hours or more "
+                    "(e.g., a 3-day festival pass), please leave this field empty."
+                )
+            ]
+        }
+
+
+class CheckUpdateOnlyAllowedFieldsForOfferFromProviderTest:
+    # accepted by an Allociné provider, refused by a plain one
+    ALLOCINE_ONLY = ["isDuo"]
+
+    # accepted by a public API provider, refused by the two others
+    PUBLIC_API_ONLY = [
+        "bookingAllowedDatetime",
+        "bookingContact",
+        "bookingEmail",
+        "durationMinutes",
+        "ean",
+        "extraData",
+        "idAtProvider",
+        "isActive",
+        "publicationDatetime",
+        "withdrawalDetails",
+    ]
+
+    def build_public_api_provider(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        providers_factories.OffererProviderFactory(provider=provider)
+        return provider
+
+    def test_should_accept_every_field_of_the_shared_set(self):
+        provider = providers_factories.ProviderFactory()
+
+        validation.check_update_only_allowed_fields_for_offer_from_provider(
+            set(validation.EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER), provider
+        )
+
+    def test_should_accept_every_field_of_the_allocine_set(self):
+        provider = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
+        assert provider.isAllocine
+
+        validation.check_update_only_allowed_fields_for_offer_from_provider(
+            set(validation.EDITABLE_FIELDS_FOR_ALLOCINE_OFFER), provider
+        )
+
+    def test_should_accept_every_field_of_the_public_api_set(self):
+        provider = self.build_public_api_provider()
+        assert provider.hasOffererProvider
+
+        validation.check_update_only_allowed_fields_for_offer_from_provider(
+            set(validation.EDITABLE_FIELDS_FOR_INDIVIDUAL_OFFERS_API_PROVIDER), provider
+        )
+
+    @pytest.mark.parametrize("field", ALLOCINE_ONLY)
+    def test_reject_an_allocine_field_only_for_another_provider(self, field):
+        with pytest.raises(ApiErrors) as error:
+            validation.check_update_only_allowed_fields_for_offer_from_provider(
+                {field}, providers_factories.ProviderFactory()
+            )
+
+        assert error.value.errors == {field: ["Vous ne pouvez pas modifier ce champ"]}
+
+    @pytest.mark.parametrize("field", PUBLIC_API_ONLY)
+    def test_should_reject_a_public_api_field_only_for_another_provider(self, field):
+        allocine = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
+        with pytest.raises(ApiErrors) as error:
+            validation.check_update_only_allowed_fields_for_offer_from_provider({field}, allocine)
+
+        assert error.value.errors == {field: ["Vous ne pouvez pas modifier ce champ"]}
+
+    @pytest.mark.parametrize("provider_kind", ["plain", "allocine", "public_api"])
+    def test_should_reject_a_field_outside_every_set(self, provider_kind):
+        provider = {
+            "plain": lambda: providers_factories.ProviderFactory(),
+            "allocine": lambda: providers_factories.AllocineProviderFactory(localClass="AllocineStocks"),
+            "public_api": self.build_public_api_provider,
+        }[provider_kind]()
+
+        with pytest.raises(ApiErrors) as error:
+            validation.check_update_only_allowed_fields_for_offer_from_provider({"isNational"}, provider)
+
+        assert error.value.errors == {"isNational": ["Vous ne pouvez pas modifier ce champ"]}
+
+
+class CheckUrlIsCoherentWithSubcategoryTest:
+    @pytest.mark.parametrize("url", [None, ""])
+    def test_should_accept_an_offline_only_subcategory_without_url(self, url):
+        assert subcategories.SEANCE_CINE.is_offline_only
+
+        validation.check_url_is_coherent_with_subcategory(subcategories.SEANCE_CINE, url)
+
+    def test_should_raise_when_an_offline_only_subcategory_has_a_url(self):
+        with pytest.raises(ApiErrors) as error:
+            validation.check_url_is_coherent_with_subcategory(
+                subcategories.SEANCE_CINE, "https://cinema.example.com/en-ligne"
+            )
+
+        assert error.value.errors == {
+            "url": ['Une offre de sous-catégorie "Séance de cinéma" ne peut contenir un champ `url`']
+        }
+
+    def test_should_accept_an_online_only_subcategory_with_a_url(self):
+        assert subcategories.LIVESTREAM_MUSIQUE.is_online_only
+
+        validation.check_url_is_coherent_with_subcategory(
+            subcategories.LIVESTREAM_MUSIQUE, "https://concert.example.com/live"
+        )
+
+    @pytest.mark.parametrize("url", [None, ""])
+    def test_should_raise_when_an_online_only_subcategory_has_no_url(self, url):
+        with pytest.raises(ApiErrors) as error:
+            validation.check_url_is_coherent_with_subcategory(subcategories.LIVESTREAM_MUSIQUE, url)
+
+        assert error.value.errors == {
+            "url": ['Une offre de catégorie "Livestream musical" doit contenir un champ `url`']
+        }
+
+    @pytest.mark.parametrize("url", [None, "https://jeu.example.com"])
+    def test_should_accept_both_ways_when_the_subcategory_is_neither(self, url):
+        subcategory = subcategories.JEU_SUPPORT_PHYSIQUE
+        assert not subcategory.is_offline_only and not subcategory.is_online_only
+
+        validation.check_url_is_coherent_with_subcategory(subcategory, url)
+
+
+class CheckUrlAndOffererAddressAreNotBothSetTest:
+    def test_should_accept_a_digital_offer(self):
+        validation.check_url_and_offererAddress_are_not_both_set("https://cinema.example.com/en-ligne", None)
+
+    def test_should_accept_a_physical_offer(self):
+        offerer_address = offerers_factories.OfferLocationFactory()
+
+        validation.check_url_and_offererAddress_are_not_both_set(None, offerer_address)
+
+    def test_should_raise_when_both_are_set(self):
+        offerer_address = offerers_factories.OfferLocationFactory()
+
+        with pytest.raises(ApiErrors) as error:
+            validation.check_url_and_offererAddress_are_not_both_set(
+                "https://cinema.example.com/en-ligne", offerer_address
+            )
+
+        assert error.value.errors == {"offererAddress": ["Une offre numérique ne peut pas avoir d'adresse"]}
+
+    @pytest.mark.parametrize("url", [None, ""])
+    def test_should_raise_when_neither_is_set(self, url):
+        with pytest.raises(ApiErrors) as error:
+            validation.check_url_and_offererAddress_are_not_both_set(url, None)
+
+        assert error.value.errors == {"offererAddress": ["Une offre physique doit avoir une adresse"]}
+
+
+class FormatExtraDataTest:
+    def test_should_keep_only_the_filled_conditional_fields_of_the_subcategory(self):
+        extra_data = {
+            "musicType": "-1",  # applicable and filled
+            "musicSubType": "100",  # applicable and filled
+            "gtl_id": "19000000",  # applicable and filled in deserializer
+            "other": "value",  # not applicable field
+            "performer": "",  # applicable but empty
+        }
+
+        assert validation.format_extra_data(subcategories.FESTIVAL_MUSIQUE.id, extra_data) == {
+            "musicType": "-1",
+            "musicSubType": "100",
+            "gtl_id": "19000000",
+        }
+
+    def test_should_return_none_when_there_is_no_extra_data(self):
+        assert validation.format_extra_data(subcategories.FESTIVAL_MUSIQUE.id, None) is None
+
+
+class CheckCanUpdateOfferTest:
+    SUBCATEGORY = subcategories.SEANCE_CINE
+
+    def build_offer(self, **overrides):
+        """approved, provider-less, physical offer that passes every check."""
+        defaults = {
+            "subcategoryId": self.SUBCATEGORY.id,
+            "validation": OfferValidationStatus.APPROVED,
+            "ean": "9782070100002",
+            "lastProvider": None,
+            "withdrawalType": None,
+            "withdrawalDelay": None,
+            "name": "Les Quatre Cents Coups",
+            "description": "Antoine Doinel, treize ans, fugue dans les rues de Paris.",
+            "url": None,
+            "audioDisabilityCompliant": True,
+            "mentalDisabilityCompliant": False,
+            "motorDisabilityCompliant": True,
+            "visualDisabilityCompliant": False,
+            "isDuo": False,
+            "idAtProvider": None,
+            "extraData": {"stageDirector": "François Truffaut"},
+            "durationMinutes": 99,
+            "bookingContact": "contact@example.com",
+            "withdrawalDetails": "À retirer à la caisse",
+        }
+        # `overrides` always wins, including when it passes `None`
+        return offers_factories.OfferFactory(**{**defaults, **overrides})
+
+    @pytest.fixture(name="venue_provider")
+    def venue_provider_fixture(self):
+        return providers_factories.VenueProviderFactory()
+
+    def test_should_accept_a_draft_offer(self, venue_provider):
+        offer = self.build_offer(validation=OfferValidationStatus.DRAFT)
+
+        validation.check_can_update_offer(
+            offer, {"name": "Jules et Jim"}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+    @mock.patch("pcapi.core.offers.validation.check_validation_status")
+    def test_should_delegate_the_status_check(self, check_validation_status, venue_provider):
+        offer = self.build_offer()
+
+        validation.check_can_update_offer(offer, {}, mandatory_extra_data_fields=set(), venue_provider=venue_provider)
+
+        check_validation_status.assert_called_once_with(offer)
+
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            {},
+            {"name": "Les Quatre Cents Coups", "durationMinutes": 99},
+        ],
+        ids=["empty body", "values equal to the offer's"],
+    )
+    def test_should_return_early_when_no_field_changes(self, fields, venue_provider):
+        offer = self.build_offer(offererAddress=None)
+
+        validation.check_can_update_offer(
+            offer, fields, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+    @pytest.mark.parametrize(
+        "changed_field,expected_key",
+        [
+            ("audioDisabilityCompliant", "audio_disability_compliant"),
+            ("mentalDisabilityCompliant", "mental_disability_compliant"),
+            ("motorDisabilityCompliant", "motor_disability_compliant"),
+            ("visualDisabilityCompliant", "visual_disability_compliant"),
+        ],
+    )
+    @mock.patch("pcapi.core.offers.validation.check_accessibility_compliance")
+    def test_should_check_accessibility_when_any_of_its_four_fields_changes(
+        self, check_accessibility_compliance, changed_field, expected_key, venue_provider
+    ):
+        offer = self.build_offer()
+        new_value = not getattr(offer, changed_field)
+
+        validation.check_can_update_offer(
+            offer, {changed_field: new_value}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+        expected = {
+            "audio_disability_compliant": offer.audioDisabilityCompliant,
+            "mental_disability_compliant": offer.mentalDisabilityCompliant,
+            "motor_disability_compliant": offer.motorDisabilityCompliant,
+            "visual_disability_compliant": offer.visualDisabilityCompliant,
+        }
+        expected[expected_key] = new_value
+        check_accessibility_compliance.assert_called_once_with(**expected)
+
+    @mock.patch("pcapi.core.offers.validation.check_accessibility_compliance")
+    def test_should_not_check_accessibility_when_none_of_its_fields_changes(
+        self, check_accessibility_compliance, venue_provider
+    ):
+        offer = self.build_offer()
+
+        validation.check_can_update_offer(
+            offer,
+            {"description": "Une autre description."},
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        check_accessibility_compliance.assert_not_called()
+
+    @mock.patch("pcapi.core.offers.validation.format_extra_data")
+    @mock.patch("pcapi.core.offers.validation.check_extra_data")
+    def test_should_check_extra_data_against_the_offer_own_ean(
+        self, check_extra_data, format_extra_data, venue_provider
+    ):
+        offer = self.build_offer()
+        new_extra_data = {"stageDirector": "Jean Renoir"}
+
+        validation.check_can_update_offer(
+            offer,
+            {"extraData": new_extra_data},
+            mandatory_extra_data_fields={"stageDirector"},
+            venue_provider=venue_provider,
+        )
+
+        format_extra_data.assert_called_once_with(self.SUBCATEGORY.id, new_extra_data)
+        check_extra_data.assert_called_once_with(
+            format_extra_data.return_value,
+            offer.venue,
+            {"stageDirector"},
+            offer=offer,
+            ean=offer.ean,
+        )
+
+    @mock.patch("pcapi.core.offers.validation.check_extra_data")
+    def test_should_pass_an_empty_dict_when_the_extra_data_is_cleared(self, check_extra_data, venue_provider):
+        # `format_extra_data` answers `None` on a null input, and the check expects a dict
+        offer = self.build_offer()
+
+        validation.check_can_update_offer(
+            offer, {"extraData": None}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+        assert check_extra_data.call_args.args[0] == {}
+
+    @mock.patch("pcapi.core.offers.validation.check_extra_data")
+    def test_should_not_check_extra_data_when_it_does_not_change(self, check_extra_data, venue_provider):
+        offer = self.build_offer()
+
+        validation.check_can_update_offer(
+            offer, {"extraData": offer.extraData}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+        check_extra_data.assert_not_called()
+
+    @mock.patch("pcapi.core.offers.validation.check_is_duo_compliance")
+    def test_should_check_duo_compliance_against_the_offer_subcategory(self, check_is_duo_compliance, venue_provider):
+        offer = self.build_offer()
+
+        validation.check_can_update_offer(
+            offer, {"isDuo": True}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+        check_is_duo_compliance.assert_called_once_with(True, self.SUBCATEGORY)
+
+    @mock.patch("pcapi.core.offers.validation.check_can_input_id_at_provider")
+    @mock.patch("pcapi.core.offers.validation.check_can_input_id_at_provider_for_this_venue")
+    def test_should_check_the_id_at_provider_against_the_provider_and_the_venue(
+        self, check_can_input_id_at_provider_for_this_venue, check_can_input_id_at_provider, venue_provider
+    ):
+        offer = self.build_offer()
+
+        validation.check_can_update_offer(
+            offer, {"idAtProvider": "seance-du-soir"}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+        check_can_input_id_at_provider.assert_called_once_with(offer.lastProvider, "seance-du-soir")
+        check_can_input_id_at_provider_for_this_venue.assert_called_once_with(offer.venueId, "seance-du-soir", offer.id)
+
+    @mock.patch("pcapi.core.offers.validation.check_offer_name_does_not_contain_ean")
+    def test_should_check_the_name_does_not_contain_an_ean(self, check_offer_name_does_not_contain_ean, venue_provider):
+        offer = self.build_offer()
+
+        validation.check_can_update_offer(
+            offer, {"name": "Jules et Jim"}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+        check_offer_name_does_not_contain_ean.assert_called_once_with("Jules et Jim")
+
+    @mock.patch("pcapi.core.offers.validation.check_offer_name_does_not_contain_ean")
+    def test_should_refuse_a_null_name(self, check_offer_name_does_not_contain_ean, venue_provider):
+        offer = self.build_offer()
+
+        with pytest.raises(exceptions.OfferException) as error:
+            validation.check_can_update_offer(
+                offer, {"name": None}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+            )
+
+        assert error.value.errors == {"name": ["cannot be null"]}
+        check_offer_name_does_not_contain_ean.assert_not_called()
+
+    @pytest.mark.parametrize("changed_field", ["withdrawalDetails", "bookingContact"])
+    @mock.patch("pcapi.core.offers.validation.check_offer_withdrawal")
+    def test_should_check_withdrawal_against_the_type_and_delay_stored_on_the_offer(
+        self, check_offer_withdrawal, changed_field, venue_provider
+    ):
+        offer = self.build_offer()
+        venue_provider = providers_factories.VenueProviderFactory()
+
+        validation.check_can_update_offer(
+            offer, {changed_field: "nouvelle valeur"}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+        expected_contact = "nouvelle valeur" if changed_field == "bookingContact" else offer.bookingContact
+        check_offer_withdrawal.assert_called_once_with(
+            withdrawal_type=offer.withdrawalType,
+            withdrawal_delay=offer.withdrawalDelay,
+            subcategory_id=self.SUBCATEGORY.id,
+            booking_contact=expected_contact,
+            provider=offer.lastProvider,
+            venue_provider=venue_provider,
+        )
+
+    @mock.patch("pcapi.core.offers.validation.check_offer_duration")
+    def test_should_check_the_resulting_duration(self, check_offer_duration, venue_provider):
+        offer = self.build_offer()
+
+        validation.check_can_update_offer(
+            offer, {"durationMinutes": 1440}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+        check_offer_duration.assert_called_once_with(1440)
+
+    @mock.patch("pcapi.core.offers.validation.check_update_only_allowed_fields_for_offer_from_provider")
+    def test_should_check_the_whitelist_against_the_changed_fields(
+        self, check_update_only_allowed_fields, venue_provider
+    ):
+        provider = providers_factories.PublicApiProviderFactory()
+        offer = self.build_offer(lastProvider=provider)
+
+        validation.check_can_update_offer(
+            offer,
+            {"name": "Jules et Jim", "durationMinutes": 120, "description": "Deux amis."},
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        check_update_only_allowed_fields.assert_called_once_with({"name", "durationMinutes", "description"}, provider)
+
+    @mock.patch("pcapi.core.offers.validation.check_update_only_allowed_fields_for_offer_from_provider")
+    def test_should_not_check_the_whitelist_for_an_offer_created_on_the_pro_interface(
+        self, check_update_only_allowed_fields, venue_provider
+    ):
+        offer = self.build_offer(lastProvider=None)
+
+        validation.check_can_update_offer(
+            offer, {"name": "Jules et Jim"}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        )
+
+        check_update_only_allowed_fields.assert_not_called()
+
+    @mock.patch("pcapi.core.offers.validation.check_url_is_coherent_with_subcategory")
+    @mock.patch("pcapi.core.offers.validation.check_url_and_offererAddress_are_not_both_set")
+    def test_should_always_check_location_coherence(
+        self, check_url_and_offererAddress_are_not_both_set, check_url_is_coherent_with_subcategory, venue_provider
+    ):
+        offer = self.build_offer()
+
+        validation.check_can_update_offer(
+            offer,
+            {"description": "Une autre description."},
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        check_url_is_coherent_with_subcategory.assert_called_once_with(self.SUBCATEGORY, offer.url)
+        check_url_and_offererAddress_are_not_both_set.assert_called_once_with(offer.url, offer.offererAddress)
+
+    @mock.patch("pcapi.core.offers.validation.check_url_is_coherent_with_subcategory")
+    @mock.patch("pcapi.core.offers.validation.check_url_and_offererAddress_are_not_both_set")
+    def test_should_check_location_coherence_on_the_resulting_values(
+        self, check_url_and_offererAddress_are_not_both_set, check_url_is_coherent_with_subcategory, venue_provider
+    ):
+        offer = self.build_offer(url="https://cinema.example.com/en-ligne")
+        new_offerer_address = offerers_factories.OfferLocationFactory()
+
+        validation.check_can_update_offer(
+            offer,
+            {"url": None, "offererAddress": new_offerer_address},
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        check_url_is_coherent_with_subcategory.assert_called_once_with(self.SUBCATEGORY, None)
+        check_url_and_offererAddress_are_not_both_set.assert_called_once_with(None, new_offerer_address)

--- a/api/tests/core/videos/test_api.py
+++ b/api/tests/core/videos/test_api.py
@@ -1,7 +1,11 @@
 import json
+import logging
+from unittest import mock
 
 import pytest
 
+from pcapi.connectors import youtube
+from pcapi.core.offers import factories as offers_factories
 from pcapi.core.videos import api
 from pcapi.core.videos import exceptions
 from pcapi.utils.requests import ExternalAPIException
@@ -90,3 +94,134 @@ class GetVideoMetadataFromCacheTest:
 
         with pytest.raises(ExternalAPIException):
             api.get_video_metadata_from_cache(video_url)
+
+
+@pytest.mark.usefixtures("db_session")
+class UpsertVideoAndMetadataTest:
+    GET_METADATA = "pcapi.core.videos.api.get_video_metadata_from_cache"
+    VIDEO_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    VIDEO_METADATA = youtube.YoutubeVideoMetadata(
+        id="dQw4w9WgXcQ",
+        title="Les Quatre Cents Coups, bande annonce",
+        thumbnail_url="https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+        duration=132,
+    )
+
+    def read_log(self, caplog):
+        [record] = [r for r in caplog.records if getattr(r, "technical_message_id", "").startswith("offer.video.")]
+        return record
+
+    @mock.patch(GET_METADATA)
+    def test_should_create_the_metadata_when_the_offer_has_none(self, get_video_metadata_from_cache):
+        get_video_metadata_from_cache.return_value = self.VIDEO_METADATA
+        offer = offers_factories.OfferFactory()
+        assert offer.metaData is None
+
+        api.upsert_video_and_metadata(self.VIDEO_URL, offer)
+
+        assert offer.metaData is not None
+
+    @mock.patch(GET_METADATA)
+    def test_should_store_the_metadata_returned_by_the_cache(self, get_video_metadata_from_cache):
+        get_video_metadata_from_cache.return_value = self.VIDEO_METADATA
+        offer = offers_factories.OfferFactory()
+
+        api.upsert_video_and_metadata(self.VIDEO_URL, offer)
+
+        get_video_metadata_from_cache.assert_called_once_with(self.VIDEO_URL)
+        assert offer.metaData.videoUrl == self.VIDEO_URL
+        assert offer.metaData.videoExternalId == "dQw4w9WgXcQ"
+        assert offer.metaData.videoTitle == "Les Quatre Cents Coups, bande annonce"
+        assert offer.metaData.videoThumbnailUrl == "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+        assert offer.metaData.videoDuration == 132
+
+    @mock.patch(GET_METADATA)
+    def test_should_replace_the_metadata_of_a_video_that_is_already_there(self, get_video_metadata_from_cache):
+        get_video_metadata_from_cache.return_value = self.VIDEO_METADATA
+        meta_data = offers_factories.OfferMetaDataFactory(
+            videoUrl="https://www.youtube.com/watch?v=WtM4OW2qVjY", videoTitle="Jules et Jim", videoDuration=90
+        )
+
+        api.upsert_video_and_metadata(self.VIDEO_URL, meta_data.offer)
+
+        assert meta_data.videoUrl == self.VIDEO_URL
+        assert meta_data.videoTitle == "Les Quatre Cents Coups, bande annonce"
+        assert meta_data.videoDuration == 132
+
+    @mock.patch(GET_METADATA)
+    def test_should_log_an_addition_when_the_offer_had_no_metadata(self, get_video_metadata_from_cache, caplog):
+        get_video_metadata_from_cache.return_value = self.VIDEO_METADATA
+        offer = offers_factories.OfferFactory()
+
+        with caplog.at_level(logging.INFO):
+            api.upsert_video_and_metadata(self.VIDEO_URL, offer, provider_id=12)
+
+        log = self.read_log(caplog)
+        assert log.technical_message_id == "offer.video.added"
+        assert log.extra == {
+            "offer_id": offer.id,
+            "venue_id": offer.venueId,
+            "video_url": self.VIDEO_URL,
+            "provider_id": 12,
+        }
+
+    @mock.patch(GET_METADATA)
+    def test_should_log_an_addition_when_the_metadata_carried_no_video(self, get_video_metadata_from_cache, caplog):
+        get_video_metadata_from_cache.return_value = self.VIDEO_METADATA
+        meta_data = offers_factories.OfferMetaDataFactory(videoUrl=None)
+
+        with caplog.at_level(logging.INFO):
+            api.upsert_video_and_metadata(self.VIDEO_URL, meta_data.offer)
+
+        assert self.read_log(caplog).technical_message_id == "offer.video.added"
+
+    @mock.patch(GET_METADATA)
+    def test_should_log_an_update_when_the_offer_already_had_a_video(self, get_video_metadata_from_cache, caplog):
+        get_video_metadata_from_cache.return_value = self.VIDEO_METADATA
+        meta_data = offers_factories.OfferMetaDataFactory(videoUrl="https://www.youtube.com/watch?v=WtM4OW2qVjY")
+
+        with caplog.at_level(logging.INFO):
+            api.upsert_video_and_metadata(self.VIDEO_URL, meta_data.offer)
+
+        assert self.read_log(caplog).technical_message_id == "offer.video.updated"
+
+
+@pytest.mark.usefixtures("db_session")
+class RemoveVideoDataFromOfferMetadataTest:
+    VIDEO_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    def build_meta_data(self):
+        return offers_factories.OfferMetaDataFactory(
+            videoUrl=self.VIDEO_URL,
+            videoDuration=132,
+            videoExternalId="dQw4w9WgXcQ",
+            videoThumbnailUrl="https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+            videoTitle="Les Quatre Cents Coups, bande annonce",
+        )
+
+    def test_should_clear_every_video_field(self):
+        meta_data = self.build_meta_data()
+        offer = meta_data.offer
+
+        api.remove_video_data_from_offer_metadata(meta_data, offer.id, offer.venueId, self.VIDEO_URL)
+
+        assert meta_data.videoUrl is None
+        assert meta_data.videoDuration is None
+        assert meta_data.videoExternalId is None
+        assert meta_data.videoThumbnailUrl is None
+        assert meta_data.videoTitle is None
+
+    def test_should_log_the_deletion(self, caplog):
+        meta_data = self.build_meta_data()
+        offer = meta_data.offer
+
+        with caplog.at_level(logging.INFO):
+            api.remove_video_data_from_offer_metadata(meta_data, offer.id, offer.venueId, self.VIDEO_URL, 12)
+
+        [log] = [r for r in caplog.records if getattr(r, "technical_message_id", None) == "offer.video.deleted"]
+        assert log.extra == {
+            "offer_id": offer.id,
+            "venue_id": offer.venueId,
+            "video_url": self.VIDEO_URL,
+            "provider_id": 12,
+        }

--- a/api/tests/routes/public/individual_offers/v1/events/patch_event_test.py
+++ b/api/tests/routes/public/individual_offers/v1/events/patch_event_test.py
@@ -372,7 +372,7 @@ class Returns200Test(PatchEventEndpointHelper):
         db.session.refresh(event)
         assert getattr(event, column) == new_value
 
-    def test_should_update_item_collection_details_on_an_in_app_ticketed_event(self):
+    def test_should_update_the_booking_contact_on_an_in_app_ticketed_event(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         event = self.setup_base_resource(
             venue=venue_provider.venue,
@@ -385,14 +385,37 @@ class Returns200Test(PatchEventEndpointHelper):
         response = self.make_request(
             plain_api_key,
             {"event_id": event.id},
-            json_body={"itemCollectionDetails": "À retirer au guichet du théâtre"},
+            json_body={"bookingContact": "nouveau@theatre.fr"},
         )
 
         assert response.status_code == 200, response.json
-        assert response.json["itemCollectionDetails"] == "À retirer au guichet du théâtre"
+        assert response.json["bookingContact"] == "nouveau@theatre.fr"
 
         db.session.refresh(event)
-        assert event.withdrawalDetails == "À retirer au guichet du théâtre"
+        assert event.bookingContact == "nouveau@theatre.fr"
+
+    def test_should_update_the_booking_contact_when_the_ticketing_is_set_on_the_venue(self):
+        plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=False)
+        providers_factories.VenueProviderExternalUrlsFactory(venueProvider=venue_provider)
+        event = self.setup_base_resource(
+            venue=venue_provider.venue,
+            provider=venue_provider.provider,
+            subcategoryId=subcategories.CONCERT.id,
+            withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
+        )
+        assert not venue_provider.provider.hasTicketingService
+        assert venue_provider.hasTicketingService
+
+        response = self.make_request(
+            plain_api_key,
+            {"event_id": event.id},
+            json_body={"bookingContact": "nouveau@theatre.fr"},
+        )
+
+        assert response.status_code == 200, response.json
+
+        db.session.refresh(event)
+        assert event.bookingContact == "nouveau@theatre.fr"
 
     # --- `categoryRelatedFields`
 
@@ -1360,6 +1383,7 @@ class Returns200Test(PatchEventEndpointHelper):
         num_queries += 1  # selectinload the price categories
         num_queries += 1  # selectinload the mediations
         num_queries += 1  # selectinload the stocks
+        num_queries += 1  # retrieve the venue provider
         num_queries += 1  # lazy-load `provider.offererProvider`, for `hasOffererProvider`
         num_queries += 1  # update the offer
 
@@ -1930,7 +1954,7 @@ class Returns400Test(PatchEventEndpointHelper):
             "offer": ["Une offre qui a un ticket retirable doit avoir l'email du contact de réservation"]
         }
 
-    def test_should_raise_400_because_the_provider_does_not_support_the_ticketing_interface(self):
+    def test_should_raise_400_because_neither_the_provider_nor_the_venue_supports_the_ticketing_interface(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider(provider_has_ticketing_urls=False)
         event = self.setup_base_resource(
             venue=venue_provider.venue,
@@ -1939,11 +1963,12 @@ class Returns400Test(PatchEventEndpointHelper):
             withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
         )
         assert not venue_provider.provider.hasTicketingService
+        assert not venue_provider.hasTicketingService
 
         response = self.make_request(
             plain_api_key,
             {"event_id": event.id},
-            json_body={"itemCollectionDetails": "À retirer au guichet du théâtre"},
+            json_body={"bookingContact": "nouveau@theatre.fr"},
         )
 
         assert response.status_code == 400

--- a/api/tests/routes/public/individual_offers/v1/products/patch_product_test.py
+++ b/api/tests/routes/public/individual_offers/v1/products/patch_product_test.py
@@ -471,6 +471,35 @@ class Returns200Test(PatchProductEndpointHelper):
         db.session.refresh(product)
         assert product.extraData == {"musicType": "501", "musicSubType": "-1", "gtl_id": "02000000"}
 
+    def test_should_update_the_category_related_fields_of_a_subcategory_that_requires_an_ean(self):
+        plain_api_key, venue_provider = self.setup_active_venue_provider()
+        product = self.setup_base_resource(
+            venue=venue_provider.venue,
+            provider=venue_provider.provider,
+            subcategoryId=subcategories.LIVRE_AUDIO_PHYSIQUE.id,
+            ean="9782070100002",
+            extraData={"author": "Marguerite Duras"},
+        )
+
+        response = self.make_request(
+            plain_api_key,
+            json_body={
+                "offerId": product.id,
+                "categoryRelatedFields": {"category": "LIVRE_AUDIO_PHYSIQUE", "author": "Marguerite Yourcenar"},
+            },
+        )
+
+        assert response.status_code == 200, response.json
+        assert response.json["categoryRelatedFields"] == {
+            "category": "LIVRE_AUDIO_PHYSIQUE",
+            "author": "Marguerite Yourcenar",
+            "ean": "9782070100002",
+        }
+
+        db.session.refresh(product)
+        assert product.extraData["author"] == "Marguerite Yourcenar"
+        assert product.ean == "9782070100002"
+
     def test_should_ignore_the_ean_sent_in_the_category_related_fields(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         product = self.setup_base_resource(
@@ -1388,6 +1417,7 @@ class Returns200Test(PatchProductEndpointHelper):
         num_queries += 1  # selectinload the stocks
         num_queries += 1  # selectinload the mediations
         num_queries += 1  # selectinload the price categories
+        num_queries += 1  # retrieve the venue provider
         num_queries += 1  # update the offer
 
         with testing.assert_num_queries(num_queries):
@@ -1786,25 +1816,21 @@ class Returns400Test(PatchProductEndpointHelper):
             ]
         }
 
-    def test_should_raise_400_when_sending_category_related_fields_on_a_subcategory_that_requires_an_ean(
-        self,
-    ):
+    def test_should_raise_400_when_the_offer_has_no_ean_on_a_subcategory_that_requires_one(self):
         plain_api_key, venue_provider = self.setup_active_venue_provider()
         product = self.setup_base_resource(
             venue=venue_provider.venue,
             provider=venue_provider.provider,
-            subcategoryId=subcategories.SUPPORT_PHYSIQUE_FILM.id,
-            ean="9782070100002",
-            extraData=None,
+            subcategoryId=subcategories.LIVRE_AUDIO_PHYSIQUE.id,
+            ean=None,
+            extraData={"author": "Marguerite Duras"},
         )
-        # the offer does have an ean: it is the request that cannot carry one
-        assert product.ean == "9782070100002"
 
         response = self.make_request(
             plain_api_key,
             json_body={
                 "offerId": product.id,
-                "categoryRelatedFields": {"category": "SUPPORT_PHYSIQUE_FILM", "ean": "9782070100002"},
+                "categoryRelatedFields": {"category": "LIVRE_AUDIO_PHYSIQUE", "author": "Marguerite Yourcenar"},
             },
         )
 

--- a/api/tests/routes/public/individual_offers/v1/test_utils.py
+++ b/api/tests/routes/public/individual_offers/v1/test_utils.py
@@ -4,11 +4,14 @@ import pytest
 import sqlalchemy.orm as sa_orm
 
 from pcapi.core import testing
+from pcapi.core.categories import subcategories
 from pcapi.core.geography import factories as geography_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import schemas as offerers_schemas
+from pcapi.models import api_errors
 from pcapi.routes.public.individual_offers.v1 import serialization
 from pcapi.routes.public.individual_offers.v1 import utils
+from pcapi.routes.public.individual_offers.v1.serializers import events as events_serializers
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -208,3 +211,24 @@ class GetVenueWithOffererAddressTest:
         with testing.assert_num_queries(1):
             fetched_venue = utils.get_venue_with_offerer_address(venue_id)
             assert fetched_venue.offererAddress.addressId
+
+
+class CheckOfferSubcategoryTest:
+    def test_should_accept_a_body_that_carries_no_category_related_fields(self):
+        body = events_serializers.EventOfferEdition(name="Jules et Jim")
+
+        utils.check_offer_subcategory(body, subcategories.SEANCE_CINE.id)
+
+    def test_should_accept_the_subcategory_the_offer_already_has(self):
+        body = events_serializers.EventOfferEdition(category_related_fields={"category": "SEANCE_CINE"})
+
+        utils.check_offer_subcategory(body, subcategories.SEANCE_CINE.id)
+
+    def test_should_refuse_another_subcategory_for_an_event(self):
+        body = events_serializers.EventOfferEdition(category_related_fields={"category": "SEANCE_CINE"})
+
+        with pytest.raises(api_errors.ApiErrors) as error:
+            utils.check_offer_subcategory(body, subcategories.CONCERT.id)
+
+        assert error.value.errors == {"categoryRelatedFields.category": ["The category cannot be changed"]}
+        assert error.value.status_code == 400

--- a/api/tests/routes/public/individual_offers/v1/test_utils.py
+++ b/api/tests/routes/public/individual_offers/v1/test_utils.py
@@ -1,0 +1,210 @@
+from unittest import mock
+
+import pytest
+import sqlalchemy.orm as sa_orm
+
+from pcapi.core import testing
+from pcapi.core.geography import factories as geography_factories
+from pcapi.core.offerers import factories as offerers_factories
+from pcapi.core.offerers import schemas as offerers_schemas
+from pcapi.routes.public.individual_offers.v1 import serialization
+from pcapi.routes.public.individual_offers.v1 import utils
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class ExtractVenueAndOffererAddressFromLocationTest:
+    GET_VENUE = "pcapi.routes.public.individual_offers.v1.utils.get_venue_with_offerer_address"
+    GET_ADDRESS = "pcapi.routes.public.utils.get_address_or_raise_404"
+    GET_VENUE_LOCATION = "pcapi.core.offers.api.get_or_create_offerer_address_from_address_body"
+    GET_OFFER_LOCATION = "pcapi.core.offerers.api.get_or_create_offer_location"
+
+    # --- No location sent
+
+    @mock.patch(GET_VENUE)
+    def test_should_return_no_venue_and_no_offerer_address_when_no_location_is_sent(
+        self, get_venue_with_offerer_address
+    ):
+        assert utils.extract_venue_and_offerer_address_from_location(None) == (None, None)
+        get_venue_with_offerer_address.assert_not_called()
+
+    # --- Venue resolution
+
+    @mock.patch(GET_VENUE)
+    def test_should_look_the_venue_up_by_the_id_sent_in_the_location(self, get_venue_with_offerer_address):
+        venue = offerers_factories.VenueFactory()
+        get_venue_with_offerer_address.return_value = venue
+
+        returned_venue, _ = utils.extract_venue_and_offerer_address_from_location(
+            serialization.PhysicalLocation(venue_id=venue.id)
+        )
+
+        get_venue_with_offerer_address.assert_called_once_with(venue.id)
+        assert returned_venue == venue
+
+    @mock.patch(GET_VENUE)
+    def test_should_not_look_the_venue_up_when_it_is_given_by_the_caller(self, get_venue_with_offerer_address):
+        venue = offerers_factories.VenueFactory()
+
+        returned_venue, _ = utils.extract_venue_and_offerer_address_from_location(
+            serialization.PhysicalLocation(venue_id=venue.id), venue=venue
+        )
+
+        get_venue_with_offerer_address.assert_not_called()
+        assert returned_venue == venue
+
+    # --- Physical and digital locations
+
+    @pytest.mark.parametrize(
+        "build_location",
+        [
+            lambda venue: serialization.PhysicalLocation(venue_id=venue.id),
+            lambda venue: serialization.DigitalLocation(venue_id=venue.id, url="https://example.com"),
+        ],
+        ids=["physical", "digital"],
+    )
+    @mock.patch(GET_ADDRESS)
+    @mock.patch(GET_VENUE_LOCATION)
+    def test_should_reuse_the_venue_location_without_looking_up_an_address(
+        self, get_or_create_offerer_address_from_address_body, get_address_or_raise_404, build_location
+    ):
+        venue = offerers_factories.VenueFactory()
+
+        _, offerer_address = utils.extract_venue_and_offerer_address_from_location(build_location(venue), venue=venue)
+
+        get_address_or_raise_404.assert_not_called()
+        get_or_create_offerer_address_from_address_body.assert_called_once_with(
+            offerers_schemas.LocationOnlyOnVenueModel(), venue
+        )
+        assert offerer_address == get_or_create_offerer_address_from_address_body.return_value
+
+    # --- Address location
+
+    @mock.patch(GET_ADDRESS)
+    def test_should_look_the_address_up_by_the_id_sent_in_the_location(self, get_address_or_raise_404):
+        venue = offerers_factories.VenueFactory()
+        address = geography_factories.AddressFactory()
+        get_address_or_raise_404.return_value = address
+
+        utils.extract_venue_and_offerer_address_from_location(
+            serialization.AddressLocation(venue_id=venue.id, address_id=address.id, address_label="Salle Jean Vilar"),
+            venue=venue,
+        )
+
+        get_address_or_raise_404.assert_called_once_with(address.id)
+
+    @mock.patch(GET_OFFER_LOCATION)
+    @mock.patch(GET_ADDRESS)
+    def test_should_create_an_offer_location_when_the_address_differs_from_the_venue_one(
+        self, get_address_or_raise_404, get_or_create_offer_location
+    ):
+        venue = offerers_factories.VenueFactory()
+        address = geography_factories.AddressFactory()
+        get_address_or_raise_404.return_value = address
+
+        _, offerer_address = utils.extract_venue_and_offerer_address_from_location(
+            serialization.AddressLocation(venue_id=venue.id, address_id=address.id, address_label="Salle Jean Vilar"),
+            venue=venue,
+        )
+
+        get_or_create_offer_location.assert_called_once_with(
+            offerer_id=venue.managingOffererId,
+            venue_id=venue.id,
+            address_id=address.id,
+            label="Salle Jean Vilar",
+        )
+        assert offerer_address == get_or_create_offer_location.return_value
+
+    @mock.patch(GET_OFFER_LOCATION)
+    @mock.patch(GET_ADDRESS)
+    def test_should_create_an_offer_location_when_only_the_label_differs_from_the_venue_public_name(
+        self, get_address_or_raise_404, get_or_create_offer_location
+    ):
+        venue = offerers_factories.VenueFactory()
+        get_address_or_raise_404.return_value = venue.offererAddress.address
+
+        utils.extract_venue_and_offerer_address_from_location(
+            serialization.AddressLocation(
+                venue_id=venue.id,
+                address_id=venue.offererAddress.addressId,
+                address_label="Salle Jean Vilar",
+            ),
+            venue=venue,
+        )
+
+        get_or_create_offer_location.assert_called_once_with(
+            offerer_id=venue.managingOffererId,
+            venue_id=venue.id,
+            address_id=venue.offererAddress.addressId,
+            label="Salle Jean Vilar",
+        )
+
+    @mock.patch(GET_VENUE_LOCATION)
+    @mock.patch(GET_ADDRESS)
+    def test_should_reuse_the_venue_location_when_the_address_and_the_label_match_the_venue_ones(
+        self, get_address_or_raise_404, get_or_create_offerer_address_from_address_body
+    ):
+        venue = offerers_factories.VenueFactory()
+        get_address_or_raise_404.return_value = venue.offererAddress.address
+
+        _, offerer_address = utils.extract_venue_and_offerer_address_from_location(
+            serialization.AddressLocation(
+                venue_id=venue.id,
+                address_id=venue.offererAddress.addressId,
+                address_label=venue.publicName,
+            ),
+            venue=venue,
+        )
+
+        get_or_create_offerer_address_from_address_body.assert_called_once_with(
+            offerers_schemas.LocationOnlyOnVenueModel(), venue
+        )
+        assert offerer_address == get_or_create_offerer_address_from_address_body.return_value
+
+    @mock.patch(GET_OFFER_LOCATION)
+    @mock.patch(GET_VENUE_LOCATION)
+    @mock.patch(GET_ADDRESS)
+    def test_should_create_an_offer_location_when_no_label_is_sent_and_the_venue_has_a_public_name(
+        self, get_address_or_raise_404, get_or_create_offerer_address_from_address_body, get_or_create_offer_location
+    ):
+        venue = offerers_factories.VenueFactory()
+        get_address_or_raise_404.return_value = venue.offererAddress.address
+
+        utils.extract_venue_and_offerer_address_from_location(
+            serialization.AddressLocation(
+                venue_id=venue.id, address_id=venue.offererAddress.addressId, address_label=None
+            ),
+            venue=venue,
+        )
+
+        get_or_create_offerer_address_from_address_body.assert_not_called()
+        get_or_create_offer_location.assert_called_once_with(
+            offerer_id=venue.managingOffererId,
+            venue_id=venue.id,
+            address_id=venue.offererAddress.addressId,
+            label=None,
+        )
+
+
+class GetVenueWithOffererAddressTest:
+    def test_should_return_the_venue_matching_the_id(self):
+        venue = offerers_factories.VenueFactory()
+        offerers_factories.VenueFactory()
+
+        assert utils.get_venue_with_offerer_address(venue.id) == venue
+
+    def test_should_raise_when_no_venue_matches_the_id(self):
+        venue = offerers_factories.VenueFactory()
+
+        with pytest.raises(sa_orm.exc.NoResultFound):
+            utils.get_venue_with_offerer_address(venue.id + 1000)
+
+    def test_should_load_the_offerer_address_along_with_the_venue(self):
+        venue = offerers_factories.VenueFactory()
+
+        venue_id = venue.id
+
+        with testing.assert_num_queries(1):
+            fetched_venue = utils.get_venue_with_offerer_address(venue_id)
+            assert fetched_venue.offererAddress.addressId

--- a/api/tests/routes/public/individual_offers/v1/test_utils.py
+++ b/api/tests/routes/public/individual_offers/v1/test_utils.py
@@ -1,3 +1,4 @@
+import base64
 from unittest import mock
 
 import pytest
@@ -8,10 +9,17 @@ from pcapi.core.categories import subcategories
 from pcapi.core.geography import factories as geography_factories
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import schemas as offerers_schemas
+from pcapi.core.offers import exceptions as offers_exceptions
+from pcapi.core.offers import factories as offers_factories
+from pcapi.core.offers import validation as offers_validation
+from pcapi.core.videos import exceptions as videos_exceptions
 from pcapi.models import api_errors
+from pcapi.routes.public import utils as public_utils
+from pcapi.routes.public.individual_offers.v1 import constants
 from pcapi.routes.public.individual_offers.v1 import serialization
 from pcapi.routes.public.individual_offers.v1 import utils
 from pcapi.routes.public.individual_offers.v1.serializers import events as events_serializers
+from pcapi.utils import image_conversion
 
 
 pytestmark = pytest.mark.usefixtures("db_session")
@@ -232,3 +240,130 @@ class CheckOfferSubcategoryTest:
 
         assert error.value.errors == {"categoryRelatedFields.category": ["The category cannot be changed"]}
         assert error.value.status_code == 400
+
+
+class SaveImageTest:
+    GET_BYTES = "pcapi.routes.public.utils.get_bytes_from_base64_string"
+    CREATE_MEDIATION = "pcapi.core.offers.api.create_mediation"
+
+    def build_image_body(self, **overrides):
+        defaults = {"file": base64.b64encode(b"an image").decode(), "credit": "Jane Doe"}
+        return serialization.ImageBody(**{**defaults, **overrides})
+
+    @mock.patch(CREATE_MEDIATION)
+    def test_should_create_a_mediation_from_the_decoded_image(self, create_mediation):
+        offer = offers_factories.OfferFactory()
+
+        utils.save_image(self.build_image_body(), offer)
+
+        create_mediation.assert_called_once_with(
+            user=None,
+            offer=offer,
+            credit="Jane Doe",
+            image_as_bytes=b"an image",
+            min_width=constants.MIN_IMAGE_WIDTH,
+            min_height=constants.MIN_IMAGE_HEIGHT,
+            max_width=constants.MAX_IMAGE_WIDTH,
+            max_height=constants.MAX_IMAGE_HEIGHT,
+            aspect_ratio=constants.ASPECT_RATIO,
+        )
+
+    @mock.patch(CREATE_MEDIATION)
+    @mock.patch(GET_BYTES)
+    def test_should_refuse_a_file_that_is_not_base64(self, get_bytes_from_base64_string, create_mediation):
+        get_bytes_from_base64_string.side_effect = public_utils.InvalidBase64Exception()
+
+        with pytest.raises(api_errors.ApiErrors) as error:
+            utils.save_image(self.build_image_body(), offers_factories.OfferFactory())
+
+        assert error.value.errors == {"imageFile": ["The value must be a valid base64 string."]}
+        create_mediation.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "raised_error,expected_message",
+        [
+            (offers_exceptions.ImageTooSmall(400, 600), "The image is too small. It must be above 400x600 pixels."),
+            (offers_exceptions.ImageTooLarge(800, 1200), "The image is too large. It must be below 800x1200 pixels."),
+            (
+                offers_exceptions.UnacceptedFileType(offers_validation.ACCEPTED_THUMBNAIL_FORMATS, "gif"),
+                f"The image format is not accepted. It must be in {offers_validation.ACCEPTED_THUMBNAIL_FORMATS}.",
+            ),
+            (offers_exceptions.UnidentifiedImage(), "The file is not a valid image."),
+            (
+                offers_exceptions.FileSizeExceeded(10_000_000),
+                "The file is too large. It must be less than 10000000 bytes.",
+            ),
+            (offers_exceptions.MissingImage(), "The image is not valid."),
+            (
+                image_conversion.ImageRatioError(expected=0.6666666, found=1.3333333),
+                "Bad image ratio: expected 0.66, found 1.33",
+            ),
+        ],
+        ids=["too small", "too large", "bad format", "not an image", "too heavy", "other", "bad ratio"],
+    )
+    @mock.patch(CREATE_MEDIATION)
+    def test_should_translate_the_image_errors(self, create_mediation, raised_error, expected_message):
+        create_mediation.side_effect = raised_error
+
+        with pytest.raises(api_errors.ApiErrors) as error:
+            utils.save_image(self.build_image_body(), offers_factories.OfferFactory())
+
+        assert error.value.errors == {"imageFile": expected_message}
+
+
+class UpdateOrDeleteVideoTest:
+    UPSERT_VIDEO = "pcapi.core.videos.api.upsert_video_and_metadata"
+    REMOVE_VIDEO = "pcapi.core.videos.api.remove_video_data_from_offer_metadata"
+    VIDEO_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    @mock.patch(UPSERT_VIDEO)
+    def test_should_upsert_the_video_when_a_url_is_sent(self, upsert_video_and_metadata):
+        offer = offers_factories.OfferFactory()
+
+        utils.update_or_delete_video(self.VIDEO_URL, offer, provider_id=12)
+
+        upsert_video_and_metadata.assert_called_once_with(self.VIDEO_URL, offer, 12)
+
+    @mock.patch(UPSERT_VIDEO)
+    def test_should_refuse_a_video_that_cannot_be_found_on_youtube(self, upsert_video_and_metadata):
+        upsert_video_and_metadata.side_effect = videos_exceptions.YoutubeVideoNotFound()
+
+        with pytest.raises(offers_exceptions.OfferException) as error:
+            utils.update_or_delete_video(self.VIDEO_URL, offers_factories.OfferFactory(), provider_id=12)
+
+        assert error.value.errors == {
+            "videoUrl": [
+                "This video cannot be found on youtube. It is most likely a private video. Please check your URL."
+            ]
+        }
+
+    @mock.patch(REMOVE_VIDEO)
+    def test_should_delete_the_video_when_no_url_is_sent(self, remove_video_data_from_offer_metadata):
+        meta_data = offers_factories.OfferMetaDataFactory(videoUrl=self.VIDEO_URL)
+        offer = meta_data.offer
+
+        utils.update_or_delete_video(None, offer, provider_id=12)
+
+        remove_video_data_from_offer_metadata.assert_called_once_with(
+            meta_data, offer.id, offer.venueId, self.VIDEO_URL, 12
+        )
+
+    @mock.patch(REMOVE_VIDEO)
+    @mock.patch(UPSERT_VIDEO)
+    def test_should_do_nothing_when_no_url_is_sent_and_the_offer_has_no_metadata(
+        self, upsert_video_and_metadata, remove_video_data_from_offer_metadata
+    ):
+        utils.update_or_delete_video(None, offers_factories.OfferFactory(), provider_id=12)
+
+        upsert_video_and_metadata.assert_not_called()
+        remove_video_data_from_offer_metadata.assert_not_called()
+
+    @mock.patch(REMOVE_VIDEO)
+    def test_should_do_nothing_when_no_url_is_sent_and_the_offer_carries_no_video(
+        self, remove_video_data_from_offer_metadata
+    ):
+        meta_data = offers_factories.OfferMetaDataFactory(videoUrl=None)
+
+        utils.update_or_delete_video(None, meta_data.offer, provider_id=12)
+
+        remove_video_data_from_offer_metadata.assert_not_called()

--- a/api/tests/routes/public/services/test_authorization.py
+++ b/api/tests/routes/public/services/test_authorization.py
@@ -9,23 +9,32 @@ from pcapi.routes.public.services import authorization
 
 @pytest.mark.usefixtures("db_session")
 class GetVenueProviderOrRaise404Test:
-    def should_raise_resource_not_found_error_when_no_venue_provider(self):
-        venue = offerers_factories.VenueFactory()
+    def setup_current_provider(self):
         provider = providers_factories.ProviderFactory()
-        api_key = offerers_factories.ApiKeyFactory(provider=provider)
-        g.current_api_key = api_key
+        g.current_api_key = offerers_factories.ApiKeyFactory(provider=provider)
+        return provider
+
+    def test_should_return_the_venue_provider_linking_the_venue_to_the_current_provider(self):
+        venue = offerers_factories.VenueFactory()
+        provider = self.setup_current_provider()
+        venue_provider = providers_factories.VenueProviderFactory(venue=venue, provider=provider)
+
+        assert authorization.get_venue_provider_or_raise_404(venue_id=venue.id) == venue_provider
+
+    def test_should_raise_a_404_when_the_venue_is_not_linked_to_the_current_provider(self):
+        venue = offerers_factories.VenueFactory()
+        self.setup_current_provider()
 
         with pytest.raises(api_errors.ResourceNotFoundError) as exc_info:
             authorization.get_venue_provider_or_raise_404(venue_id=venue.id)
 
         assert exc_info.value.errors == {"global": "Venue cannot be found"}
+        assert exc_info.value.status_code == 404
 
-    def should_raise_resource_not_found_error_when_venue_provider_is_not_active(self):
+    def test_should_raise_a_404_when_the_venue_provider_is_not_active(self):
         venue = offerers_factories.VenueFactory()
-        provider = providers_factories.ProviderFactory()
+        provider = self.setup_current_provider()
         providers_factories.VenueProviderFactory(venue=venue, provider=provider, isActive=False)
-        api_key = offerers_factories.ApiKeyFactory(provider=provider)
-        g.current_api_key = api_key
 
         with pytest.raises(api_errors.ResourceNotFoundError) as exc_info:
             authorization.get_venue_provider_or_raise_404(venue_id=venue.id)

--- a/api/tests/routes/public/test_utils.py
+++ b/api/tests/routes/public/test_utils.py
@@ -1,0 +1,28 @@
+import pytest
+
+from pcapi.core.geography import factories as geography_factories
+from pcapi.models import api_errors
+from pcapi.routes.public import utils
+
+
+pytestmark = pytest.mark.usefixtures("db_session")
+
+
+class GetAddressOrRaise404Test:
+    def test_should_return_the_address_matching_the_id(self):
+        address = geography_factories.AddressFactory()
+        geography_factories.AddressFactory()
+
+        assert utils.get_address_or_raise_404(address.id) == address
+
+    def test_should_raise_a_404_when_no_address_matches_the_id(self):
+        address = geography_factories.AddressFactory()
+        unknown_address_id = address.id + 1000
+
+        with pytest.raises(api_errors.ResourceNotFoundError) as error:
+            utils.get_address_or_raise_404(unknown_address_id)
+
+        assert error.value.errors == {
+            "location.AddressLocation.addressId": [f"There is no address with id {unknown_address_id}"]
+        }
+        assert error.value.status_code == 404


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-XXXXX)

Refacto de l'édition d'offre, pour le chemin API publique uniquement. L'API privée (`routes/pro/offers.py`) continue d'appeler l'ancienne fonction, renommée `old_update_offer` : sa migration se fera dans [la PR suivante](https://github.com/pass-culture/pass-culture-main/pull/23971).

### Refacto

- `core.offers.api.update_offer` est dupliquée : l'ancienne devient `old_update_offer` (API privée), la nouvelle `update_offer` n'est appelée que par `products.py` et `events.py`
- La nouvelle fonction `update_offer` prend des arguments nommés explicitement à la place du schéma intermédiaire `offers_schemas.UpdateOffer`
- `is_from_private_api` disparaît de la nouvelle fonction : l'appelant déclare lui-même ses champs obligatoires (`mandatory_extra_data_fields`), et l'API publique traduit ses propres messages d'erreur (`utils.translate_offer_errors`)
- Les validations sont centralisées dans `validation.check_can_update_offer`, appelée avant toute écriture sur l'offre -> le bloc `no_autoflush` disparaît : il protégeait l'accès à `offer.offererAddress` dans des checks qui suivaient la mutation, il n'y a plus rien à protéger

### Changements fonctionnels 

- Le `venue_provider` est désormais toujours résolu (et plus seulement quand la location change) puis transmis à `check_offer_withdrawal`. Un provider dont la billetterie est configurée au niveau de la venue peut maintenant éditer une offre `withdrawalType=IN_APP`
- La validation portant désormais sur l'offre résultante, envoyer `categoryRelatedFields` sur une sous-catégorie qui exige un EAN ne renvoie plus 400 quand l'offre possède déjà un EAN

### Code supprimé

- L'extraction de l'EAN depuis `extraData` (`try`/`except` + `logger.warning`)
- Le check `offer.is_soft_deleted()` : `Offer` n'hérite pas de `SoftDeletableMixin` (seuls `Stock` et `Venue`), il évaluait toujours à `False`
- `offer.fieldsUpdated` n'est plus alimenté : la colonne n'est lue nulle part

---

- [x] Travail pair testé en environnement de preview
