### PR TITLE
(PC-43577)[API] feat: add FF to enable cinema ETLs sync

### DIFF
--- a/api/src/pcapi/core/providers/commands.py
+++ b/api/src/pcapi/core/providers/commands.py
@@ -1,16 +1,15 @@
+import enum
 import logging
 from time import time
 
 import click
 
-import pcapi.core.providers.models as providers_models
 import pcapi.core.providers.repository as providers_repository
 import pcapi.utils.cron as cron_decorators
+from pcapi.connectors.ems import EMSScheduleConnector
 from pcapi.core.providers import allocine
 from pcapi.local_providers import provider_manager
-from pcapi.models import db
 from pcapi.models.feature import FeatureToggle
-from pcapi.utils import logging as logging_utils
 from pcapi.utils.blueprint import Blueprint
 
 from .etls.boost_etl import BoostExtractTransformLoadProcess
@@ -22,6 +21,25 @@ from .titelive_utils import generate_titelive_gtl_from_file
 
 blueprint = Blueprint(__name__, __name__)
 logger = logging.getLogger(__name__)
+
+
+class CinemaLocalClasses(enum.StrEnum):
+    CDSStocks = "CDSStocks"
+    CGRStocks = "CGRStocks"
+    BoostStocks = "BoostStocks"
+    EMSStocks = "EMSStocks"
+
+
+_LOCAL_CLASS_NAME_TO_ETL_CLASS: dict[
+    str,
+    type[BoostExtractTransformLoadProcess]
+    | type[CineOfficeExtractTransformLoadProcess]
+    | type[CGRExtractTransformLoadProcess],
+] = {
+    "BoostStocks": BoostExtractTransformLoadProcess,
+    "CDSStocks": CineOfficeExtractTransformLoadProcess,  # INFO: CDS is the old name of CineOffice
+    "CGRStocks": CGRExtractTransformLoadProcess,
+}
 
 
 @blueprint.cli.command("synchronize_allocine_products")
@@ -38,64 +56,6 @@ def synchronize_allocine_products() -> None:
 @cron_decorators.cron_require_feature(FeatureToggle.SYNCHRONIZE_ALLOCINE_PRODUCTS_FROM_BIGQUERY_TABLES)
 def synchronize_allocine_products_with_bigquery() -> None:
     allocine.synchronize_products_with_bigquery()
-
-
-# TODO (tcoudray-pass, 07/10/25): Remove this command once Boost has been migrated to new integration
-@blueprint.cli.command("test_etl_integration")
-@click.option("-vp", "--venue-provider-id", required=True, help="Venue provider id", type=int)
-def test_etl_integration(venue_provider_id: int) -> None:
-    venue_provider: providers_models.VenueProvider = (
-        db.session.query(providers_models.VenueProvider).filter_by(id=venue_provider_id).one()
-    )
-
-    local_class_to_etl_mapping: dict[
-        str,
-        type[
-            BoostExtractTransformLoadProcess
-            | CineOfficeExtractTransformLoadProcess
-            | CGRExtractTransformLoadProcess
-            | EMSExtractTransformLoadProcess
-        ],
-    ] = {
-        "BoostStocks": BoostExtractTransformLoadProcess,
-        # INFO: CDS is the old name of CineOffice
-        "CDSStocks": CineOfficeExtractTransformLoadProcess,
-        "CGRStocks": CGRExtractTransformLoadProcess,
-        "EMSStocks": EMSExtractTransformLoadProcess,
-    }
-
-    if venue_provider.provider.localClass not in local_class_to_etl_mapping:
-        logger.warning("ETL integration not available for %s", venue_provider.provider.localClass)
-        return
-
-    with logging_utils.logging_at_level(logging.getLogger("pcapi"), level=logging.DEBUG):
-        etl_class = local_class_to_etl_mapping[venue_provider.provider.localClass]
-        etl_process = etl_class(venue_provider)
-        etl_process.execute()
-
-
-@blueprint.cli.command("debug_synchronize_venue_provider")
-@click.option("-vp", "--venue-provider-id", required=True, help="Venue provider id", type=int)
-def debug_synchronize_venue_provider(venue_provider_id: int) -> None:
-    """
-    Start synchronize_venue_provider with `pcapi` logger at DEBUG level
-    """
-    with logging_utils.logging_at_level(logging.getLogger("pcapi"), level=logging.DEBUG):
-        venue_provider: providers_models.VenueProvider = (
-            db.session.query(providers_models.VenueProvider).filter_by(id=venue_provider_id).one()
-        )
-
-        if venue_provider.provider.localClass == "EMSStocks":
-            assert venue_provider.venueIdAtOfferProvider  # to make mypy happy
-            ems_cinema_details = providers_repository.get_ems_cinema_details(venue_provider.venueIdAtOfferProvider)
-            target_version = ems_cinema_details.lastVersion - 1  # retry from previous version
-
-            provider_manager.synchronize_ems_venue_provider(
-                venue_provider=venue_provider, target_version=target_version
-            )
-            return
-
-        provider_manager.synchronize_venue_provider(venue_provider=venue_provider)
 
 
 @blueprint.cli.command("update_providables")
@@ -154,36 +114,85 @@ def synchronize_allocine_stocks() -> None:
     provider_manager.synchronize_venue_providers(venue_providers)
 
 
+# (tcoudray-pass, 7/9/26) TODO: Temporary private function
+# To be removed when `synchronize_boost_stocks`, `synchronize_cgr_stocks` and `synchronize_cine_office_stocks`
+# are replaced with `synchronize_cinema_provider_offers` (PC-43579)
+def _synchronize_cinema_provider_offers(local_class: CinemaLocalClasses) -> None:
+    ETLClass = _LOCAL_CLASS_NAME_TO_ETL_CLASS[local_class]
+    cinema_provider = providers_repository.get_cinema_provider_by_local_class(local_class)
+    venue_providers = providers_repository.get_active_venue_providers_by_provider(cinema_provider.id)
+
+    for venue_provider in venue_providers:
+        try:
+            ETLClass(venue_provider).execute()
+        except Exception as exception:
+            # we except all exceptions to prevent that
+            # one faulty venue blocks the synchronisation
+            # of other venues
+            logger.warning(
+                "Error while synchronizing cinema venue",
+                extra={
+                    "venue_provider_id": venue_provider.id,
+                    "venue_id": venue_provider.venueId,
+                    "provider_id": venue_provider.providerId,
+                    "exc": exception,
+                },
+            )
+
+
+@blueprint.cli.command("synchronize_cinema_provider_offers")
+@cron_decorators.log_cron_with_transaction
+@cron_decorators.cron_require_feature(FeatureToggle.ENABLE_RECURRENT_CRON)
+@click.argument("local_class", type=click.Choice(CinemaLocalClasses, case_sensitive=False), required=True)
+def synchronize_cinema_provider_offers(local_class: CinemaLocalClasses) -> None:
+    _synchronize_cinema_provider_offers(local_class)
+
+
+# (tcoudray-pass, 7/9/26) TODO: To be replaced with `synchronize_cinema_provider_offers` (PC-43579)
 @blueprint.cli.command("synchronize_cine_office_stocks")
 @cron_decorators.log_cron_with_transaction
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_RECURRENT_CRON)
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_CDS_IMPLEMENTATION)
 def synchronize_cine_office_stocks() -> None:
     """Launch Ciné Office synchronization."""
+    if FeatureToggle.WIP_ENABLE_ETL_SYNC.is_active():
+        _synchronize_cinema_provider_offers(CinemaLocalClasses.CDSStocks)
+        return
+
     cine_office_stocks_provider = providers_repository.get_provider_by_local_class("CDSStocks")
     assert cine_office_stocks_provider  # helps mypy
     venue_providers = providers_repository.get_active_venue_providers_by_provider(cine_office_stocks_provider.id)
     provider_manager.synchronize_venue_providers(venue_providers)
 
 
+# (tcoudray-pass, 7/9/26) TODO: To be replaced with `synchronize_cinema_provider_offers` (PC-43579)
 @blueprint.cli.command("synchronize_boost_stocks")
 @cron_decorators.log_cron_with_transaction
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_RECURRENT_CRON)
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_BOOST_API_INTEGRATION)
 def synchronize_boost_stocks() -> None:
     """Launch Boost synchronization."""
+    if FeatureToggle.WIP_ENABLE_ETL_SYNC.is_active():
+        _synchronize_cinema_provider_offers(CinemaLocalClasses.BoostStocks)
+        return
+
     boost_stocks_provider = providers_repository.get_provider_by_local_class("BoostStocks")
     assert boost_stocks_provider  # helps mypy
     venue_providers = providers_repository.get_active_venue_providers_by_provider(boost_stocks_provider.id)
     provider_manager.synchronize_venue_providers(venue_providers)
 
 
+# (tcoudray-pass, 7/9/26) TODO: To be replaced with `synchronize_cinema_provider_offers` (PC-43579)
 @blueprint.cli.command("synchronize_cgr_stocks")
 @cron_decorators.log_cron_with_transaction
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_RECURRENT_CRON)
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_CGR_INTEGRATION)
 def synchronize_cgr_stocks() -> None:
     """Launch CGR synchronization."""
+    if FeatureToggle.WIP_ENABLE_ETL_SYNC.is_active():
+        _synchronize_cinema_provider_offers(CinemaLocalClasses.CGRStocks)
+        return
+
     cgr_stocks_provider = providers_repository.get_provider_by_local_class("CGRStocks")
     assert cgr_stocks_provider  # helps mypy
     venue_providers = providers_repository.get_active_venue_providers_by_provider(cgr_stocks_provider.id)
@@ -196,6 +205,34 @@ def synchronize_cgr_stocks() -> None:
 @cron_decorators.cron_require_feature(FeatureToggle.ENABLE_EMS_INTEGRATION)
 def synchronize_ems_stocks_on_schedule() -> None:
     """Launch EMS synchronization"""
+    if FeatureToggle.WIP_ENABLE_ETL_SYNC.is_active():
+        cinema_provider = providers_repository.get_cinema_provider_by_local_class("EMSStocks")
+        venue_providers = providers_repository.get_active_venue_providers_by_provider(cinema_provider.id)
+
+        ems_connector = EMSScheduleConnector()
+        # we fetch the schedules once and not inside the ETL process
+        # for there is no endpoint to fetch the schedules for only
+        # one cinema.
+        schedules = ems_connector.get_schedules()
+
+        for venue_provider in venue_providers:
+            try:
+                EMSExtractTransformLoadProcess(venue_provider).with_schedules_data(schedules).execute()
+            except Exception as exception:
+                # we except all exceptions to prevent that
+                # one faulty venue blocks the synchronisation
+                # of other venues
+                logger.warning(
+                    "Error while synchronizing cinema venue",
+                    extra={
+                        "venue_provider_id": venue_provider.id,
+                        "venue_id": venue_provider.venueId,
+                        "provider_id": venue_provider.providerId,
+                        "exc": exception,
+                    },
+                )
+        return
+
     provider_manager.synchronize_ems_venue_providers(from_last_version=True)
 
 

--- a/api/src/pcapi/core/providers/etls/ems_etl.py
+++ b/api/src/pcapi/core/providers/etls/ems_etl.py
@@ -39,14 +39,24 @@ class EMSExtractTransformLoadProcess(CinemaETLProcessTemplate[EMSScheduleConnect
         assert venue_provider.venueIdAtOfferProvider  # to make mypy happy
         self.ems_cinema_details = repository.get_ems_cinema_details(venue_provider.venueIdAtOfferProvider)
         self.target_version = 0
+        self._schedules: None | ems_serializers.ScheduleResponse = None
         if from_last_version:
             self.target_version = self.ems_cinema_details.lastVersion
+
+    def with_schedules_data(self, schedules: ems_serializers.ScheduleResponse) -> "EMSExtractTransformLoadProcess":
+        """
+        EMS does not have an endpoint to fetch the schedules for a given cinema.
+        In order to avoid fetching all the schedules each time we are executing the process for a cinema,
+        we add this helper to give the process the schedules data (fetched only once) and skip the extract step.
+        """
+        self._schedules = schedules
+        return self
 
     def _extract(self) -> EMSExtractResult:
         """
         Step 1: Fetch data from EMS API
         """
-        schedules = self.api_client.get_schedules(self.target_version)
+        schedules = self._schedules or self.api_client.get_schedules(self.target_version)
 
         site_with_events = None
         for site in schedules.sites:

--- a/api/src/pcapi/core/providers/repository.py
+++ b/api/src/pcapi/core/providers/repository.py
@@ -48,6 +48,10 @@ def get_provider_by_local_class(local_class: str) -> models.Provider | None:
     return db.session.query(models.Provider).filter_by(localClass=local_class).one_or_none()
 
 
+def get_cinema_provider_by_local_class(local_class: str) -> models.Provider:
+    return db.session.query(models.Provider).filter_by(localClass=local_class).one()
+
+
 def get_provider_by_name(name: str) -> models.Provider:
     return db.session.query(models.Provider).filter_by(name=name).one()
 

--- a/api/src/pcapi/local_providers/provider_manager.py
+++ b/api/src/pcapi/local_providers/provider_manager.py
@@ -15,6 +15,7 @@ from pcapi.local_providers.cinema_providers.cgr.cgr_stocks import CGRStocks
 from pcapi.local_providers.cinema_providers.ems.ems_stocks import EMSStocks
 from pcapi.local_providers.local_provider import LocalProvider
 from pcapi.models import db
+from pcapi.models.feature import FeatureToggle
 from pcapi.utils import cron
 from pcapi.utils import logging as logging_utils
 from pcapi.utils import requests
@@ -82,7 +83,7 @@ def synchronize_venue_provider(venue_provider: provider_models.VenueProvider, li
     )
     # new integration
     if (
-        venue_provider.isNewEtlIntegrationEnabled
+        FeatureToggle.WIP_ENABLE_ETL_SYNC.is_active()
         and venue_provider.provider.localClass in _LOCAL_CLASS_NAME_TO_ETL_CLASS
     ):
         execute_cinema_etl_process(venue_provider)

--- a/api/src/pcapi/models/feature.py
+++ b/api/src/pcapi/models/feature.py
@@ -139,6 +139,7 @@ class FeatureToggle(enum.Enum):
         "Utiliser les Universal Links au lieu des Firebase dynamic links (déprécié à partir du 25/08/2025)"
     )
     # For features under construction, a temporary feature flag must be named with the `WIP_` prefix
+    WIP_ENABLE_ETL_SYNC = "Active la nouvelle synchronisation des cinémas (Boost, CGR, Ciné Office)"
     WIP_ENABLE_FINANCE_SETTLEMENTS = "Active le workflow finance des règlements"
     WIP_ENABLE_NEW_BREVO_RECOMMENDATION_WEBHOOK = "Active la nouvelle version du webhook de recommandation Brevo"
     WIP_IMGPROXY_PRO = "Activer l'utilisation du nouveau format de requête pour le resizing d'image sur le portail pro"
@@ -208,6 +209,7 @@ FEATURES_DISABLED_BY_DEFAULT: tuple[FeatureToggle, ...] = (
     FeatureToggle.SYNCHRONIZE_ALLOCINE_PRODUCTS_FROM_BIGQUERY_TABLES,
     FeatureToggle.SYNCHRONIZE_EVENT_SERIES_FROM_BIGQUERY_TABLES,
     FeatureToggle.WIP_ENABLE_CULTURAL_OUTREACH,
+    FeatureToggle.WIP_ENABLE_ETL_SYNC,
     FeatureToggle.WIP_ENABLE_FINANCE_SETTLEMENTS,
     FeatureToggle.WIP_ENABLE_NEW_BREVO_RECOMMENDATION_WEBHOOK,
     FeatureToggle.WIP_CLOSE_VENUE,

--- a/api/src/pcapi/routes/backoffice/templates/venue/get/providers_actions.html
+++ b/api/src/pcapi/routes/backoffice/templates/venue/get/providers_actions.html
@@ -26,23 +26,6 @@
         {% endif %}
       </li>
       <li class="dropdown-item p-0">
-        {% if has_permission("MANAGE_TECH_PARTNERS") and new_etl_integration_can_be_enabled(venue_provider) %}
-          <form action="{{ url_for('backoffice_web.venue.toggle_new_cinema_integration_is_enabled', venue_id=venue.id, provider_id=venue_provider.provider.id) }}"
-                name="{{ url_for('backoffice_web.venue.toggle_new_cinema_integration_is_enabled', venue_id=venue.id, provider_id=venue_provider.provider.id) | action_to_name }}"
-                method="post">
-            {{ csrf_token }}
-            <button type="submit"
-                    class="btn btn-sm d-block w-100 text-start px-3">
-              {% if venue_provider.isNewEtlIntegrationEnabled %}
-                Désactiver la nouvelle intégration cinéma
-              {% else %}
-                Activer la nouvelle intégration cinéma
-              {% endif %}
-            </button>
-          </form>
-        {% endif %}
-      </li>
-      <li class="dropdown-item p-0">
         {% if venue_provider.isActive and (venue_provider.isFromCinemaProvider or venue_provider.isFromAllocineProvider) %}
           <form action="{{ url_for('backoffice_web.venue.add_cinema_sessions_synchronize_task', venue_id=venue.id, provider_id=venue_provider.provider.id) }}"
                 name="{{ url_for('backoffice_web.venue.add_cinema_sessions_synchronize_task', venue_id=venue.id, provider_id=venue_provider.provider.id) | action_to_name }}"

--- a/api/src/pcapi/routes/backoffice/venues/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/venues/blueprint.py
@@ -594,25 +594,6 @@ def toggle_venue_provider_is_active(venue_id: int, provider_id: int) -> response
     return redirect(url_for("backoffice_web.venue.get", venue_id=venue_id), code=303)
 
 
-# TODO (tcoudray-pass, 04/02/26): Remove when we get rid of old local providers integrations
-# See https://passculture.atlassian.net/browse/PC-40117
-@venue_blueprint.route("/<int:venue_id>/provider/<int:provider_id>/cinema-integration", methods=["POST"])
-@access_control.permission_required(perm_models.Permissions.MANAGE_TECH_PARTNERS)
-def toggle_new_cinema_integration_is_enabled(venue_id: int, provider_id: int) -> response_utils.BackofficeResponse:
-    venue_provider = _fetch_venue_provider(venue_id, provider_id)
-    venue_provider.isNewEtlIntegrationEnabled = not venue_provider.isNewEtlIntegrationEnabled
-    db.session.flush()
-
-    flash(
-        Markup("La nouvelle intégration cinéma a été {verb}.").format(
-            verb="activée" if venue_provider.isNewEtlIntegrationEnabled else "désactivée"
-        ),
-        "success",
-    )
-
-    return redirect(url_for("backoffice_web.venue.get", venue_id=venue_id), code=303)
-
-
 @venue_blueprint.route("/<int:venue_id>/provider/<int:provider_id>/synchronize-cinema", methods=["POST"])
 @access_control.permission_required_in(
     [perm_models.Permissions.ADVANCED_PRO_SUPPORT, perm_models.Permissions.MANAGE_TECH_PARTNERS]

--- a/api/tests/local_providers/provider_manager_test.py
+++ b/api/tests/local_providers/provider_manager_test.py
@@ -50,6 +50,7 @@ class SynchronizeVenueProviderTest:
         mock_updateObjects.assert_called_once_with(10)
         mock_execute.assert_not_called()
 
+    @pytest.mark.features(WIP_ENABLE_ETL_SYNC=1)
     @pytest.mark.parametrize(
         "cinema_details_factory",
         [
@@ -67,7 +68,6 @@ class SynchronizeVenueProviderTest:
         pivot = cinema_details.cinemaProviderPivot
         venue_provider = providers_factories.VenueProviderFactory(
             provider=pivot.provider,
-            isNewEtlIntegrationEnabled=True,
             venueIdAtOfferProvider=pivot.idAtProvider,
         )
 

--- a/api/tests/routes/backoffice/venues_test.py
+++ b/api/tests/routes/backoffice/venues_test.py
@@ -3424,40 +3424,6 @@ class PostToggleVenueProviderIsActiveTest(PostEndpointHelper):
         assert db.session.query(history_models.ActionHistory).count() == 0
 
 
-class ToggleNewCinemaIntegrationIsEnabledTestPost(PostEndpointHelper):
-    endpoint = "backoffice_web.venue.toggle_new_cinema_integration_is_enabled"
-    endpoint_kwargs = {"venue_id": 1, "provider_id": 1}
-    needed_permission = perm_models.Permissions.MANAGE_TECH_PARTNERS
-
-    @pytest.mark.parametrize("is_enabled,verb", [(True, "désactivée"), (False, "activée")])
-    def test_toggle_new_cinema_integration_is_enabled(self, authenticated_client, legit_user, is_enabled, verb):
-        venue_provider = providers_factories.VenueProviderFactory(
-            provider__name="Test provider", isNewEtlIntegrationEnabled=is_enabled
-        )
-
-        response = self.post_to_endpoint(
-            authenticated_client, venue_id=venue_provider.venue.id, provider_id=venue_provider.provider.id
-        )
-        assert response.status_code == 303
-
-        db.session.refresh(venue_provider)
-        assert venue_provider.isNewEtlIntegrationEnabled is not is_enabled
-
-        response = authenticated_client.get(response.location)
-        assert html_parser.extract_alert(response.data) == f"La nouvelle intégration cinéma a été {verb}."
-
-    def test_toggle_wrong_provider(self, authenticated_client):
-        venue_provider = providers_factories.VenueProviderFactory()
-
-        response = self.post_to_endpoint(authenticated_client, venue_id=venue_provider.venue.id, provider_id=0)
-        assert response.status_code == 404
-        assert (
-            db.session.query(providers_models.VenueProvider)
-            .filter(providers_models.VenueProvider.id == venue_provider.id)
-            .one()
-        )
-
-
 class AddCinemaSessionsSynchronizeTaskPostTest(PostEndpointHelper):
     endpoint = "backoffice_web.venue.add_cinema_sessions_synchronize_task"
     endpoint_kwargs = {"venue_id": 1, "provider_id": 1}


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43577)

Ce qui est fait dans ce ticket :
- Suppression de deux commandes flask qui n'ont plus lieu d'être : 
   - `test_etl_integration`
   - `debug_synchronize_venue_provider`
- Ajout d'un FF `WIP_ENABLE_ETL_SYNC` pour activer les nouvelles synchronisation cinéma (ETL) pour Boost, CGR et Ciné Office
- Suppression de la possibilité d'activer la nouvelle synchro pour un cinéma donné via le BO (car c'est géré par le FF) ; la colonne `isNewEtlIntegrationEnabled` sera supprimée dans un prochain ticket ([ticket](https://passculture.atlassian.net/browse/PC-40117))
- Ajout de la commande `synchronize_cinema_provider_offers` (qui dans un deuxième temps remplacera toutes les commandes particulières de pour Ciné Office, Boost et CGR)
