### PR TITLE
(PC-42939)[API] feat: align back and front whitelisting

### DIFF
--- a/api/src/pcapi/core/artist/api.py
+++ b/api/src/pcapi/core/artist/api.py
@@ -1,5 +1,7 @@
 import logging
+import typing
 from dataclasses import dataclass
+from functools import partial
 
 import sqlalchemy as sa
 import sqlalchemy.exc as sa_exc
@@ -9,14 +11,21 @@ from pcapi.core.artist import models
 from pcapi.core.artist.models import Artist
 from pcapi.core.artist.models import ArtistProductLink
 from pcapi.core.artist.models import ArtistType
+from pcapi.core.categories import subcategories
 from pcapi.core.offers.models import ImageType
 from pcapi.core.offers.models import Product
 from pcapi.core.offers.models import ProductMediation
+from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.routes.serialization import artist_serialize
+from pcapi.utils.string import to_camelcase
+from pcapi.utils.transaction_manager import on_commit
 
 
 logger = logging.getLogger(__name__)
+
+# TODO (tpommellet-pass): drop the union once `offers_schemas.CreateOffer` is migrated to pydantic v2
+ArtistOfferLinkBody = artist_serialize.ArtistOfferLinkBodyModel | artist_serialize.ArtistOfferLinkBodyModelV2
 
 
 @dataclass(frozen=True)
@@ -73,7 +82,7 @@ def create_artist_offer_link(offer_id: int, artist_offer_link: ArtistOfferLinkKe
 
 
 def get_artist_offer_link_key(
-    link: models.ArtistOfferLink | artist_serialize.ArtistOfferLinkBodyModel,
+    link: models.ArtistOfferLink | ArtistOfferLinkBody,
 ) -> ArtistOfferLinkKey:
     custom_name = link.artist_name if link.artist_id is None else None
     return ArtistOfferLinkKey(
@@ -83,14 +92,32 @@ def get_artist_offer_link_key(
     )
 
 
+def check_artist_offer_links(
+    artist_offer_links: typing.Sequence[ArtistOfferLinkBody], subcategory: subcategories.Subcategory
+) -> None:
+    for link in artist_offer_links:
+        # TODO (tpommellet-pass): refacto once artists are no longer stored in extradata
+        # Convert snake_case ArtistType values to camelCase to match conditional_fields keys (ArtistFieldEnum)
+        if to_camelcase(link.artist_type.value) not in subcategory.conditional_fields:
+            raise api_errors.ApiErrors(
+                errors={"artistOfferLinks": ["Le type d'artiste n'est pas autorisé pour cette sous catégorie"]}
+            )
+
+
 def upsert_artist_offer_links(
-    artist_offer_links: list[artist_serialize.ArtistOfferLinkBodyModel], offer: models.Offer
+    artist_offer_links: typing.Sequence[ArtistOfferLinkBody],
+    offer: models.Offer,
+    *,
+    subcategory_id: str | None = None,
 ) -> tuple:
     """
     Update artist offer links for a specific offer based on a new list of artist offer links.
     - Deletes existing artist offer links that are not in the new list
     - Creates new artist offer links for entries that don't already exist
     """
+    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id or offer.subcategoryId]
+    check_artist_offer_links(artist_offer_links, subcategory)
+
     current_links_keys = {get_artist_offer_link_key(link) for link in offer.artistOfferLinks}
     incoming_links_keys = {get_artist_offer_link_key(link) for link in artist_offer_links}
 
@@ -108,6 +135,26 @@ def upsert_artist_offer_links(
             created_keys.append(incoming_key)
 
     db.session.flush()
+    db.session.expire(offer, ["artistOfferLinks"])
+
+    if deleted_keys:
+        on_commit(
+            partial(
+                logger.info,
+                "Artist offer links have been deleted",
+                extra={"offer_id": offer.id, "venue_id": offer.venueId, "links": [str(k) for k in deleted_keys]},
+                technical_message_id="offer.artistOfferLinks.deleted",
+            )
+        )
+    if created_keys:
+        on_commit(
+            partial(
+                logger.info,
+                "Artist offer links have been created",
+                extra={"offer_id": offer.id, "venue_id": offer.venueId, "links": [str(k) for k in created_keys]},
+                technical_message_id="offer.artistOfferLinks.created",
+            )
+        )
 
     return (
         created_keys,

--- a/api/src/pcapi/core/cultural_outreach/api.py
+++ b/api/src/pcapi/core/cultural_outreach/api.py
@@ -7,6 +7,7 @@ from sqlalchemy.dialects.postgresql import insert
 
 import pcapi.core.offers.models as offers_models
 from pcapi.models import db
+from pcapi.utils.date import get_naive_utc_now
 from pcapi.utils.transaction_manager import on_commit
 
 from . import models
@@ -29,6 +30,19 @@ def _check_can_claim_cultural_outreach(offer: offers_models.Offer) -> bool:
             {"global": ["Le statut de l'offre ne permet pas de déclarer une action de médiation"]}
         )
     return True
+
+
+def set_cultural_outreach_claim(offer: offers_models.Offer, is_claimed: bool) -> None:
+    cultural_outreach = offer.culturalOutreach
+    was_claimed = cultural_outreach is not None and cultural_outreach.claimedDatetime is not None
+
+    if is_claimed == was_claimed:
+        return
+
+    if cultural_outreach is None:
+        create_cultural_outreach_claim(offer)
+    else:
+        update_cultural_outreach_claim(get_naive_utc_now() if is_claimed else None, offer)
 
 
 def create_cultural_outreach_claim(

--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -3184,7 +3184,9 @@ def get_or_create_offer_location(
     return offerer_address
 
 
-def create_offerer_address_from_address_api(address: offerers_schemas.LocationModel) -> geography_models.Address:
+def create_offerer_address_from_address_api(
+    address: offerers_schemas.LocationModel | offerers_schemas.CoreLocationModelV2,
+) -> geography_models.Address:
     try:
         insee_code = (
             address.inseeCode
@@ -3207,17 +3209,17 @@ def create_offerer_address_from_address_api(address: offerers_schemas.LocationMo
 
 
 def get_offer_location_from_address(
-    offerer_id: int, address: offerers_schemas.LocationModel, venue_id: int
+    offerer_id: int,
+    address: offerers_schemas.LocationModel | offerers_schemas.CoreLocationModelV2,
+    venue_id: int,
 ) -> offerers_models.OffererAddress:
     assert offerer_id
-    if not address.label:
-        address.label = None
     address_from_api = create_offerer_address_from_address_api(address)
     return get_or_create_offer_location(
         offerer_id=offerer_id,
         venue_id=venue_id,
         address_id=address_from_api.id,
-        label=address.label,
+        label=address.label or None,
     )
 
 

--- a/api/src/pcapi/core/offerers/schemas.py
+++ b/api/src/pcapi/core/offerers/schemas.py
@@ -42,6 +42,10 @@ class CoreLocationModelV2(BaseModelV2):
         return city
 
 
+class CoreLocationOnlyOnVenueModelV2(BaseModelV2):
+    isVenueLocation: typing.Literal[True] = True
+
+
 # Legacy (pydantic V1)
 class RequiredStrippedString(pydantic_v1.ConstrainedStr):
     strip_whitespace = True

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -73,7 +73,6 @@ from pcapi.utils import db as db_utils
 from pcapi.utils import image_conversion
 from pcapi.utils import requests
 from pcapi.utils.chunks import get_chunks
-from pcapi.utils.custom_keys import get_field
 from pcapi.utils.custom_logic import OPERATIONS
 from pcapi.utils.date import get_naive_utc_now
 from pcapi.utils.redis import get_redis_client
@@ -287,10 +286,16 @@ def create_offer(
 
 
 def get_or_create_offerer_address_from_address_body(
-    address_body: offerers_schemas.LocationModel | offerers_schemas.LocationOnlyOnVenueModel,
+    address_body: offerers_schemas.LocationModel
+    | offerers_schemas.LocationOnlyOnVenueModel
+    | offerers_schemas.CoreLocationModelV2
+    | offerers_schemas.CoreLocationOnlyOnVenueModelV2,
     venue: offerers_models.Venue,
 ) -> offerers_models.OffererAddress:
-    if isinstance(address_body, offerers_schemas.LocationOnlyOnVenueModel):
+    if isinstance(
+        address_body,
+        (offerers_schemas.LocationOnlyOnVenueModel, offerers_schemas.CoreLocationOnlyOnVenueModelV2),
+    ):
         # Use the same address as the venue, but offer must not be linked to a VENUE_LOCATION
         return offerers_api.get_or_create_offer_location(
             offerer_id=venue.managingOffererId,
@@ -300,228 +305,6 @@ def get_or_create_offerer_address_from_address_body(
         )
 
     return offerers_api.get_offer_location_from_address(venue.managingOffererId, address_body, venue_id=venue.id)
-
-
-# TODO (@tpommellet): replace by `update_offer`
-def old_update_offer(
-    offer: models.Offer,
-    body: schemas.UpdateOffer,
-    venue: offerers_models.Venue | None = None,
-    offerer_address: offerers_models.OffererAddress | None = None,
-    is_from_private_api: bool = False,
-) -> models.Offer:
-    validation.check_validation_status(offer)
-
-    aliases = set(body.dict(by_alias=True))
-    fields = body.dict(by_alias=True, exclude_unset=True)
-    fields.pop("artistOfferLinks", None)
-    fields.pop("hasCulturalOutreachClaim", None)
-    artist_offer_links = body.artist_offer_links
-    has_cultural_outreach_claim = body.has_cultural_outreach_claim
-
-    # updated using the pro interface
-    if body.location:
-        offerer_address_from_body = get_or_create_offerer_address_from_address_body(
-            address_body=body.location, venue=offer.venue
-        )
-
-        if offerer_address_from_body is not None:
-            fields["offererAddress"] = offerer_address_from_body
-            fields.pop("location", None)
-
-    should_send_mail = fields.pop("shouldSendMail", False)
-
-    if venue:
-        fields["venue"] = venue
-
-    if offerer_address:
-        fields["offererAddress"] = offerer_address
-
-    updates = {key: value for key, value in fields.items() if getattr(offer, key) != value}
-    updates_set = set(updates)
-
-    subcategory_id = updates.get("subcategoryId", offer.subcategoryId)
-    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
-
-    if artist_offer_links is not None:
-        validation.check_artist_offer_links(artist_offer_links, subcategory)
-        created_links, deleted_links = artist_api.upsert_artist_offer_links(artist_offer_links, offer)
-        db.session.expire(offer, ["artistOfferLinks"])
-
-        if deleted_links:
-            on_commit(
-                partial(
-                    logger.info,
-                    "Artist offer links have been deleted",
-                    extra={"offer_id": offer.id, "venue_id": offer.venueId, "links": [str(k) for k in deleted_links]},
-                    technical_message_id="offer.artistOfferLinks.deleted",
-                )
-            )
-        if created_links:
-            on_commit(
-                partial(
-                    logger.info,
-                    "Artist offer links have been created",
-                    extra={"offer_id": offer.id, "venue_id": offer.venueId, "links": [str(k) for k in created_links]},
-                    technical_message_id="offer.artistOfferLinks.created",
-                )
-            )
-
-    if has_cultural_outreach_claim is not None:
-        outreach = offer.culturalOutreach
-        is_currently_claimed = outreach is not None and outreach.claimedDatetime is not None
-        if has_cultural_outreach_claim != is_currently_claimed:
-            if outreach is None:
-                cultural_outreach_api.create_cultural_outreach_claim(offer)
-            else:
-                claim_datetime = get_naive_utc_now() if has_cultural_outreach_claim else None
-                cultural_outreach_api.update_cultural_outreach_claim(claim_datetime, offer)
-
-    if not updates:
-        return offer
-
-    if "bookingAllowedDatetime" in updates:
-        bookingAllowedDatetime = get_field(offer, updates, "bookingAllowedDatetime", aliases=aliases)
-        if not bookingAllowedDatetime or (bookingAllowedDatetime <= datetime.datetime.now(datetime.UTC)):
-            reminders_notifications.notify_users_offer_is_bookable(offer)
-
-    if (
-        "audioDisabilityCompliant" in updates
-        or "mentalDisabilityCompliant" in updates
-        or "motorDisabilityCompliant" in updates
-        or "visualDisabilityCompliant" in updates
-    ):
-        validation.check_accessibility_compliance(
-            audio_disability_compliant=get_field(offer, updates, "audioDisabilityCompliant", aliases=aliases),
-            mental_disability_compliant=get_field(offer, updates, "mentalDisabilityCompliant", aliases=aliases),
-            motor_disability_compliant=get_field(offer, updates, "motorDisabilityCompliant", aliases=aliases),
-            visual_disability_compliant=get_field(offer, updates, "visualDisabilityCompliant", aliases=aliases),
-        )
-
-    if "extraData" in updates or "ean" in updates:
-        formatted_extra_data = validation.format_extra_data(subcategory_id, body.extra_data) or {}
-        validation.check_offer_extra_data(
-            subcategory_id, formatted_extra_data, offer.venue, is_from_private_api, offer=offer, ean=body.ean
-        )
-
-    if "isDuo" in updates:
-        is_duo = get_field(offer, updates, "isDuo", aliases=aliases)
-        validation.check_is_duo_compliance(is_duo, subcategory)
-
-    if "idAtProvider" in updates:
-        id_at_provider = get_field(offer, updates, "idAtProvider", aliases=aliases)
-        validation.check_can_input_id_at_provider(offer.lastProvider, id_at_provider)
-        validation.check_can_input_id_at_provider_for_this_venue(offer.venueId, id_at_provider, offer.id)
-
-    if "name" in updates:
-        name = get_field(offer, updates, "name", aliases=aliases)
-        if name is None:
-            raise exceptions.OfferException({"name": ["cannot be null"]})
-        validation.check_offer_name_does_not_contain_ean(name)
-
-    if (
-        "withdrawalType" in updates
-        or "withdrawalDelay" in updates
-        or "withdrawalDetails" in updates
-        or "bookingContact" in updates
-    ):
-        booking_contact = get_field(offer, updates, "bookingContact", aliases=aliases)
-        withdrawal_delay = get_field(offer, updates, "withdrawalDelay", aliases=aliases)
-        withdrawal_type = get_field(offer, updates, "withdrawalType", aliases=aliases)
-        validation.check_offer_withdrawal(
-            withdrawal_type=withdrawal_type,
-            withdrawal_delay=withdrawal_delay,
-            subcategory_id=subcategory_id,
-            booking_contact=booking_contact,
-            provider=offer.lastProvider,
-        )
-
-    try:
-        updates["ean"] = updates["extraData"].pop("ean")
-
-        # TODO(jbaudet - 11/2025): remove this whole try/except in a
-        # couple of weeks, after checking that this warning never
-        # appears.
-        # Caller should use body.ean instead of body.extra_data["ean"]
-        # This seems to be ok today, but... lets wait a little bit before
-        # doing anything stupid.
-        logger.warning(
-            "update_offer: extracting EAN from extraData (use body.ean instead)",
-            extra={"offer": offer.id, "ean": updates["ean"]},
-        )
-    except (KeyError, AttributeError):
-        pass
-
-    # - The offer URL must not be removed if the offer has an online subcategory.
-    if offer.url and "url" in body.__fields_set__ and body.url is None:
-        offer_subcategory = subcategories.ALL_SUBCATEGORIES_DICT[offer.subcategoryId]
-        validation.check_url_is_coherent_with_subcategory(offer_subcategory, None)
-
-    if "subcategoryId" in updates and offer.status != models.OfferStatus.DRAFT:
-        raise exceptions.UnallowedUpdate("subcategoryId")
-
-    if "durationMinutes" in updates:
-        duration_minutes = get_field(offer, updates, "durationMinutes", aliases=aliases)
-        validation.check_duration_minutes(duration_minutes, is_from_private_api)
-
-    if offer.lastProvider is not None:
-        validation.check_update_only_allowed_fields_for_offer_from_provider(updates_set, offer.lastProvider)
-    if offer.is_soft_deleted():
-        raise pc_object.DeletedRecordException()
-
-    changes = {}
-    for key, value in updates.items():
-        if key == "extraData":
-            if offer.product:
-                continue
-        changes[key] = {"oldValue": getattr(offer, key), "newValue": value}
-        setattr(offer, key, value)
-
-    with db.session.no_autoflush:
-        # the creation process is splitted into several steps. URL and
-        # address might be set only in the end. Therefore, this
-        # validation is meaningless until the offer has been finalized.
-        if offer.status != models.OfferStatus.DRAFT:
-            validation.check_url_is_coherent_with_subcategory(offer.subcategory, offer.url)
-            validation.check_url_and_offererAddress_are_not_both_set(offer.url, offer.offererAddress)
-
-    if offer.isFromAllocine:
-        offer.fieldsUpdated = list(set(offer.fieldsUpdated) | updates_set)
-    db.session.add(offer)
-
-    # This log is used for analytics purposes.
-    # If you need to make a 'breaking change' of this log, please contact the data team.
-    # Otherwise, you will break some dashboards
-    on_commit(
-        partial(
-            logger.info,
-            "Offer has been updated",
-            extra={
-                "offer_id": offer.id,
-                "venue_id": offer.venueId,
-                "product_id": offer.productId,
-                "changes": {**changes},
-            },
-            technical_message_id="offer.updated",
-        )
-    )
-
-    withdrawal_fields = {"bookingContact", "withdrawalDelay", "withdrawalDetails", "withdrawalType"}
-    withdrawal_updated = updates_set & withdrawal_fields
-    oa_updated = "offererAddress" in updates
-    if should_send_mail and (withdrawal_updated or oa_updated):
-        transactional_mails.send_email_for_each_ongoing_booking(offer)
-
-    on_commit(
-        partial(
-            search.async_index_offer_ids,
-            [offer.id],
-            reason=IndexationReason.OFFER_UPDATE,
-            log_extra={"changes": updates_set},
-        )
-    )
-
-    return offer
 
 
 def update_offer(
@@ -538,6 +321,7 @@ def update_offer(
     extra_data: models.OfferExtraData | dict[str, typing.Any] | None | T_UNCHANGED = UNCHANGED,
     id_at_provider: str | None | T_UNCHANGED = UNCHANGED,
     is_duo: bool | None | T_UNCHANGED = UNCHANGED,
+    is_national: bool | None | T_UNCHANGED = UNCHANGED,
     mental_disability_compliant: bool | None | T_UNCHANGED = UNCHANGED,
     motor_disability_compliant: bool | None | T_UNCHANGED = UNCHANGED,
     name: str | None | T_UNCHANGED = UNCHANGED,
@@ -552,7 +336,12 @@ def update_offer(
     venue: offerers_models.Venue | None = None,
     offerer_address: offerers_models.OffererAddress | None = None,
     venue_provider: providers_models.VenueProvider | None = None,
+    should_send_mail: bool = False,
 ) -> models.Offer:
+    # an offer carrying a url is national
+    if is_national is not UNCHANGED:
+        is_national = True if (url is not UNCHANGED and url) else bool(is_national)
+
     fields: dict[str, typing.Any] = {
         "audioDisabilityCompliant": audio_disability_compliant,
         "bookingAllowedDatetime": booking_allowed_datetime,
@@ -566,6 +355,7 @@ def update_offer(
         "idAtProvider": id_at_provider,
         # an explicit `null` disables double bookings rather than clearing the field
         "isDuo": bool(is_duo) if is_duo is not UNCHANGED else UNCHANGED,
+        "isNational": is_national,
         "mentalDisabilityCompliant": mental_disability_compliant,
         "motorDisabilityCompliant": motor_disability_compliant,
         "name": name,
@@ -627,6 +417,12 @@ def update_offer(
             technical_message_id="offer.updated",
         )
     )
+
+    withdrawal_fields = {"bookingContact", "withdrawalDelay", "withdrawalDetails", "withdrawalType"}
+    withdrawal_updated = updates_set & withdrawal_fields
+    oa_updated = "offererAddress" in updates
+    if should_send_mail and (withdrawal_updated or oa_updated):
+        transactional_mails.send_email_for_each_ongoing_booking(offer)
 
     on_commit(
         partial(

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -262,7 +262,7 @@ def create_offer(
     db.session.flush()
 
     if artist_offer_links is not None:
-        validation.check_artist_offer_links(artist_offer_links, subcategory)
+        artist_api.check_artist_offer_links(artist_offer_links, subcategory)
 
         for artist_offer_link in artist_offer_links:
             link_key = artist_api.get_artist_offer_link_key(artist_offer_link)

--- a/api/src/pcapi/core/offers/api.py
+++ b/api/src/pcapi/core/offers/api.py
@@ -66,7 +66,6 @@ from pcapi.core.reminders.external import reminders_notifications
 from pcapi.core.search.models import IndexationReason
 from pcapi.models import db
 from pcapi.models import offer_mixin
-from pcapi.models import pc_object
 from pcapi.models.offer_mixin import OfferValidationType
 from pcapi.utils import date as date_utils
 from pcapi.utils import db as db_utils
@@ -333,6 +332,8 @@ def update_offer(
     withdrawal_details: str | None | T_UNCHANGED = UNCHANGED,
     withdrawal_type: models.WithdrawalTypeEnum | None | T_UNCHANGED = UNCHANGED,
     mandatory_extra_data_fields: typing.Collection[str],
+    editable_fields: typing.Collection[str] | None = None,
+    not_editable_fields: typing.Collection[str] = (),
     venue: offerers_models.Venue | None = None,
     offerer_address: offerers_models.OffererAddress | None = None,
     venue_provider: providers_models.VenueProvider | None = None,
@@ -367,7 +368,9 @@ def update_offer(
         "withdrawalDetails": withdrawal_details,
         "withdrawalType": withdrawal_type,
     }
+
     fields = {key: value for key, value in fields.items() if value is not UNCHANGED}
+
     if venue:
         fields["venue"] = venue
     if offerer_address:
@@ -379,6 +382,8 @@ def update_offer(
         offer,
         updates,
         mandatory_extra_data_fields=mandatory_extra_data_fields,
+        editable_fields=editable_fields,
+        not_editable_fields=not_editable_fields,
         venue_provider=venue_provider,
     )
 

--- a/api/src/pcapi/core/offers/schemas.py
+++ b/api/src/pcapi/core/offers/schemas.py
@@ -10,8 +10,6 @@ from pydantic.v1 import HttpUrl
 from pydantic.v1 import root_validator
 from pydantic.v1 import validator
 
-from pcapi.core.offerers import models as offerers_models
-from pcapi.core.offerers import schemas as offerers_schemas
 from pcapi.core.offers import models as offers_models
 from pcapi.routes.public.individual_offers.v1 import serialization as individual_offers_v1_serialization
 from pcapi.routes.serialization import BaseModel
@@ -69,57 +67,6 @@ class CreateOffer(BaseModel):
         return is_national
 
     class Config:
-        alias_generator = serialization_utils.to_camel
-        extra = "forbid"
-
-
-class UpdateOffer(BaseModel):
-    name: str | None = None
-    audio_disability_compliant: bool | None = None
-    mental_disability_compliant: bool | None = None
-    motor_disability_compliant: bool | None = None
-    visual_disability_compliant: bool | None = None
-
-    artist_offer_links: list[artist_serialize.ArtistOfferLinkBodyModel] | None = None
-    location: offerers_schemas.LocationModel | offerers_schemas.LocationOnlyOnVenueModel | None = None
-    booking_contact: EmailStr | None = None
-    booking_email: EmailStr | None = None
-    description: str | None = None
-    duration_minutes: int | None = None
-    external_ticket_office_url: HttpUrl | None = None
-    ean: str | None = None
-    extra_data: typing.Any = None
-    has_cultural_outreach_claim: bool | None = None
-    id_at_provider: str | None = None
-    is_duo: bool | None = None
-    offerer_address: offerers_models.OffererAddress | None
-    url: HttpUrl | None = None
-    withdrawal_delay: int | None = None
-    withdrawal_details: str | None = None
-    withdrawal_type: offers_models.WithdrawalTypeEnum | None = None
-    publicationDatetime: datetime.datetime | None
-    bookingAllowedDatetime: datetime.datetime | None
-    subcategory_id: str | None = None
-
-    # is_national must be placed after url so that the validator
-    # can access the url field in the dict of values
-    # (which contains only previously validated fields)
-    is_national: bool | None = None
-
-    should_send_mail: bool | None = None
-
-    @validator("is_duo")
-    def validate_is_duo(cls, is_duo: bool | None) -> bool:
-        return bool(is_duo)
-
-    @validator("is_national")
-    def validate_is_national(cls, is_national: bool | None, values: dict) -> bool:
-        url = values.get("url")
-        is_national = True if url else bool(is_national)
-        return is_national
-
-    class Config:
-        arbitrary_types_allowed = True
         alias_generator = serialization_utils.to_camel
         extra = "forbid"
 

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -37,12 +37,10 @@ from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferStatus
 from pcapi.models.offer_mixin import OfferValidationStatus
-from pcapi.routes.serialization import artist_serialize
 from pcapi.routes.serialization import stock_serialize as serialization
 from pcapi.utils import date
 from pcapi.utils.custom_keys import get_field
 from pcapi.utils.string import is_canonical_integer
-from pcapi.utils.string import to_camelcase
 
 
 logger = logging.getLogger(__name__)
@@ -1054,15 +1052,3 @@ def check_offer_can_ask_for_highlight_request(offer: models.Offer) -> None:
         raise api_errors.ApiErrors(
             errors={"global": ["La sous catégorie de l'offre ne lui permet pas de participer à un temps fort"]}
         )
-
-
-def check_artist_offer_links(
-    artist_offer_links: list[artist_serialize.ArtistOfferLinkBodyModel], subcategory: subcategories.Subcategory
-) -> None:
-    for link in artist_offer_links:
-        # TODO (tpommellet-pass): refacto once artists are no longer stored in extradata
-        # Convert snake_case ArtistType values to camelCase to match conditional_fields keys (ArtistFieldEnum)
-        if to_camelcase(link.artist_type.value) not in subcategory.conditional_fields:
-            raise api_errors.ApiErrors(
-                errors={"artistOfferLinks": ["Le type d'artiste n'est pas autorisé pour cette sous catégorie"]}
-            )

--- a/api/src/pcapi/core/offers/validation.py
+++ b/api/src/pcapi/core/offers/validation.py
@@ -45,35 +45,7 @@ from pcapi.utils.string import is_canonical_integer
 
 logger = logging.getLogger(__name__)
 
-EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER = {
-    "name",
-    "audioDisabilityCompliant",
-    "externalTicketOfficeUrl",
-    "mentalDisabilityCompliant",
-    "motorDisabilityCompliant",
-    "visualDisabilityCompliant",
-    "description",
-    "offererAddress",
-    "venue",
-    "url",
-}
-EDITABLE_FIELDS_FOR_ALLOCINE_OFFER = {"isDuo"} | EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER
 EDITABLE_FIELDS_FOR_ALLOCINE_STOCK = {"bookingLimitDatetime", "price", "priceCategory", "quantity"}
-EDITABLE_FIELDS_FOR_INDIVIDUAL_OFFERS_API_PROVIDER = {
-    "name",
-    "description",
-    "isActive",
-    "isDuo",
-    "bookingContact",
-    "bookingEmail",
-    "ean",
-    "extraData",
-    "withdrawalDetails",
-    "durationMinutes",
-    "idAtProvider",
-    "bookingAllowedDatetime",
-    "publicationDatetime",
-} | EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER
 
 MAX_THUMBNAIL_SIZE = 10_000_000
 MIN_THUMBNAIL_WIDTH = 400
@@ -102,18 +74,18 @@ def check_can_edit_synchronized_stock(
         raise exceptions.OfferException({"global": ["Les offres importées ne sont pas modifiables"]})
 
 
-def check_update_only_allowed_fields_for_offer_from_provider(
-    updated_fields: set, provider: providers_models.Provider
+def check_fields_are_editable(
+    updated_fields: set[str],
+    editable_fields: typing.Collection[str] | None = None,
+    not_editable_fields: typing.Collection[str] = (),
 ) -> None:
-    if provider.isAllocine:
-        rejected_fields = updated_fields - EDITABLE_FIELDS_FOR_ALLOCINE_OFFER
-    elif provider.hasOffererProvider:
-        rejected_fields = updated_fields - EDITABLE_FIELDS_FOR_INDIVIDUAL_OFFERS_API_PROVIDER
-    else:
-        rejected_fields = updated_fields - EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER
+    rejected_fields = set(updated_fields) & set(not_editable_fields)
+
+    if editable_fields is not None:
+        rejected_fields |= set(updated_fields) - set(editable_fields)
     if rejected_fields:
         api_error = api_errors.ApiErrors()
-        for field in rejected_fields:
+        for field in sorted(rejected_fields):
             api_error.add_error(field, "Vous ne pouvez pas modifier ce champ")
 
         raise api_error
@@ -624,6 +596,8 @@ def check_can_update_offer(
     updates: dict[str, typing.Any],
     *,
     mandatory_extra_data_fields: typing.Collection[str],
+    editable_fields: typing.Collection[str] | None = None,
+    not_editable_fields: typing.Collection[str] = (),
     venue_provider: providers_models.VenueProvider | None = None,
 ) -> None:
     check_validation_status(offer)
@@ -633,8 +607,7 @@ def check_can_update_offer(
 
     updated_fields = set(updates)
 
-    if offer.lastProvider is not None:
-        check_update_only_allowed_fields_for_offer_from_provider(updated_fields, offer.lastProvider)
+    check_fields_are_editable(updated_fields, editable_fields, not_editable_fields)
 
     if "subcategoryId" in updates and offer.status != OfferStatus.DRAFT:
         raise exceptions.UnallowedUpdate("subcategoryId")

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -6,6 +6,8 @@ from flask import request
 from flask_login import current_user
 from flask_login import login_required
 
+import pcapi.core.artist.api as artist_api
+import pcapi.core.cultural_outreach.api as cultural_outreach_api
 import pcapi.core.offers.api as offers_api
 import pcapi.core.offers.constants as offers_constants
 import pcapi.core.offers.repository as offers_repository
@@ -498,9 +500,17 @@ def patch_offer(
             address_body=body.location, venue=offer.venue
         )
 
+    subcategory_id = updates.get("subcategoryId", offer.subcategoryId)
+
+    if body.artist_offer_links is not None:
+        artist_api.upsert_artist_offer_links(body.artist_offer_links, offer, subcategory_id=subcategory_id)
+
+    if body.hasCulturalOutreachClaim is not None:
+        cultural_outreach_api.set_cultural_outreach_claim(offer, body.hasCulturalOutreachClaim)
+
     offers_api.update_offer(
         offer,
-        mandatory_extra_data_fields=_mandatory_extra_data_fields(updates.get("subcategoryId", offer.subcategoryId)),
+        mandatory_extra_data_fields=_mandatory_extra_data_fields(subcategory_id),
         audio_disability_compliant=updates.get("audioDisabilityCompliant", offers_api.UNCHANGED),
         booking_allowed_datetime=updates.get("bookingAllowedDatetime", offers_api.UNCHANGED),
         booking_contact=updates.get("bookingContact", offers_api.UNCHANGED),

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -441,6 +441,15 @@ def patch_all_offers_active_status(
     return offers_serialize.PatchAllOffersActiveStatusResponseModel()
 
 
+def _mandatory_extra_data_fields(subcategory_id: str) -> set[str]:
+    subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
+    return {
+        name
+        for name, conditional_field in subcategory.conditional_fields.items()
+        if conditional_field.is_required_in_internal_form
+    }
+
+
 @private_api.route("/offers/<int:offer_id>", methods=["PATCH"])
 @login_required
 @spectree_serialize(
@@ -473,11 +482,49 @@ def patch_offer(
     rest.check_venue_is_opened(offer.venue)
 
     updates = body.model_dump(by_alias=True, exclude_unset=True)
+
+    ean: str | None | offers_api.T_UNCHANGED = offers_api.UNCHANGED
+    extra_data: typing.Any = updates.get("extraData", offers_api.UNCHANGED)
+
     if body_extra_data := offers_api.deserialize_extra_data(body.extraData, offer.subcategoryId):
         if "ean" in body_extra_data:
-            updates["ean"] = body_extra_data.pop("ean")
-        updates["extraData"] = body_extra_data
-    offers_api.old_update_offer(offer, offers_schemas.UpdateOffer(**updates), is_from_private_api=True)
+            ean = body_extra_data.pop("ean")
+        extra_data = body_extra_data
+
+    offerer_address = None
+
+    if body.location:
+        offerer_address = offers_api.get_or_create_offerer_address_from_address_body(
+            address_body=body.location, venue=offer.venue
+        )
+
+    offers_api.update_offer(
+        offer,
+        mandatory_extra_data_fields=_mandatory_extra_data_fields(updates.get("subcategoryId", offer.subcategoryId)),
+        audio_disability_compliant=updates.get("audioDisabilityCompliant", offers_api.UNCHANGED),
+        booking_allowed_datetime=updates.get("bookingAllowedDatetime", offers_api.UNCHANGED),
+        booking_contact=updates.get("bookingContact", offers_api.UNCHANGED),
+        booking_email=updates.get("bookingEmail", offers_api.UNCHANGED),
+        description=updates.get("description", offers_api.UNCHANGED),
+        duration_minutes=updates.get("durationMinutes", offers_api.UNCHANGED),
+        ean=ean,
+        external_ticket_office_url=updates.get("externalTicketOfficeUrl", offers_api.UNCHANGED),
+        extra_data=extra_data,
+        is_duo=updates.get("isDuo", offers_api.UNCHANGED),
+        is_national=updates.get("isNational", offers_api.UNCHANGED),
+        mental_disability_compliant=updates.get("mentalDisabilityCompliant", offers_api.UNCHANGED),
+        motor_disability_compliant=updates.get("motorDisabilityCompliant", offers_api.UNCHANGED),
+        name=updates.get("name", offers_api.UNCHANGED),
+        offerer_address=offerer_address,
+        publication_datetime=updates.get("publicationDatetime", offers_api.UNCHANGED),
+        subcategory_id=updates.get("subcategoryId", offers_api.UNCHANGED),
+        url=updates.get("url", offers_api.UNCHANGED),
+        visual_disability_compliant=updates.get("visualDisabilityCompliant", offers_api.UNCHANGED),
+        withdrawal_delay=updates.get("withdrawalDelay", offers_api.UNCHANGED),
+        withdrawal_details=updates.get("withdrawalDetails", offers_api.UNCHANGED),
+        withdrawal_type=updates.get("withdrawalType", offers_api.UNCHANGED),
+        should_send_mail=bool(body.shouldSendMail),
+    )
     db.session.flush()
     offer = offers_repository.get_offer_by_id(
         offer_id,

--- a/api/src/pcapi/routes/pro/offers.py
+++ b/api/src/pcapi/routes/pro/offers.py
@@ -443,6 +443,60 @@ def patch_all_offers_active_status(
     return offers_serialize.PatchAllOffersActiveStatusResponseModel()
 
 
+NOT_EDITABLE_WHEN_PRODUCT_BASED = {
+    "artistOfferLinks",
+    "description",
+    "durationMinutes",
+    "ean",
+    "extraData",
+    "hasCulturalOutreachClaim",
+    "name",
+    "subcategoryId",
+}
+
+NOT_EDITABLE_WHEN_SYNCHRONIZED = {
+    "artistOfferLinks",
+    "bookingAllowedDatetime",
+    "bookingContact",
+    "bookingEmail",
+    "description",
+    "durationMinutes",
+    "ean",
+    "extraData",
+    "isDuo",
+    "isNational",
+    "name",
+    "offererAddress",
+    "publicationDatetime",
+    "subcategoryId",
+    "url",
+    "withdrawalDelay",
+    "withdrawalDetails",
+    "withdrawalType",
+}
+# (tcoudray-pass, 10/02/26) to unblock the synchronization of EPNs, museums may edit
+# the name and the description of their synchronized offers
+EDITABLE_FOR_A_MUSEUM_WHEN_SYNCHRONIZED = {"description", "name"}
+EDITABLE_WHEN_SYNCHRONIZED_BY_ALLOCINE = {"withdrawalDetails"}
+
+
+def _get_not_editable_fields(offer: models.Offer) -> set[str]:
+    not_editable_fields: set[str] = set()
+
+    if offer.productId is not None:
+        not_editable_fields |= NOT_EDITABLE_WHEN_PRODUCT_BASED
+
+    if offer.lastProvider is not None:
+        not_editable_synchronized_fields = set(NOT_EDITABLE_WHEN_SYNCHRONIZED)
+        if offer.venue.activity == offerers_models.Activity.MUSEUM:
+            not_editable_synchronized_fields -= EDITABLE_FOR_A_MUSEUM_WHEN_SYNCHRONIZED
+        if offer.isFromAllocine:
+            not_editable_synchronized_fields -= EDITABLE_WHEN_SYNCHRONIZED_BY_ALLOCINE
+        not_editable_fields |= not_editable_synchronized_fields
+
+    return not_editable_fields
+
+
 def _mandatory_extra_data_fields(subcategory_id: str) -> set[str]:
     subcategory = subcategories.ALL_SUBCATEGORIES_DICT[subcategory_id]
     return {
@@ -501,16 +555,27 @@ def patch_offer(
         )
 
     subcategory_id = updates.get("subcategoryId", offer.subcategoryId)
+    not_editable_fields = _get_not_editable_fields(offer)
 
     if body.artist_offer_links is not None:
-        artist_api.upsert_artist_offer_links(body.artist_offer_links, offer, subcategory_id=subcategory_id)
+        validation.check_fields_are_editable({"artistOfferLinks"}, not_editable_fields=not_editable_fields)
+        artist_api.upsert_artist_offer_links(
+            body.artist_offer_links,
+            offer,
+            subcategory_id=subcategory_id,
+        )
 
     if body.hasCulturalOutreachClaim is not None:
-        cultural_outreach_api.set_cultural_outreach_claim(offer, body.hasCulturalOutreachClaim)
+        validation.check_fields_are_editable({"hasCulturalOutreachClaim"}, not_editable_fields=not_editable_fields)
+        cultural_outreach_api.set_cultural_outreach_claim(
+            offer,
+            body.hasCulturalOutreachClaim,
+        )
 
     offers_api.update_offer(
         offer,
         mandatory_extra_data_fields=_mandatory_extra_data_fields(subcategory_id),
+        not_editable_fields=not_editable_fields,
         audio_disability_compliant=updates.get("audioDisabilityCompliant", offers_api.UNCHANGED),
         booking_allowed_datetime=updates.get("bookingAllowedDatetime", offers_api.UNCHANGED),
         booking_contact=updates.get("bookingContact", offers_api.UNCHANGED),

--- a/api/src/pcapi/routes/public/individual_offers/v1/events.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/events.py
@@ -308,6 +308,7 @@ def edit_event(event_id: int, body: events_serializers.EventOfferEdition) -> eve
             url=body.location.url if isinstance(body.location, serialization.DigitalLocation) else None,
             withdrawal_details=updates.get("itemCollectionDetails", offers_api.UNCHANGED),
             mandatory_extra_data_fields=utils.mandatory_extra_data_fields(offer.subcategoryId),
+            editable_fields=utils.get_editable_fields(offer.lastProvider),
             venue=venue,
             offerer_address=offerer_address,
             venue_provider=venue_provider,

--- a/api/src/pcapi/routes/public/individual_offers/v1/products.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/products.py
@@ -587,6 +587,7 @@ def edit_product(body: products_serializers.ProductOfferEdition) -> serializatio
         publication_datetime=publication_datetime,
         withdrawal_details=updates.get("itemCollectionDetails", offers_api.UNCHANGED),
         mandatory_extra_data_fields=utils.mandatory_extra_data_fields(offer.subcategoryId),
+        editable_fields=utils.get_editable_fields(offer.lastProvider),
         venue=venue,
         offerer_address=offerer_address,
         venue_provider=venue_provider,

--- a/api/src/pcapi/routes/public/individual_offers/v1/utils.py
+++ b/api/src/pcapi/routes/public/individual_offers/v1/utils.py
@@ -330,3 +330,43 @@ def translate_offer_errors(errors: dict[str, typing.Any]) -> dict[str, typing.An
         translated[key] = messages
 
     return translated
+
+
+EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER = {
+    "name",
+    "audioDisabilityCompliant",
+    "externalTicketOfficeUrl",
+    "mentalDisabilityCompliant",
+    "motorDisabilityCompliant",
+    "visualDisabilityCompliant",
+    "description",
+    "offererAddress",
+    "venue",
+    "url",
+}
+EDITABLE_FIELDS_FOR_ALLOCINE_OFFER = {"isDuo"} | EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER
+EDITABLE_FIELDS_FOR_INDIVIDUAL_OFFERS_API_PROVIDER = {
+    "name",
+    "description",
+    "isActive",
+    "isDuo",
+    "bookingContact",
+    "bookingEmail",
+    "ean",
+    "extraData",
+    "withdrawalDetails",
+    "durationMinutes",
+    "idAtProvider",
+    "bookingAllowedDatetime",
+    "publicationDatetime",
+} | EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER
+
+
+def get_editable_fields(provider: providers_models.Provider | None) -> set[str] | None:
+    if provider is None:
+        return None
+    if provider.isAllocine:
+        return EDITABLE_FIELDS_FOR_ALLOCINE_OFFER
+    if provider.hasOffererProvider:
+        return EDITABLE_FIELDS_FOR_INDIVIDUAL_OFFERS_API_PROVIDER
+    return EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER

--- a/api/src/pcapi/routes/serialization/address_serialize.py
+++ b/api/src/pcapi/routes/serialization/address_serialize.py
@@ -9,8 +9,8 @@ from pcapi.routes.serialization import BaseModel
 from pcapi.routes.serialization import HttpBodyModel
 
 
-class LocationOnlyOnVenueBodyModelV2(HttpBodyModel):
-    isVenueLocation: typing.Literal[True] = True
+class LocationOnlyOnVenueBodyModelV2(HttpBodyModel, offerers_schema.CoreLocationOnlyOnVenueModelV2):
+    pass
 
 
 class LocationBodyModelV2(HttpBodyModel, offerers_schema.CoreLocationModelV2):

--- a/api/tests/core/artist/test_api.py
+++ b/api/tests/core/artist/test_api.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 
 import pytest
@@ -7,9 +8,12 @@ import pcapi.core.offers.factories as offers_factories
 from pcapi.core.artist import exceptions as artist_exceptions
 from pcapi.core.artist import models as artist_models
 from pcapi.core.artist.api import ArtistOfferLinkKey
+from pcapi.core.artist.api import check_artist_offer_links
 from pcapi.core.artist.api import create_artist_offer_link
 from pcapi.core.artist.api import get_artist_image_url
 from pcapi.core.artist.api import upsert_artist_offer_links
+from pcapi.core.categories import subcategories
+from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.routes.serialization import artist_serialize
 
@@ -165,7 +169,7 @@ class CreateArtistOfferLinkTest:
 @pytest.mark.usefixtures("db_session")
 class UpsertArtistOfferLinksTest:
     def test_patch_offer_with_new_link(self):
-        offer = offers_factories.OfferFactory()
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONCERT.id)
         artist = artist_factories.ArtistFactory()
 
         incoming_links = [
@@ -185,7 +189,7 @@ class UpsertArtistOfferLinksTest:
 
     def test_patch_offer_without_link(self):
         artist = artist_factories.ArtistFactory()
-        offer = offers_factories.OfferFactory()
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONCERT.id)
         artist_factories.ArtistOfferLinkFactory(artist_id=artist.id, offer_id=offer.id)
 
         upsert_artist_offer_links([], offer)
@@ -195,7 +199,7 @@ class UpsertArtistOfferLinksTest:
 
     def test_patch_offer_with_existing_link(self):
         artist = artist_factories.ArtistFactory()
-        offer = offers_factories.OfferFactory()
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONCERT.id)
         existing_link = artist_factories.ArtistOfferLinkFactory(artist_id=artist.id, offer_id=offer.id)
         existing_link_id = existing_link.id
 
@@ -214,7 +218,7 @@ class UpsertArtistOfferLinksTest:
 
     @mock.patch("pcapi.core.artist.api.create_artist_offer_link")
     def test_patch_offer_with_duplicate_link(self, mock_create_artist_offer_link):
-        offer = offers_factories.OfferFactory()
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.CONCERT.id)
         artist = artist_factories.ArtistFactory()
 
         incoming_links = [
@@ -228,3 +232,79 @@ class UpsertArtistOfferLinksTest:
         upsert_artist_offer_links(incoming_links, offer)
         mock_create_artist_offer_link.assert_called()
         assert len(mock_create_artist_offer_link.call_args_list[0]) == 2
+
+
+@pytest.mark.usefixtures("db_session")
+class UpsertArtistOfferLinksValidationTest:
+    def _link(self, artist_type: artist_models.ArtistType) -> artist_serialize.ArtistOfferLinkBodyModel:
+        artist = artist_factories.ArtistFactory()
+        return artist_serialize.ArtistOfferLinkBodyModel(
+            artist_id=artist.id, artist_type=artist_type, artist_name=artist.name
+        )
+
+    def test_check_the_links_against_the_resulting_subcategory(self):
+        # a performer is refused by the subcategory of the offer, but allowed by the one it moves to
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
+
+        upsert_artist_offer_links(
+            [self._link(artist_models.ArtistType.PERFORMER)],
+            offer,
+            subcategory_id=subcategories.CONCERT.id,
+        )
+
+        assert len(db.session.query(artist_models.ArtistOfferLink).all()) == 1
+
+    def test_refuse_the_links_the_subcategory_does_not_allow(self):
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
+
+        with pytest.raises(api_errors.ApiErrors) as error:
+            upsert_artist_offer_links([self._link(artist_models.ArtistType.PERFORMER)], offer)
+
+        assert error.value.errors == {
+            "artistOfferLinks": ["Le type d'artiste n'est pas autorisé pour cette sous catégorie"]
+        }
+
+    def test_log_created_and_deleted_links(self, caplog):
+        offer = offers_factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
+
+        with caplog.at_level(logging.INFO):
+            upsert_artist_offer_links([self._link(artist_models.ArtistType.AUTHOR)], offer)
+
+        created_logs = [record for record in caplog.records if "Artist offer links have been created" in record.message]
+        assert len(created_logs) == 1
+        assert created_logs[0].technical_message_id == "offer.artistOfferLinks.created"
+        assert created_logs[0].extra["offer_id"] == offer.id
+
+        with caplog.at_level(logging.INFO):
+            upsert_artist_offer_links([], offer)
+
+        deleted_logs = [record for record in caplog.records if "Artist offer links have been deleted" in record.message]
+        assert len(deleted_logs) == 1
+        assert deleted_logs[0].technical_message_id == "offer.artistOfferLinks.deleted"
+
+
+class CheckArtistOfferLinksTest:
+    def test_check_artist_offer_links_should_not_raise(self):
+        artist_offer_links = [
+            artist_serialize.ArtistOfferLinkBodyModel(
+                artist_id="any-id",
+                artist_type=artist_models.ArtistType.AUTHOR,
+                artist_name="any-name",
+            )
+        ]
+        check_artist_offer_links(artist_offer_links, subcategories.SEANCE_CINE)
+
+    def test_check_artist_offer_links_should_raise(self):
+        artist_offer_links = [
+            artist_serialize.ArtistOfferLinkBodyModel(
+                artist_id="any-id",
+                artist_type=artist_models.ArtistType.PERFORMER,
+                artist_name="any-name",
+            )
+        ]
+        with pytest.raises(api_errors.ApiErrors) as exc:
+            check_artist_offer_links(artist_offer_links, subcategories.SEANCE_CINE)
+
+        assert exc.value.errors == {
+            "artistOfferLinks": ["Le type d'artiste n'est pas autorisé pour cette sous catégorie"]
+        }

--- a/api/tests/core/cultural_outreach/test_api.py
+++ b/api/tests/core/cultural_outreach/test_api.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from unittest import mock
 
 import pytest
 import sqlalchemy as sa
@@ -148,3 +149,42 @@ class UpdateCulturalOutreachClaimTest:
         assert exc.value.errors == {
             "global": ["Le statut de l'offre ne permet pas de déclarer une action de médiation"]
         }
+
+
+class SetCulturalOutreachClaimTest:
+    @mock.patch("pcapi.core.cultural_outreach.api.update_cultural_outreach_claim")
+    @time_machine.travel("2026-04-21 12:00:00", tick=False)
+    def test_turns_the_claim_to_true(self, mocked_update_claim):
+        offer = offers_factories.OfferFactory()
+        cultural_outreach_factories.CulturalOutreachFactory(offer=offer)
+
+        cultural_outreach_api.set_cultural_outreach_claim(offer, True)
+
+        mocked_update_claim.assert_called_once_with(datetime.datetime(2026, 4, 21, 12, 0, 0), offer)
+
+    @mock.patch("pcapi.core.cultural_outreach.api.update_cultural_outreach_claim")
+    @time_machine.travel("2026-04-21 12:00:00", tick=False)
+    def test_does_not_update_the_claim_datetime_when_already_claimed(self, mocked_update_claim):
+        offer = offers_factories.OfferFactory()
+        cultural_outreach_factories.ClaimedCulturalOutreachFactory(offer=offer)
+
+        cultural_outreach_api.set_cultural_outreach_claim(offer, True)
+
+        mocked_update_claim.assert_not_called()
+
+    @mock.patch("pcapi.core.cultural_outreach.api.update_cultural_outreach_claim")
+    def test_turns_the_claim_to_false(self, mocked_update_claim):
+        offer = offers_factories.OfferFactory()
+        cultural_outreach_factories.ClaimedCulturalOutreachFactory(offer=offer)
+
+        cultural_outreach_api.set_cultural_outreach_claim(offer, False)
+
+        mocked_update_claim.assert_called_once_with(None, offer)
+
+    @mock.patch("pcapi.core.cultural_outreach.api.create_cultural_outreach_claim")
+    def test_creates_the_claim_when_the_offer_has_none(self, mocked_create_claim):
+        offer = offers_factories.OfferFactory()
+
+        cultural_outreach_api.set_cultural_outreach_claim(offer, True)
+
+        mocked_create_claim.assert_called_once_with(offer)

--- a/api/tests/core/offerers/test_api.py
+++ b/api/tests/core/offerers/test_api.py
@@ -4090,8 +4090,6 @@ class GetOfferLocationFromAddressTest:
         offerers_api.get_offer_location_from_address(venue.managingOffererId, address_body, venue_id=venue.id)
 
         assert get_or_create_offer_location.call_args.kwargs["label"] is None
-        # the body is edited in place, not copied
-        assert address_body.label is None
 
     def test_should_refuse_a_missing_offerer(self):
         venue = offerers_factories.VenueFactory()

--- a/api/tests/core/offers/test_api.py
+++ b/api/tests/core/offers/test_api.py
@@ -26,7 +26,6 @@ import pcapi.core.chronicles.factories as chronicles_factories
 import pcapi.core.chronicles.models as chronicles_models
 import pcapi.core.criteria.factories as criteria_factories
 import pcapi.core.criteria.models as criteria_models
-import pcapi.core.cultural_outreach.factories as cultural_outreach_factories
 import pcapi.core.educational.factories as educational_factories
 import pcapi.core.educational.models as educational_models
 import pcapi.core.finance.factories as finance_factories
@@ -67,7 +66,7 @@ from pcapi.models import api_errors
 from pcapi.models import db
 from pcapi.models.offer_mixin import OfferValidationStatus
 from pcapi.models.offer_mixin import OfferValidationType
-from pcapi.routes.serialization import artist_serialize
+from pcapi.routes.public.individual_offers.v1 import utils as public_offers_utils
 from pcapi.utils import date as date_utils
 from pcapi.utils.human_ids import humanize
 from pcapi.utils.transaction_manager import atomic
@@ -1723,589 +1722,6 @@ class CreateOfferTest:
 
 
 @pytest.mark.usefixtures("db_session")
-class OldUpdateOfferTest:
-    @mock.patch("pcapi.core.search.async_index_offer_ids")
-    def test_basics(self, mocked_async_index_offer_ids, caplog):
-        offer = factories.OfferFactory(
-            isDuo=False, bookingEmail="old@example.com", subcategoryId=subcategories.ESCAPE_GAME.id
-        )
-
-        body = offers_schemas.UpdateOffer(isDuo=True, bookingEmail="new@example.com")
-        with caplog.at_level(logging.DEBUG):
-            offer = api.old_update_offer(offer, body)
-        db.session.flush()
-
-        assert offer.isDuo
-        assert offer.bookingEmail == "new@example.com"
-        mocked_async_index_offer_ids.assert_called_once_with(
-            [offer.id],
-            reason=IndexationReason.OFFER_UPDATE,
-            log_extra={"changes": {"bookingEmail", "isDuo"}},
-        )
-
-        # Test tracking
-        last_record = caplog.records[-1]
-        assert last_record.technical_message_id == "offer.updated"
-        assert last_record.message == "Offer has been updated"
-        assert last_record.extra == {
-            "offer_id": offer.id,
-            "venue_id": offer.venueId,
-            "product_id": offer.productId,
-            "changes": {
-                "bookingEmail": {"oldValue": "old@example.com", "newValue": "new@example.com"},
-                "isDuo": {"oldValue": False, "newValue": True},
-            },
-        }
-
-    def test_update_extra_data_should_raise_error_when_mandatory_field_not_provided(self):
-        offer = factories.OfferFactory(subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id)
-        body = offers_schemas.UpdateOffer(extraData={"author": "Asimov"})
-        with pytest.raises(api_errors.ApiErrors) as error:
-            api.old_update_offer(offer, body)
-
-        assert error.value.errors == {
-            "showType": ["Ce champ est obligatoire"],
-            "showSubType": ["Ce champ est obligatoire"],
-        }
-
-    def test_error_when_missing_mandatory_extra_data(self):
-        offer = factories.OfferFactory(
-            subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id, extraData={"showType": 200}
-        )
-        body = offers_schemas.UpdateOffer(extraData=None)
-        with pytest.raises(api_errors.ApiErrors) as error:
-            api.old_update_offer(offer, body)
-        assert error.value.errors == {
-            "showType": ["Ce champ est obligatoire"],
-            "showSubType": ["Ce champ est obligatoire"],
-        }
-
-    def test_update_offer_with_existing_ean(self):
-        offer = factories.OfferFactory(
-            name="Old name",
-            ean="1234567890123",
-            extraData={"gtl_id": "02000000"},
-            subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
-        )
-        body = offers_schemas.UpdateOffer(name="New name", description="new Description")
-        offer = api.old_update_offer(offer, body)
-        db.session.flush()
-
-        assert offer.name == "New name"
-        assert offer.description == "new Description"
-
-    def test_cannot_update_with_name_containing_ean(self):
-        offer = factories.OfferFactory(name="Old name", ean="1234567890124")
-        body = offers_schemas.UpdateOffer(name="Luftballons 1234567890124")
-        with pytest.raises(exceptions.OfferException) as error:
-            api.old_update_offer(offer, body)
-
-        assert error.value.errors == {"name": ["Le titre d'une offre ne peut contenir l'EAN"]}
-        assert db.session.query(models.Offer).one().name == "Old name"
-
-    def test_success_on_allocine_offer(self):
-        provider = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
-        offer = factories.OfferFactory(
-            lastProvider=provider, name="Old name", subcategoryId=subcategories.SEANCE_CINE.id
-        )
-        body = offers_schemas.UpdateOffer(name="Old name", isDuo=True)
-        api.old_update_offer(offer, body)
-
-        offer = db.session.query(models.Offer).one()
-        assert offer.name == "Old name"
-        assert offer.isDuo
-
-    def test_forbidden_on_allocine_offer_on_certain_fields(self):
-        provider = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
-        offer = factories.OfferFactory(
-            lastProvider=provider, durationMinutes=90, subcategoryId=subcategories.SEANCE_CINE.id
-        )
-        body = offers_schemas.UpdateOffer(durationMinutes=120, isDuo=True)
-        with pytest.raises(api_errors.ApiErrors) as error:
-            api.old_update_offer(offer, body)
-
-        assert error.value.errors == {"durationMinutes": ["Vous ne pouvez pas modifier ce champ"]}
-        offer = db.session.query(models.Offer).one()
-        assert offer.durationMinutes == 90
-        assert not offer.isDuo
-
-    def test_success_on_imported_offer_on_external_ticket_office_url(self):
-        provider = providers_factories.AllocineProviderFactory()
-        offer = factories.OfferFactory(
-            externalTicketOfficeUrl="http://example.org",
-            lastProvider=provider,
-            name="Old name",
-            ean="1234567890124",
-        )
-        body = offers_schemas.UpdateOffer(externalTicketOfficeUrl="https://example.com")
-        api.old_update_offer(offer, body)
-
-        offer = db.session.query(models.Offer).one()
-        assert offer.name == "Old name"
-        assert offer.externalTicketOfficeUrl == "https://example.com"
-
-    def test_success_on_imported_offer_on_accessibility_fields(self):
-        provider = providers_factories.AllocineProviderFactory()
-        offer = factories.OfferFactory(
-            lastProvider=provider,
-            name="Old name",
-            audioDisabilityCompliant=True,
-            visualDisabilityCompliant=False,
-            motorDisabilityCompliant=False,
-            mentalDisabilityCompliant=True,
-        )
-        body = offers_schemas.UpdateOffer(
-            name="Old name",
-            audioDisabilityCompliant=False,
-            visualDisabilityCompliant=True,
-            motorDisabilityCompliant=True,
-            mentalDisabilityCompliant=False,
-        )
-        api.old_update_offer(offer, body)
-
-        offer = db.session.query(models.Offer).one()
-        assert offer.name == "Old name"
-        assert offer.audioDisabilityCompliant is False
-        assert offer.visualDisabilityCompliant is True
-        assert offer.motorDisabilityCompliant is True
-        assert offer.mentalDisabilityCompliant is False
-
-    def test_success_on_imported_offer_with_product_not_music_related_with_gtl_id(self):
-        provider = providers_factories.PublicApiProviderFactory(name="BookProvider")
-        product = factories.ProductFactory(
-            subcategoryId=subcategories.LIVRE_PAPIER.id,
-            lastProvider=provider,
-            ean="1234567890123",
-            extraData={"gtl_id": "01020602", "author": "Asimov"},
-        )
-        offer = factories.OfferFactory(
-            product=product,
-            lastProvider=provider,
-            audioDisabilityCompliant=True,
-            visualDisabilityCompliant=False,
-            motorDisabilityCompliant=False,
-            mentalDisabilityCompliant=True,
-        )
-        body = offers_schemas.UpdateOffer(
-            name="Old name",
-            audioDisabilityCompliant=False,
-            visualDisabilityCompliant=True,
-            motorDisabilityCompliant=True,
-            mentalDisabilityCompliant=False,
-        )
-        api.old_update_offer(offer, body)
-
-        offer = db.session.query(models.Offer).one()
-        assert offer.name == "Old name"
-        assert offer.audioDisabilityCompliant is False
-        assert offer.visualDisabilityCompliant is True
-        assert offer.motorDisabilityCompliant is True
-        assert offer.mentalDisabilityCompliant is False
-
-    def test_forbidden_on_imported_offer_on_other_fields(self):
-        provider = providers_factories.PublicApiProviderFactory()
-        offer = factories.OfferFactory(
-            lastProvider=provider,
-            durationMinutes=90,
-            isDuo=False,
-            audioDisabilityCompliant=True,
-            subcategoryId=subcategories.SEANCE_CINE.id,
-        )
-        body = offers_schemas.UpdateOffer(
-            durationMinutes=120,
-            isDuo=True,
-            audioDisabilityCompliant=False,
-        )
-        with pytest.raises(api_errors.ApiErrors) as error:
-            api.old_update_offer(offer, body)
-
-        assert error.value.errors == {
-            "durationMinutes": ["Vous ne pouvez pas modifier ce champ"],
-            "isDuo": ["Vous ne pouvez pas modifier ce champ"],
-        }
-        offer = db.session.query(models.Offer).one()
-        assert offer.durationMinutes == 90
-        assert offer.isDuo is False
-        assert offer.audioDisabilityCompliant is True
-
-    @pytest.mark.parametrize(
-        "validation_status", [models.OfferValidationStatus.PENDING, models.OfferValidationStatus.REJECTED]
-    )
-    def test_update_non_editable_offer_fails(self, validation_status):
-        offer = factories.OfferFactory(name="Soliloquy", validation=validation_status)
-        body = offers_schemas.UpdateOffer(name="Monologue")
-
-        with pytest.raises(exceptions.OfferException) as error:
-            api.old_update_offer(offer, body)
-
-        assert error.value.errors == {
-            "global": ["Les offres refusées ou en attente de validation ne sont pas modifiables"]
-        }
-        offer = db.session.query(models.Offer).one()
-        assert offer.name == "Soliloquy"
-
-    def test_success_on_updating_id_at_provider(self):
-        provider = providers_factories.PublicApiProviderFactory()
-        offerer = offerers_factories.OffererFactory()
-        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
-        offer = factories.OfferFactory(
-            lastProvider=provider,
-            name="Offer linked to a provider",
-            ean="1234567890124",
-        )
-        body = offers_schemas.UpdateOffer(idAtProvider="some_id_at_provider")
-        api.old_update_offer(offer, body)
-
-        offer = db.session.query(models.Offer).one()
-        assert offer.name == "Offer linked to a provider"
-        assert offer.idAtProvider == "some_id_at_provider"
-
-    def test_success_should_duplicate_ean(self):
-        provider = providers_factories.PublicApiProviderFactory()
-        offerer = offerers_factories.OffererFactory()
-        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
-        offer = factories.OfferFactory(
-            lastProvider=provider,
-            name="Offer linked to a provider",
-            ean="1234567890124",
-        )
-        body = offers_schemas.UpdateOffer(ean="1234567890125")
-        api.old_update_offer(offer, body)
-
-        offer = db.session.query(models.Offer).one()
-        assert offer.ean == "1234567890125"
-
-    def test_success_should_not_duplicate_ean_when_it_is_an_empty_string(self):
-        provider = providers_factories.PublicApiProviderFactory()
-        offerer = offerers_factories.OffererFactory()
-        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
-        offer = factories.EventOfferFactory(lastProvider=provider, name="Offer linked to a provider", ean=None)
-        body = offers_schemas.UpdateOffer(ean=None)
-        api.old_update_offer(offer, body)
-
-        offer = db.session.query(models.Offer).one()
-        assert offer.ean == None
-
-    def test_raise_error_on_updating_id_at_provider(self):
-        offer = factories.OfferFactory(
-            lastProvider=None,
-            name="Offer linked to a provider",
-            ean="1234567890124",
-        )
-        body = offers_schemas.UpdateOffer(idAtProvider="some_id_at_provider")
-        with pytest.raises(exceptions.OfferException) as error:
-            api.old_update_offer(offer, body)
-
-        assert error.value.errors["idAtProvider"] == [
-            "Une offre ne peut être créée ou éditée avec un idAtProvider si elle n'a pas de provider"
-        ]
-
-    def test_raise_error_on_updating_id_at_provider_because_this_id_is_already_taken(self):
-        provider = providers_factories.PublicApiProviderFactory()
-        offerer = offerers_factories.OffererFactory()
-        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
-        venue = offerers_factories.VenueFactory()
-        id_at_provider = "rolalala"
-
-        # existing offer with `id_at_provider`
-        factories.OfferFactory(
-            lastProvider=provider,
-            name="Offer linked to a provider",
-            venue=venue,
-            idAtProvider=id_at_provider,
-        )
-        offer = factories.OfferFactory(
-            lastProvider=provider,
-            name="Offer linked to a provider",
-            ean="1234567890124",
-            venue=venue,
-        )
-
-        body = offers_schemas.UpdateOffer(idAtProvider=id_at_provider)
-        with pytest.raises(exceptions.OfferException) as error:
-            api.old_update_offer(offer, body)
-
-        assert error.value.errors["idAtProvider"] == ["`rolalala` is already taken by another venue offer"]
-
-    @pytest.mark.parametrize("hasUrl", [True, False])
-    def test_offer_update_accordingly_of_its_digitalness(self, hasUrl):
-        kwargs = {}
-        if hasUrl:
-            kwargs["siret"] = None
-            kwargs["comment"] = "Digital venue"
-        venue = offerers_factories.VenueFactory(**kwargs)
-        offerer_address = offerers_factories.OfferLocationFactory(offerer=venue.managingOfferer)
-        offer = factories.OfferFactory(
-            offererAddress=None,
-            venue=venue,
-            url="http://example.com" if hasUrl else None,
-            subcategoryId=subcategories.VOD.id if hasUrl else subcategories.SPECTACLE_REPRESENTATION.id,
-        )
-        body = offers_schemas.UpdateOffer(name="New name", offererAddress=offerer_address)
-        if hasUrl:
-            with pytest.raises(api_errors.ApiErrors) as error:
-                api.old_update_offer(offer, body)
-                assert error.value.errors["offerUrl"] == ["Une offre numérique ne peut pas avoir d'adresse"]
-        else:
-            api.old_update_offer(offer, body)
-            offer = db.session.query(models.Offer).one()
-            assert offer.offererAddress == offerer_address
-
-    def test_update_offerer_address(self):
-        new_offerer_address = offerers_factories.OfferLocationFactory(
-            address__latitude=50.63153,
-            address__longitude=3.06089,
-            address__postalCode="59000",
-            address__city="Lille",
-        )
-        offer = factories.OfferFactory()
-        body = offers_schemas.UpdateOffer()
-
-        updated_offer = api.old_update_offer(offer, body, offerer_address=new_offerer_address)
-
-        db.session.commit()
-        db.session.refresh(updated_offer)
-
-        assert updated_offer
-        assert updated_offer.offererAddressId == new_offerer_address.id
-
-    def test_update_both_venue_and_offerer_address(self):
-        offer = factories.OfferFactory()
-        new_venue = offerers_factories.VenueFactory(managingOfferer=offer.venue.managingOfferer)
-        new_offerer_address = offerers_factories.OfferLocationFactory(
-            address__latitude=50.63153,
-            address__longitude=3.06089,
-            address__postalCode="59000",
-            address__city="Lille",
-            venue=new_venue,
-            offerer=new_venue.managingOfferer,
-        )
-        body = offers_schemas.UpdateOffer()
-
-        updated_offer = api.old_update_offer(offer, body, venue=new_venue, offerer_address=new_offerer_address)
-
-        db.session.commit()
-        db.session.refresh(updated_offer)
-
-        assert updated_offer
-        assert updated_offer.offererAddressId == new_offerer_address.id
-        assert updated_offer.venueId == new_venue.id
-
-    @pytest.mark.parametrize(
-        "bookingAllowedDatetime,expected_calls_count",
-        [
-            (datetime.now(UTC) - timedelta(minutes=5), 1),
-            (None, 1),
-            (datetime.now(UTC) + timedelta(days=5), 0),
-        ],
-    )
-    @mock.patch("pcapi.core.reminders.external.reminders_notifications.notify_users_offer_is_bookable")
-    def test_booking_allowed_datetime_update(
-        self, notify_users_offer_is_bookable_mock, bookingAllowedDatetime, expected_calls_count
-    ):
-        offer = factories.OfferFactory(bookingAllowedDatetime=datetime.now() + timedelta(days=1))
-
-        body = offers_schemas.UpdateOffer(bookingAllowedDatetime=bookingAllowedDatetime)
-
-        updated_offer = api.old_update_offer(offer, body)
-        assert len(notify_users_offer_is_bookable_mock.mock_calls) == expected_calls_count
-        assert updated_offer.bookingAllowedDatetime == bookingAllowedDatetime
-
-    @mock.patch("pcapi.core.offers.validation.check_offer_withdrawal")
-    @mock.patch("pcapi.core.offers.validation.check_is_duo_compliance")
-    @mock.patch("pcapi.core.offers.validation.check_offer_extra_data")
-    def test_update_draft_offer_with_subcategory_uses_new_subcategory_for_validation(
-        self, mock_check_extra_data, mock_check_is_duo, mock_check_withdrawal
-    ):
-        draft_offer = factories.OfferFactory(
-            subcategoryId=subcategories.SEANCE_CINE.id,
-            validation=models.OfferValidationStatus.DRAFT,
-        )
-
-        body = offers_schemas.UpdateOffer(
-            subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id,
-            isDuo=True,
-            extraData={"showType": 200, "showSubType": 201},
-            withdrawalType=models.WithdrawalTypeEnum.IN_APP,
-        )
-
-        api.old_update_offer(draft_offer, body)
-
-        mock_check_is_duo.assert_called_once()
-        call_args = mock_check_is_duo.call_args
-        assert call_args[0][1].id == subcategories.SPECTACLE_REPRESENTATION.id
-
-        mock_check_extra_data.assert_called_once()
-        call_args = mock_check_extra_data.call_args
-        assert call_args[0][0] == subcategories.SPECTACLE_REPRESENTATION.id
-
-        mock_check_withdrawal.assert_called_once()
-        call_args = mock_check_withdrawal.call_args
-        assert call_args[1]["subcategory_id"] == subcategories.SPECTACLE_REPRESENTATION.id
-
-    @mock.patch("pcapi.core.artist.api.upsert_artist_offer_links", return_value=([], []))
-    def test_update_offer_without_artist_offer_links(self, mock_upsert_artist_offer_links):
-        offer = factories.OfferFactory()
-        body = offers_schemas.UpdateOffer(name="Updated Name")
-
-        api.old_update_offer(offer, body)
-
-        mock_upsert_artist_offer_links.assert_not_called()
-
-    @mock.patch("pcapi.core.artist.api.upsert_artist_offer_links", return_value=([], []))
-    def test_update_offer_with_artist_offer_links(self, mock_upsert_artist_offer_links):
-        offer = factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
-
-        artist_offer_links = [
-            {
-                "artistId": "any-id",
-                "artistType": artist_models.ArtistType.AUTHOR,
-                "artistName": "any-name",
-            }
-        ]
-        body = offers_schemas.UpdateOffer(artistOfferLinks=artist_offer_links)
-
-        api.old_update_offer(offer, body)
-
-        mock_upsert_artist_offer_links.assert_called_once_with(
-            [
-                artist_serialize.ArtistOfferLinkBodyModel(
-                    artist_id="any-id", artist_type=artist_models.ArtistType.AUTHOR, artist_name="any-name"
-                )
-            ],
-            offer,
-        )
-
-    def test_raise_error_when_artist_type_is_not_allowed(self):
-        offer = factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
-
-        artist_offer_links = [
-            {
-                "artistId": "any-id",
-                "artistType": artist_models.ArtistType.PERFORMER,
-                "artistName": "any-name",
-            }
-        ]
-        body = offers_schemas.UpdateOffer(artistOfferLinks=artist_offer_links)
-
-        with pytest.raises(api_errors.ApiErrors) as error:
-            api.old_update_offer(offer, body)
-
-        assert error.value.errors == {
-            "artistOfferLinks": ["Le type d'artiste n'est pas autorisé pour cette sous catégorie"]
-        }
-
-    @mock.patch("pcapi.core.artist.api.upsert_artist_offer_links")
-    def test_update_offer_log_deleted_artist_offer_links(self, mock_upsert_artist_offer_links, caplog):
-        offer = factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
-
-        deleted_key = ArtistOfferLinkKey("author", "artist-id", None)
-        mock_upsert_artist_offer_links.return_value = ([], [deleted_key])
-
-        artist_offer_links = [
-            {
-                "artistId": "any-id",
-                "artistType": artist_models.ArtistType.AUTHOR,
-                "artistName": "any-name",
-            }
-        ]
-        body = offers_schemas.UpdateOffer(artistOfferLinks=artist_offer_links)
-        api.old_update_offer(offer, body)
-
-        with caplog.at_level(logging.INFO):
-            api.old_update_offer(offer, body)
-
-        deletion_logs = [
-            record for record in caplog.records if "Artist offer links have been deleted" in record.message
-        ]
-
-        assert len(deletion_logs) == 1
-
-        log_record = deletion_logs[0]
-        assert log_record.extra == {
-            "offer_id": offer.id,
-            "venue_id": offer.venueId,
-            "links": [str(ArtistOfferLinkKey(artist_type="author", artist_id="artist-id", custom_name=None))],
-        }
-        assert log_record.technical_message_id == "offer.artistOfferLinks.deleted"
-
-    @mock.patch("pcapi.core.artist.api.upsert_artist_offer_links")
-    def test_update_offer_log_created_artist_offer_links(self, mock_upsert_artist_offer_links, caplog):
-        offer = factories.OfferFactory(subcategoryId=subcategories.SEANCE_CINE.id)
-
-        created_key = ArtistOfferLinkKey("author", "artist-id", None)
-        mock_upsert_artist_offer_links.return_value = ([created_key], [])
-
-        artist_offer_links = [
-            {
-                "artistId": "artist-id",
-                "artistType": artist_models.ArtistType.AUTHOR,
-                "artistName": "any-name",
-            }
-        ]
-        body = offers_schemas.UpdateOffer(artistOfferLinks=artist_offer_links)
-        api.old_update_offer(offer, body)
-
-        with caplog.at_level(logging.INFO):
-            api.old_update_offer(offer, body)
-
-        creation_logs = [
-            record for record in caplog.records if "Artist offer links have been created" in record.message
-        ]
-
-        assert len(creation_logs) == 1
-
-        log_record = creation_logs[0]
-        assert log_record.extra == {
-            "offer_id": offer.id,
-            "venue_id": offer.venueId,
-            "links": [str(ArtistOfferLinkKey(artist_type="author", artist_id="artist-id", custom_name=None))],
-        }
-        assert log_record.technical_message_id == "offer.artistOfferLinks.created"
-
-    @mock.patch("pcapi.core.cultural_outreach.api.update_cultural_outreach_claim")
-    @time_machine.travel("2026-04-21 12:00:00", tick=False)
-    def test_update_offer_turns_cultural_outreach_claim_to_true(self, mocked_update_claim):
-        offer = factories.OfferFactory(subcategoryId=subcategories.ESCAPE_GAME.id)
-        cultural_outreach_factories.CulturalOutreachFactory(offer=offer)
-
-        body = offers_schemas.UpdateOffer(hasCulturalOutreachClaim=True)
-        api.old_update_offer(offer, body)
-
-        mocked_update_claim.assert_called_once_with(datetime(2026, 4, 21, 12, 0, 0), offer)
-
-    @mock.patch("pcapi.core.cultural_outreach.api.update_cultural_outreach_claim")
-    @time_machine.travel("2026-04-21 12:00:00", tick=False)
-    def test_update_offer_does_not_update_cultural_outreach_claim_datetime(self, mocked_update_claim):
-        offer = factories.OfferFactory(subcategoryId=subcategories.ESCAPE_GAME.id)
-        cultural_outreach_factories.ClaimedCulturalOutreachFactory(offer=offer)
-
-        body = offers_schemas.UpdateOffer(hasCulturalOutreachClaim=True)
-        api.old_update_offer(offer, body)
-
-        mocked_update_claim.assert_not_called()
-
-    @mock.patch("pcapi.core.cultural_outreach.api.update_cultural_outreach_claim")
-    def test_update_offer_turns_cultural_outreach_claim_to_false(self, mocked_update_claim):
-        offer = factories.OfferFactory(subcategoryId=subcategories.ESCAPE_GAME.id)
-        cultural_outreach_factories.ClaimedCulturalOutreachFactory(offer=offer)
-
-        body = offers_schemas.UpdateOffer(hasCulturalOutreachClaim=False)
-        api.old_update_offer(offer, body)
-
-        mocked_update_claim.assert_called_once_with(None, offer)
-
-    @mock.patch("pcapi.core.cultural_outreach.api.create_cultural_outreach_claim")
-    def test_update_offer_creates_cultural_outreach_claim(self, mocked_create_claim):
-        offer = factories.OfferFactory(subcategoryId=subcategories.ESCAPE_GAME.id)
-
-        body = offers_schemas.UpdateOffer(hasCulturalOutreachClaim=True)
-        api.old_update_offer(offer, body)
-
-        mocked_create_claim.assert_called_once_with(offer)
-
-
-@pytest.mark.usefixtures("db_session")
 class UpdateOfferTest:
     FROZEN_NOW = datetime(2026, 8, 11, 12, 0, tzinfo=UTC)
 
@@ -2341,8 +1757,77 @@ class UpdateOfferTest:
             offer,
             {"bookingEmail": "new@example.com", "name": "Jules et Jim"},
             mandatory_extra_data_fields=set(),
+            editable_fields=None,
+            not_editable_fields=(),
             venue_provider=venue_provider,
         )
+
+    def test_should_force_is_national_when_a_url_is_sent_in_the_same_request(self):
+        offer = self.build_offer(
+            subcategoryId=subcategories.VOD.id,
+            offererAddress=None,
+            url="https://example.com/vod",
+            isNational=False,
+        )
+
+        api.update_offer(
+            offer,
+            url="https://example.com/another-vod",
+            is_national=False,
+            mandatory_extra_data_fields=set(),
+        )
+
+        assert offer.isNational is True
+
+    def test_should_not_force_is_national_when_the_url_is_not_in_the_same_request(self):
+        offer = self.build_offer(isNational=True)
+
+        api.update_offer(offer, is_national=False, mandatory_extra_data_fields=set())
+
+        assert offer.isNational is False
+
+    @mock.patch("pcapi.core.mails.transactional.send_email_for_each_ongoing_booking")
+    def test_should_send_the_withdrawal_emails_when_asked_to(self, mocked_send_email):
+        offer = self.build_offer(withdrawalDetails="À retirer à la caisse")
+
+        api.update_offer(
+            offer,
+            withdrawal_details="À retirer au guichet",
+            should_send_mail=True,
+            mandatory_extra_data_fields=set(),
+        )
+
+        mocked_send_email.assert_called_once_with(offer)
+
+    @mock.patch("pcapi.core.mails.transactional.send_email_for_each_ongoing_booking")
+    def test_should_send_the_withdrawal_emails_when_the_address_changes(self, mocked_send_email):
+        offer = self.build_offer()
+        offerer_address = offerers_factories.OfferLocationFactory(offerer=offer.venue.managingOfferer)
+
+        api.update_offer(
+            offer,
+            offerer_address=offerer_address,
+            should_send_mail=True,
+            mandatory_extra_data_fields=set(),
+        )
+
+        mocked_send_email.assert_called_once_with(offer)
+
+    @mock.patch("pcapi.core.mails.transactional.send_email_for_each_ongoing_booking")
+    def test_should_not_send_the_withdrawal_emails_when_no_withdrawal_field_changes(self, mocked_send_email):
+        offer = self.build_offer()
+
+        api.update_offer(offer, name="Jules et Jim", should_send_mail=True, mandatory_extra_data_fields=set())
+
+        mocked_send_email.assert_not_called()
+
+    @mock.patch("pcapi.core.mails.transactional.send_email_for_each_ongoing_booking")
+    def test_should_not_send_the_withdrawal_emails_unless_asked_to(self, mocked_send_email):
+        offer = self.build_offer(withdrawalDetails="À retirer à la caisse")
+
+        api.update_offer(offer, withdrawal_details="À retirer au guichet", mandatory_extra_data_fields=set())
+
+        mocked_send_email.assert_not_called()
 
     def test_should_write_the_fields_that_change(self, venue_provider):
         offer = self.build_offer()
@@ -2418,9 +1903,8 @@ class UpdateOfferTest:
         db.session.flush()
 
         assert offer.dateUpdated == date_updated
-        check_can_update_offer.assert_called_once_with(
-            offer, {}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
-        )
+        check_can_update_offer.assert_called_once()
+        assert check_can_update_offer.call_args.args == (offer, {})
         mocked_async_index_offer_ids.assert_not_called()
         update_logs = [
             record for record in caplog.records if getattr(record, "technical_message_id", None) == "offer.updated"
@@ -2499,6 +1983,392 @@ class UpdateOfferTest:
             reason=IndexationReason.OFFER_UPDATE,
             log_extra={"changes": {"name", "bookingEmail"}},
         )
+
+    def test_update_extra_data_should_raise_error_when_mandatory_field_not_provided(self):
+        offer = factories.OfferFactory(subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id)
+        with pytest.raises(api_errors.ApiErrors) as error:
+            api.update_offer(
+                offer, extra_data={"author": "Asimov"}, mandatory_extra_data_fields={"showType", "showSubType"}
+            )
+
+        assert error.value.errors == {
+            "showType": ["Ce champ est obligatoire"],
+            "showSubType": ["Ce champ est obligatoire"],
+        }
+
+    def test_error_when_missing_mandatory_extra_data(self):
+        offer = factories.OfferFactory(
+            subcategoryId=subcategories.SPECTACLE_REPRESENTATION.id, extraData={"showType": 200}
+        )
+        with pytest.raises(api_errors.ApiErrors) as error:
+            api.update_offer(offer, extra_data=None, mandatory_extra_data_fields={"showType", "showSubType"})
+        assert error.value.errors == {
+            "showType": ["Ce champ est obligatoire"],
+            "showSubType": ["Ce champ est obligatoire"],
+        }
+
+    def test_update_offer_with_existing_ean(self):
+        offer = factories.OfferFactory(
+            name="Old name",
+            ean="1234567890123",
+            extraData={"gtl_id": "02000000"},
+            subcategoryId=subcategories.SUPPORT_PHYSIQUE_MUSIQUE_CD.id,
+        )
+        offer = api.update_offer(
+            offer, name="New name", description="new Description", mandatory_extra_data_fields=set()
+        )
+        db.session.flush()
+
+        assert offer.name == "New name"
+        assert offer.description == "new Description"
+
+    def test_cannot_update_with_name_containing_ean(self):
+        offer = factories.OfferFactory(name="Old name", ean="1234567890124")
+        with pytest.raises(exceptions.OfferException) as error:
+            api.update_offer(offer, name="Luftballons 1234567890124", mandatory_extra_data_fields=set())
+
+        assert error.value.errors == {"name": ["Le titre d'une offre ne peut contenir l'EAN"]}
+        assert db.session.query(models.Offer).one().name == "Old name"
+
+    def test_success_on_allocine_offer(self):
+        provider = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
+        offer = factories.OfferFactory(
+            lastProvider=provider, name="Old name", subcategoryId=subcategories.SEANCE_CINE.id
+        )
+        api.update_offer(offer, name="Old name", is_duo=True, mandatory_extra_data_fields=set())
+
+        offer = db.session.query(models.Offer).one()
+        assert offer.name == "Old name"
+        assert offer.isDuo
+
+    def test_forbidden_on_allocine_offer_on_certain_fields(self):
+        provider = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
+        offer = factories.OfferFactory(
+            lastProvider=provider, durationMinutes=90, subcategoryId=subcategories.SEANCE_CINE.id
+        )
+        with pytest.raises(api_errors.ApiErrors) as error:
+            api.update_offer(
+                offer,
+                duration_minutes=120,
+                is_duo=True,
+                editable_fields=public_offers_utils.get_editable_fields(offer.lastProvider),
+                mandatory_extra_data_fields=set(),
+            )
+
+        assert error.value.errors == {"durationMinutes": ["Vous ne pouvez pas modifier ce champ"]}
+        offer = db.session.query(models.Offer).one()
+        assert offer.durationMinutes == 90
+        assert not offer.isDuo
+
+    def test_success_on_imported_offer_on_external_ticket_office_url(self):
+        provider = providers_factories.AllocineProviderFactory()
+        offer = factories.OfferFactory(
+            externalTicketOfficeUrl="http://example.org",
+            lastProvider=provider,
+            name="Old name",
+            ean="1234567890124",
+        )
+        api.update_offer(offer, external_ticket_office_url="https://example.com", mandatory_extra_data_fields=set())
+
+        offer = db.session.query(models.Offer).one()
+        assert offer.name == "Old name"
+        assert offer.externalTicketOfficeUrl == "https://example.com"
+
+    def test_success_on_imported_offer_on_accessibility_fields(self):
+        provider = providers_factories.AllocineProviderFactory()
+        offer = factories.OfferFactory(
+            lastProvider=provider,
+            name="Old name",
+            audioDisabilityCompliant=True,
+            visualDisabilityCompliant=False,
+            motorDisabilityCompliant=False,
+            mentalDisabilityCompliant=True,
+        )
+        api.update_offer(
+            offer,
+            name="Old name",
+            audio_disability_compliant=False,
+            visual_disability_compliant=True,
+            motor_disability_compliant=True,
+            mental_disability_compliant=False,
+            mandatory_extra_data_fields=set(),
+        )
+
+        offer = db.session.query(models.Offer).one()
+        assert offer.name == "Old name"
+        assert offer.audioDisabilityCompliant is False
+        assert offer.visualDisabilityCompliant is True
+        assert offer.motorDisabilityCompliant is True
+        assert offer.mentalDisabilityCompliant is False
+
+    def test_success_on_imported_offer_with_product_not_music_related_with_gtl_id(self):
+        provider = providers_factories.PublicApiProviderFactory(name="BookProvider")
+        product = factories.ProductFactory(
+            subcategoryId=subcategories.LIVRE_PAPIER.id,
+            lastProvider=provider,
+            ean="1234567890123",
+            extraData={"gtl_id": "01020602", "author": "Asimov"},
+        )
+        offer = factories.OfferFactory(
+            product=product,
+            lastProvider=provider,
+            audioDisabilityCompliant=True,
+            visualDisabilityCompliant=False,
+            motorDisabilityCompliant=False,
+            mentalDisabilityCompliant=True,
+        )
+        api.update_offer(
+            offer,
+            name="Old name",
+            audio_disability_compliant=False,
+            visual_disability_compliant=True,
+            motor_disability_compliant=True,
+            mental_disability_compliant=False,
+            mandatory_extra_data_fields=set(),
+        )
+
+        offer = db.session.query(models.Offer).one()
+        assert offer.name == "Old name"
+        assert offer.audioDisabilityCompliant is False
+        assert offer.visualDisabilityCompliant is True
+        assert offer.motorDisabilityCompliant is True
+        assert offer.mentalDisabilityCompliant is False
+
+    def test_forbidden_on_imported_offer_on_other_fields(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        offer = factories.OfferFactory(
+            lastProvider=provider,
+            durationMinutes=90,
+            isDuo=False,
+            audioDisabilityCompliant=True,
+            subcategoryId=subcategories.SEANCE_CINE.id,
+        )
+        with pytest.raises(api_errors.ApiErrors) as error:
+            api.update_offer(
+                offer,
+                duration_minutes=120,
+                is_duo=True,
+                audio_disability_compliant=False,
+                editable_fields=public_offers_utils.get_editable_fields(offer.lastProvider),
+                mandatory_extra_data_fields=set(),
+            )
+
+        assert error.value.errors == {
+            "durationMinutes": ["Vous ne pouvez pas modifier ce champ"],
+            "isDuo": ["Vous ne pouvez pas modifier ce champ"],
+        }
+        offer = db.session.query(models.Offer).one()
+        assert offer.durationMinutes == 90
+        assert offer.isDuo is False
+        assert offer.audioDisabilityCompliant is True
+
+    @pytest.mark.parametrize(
+        "validation_status", [models.OfferValidationStatus.PENDING, models.OfferValidationStatus.REJECTED]
+    )
+    def test_update_non_editable_offer_fails(self, validation_status):
+        offer = factories.OfferFactory(name="Soliloquy", validation=validation_status)
+
+        with pytest.raises(exceptions.OfferException) as error:
+            api.update_offer(offer, name="Monologue", mandatory_extra_data_fields=set())
+
+        assert error.value.errors == {
+            "global": ["Les offres refusées ou en attente de validation ne sont pas modifiables"]
+        }
+        offer = db.session.query(models.Offer).one()
+        assert offer.name == "Soliloquy"
+
+    def test_success_on_updating_id_at_provider(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        offerer = offerers_factories.OffererFactory()
+        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
+        offer = factories.OfferFactory(
+            lastProvider=provider,
+            name="Offer linked to a provider",
+            ean="1234567890124",
+        )
+        api.update_offer(offer, id_at_provider="some_id_at_provider", mandatory_extra_data_fields=set())
+
+        offer = db.session.query(models.Offer).one()
+        assert offer.name == "Offer linked to a provider"
+        assert offer.idAtProvider == "some_id_at_provider"
+
+    def test_success_should_duplicate_ean(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        offerer = offerers_factories.OffererFactory()
+        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
+        offer = factories.OfferFactory(
+            lastProvider=provider,
+            name="Offer linked to a provider",
+            ean="1234567890124",
+        )
+        api.update_offer(offer, ean="1234567890125", mandatory_extra_data_fields=set())
+
+        offer = db.session.query(models.Offer).one()
+        assert offer.ean == "1234567890125"
+
+    def test_success_should_not_duplicate_ean_when_it_is_an_empty_string(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        offerer = offerers_factories.OffererFactory()
+        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
+        offer = factories.EventOfferFactory(lastProvider=provider, name="Offer linked to a provider", ean=None)
+        api.update_offer(offer, ean=None, mandatory_extra_data_fields=set())
+
+        offer = db.session.query(models.Offer).one()
+        assert offer.ean == None
+
+    def test_raise_error_on_updating_id_at_provider(self):
+        offer = factories.OfferFactory(
+            lastProvider=None,
+            name="Offer linked to a provider",
+            ean="1234567890124",
+        )
+        with pytest.raises(exceptions.OfferException) as error:
+            api.update_offer(offer, id_at_provider="some_id_at_provider", mandatory_extra_data_fields=set())
+
+        assert error.value.errors["idAtProvider"] == [
+            "Une offre ne peut être créée ou éditée avec un idAtProvider si elle n'a pas de provider"
+        ]
+
+    def test_raise_error_on_updating_id_at_provider_because_this_id_is_already_taken(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        offerer = offerers_factories.OffererFactory()
+        providers_factories.OffererProviderFactory(offerer=offerer, provider=provider)
+        venue = offerers_factories.VenueFactory()
+        id_at_provider = "rolalala"
+
+        # existing offer with `id_at_provider`
+        factories.OfferFactory(
+            lastProvider=provider,
+            name="Offer linked to a provider",
+            venue=venue,
+            idAtProvider=id_at_provider,
+        )
+        offer = factories.OfferFactory(
+            lastProvider=provider,
+            name="Offer linked to a provider",
+            ean="1234567890124",
+            venue=venue,
+        )
+
+        with pytest.raises(exceptions.OfferException) as error:
+            api.update_offer(offer, id_at_provider=id_at_provider, mandatory_extra_data_fields=set())
+
+        assert error.value.errors["idAtProvider"] == ["`rolalala` is already taken by another venue offer"]
+
+    @pytest.mark.parametrize("hasUrl", [True, False])
+    def test_offer_update_accordingly_of_its_digitalness(self, hasUrl):
+        kwargs = {}
+        if hasUrl:
+            kwargs["siret"] = None
+            kwargs["comment"] = "Digital venue"
+        venue = offerers_factories.VenueFactory(**kwargs)
+        offerer_address = offerers_factories.OfferLocationFactory(offerer=venue.managingOfferer)
+        offer = factories.OfferFactory(
+            offererAddress=None,
+            venue=venue,
+            url="http://example.com" if hasUrl else None,
+            subcategoryId=subcategories.VOD.id if hasUrl else subcategories.SPECTACLE_REPRESENTATION.id,
+        )
+        if hasUrl:
+            with pytest.raises(api_errors.ApiErrors) as error:
+                api.update_offer(
+                    offer, name="New name", offerer_address=offerer_address, mandatory_extra_data_fields=set()
+                )
+                assert error.value.errors["offerUrl"] == ["Une offre numérique ne peut pas avoir d'adresse"]
+        else:
+            api.update_offer(offer, name="New name", offerer_address=offerer_address, mandatory_extra_data_fields=set())
+            offer = db.session.query(models.Offer).one()
+            assert offer.offererAddress == offerer_address
+
+    def test_update_offerer_address(self):
+        new_offerer_address = offerers_factories.OfferLocationFactory(
+            address__latitude=50.63153,
+            address__longitude=3.06089,
+            address__postalCode="59000",
+            address__city="Lille",
+        )
+        offer = factories.OfferFactory()
+
+        updated_offer = api.update_offer(offer, mandatory_extra_data_fields=set(), offerer_address=new_offerer_address)
+
+        db.session.commit()
+        db.session.refresh(updated_offer)
+
+        assert updated_offer
+        assert updated_offer.offererAddressId == new_offerer_address.id
+
+    def test_update_both_venue_and_offerer_address(self):
+        offer = factories.OfferFactory()
+        new_venue = offerers_factories.VenueFactory(managingOfferer=offer.venue.managingOfferer)
+        new_offerer_address = offerers_factories.OfferLocationFactory(
+            address__latitude=50.63153,
+            address__longitude=3.06089,
+            address__postalCode="59000",
+            address__city="Lille",
+            venue=new_venue,
+            offerer=new_venue.managingOfferer,
+        )
+
+        updated_offer = api.update_offer(
+            offer, mandatory_extra_data_fields=set(), venue=new_venue, offerer_address=new_offerer_address
+        )
+
+        db.session.commit()
+        db.session.refresh(updated_offer)
+
+        assert updated_offer
+        assert updated_offer.offererAddressId == new_offerer_address.id
+        assert updated_offer.venueId == new_venue.id
+
+    @pytest.mark.parametrize(
+        "bookingAllowedDatetime,expected_calls_count",
+        [
+            (datetime.now(UTC) - timedelta(minutes=5), 1),
+            (None, 1),
+            (datetime.now(UTC) + timedelta(days=5), 0),
+        ],
+    )
+    @mock.patch("pcapi.core.reminders.external.reminders_notifications.notify_users_offer_is_bookable")
+    def test_booking_allowed_datetime_update(
+        self, notify_users_offer_is_bookable_mock, bookingAllowedDatetime, expected_calls_count
+    ):
+        offer = factories.OfferFactory(bookingAllowedDatetime=datetime.now() + timedelta(days=1))
+
+        updated_offer = api.update_offer(
+            offer, booking_allowed_datetime=bookingAllowedDatetime, mandatory_extra_data_fields=set()
+        )
+        assert len(notify_users_offer_is_bookable_mock.mock_calls) == expected_calls_count
+        assert updated_offer.bookingAllowedDatetime == bookingAllowedDatetime
+
+    @mock.patch("pcapi.core.offers.validation.check_offer_withdrawal")
+    @mock.patch("pcapi.core.offers.validation.check_is_duo_compliance")
+    @mock.patch("pcapi.core.offers.validation.check_extra_data")
+    def test_update_draft_offer_with_subcategory_uses_new_subcategory_for_validation(
+        self, mock_check_extra_data, mock_check_is_duo, mock_check_withdrawal
+    ):
+        draft_offer = factories.OfferFactory(
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            validation=models.OfferValidationStatus.DRAFT,
+        )
+
+        api.update_offer(
+            draft_offer,
+            subcategory_id=subcategories.SPECTACLE_REPRESENTATION.id,
+            is_duo=True,
+            extra_data={"showType": 200, "showSubType": 201},
+            withdrawal_type=models.WithdrawalTypeEnum.IN_APP,
+            mandatory_extra_data_fields=set(),
+        )
+
+        mock_check_is_duo.assert_called_once()
+        call_args = mock_check_is_duo.call_args
+        assert call_args[0][1].id == subcategories.SPECTACLE_REPRESENTATION.id
+
+        mock_check_extra_data.assert_called_once()
+
+        mock_check_withdrawal.assert_called_once()
+        call_args = mock_check_withdrawal.call_args
+        assert call_args[1]["subcategory_id"] == subcategories.SPECTACLE_REPRESENTATION.id
 
 
 @pytest.mark.usefixtures("db_session")

--- a/api/tests/core/offers/test_validation.py
+++ b/api/tests/core/offers/test_validation.py
@@ -7,7 +7,6 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-import pcapi.core.artist.models as artist_models
 import pcapi.core.providers.factories as providers_factories
 from pcapi.core.categories import subcategories
 from pcapi.core.educational import factories as educational_factories
@@ -19,7 +18,6 @@ from pcapi.core.offers.models import OfferValidationStatus
 from pcapi.core.offers.models import WithdrawalTypeEnum
 from pcapi.core.providers.repository import get_provider_by_local_class
 from pcapi.models.api_errors import ApiErrors
-from pcapi.routes.serialization import artist_serialize
 from pcapi.utils import date as date_utils
 
 import tests
@@ -1243,33 +1241,6 @@ class CheckActivationCodesExpirationDatetimeTest:
         }
 
 
-class CheckArtistOfferLinksTest:
-    def test_check_artist_offer_links_should_not_raise(self):
-        artist_offer_links = [
-            artist_serialize.ArtistOfferLinkBodyModel(
-                artist_id="any-id",
-                artist_type=artist_models.ArtistType.AUTHOR,
-                artist_name="any-name",
-            )
-        ]
-        validation.check_artist_offer_links(artist_offer_links, subcategories.SEANCE_CINE)
-
-    def test_check_artist_offer_links_should_raise(self):
-        artist_offer_links = [
-            artist_serialize.ArtistOfferLinkBodyModel(
-                artist_id="any-id",
-                artist_type=artist_models.ArtistType.PERFORMER,
-                artist_name="any-name",
-            )
-        ]
-        with pytest.raises(ApiErrors) as exc:
-            validation.check_artist_offer_links(artist_offer_links, subcategories.SEANCE_CINE)
-
-        assert exc.value.errors == {
-            "artistOfferLinks": ["Le type d'artiste n'est pas autorisé pour cette sous catégorie"]
-        }
-
-
 class CheckAccessibilityComplianceTest:
     @pytest.mark.parametrize(
         "missing_field",
@@ -1338,83 +1309,6 @@ class CheckDurationMinutesTest:
                 )
             ]
         }
-
-
-class CheckUpdateOnlyAllowedFieldsForOfferFromProviderTest:
-    # accepted by an Allociné provider, refused by a plain one
-    ALLOCINE_ONLY = ["isDuo"]
-
-    # accepted by a public API provider, refused by the two others
-    PUBLIC_API_ONLY = [
-        "bookingAllowedDatetime",
-        "bookingContact",
-        "bookingEmail",
-        "durationMinutes",
-        "ean",
-        "extraData",
-        "idAtProvider",
-        "isActive",
-        "publicationDatetime",
-        "withdrawalDetails",
-    ]
-
-    def build_public_api_provider(self):
-        provider = providers_factories.PublicApiProviderFactory()
-        providers_factories.OffererProviderFactory(provider=provider)
-        return provider
-
-    def test_should_accept_every_field_of_the_shared_set(self):
-        provider = providers_factories.ProviderFactory()
-
-        validation.check_update_only_allowed_fields_for_offer_from_provider(
-            set(validation.EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER), provider
-        )
-
-    def test_should_accept_every_field_of_the_allocine_set(self):
-        provider = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
-        assert provider.isAllocine
-
-        validation.check_update_only_allowed_fields_for_offer_from_provider(
-            set(validation.EDITABLE_FIELDS_FOR_ALLOCINE_OFFER), provider
-        )
-
-    def test_should_accept_every_field_of_the_public_api_set(self):
-        provider = self.build_public_api_provider()
-        assert provider.hasOffererProvider
-
-        validation.check_update_only_allowed_fields_for_offer_from_provider(
-            set(validation.EDITABLE_FIELDS_FOR_INDIVIDUAL_OFFERS_API_PROVIDER), provider
-        )
-
-    @pytest.mark.parametrize("field", ALLOCINE_ONLY)
-    def test_reject_an_allocine_field_only_for_another_provider(self, field):
-        with pytest.raises(ApiErrors) as error:
-            validation.check_update_only_allowed_fields_for_offer_from_provider(
-                {field}, providers_factories.ProviderFactory()
-            )
-
-        assert error.value.errors == {field: ["Vous ne pouvez pas modifier ce champ"]}
-
-    @pytest.mark.parametrize("field", PUBLIC_API_ONLY)
-    def test_should_reject_a_public_api_field_only_for_another_provider(self, field):
-        allocine = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
-        with pytest.raises(ApiErrors) as error:
-            validation.check_update_only_allowed_fields_for_offer_from_provider({field}, allocine)
-
-        assert error.value.errors == {field: ["Vous ne pouvez pas modifier ce champ"]}
-
-    @pytest.mark.parametrize("provider_kind", ["plain", "allocine", "public_api"])
-    def test_should_reject_a_field_outside_every_set(self, provider_kind):
-        provider = {
-            "plain": lambda: providers_factories.ProviderFactory(),
-            "allocine": lambda: providers_factories.AllocineProviderFactory(localClass="AllocineStocks"),
-            "public_api": self.build_public_api_provider,
-        }[provider_kind]()
-
-        with pytest.raises(ApiErrors) as error:
-            validation.check_update_only_allowed_fields_for_offer_from_provider({"isNational"}, provider)
-
-        assert error.value.errors == {"isNational": ["Vous ne pouvez pas modifier ce champ"]}
 
 
 class CheckUrlIsCoherentWithSubcategoryTest:
@@ -1503,6 +1397,32 @@ class FormatExtraDataTest:
 
     def test_should_return_none_when_there_is_no_extra_data(self):
         assert validation.format_extra_data(subcategories.FESTIVAL_MUSIQUE.id, None) is None
+
+
+class CheckFieldsAreEditableTest:
+    def test_should_accept_everything_when_unrestricted(self):
+        validation.check_fields_are_editable({"name", "isDuo"})
+
+    def test_should_reject_what_is_outside_the_editable_fields(self):
+        with pytest.raises(ApiErrors) as error:
+            validation.check_fields_are_editable({"name", "isDuo"}, editable_fields={"name"})
+
+        assert error.value.errors == {"isDuo": ["Vous ne pouvez pas modifier ce champ"]}
+
+    def test_should_reject_what_is_inside_the_not_editable_fields(self):
+        with pytest.raises(ApiErrors) as error:
+            validation.check_fields_are_editable({"name", "isDuo"}, not_editable_fields={"isDuo"})
+
+        assert error.value.errors == {"isDuo": ["Vous ne pouvez pas modifier ce champ"]}
+
+    def test_should_report_every_rejected_field(self):
+        with pytest.raises(ApiErrors) as error:
+            validation.check_fields_are_editable({"name", "isDuo"}, editable_fields=set())
+
+        assert error.value.errors == {
+            "isDuo": ["Vous ne pouvez pas modifier ce champ"],
+            "name": ["Vous ne pouvez pas modifier ce champ"],
+        }
 
 
 class CheckCanUpdateOfferTest:
@@ -1705,6 +1625,17 @@ class CheckCanUpdateOfferTest:
             venue_provider=venue_provider,
         )
 
+    def test_should_check_extra_data_when_only_the_ean_changes(self, venue_provider):
+        offer = self.build_offer(ean="9782070100002")
+
+        with mock.patch("pcapi.core.offers.validation.check_extra_data") as check_extra_data:
+            validation.check_can_update_offer(
+                offer, {"ean": "9782070100003"}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+            )
+
+        check_extra_data.assert_called_once()
+        assert check_extra_data.call_args.kwargs["ean"] == "9782070100003"
+
     @mock.patch("pcapi.core.offers.validation.check_offer_duration")
     def test_should_check_the_resulting_duration(self, check_offer_duration, venue_provider):
         offer = self.build_offer()
@@ -1715,37 +1646,86 @@ class CheckCanUpdateOfferTest:
 
         check_offer_duration.assert_called_once_with(1440)
 
-    @mock.patch("pcapi.core.offers.validation.check_update_only_allowed_fields_for_offer_from_provider")
-    def test_should_check_the_whitelist_against_the_changed_fields(
-        self, check_update_only_allowed_fields, venue_provider
+    @mock.patch("pcapi.core.offers.validation.check_url_is_coherent_with_subcategory")
+    @mock.patch("pcapi.core.offers.validation.check_url_and_offererAddress_are_not_both_set")
+    def test_should_skip_location_coherence_on_a_draft_offer(
+        self, check_url_and_offererAddress_are_not_both_set, check_url_is_coherent_with_subcategory, venue_provider
     ):
-        provider = providers_factories.PublicApiProviderFactory()
-        offer = self.build_offer(lastProvider=provider)
+        offer = self.build_offer(validation=OfferValidationStatus.DRAFT, url=None)
+
+        validation.check_can_update_offer(
+            offer,
+            {"description": "Une autre description."},
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        check_url_is_coherent_with_subcategory.assert_not_called()
+        check_url_and_offererAddress_are_not_both_set.assert_not_called()
+
+    @mock.patch("pcapi.core.offers.validation.check_fields_are_editable")
+    def test_should_check_the_changed_fields_against_what_the_caller_allows(
+        self, check_fields_are_editable, venue_provider
+    ):
+        offer = self.build_offer()
 
         validation.check_can_update_offer(
             offer,
             {"name": "Jules et Jim", "durationMinutes": 120, "description": "Deux amis."},
             mandatory_extra_data_fields=set(),
+            editable_fields={"name"},
+            not_editable_fields={"description"},
             venue_provider=venue_provider,
         )
 
-        check_update_only_allowed_fields.assert_called_once_with({"name", "durationMinutes", "description"}, provider)
-
-    @mock.patch("pcapi.core.offers.validation.check_update_only_allowed_fields_for_offer_from_provider")
-    def test_should_not_check_the_whitelist_for_an_offer_created_on_the_pro_interface(
-        self, check_update_only_allowed_fields, venue_provider
-    ):
-        offer = self.build_offer(lastProvider=None)
-
-        validation.check_can_update_offer(
-            offer, {"name": "Jules et Jim"}, mandatory_extra_data_fields=set(), venue_provider=venue_provider
+        check_fields_are_editable.assert_called_once_with(
+            {"name", "durationMinutes", "description"}, {"name"}, {"description"}
         )
 
-        check_update_only_allowed_fields.assert_not_called()
+    @mock.patch("pcapi.core.offers.validation.check_offer_withdrawal")
+    def test_should_check_withdrawal_against_the_requested_type_and_delay(self, check_offer_withdrawal, venue_provider):
+        offer = self.build_offer(withdrawalType=None, withdrawalDelay=None)
+
+        validation.check_can_update_offer(
+            offer,
+            {"withdrawalType": WithdrawalTypeEnum.ON_SITE, "withdrawalDelay": 3600},
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+        check_offer_withdrawal.assert_called_once_with(
+            withdrawal_type=WithdrawalTypeEnum.ON_SITE,
+            withdrawal_delay=3600,
+            subcategory_id=self.SUBCATEGORY.id,
+            booking_contact=offer.bookingContact,
+            provider=offer.lastProvider,
+            venue_provider=venue_provider,
+        )
+
+    def test_should_accept_a_subcategory_change_on_a_draft_offer(self, venue_provider):
+        offer = self.build_offer(validation=OfferValidationStatus.DRAFT)
+
+        validation.check_can_update_offer(
+            offer,
+            {"subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id},
+            mandatory_extra_data_fields=set(),
+            venue_provider=venue_provider,
+        )
+
+    def test_should_refuse_a_subcategory_change_on_a_published_offer(self, venue_provider):
+        offer = self.build_offer()
+
+        with pytest.raises(exceptions.UnallowedUpdate):
+            validation.check_can_update_offer(
+                offer,
+                {"subcategoryId": subcategories.SPECTACLE_REPRESENTATION.id},
+                mandatory_extra_data_fields=set(),
+                venue_provider=venue_provider,
+            )
 
     @mock.patch("pcapi.core.offers.validation.check_url_is_coherent_with_subcategory")
     @mock.patch("pcapi.core.offers.validation.check_url_and_offererAddress_are_not_both_set")
-    def test_should_always_check_location_coherence(
+    def test_should_check_location_coherence_on_a_published_offer(
         self, check_url_and_offererAddress_are_not_both_set, check_url_is_coherent_with_subcategory, venue_provider
     ):
         offer = self.build_offer()

--- a/api/tests/routes/pro/patch_offer_test.py
+++ b/api/tests/routes/pro/patch_offer_test.py
@@ -32,6 +32,7 @@ from pcapi.core.search.models import IndexationReason
 from pcapi.core.testing import assert_num_queries
 from pcapi.models import db
 from pcapi.models.api_errors import OBJECT_NOT_FOUND_ERROR_MESSAGE
+from pcapi.routes.pro import offers as offers_routes
 from pcapi.utils import date as date_utils
 from pcapi.utils.date import format_into_utc_date
 
@@ -564,7 +565,6 @@ class Returns200Test:
         )
 
         data = {
-            "name": "New name",
             "externalTicketOfficeUrl": "http://example.net",
             "extraData": {
                 "cast": ["Joan Baez", "Joe Cocker", "David Crosby"],
@@ -597,7 +597,7 @@ class Returns200Test:
         assert response.json["id"] == offer.id
 
         updated_offer = db.session.get(Offer, offer.id)
-        assert updated_offer.name == "New name"
+        assert updated_offer.externalTicketOfficeUrl == "http://example.net"
         assert updated_offer.extraData == {
             "cast": ["Joan Baez", "Joe Cocker", "David Crosby"],
             "eidr": "10.5240/ADBD-3CAA-43A0-7BF0-86E2-K",
@@ -1292,101 +1292,6 @@ class Returns200Test:
         assert updated_offer.url is None
         assert updated_offer.offererAddress is None
 
-    def test_patch_editable_field_of_an_offer_from_public_api_provider(self, client):
-        provider = providers_factories.PublicApiProviderFactory()
-        providers_factories.OffererProviderFactory(provider=provider)
-        venue = offerers_factories.VenueFactory()
-        offer = offers_factories.EventOfferFactory(
-            lastProviderId=provider.id,
-            venue=venue,
-            name="Old name",
-            description="Old description",
-            bookingEmail="old@example.com",
-            bookingContact="old-contact@example.com",
-            audioDisabilityCompliant=False,
-            mentalDisabilityCompliant=False,
-            motorDisabilityCompliant=False,
-            visualDisabilityCompliant=False,
-            externalTicketOfficeUrl="http://old.com",
-            isDuo=False,
-            durationMinutes=60,
-            publicationDatetime=datetime.datetime(2026, 8, 15, 12, 0, tzinfo=datetime.UTC),
-            bookingAllowedDatetime=datetime.datetime(2026, 8, 14, 12, 0, tzinfo=datetime.UTC),
-            extraData={"old": "data"},
-            idAtProvider="old-id",
-            offererAddress=None,
-        )
-        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
-
-        new_publication_datetime = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=3)
-        new_booking_allowed_datetime = datetime.datetime.now(tz=datetime.UTC) + datetime.timedelta(days=2)
-
-        data = {
-            "name": "New name",
-            "description": "New description",
-            "bookingEmail": "new@example.com",
-            "bookingContact": "new-contact@example.com",
-            "audioDisabilityCompliant": True,
-            "mentalDisabilityCompliant": True,
-            "motorDisabilityCompliant": True,
-            "visualDisabilityCompliant": True,
-            "externalTicketOfficeUrl": "http://new.com",
-            "isDuo": True,
-            "durationMinutes": 90,
-            "publicationDatetime": format_into_utc_date(new_publication_datetime),
-            "bookingAllowedDatetime": format_into_utc_date(new_booking_allowed_datetime),
-            "extraData": {"ean": "1234567890123", "author": "New author"},
-            "location": {
-                "isVenueLocation": True,
-            },
-        }
-
-        response = client.with_session_auth("user@example.com").patch(
-            self.endpoint.format(offer_id=offer.id), json=data
-        )
-
-        assert response.status_code == 200, response.json
-        updated_offer = db.session.get(Offer, offer.id)
-        assert updated_offer.name == "New name"
-        assert updated_offer.description == "New description"
-        assert updated_offer.bookingEmail == "new@example.com"
-        assert updated_offer.bookingContact == "new-contact@example.com"
-        assert updated_offer.audioDisabilityCompliant is True
-        assert updated_offer.mentalDisabilityCompliant is True
-        assert updated_offer.motorDisabilityCompliant is True
-        assert updated_offer.visualDisabilityCompliant is True
-        assert updated_offer.externalTicketOfficeUrl == "http://new.com"
-        assert updated_offer.isDuo is True
-        assert updated_offer.durationMinutes == 90
-        assert updated_offer.publicationDatetime == new_publication_datetime
-        assert updated_offer.bookingAllowedDatetime == new_booking_allowed_datetime
-        assert updated_offer.extraData == {"author": "New author"}
-        assert updated_offer.ean == "1234567890123"
-        assert updated_offer.offererAddress.address == venue.offererAddress.address
-
-    def test_patch_allocine_offer_keeps_track_of_updated_fields(self, client):
-        venue = offerers_factories.VenueFactory()
-        allocine_provider = providers_factories.AllocineProviderFactory()
-        offer = offers_factories.OfferFactory(
-            venue=venue,
-            lastProvider=allocine_provider,
-            subcategoryId=subcategories.SEANCE_CINE.id,
-            name="Film",
-            isDuo=False,
-        )
-        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=venue.managingOfferer)
-
-        response = client.with_session_auth("user@example.com").patch(
-            self.endpoint.format(offer_id=offer.id), json={"name": "Un autre nom", "isDuo": True}
-        )
-
-        assert response.status_code == 200, response.json
-
-        updated_offer = db.session.get(Offer, offer.id)
-        assert updated_offer.name == "Un autre nom"
-        assert updated_offer.isDuo is True
-        assert set(updated_offer.fieldsUpdated) == {"name", "isDuo"}
-
     def test_patch_offer_withdrawing_a_cultural_outreach_claim_that_does_not_exist_is_a_noop(self, client):
         # `update_cultural_outreach_claim` is only called when the offer
         # already has a cultural outreach, so nothing happens here.
@@ -1838,24 +1743,6 @@ class Returns200Test:
         assert db.session.get(Offer, offer.id).bookingContact == "new@conta.ct"
         assert len(mails_testing.outbox) == 2
 
-    def test_patch_withdrawal_details_of_an_in_app_offer_from_a_provider_with_a_ticketing_service(self, client):
-        # `in_app` is only allowed when the offer provider supports ticketing
-        provider = providers_factories.PublicApiProviderFactory()
-        providers_factories.OffererProviderFactory(provider=provider)
-        offer = offers_factories.EventOfferFactory(
-            lastProvider=provider,
-            withdrawalType=offers_models.WithdrawalTypeEnum.IN_APP,
-            bookingContact="booking@conta.ct",
-        )
-        offerers_factories.UserOffererFactory(user__email="user@example.com", offerer=offer.venue.managingOfferer)
-
-        response = client.with_session_auth("user@example.com").patch(
-            self.endpoint.format(offer_id=offer.id), json={"withdrawalDetails": "Billet dans l'application"}
-        )
-
-        assert response.status_code == 200, response.json
-        assert db.session.get(Offer, offer.id).withdrawalDetails == "Billet dans l'application"
-
     def test_patch_offer_response_contains_video_highlight_and_cultural_outreach_data(self, client):
         user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
         venue = offerers_factories.VenueFactory(
@@ -1940,25 +1827,67 @@ class Returns200Test:
         assert updated_offer.publicationDatetime == publication_datetime
         assert updated_offer.validation == OfferValidationStatus.DRAFT
 
-    def test_should_not_fail_when_updating_duration_or_description_of_an_offer_with_a_product_but_not_update_them(
-        self, client, venue, auth_client
-    ):
-        product = offers_factories.ProductFactory(
-            subcategoryId=subcategories.LIVRE_PAPIER.id,
-            ean="1111111111111",
-            name="New name",
-            description="description",
-            durationMinutes=60,
+    def test_patch_the_editable_fields_of_a_synchronized_offer(self, client):
+        provider = providers_factories.PublicApiProviderFactory()
+        providers_factories.OffererProviderFactory(provider=provider)
+        user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
+        venue = offerers_factories.VenueFactory(
+            managingOfferer=user_offerer.offerer, activity=offerers_models.Activity.PERFORMANCE_HALL
         )
-        offer = offers_factories.OfferFactory(venue=venue, product=product, extraData={})
-
-        response = auth_client.patch(
-            self.endpoint.format(offer_id=offer.id), json={"description": "tototo", "durationMinutes": 120}
+        offer = offers_factories.OfferFactory(
+            venue=venue,
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            lastProvider=provider,
+            audioDisabilityCompliant=False,
+            externalTicketOfficeUrl="http://old.com",
         )
 
-        assert response.status_code == 200
-        assert db.session.get(Offer, offer.id).description == "description"
-        assert db.session.get(Offer, offer.id).durationMinutes == 60
+        response = client.with_session_auth("user@example.com").patch(
+            self.endpoint.format(offer_id=offer.id),
+            json={"audioDisabilityCompliant": True, "externalTicketOfficeUrl": "http://new.com"},
+        )
+
+        assert response.status_code == 200, response.json
+        updated_offer = db.session.get(Offer, offer.id)
+        assert updated_offer.audioDisabilityCompliant is True
+        assert updated_offer.externalTicketOfficeUrl == "http://new.com"
+
+    def test_patch_a_read_only_field_with_its_current_value(self, client):
+        user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
+        venue = offerers_factories.VenueFactory(
+            managingOfferer=user_offerer.offerer, activity=offerers_models.Activity.PERFORMANCE_HALL
+        )
+        offer = offers_factories.OfferFactory(
+            venue=venue,
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            lastProvider=providers_factories.ProviderFactory(),
+            name="Un nom",
+        )
+
+        response = client.with_session_auth("user@example.com").patch(
+            self.endpoint.format(offer_id=offer.id), json={"name": "Un nom"}
+        )
+
+        assert response.status_code == 200, response.json
+
+    def test_patch_the_name_of_a_synchronized_offer_in_a_museum(self, client):
+        user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
+        venue = offerers_factories.VenueFactory(
+            managingOfferer=user_offerer.offerer, activity=offerers_models.Activity.MUSEUM
+        )
+        offer = offers_factories.OfferFactory(
+            venue=venue,
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            lastProvider=providers_factories.ProviderFactory(),
+            name="Un nom",
+        )
+
+        response = client.with_session_auth("user@example.com").patch(
+            self.endpoint.format(offer_id=offer.id), json={"name": "Un autre nom"}
+        )
+
+        assert response.status_code == 200, response.json
+        assert db.session.get(Offer, offer.id).name == "Un autre nom"
 
 
 class Returns400Test:
@@ -2703,7 +2632,7 @@ class Returns400Test:
         )
 
         assert response.status_code == 400
-        assert response.json["global"] == ["Les extraData des offres avec produit ne sont pas modifiables"]
+        assert response.json == {"ean": ["Vous ne pouvez pas modifier ce champ"]}
 
     def should_fail_when_updating_a_non_ean_extra_data_of_an_offer_with_a_product(self, client, venue, auth_client):
         # no extraData of an offer with a product can be changed, not only its EAN
@@ -2720,7 +2649,7 @@ class Returns400Test:
         )
 
         assert response.status_code == 400
-        assert response.json["global"] == ["Les extraData des offres avec produit ne sont pas modifiables"]
+        assert response.json == {"extraData": ["Vous ne pouvez pas modifier ce champ"]}
         assert db.session.get(Offer, offer.id).extraData == {}
 
     def when_only_the_venue_provider_has_a_ticketing_service(self, client, venue, auth_client):
@@ -2783,7 +2712,7 @@ class Returns400Test:
         provider = providers_factories.ProviderFactory(localClass="TiteliveMusicProvider")
         offer = offers_factories.OfferFactory(venue=venue, lastProvider=provider)
 
-        # bookingEmail is not in EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER
+        # bookingEmail belongs to the synchronization, not to the offerer
         data = {"bookingEmail": "test@example.com"}
         response = client.with_session_auth("user@example.com").patch(
             self.endpoint.format(offer_id=offer.id), json=data
@@ -2792,6 +2721,41 @@ class Returns400Test:
         assert response.status_code == 400
         assert "bookingEmail" in response.json
         assert "Vous ne pouvez pas modifier ce champ" in response.json["bookingEmail"][0]
+
+    def when_updating_a_read_only_field_of_a_synchronized_offer(self, client):
+        user_offerer = offerers_factories.UserOffererFactory(user__email="user@example.com")
+        venue = offerers_factories.VenueFactory(
+            managingOfferer=user_offerer.offerer, activity=offerers_models.Activity.PERFORMANCE_HALL
+        )
+        offer = offers_factories.OfferFactory(
+            venue=venue,
+            subcategoryId=subcategories.SEANCE_CINE.id,
+            lastProvider=providers_factories.ProviderFactory(),
+            name="Un nom",
+            isDuo=False,
+        )
+
+        response = client.with_session_auth("user@example.com").patch(
+            self.endpoint.format(offer_id=offer.id), json={"name": "Un autre nom", "isDuo": True}
+        )
+
+        assert response.status_code == 400
+        assert response.json == {
+            "isDuo": ["Vous ne pouvez pas modifier ce champ"],
+            "name": ["Vous ne pouvez pas modifier ce champ"],
+        }
+        assert db.session.get(Offer, offer.id).name == "Un nom"
+
+    def when_updating_a_read_only_field_of_a_product_based_offer(self, client, venue, auth_client):
+        product = offers_factories.ProductFactory(subcategoryId=subcategories.LIVRE_PAPIER.id)
+        offer = offers_factories.OfferFactory(venue=venue, product=product)
+
+        response = auth_client.patch(
+            self.endpoint.format(offer_id=offer.id), json={"description": "Une autre description."}
+        )
+
+        assert response.status_code == 400
+        assert response.json == {"description": ["Vous ne pouvez pas modifier ce champ"]}
 
 
 class Returns401Test:
@@ -2914,3 +2878,54 @@ def venue_fixture(user_offerer):
 @pytest.fixture(name="auth_client")
 def auth_client_fixture(user_offerer, client):
     return client.with_session_auth(user_offerer.user.email)
+
+
+@pytest.mark.usefixtures("db_session")
+class GetNotEditableFieldsTest:
+    def build_synchronized_offer(self, venue=None, provider=None, **overrides):
+        return offers_factories.OfferFactory(
+            venue=venue or offerers_factories.VenueFactory(activity=offerers_models.Activity.PERFORMANCE_HALL),
+            lastProvider=provider or providers_factories.ProviderFactory(),
+            **overrides,
+        )
+
+    def test_should_let_an_offerer_change_everything_on_its_own_offer(self):
+        offer = offers_factories.OfferFactory()
+
+        assert offers_routes._get_not_editable_fields(offer) == set()
+
+    def test_should_refuse_what_a_synchronization_fills(self):
+        offer = self.build_synchronized_offer()
+
+        assert offers_routes._get_not_editable_fields(offer) == offers_routes.NOT_EDITABLE_WHEN_SYNCHRONIZED
+
+    def test_should_let_the_offerer_claim_the_cultural_outreach_of_a_synchronized_offer(self):
+        offer = self.build_synchronized_offer()
+
+        assert "hasCulturalOutreachClaim" not in offers_routes._get_not_editable_fields(offer)
+
+    @pytest.mark.parametrize("field", ["description", "name"])
+    def test_should_let_a_museum_change_the_name_and_the_description(self, field):
+        venue = offerers_factories.VenueFactory(activity=offerers_models.Activity.MUSEUM)
+        offer = self.build_synchronized_offer(venue=venue)
+
+        assert field not in offers_routes._get_not_editable_fields(offer)
+
+    def test_should_let_the_offerer_change_the_withdrawal_details_of_an_allocine_offer(self):
+        provider = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
+        offer = self.build_synchronized_offer(provider=provider)
+        assert offer.isFromAllocine
+
+        assert "withdrawalDetails" not in offers_routes._get_not_editable_fields(offer)
+
+    def test_should_refuse_what_a_product_describes(self):
+        offer = offers_factories.OfferFactory(product=offers_factories.ProductFactory())
+
+        assert offers_routes._get_not_editable_fields(offer) == offers_routes.NOT_EDITABLE_WHEN_PRODUCT_BASED
+
+    def test_should_refuse_both_on_a_synchronized_offer_based_on_a_product(self):
+        offer = self.build_synchronized_offer(product=offers_factories.ProductFactory())
+
+        assert offers_routes._get_not_editable_fields(offer) == (
+            offers_routes.NOT_EDITABLE_WHEN_PRODUCT_BASED | offers_routes.NOT_EDITABLE_WHEN_SYNCHRONIZED
+        )

--- a/api/tests/routes/public/individual_offers/v1/test_utils.py
+++ b/api/tests/routes/public/individual_offers/v1/test_utils.py
@@ -12,6 +12,7 @@ from pcapi.core.offerers import schemas as offerers_schemas
 from pcapi.core.offers import exceptions as offers_exceptions
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import validation as offers_validation
+from pcapi.core.providers import factories as providers_factories
 from pcapi.core.videos import exceptions as videos_exceptions
 from pcapi.models import api_errors
 from pcapi.routes.public import utils as public_utils
@@ -367,3 +368,26 @@ class UpdateOrDeleteVideoTest:
         utils.update_or_delete_video(None, meta_data.offer, provider_id=12)
 
         remove_video_data_from_offer_metadata.assert_not_called()
+
+
+class GetEditableFieldsTest:
+    def test_should_not_restrict_an_offer_without_provider(self):
+        assert utils.get_editable_fields(None) is None
+
+    def test_should_answer_the_shared_set_for_a_plain_provider(self):
+        provider = providers_factories.ProviderFactory()
+
+        assert utils.get_editable_fields(provider) == utils.EDITABLE_FIELDS_FOR_OFFER_FROM_PROVIDER
+
+    def test_should_answer_the_allocine_set_for_allocine(self):
+        provider = providers_factories.AllocineProviderFactory(localClass="AllocineStocks")
+        assert provider.isAllocine
+
+        assert utils.get_editable_fields(provider) == utils.EDITABLE_FIELDS_FOR_ALLOCINE_OFFER
+
+    def test_should_answer_the_api_set_for_an_integrator(self):
+        provider = providers_factories.PublicApiProviderFactory()
+        providers_factories.OffererProviderFactory(provider=provider)
+        assert provider.hasOffererProvider
+
+        assert utils.get_editable_fields(provider) == utils.EDITABLE_FIELDS_FOR_INDIVIDUAL_OFFERS_API_PROVIDER


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/jira/software/c/projects/PC/boards/66?selectedIssue=PC-42939)

commits importants 💡 
- commit 1 : la route pro appelle le nouveau `update_offer` introduit côté public. `old_update_offer` et le schéma `offers_schemas.UpdateOffer` disparaissent, AUCUN changement fonctionnel.

- commit 2 : les `artistOfferLinks` et le `culturalOutreach` sont désormais traités par la route. AUCUN changement fonctionnel

- commit 3 : miroir back de la logique front de readonly (`getFormReadOnlyFields`)