### PR TITLE
(BSR)[API] build: help uv manage a private dependency

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -75,7 +75,8 @@ dependencies = [
   "shapely ==2.1.2",
   "slack-sdk==3.43.0",
   "spectree ==1.5.8",
-  "sqlalchemy-easy-softdelete @ git+https://github.com/pass-culture/sqlalchemy-easy-softdelete.git",
+  # from our private fork
+  "sqlalchemy-easy-softdelete",
   "sqlalchemy[mypy]==2.0.52",
   "time-machine==3.4.0",
   "transitions ==0.9.3",
@@ -325,3 +326,6 @@ verbosity_assertions = 2
 
 [tool.djlint]
 profile="jinja"
+
+[tool.uv.sources]
+sqlalchemy-easy-softdelete = { git = "https://github.com/pass-culture/sqlalchemy-easy-softdelete.git" }


### PR DESCRIPTION
`uv` essaye de récupérer une version inexistante dans notre repo privé: aidons-le à comprendre comment résoudre

> "message": "× No solution found when resolving dependencies:
╰─▶ Because there is no version of sqlalchemy-easy-softdelete==0.9.1 and your project depends on sqlalchemy-easy-softdelete==0.9.1, we can conclude that your project's requirements are unsatisfiable." 