### PR TITLE
(PC-43076)[API] fix: close venue: hybrid property fix (sql part)

### DIFF
--- a/api/src/pcapi/core/offers/models.py
+++ b/api/src/pcapi/core/offers/models.py
@@ -1042,6 +1042,7 @@ class Offer(PcObject, Model, ValidationMixin, AccessibilityMixin):
         # explicit join on Venue then Offerer
         return sa.and_(
             cls.isPublished,
+            offerers_models.Venue.state == None,
             offerers_models.Offerer.isActive,
             offerers_models.Offerer.isValidated,
         )


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43076)

Fix : la partie SQL d'une propriété hybride n'était pas équivalente à celle en Python, il manquait une condition.