### PR TITLE
(BSR)[PRO] fix: typo in tags

### DIFF
--- a/pro/src/design-system/Tag/Tag.tsx
+++ b/pro/src/design-system/Tag/Tag.tsx
@@ -59,7 +59,7 @@ export const Tag = ({
       {finalIcon && (
         <SvgIcon className={styles.icon} src={finalIcon} width="16" />
       )}
-      <p>{label}</p>
+      <p className={styles.tag}>{label}</p>
     </span>
   )
 }


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

Mauvaise police dans le composant Tag suite à l'ajout de la balise `p` pour remplacer l'ancien `span` (a11y)

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

<!--
If your PR includes UI changes, please add screenshots or GIFs here to show before and after.

Example:

Before | After
:---: | :---:
![before](link-to-before-image) | ![after](link-to-after-image)
-->
