### PR TITLE
(PC-43536)[BO] feat: add timezone field to the offers generator form

### DIFF
--- a/api/src/pcapi/core/geography/constants.py
+++ b/api/src/pcapi/core/geography/constants.py
@@ -2,3 +2,18 @@ WGS_SPATIAL_REFERENCE_IDENTIFIER = 4326
 MAX_LATITUDE = 90
 MAX_LONGITUDE = 180
 NON_DISCLOSED_ADDRESS = "Adresse non diffusée"
+
+TIME_ZONE_COUNTRY_CODE = {
+    "America/Cayenne": "GF",
+    "America/Guadeloupe": "GP",
+    "America/Martinique": "MQ",
+    "America/Miquelon": "PM",
+    "America/St_Barthelemy": "BL",
+    "Europe/Paris": "FR",
+    "Indian/Mayotte": "YT",
+    "Indian/Reunion": "RE",
+    "Pacific/Noumea": "NC",
+    "Pacific/Pitcairn": "PN",
+    "Pacific/Tahiti": "PF",
+    "Pacific/Wallis": "WF",
+}

--- a/api/src/pcapi/core/offers/generator.py
+++ b/api/src/pcapi/core/offers/generator.py
@@ -2,18 +2,19 @@ import datetime
 import decimal
 
 import faker
+import pytz
 import sqlalchemy as sa
 
 from pcapi.connectors.acceslibre import ExpectedFieldsEnum as acceslibre_enum
 from pcapi.core import search
 from pcapi.core.categories import subcategories
 from pcapi.core.geography import factories as geography_factories
+from pcapi.core.geography.constants import TIME_ZONE_COUNTRY_CODE
 from pcapi.core.offerers import factories as offerers_factories
 from pcapi.core.offerers import models as offerers_models
 from pcapi.core.offers import factories as offers_factories
 from pcapi.core.offers import models as offers_models
 from pcapi.core.offers.constants import DEFAULT_PRICE_LABEL
-from pcapi.core.search import models as search_models
 from pcapi.models import db
 from pcapi.utils import date as date_utils
 from pcapi.utils import siren as siren_utils
@@ -37,7 +38,11 @@ def _create_offerer() -> offerers_models.Offerer:
 
 
 def _create_cinema_offer(
-    venue: offerers_models.Venue, offer_name: str, price: decimal.Decimal, is_duo: bool
+    venue: offerers_models.Venue,
+    offer_name: str,
+    price: decimal.Decimal,
+    is_duo: bool,
+    timezone: str,
 ) -> offers_models.Offer:
     fake = faker.Faker(["fr-FR"])
     offer_description = fake.paragraph(nb_sentences=30)
@@ -70,11 +75,16 @@ def _create_cinema_offer(
     )
     db.session.add(offer_metadata)
     price_category = offers_factories.PriceCategoryFactory(offer=offer, label=DEFAULT_PRICE_LABEL, price=price)
+    # Create screenings for the next 18 days separated by holes of 4 days
+    future_day_delta = (0, 1, 2, 3, 7, 8, 9, 10, 14, 15, 16, 17)
 
-    for daydelta in range(0, 20, 4):
-        day = datetime.date.today() + datetime.timedelta(days=daydelta)
-        for hour in (9, 15, 18):
-            beginning_datetime = datetime.datetime.combine(day, datetime.time(hour=hour))
+    for daydelta in future_day_delta:
+        day = datetime.datetime.now(pytz.timezone(timezone)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) + datetime.timedelta(days=daydelta)
+        for hour in (9, 15, 18) if (daydelta % 2) else (14, 19):
+            minute = ((hour - 9) // 3) * 15  # 0, 30, 45 or 15, 45
+            beginning_datetime = date_utils.to_naive_utc_datetime(day.replace(hour=hour, minute=minute))
             stock = offers_factories.StockFactory.build(
                 offer=offer,
                 price=price,
@@ -89,9 +99,11 @@ def _create_cinema_offer(
     return offer
 
 
-def _create_venue(offerer: offerers_models.Offerer, activity: offerers_models.Activity) -> offerers_models.Venue:
+def _create_venue(
+    offerer: offerers_models.Offerer, activity: offerers_models.Activity, timezone: str
+) -> offerers_models.Venue:
     fake = faker.Faker(["fr-FR"])
-    latitude, longitude, _, _, _ = fake.local_latlng(country_code="FR") or (
+    latitude, longitude, _, _, _ = fake.local_latlng(country_code=TIME_ZONE_COUNTRY_CODE[timezone]) or (
         geography_factories.DEFAULT_LATITUDE,
         geography_factories.DEFAULT_LONGITUDE,
         0,
@@ -103,6 +115,7 @@ def _create_venue(offerer: offerers_models.Offerer, activity: offerers_models.Ac
         postalCode=fake.postcode(),
         latitude=decimal.Decimal(latitude),
         longitude=decimal.Decimal(longitude),
+        timezone=timezone,
     )
     venue: offerers_models.Venue = offerers_factories.VenueFactory.create(
         activity=activity,
@@ -176,19 +189,19 @@ def _create_venue(offerer: offerers_models.Offerer, activity: offerers_models.Ac
 
 
 def create_offer(
-    offer_name: str, price: decimal.Decimal, subcategory_id: str, is_duo: bool
+    offer_name: str, price: decimal.Decimal, subcategory_id: str, is_duo: bool, timezone: str
 ) -> offers_models.Offer | None:
     # For the moment this function can only generate offers having SEANCE_CINE subcategory
     offerer = _create_offerer()
     offer = None
     venue = None
     if subcategory_id == subcategories.SEANCE_CINE.id:
-        venue = _create_venue(offerer, offerers_models.Activity.CINEMA)
-        offer = _create_cinema_offer(venue, offer_name, price, is_duo)
+        venue = _create_venue(offerer, offerers_models.Activity.CINEMA, timezone)
+        offer = _create_cinema_offer(venue, offer_name, price, is_duo, timezone)
 
     if offer is not None and venue is not None:
-        search.async_index_venue_ids([venue.id], search_models.IndexationReason.VENUE_CREATION)
-        search.async_index_offer_ids([offer.id], search_models.IndexationReason.OFFER_CREATION)
+        search.reindex_venue_ids([venue.id])
+        search.reindex_offer_ids([offer.id])
     return offer
 
 

--- a/api/src/pcapi/routes/backoffice/dev/blueprint.py
+++ b/api/src/pcapi/routes/backoffice/dev/blueprint.py
@@ -583,6 +583,7 @@ def generate_offer() -> response_utils.BackofficeResponse:
         price=form.price.data,
         subcategory_id=form.subcategory_id.data,
         is_duo=form.is_duo.data,
+        timezone=form.timezone.data,
     )
 
     flash("Offre créée avec succès", "success")

--- a/api/src/pcapi/routes/backoffice/dev/forms.py
+++ b/api/src/pcapi/routes/backoffice/dev/forms.py
@@ -7,11 +7,13 @@ from flask_wtf import FlaskForm
 
 from pcapi.core.categories import subcategories
 from pcapi.core.finance.conf import GRANTED_DEPOSIT_AMOUNT_18_v2
+from pcapi.core.geography.constants import TIME_ZONE_COUNTRY_CODE
 from pcapi.core.subscription.ubble import schemas as ubble_schemas
 from pcapi.core.users.generator import GeneratedIdProvider
 from pcapi.core.users.generator import GeneratedSubscriptionStep
 from pcapi.routes.backoffice.forms import fields
 from pcapi.routes.backoffice.forms import utils
+from pcapi.utils import date as date_utils
 
 
 class SimpleComponentsForm(FlaskForm):
@@ -239,5 +241,11 @@ class OfferGeneratorForm(utils.PCForm):
         "Sous-catégorie",
         choices=[(subcategories.SEANCE_CINE.id, subcategories.SEANCE_CINE.app_label)],
         default=subcategories.SEANCE_CINE.id,
+    )
+    timezone = fields.PCSelectField(
+        "Fuseau horaire",
+        choices=[(e, e) for e in TIME_ZONE_COUNTRY_CODE],
+        default=date_utils.METROPOLE_TIMEZONE,
+        validators=[wtforms.validators.Optional()],
     )
     is_duo = fields.PCSwitchBooleanField("Offre Duo", default=False)

--- a/api/src/pcapi/routes/backoffice/templates/dev/offers_generator.html
+++ b/api/src/pcapi/routes/backoffice/templates/dev/offers_generator.html
@@ -37,6 +37,9 @@
               <div class="mb-1">
                 <span class="fw-bold">Partenaire culturel :</span> {{ offer.venue.name }}
               </div>
+              <div class="mb-1">
+                <span class="fw-bold">Fuseau horaire :</span> {{ offer.offererAddress.address.timezone }}
+              </div>
               {{ build_modal_form("deactivate-offer", url_for("backoffice_web.dev.deactivate_offer", offer_id=offer.id) , deactivate_offer_form, "Désactiver l'offre", "Désactiver l'offre", "Valider") }}
             </div>
             <hr>

--- a/api/src/pcapi/routes/internal/e2e_offer.py
+++ b/api/src/pcapi/routes/internal/e2e_offer.py
@@ -22,10 +22,14 @@ def generate_offer() -> tuple[dict, int]:
         price=form.price.data,
         subcategory_id=form.subcategory_id.data,
         is_duo=form.is_duo.data,
+        timezone=form.timezone.data,
     )
 
     if offer is None:
         return {"subcategoryId": ["Invalid subcategoryId"]}, 400
+
+    offerer_address = offer.offererAddress
+    assert offerer_address  # helps mypy
 
     return {
         "id": offer.id,
@@ -33,6 +37,7 @@ def generate_offer() -> tuple[dict, int]:
         "subcategoryId": offer.subcategoryId,
         "venueId": offer.venueId,
         "isDuo": offer.isDuo,
+        "timezone": offerer_address.address.timezone,
     }, 200
 
 

--- a/api/tests/routes/backoffice/dev_test.py
+++ b/api/tests/routes/backoffice/dev_test.py
@@ -173,7 +173,7 @@ class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermis
         assert response.status_code == 200
         query_args = response.request.args.to_dict()
         user_id = query_args["userId"]
-        user = db.session.query(users_models.User).get(user_id)
+        user = db.session.get(users_models.User, user_id)
         assert user.postalCode == "63170"
 
     def test_user_postal_code_ignored_before_profile_completion(self, authenticated_client):
@@ -188,7 +188,7 @@ class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermis
         assert response.status_code == 200
         query_args = response.request.args.to_dict()
         user_id = query_args["userId"]
-        user = db.session.query(users_models.User).get(user_id)
+        user = db.session.get(users_models.User, user_id)
         assert user.postalCode is None
 
     @pytest.mark.settings(ENABLE_TEST_USER_GENERATION=1)
@@ -210,7 +210,7 @@ class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermis
         assert response.status_code == 200
         query_args = response.request.args.to_dict()
         user_id = query_args["userId"]
-        user = db.session.query(users_models.User).get(user_id)
+        user = db.session.get(users_models.User, user_id)
         assert user.activity == expected_activity
 
     def test_user_credit(self, authenticated_client):
@@ -221,7 +221,7 @@ class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermis
         query_args = response.request.args.to_dict()
         assert "userId" in query_args, response.data
         user_id = query_args["userId"]
-        user = db.session.query(users_models.User).get(user_id)
+        user = db.session.get(users_models.User, user_id)
         assert user.deposit.amount == 36
 
     def test_user_credit_default_amount(self, authenticated_client):
@@ -232,7 +232,7 @@ class UserGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermis
         query_args = response.request.args.to_dict()
         assert "userId" in query_args, response.data
         user_id = query_args["userId"]
-        user = db.session.query(users_models.User).get(user_id)
+        user = db.session.get(users_models.User, user_id)
         assert user.wallet_balance == 150
 
 
@@ -305,7 +305,7 @@ class OfferGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermi
 
         assert response.status_code == 200
         offer_id = response.request.path.rsplit("/")[-1]
-        offer = db.session.query(offers_models.Offer).get(offer_id)
+        offer = db.session.get(offers_models.Offer, offer_id)
         assert offer.subcategoryId == "SEANCE_CINE"
         assert offer.description in html_parser.content_as_text(response.data)
         assert offer.publicationDatetime is not None
@@ -318,8 +318,18 @@ class OfferGenerationPostRouteTest(post_endpoint_helper.PostEndpointWithoutPermi
         response = self.post_to_endpoint(authenticated_client, form=form, follow_redirects=True)
         assert response.status_code == 200
         offer_id = response.request.path.rsplit("/")[-1]
-        offer = db.session.query(offers_models.Offer).get(offer_id)
+        offer = db.session.get(offers_models.Offer, offer_id)
         assert offer.isDuo == is_duo
+
+    @pytest.mark.settings(ENABLE_TEST_OFFER_GENERATION=True)
+    @pytest.mark.parametrize("timezone", ["Europe/Paris", "Pacific/Noumea"])
+    def test_offer_creation_timezone(self, authenticated_client, timezone):
+        form = {"name": "Test Offer", "price": 13.4, "subcategory_id": "SEANCE_CINE", "timezone": timezone}
+        response = self.post_to_endpoint(authenticated_client, form=form, follow_redirects=True)
+        assert response.status_code == 200
+        offer_id = response.request.path.rsplit("/")[-1]
+        offer = db.session.get(offers_models.Offer, offer_id)
+        assert offer.offererAddress.address.timezone == timezone
 
 
 class OfferGenerationGetRouteTest(GetEndpointWithoutPermissionHelper):

--- a/api/tests/routes/internal/offer_test.py
+++ b/api/tests/routes/internal/offer_test.py
@@ -29,11 +29,44 @@ class E2EOfferTest:
         assert offer.publicationDatetime is not None
         assert offer.name == "Test Offer"
         assert offer.subcategoryId == "SEANCE_CINE"
+        assert offer.offererAddress.address.timezone == "Europe/Paris"
 
         assert response.json["id"] == offer.id
         assert response.json["name"] == "Test Offer"
         assert response.json["subcategoryId"] == "SEANCE_CINE"
         assert response.json["venueId"] == offer.venueId
+        assert response.json["timezone"] == "Europe/Paris"
+
+    @pytest.mark.parametrize(
+        "timezone",
+        [
+            "America/Cayenne",
+            "America/Guadeloupe",
+            "America/Martinique",
+            "America/Miquelon",
+            "America/St_Barthelemy",
+            "Europe/Paris",
+            "Indian/Mayotte",
+            "Indian/Reunion",
+            "Pacific/Noumea",
+            "Pacific/Pitcairn",
+            "Pacific/Tahiti",
+            "Pacific/Wallis",
+        ],
+    )
+    def test_create_offer_timezone(self, auth_client, timezone):
+        response = auth_client.post(
+            "/e2e/offer", {"name": "Test Offer", "subcategory_id": "SEANCE_CINE", "price": 8.2, "timezone": timezone}
+        )
+        assert response.status_code == 200
+
+        offers = db.session.query(offers_models.Offer).all()
+
+        assert len(offers) == 1
+        offer = offers[0]
+        assert offer.offererAddress.address.timezone == timezone
+
+        assert response.json["timezone"] == timezone
 
     @pytest.mark.parametrize("is_duo", [True, False])
     def test_create_offer_duo(self, auth_client, is_duo):
@@ -61,6 +94,15 @@ class E2EOfferTest:
 
         assert response.status_code == 400
         assert response.json == {"subcategory_id": ["Not a valid choice."]}
+
+    def test_create_offer_invalid_timezone(self, auth_client):
+        response = auth_client.post(
+            "/e2e/offer",
+            {"name": "Test Offer", "subcategory_id": "SEANCE_CINE", "price": 8.2, "timezone": "Nowhere/Lost"},
+        )
+
+        assert response.status_code == 400
+        assert response.json == {"timezone": ["Not a valid choice."]}
 
 
 class E2EOfferDeactivateTest:


### PR DESCRIPTION
## 🎯 Related Ticket or 🔧 Changes Made

[Ticket Jira](https://passculture.atlassian.net/browse/PC-43536)

- Add `Timezone` field to offers generator form
- Add more simultaneous screenings for generated cinema offer