### PR TITLE
(PC-43498)[BO] fix: fix product search not showing existing Titelive …

### DIFF
--- a/api/src/pcapi/connectors/big_query/queries/product.py
+++ b/api/src/pcapi/connectors/big_query/queries/product.py
@@ -213,6 +213,13 @@ class TiteLiveBookArticle(pydantic_v2.BaseModel):
     id_lectorat: str | None = None
     taux_tva: str | None = None
 
+    @pydantic_v2.field_validator("id_lectorat", mode="before")
+    @classmethod
+    def validate_id_lectorat(cls, value: typing.Any) -> str | None:
+        if value is None:
+            return None
+        return str(value)
+
     @pydantic_v2.field_validator("taux_tva", mode="before")
     @classmethod
     def validate_code_tva(cls, value: typing.Any) -> str | None:

--- a/api/src/pcapi/routes/backoffice/products/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/products/blueprint.py
@@ -1,5 +1,6 @@
 import dataclasses
 import enum
+import logging
 from collections import defaultdict
 
 import sqlalchemy as sa
@@ -40,6 +41,9 @@ from pcapi.utils import requests
 from pcapi.utils.transaction_manager import mark_transaction_as_invalid
 
 from . import forms
+
+
+logger = logging.getLogger(__name__)
 
 
 list_products_blueprint = backoffice_blueprint.child_backoffice_blueprint(
@@ -576,7 +580,8 @@ def search_product() -> response_utils.BackofficeResponse:
                 )
             try:
                 data = TypeAdapter(TiteLiveBookWork).validate_python(titelive_data["oeuvre"])
-            except Exception:
+            except Exception as err:
+                logger.warning("Failed to parse Titelive data", extra={"ean": ean, "err": err})
                 titelive_data = {}
                 ineligibility_reason = None
             else:

--- a/api/tests/routes/backoffice/finance_test.py
+++ b/api/tests/routes/backoffice/finance_test.py
@@ -123,7 +123,18 @@ class ListIncidentsTest(GetEndpointHelper):
 
     def test_list_incident_by_offer_id(self, authenticated_client):
         booking_finance_incident1 = finance_factories.IndividualBookingFinanceIncidentFactory()
-        finance_factories.IndividualBookingFinanceIncidentFactory()
+        # Ensure that incident2.id, booking2.id and offer2.id != incident1.id, booking1.id or offer1.id
+        # whatever the current db sequences are, since the search is a big OR on all these columns
+        max_id = max(
+            booking_finance_incident1.incidentId,
+            booking_finance_incident1.bookingId,
+            booking_finance_incident1.booking.stock.offerId,
+        )
+        finance_factories.IndividualBookingFinanceIncidentFactory(
+            incident__id=max_id + 1,
+            booking__id=max_id + 1,
+            booking__stock__offer__id=max_id + 1,
+        )
 
         offer_id = str(booking_finance_incident1.booking.stock.offerId)
 

--- a/api/tests/routes/backoffice/search_product_test.py
+++ b/api/tests/routes/backoffice/search_product_test.py
@@ -1,3 +1,4 @@
+import copy
 import pathlib
 import re
 from unittest.mock import patch
@@ -152,6 +153,56 @@ class SearchProductTest(search_helpers.SearchHelper, GetEndpointHelper):
         else:
             assert "Inéligible pass Culture " in card_text[0]
 
+        assert "EAN whitelisté Non" in card_text[0]
+
+    @patch("pcapi.routes.backoffice.products.blueprint.get_by_ean13")
+    def test_search_by_ean_unexisting_product_on_database_but_exist_on_titelive_with_int_id_lectorat(
+        self, mock_get_by_ean13, authenticated_client
+    ):
+        titelive_data = copy.deepcopy(fixtures.BOOK_BY_SINGLE_EAN_FIXTURE)
+        titelive_data["oeuvre"]["article"][0]["id_lectorat"] = 0
+        mock_get_by_ean13.return_value = titelive_data
+        article = titelive_data["oeuvre"]["article"][0]
+
+        with assert_num_queries(self.expected_num_queries):
+            response = authenticated_client.get(
+                url_for(
+                    self.endpoint,
+                    q="1234567891235",
+                    product_filter_type=ProductFilterTypeEnum.EAN.name,
+                )
+            )
+            assert response.status_code == 200
+
+        assert (
+            "Ce produit n'est pas encore dans la base de données du pass Culture. Vous pouvez l'ajouter en cliquant sur le bouton ci-dessous."
+            in html_parser.extract_alert(response.data)
+        )
+
+        buttons = html_parser.extract(response.data, "button")
+        assert "Importer ce produit dans la base de données du pass Culture" in buttons
+
+        soup = html_parser.get_soup(response.data)
+        card_titles = html_parser.extract_cards_titles(response.data)
+        card_text = html_parser.extract_cards_text(response.data)
+        card_ean = soup.find(id="titelive-data")
+
+        assert card_ean
+        assert card_titles[0] == "Détails du Produit"
+        assert soup.select(f'div.pc-ean-result img[src="{article["imagesUrl"]["recto"]}"]')
+        assert titelive_data["oeuvre"]["titre"] in card_text[0]
+        assert "EAN-13 " + titelive_data["ean"] in card_text[0]
+        assert "Lectorat " + format_titelive_id_lectorat(article["id_lectorat"]) in card_text[0]
+
+        assert (
+            f"Prix HT {finance_utils.format_currency_for_backoffice(article['prixpays']['fr']['value'])}"
+            in card_text[0]
+        )
+        assert "Taux TVA 5,50 %" in card_text[0]
+        assert "Code CLIL " + article["code_clil"] in card_text[0]
+        assert "Code support " + article["libellesupport"] + " (" + article["codesupport"] + ")" in card_text[0]
+
+        assert "Inéligible pass Culture " not in card_text[0]
         assert "EAN whitelisté Non" in card_text[0]
 
     @patch("pcapi.routes.backoffice.products.blueprint.get_by_ean13")


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[PC-43498](https://passculture.atlassian.net/browse/PC-43498)

> Lors de la recherche d'un produit par EAN non existant en base dans le Backoffice, les données renvoyées par Titelive n'étaient pas affichées si `id_lectorat` était renvoyé n'était pas une string, provoquant un échec de validation Pydantic silencieux. Ce changement garantit la conversion de `id_lectorat` en chaîne de caractères et ajoute un log de diagnostic en cas d'erreur de parsing.

### 🔧 Changements
- **Pydantic Model (`TiteLiveBookArticle`)** : ajout d'un validateur `mode="before"` sur `id_lectorat` pour convertir automatiquement les valeurs non nulles en `str`.
- **Backoffice Route (`search_product`)** : ajout d'un log `logger.warning` traçant l'EAN et l'erreur en cas d'échec de parsing des données de l'œuvre Titelive, au lieu d'avaler silencieusement l'exception.

### 🧪 Comment tester
1. Se rendre sur la page de recherche produit du Backoffice (`/backoffice/products/search`).
2. Effectuer une recherche par EAN pour un livre Titelive non importé en base locale (notamment un produit ayant un `id_lectorat` numérique), exemple: `9791043302206`.
3. Vérifier que les informations du livre s'affichent correctement dans le résultat de recherche sans réinitialiser les données Titelive.

---
**🧭 Review effort : 1/5** — _Correctif ciblé et localisé sur la validation Pydantic et l'observabilité._

**🗂️ Walkthrough**

| Fichier(s) | Résumé |
|---|---|
| `api/src/pcapi/connectors/big_query/queries/product.py` | Ajout du validateur `validate_id_lectorat` pour normaliser le type en `str`. |
| `api/src/pcapi/routes/backoffice/products/blueprint.py` | Ajout d'un warning logué lors d'un échec de validation Pydantic de `titelive_data["oeuvre"]`. |

[PC-43498]: https://passculture.atlassian.net/browse/PC-43498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ