### PR TITLE
(BSR)[PRO] fix: add dependabot prefix to prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
     open-pull-requests-limit: 15
     pull-request-branch-name:
       max-length: 76
-      template: '{dependency}-{version}'
+      template: 'dependabot/{dependency}-{version}'
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -40,7 +40,7 @@ updates:
     open-pull-requests-limit: 10
     pull-request-branch-name:
       max-length: 76
-      template: '{dependency}-{version}'
+      template: 'dependabot/{dependency}-{version}'
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -57,7 +57,7 @@ updates:
     open-pull-requests-limit: 15
     pull-request-branch-name:
       max-length: 76
-      template: '{dependency}-{version}'
+      template: 'dependabot/{dependency}-{version}'
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -87,7 +87,7 @@ updates:
     open-pull-requests-limit: 10
     pull-request-branch-name:
       max-length: 76
-      template: '{dependency}-{version}'
+      template: 'dependabot/{dependency}-{version}'
     cooldown:
       # The property 'semver-major-days' is not supported for the package ecosystem 'github-actions'.
       default-days: 14


### PR DESCRIPTION
Cf issue : https://github.com/dependabot/fetch-metadata/issues/744

`fetch-metadata` s'attend à avoir `dependabot/` en préfixe de branche, ce sans quoi on tombe sur l'erreur (actuellement présente sur la totalité de nos PRs, que j'ai fermées): 

`Parsing Dependabot metadata
Error: PR does not contain metadata, nothing to do.`
