### PR TITLE
(PC-43450)[PRO] feat: resolve image upload issue

### DIFF
--- a/pro/package.json
+++ b/pro/package.json
@@ -65,6 +65,7 @@
     "downshift": "9.4.0",
     "libphonenumber-js": "1.13.9",
     "lodash.invert": "4.3.0",
+    "magic-bytes.js": "^1.13.1",
     "qrcode.react": "4.2.0",
     "react": "19.2.8",
     "react-avatar-editor": "15.1.0",

--- a/pro/pnpm-lock.yaml
+++ b/pro/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       lodash.invert:
         specifier: 4.3.0
         version: 4.3.0
+      magic-bytes.js:
+        specifier: ^1.13.1
+        version: 1.13.1
       qrcode.react:
         specifier: 4.2.0
         version: 4.2.0(react@19.2.8)
@@ -148,7 +151,7 @@ importers:
         version: 10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.2)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0))
       '@storybook/react-vite':
         specifier: 10.5.10
-        version: 10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(supports-color@7.2.0)(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0))
+        version: 10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0))
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1
@@ -184,13 +187,13 @@ importers:
         version: 6.0.5(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0))
       '@vitest/coverage-istanbul':
         specifier: 4.1.7
-        version: 4.1.7(supports-color@7.2.0)(vitest@4.1.7)
+        version: 4.1.7(vitest@4.1.7)
       axe-core:
         specifier: 4.13.0
         version: 4.13.0
       check-unused-css:
         specifier: 0.5.5
-        version: 0.5.5(supports-color@7.2.0)(typescript@6.0.3)
+        version: 0.5.5(typescript@6.0.3)
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -229,10 +232,10 @@ importers:
         version: 7.0.0(react-dom@19.2.8(react@19.2.8))(react-router@8.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))
       stylelint:
         specifier: 16.26.1
-        version: 16.26.1(supports-color@7.2.0)(typescript@6.0.3)
+        version: 16.26.1(typescript@6.0.3)
       stylelint-config-standard-scss:
         specifier: 16.0.0
-        version: 16.0.0(postcss@8.5.26)(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3))
+        version: 16.0.0(postcss@8.5.26)(stylelint@16.26.1(typescript@6.0.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -3331,6 +3334,9 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
+  magic-bytes.js@1.13.1:
+    resolution: {integrity: sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -4644,20 +4650,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7(supports-color@7.2.0)':
+  '@babel/core@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -4682,19 +4688,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -4721,7 +4727,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
 
-  '@babel/traverse@7.29.8(supports-color@7.2.0)':
+  '@babel/traverse@7.29.8':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.8
@@ -4729,7 +4735,7 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5914,16 +5920,16 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.5(@types/react@19.2.17)
 
-  '@storybook/react-vite@10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(supports-color@7.2.0)(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0))':
+  '@storybook/react-vite@10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0))
       '@rollup/pluginutils': 5.4.0
       '@storybook/builder-vite': 10.5.10(esbuild@0.28.2)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0))
-      '@storybook/react': 10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(supports-color@7.2.0)(typescript@6.0.3)
+      '@storybook/react': 10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 19.2.8
-      react-docgen: 8.0.3(supports-color@7.2.0)
+      react-docgen: 8.0.3
       react-dom: 19.2.8(react@19.2.8)
       resolve: 1.22.12
       storybook: 10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8)
@@ -5939,12 +5945,12 @@ snapshots:
       - supports-color
       - webpack
 
-  '@storybook/react@10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(supports-color@7.2.0)(typescript@6.0.3)':
+  '@storybook/react@10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.5.10(@types/react-dom@19.2.5(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8))
       react: 19.2.8
-      react-docgen: 8.0.3(supports-color@7.2.0)
+      react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.8(react@19.2.8)
       storybook: 10.5.10(@types/react@19.2.17)(prettier@3.9.6)(react@19.2.8)
@@ -6090,11 +6096,11 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@typescript-eslint/project-service@8.67.0(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.67.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.67.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -6105,13 +6111,13 @@ snapshots:
 
   '@typescript-eslint/types@8.67.0': {}
 
-  '@typescript-eslint/typescript-estree@8.67.0(supports-color@7.2.0)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.67.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.67.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.67.0(typescript@6.0.3)
       '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/visitor-keys': 8.67.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
@@ -6161,9 +6167,9 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.103.1)(terser@5.50.0)(yaml@2.9.0)
 
-  '@vitest/coverage-istanbul@4.1.7(supports-color@7.2.0)(vitest@4.1.7)':
+  '@vitest/coverage-istanbul@4.1.7(vitest@4.1.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/core': 7.29.7
       '@istanbuljs/schema': 0.1.6
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -6430,9 +6436,9 @@ snapshots:
 
   check-error@2.1.3: {}
 
-  check-unused-css@0.5.5(supports-color@7.2.0)(typescript@6.0.3):
+  check-unused-css@0.5.5(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.67.0(supports-color@7.2.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@6.0.3)
       css-selector-parser: 3.3.0
       estree-walker: 3.0.3
       get-tsconfig: 4.14.2
@@ -6550,11 +6556,9 @@ snapshots:
 
   date-fns@4.4.0: {}
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
   decimal.js@10.6.0: {}
 
@@ -7180,6 +7184,8 @@ snapshots:
 
   lz-string@1.5.0: {}
 
+  magic-bytes.js@1.13.1: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -7557,10 +7563,10 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  react-docgen@8.0.3(supports-color@7.2.0):
+  react-docgen@8.0.3:
     dependencies:
-      '@babel/core': 7.29.7(supports-color@7.2.0)
-      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/core': 7.29.7
+      '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -7905,33 +7911,33 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  stylelint-config-recommended-scss@16.0.2(postcss@8.5.26)(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3)):
+  stylelint-config-recommended-scss@16.0.2(postcss@8.5.26)(stylelint@16.26.1(typescript@6.0.3)):
     dependencies:
       postcss-scss: 4.0.9(postcss@8.5.26)
-      stylelint: 16.26.1(supports-color@7.2.0)(typescript@6.0.3)
-      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3))
-      stylelint-scss: 6.14.0(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3))
+      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@6.0.3))
+      stylelint-scss: 6.14.0(stylelint@16.26.1(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.26
 
-  stylelint-config-recommended@17.0.0(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3)):
+  stylelint-config-recommended@17.0.0(stylelint@16.26.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@7.2.0)(typescript@6.0.3)
+      stylelint: 16.26.1(typescript@6.0.3)
 
-  stylelint-config-standard-scss@16.0.0(postcss@8.5.26)(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3)):
+  stylelint-config-standard-scss@16.0.0(postcss@8.5.26)(stylelint@16.26.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@7.2.0)(typescript@6.0.3)
-      stylelint-config-recommended-scss: 16.0.2(postcss@8.5.26)(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3))
-      stylelint-config-standard: 39.0.1(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3))
+      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint-config-recommended-scss: 16.0.2(postcss@8.5.26)(stylelint@16.26.1(typescript@6.0.3))
+      stylelint-config-standard: 39.0.1(stylelint@16.26.1(typescript@6.0.3))
     optionalDependencies:
       postcss: 8.5.26
 
-  stylelint-config-standard@39.0.1(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3)):
+  stylelint-config-standard@39.0.1(stylelint@16.26.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@7.2.0)(typescript@6.0.3)
-      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3))
+      stylelint: 16.26.1(typescript@6.0.3)
+      stylelint-config-recommended: 17.0.0(stylelint@16.26.1(typescript@6.0.3))
 
-  stylelint-scss@6.14.0(stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3)):
+  stylelint-scss@6.14.0(stylelint@16.26.1(typescript@6.0.3)):
     dependencies:
       css-tree: 3.2.1
       is-plain-object: 5.0.0
@@ -7941,9 +7947,9 @@ snapshots:
       postcss-resolve-nested-selector: 0.1.6
       postcss-selector-parser: 7.1.5
       postcss-value-parser: 4.2.0
-      stylelint: 16.26.1(supports-color@7.2.0)(typescript@6.0.3)
+      stylelint: 16.26.1(typescript@6.0.3)
 
-  stylelint@16.26.1(supports-color@7.2.0)(typescript@6.0.3):
+  stylelint@16.26.1(typescript@6.0.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
@@ -7956,7 +7962,7 @@ snapshots:
       cosmiconfig: 9.0.2(typescript@6.0.3)
       css-functions-list: 3.3.3
       css-tree: 3.2.1
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
       file-entry-cache: 11.1.5
@@ -8217,7 +8223,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.4.0
-      '@vitest/coverage-istanbul': 4.1.7(supports-color@7.2.0)(vitest@4.1.7)
+      '@vitest/coverage-istanbul': 4.1.7(vitest@4.1.7)
       jsdom: 30.0.1
     transitivePeerDependencies:
       - msw

--- a/pro/src/commons/utils/factories/imageUploadArgsFactories.ts
+++ b/pro/src/commons/utils/factories/imageUploadArgsFactories.ts
@@ -1,5 +1,21 @@
 import type { OnImageUploadArgs } from '@/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit'
 
+const JPEG_SIGNATURE = [
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+]
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+export const imageFileFactory = (
+  name = 'test-image.jpg',
+  format: 'jpeg' | 'png' = 'jpeg'
+): File => {
+  const signature = format === 'png' ? PNG_SIGNATURE : JPEG_SIGNATURE
+
+  return new File([new Uint8Array(signature)], name, {
+    type: `image/${format}`,
+  })
+}
+
 export const imageUploadArgsFactory = (): OnImageUploadArgs => ({
   imageFile: new File([''], 'filename'),
   imageCroppedDataUrl: 'https://example.com/image.jpg',

--- a/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.spec.tsx
+++ b/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.spec.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
+import { imageFileFactory } from '@/commons/utils/factories/imageUploadArgsFactories'
+
 import { MAX_FILE_SIZE } from './constants'
 import { ImageDragAndDrop } from './ImageDragAndDrop'
 
@@ -43,13 +45,10 @@ describe('ImageDragAndDrop', () => {
   })
 
   it('should display the correct text when dragging over', async () => {
-    const file = Object.assign(
-      new File(['test'], 'test-image.jpg', { type: 'image/jpeg' }),
-      {
-        width: 800,
-        height: 600,
-      }
-    )
+    const file = Object.assign(imageFileFactory(), {
+      width: 800,
+      height: 600,
+    })
     const data = mockData([file])
 
     render(<ImageDragAndDrop />)
@@ -66,13 +65,10 @@ describe('ImageDragAndDrop', () => {
   })
 
   it('should call onDropOrSelected when a valid file is dropped', async () => {
-    const file = Object.assign(
-      new File(['test'], 'test-image.jpg', { type: 'image/jpeg' }),
-      {
-        width: 800,
-        height: 600,
-      }
-    )
+    const file = Object.assign(imageFileFactory(), {
+      width: 800,
+      height: 600,
+    })
     const data = mockData([file])
 
     const onDropOrSelected = vi.fn()
@@ -83,7 +79,8 @@ describe('ImageDragAndDrop', () => {
     await waitFor(() => {
       expect(onDropOrSelected).toHaveBeenCalledWith(
         expect.objectContaining({
-          path: './test-image.jpg',
+          name: 'test-image.jpg',
+          type: 'image/jpeg',
           width: 800,
           height: 600,
         })
@@ -116,13 +113,10 @@ describe('ImageDragAndDrop', () => {
   })
 
   it('should display the appropriate err message when the file is too large & call onError', async () => {
-    const file = Object.assign(
-      new File(['test'], 'test-image.jpg', { type: 'image/jpeg' }),
-      {
-        width: 800,
-        height: 600,
-      }
-    )
+    const file = Object.assign(imageFileFactory(), {
+      width: 800,
+      height: 600,
+    })
     Object.defineProperty(file, 'size', { value: MAX_FILE_SIZE + 1 })
     const data = mockData([file])
 
@@ -156,13 +150,10 @@ describe('ImageDragAndDrop', () => {
     })
 
     it('should display the appropriate error message when the image has too short dimensions', async () => {
-      const file = Object.assign(
-        new File(['test'], 'test-image.jpg', { type: 'image/jpeg' }),
-        {
-          width: 10,
-          height: 10,
-        }
-      )
+      const file = Object.assign(imageFileFactory(), {
+        width: 10,
+        height: 10,
+      })
 
       const data = mockData([file])
 
@@ -192,13 +183,10 @@ describe('ImageDragAndDrop', () => {
     })
 
     it('should display the appropriate error message when the image has too large dimensions', async () => {
-      const file = Object.assign(
-        new File(['test'], 'test-image.jpg', { type: 'image/jpeg' }),
-        {
-          width: 81,
-          height: 1_000_000,
-        }
-      )
+      const file = Object.assign(imageFileFactory(), {
+        width: 81,
+        height: 1_000_000,
+      })
 
       const data = mockData([file])
 

--- a/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
+++ b/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
@@ -73,6 +73,9 @@ export const ImageDragAndDrop = forwardRef(
       }
 
       try {
+        const content = await file.arrayBuffer()
+        const image = new File([content], file.name, { type: file.type })
+
         const { width, height } = await getImageDimensions(file)
 
         const errors: string[] = []
@@ -95,8 +98,7 @@ export const ImageDragAndDrop = forwardRef(
           setCustomErrors(errors)
           onError?.(errors)
         } else if (onDropOrSelected) {
-          const image = Object.assign(file, { width, height })
-          onDropOrSelected(image)
+          onDropOrSelected(Object.assign(image, { width, height }))
         }
       } catch {
         const error = ['file-invalid-type']

--- a/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
+++ b/pro/src/components/ImageDragAndDrop/ImageDragAndDrop.tsx
@@ -12,6 +12,7 @@ import {
   UPLOAD_IMAGE_MAX_RESOLUTION,
 } from './constants'
 import { getImageDimensions } from './getImageDimensions'
+import { getImageFormat } from './getImageFormat'
 import { ImageConstraintCheck } from './ImageConstraintCheck'
 import styles from './ImageDragAndDrop.module.scss'
 
@@ -79,6 +80,10 @@ export const ImageDragAndDrop = forwardRef(
         const { width, height } = await getImageDimensions(file)
 
         const errors: string[] = []
+
+        if (getImageFormat(content) === null) {
+          errors.push('file-invalid-type')
+        }
 
         if (minSizes) {
           const { width: minWidth, height: minHeight } = minSizes

--- a/pro/src/components/ImageDragAndDrop/getImageFormat.ts
+++ b/pro/src/components/ImageDragAndDrop/getImageFormat.ts
@@ -1,0 +1,16 @@
+import { filetypemime } from 'magic-bytes.js'
+
+import { ALLOWED_IMAGE_TYPES_TO_EXTENSIONS } from './constants'
+
+const SUPPORTED_MIME_TYPES = new Set(
+  Object.keys(ALLOWED_IMAGE_TYPES_TO_EXTENSIONS)
+)
+
+export const getImageFormat = (content: ArrayBuffer): string | null => {
+  const detectedMimeTypes = filetypemime(new Uint8Array(content))
+
+  return (
+    detectedMimeTypes.find((mimeType) => SUPPORTED_MIME_TYPES.has(mimeType)) ??
+    null
+  )
+}

--- a/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.spec.tsx
+++ b/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.spec.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { forwardRef } from 'react'
+import { forwardRef, useState } from 'react'
 
 import { imageFileFactory } from '@/commons/utils/factories/imageUploadArgsFactories'
 import { UploaderModeEnum } from '@/commons/utils/imageUploadTypes'
@@ -295,6 +295,53 @@ describe('ImageDragAndDropUploader', () => {
     await waitFor(() => {
       expect(screen.getByText('Modifier une image')).toBeInTheDocument()
     })
+  })
+
+  it('should keep the picked file when the editor is closed without importing', async () => {
+    // The "Modifier" button only shows once the parent displays the imported image
+    const StatefulImageUploader = () => {
+      const [croppedImageUrl, setCroppedImageUrl] = useState('')
+
+      return (
+        <ImageDragAndDropUploader
+          mode={UploaderModeEnum.OFFER}
+          onImageDelete={() => {}}
+          initialValues={{ croppedImageUrl }}
+          onImageUpload={(values) =>
+            setCroppedImageUrl(values.imageCroppedDataUrl ?? '')
+          }
+        />
+      )
+    }
+
+    renderWithProviders(<StatefulImageUploader />)
+
+    await userEvent.upload(
+      screen.getByLabelText('Importez une image'),
+      mockImageFile
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Modifier une image')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByText('Importer'))
+
+    // Reopen the editor, then close it without importing.
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Modifier l’image' })
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Modifier une image')).toBeInTheDocument()
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'Annuler' }))
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Modifier l’image' })
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Modifier une image')).toBeInTheDocument()
+    })
+
+    expect(fetchMock).not.toHaveBeenCalledWith('my img')
   })
 
   it('should display a toaster and call onImageDelete, as soon as a file is delete successfully', async () => {

--- a/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.spec.tsx
+++ b/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.spec.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { forwardRef } from 'react'
 
+import { imageFileFactory } from '@/commons/utils/factories/imageUploadArgsFactories'
 import { UploaderModeEnum } from '@/commons/utils/imageUploadTypes'
 import { renderWithProviders } from '@/commons/utils/renderWithProviders'
 
@@ -13,10 +14,10 @@ import {
 const snackBarSuccess = vi.fn()
 const snackBarError = vi.fn()
 
-const mockImageFile = Object.assign(
-  new File(['test'], 'test-image.jpg', { type: 'image/jpeg' }),
-  { width: 10, height: 10 }
-)
+const mockImageFile = Object.assign(imageFileFactory(), {
+  width: 10,
+  height: 10,
+})
 
 vi.mock('@/commons/hooks/useSnackBar', () => ({
   useSnackBar: () => ({

--- a/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.tsx
+++ b/pro/src/components/ImageDragAndDropUploader/ImageDragAndDropUploader.tsx
@@ -63,6 +63,7 @@ export const ImageDragAndDropUploader = ({
   const [draftCredit, setDraftCredit] = useState<string | undefined>(credit)
   const [dragDropResetKey, setDragDropResetKey] = useState(0)
   const previousDraftImage = usePrevious(draftImage)
+  const previousIsModalImageOpen = usePrevious(isModalImageOpen)
 
   const imageUrl = croppedImageUrl || originalImageUrl
   const hasImage = !!imageUrl
@@ -76,10 +77,18 @@ export const ImageDragAndDropUploader = ({
     // This is to manage the focus when ImageDragAndDropUploader is re-rendered
     // after an image deletion (after a button action click, not as a result
     // of a deletion from the modal options)
-    if (previousDraftImage && !draftImage) {
+    const hasDeletedImage = previousDraftImage && !draftImage
+    const hasClosedEditor = previousIsModalImageOpen && !isModalImageOpen
+
+    if (hasDeletedImage || hasClosedEditor) {
       inputDragAndDropRef.current?.focus()
     }
-  }, [draftImage, previousDraftImage])
+  }, [
+    draftImage,
+    previousDraftImage,
+    isModalImageOpen,
+    previousIsModalImageOpen,
+  ])
 
   const onImageDeleteHandler = () => {
     if (warnBeforeDeleting && !isDeleteImageOpen) {
@@ -165,7 +174,6 @@ export const ImageDragAndDropUploader = ({
           }}
           onOpenChange={(open) => {
             if (!open) {
-              setDraftImage(undefined)
               setDragDropResetKey((prev) => prev + 1)
             }
             setIsModalImageOpen(open)

--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
@@ -140,6 +140,22 @@ describe('ModalImageUpsertOrEdit', () => {
     })
   })
 
+  it('should display the image editor with the picked file instead of reloading it from its url', async () => {
+    const mockImageUrl = 'http://example.com/image.jpg'
+    renderModalImageCrop({
+      initialValues: {
+        draftImage: imageFileFactory(),
+        croppedImageUrl: mockImageUrl,
+      },
+    })
+    await waitForRender()
+
+    expect(await screen.findByLabelText("Editeur d'image")).toBeInTheDocument()
+    expect(screen.queryByTestId('spinner-img-load')).not.toBeInTheDocument()
+
+    expect(fetchMock).not.toHaveBeenCalledWith(mockImageUrl)
+  })
+
   describe('when an image is loaded', () => {
     it('should render an image editor & a preview with the loaded image', async () => {
       vi.spyOn(imageUtils, 'getImageBitmap').mockResolvedValue({

--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.spec.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React, { forwardRef } from 'react'
 
+import { imageFileFactory } from '@/commons/utils/factories/imageUploadArgsFactories'
 import * as imageUtils from '@/commons/utils/image'
 import { UploaderModeEnum } from '@/commons/utils/imageUploadTypes'
 import { renderWithProviders } from '@/commons/utils/renderWithProviders'
@@ -53,7 +54,7 @@ const defaultProps: ModalImageUpsertOrEditProps = {
   onImageUpload,
   onImageDelete,
   initialValues: {
-    draftImage: new File(['content'], 'draftImage.png', { type: 'image/png' }),
+    draftImage: imageFileFactory('draftImage.png', 'png'),
   },
 }
 
@@ -109,13 +110,10 @@ describe('ModalImageUpsertOrEdit', () => {
 
     await waitForRender()
 
-    const imageFile = Object.assign(
-      new File(['test'], 'test-image.jpg', { type: 'image/jpeg' }),
-      {
-        width: 500,
-        height: 500,
-      }
-    )
+    const imageFile = Object.assign(imageFileFactory(), {
+      width: 500,
+      height: 500,
+    })
 
     await userEvent.upload(screen.getByLabelText('Importez une image'), [
       imageFile,
@@ -321,13 +319,10 @@ describe('ModalImageUpsertOrEdit', () => {
         })
         await userEvent.click(replaceButton)
 
-        const imageFile = Object.assign(
-          new File(['test'], 'test-image.jpg', { type: 'image/jpeg' }),
-          {
-            width: 10,
-            height: 10,
-          }
-        )
+        const imageFile = Object.assign(imageFileFactory(), {
+          width: 10,
+          height: 10,
+        })
         await userEvent.upload(screen.getByLabelText('Importez une image'), [
           imageFile,
         ])

--- a/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.tsx
+++ b/pro/src/components/ModalImageUpsertOrEdit/ModalImageUpsertOrEdit.tsx
@@ -100,7 +100,7 @@ export const ModalImageUpsertOrEdit = ({
   const editorRef = useRef<AvatarEditorRef>(null)
   const snackBar = useSnackBar()
   const [isLoadingImage, setIsLoadingImage] = useState(
-    !!previouslyUploadedImageUrl
+    !draftImage && !!previouslyUploadedImageUrl
   )
   const [isPaintingImage, setIsPaintingImage] = useState(true)
   const [image, setImage] = useState<File | undefined>(draftImage)
@@ -143,10 +143,10 @@ export const ModalImageUpsertOrEdit = ({
 
     // Waiting the dialog to be opened is a minor optimization to avoid loading an image that
     // might never be displayed since the dialog is always rendered.
-    if (open && previouslyUploadedImageUrl) {
+    if (open && !draftImage && previouslyUploadedImageUrl) {
       setImageFromUrl(previouslyUploadedImageUrl)
     }
-  }, [open, previouslyUploadedImageUrl, snackBar])
+  }, [open, draftImage, previouslyUploadedImageUrl, snackBar])
 
   useEffect(() => {
     setImage(draftImage)

--- a/pro/src/layouts/CollectiveVenuePageLayout/components/Header.spec.tsx
+++ b/pro/src/layouts/CollectiveVenuePageLayout/components/Header.spec.tsx
@@ -13,6 +13,7 @@ import * as useAnalytics from '@/app/App/analytics/firebase'
 import { Events } from '@/commons/core/FirebaseEvents/constants'
 import * as useSnackBar from '@/commons/hooks/useSnackBar'
 import { DisplayableActivityMap } from '@/commons/mappings/DisplayableActivity'
+import { imageFileFactory } from '@/commons/utils/factories/imageUploadArgsFactories'
 import { sharedCurrentUserFactory } from '@/commons/utils/factories/storeFactories'
 import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
 import { UploaderModeEnum } from '@/commons/utils/imageUploadTypes'
@@ -131,7 +132,7 @@ describe('Header', () => {
       logEvent: mockLogEvent,
     }))
 
-    const mockFile = Object.assign(new File(['fake img'], 'fake_img.jpg'), {
+    const mockFile = Object.assign(imageFileFactory('fake_img.jpg'), {
       width: 100,
       height: 100,
     })

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/__specs__/OfferEducationalForm.spec.tsx
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/OfferEducationalForm/__specs__/OfferEducationalForm.spec.tsx
@@ -16,6 +16,7 @@ import {
   defaultGetVenue,
   getCollectiveOfferTemplateFactory,
 } from '@/commons/utils/factories/collectiveApiFactories'
+import { imageFileFactory } from '@/commons/utils/factories/imageUploadArgsFactories'
 import {
   managedVenueFactory,
   userOffererFactory,
@@ -280,7 +281,7 @@ describe('OfferEducationalForm', () => {
     const imageInput = screen.getByLabelText('Importez une image')
     await userEvent.upload(
       imageInput,
-      Object.assign(new File(['fake img'], 'fake_img.jpg'), {
+      Object.assign(imageFileFactory('fake_img.jpg'), {
         width: 500,
         height: 900,
       })

--- a/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/useCollectiveOfferImageUpload.ts
+++ b/pro/src/pages/CollectiveOffer/CollectiveOffer/components/OfferEducational/useCollectiveOfferImageUpload.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 
 import { api } from '@/apiClient/api'
+import { getHumanReadableApiError } from '@/apiClient/helpers'
 import type {
   GetCollectiveOfferResponseModel,
   GetCollectiveOfferTemplateResponseModel,
@@ -94,7 +95,10 @@ export const useCollectiveOfferImageUpload = (
         sendSentryCustomError(error)
 
         return snackBar.error(
-          'Une erreur est survenue lors de l’envoi de votre image'
+          getHumanReadableApiError(
+            error,
+            'Une erreur est survenue lors de l’envoi de votre image'
+          )
         )
       }
     },

--- a/pro/src/pages/Homepage/components/PartnerPageCard/PartnerPageCard.spec.tsx
+++ b/pro/src/pages/Homepage/components/PartnerPageCard/PartnerPageCard.spec.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import type { GetVenueResponseModel } from '@/apiClient/v1'
 import * as useAnalytics from '@/app/App/analytics/firebase'
 import { Events, HomepageEvents } from '@/commons/core/FirebaseEvents/constants'
+import { imageFileFactory } from '@/commons/utils/factories/imageUploadArgsFactories'
 import { makeGetVenueResponseModel } from '@/commons/utils/factories/venueFactories'
 import { UploaderModeEnum } from '@/commons/utils/imageUploadTypes'
 import { renderWithProviders } from '@/commons/utils/renderWithProviders'
@@ -89,7 +90,7 @@ describe('PartnerPageCard', () => {
 
   it('should log CLICKED_ADD_IMAGE on image upload', async () => {
     const user = userEvent.setup()
-    const mockFile = Object.assign(new File(['fake img'], 'fake_img.jpg'), {
+    const mockFile = Object.assign(imageFileFactory('fake_img.jpg'), {
       width: 100,
       height: 100,
     })

--- a/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/IndividualOfferMediaScreen.spec.tsx
+++ b/pro/src/pages/IndividualOffer/IndividualOfferMedia/components/IndividualOfferMediaScreen.spec.tsx
@@ -19,6 +19,7 @@ import {
   OFFER_WIZARD_MODE,
 } from '@/commons/core/Offers/constants'
 import { getIndividualOfferUrl } from '@/commons/core/Offers/utils/getIndividualOfferUrl'
+import { imageFileFactory } from '@/commons/utils/factories/imageUploadArgsFactories'
 import {
   getIndividualOfferFactory,
   individualOfferContextValuesFactory,
@@ -225,7 +226,7 @@ describe('IndividualOfferMediaScreen', () => {
       const imageInput = screen.getByLabelText('Importez une image')
       await userEvent.upload(
         imageInput,
-        Object.assign(new File(['fake img'], 'fake_img.jpg'), {
+        Object.assign(imageFileFactory('fake_img.jpg'), {
           width: 100,
           height: 100,
         })


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made


[Ticket Jira](https://passculture.atlassian.net/jira/software/c/projects/PC/boards/66?selectedIssue=PC-43450)

[Erreur Sentry](https://pass-culture.sentry.io/issues/142811384/events/a097579837d24ababfd184c4c25bb5b9/?project=4508818035638352&referrer=next-event) 

### commit 1 : lire le contenu du fichier dès sa sélection

**Problème :**

- Le fichier est validé à la sélection, mais son contenu n'est lu qu'à la **soumission du formulaire**, parfois plusieurs minutes plus tard. Entre les deux, on ne garde qu'une référence
- Si le fichier n'est plus lisible d'ici là (photo choisie depuis la photothèque macOS, fichier déplacé), l'envoi est interrompu
-  ➡️ le back reçoit un body tronqué

**Solution : lire le contenu du fichier dès la sélection**

### commit 2 : checker le format de l'image directement depuis son contenu

**Problème :**

- On configure aujourd'hui la librairie `dropzone` avec : `accept: ALLOWED_IMAGE_TYPES_TO_EXTENSIONS`
- Mais comme décrit dans [la documentation](https://react-dropzone.js.org/examples/accept#restoring-the-full-mime-type-table), `dropzone` vérifie deux choses :
  - le type MIME rapporté par l'OS (sur macOS le type MIME est dérivé de l'extension !)
  - l'extension du nom de fichier
- ➡️ Sur Safari, un fichier `.heic` renommé en `.jpg` passe la validation front mais lève une erreur côté back

**Solution : vérification du format réel à partir des magic bytes (`magic-bytes.js`), avec un whitelisting dérivé de `ALLOWED_IMAGE_TYPES_TO_EXTENSIONS`**

### commit 3 : rééditer l'image d'origine plutôt que son aperçu

**Problème :**

- Après l'upload d'une nouvelle image, au clic sur « Modifier l'image », la modale ne réutilise pas le fichier déjà en mémoire : elle **recharge l'aperçu recadré** via `getFileFromURL`
- Or cet aperçu est produit par `canvas.toDataURL()`  donc du **PNG sans perte** 
- ➡️ Un JPEG de 3,4 Mo choisi par l'usager devient un fichier de 20,2 Mo

**Solution : réutiliser le fichier déjà en mémoire tant que l'image n'est pas supprimée ou remplacée**
