### PR TITLE
(PC-43427)[PRO] fix: adjust validationschema

### DIFF
--- a/pro/src/commons/core/VenueEdition/__specs__/serializers.spec.ts
+++ b/pro/src/commons/core/VenueEdition/__specs__/serializers.spec.ts
@@ -5,6 +5,12 @@ describe('Venue edition payload serializer', () => {
     expect(serializeEditVenueBodyModel({}, true, false)).toEqual({})
   })
 
+  it('should default alreadyHasOpeningHours to false when not provided', () => {
+    expect(serializeEditVenueBodyModel({ openingHours: null }, true)).toEqual({
+      openingHours: null,
+    })
+  })
+
   it('should serialize newly added opening hours', () => {
     expect(
       serializeEditVenueBodyModel(

--- a/pro/src/commons/core/VenueEdition/__specs__/validationSchema.spec.ts
+++ b/pro/src/commons/core/VenueEdition/__specs__/validationSchema.spec.ts
@@ -1,4 +1,3 @@
-import { ActivityNotOpenToPublic, ActivityOpenToPublic } from '@/apiClient/v1'
 import { getYupValidationSchemaErrors } from '@/commons/utils/yupValidationTestHelpers'
 
 import { getVolunteeringUrlError } from '../getVolunteeringUrlError'
@@ -22,7 +21,6 @@ describe('VenueEditionForm validationSchema', () => {
     isOpenToPublic: 'true',
     openingHours: null,
     description: 'description',
-    activity: ActivityOpenToPublic.ART_GALLERY,
     volunteeringUrl: null,
   }
 
@@ -119,7 +117,6 @@ describe('VenueEditionForm validationSchema', () => {
       formValues: {
         ...defaultValues,
         isOpenToPublic: 'false',
-        activity: ActivityNotOpenToPublic.PRESS_OR_MEDIA,
         openingHours: {
           MONDAY: null,
         },
@@ -130,48 +127,12 @@ describe('VenueEditionForm validationSchema', () => {
 
   cases.forEach(({ description, formValues, expectedErrors }) => {
     it(`should validate the form for case: ${description}`, async () => {
-      const errors = await getYupValidationSchemaErrors(getValidationSchema(), {
-        ...formValues,
-        culturalDomains: ['test'],
-      })
+      const errors = await getYupValidationSchemaErrors(
+        getValidationSchema(),
+        formValues
+      )
       expect(errors).toEqual(expectedErrors)
     })
-  })
-
-  it('should require activity when feature flag is enabled and venue is open to public', async () => {
-    const errors = await getYupValidationSchemaErrors(getValidationSchema(), {
-      ...defaultValues,
-      activity: null,
-      culturalDomains: ['string'],
-    })
-
-    expect(errors).toEqual(['Veuillez renseigner ce champ'])
-  })
-
-  it('should require domains array', async () => {
-    const errors = await getYupValidationSchemaErrors(getValidationSchema(), {
-      ...defaultValues,
-      isOpenToPublic: 'false',
-      activity: 'PRESS_OR_MEDIA',
-      culturalDomains: null,
-    })
-
-    expect(errors).toEqual([
-      'Veuillez sélectionner un ou plusieurs domaines d’activité',
-    ])
-  })
-
-  it('should require domains values', async () => {
-    const errors = await getYupValidationSchemaErrors(getValidationSchema(), {
-      ...defaultValues,
-      isOpenToPublic: 'false',
-      activity: 'PRESS_OR_MEDIA',
-      culturalDomains: [],
-    })
-
-    expect(errors).toEqual([
-      'Veuillez sélectionner un ou plusieurs domaines d’activité',
-    ])
   })
 
   it('should call getVolunteeringUrlError to validate volunteeringUrl', async () => {

--- a/pro/src/commons/core/VenueEdition/serializeEditVenueBodyModel.ts
+++ b/pro/src/commons/core/VenueEdition/serializeEditVenueBodyModel.ts
@@ -8,12 +8,22 @@ import { OPENING_HOURS_DAYS } from '@/commons/utils/date'
 
 import type { VenueEditionFormValues } from './types'
 
+interface VenueReadOnlyFields {
+  activity?: ActivityOpenToPublic | ActivityNotOpenToPublic | null
+  culturalDomains?: string[]
+}
+
 export const serializeEditVenueBodyModel = (
   formValues: Partial<VenueEditionFormValues>,
   hideSiret: boolean,
-  alreadyHasOpeningHours: boolean = false
+  alreadyHasOpeningHours: boolean = false,
+  venueReadOnlyFields?: VenueReadOnlyFields
 ): EditVenueBodyModel => {
-  const payload = buildEditVenuePayload(formValues, alreadyHasOpeningHours)
+  const payload = buildEditVenuePayload(
+    formValues,
+    alreadyHasOpeningHours,
+    venueReadOnlyFields
+  )
 
   if (hideSiret && payload.siret) {
     delete payload.siret
@@ -24,9 +34,10 @@ export const serializeEditVenueBodyModel = (
 
 function buildEditVenuePayload(
   formValues: Partial<VenueEditionFormValues>,
-  alreadyHasOpeningHours: boolean
+  alreadyHasOpeningHours: boolean,
+  venueReadOnlyFields?: VenueReadOnlyFields
 ): EditVenueBodyModel {
-  const normalizedActivity = normalizeActivity(formValues.activity)
+  const normalizedActivity = normalizeActivity(venueReadOnlyFields?.activity)
 
   // TODO: this is a PATCH request. It should only contains changed values
   return {
@@ -51,7 +62,7 @@ function buildEditVenuePayload(
       ? formValues.isOpenToPublic === 'true'
       : undefined,
     activity: normalizedActivity,
-    culturalDomains: formValues.culturalDomains,
+    culturalDomains: venueReadOnlyFields?.culturalDomains,
     volunteeringUrl:
       formValues.volunteeringUrl === undefined
         ? undefined
@@ -61,7 +72,7 @@ function buildEditVenuePayload(
 }
 
 export function normalizeActivity(
-  activity: VenueEditionFormValues['activity']
+  activity: ActivityOpenToPublic | ActivityNotOpenToPublic | null | undefined
 ): ActivityOpenToPublic | ActivityNotOpenToPublic | null | undefined {
   if ((activity as string | null) === 'GAMES_CENTRE') {
     return null

--- a/pro/src/commons/core/VenueEdition/setInitialFormValues.ts
+++ b/pro/src/commons/core/VenueEdition/setInitialFormValues.ts
@@ -22,8 +22,6 @@ export const setInitialFormValues = (
     webSite: venue.contact?.website || '',
     isOpenToPublic: venue.isOpenToPublic.toString(),
     openingHours: normalizeOpeningHoursForForm(venue),
-    activity: venue.activity as VenueEditionFormValues['activity'], // Force is needed because of "GAMES_CENTRE" which is present in `DisplayableActivity`, but not in `ActivityOpenToPublic`
-    culturalDomains: venue.collectiveDomains.map((domain) => domain.name),
     volunteeringUrl: venue.volunteeringUrl ?? null,
     withdrawalDetails: venue.withdrawalDetails ?? null,
   }

--- a/pro/src/commons/core/VenueEdition/types.ts
+++ b/pro/src/commons/core/VenueEdition/types.ts
@@ -1,8 +1,4 @@
-import type {
-  ActivityNotOpenToPublic,
-  ActivityOpenToPublic,
-  WeekdayOpeningHoursTimespans,
-} from '@/apiClient/v1'
+import type { WeekdayOpeningHoursTimespans } from '@/apiClient/v1'
 import type { AccessibilityFormValues } from '@/commons/core/shared/types'
 import type { Nullable } from '@/commons/utils/types'
 
@@ -15,8 +11,6 @@ export interface VenueEditionFormValues {
   webSite?: string | null
   isOpenToPublic: string
   openingHours?: WeekdayOpeningHoursTimespans | null
-  activity?: ActivityOpenToPublic | ActivityNotOpenToPublic | null
-  culturalDomains?: string[]
   volunteeringUrl?: string | null
   withdrawalDetails?: string | null
 }

--- a/pro/src/commons/core/VenueEdition/validationSchema.ts
+++ b/pro/src/commons/core/VenueEdition/validationSchema.ts
@@ -2,13 +2,6 @@ import { openToPublicValidationSchema } from 'components/OpenToPublicToggle/vali
 import type { ObjectSchema } from 'yup'
 import * as yup from 'yup'
 
-import type {
-  ActivityNotOpenToPublic,
-  ActivityOpenToPublic,
-} from '@/apiClient/v1'
-import { ActivityNotOpenToPublicMap } from '@/commons/mappings/ActivityNotOpenToPublic'
-import { ActivityOpenToPublicMap } from '@/commons/mappings/ActivityOpenToPublic'
-import { getMapKeys } from '@/commons/mappings/helpers'
 import { emailSchema } from '@/commons/utils/isValidEmail'
 import { phoneNumberSchema } from '@/commons/utils/yup/phoneNumberSchema'
 
@@ -80,13 +73,6 @@ const openingHoursSchemaShape = {
 }
 
 export const getValidationSchema = (): ObjectSchema<VenueEditionFormValues> => {
-  const activityTypeValuesOpenToPublic = getMapKeys(
-    ActivityOpenToPublicMap
-  ) as ActivityOpenToPublic[]
-  const activityTypeValuesNotOpenToPublic = getMapKeys(
-    ActivityNotOpenToPublicMap
-  ) as ActivityNotOpenToPublic[]
-
   return yup
     .object()
     .shape({
@@ -123,39 +109,6 @@ export const getValidationSchema = (): ObjectSchema<VenueEditionFormValues> => {
         .when('isOpenToPublic', {
           is: 'true',
           then: (schema) => schema.shape(openingHoursSchemaShape),
-        }),
-      activity: yup
-        .mixed<ActivityNotOpenToPublic | ActivityOpenToPublic>()
-        .nullable()
-        .when(['isOpenToPublic'], {
-          is: (open: string) => open === 'true',
-          then: (schema) =>
-            schema
-              .oneOf(activityTypeValuesOpenToPublic, 'Activité non valide')
-              .required('Veuillez renseigner ce champ'),
-        })
-        .when(['isOpenToPublic'], {
-          is: (open: string) => open === 'false',
-          then: (schema) =>
-            schema
-              .oneOf(activityTypeValuesNotOpenToPublic, 'Activité non valide')
-              .required('Veuillez renseigner ce champ'),
-        }),
-      culturalDomains: yup
-        .array()
-        .of(yup.string().required())
-        .when('isOpenToPublic', {
-          is: (open: string) => open === 'false',
-          then: (schema) =>
-            schema
-              .required(
-                'Veuillez sélectionner un ou plusieurs domaines d’activité'
-              )
-              .min(
-                1,
-                'Veuillez sélectionner un ou plusieurs domaines d’activité'
-              ),
-          otherwise: (schema) => schema,
         }),
       volunteeringUrl: yup.string().test(volunteeringUrlSchema).nullable(),
       withdrawalDetails: yup.string().nullable(),

--- a/pro/src/pages/IndividualVenuePageEdition/components/VenueEditionForm.tsx
+++ b/pro/src/pages/IndividualVenuePageEdition/components/VenueEditionForm.tsx
@@ -4,7 +4,11 @@ import { useNavigate } from 'react-router'
 
 import { api } from '@/apiClient/api'
 import { isErrorAPIError } from '@/apiClient/helpers'
-import type { GetVenueResponseModel } from '@/apiClient/v1'
+import type {
+  ActivityNotOpenToPublic,
+  ActivityOpenToPublic,
+  GetVenueResponseModel,
+} from '@/apiClient/v1'
 import { useAnalytics } from '@/app/App/analytics/firebase'
 import { Events } from '@/commons/core/FirebaseEvents/constants'
 import { getVolunteeringUrlError } from '@/commons/core/VenueEdition/getVolunteeringUrlError'
@@ -69,7 +73,18 @@ export const VenueEditionForm = ({ venue }: VenueFormProps) => {
         body: serializeEditVenueBodyModel(
           values,
           !venue.siret,
-          venue.openingHours !== null
+          venue.openingHours !== null,
+          {
+            // Cast is needed because "GAMES_CENTRE" is present in
+            // `DisplayableActivity` but not in ActivityOpenToPublic | ActivityNotOpenToPublic
+            activity: venue.activity as
+              | ActivityOpenToPublic
+              | ActivityNotOpenToPublic
+              | null,
+            culturalDomains: venue.collectiveDomains.map(
+              (domain) => domain.name
+            ),
+          }
         ),
       })
 

--- a/pro/src/pages/VenueSettings/GeneralInformation/GeneralInformation.spec.tsx
+++ b/pro/src/pages/VenueSettings/GeneralInformation/GeneralInformation.spec.tsx
@@ -332,6 +332,7 @@ describe('GeneralInformation', () => {
         id: 1,
         isOpenToPublic: true,
         activity: DisplayableActivity.FESTIVAL,
+        collectiveDomains: [{ id: 1, name: 'Danse' }],
         location: {
           ...defaultGetVenue.location,
           street: '123 Rue Principale',

--- a/pro/src/pages/VenueSettings/GeneralInformation/commons/schema.ts
+++ b/pro/src/pages/VenueSettings/GeneralInformation/commons/schema.ts
@@ -52,5 +52,19 @@ export const venueSettingsValidationSchema = yup
       .string()
       .nullable()
       .required('Veuillez sélectionner une activité parmi les suggestions'),
+    culturalDomains: yup
+      .array()
+      .of(yup.string().defined())
+      .when('isOpenToPublic', {
+        is: (open: string) => open === 'false',
+        then: (schema) =>
+          schema.nullable().test({
+            name: 'has-at-least-one-domain',
+            message:
+              'Veuillez sélectionner un ou plusieurs domaines d’activité',
+            test: (value) => Boolean(value?.filter(Boolean).length),
+          }),
+        otherwise: (schema) => schema.nullable(),
+      }),
   })
   .concat(SiretOrCommentValidationSchema)


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43427)

Problème: on ne pouvait pas "Enregistrer" sur la page de l'application si l'utilisateur avait un lieu non ouvert au public sans domaine d'activité

On attendait que le culturalDomains soit définis sauf qu'il était optionnel sur la page paramètre donc il y avait un décalage dans la validation, j'en profite pour clean aussi activity qui n'a plus besoin de validationschema vu qu'il est géré dans la page paramètre aussi