### PR TITLE
(BSR)[PRO] fix: update 'templatron' templates

### DIFF
--- a/pro/.templatron/component/<% name %>.stories.tsx.mustache
+++ b/pro/.templatron/component/<% name %>.stories.tsx.mustache
@@ -1,4 +1,4 @@
-import { StoryObj } from '@storybook/react'
+import type { StoryObj } from '@storybook/react-vite'
 import { withRouter } from 'storybook-addon-remix-react-router'
 
 import { <% name %> } from './<% name %>'

--- a/pro/.templatron/component/<% name %>.tsx.mustache
+++ b/pro/.templatron/component/<% name %>.tsx.mustache
@@ -1,22 +1,20 @@
 <%# scss.yes %>
-import cn from 'classnames'
-
 import styles from './<% name %>.module.scss'
 
 <%/ scss.yes %>
 type <% name %>Props = {
-  className?: string
+  foo?: string
 }
 
-export const <% name %> = ({ className }: <% name %>Props): JSX.Element => {
+export const <% name %> = ({ foo }: Readonly<<% name %>Props>): JSX.Element => {
   return (
     <%# scss.yes %>
-    <div className={cn(styles[`<%# toKebabCase %><% name %><%/ toKebabCase %>`], className)}>
+    <div className={styles['<%# toKebabCase %><% name %><%/ toKebabCase %>']}>
     <%/ scss.yes %>
     <%# scss.no %>
-    <div className={className}>
+    <div>
     <%/ scss.no %>
-      <h1><% name %></h1>
+      <h1><% name %> {foo ?? ''}</h1>
     </div>
   )
 }


### PR DESCRIPTION
## 🔧 Changes Made

> Aligner les templates Templatron de génération de composants avec les conventions actuelles du repo (Storybook Vite, typage React 19, accès aux CSS modules), pour que les nouveaux composants scaffoldés soient conformes dès la création.

https://github.com/user-attachments/assets/d8ebab4a-3662-4d4b-8e55-41222ff87d57

### 🔧 Changements
-  import `StoryObj` typé depuis `@storybook/react-vite` (remplace `@storybook/react` devenu obsolète)
- Suppression de `classnames` et de la prop `className` générique (on évite généralement d'utiliser des props classNames sur nos composants)
- Props typées en `Readonly<…>` -> obligatoire pour le linter et la CI

### 🧪 Comment tester
- Générer un nouveau composant via Templatron -> `pnpx templatron component MyComponent`
- Vérifier que les fichiers générés compilent sans erreur (`pnpm lint:js`, `pnpm build-storybook` si applicable)
- Ouvrir les fichiers et vérifier qu'il n'y ait pas d'erreur TS

---
**🧭 Review effort : 1/5** — _2 fichiers mustache, changements mécaniques sur le scaffolding._

**🗂️ Walkthrough**

| Fichier(s) | Résumé |
|---|---|
| `.templatron/component/<% name %>.stories.tsx.mustache` | Import Storybook Vite + `import type` |
| `.templatron/component/<% name %>.tsx.mustache` | Conventions React/SCSS du repo, sans `classnames` |