### PR TITLE
(PC-43075)[API] fix: close venue: early return if venue is closed

### DIFF
--- a/api/src/pcapi/core/offerers/models.py
+++ b/api/src/pcapi/core/offerers/models.py
@@ -652,7 +652,8 @@ class Venue(PcObject, Model, HasThumbMixin, AccessibilityMixin, SoftDeletableMix
     @property
     def is_eligible_for_search(self) -> bool:
         return (
-            self.managingOfferer.isActive
+            not self.is_closed
+            and self.managingOfferer.isActive
             and self.managingOfferer.isValidated
             and (bool(self.volunteeringUrl) or self.hasAtLeastOneBookableOffer)
         )

--- a/api/tests/core/offerers/test_models.py
+++ b/api/tests/core/offerers/test_models.py
@@ -214,6 +214,18 @@ class VenueIsEligibleForSearchTest:
 
         assert venue.is_eligible_for_search is False
 
+    def test_closed_venue_is_not_eligible_for_search(self):
+        # without the CLOSED state, the venue would be eligible for
+        # search
+        venue = factories.VenueFactory(
+            managingOfferer__isActive=True,
+            managingOfferer__validationStatus=ValidationStatus.VALIDATED,
+            state=models.VenueState.CLOSED,
+        )
+        offers_factories.EventStockFactory(offer__venue=venue)
+
+        assert not venue.is_eligible_for_search
+
 
 class VenueHasActiveIndividualOffersTest:
     def test_has_active_individual_offer_property(self):


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43075)

Fix : inutile de requêter les offres d'une structure (_venue_) si celle-ci est fermée, elle ne sera jamais éligible pour la recherche.