### PR TITLE
(PC-43412) ci: remove dependabot branch name template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,6 @@ updates:
     open-pull-requests-limit: 15
     pull-request-branch-name:
       max-length: 76
-      template: 'dependabot/{dependency}-{version}'
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -40,7 +39,6 @@ updates:
     open-pull-requests-limit: 10
     pull-request-branch-name:
       max-length: 76
-      template: 'dependabot/{dependency}-{version}'
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -57,7 +55,6 @@ updates:
     open-pull-requests-limit: 15
     pull-request-branch-name:
       max-length: 76
-      template: 'dependabot/{dependency}-{version}'
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -87,7 +84,6 @@ updates:
     open-pull-requests-limit: 10
     pull-request-branch-name:
       max-length: 76
-      template: 'dependabot/{dependency}-{version}'
     cooldown:
       # The property 'semver-major-days' is not supported for the package ecosystem 'github-actions'.
       default-days: 14

--- a/.github/workflows/cd_create_major_release.yml
+++ b/.github/workflows/cd_create_major_release.yml
@@ -68,18 +68,16 @@ jobs:
           # Extract major version and add 1
           major="$(echo "$latest_tag" | sed -E 's/^v([0-9]+)\..*/\1/')"
           release_number="$((major + 1))"
+          echo "release-number=$release_number" >> "$GITHUB_OUTPUT"
           
           # Get the rc tag info
           commit_hash="$(git rev-list -n 1 "$rc_tag")"
+          echo "commit-hash=$commit_hash" >> "$GITHUB_OUTPUT"
           commit_date="$(git show -s --format=%cd --date=format:'%d/%m/%Y à %H:%M' "$commit_hash")"
           subject="$(git show -s --format=%s "$commit_hash")"
           
           # compute Slack message base  — backtick are interpreted so we use [] around the release number
           message_base="de la <${{ env.RUN_URL }}|release> [v$release_number] basée sur le commit <${{ env.REPO_URL }}/$commit_hash|$subject> (poussé le $commit_date)"
-          
-          # Write outputs
-          echo "commit-hash=$commit_hash" >> "$GITHUB_OUTPUT"
-          echo "release-number=$release_number" >> "$GITHUB_OUTPUT"
           echo "message-base=$message_base" >> "$GITHUB_OUTPUT"
 
   notify-workflow-start:


### PR DESCRIPTION
Supprime le template de nom de branche pour permettre à l'action fetch-metadata de parser et retourner les infos attendues.

BSR au passage: ne pas écrire plusieurs fois d'affilée dans le `GITHUB_OUTPUT` afin de calmer `shellcheck`, qui est lancé dans `actionlint`.
<img width="332" height="45" alt="Capture d’écran 2026-08-27 à 15 41 59" src="https://github.com/user-attachments/assets/6635f099-60ae-496e-b337-f071165416fc" />
