### PR TITLE
(BSR)[BO] fix: prevent option accumulation in unfiltered select autocomplete

### DIFF
--- a/api/src/pcapi/static/backoffice/js/addons/pc-tom-select-field.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-tom-select-field.js
@@ -108,17 +108,23 @@ addonList.push(
         tomselectOptions,
         tomselectItems,
       } = $select.dataset
-      const searchField = 'tomselectDisableClientFilter' in $select.dataset ? [] : ['id', 'text']
+      const isClientFilterDisabled = 'tomselectDisableClientFilter' in $select.dataset
+      const searchField = isClientFilterDisabled ? [] : ['id', 'text']
 
       return {
         valueField: 'id',
         labelField: 'text',
         searchField,
-        load: (query, callback) => {
+        load: function(query, callback) {
           const url = `${tomselectAutocompleteUrl}?q=${encodeURIComponent(query)}`;
           fetch(url)
             .then((response) => response.json())
-            .then((json) => callback(json.items))
+            .then((json) => {
+              if (isClientFilterDisabled) {
+                this.clearOptions()
+              }
+              callback(json.items)
+            })
             .catch((error) => callback(undefined, error))
         },
         ...(tomselectOptions ? { options: JSON.parse(tomselectOptions) } : {}),


### PR DESCRIPTION
Lorsqu'on désactive le filtrage client (JS) interne à Tom Select, ce qui est le cas pour le filtre "Ville" sur la liste de comptes jeunes, on a aussi besoin de désactiver la cache JS interne (qui plus est redondant avec le cache Backend d'`api_geo` dans ce cas). Cela évite de conserver l'ensemble des résultats précédents dans la liste proposée par l'autocomplete, les accumulant à l'infini à chaque nouvelle requête.