### PR TITLE
(PC-43078)[API] feat: close venue: remove the CLOSING state

### DIFF
--- a/api/src/pcapi/core/offerers/api.py
+++ b/api/src/pcapi/core/offerers/api.py
@@ -3505,7 +3505,7 @@ def close_venue(venue: models.Venue, author: users_models.User, comment: str | N
     if venue.is_closed:
         return
 
-    venue.state = models.VenueState.CLOSING
+    venue.state = models.VenueState.CLOSED
     nullify_venue_emails(venue, author)
     history_api.add_action(history_models.ActionType.VENUE_CLOSED, author=author, venue=venue, comment=comment)
 

--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -305,7 +305,6 @@ class StructureSimulationInfos(typing.TypedDict):
 
 class VenueState(enum.Enum):
     CLOSED = "CLOSED"
-    CLOSING = "CLOSING"
 
 
 class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMixin):
@@ -914,7 +913,7 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
 
     @property
     def is_closed(self) -> bool:
-        return self.state in (VenueState.CLOSING, VenueState.CLOSED)
+        return self.state == VenueState.CLOSED
 
 
 class GooglePlacesInfo(PcObject, Model):

--- a/api/src/pcapi/core/offerers/tasks.py
+++ b/api/src/pcapi/core/offerers/tasks.py
@@ -110,8 +110,4 @@ def finalize_closing_venue_task(payload: FinalizeClosingVenuePayload) -> None:
         db.session.flush()
 
         logger.info("closing venue: pivots deleted", extra={"venue_id": venue.id})
-
-        venue.state = offerers_models.VenueState.CLOSED
-        db.session.flush()
-
         logger.info("closing venue: closed", extra={"venue_id": venue.id})

--- a/api/tests/core/offerers/test_tasks.py
+++ b/api/tests/core/offerers/test_tasks.py
@@ -8,7 +8,6 @@ from pcapi.connectors.entreprise.models import SirenInfo
 from pcapi.core.bookings import factories as bookings_factories
 from pcapi.core.history import models as history_models
 from pcapi.core.offerers import factories as offerers_factories
-from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offerers import tasks as offerers_tasks
 from pcapi.core.providers import factories as providers_factories
 from pcapi.core.users import factories as users_factories
@@ -192,17 +191,6 @@ class FinalizeClosingVenueTaskTest:
         assert all(booking.isCancelled for booking in venue.bookings)
         assert all(booking.isCancelled for booking in venue.collectiveBookings)
 
-    def test_venue_state_is_closed(self):
-        venue = offerers_factories.VenueFactory()
-        author = users_factories.BaseUserFactory()
-        self.create_synced_offers_with_bookings(venue)
-
-        payload = offerers_tasks.FinalizeClosingVenuePayload(venue_id=venue.id, author_id=author.id)
-        offerers_tasks.finalize_closing_venue_task(payload.model_dump())
-
-        db.session.refresh(venue)
-        assert venue.state == offerers_models.VenueState.CLOSED
-
     def test_pivots_have_been_deleted(self):
         venue = offerers_factories.VenueFactory()
         author = users_factories.BaseUserFactory()
@@ -214,8 +202,6 @@ class FinalizeClosingVenueTaskTest:
         db.session.refresh(venue)
         assert not venue.cinemaProviderPivot
         assert not venue.allocinePivot
-
-        assert venue.state == offerers_models.VenueState.CLOSED
 
     def create_synced_offers_with_bookings(self, venue):
         boost_pivot = providers_factories.BoostCinemaProviderPivotFactory(venue=venue)

--- a/api/tests/routes/pro/close_venue_test.py
+++ b/api/tests/routes/pro/close_venue_test.py
@@ -45,4 +45,4 @@ def test_close_venue_closes_venue(mock_finalize_closing_venue, mock_index_venue,
     response = client.post(f"/venues/{venue.id}/close")
 
     assert response.status_code == 204
-    assert venue.state == offerers_models.VenueState.CLOSING
+    assert venue.state == offerers_models.VenueState.CLOSED

--- a/pro/src/apiClient/v1/types.gen.ts
+++ b/pro/src/apiClient/v1/types.gen.ts
@@ -7177,8 +7177,7 @@ export type VenueProviderResponse = {
  * VenueState
  */
 export enum VenueState {
-    CLOSED = 'CLOSED',
-    CLOSING = 'CLOSING'
+    CLOSED = 'CLOSED'
 }
 
 /**

--- a/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
+++ b/pro/src/commons/auth/__specs__/getCurrentUserPermissions.spec.ts
@@ -183,28 +183,25 @@ describe('getCurrentUserPermissions', () => {
         })
 
         describe('when venue is closed', () => {
-          it.each([VenueState.CLOSED, VenueState.CLOSING])(
-            'should return isSelectedPartnerVenueActive as false when venue state is %s',
-            (venueState) => {
-              const userSliceState = makeUserSliceState({
-                currentUser: fakeCurrentUser,
-                selectedPartnerVenue: makeGetVenueResponseModel({
-                  id: fakeVenue.id,
-                  isOnboarded: true,
-                  state: venueState,
-                }),
-                venues: fakeVenues,
-                venuesWithPendingValidation: null,
-              })
+          it('should return isSelectedPartnerVenueActive as false when venue state is closed', () => {
+            const userSliceState = makeUserSliceState({
+              currentUser: fakeCurrentUser,
+              selectedPartnerVenue: makeGetVenueResponseModel({
+                id: fakeVenue.id,
+                isOnboarded: true,
+                state: VenueState.CLOSED,
+              }),
+              venues: fakeVenues,
+              venuesWithPendingValidation: null,
+            })
 
-              const result = getCurrentUserPermissions(userSliceState)
+            const result = getCurrentUserPermissions(userSliceState)
 
-              expect(result).toMatchObject({
-                hasSelectedPartnerVenue: true,
-                isSelectedPartnerVenueActive: false,
-              })
-            }
-          )
+            expect(result).toMatchObject({
+              hasSelectedPartnerVenue: true,
+              isSelectedPartnerVenueActive: false,
+            })
+          })
         })
 
         describe('when venue is not onboarded but onboarding was skipped', () => {

--- a/pro/src/commons/utils/withVenueHelpers.spec.ts
+++ b/pro/src/commons/utils/withVenueHelpers.spec.ts
@@ -16,7 +16,7 @@ describe('withVenueHelpers', () => {
     it('should be true when the venue is closing', () => {
       const venue = makeGetVenueResponseModel({
         id: 1,
-        state: VenueState.CLOSING,
+        state: VenueState.CLOSED,
       })
 
       expect(withVenueHelpers(venue).isClosed).toBe(true)

--- a/pro/src/commons/utils/withVenueHelpers.ts
+++ b/pro/src/commons/utils/withVenueHelpers.ts
@@ -33,9 +33,7 @@ export function withVenueHelpers(
     },
 
     get isClosed() {
-      return (
-        venue.state === VenueState.CLOSING || venue.state === VenueState.CLOSED
-      )
+      return venue.state === VenueState.CLOSED
     },
   }
 }

--- a/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
+++ b/pro/src/components/ReimbursementBankAccount/ReimbursementBankAccount.tsx
@@ -162,8 +162,7 @@ export const ReimbursementBankAccount = ({
                         ({ id, commonName, state }) => (
                           <div className={styles['linked-venue']} key={id}>
                             {commonName}
-                            {(state === VenueState.CLOSING ||
-                              state === VenueState.CLOSED) && (
+                            {state === VenueState.CLOSED && (
                               <Tag
                                 variant={TagVariant.ERROR}
                                 label="Structure fermée"

--- a/pro/src/pages/IndividualOffer/IndividualOfferDescription/commons/__specs__/utils.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferDescription/commons/__specs__/utils.spec.tsx
@@ -385,7 +385,7 @@ describe('getFormReadOnlyFields', () => {
     expect(
       getFormReadOnlyFields(getIndividualOfferFactory(), false, {
         ...defaultVenue,
-        state: VenueState.CLOSING,
+        state: VenueState.CLOSED,
       })
     ).toStrictEqual(expectedValues)
   })

--- a/pro/src/pages/Reimbursements/BankInformations/ManagedVenueItem/ManagedVenueItem.tsx
+++ b/pro/src/pages/Reimbursements/BankInformations/ManagedVenueItem/ManagedVenueItem.tsx
@@ -66,8 +66,7 @@ export function ManadgedVenueItem({
           onChange={(e) => handleVenueChange(e, venue.id)}
           hasError={hasError}
         />
-        {(venue.state === VenueState.CLOSED ||
-          venue.state === VenueState.CLOSING) && (
+        {venue.state === VenueState.CLOSED && (
           <Tag variant={TagVariant.ERROR} label="Structure fermée" />
         )}
       </div>


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43078)

Suppression de l'état intermédiate `CLOSING`, pour un lieu. La fermeture se faisait jusque là en deux temps : d'abord `CLOSING` puis `CLOSED` une fois que la tâche asynchrone en charge des offres et des réservations a terminé.

Cette étape intermédiaire ne semble plus nécessaire aujourd'hui, et pour cette première étape.