### PR TITLE
(PC-43553)[PRO] fix: align icons and text for image constraint check

### DIFF
--- a/pro/src/components/ImageDragAndDrop/ImageConstraintCheck.tsx
+++ b/pro/src/components/ImageDragAndDrop/ImageConstraintCheck.tsx
@@ -34,7 +34,11 @@ export const ImageConstraintCheck = ({
       })}
     >
       {hasInput && (
-        <SvgIcon src={hasError ? fullClearIcon : fullValidateIcon} width="16" />
+        <SvgIcon
+          className={styles['image-drag-and-drop-description-icon']}
+          src={hasError ? fullClearIcon : fullValidateIcon}
+          width="16"
+        />
       )}
       <p
         className={cn({

--- a/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.module.scss
+++ b/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.module.scss
@@ -94,13 +94,19 @@
     flex-direction: column;
     gap: var(--size-spacing-xs);
 
-    &-neutral,
     &-error,
     &-validate {
       display: flex;
       align-items: center;
       gap: var(--size-spacing-xs);
-      flex-wrap: wrap;
+    }
+
+    &-icon {
+      align-self: flex-start;
+      flex-shrink: 0;
+      margin-top: calc(
+        (var(--typography-body-accent-s-line-height) - #{rem.torem(16px)}) / 2
+      );
     }
 
     &-neutral {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43553)

<!-- Please include a summary of the changes and the related issue.
- List your changes here
- What did you add, fix, or update?
-->

<!-- Describe the steps to test your changes. Include setup instructions, commands, and expected results. -->

## 🖼️ Before & After Images

Avant : 

<img width="777" height="535" alt="Capture d’écran 2026-09-07 à 14 12 34" src="https://github.com/user-attachments/assets/ac7e08ca-e3fd-41af-afb0-74efea65b936" />

Maintenant : 
<img width="601" height="461" alt="Capture d’écran 2026-09-07 à 14 11 59" src="https://github.com/user-attachments/assets/f33206f8-aebe-42cd-9618-d35b0368abb4" />
