### PR TITLE
(BSR)[PRO] fix: e2e collectiveoffers and regression in stocks action bar

### DIFF
--- a/pro/e2e/createCollectiveOffer.e2e.ts
+++ b/pro/e2e/createCollectiveOffer.e2e.ts
@@ -251,7 +251,7 @@ test.describe('Create collective offers', () => {
       TEMPLATE_OFFERS_COLUMNS,
       [
         '',
-        `Offre vitrine${commonOfferData.title}`,
+        `${commonOfferData.title}`,
         'Toute l’année scolaire',
         `1 boulevard Poissonnière 75002 Paris`,
         'publiée',
@@ -493,13 +493,17 @@ async function searchOffer(
   waitForResponseFn: (response: Response) => boolean = (response: Response) =>
     isGetCollectiveOffersBookableResponse(response)
 ) {
+  const isNameSearchResponse = (response: Response) =>
+    waitForResponseFn(response) &&
+    new URL(response.url()).searchParams.get('name') === commonOfferData.title
+
   await page.getByRole('searchbox', { name: /Nom de l’offre/ }).clear()
   await page
     .getByRole('searchbox', { name: /Nom de l’offre/ })
     .fill(commonOfferData.title)
 
   await Promise.all([
-    page.waitForResponse(waitForResponseFn),
+    page.waitForResponse(isNameSearchResponse),
     page.getByText('Rechercher').click(),
   ])
 }

--- a/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferTimetable/components/StocksCalendar/StocksCalendar.tsx
@@ -318,6 +318,17 @@ export function StocksCalendar({ offer, mode }: StocksCalendarProps) {
             </StocksCalendarTable>
           </div>
         )}
+        {hasNoStocks &&
+          (!isOfferExposureEnabled || mode === OFFER_WIZARD_MODE.CREATION) && (
+            <StocksCalendarActionsBar
+              checkedStocks={checkedStocks}
+              hasStocks={offer.hasStocks}
+              deleteStocks={deleteStocks}
+              updateCheckedStocks={setCheckedStocks}
+              mode={mode}
+              offerId={offer.id}
+            />
+          )}
       </div>
     </>
   )


### PR DESCRIPTION
- [x] Suppression de "Offre vitrine" dans le titre attendu du tableau des offres vitrines des e2e
- [x] Fix d'une race condition dans les filtres du tableau des offres collectives
- [x] Ajout de la barre de navigation dans le funnel de création des offres individuelles au niveau de la création des stocks (son affichage était maintenant conditionné à l'affichage du tableau des stocks, et si aucun stock n'existait, alors on avait plus de barre de navigation)