### PR TITLE
(PC-43512)[API] feat: add user_cultural_survey model

### DIFF
--- a/api/alembic_version_conflict_detection.txt
+++ b/api/alembic_version_conflict_detection.txt
@@ -1,2 +1,2 @@
-a703309b6657 (pre) (head)
+6993fbbec133 (pre) (head)
 2cfe1c7bcb34 (post) (head)

--- a/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
+++ b/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
@@ -16,15 +16,15 @@ def upgrade() -> None:
     op.create_table(
         "user_cultural_survey",
         sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
-        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("userId", sa.BigInteger(), nullable=False),
         sa.Column("answers", sa.JSON(), nullable=False),
-        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
     )
     op.create_foreign_key(
         "user_cultural_survey_fkey",
         "user_cultural_survey",
         "user",
-        ["user_id"],
+        ["userId"],
         ["id"],
         ondelete="CASCADE",
     )

--- a/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
+++ b/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
@@ -26,7 +26,6 @@ def upgrade() -> None:
         "user",
         ["userId"],
         ["id"],
-        ondelete="CASCADE",
     )
 
 

--- a/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
+++ b/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
@@ -1,0 +1,34 @@
+"""Create user_cultural_survey table"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# pre/post deployment: pre
+# revision identifiers, used by Alembic.
+revision = "6993fbbec133"
+down_revision = "a703309b6657"
+branch_labels: tuple[str] | None = None
+depends_on: list[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_cultural_survey",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("answers", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+    )
+    op.create_foreign_key(
+        "user_cultural_survey_fkey",
+        "user_cultural_survey",
+        "user",
+        ["user_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_cultural_survey")

--- a/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
+++ b/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
@@ -21,13 +21,7 @@ def upgrade() -> None:
         sa.Column("answers", postgresql.JSONB, nullable=False),
         sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
         sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_foreign_key(
-        "user_cultural_survey_fkey",
-        "user_cultural_survey",
-        "user",
-        ["userId"],
-        ["id"],
+        sa.ForeignKeyConstraint(["userId"], ["user.id"], name=op.f("user_cultural_survey_userId_fkey")),
     )
 
 

--- a/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
+++ b/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
@@ -20,6 +20,7 @@ def upgrade() -> None:
         sa.Column("userId", sa.BigInteger(), nullable=False),
         sa.Column("answers", postgresql.JSONB, nullable=False),
         sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("id"),
     )
     op.create_foreign_key(
         "user_cultural_survey_fkey",

--- a/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
+++ b/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
@@ -2,6 +2,7 @@
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 
 # pre/post deployment: pre
@@ -17,7 +18,7 @@ def upgrade() -> None:
         "user_cultural_survey",
         sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
         sa.Column("userId", sa.BigInteger(), nullable=False),
-        sa.Column("answers", sa.JSON(), nullable=False),
+        sa.Column("answers", postgresql.JSONB, nullable=False),
         sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
     )
     op.create_foreign_key(

--- a/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
+++ b/api/src/pcapi/alembic/versions/20260904T095211_6993fbbec133_create_table_cultural_survey.py
@@ -21,6 +21,7 @@ def upgrade() -> None:
         sa.Column("answers", postgresql.JSONB, nullable=False),
         sa.Column("createdAt", sa.DateTime, server_default=sa.func.now()),
         sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("userId", name=op.f("user_cultural_survey_userId_unique")),
         sa.ForeignKeyConstraint(["userId"], ["user.id"], name=op.f("user_cultural_survey_userId_fkey")),
     )
 

--- a/api/src/pcapi/core/cultural_survey/models.py
+++ b/api/src/pcapi/core/cultural_survey/models.py
@@ -3,11 +3,10 @@ from datetime import datetime
 
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
-from sqlalchemy import JSON
-from sqlalchemy import func
 
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
+from pcapi.utils.date import get_naive_utc_now
 
 
 class CulturalSurveyQuestionEnum(enum.Enum):
@@ -86,19 +85,20 @@ class CulturalSurveyAnswerEnum(enum.Enum):
 class UserCulturalSurvey(PcObject, Model):
     __tablename__ = "user_cultural_survey"
 
-    user_id: sa_orm.Mapped[str] = sa_orm.mapped_column(
+    userId: sa_orm.Mapped[int] = sa_orm.mapped_column(
         sa.BigInteger,
         sa.ForeignKey("user.id", ondelete="CASCADE"),
         nullable=False,
         unique=True,
     )
 
-    answers: sa_orm.Mapped[JSON] = sa_orm.mapped_column(
+    answers: sa_orm.Mapped[sa.JSON] = sa_orm.mapped_column(
         sa.JSON,
         nullable=False,
     )
 
     created_at: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
         sa.DateTime,
-        server_default=func.utcnow(),
+        nullable=False,
+        default=get_naive_utc_now(),
     )

--- a/api/src/pcapi/core/cultural_survey/models.py
+++ b/api/src/pcapi/core/cultural_survey/models.py
@@ -1,4 +1,13 @@
 import enum
+from datetime import datetime
+
+import sqlalchemy as sa
+import sqlalchemy.orm as sa_orm
+from sqlalchemy import JSON
+from sqlalchemy import func
+
+from pcapi.models import Model
+from pcapi.models.pc_object import PcObject
 
 
 class CulturalSurveyQuestionEnum(enum.Enum):
@@ -72,3 +81,24 @@ class CulturalSurveyAnswerEnum(enum.Enum):
     JAZZ = "JAZZ"
     CLASSIQUE = "CLASSIQUE"
     MUSIQUES_AUCUN = "MUSIQUES_AUCUN"
+
+
+class UserCulturalSurvey(PcObject, Model):
+    __tablename__ = "user_cultural_survey"
+
+    user_id: sa_orm.Mapped[str] = sa_orm.mapped_column(
+        sa.BigInteger,
+        sa.ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+
+    answers: sa_orm.Mapped[JSON] = sa_orm.mapped_column(
+        sa.JSON,
+        nullable=False,
+    )
+
+    created_at: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+        sa.DateTime,
+        server_default=func.utcnow(),
+    )

--- a/api/src/pcapi/core/cultural_survey/models.py
+++ b/api/src/pcapi/core/cultural_survey/models.py
@@ -87,7 +87,7 @@ class UserCulturalSurvey(PcObject, Model):
 
     userId: sa_orm.Mapped[int] = sa_orm.mapped_column(
         sa.BigInteger,
-        sa.ForeignKey("user.id", ondelete="CASCADE"),
+        sa.ForeignKey("user.id"),
         nullable=False,
         unique=True,
     )
@@ -100,5 +100,6 @@ class UserCulturalSurvey(PcObject, Model):
     created_at: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
         sa.DateTime,
         nullable=False,
-        default=get_naive_utc_now(),
+        default=get_naive_utc_now,
+        server_default=sa.func.utcnow(),
     )

--- a/api/src/pcapi/core/cultural_survey/models.py
+++ b/api/src/pcapi/core/cultural_survey/models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.mutable import MutableList
 
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
@@ -93,8 +94,9 @@ class UserCulturalSurvey(PcObject, Model):
         unique=True,
     )
 
-    answers: sa_orm.Mapped[postgresql.JSONB] = sa_orm.mapped_column(
-        postgresql.JSONB,
+    answers: sa_orm.Mapped[list[dict]] = sa_orm.mapped_column(
+        MutableList.as_mutable(postgresql.JSONB),
+        default=list,
         nullable=False,
     )
 

--- a/api/src/pcapi/core/cultural_survey/models.py
+++ b/api/src/pcapi/core/cultural_survey/models.py
@@ -100,7 +100,7 @@ class UserCulturalSurvey(PcObject, Model):
         nullable=False,
     )
 
-    created_at: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
+    createdAt: sa_orm.Mapped[datetime] = sa_orm.mapped_column(
         sa.DateTime,
         nullable=False,
         default=get_naive_utc_now,

--- a/api/src/pcapi/core/cultural_survey/models.py
+++ b/api/src/pcapi/core/cultural_survey/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import sqlalchemy as sa
 import sqlalchemy.orm as sa_orm
+from sqlalchemy.dialects import postgresql
 
 from pcapi.models import Model
 from pcapi.models.pc_object import PcObject
@@ -92,8 +93,8 @@ class UserCulturalSurvey(PcObject, Model):
         unique=True,
     )
 
-    answers: sa_orm.Mapped[sa.JSON] = sa_orm.mapped_column(
-        sa.JSON,
+    answers: sa_orm.Mapped[postgresql.JSONB] = sa_orm.mapped_column(
+        postgresql.JSONB,
         nullable=False,
     )
 

--- a/api/src/pcapi/core/cultural_survey/models.py
+++ b/api/src/pcapi/core/cultural_survey/models.py
@@ -96,7 +96,6 @@ class UserCulturalSurvey(PcObject, Model):
 
     answers: sa_orm.Mapped[list[dict]] = sa_orm.mapped_column(
         MutableList.as_mutable(postgresql.JSONB),
-        default=list,
         nullable=False,
     )
 

--- a/api/src/pcapi/db_utils.py
+++ b/api/src/pcapi/db_utils.py
@@ -173,6 +173,7 @@ tables_to_clean: list[type[Model]] = [
     operations_models.SpecialEventResponse,
     operations_models.SpecialEventQuestion,
     operations_models.SpecialEvent,
+    cultural_survey_models.UserCulturalSurvey,
     users_models.GdprUserAnonymization,
     users_models.GdprUserDataExtract,
     users_models.SingleSignOn,
@@ -199,7 +200,6 @@ tables_to_clean: list[type[Model]] = [
     history_models.ActionHistory,
     educational_models.NationalProgram,
     dms_models.LatestDmsImport,
-    cultural_survey_models.UserCulturalSurvey,
 ]
 
 

--- a/api/src/pcapi/db_utils.py
+++ b/api/src/pcapi/db_utils.py
@@ -6,6 +6,7 @@ from sqlalchemy import text
 
 import pcapi.core.bookings.models as bookings_models
 import pcapi.core.criteria.models as criteria_models
+import pcapi.core.cultural_survey.models as cultural_survey_models
 import pcapi.core.educational.models as educational_models
 import pcapi.core.finance.models as finance_models
 import pcapi.core.fraud.models as fraud_models
@@ -198,6 +199,7 @@ tables_to_clean: list[type[Model]] = [
     history_models.ActionHistory,
     educational_models.NationalProgram,
     dms_models.LatestDmsImport,
+    cultural_survey_models.UserCulturalSurvey,
 ]
 
 


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43512)

Creation de la table UserCulturalSurvey, en vue de sauvegarder dans la DB du back, les reponses au QPI des utilisateurs en parallele de BigQuery.

Upgrade en pre et Downgrade fonctionnels.

- [X] Travail pair testé en environnement de preview
