### PR TITLE
(PC-43540)[PRO] fix: hard reload request screen when backend mismatch error

### DIFF
--- a/pro/src/apiClient/__specs__/backendVersionCompatibility.spec.ts
+++ b/pro/src/apiClient/__specs__/backendVersionCompatibility.spec.ts
@@ -1,0 +1,83 @@
+import {
+  BACKEND_VERSION_MISMATCH_EVENT,
+  notifyIfBackendVersionChanged,
+} from '../backendVersionCompatibility'
+
+vi.mock('@/commons/utils/config', () => ({
+  API_URL: 'https://backend.example',
+  VITE_APP_VERSION: 'current-version',
+  IS_DEV: false,
+}))
+
+describe('notifyIfBackendVersionChanged', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it.each([404, 405, 501])(
+    'should check the backend version for an HTTP %s error',
+    async (status) => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        text: async () => 'next-version',
+      } as Response)
+      const mismatchEventSpy = vi.spyOn(window, 'dispatchEvent')
+
+      await notifyIfBackendVersionChanged(new Response(null, { status }))
+
+      expect(fetch).toHaveBeenCalledExactlyOnceWith(
+        'https://backend.example/health/api',
+        { cache: 'no-store' }
+      )
+      expect(mismatchEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: BACKEND_VERSION_MISMATCH_EVENT })
+      )
+    }
+  )
+
+  it.each([400, 403, 422, 500])(
+    'should not check the backend version for an HTTP %s error',
+    async (status) => {
+      const mismatchEventSpy = vi.spyOn(window, 'dispatchEvent')
+
+      await notifyIfBackendVersionChanged(new Response(null, { status }))
+
+      expect(fetch).not.toHaveBeenCalled()
+      expect(mismatchEventSpy).not.toHaveBeenCalled()
+    }
+  )
+
+  it('should not emit an event when backend and frontend versions match', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      text: async () => 'current-version',
+    } as Response)
+    const mismatchEventSpy = vi.spyOn(window, 'dispatchEvent')
+
+    await notifyIfBackendVersionChanged(new Response(null, { status: 404 }))
+
+    expect(mismatchEventSpy).not.toHaveBeenCalled()
+  })
+
+  it('should not emit an event when the health check is not successful', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      text: async () => 'next-version',
+    } as Response)
+    const mismatchEventSpy = vi.spyOn(window, 'dispatchEvent')
+
+    await notifyIfBackendVersionChanged(new Response(null, { status: 404 }))
+
+    expect(mismatchEventSpy).not.toHaveBeenCalled()
+  })
+
+  it('should keep the original API error flow when the health check fails', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('Network error'))
+    const mismatchEventSpy = vi.spyOn(window, 'dispatchEvent')
+
+    await expect(
+      notifyIfBackendVersionChanged(new Response(null, { status: 404 }))
+    ).resolves.toBeUndefined()
+    expect(mismatchEventSpy).not.toHaveBeenCalled()
+  })
+})

--- a/pro/src/apiClient/api.ts
+++ b/pro/src/apiClient/api.ts
@@ -2,23 +2,31 @@ import { withCallSites } from '@/apiClient/callSite'
 import { ApiError, normalizeApiPath } from '@/apiClient/compat'
 
 import { client as adageClient } from './adage/client.gen'
+import { notifyIfBackendVersionChanged } from './backendVersionCompatibility'
 import { client as v1Client } from './v1/client.gen'
+
+export { BACKEND_VERSION_MISMATCH_EVENT } from './backendVersionCompatibility'
 
 function createApiErrorInterceptor() {
   return async (
     error: unknown,
     response: Response | undefined,
     request: Request | undefined
-  ) =>
-    response?.status && request
-      ? new ApiError(
-          request.url,
-          response.status,
-          response.statusText,
-          error,
-          `${request.method} ${normalizeApiPath(request.url)}`
-        )
-      : error
+  ) => {
+    if (!response?.status || !request) {
+      return error
+    }
+
+    await notifyIfBackendVersionChanged(response)
+
+    return new ApiError(
+      request.url,
+      response.status,
+      response.statusText,
+      error,
+      `${request.method} ${normalizeApiPath(request.url)}`
+    )
+  }
 }
 
 v1Client.interceptors.error.use(createApiErrorInterceptor())

--- a/pro/src/apiClient/backendVersionCompatibility.ts
+++ b/pro/src/apiClient/backendVersionCompatibility.ts
@@ -1,0 +1,30 @@
+import { API_URL, IS_DEV, VITE_APP_VERSION } from '@/commons/utils/config'
+
+export const BACKEND_VERSION_MISMATCH_EVENT = 'backend-version-mismatch'
+
+const BACKEND_VERSION_MISMATCH_CANDIDATE_STATUSES = new Set([404, 405, 501])
+
+export async function notifyIfBackendVersionChanged(
+  response: Response
+): Promise<void> {
+  if (
+    !VITE_APP_VERSION ||
+    IS_DEV ||
+    !BACKEND_VERSION_MISMATCH_CANDIDATE_STATUSES.has(response.status)
+  ) {
+    return
+  }
+
+  try {
+    const healthResponse = await fetch(`${API_URL}/health/api`, {
+      cache: 'no-store',
+    })
+    const backendVersion = (await healthResponse.text()).trim()
+
+    if (healthResponse.ok && backendVersion !== VITE_APP_VERSION) {
+      window.dispatchEvent(new Event(BACKEND_VERSION_MISMATCH_EVENT))
+    }
+  } catch {
+    // Keep the original API error when the health check cannot be reached.
+  }
+}

--- a/pro/src/app/App/App.spec.tsx
+++ b/pro/src/app/App/App.spec.tsx
@@ -1,9 +1,9 @@
 import { setUser } from '@sentry/browser'
-import { screen } from '@testing-library/react'
-import { Route, Routes } from 'react-router'
+import { act, screen } from '@testing-library/react'
+import { Link, Route, Routes } from 'react-router'
 import useSWR from 'swr'
 
-import { api } from '@/apiClient/api'
+import { api, BACKEND_VERSION_MISMATCH_EVENT } from '@/apiClient/api'
 import { App } from '@/app/App/App'
 import * as useAnalytics from '@/app/App/analytics/firebase'
 import * as orejime from '@/app/App/analytics/orejime'
@@ -25,6 +25,12 @@ vi.mock('@/app/App/hook/useLogExtraProData', () => ({
 }))
 vi.mock('@/app/App/hook/usePageTitle', () => ({ usePageTitle: vi.fn() }))
 vi.mock('@sentry/browser', () => ({ setUser: vi.fn() }))
+vi.mock('@/commons/utils/config', async () => ({
+  ...(await vi.importActual('@/commons/utils/config')),
+  API_URL: 'https://backend.example',
+  IS_DEV: false,
+  VITE_APP_VERSION: 'current-version',
+}))
 
 function TestBrokenCallComponent() {
   useSWR([GET_OFFER_QUERY_KEY], () => api.getOffer({ path: { offer_id: 17 } }))
@@ -39,7 +45,15 @@ const renderApp = (options?: RenderWithProvidersOptions) =>
 
       <Routes>
         <Route path="/" element={<App />}>
-          <Route path="/" element={<p>Sub component</p>} />
+          <Route
+            path="/"
+            element={
+              <>
+                <p>Sub component</p>
+                <Link to="/offres">Go to offers</Link>
+              </>
+            }
+          />
           <Route path="/adage-iframe" element={<p>ADAGE</p>} />
           <Route path="/offres" element={<p>Offres</p>} />
           <Route path="/connexion" element={<p>Login page</p>} />
@@ -95,6 +109,20 @@ describe('App', () => {
     expect(useAnalyticsSpy).not.toHaveBeenCalledWith(
       expect.objectContaining({ isCookieEnabled: true })
     )
+  })
+
+  it('should display the refresh page when the API detects a backend mismatch', async () => {
+    renderApp()
+
+    act(() => {
+      window.dispatchEvent(new Event(BACKEND_VERSION_MISMATCH_EVENT))
+    })
+
+    expect(
+      await screen.findByRole('heading', {
+        name: 'Une mise à jour est disponible',
+      })
+    ).toBeInTheDocument()
   })
 
   it('should redirect to page 404 when api has not found', async () => {

--- a/pro/src/app/App/App.tsx
+++ b/pro/src/app/App/App.tsx
@@ -6,11 +6,13 @@ import { GET_DATA_ERROR_MESSAGE } from '@/commons/core/shared/constants'
 import { useSnackBar } from '@/commons/hooks/useSnackBar'
 import { SkipLinksProvider } from '@/components/SkipLinks/SkipLinksContext'
 import { SnackBarContainer } from '@/components/SnackBarContainer/SnackBarContainer'
+import { BackendVersionMismatch } from '@/pages/Errors/BackendVersionMismatch/BackendVersionMismatch'
 
 import { useBeamer } from './analytics/beamer'
 import { useFirebase } from './analytics/firebase'
 import { useOrejime } from './analytics/orejime'
 import { useSentry } from './analytics/sentry'
+import { useCheckBackendVersion } from './hook/useCheckBackendVersion'
 import { useFocus } from './hook/useFocus'
 import { useLoadFeatureFlags } from './hook/useLoadFeatureFlags'
 import { useLogNavigation } from './hook/useLogNavigation'
@@ -22,6 +24,7 @@ export const App = (): JSX.Element | null => {
   const navigate = useNavigate()
   const snackBar = useSnackBar()
   const location = useLocation()
+  const hasBackendVersionMismatch = useCheckBackendVersion()
 
   // Main hooks
   useLoadFeatureFlags()
@@ -34,6 +37,10 @@ export const App = (): JSX.Element | null => {
   useBeamer(consentedToBeamer)
   useFirebase(consentedToFirebase)
   useLogNavigation()
+
+  if (hasBackendVersionMismatch) {
+    return <BackendVersionMismatch />
+  }
 
   return (
     <>

--- a/pro/src/app/App/hook/__specs__/useCheckBackendVersion.spec.tsx
+++ b/pro/src/app/App/hook/__specs__/useCheckBackendVersion.spec.tsx
@@ -1,0 +1,32 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { BACKEND_VERSION_MISMATCH_EVENT } from '@/apiClient/api'
+
+import { useCheckBackendVersion } from '../useCheckBackendVersion'
+
+describe('useCheckBackendVersion', () => {
+  it('should not report a mismatch before the event is emitted', () => {
+    const { result } = renderHook(() => useCheckBackendVersion())
+
+    expect(result.current).toBe(false)
+  })
+
+  it('should report a mismatch when the API interceptor emits the event', () => {
+    const { result } = renderHook(() => useCheckBackendVersion())
+
+    act(() => {
+      window.dispatchEvent(new Event(BACKEND_VERSION_MISMATCH_EVENT))
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('should stop listening when unmounted', () => {
+    const { result, unmount } = renderHook(() => useCheckBackendVersion())
+
+    unmount()
+    window.dispatchEvent(new Event(BACKEND_VERSION_MISMATCH_EVENT))
+
+    expect(result.current).toBe(false)
+  })
+})

--- a/pro/src/app/App/hook/useCheckBackendVersion.ts
+++ b/pro/src/app/App/hook/useCheckBackendVersion.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+
+import { BACKEND_VERSION_MISMATCH_EVENT } from '@/apiClient/api'
+
+export const useCheckBackendVersion = (): boolean => {
+  const [hasBackendVersionMismatch, setHasBackendVersionMismatch] =
+    useState(false)
+
+  useEffect(() => {
+    const handleBackendVersionMismatch = () => {
+      setHasBackendVersionMismatch(true)
+    }
+
+    window.addEventListener(
+      BACKEND_VERSION_MISMATCH_EVENT,
+      handleBackendVersionMismatch
+    )
+
+    return () =>
+      window.removeEventListener(
+        BACKEND_VERSION_MISMATCH_EVENT,
+        handleBackendVersionMismatch
+      )
+  }, [])
+
+  return hasBackendVersionMismatch
+}

--- a/pro/src/app/App/layouts/ErrorLayout/ErrorLayout.tsx
+++ b/pro/src/app/App/layouts/ErrorLayout/ErrorLayout.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode, useId } from 'react'
+
 import { useAppSelector } from '@/commons/hooks/useAppSelector'
 import { selectCurrentUser } from '@/commons/store/user/selectors'
 import { Button } from '@/design-system/Button/Button'
@@ -6,7 +8,7 @@ import { SvgIcon } from '@/ui-kit/SvgIcon/SvgIcon'
 
 import styles from './ErrorLayout.module.scss'
 
-interface ErrorLayoutProps {
+interface BaseErrorLayoutProps {
   /**
    * Name of the page to display in the main heading.
    * Make sure that only one heading is displayed per page.
@@ -20,21 +22,36 @@ interface ErrorLayoutProps {
    * Icon to display in the error page.
    */
   errorIcon: string
-  /**
-   * Redirect link for the button.
-   */
-  redirect?: string
 }
+
+/**
+ * Redirect link for the button.
+ */
+type RouterCTAErrorLayoutProps = BaseErrorLayoutProps & {
+  redirect?: string
+  cta?: never
+}
+
+/**
+ * Custom behavior for the redirect button.
+ */
+type CustomCTAErrorLayoutProps = BaseErrorLayoutProps & {
+  redirect?: never
+  cta?: ReactNode
+}
+
+type ErrorLayoutProps = RouterCTAErrorLayoutProps | CustomCTAErrorLayoutProps
 
 export const ErrorLayout = ({
   mainHeading,
   paragraph,
   errorIcon,
   redirect = '/',
+  cta,
 }: ErrorLayoutProps) => {
   const currentUser = useAppSelector(selectCurrentUser)
   const isConnected = !!currentUser
-
+  const errorReturnLinkId = useId()
   return (
     <main className={styles['content-wrapper']}>
       <div className={styles['content']}>
@@ -42,15 +59,15 @@ export const ErrorLayout = ({
         <h1 className={styles['title']}>{mainHeading}</h1>
         <p className={styles.description}>{paragraph}</p>
         <div className={styles['nm-redirection-link']}>
-          {/** biome-ignore lint/correctness/useUniqueElementIds: This is always
-          rendered once per page, so there cannot be id duplications.> */}
-          <Button
-            as="router-link"
-            id="error-return-link"
-            variant={ButtonVariant.SECONDARY}
-            to={redirect}
-            label={isConnected ? "Retour à la page d'accueil" : 'Retour'}
-          />
+          {cta ?? (
+            <Button
+              as="router-link"
+              id={errorReturnLinkId}
+              variant={ButtonVariant.SECONDARY}
+              to={redirect}
+              label={isConnected ? "Retour à la page d'accueil" : 'Retour'}
+            />
+          )}
         </div>
       </div>
     </main>

--- a/pro/src/pages/Errors/BackendVersionMismatch/BackendVersionMismatch.tsx
+++ b/pro/src/pages/Errors/BackendVersionMismatch/BackendVersionMismatch.tsx
@@ -1,0 +1,34 @@
+import { useId } from 'react'
+
+import { ErrorLayout } from '@/app/App/layouts/ErrorLayout/ErrorLayout'
+import { Button } from '@/design-system/Button/Button'
+import { ButtonVariant } from '@/design-system/Button/types'
+import strokeErrorIcon from '@/icons/stroke-error.svg'
+
+export const BackendVersionMismatch = () => {
+  const reloadUrl = new URL(window.location.href)
+  reloadUrl.searchParams.delete('_reload')
+  const reloadPath = `${reloadUrl.pathname}${reloadUrl.search}${reloadUrl.hash}`
+  const errorReturnLinkId = useId()
+
+  return (
+    <ErrorLayout
+      mainHeading="Une mise à jour est disponible"
+      paragraph="L'espace partenaire a été mis à jour. Cliquez ci-dessous pour continuer."
+      errorIcon={strokeErrorIcon}
+      cta={
+        <Button
+          as="router-link"
+          id={errorReturnLinkId}
+          variant={ButtonVariant.SECONDARY}
+          to={reloadPath}
+          onClick={(event) => {
+            event.preventDefault()
+            window.location.replace(reloadUrl.toString())
+          }}
+          label={'Mettre à jour'}
+        />
+      }
+    />
+  )
+}


### PR DESCRIPTION
[Ticket Jira](https://passculture.atlassian.net/browse/PC-43540)

## Fonctionnement

1. L'utilisateur déjà connecté est sur une page
2. La MEP met à jour le back et le front, mais l'utilisateur étant déjà sur une page, ne voit pas le front se mettre à jour automatiquement
3. L'utilisateur navigue vers une autre page, qui fait appel à un endpoint modifié/supprimé par exemple
4. L'utilisateur prend une 404, 405 ou 501 (codes pour l'instant couverts pour ne pas interroger `/health/api` à chaque fois, mais open à discussion)
5. L'erreur est interceptée et on contrôle si la version du back déployée (via `/health/api`) est la même version que celle enregistrée dans le frontend via `VITE_APP_VERSION`.
6. Si oui --> écran de demande de hard refresh avec bouton pour ce faire
7. Si non --> "vraie" erreur traitée normalement

<img width="945" height="721" alt="Capture d’écran 2026-09-08 à 16 51 59" src="https://github.com/user-attachments/assets/dfd7225a-13b7-4f3b-b91b-655643241c94" />
