### PR TITLE
(BSR)[PRO] fix: sonar issue aria invalid and ambiguous spacing

### DIFF
--- a/pro/src/design-system/RadioButton/RadioButton.spec.tsx
+++ b/pro/src/design-system/RadioButton/RadioButton.spec.tsx
@@ -150,11 +150,10 @@ describe('<RadioButton />', () => {
   })
 
   it('handles error state', () => {
-    const { getByLabelText } = render(
+    const { container } = render(
       <RadioButton label="Label" name="groupe" value="valeur" hasError />
     )
-    const radio = getByLabelText('Label')
-    expect(radio).toHaveAttribute('aria-invalid', 'true')
+    expect(container.firstChild).toHaveClass('has-error')
   })
 
   it('calls onChange on click', () => {

--- a/pro/src/design-system/RadioButton/RadioButton.tsx
+++ b/pro/src/design-system/RadioButton/RadioButton.tsx
@@ -93,7 +93,6 @@ export const RadioButton = forwardRef(
               disabled={disabled}
               name={name}
               checked={checked}
-              aria-invalid={hasError}
             />
             <div>
               <span>{label}</span>

--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.spec.tsx
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.spec.tsx
@@ -99,10 +99,10 @@ describe('<RadioButtonGroup />', () => {
     )
     const errorAlert = screen.getByRole('alert')
     expect(errorAlert).toHaveTextContent(errorMessage)
-    options.forEach((option) => {
-      const radio = screen.getByRole('radio', { name: option.label })
-      expect(radio).toHaveAttribute('aria-invalid', 'true')
+    const group = screen.getByRole('group', {
+      name: 'Radio Button Group with Error',
     })
+    expect(group).toHaveAttribute('aria-invalid', 'true')
   })
 
   it('calls onChange when an option is selected', () => {

--- a/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/pro/src/design-system/RadioButtonGroup/RadioButtonGroup.tsx
@@ -85,6 +85,7 @@ export const RadioButtonGroup = ({
   return (
     <fieldset
       aria-describedby={describedByIds || undefined}
+      aria-invalid={!!error || undefined}
       className={cn(styles['radio-button-group'], {
         [styles['label-as-text']]: isStringLabel,
       })}

--- a/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/VenueProviderList/VenueProviderCard.tsx
+++ b/pro/src/pages/VenueSettings/SynchronizationProviders/components/VenueProvidersManager/VenueProviderList/VenueProviderCard.tsx
@@ -54,9 +54,8 @@ export const VenueProviderCard = ({
       {isPublicAPIProvider ? (
         <div className={style['venue-provider-info-container']}>
           <div className={style['venue-provider-account-info']}>
-            Date d&apos;ajout :
+            Date d'ajout :{' '}
             <span>
-              {' '}
               {formatLocalTimeDateString(
                 dateCreated,
                 venueDepartmentCode,

--- a/pro/src/ui-kit/form/IconRadio/IconRadio.tsx
+++ b/pro/src/ui-kit/form/IconRadio/IconRadio.tsx
@@ -9,8 +9,6 @@ interface IconRadioProps {
   name: string
   label: string
   icon: string | JSX.Element
-  hasError?: boolean
-  className?: string
   checked?: boolean
   disabled?: boolean
   onChange?: React.InputHTMLAttributes<HTMLInputElement>['onChange']
@@ -19,16 +17,7 @@ interface IconRadioProps {
 
 export const IconRadio = forwardRef(
   (
-    {
-      name,
-      label,
-      icon,
-      hasError,
-      checked,
-      disabled,
-      onChange,
-      onBlur,
-    }: IconRadioProps,
+    { name, label, icon, checked, disabled, onChange, onBlur }: IconRadioProps,
     ref: ForwardedRef<HTMLInputElement>
   ): JSX.Element => {
     const labelId = useId()
@@ -46,7 +35,6 @@ export const IconRadio = forwardRef(
             className={cn(styles['icon-radio-input'], {
               [styles['icon-radio-input-checked']]: checked,
             })}
-            aria-invalid={hasError}
             checked={checked}
             disabled={disabled}
             name={name}

--- a/pro/src/ui-kit/form/IconRadioGroup/IconRadioGroup.module.scss
+++ b/pro/src/ui-kit/form/IconRadioGroup/IconRadioGroup.module.scss
@@ -19,12 +19,6 @@
     width: fit-content;
   }
 
-  &-item {
-    display: inline-flex;
-    align-items: center;
-    cursor: pointer;
-  }
-
   &-scale {
     @include fonts.body-accent-xs;
 

--- a/pro/src/ui-kit/form/IconRadioGroup/IconRadioGroup.tsx
+++ b/pro/src/ui-kit/form/IconRadioGroup/IconRadioGroup.tsx
@@ -51,6 +51,7 @@ export const IconRadioGroup = ({
       className={styles['icon-radio-group']}
       name={`icon-radio-group-${name}`}
       aria-describedby={`${hasError ? errorId : ''} ${scaleId}`}
+      aria-invalid={hasError || undefined}
     >
       <legend className={styles['icon-radio-group-legend']}>
         {legend}
@@ -66,12 +67,10 @@ export const IconRadioGroup = ({
           {group.map((item) => (
             <IconRadio
               name={name}
-              className={styles['icon-radio-group-item']}
               key={item.label}
               icon={item.icon}
               label={item.label}
               checked={item.value === value}
-              hasError={hasError}
               onChange={() => {
                 onChange(item.value)
               }}


### PR DESCRIPTION
aria-invalid ne peut pas être mis sur un radio -> on le retire et on l'ajoute à son fieldset
ambiguous spacing -> on l'ajoute avant le

RadioButtonGroup

En local : 
<img width="269" height="220" alt="Capture d’écran 2026-08-26 à 11 53 55" src="https://github.com/user-attachments/assets/0735e9bb-d900-4ebd-a0db-8d71307bdff6" />

Testing : 
<img width="269" height="220" alt="Capture d’écran 2026-08-26 à 11 53 45" src="https://github.com/user-attachments/assets/819474ac-2279-47c0-aa65-ee0dc892b37a" />

IconRadioGroup :

En local : 
<img width="186" height="164" alt="Capture d’écran 2026-08-26 à 11 58 08" src="https://github.com/user-attachments/assets/6f4e13cf-4923-4580-be2e-d96862d43353" />

Testing :
<img width="186" height="164" alt="Capture d’écran 2026-08-26 à 11 58 13" src="https://github.com/user-attachments/assets/55909c34-bf2e-4144-b67d-88870c2d7aa3" />

RadioButton : 

En local :
<img width="658" height="748" alt="Capture d’écran 2026-08-26 à 12 03 23" src="https://github.com/user-attachments/assets/6b2afeea-f27a-42ea-8218-6ac813e89f0d" />

Testing :
<img width="658" height="748" alt="Capture d’écran 2026-08-26 à 12 04 07" src="https://github.com/user-attachments/assets/1603f3c4-673b-4f93-8d45-14fb49c2170c" />

