### PR TITLE
(BSR)[API] chore: check that DEMARCHE_NUMERIQUE_CREATE_UBBLE_MIN_DATE_TIME value is well deployed in prod

### DIFF
--- a/api/src/pcapi/scripts/check_env/main.py
+++ b/api/src/pcapi/scripts/check_env/main.py
@@ -1,0 +1,15 @@
+import logging
+
+from pcapi import settings
+
+
+logger = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    from pcapi.app import app
+
+    app.app_context().push()
+
+    logger.info(
+        "DEMARCHE_NUMERIQUE_CREATE_UBBLE_MIN_DATETIME = %s", settings.DEMARCHE_NUMERIQUE_CREATE_UBBLE_MIN_DATETIME
+    )


### PR DESCRIPTION
M'assurer que la variable d'environnement est bien déployée en prod avant d'activer le FF.
Lecture seule, ça n'écrit rien et n'accède pas à la base de données.