### PR TITLE
(BSR)[API] bump: pgcli to 4.6.0

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -99,7 +99,7 @@ dev = [
   "ipdb==0.13.13",
   "jsbeautifier==2.0.3",                  # djlint requires 1.15.1 which is broken
   "mypy==2.3.0",
-  "pgcli==4.5.0",
+  "pgcli==4.6.0",
   "psycopg[binary]==3.3.4",
   "pytest==9.1.1",
   "pytest-dotenv ==0.5.2",

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -2125,7 +2125,7 @@ dev = [
     { name = "ipdb", specifier = "==0.13.13" },
     { name = "jsbeautifier", specifier = "==2.0.3" },
     { name = "mypy", specifier = "==2.3.0" },
-    { name = "pgcli", specifier = "==4.5.0" },
+    { name = "pgcli", specifier = "==4.6.0" },
     { name = "psycopg", extras = ["binary"], specifier = "==3.3.4" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-dotenv", specifier = "==0.5.2" },
@@ -2159,7 +2159,7 @@ wheels = [
 
 [[package]]
 name = "pgcli"
-version = "4.5.0"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cli-helpers", extra = ["styles"] },
@@ -2174,9 +2174,9 @@ dependencies = [
     { name = "sqlparse" },
     { name = "tzlocal" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/ca/b081f0ae381425f87dd751b449c33aca7398c2183799fc56501fe7c26975/pgcli-4.5.0.tar.gz", hash = "sha256:9dce07f5b628068156256cb818e5191a773afe6eeb7054f210fa892813625e3e", size = 665814, upload-time = "2026-06-03T00:03:20.685Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/5d/d6fcf98556e6089915e12af12c6189e9d774d82b473c4ce9e124a62ec235/pgcli-4.6.0.tar.gz", hash = "sha256:4b0633a6ce753ea38fb1fe2dc54b66b732c4d0b29fadf48cad78b2e7f6636d9d", size = 671208, upload-time = "2026-08-26T08:14:39.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/f7/3619b56e90b96fc7e1bb96711c4323e3bd567309ba9896551c0cbcd5075f/pgcli-4.5.0-py3-none-any.whl", hash = "sha256:c17fd6d7a29e6eeddc100885f4c5f5867e9ec632722504f2c2da4859343127a2", size = 86816, upload-time = "2026-06-03T00:03:19.371Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/63/39cfc5be0a1dd619ee506c971a9c4814b8882e4635ba3181ec8319589eaf/pgcli-4.6.0-py3-none-any.whl", hash = "sha256:bdf524c6f5046b9993520d44d452046001c7593d9c6e6fe60234e75d37a6178d", size = 88040, upload-time = "2026-08-26T08:14:38.077Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Changelog: https://github.com/dbcli/pgcli/compare/v4.5.0...v4.6.0