### PR TITLE
(PC-43242)[API] script: fix inseecode for some manual addresses

### DIFF
--- a/api/src/pcapi/scripts/address/main.py
+++ b/api/src/pcapi/scripts/address/main.py
@@ -1,0 +1,98 @@
+"""
+Job console documentation here: https://www.notion.so/passcultureapp/Documentation-Job-Console-769beeacd5a146de9c97b6f8ee544276
+
+You can start the job from the infra repository with github cli :
+
+gh workflow run on_dispatch_pcapi_console_job.yaml \
+  -f ENVIRONMENT_SHORT_NAME=tst \
+  -f RESOURCES="512Mi/.5" \
+  -f BRANCH_NAME=master \
+  -f NAMESPACE=set_location_type_for_offers \
+  -f SCRIPT_ARGUMENTS="";
+
+"""
+
+import argparse
+import logging
+
+import sqlalchemy as sa
+
+import pcapi.core.geography.models as geography_models
+import pcapi.core.offerers.models as offerer_models
+from pcapi.models import db
+from pcapi.utils.transaction_manager import atomic
+from pcapi.utils.transaction_manager import mark_transaction_as_invalid
+
+
+logger = logging.getLogger(__name__)
+
+
+def main(apply: bool = False) -> None:
+    addresses_with_missing_insees = (
+        db.session.query(geography_models.Address)
+        .filter(
+            geography_models.Address.inseeCode.is_(None),
+            geography_models.Address.banId.is_not(None),
+            geography_models.Address.isManualEdition.is_(False),
+        )
+        .all()
+    )
+    logger.info("Found %d addresses with missing inseeCode", len(addresses_with_missing_insees))
+    for address in addresses_with_missing_insees:
+        try:
+            with atomic():
+                if not apply:
+                    mark_transaction_as_invalid()
+                assert address.banId
+                address.inseeCode = address.banId[0:5]
+                db.session.flush()
+        except sa.exc.IntegrityError:
+            sister_address = (
+                db.session.query(geography_models.Address)
+                .filter(
+                    geography_models.Address.street == address.street,
+                    geography_models.Address.city == address.city,
+                    geography_models.Address.departmentCode == address.departmentCode,
+                    geography_models.Address.postalCode == address.postalCode,
+                    geography_models.Address.latitude == address.latitude,
+                    geography_models.Address.longitude == address.longitude,
+                    geography_models.Address.timezone == address.timezone,
+                    geography_models.Address.banId == address.banId,
+                    geography_models.Address.isManualEdition.is_(False),
+                    geography_models.Address.inseeCode.is_not(None),
+                )
+                .one_or_none()
+            )
+            if sister_address:
+                try:
+                    with atomic():
+                        if not apply:
+                            mark_transaction_as_invalid()
+                        db.session.query(offerer_models.OffererAddress).filter(
+                            offerer_models.OffererAddress.addressId == address.id
+                        ).update({offerer_models.OffererAddress.addressId: sister_address.id})
+                        db.session.flush()
+                        db.session.delete(address)
+                        db.session.flush()
+                except sa.exc.IntegrityError:
+                    logger.info(
+                        "Failed to update location from address id %s to address id %s, please run PC-40918",
+                        address.id,
+                        sister_address.id,
+                    )
+
+            else:
+                logger.info("manual check needed for address id %s", address.id)
+
+
+if __name__ == "__main__":
+    from pcapi.app import app
+
+    app.app_context().push()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+
+    main(args.apply)
+    logger.info("Finished")

--- a/api/tests/scripts/address/test_fix_missing_inseeCode.py
+++ b/api/tests/scripts/address/test_fix_missing_inseeCode.py
@@ -1,0 +1,66 @@
+from pcapi.core.geography.factories import AddressFactory
+from pcapi.core.geography.models import Address
+from pcapi.core.offerers.factories import OfferLocationFactory
+from pcapi.models import db
+
+
+def test_fix_missing_inseeCode(db_session):
+    address = AddressFactory(city="Perceval", inseeCode=None, banId="12345678901234")
+    assert address.inseeCode is None
+    from pcapi.scripts.address.main import main
+
+    main(apply=False)
+    main(apply=True)
+
+    assert address.inseeCode == "12345"
+
+
+def test_with_existing_correct_address(db_session):
+    """if address has correct duplicate, change related locations to correct duplicate and delete the address"""
+    address = AddressFactory(city="Perceval", inseeCode=None, banId="12345678901234")
+    good_address = AddressFactory(
+        city="Perceval",
+        inseeCode="12345",
+        banId="12345678901234",
+        street=address.street,
+        postalCode=address.postalCode,
+        departmentCode=address.departmentCode,
+        latitude=address.latitude,
+        longitude=address.longitude,
+        timezone=address.timezone,
+    )
+    location = OfferLocationFactory(address=address)
+    assert location.addressId == address.id
+    from pcapi.scripts.address.main import main
+
+    main(apply=False)
+    main(apply=True)
+
+    assert db.session.query(Address).filter(Address.city == "Perceval").one() == good_address
+    assert location.addressId == good_address.id
+
+
+def test_with_duplicate_offer_location(db_session):
+    """if address has correct duplicate and both have similar offerlocations, display log and don't do anything until PC-40918 is run"""
+    address = AddressFactory(city="Perceval", inseeCode=None, banId="12345678901234")
+    good_address = AddressFactory(
+        city="Perceval",
+        inseeCode="12345",
+        banId="12345678901234",
+        street=address.street,
+        postalCode=address.postalCode,
+        departmentCode=address.departmentCode,
+        latitude=address.latitude,
+        longitude=address.longitude,
+        timezone=address.timezone,
+    )
+    location = OfferLocationFactory(address=address)
+    OfferLocationFactory(address=good_address, offerer=location.offerer, venue=location.venue, label=location.label)
+    assert location.addressId == address.id
+    from pcapi.scripts.address.main import main
+
+    main(apply=False)
+    main(apply=True)
+
+    assert db.session.query(Address).filter(Address.city == "Perceval").count() == 2
+    assert location.addressId == address.id


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43242)

On essaie d editer ladresse sans inseecode a partir du ban_id qu'elle possede:
-si l'update réussi, on a une adresse defcetueuse en moins
-si l'update fail, c'est qu'on a une adresse "en double"
    -dans les localisations, on remplace l'adresse defectueuse par son double avec inseecode:
        -si l'update réussi, c'est que la localisation n'tait connecté a aucune offre
        -Si l'update fail, c'est qu'il y a des localisations en double
        -on cherche toutes les offres avec la localisation contenant l'adresse fautive, on les deplace vers les localisations avec la bonne adresse, et on supprime la localisation avec adresse fautive. On crée ainsi des adresses orphelines qui pourront etre supprimées en repassant le script
**:warning: Ne pas merger dans `master`!**

<!-- Ajouter le label `do-not-merge` pour que la CI bloque le merge -->

Mon script a tourné sur :

- Testing :
 Pas sur testing car pas suffisamment de data
- Staging :
  - [ x] Dry run : (https://github.com/pass-culture/infra/actions/runs/35359422290)
  - [ x ] Actual run : https://github.com/pass-culture/infra/actions/runs/35600185369/job/106334677408 (1er run pour supprimer tous les cas simple + supprimer les OAs des cas complexes)
  - https://github.com/pass-culture/infra/actions/runs/35602272528/job/106341449706(2eme run)
- Production :
  - [ ] Dry run : lien vers le job
  - [ ] Actual run : lien vers le job
- Intégration (**:warning: ne pas oublier cet environnement**) :
  - [ ] Dry run : lien vers le job
  - [ ] Actual run : lien vers le job
