### PR TITLE
(BSR)[PRO] fix: remove redundant roles from list elements

### DIFF
--- a/pro/src/pages/Homepage/components/HighlightHome/ModalHighlight/ModalHighlight.tsx
+++ b/pro/src/pages/Homepage/components/HighlightHome/ModalHighlight/ModalHighlight.tsx
@@ -84,8 +84,7 @@ export const ModalHighlight = ({
             <h2 className={styles['highlight-title']}>
               Les prochains temps forts :{' '}
             </h2>
-            {/* biome-ignore lint/a11y/noRedundantRoles: correct voiceover bug with list displayed with flex */}
-            <ul className={styles['cards-container']} role="list">
+            <ul className={styles['cards-container']}>
               {data?.map(
                 ({
                   id,
@@ -95,8 +94,7 @@ export const ModalHighlight = ({
                   communicationDate,
                   highlightDatespan,
                 }) => (
-                  // biome-ignore lint/a11y/noRedundantRoles: correct voiceover bug with list displayed with flex
-                  <li key={id} role="listitem">
+                  <li key={id}>
                     <HighlightCard
                       imageSrc={mediationUrl}
                       title={name}


### PR DESCRIPTION
On n'utilise plus de flex (on utilise grid maintenant) donc le commentaire n'est plus d'actualité, et on peut supprimer les rôles sur < ul > et < li >