### PR TITLE
(PC-43499)[BO] fix: keep batch action bar listener across htmx requests

### DIFF
--- a/api/src/pcapi/static/backoffice/js/addons/pc-batch-action-form.js
+++ b/api/src/pcapi/static/backoffice/js/addons/pc-batch-action-form.js
@@ -87,6 +87,8 @@ addonList.push(
 
     initialize = () => {
       this.refreshState()
+
+      addEventListener('pcTableMultiSelect:change', this.#onBatchSelectionChange)
     }
 
     refreshState = () => {
@@ -104,11 +106,6 @@ addonList.push(
 
     bindEvents = () => {
       this.refreshState()
-      addEventListener('pcTableMultiSelect:change', this.#onBatchSelectionChange)
-    }
-
-    unbindEvents = () => {
-      removeEventListener('pcTableMultiSelect:change', this.#onBatchSelectionChange)
     }
 
     #onBatchSelectionChange = ({ detail }) => {


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43499)

### Observation

Ce bug m'a intrigué car je ne le reproduisais pas sur mon poste sous Linux mais le reproduisais sous macOS, et Patrick aussi sous Windows.

### Reproduction / Fausse correction

Il dépend en effet de l'ordre de "bundle-isation" des addons qui est décidé par `path.iterdir()` à [cette ligne](https://github.com/pass-culture/pass-culture-main/blob/master/api/src/pcapi/routes/backoffice/utils/static.py#L110), ordre qui a l'air de dépendre du filesystem sur lequel on l'exécute :

> The children are yielded in arbitrary order [...]

Source : https://docs.python.org/3/library/pathlib.html#pathlib.Path.iterdir.

On peut le vérifier en s'amusant à réordonner cette bundle-isation avec `paths = sorted(path.iterdir())` (qui déclenche le bug déterministiquement), ou avec son inverse `paths = sorted(path.iterdir(), reverse=True)` (qui à l'inverse "corrige" le bug déterministiquement).

### Cause

Le masquage de la barre d'actions groupées repose sur l'event `pcTableMultiSelect:change` qui est émis lors du swap htmx, à un moment où les addons sont tous débranchés :

1. `htmx:beforeRequest  → app.unbindEvents()` : `PcBatchActionForm` n'écoute plus.
2. `htmx:beforeSwap → batchSelect(false)` :  émet `change(selected=0)` dans le vide, puisque `PcBatchActionForm` n'écoute plus.
3. `htmx:afterRequest → app.bindEvents()` :  Rebranchement du listener `PcBatchActionForm`, mais trop tard.

La barre n'était masquée que si un rebranchement ultérieur réémettait l'event alors que `PcBatchActionForm` était déjà rebranché, ce qui dépendait de l'ordre dans lequel les addons étaient bundlés, comme expliqué au-dessus.

### Correctif

`PcBatchActionForm` branche son listener une seule fois dans `initialize` au lieu de `bindEvents`/`unbindEvents`. C'est un écouteur sur `window`, indépendant du DOM échangé : il n'a pas besoin d'être rebranché à chaque requête htmx. Et il n'y a pas de risque de stacking des events listeners car l'ajout de 2 listeners dont le handler est la même méthode ne duplique jamais son rattachement.

## Preview

https://preview-899f2ce.backoffice.testing.passculture.team/

---

- [ ] Travail pair testé en environnement de preview
