### PR TITLE
(BSR)[PRO] fix: e2e test

### DIFF
--- a/pro/src/components/SnackBarContainer/SnackBarContainer.tsx
+++ b/pro/src/components/SnackBarContainer/SnackBarContainer.tsx
@@ -30,7 +30,10 @@ export const SnackBarContainer = (): JSX.Element => {
   const [portalTarget, setPortalTarget] = useState<Element>(() => document.body)
 
   useEffect(() => {
-    setPortalTarget(document.querySelector('dialog[open]') ?? document.body)
+    setPortalTarget(
+      document.querySelector('dialog[data-snackbar-portal][open]') ??
+        document.body
+    )
   }, [snackBars.length])
 
   const sortedSnackBars = snackBars

--- a/pro/src/design-system/DetailedModal/DetailedModal.tsx
+++ b/pro/src/design-system/DetailedModal/DetailedModal.tsx
@@ -91,6 +91,7 @@ export const DetailedModal = ({
       onClose={onClose}
       ariaLabelledBy={titleId}
       ariaDescribedBy={dialogAriaDescribedBy}
+      isSnackBarPortalTarget
     >
       <div
         className={cx(styles['detailed-modal'], {

--- a/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
+++ b/pro/src/ui-kit/BaseDialog/BaseDialog.tsx
@@ -31,6 +31,11 @@ export interface BaseDialogProps {
    * override that target (e.g. a dropdown trigger instead of a menu item).
    */
   refToFocusOnClose?: React.RefObject<HTMLElement | null>
+  /**
+   * When true, marks this dialog as an eligible target for the snackbar portal.
+   * Only set on DetailedModal — not on SimpleModal / navigation guard dialogs.
+   */
+  isSnackBarPortalTarget?: boolean
 }
 
 /**
@@ -48,6 +53,7 @@ export const BaseDialog = ({
   ariaDescribedBy,
   children,
   refToFocusOnClose,
+  isSnackBarPortalTarget = false,
 }: BaseDialogProps): JSX.Element => {
   const dialogRef = useRef<HTMLDialogElement>(null)
 
@@ -104,6 +110,7 @@ export const BaseDialog = ({
       aria-labelledby={ariaLabelledBy}
       aria-describedby={ariaDescribedBy}
       className={styles['base-dialog']}
+      data-snackbar-portal={isSnackBarPortalTarget ? '' : undefined}
     >
       {children}
     </dialog>


### PR DESCRIPTION
Quand une snackbar apparaissait pendant qu'une modal était ouverte, elle se retrouvait à l'intérieur de cette dialog et en cliquant sur "Enregistrer et quitter" la dialog se fermait et la snackbar était fermé directement

On ajoute la snackbar dans le dialog seulement pour les DetailedModal car la modal reste ouverte après l'affichage d'une snackbar 